### PR TITLE
Schema organisation (Take 2)

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -41,21 +41,6 @@ import collection.JavaConversions._
       }
     }
 
-    scenario("Include organisation metadata", ArticleComponents) {
-
-      Given("I am on an article entitled 'Liu Xiang pulls up in opening race at second consecutive Olympics'")
-      goTo("/sport/2012/aug/07/liu-xiang-injured-olympics") { browser =>
-        import browser._
-
-        Then("there should be organisation metadata")
-
-        val org = findFirst("span[itemtype='http://schema.org/Organization']")
-
-        org.findFirst("[itemprop=name]").getText should be("The Guardian")
-        org.findFirst("meta[itemprop=logo]").getAttribute("content") should be("https://static-secure.guim.co.uk/icons/social/og/gu-logo-fallback.png")
-      }
-    }
-
     scenario("Display a short description of the article", ArticleComponents) {
 
       Given("I am on an article entitled 'Putting a price on the rivers and rain diminishes us all'")

--- a/article/test/ArticleMetaDataTest.scala
+++ b/article/test/ArticleMetaDataTest.scala
@@ -1,0 +1,19 @@
+import org.jsoup.Jsoup
+import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import play.api.test.Helpers._
+import play.api.test._
+import test.{ConfiguredTestSuite, TestRequest}
+
+@DoNotDiscover class ArticleMetaDataTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+
+  val articleUrl = "environment/2012/feb/22/capitalise-low-carbon-future"
+
+  it should "Include organisation metadata" in {
+    val result = controllers.ArticleController.renderArticle(articleUrl)(TestRequest(articleUrl))
+    val body = Jsoup.parseBodyFragment(contentAsString(result))
+    status(result) should be(200)
+
+    body.getElementsByAttributeValue("data-schema", "organization")
+  }
+
+}

--- a/article/test/ArticleMetaDataTest.scala
+++ b/article/test/ArticleMetaDataTest.scala
@@ -1,8 +1,9 @@
+package test
+
 import org.jsoup.Jsoup
+import play.api.libs.json._
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
-import play.api.test._
-import test.{ConfiguredTestSuite, TestRequest}
 
 @DoNotDiscover class ArticleMetaDataTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
@@ -13,7 +14,16 @@ import test.{ConfiguredTestSuite, TestRequest}
     val body = Jsoup.parseBodyFragment(contentAsString(result))
     status(result) should be(200)
 
-    body.getElementsByAttributeValue("data-schema", "organization")
+    val script = body.getElementsByAttributeValue("data-schema", "organization")
+    script.size() should be(1)
+
+    val data: JsValue = Json.parse(script.first().html())
+    (data \ "name").as[String] should be("The Guardian")
+    (data \ "logo").as[String] should include("152x152.png")
+
+    val socialNetworks = (data \ "sameAs").as[List[String]]
+
+    socialNetworks.size should be(4)
   }
 
 }

--- a/article/test/package.scala
+++ b/article/test/package.scala
@@ -7,10 +7,12 @@ object ArticleComponents extends Tag("article components")
 class ArticleTestSuite extends Suites (
   new AnalyticsFeatureTest,
   new ArticleControllerTest,
+  new ArticleMetaDataTest,
   new ArticleFeatureTest,
   new CdnHealthCheckTest,
   new HealthCheckTest,
-  new SectionsNavigationFeatureTest ) with SingleServerSuite {
+  new SectionsNavigationFeatureTest
+) with SingleServerSuite {
 
   override lazy val port: Int = conf.HealthCheck.testPort
 }

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -121,43 +121,40 @@ to apply any necessary changes to non-shared code there too.
             <div class="popup popup--search is-off"><div class="js-search-placeholder"></div></div>
 
             <div class="l-header-main">
