### PR TITLE
Change importance to a boolean

### DIFF
--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -152,11 +152,9 @@
                 <input type="checkbox" data-bind="
                     checked: meta.uneditable" />
 
-                <label>Importance</label>
-                <select data-bind="options: props.optionsImportance,
-                    optionsCaption: 'default',
-                    value: meta.importance,
-                    valueAllowUnset: true"></select>
+                <label>Important</label>
+                <input type="checkbox" data-bind="
+                    checked: meta.important" />
 
                 <div class="tools">
                     <button class="tool" data-bind="

--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -51,15 +51,9 @@ define([
             'showLatestUpdate',
             'excludeFromRss',
             'apiQuery',
-            'importance']);
+            'important']);
 
         populateObservables(this.meta, opts);
-
-        this.props = {
-            optionsImportance: [
-                'critical', 'important'
-            ]
-        };
 
         this.state = asObservableProps([
             'isOpen',

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -142,11 +142,11 @@ trait FrontJson extends ExecutionContexts with Logging {
       showSections    = (json \ "showSections").asOpt[Boolean],
       uneditable      = (json \ "uneditable").asOpt[Boolean],
       hideKickers     = (json \ "hideKickers").asOpt[Boolean],
-      showDateHeader =  (json \ "showDateHeader").asOpt[Boolean],
+      showDateHeader  =  (json \ "showDateHeader").asOpt[Boolean],
       showLatestUpdate = (json \ "showLatestUpdate").asOpt[Boolean],
-      excludeFromRss = (json \ "excludeFromRss").asOpt[Boolean],
-      showTimestamps = (json \ "showTimestamps").asOpt[Boolean],
-      importance = (json \ "importance").asOpt[String]
+      excludeFromRss  = (json \ "excludeFromRss").asOpt[Boolean],
+      showTimestamps  = (json \ "showTimestamps").asOpt[Boolean],
+      important       = (json \ "important").asOpt[Boolean]
     )
 
   private def parsePressedJson(j: String): Option[FaciaPage] = {


### PR DESCRIPTION
Because `critical` is now replaced by `canonical`.

@stephanfowler @robertberry 

This requires changes in [facia-scala-client](https://github.com/guardian/facia-scala-client/search?utf8=%E2%9C%93&q=importance)