-                <span itemscope itemtype="http://schema.org/Organization">
-                    <meta itemprop="logo" content="https://static-secure.guim.co.uk/icons/social/og/gu-logo-fallback.png" />
-                    @if(metaData.section == "observer" && metaData.isFront) {
-                        <a href="@LinkTo{@metaData.url}" data-link-name="site logo" id="logo" class="logo-wrapper logo-wrapper--observer" itemprop="url" data-component="logo">
-                            @if(metaData.hasSlimHeader) {
-                                @fragments.inlineSvg("observer-logo-160", "logo")
-                            } else {
-                                <span class="u-h" itemprop="name">The Observer</span>
-                                @fragments.inlineSvg("observer-logo-320", "logo")
-                            }
-                        </a>
-                    } else {
-                        <a href="@LinkTo{/}" data-link-name="site logo" id="logo" class="logo-wrapper" itemprop="url" data-component="logo">
-                            <span class="u-h" itemprop="name">The Guardian</span>
-                            @if(metaData.hasSlimHeader) {
-                                @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
-                                <!--[if (gt IE 8)&(IEMobile)]><!-->
-                                    @fragments.inlineSvg("guardian-logo-160", "logo")
-                                <!--<![endif]-->
-                                <!--[if (lt IE 9)&(!IEMobile)]>
-                                  <span class="inline-logo inline-guardian-logo-160"></span>
-                                <![endif]-->
-                            } else {
-                                <!--[if (gt IE 8)&(IEMobile)]><!-->
-                                    @fragments.inlineSvg("guardian-logo-320", "logo")
-                                <!--<![endif]-->
-                                <!--[if (lt IE 9)&(!IEMobile)]>
-                                    <span class="inline-logo inline-guardian-logo-320"></span>
-                                <![endif]-->
-                                <span class="logo__tagline hide-on-mobile">Winner of the Pulitzer prize</span>
-                            }
-                        </a>
-                    }
-                    @if(metaData.hasSlimHeader) {
-                        @fragments.nav.navigationToggle(metaData)
-                    }
-                </span>
+                @if(metaData.section == "observer" && metaData.isFront) {
+                    <a href="@LinkTo{@metaData.url}" data-link-name="site logo" id="logo" class="logo-wrapper logo-wrapper--observer" itemprop="url" data-component="logo">
+                        @if(metaData.hasSlimHeader) {
+                            @fragments.inlineSvg("observer-logo-160", "logo")
+                        } else {
+                            <span class="u-h">The Observer</span>
+                            @fragments.inlineSvg("observer-logo-320", "logo")
+                        }
+                    </a>
+                } else {
+                    <a href="@LinkTo{/}" data-link-name="site logo" id="logo" class="logo-wrapper" itemprop="url" data-component="logo">
+                        <span class="u-h">The Guardian</span>
+                        @if(metaData.hasSlimHeader) {
+                            @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
+                            <!--[if (gt IE 8)&(IEMobile)]><!-->
+                                @fragments.inlineSvg("guardian-logo-160", "logo")
+                            <!--<![endif]-->
+                            <!--[if (lt IE 9)&(!IEMobile)]>
+                              <span class="inline-logo inline-guardian-logo-160"></span>
+                            <![endif]-->
+                        } else {
+                            <!--[if (gt IE 8)&(IEMobile)]><!-->
+                                @fragments.inlineSvg("guardian-logo-320", "logo")
+                            <!--<![endif]-->
+                            <!--[if (lt IE 9)&(!IEMobile)]>
+                                <span class="inline-logo inline-guardian-logo-320"></span>
+                            <![endif]-->
+                            <span class="logo__tagline hide-on-mobile">Winner of the Pulitzer prize</span>
+                        }
+                    </a>
+                }
+                @if(metaData.hasSlimHeader) {
+                    @fragments.nav.navigationToggle(metaData)
+                }
             </div>
         </div>
         @fragments.nav.navigation(metaData)

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -114,7 +114,7 @@
 
 <meta name="google-site-verification" content="LR-FN6c2gIEUoo3k049w1nxyHykmac5ZE3SaUOiKc30" />
 
-<script type="application/ld+json">
+<script data-schema="organization" type="application/ld+json">
     {
         "@@context" : "http://schema.org",
         "@@type" : "Organization",


### PR DESCRIPTION
A test to see whether using JSON+LD to define our oragnization schema will get the knowledge graph panel to appear in Google search results.

https://developers.google.com/structured-data/customize/overview

To do this I have removed the normal oraganization schema from our header markup. Best viewed without whitespace changes: 
https://github.com/guardian/frontend/pull/8728/files?w=1

Have now added a new ArticleMetaData test suite, which parses the resulting JSON.

/cc @gklopper @oliverjash
