### PR TITLE
Xwords: highlight intersecting entries

### DIFF
--- a/static/src/javascripts/es6/projects/common/modules/crosswords/grid.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/grid.js
@@ -52,7 +52,8 @@ var Cell = React.createClass({
                 className: classNames({
                     'crossword__cell': true,
                     'crossword__cell--focussed': this.props.isFocussed,
-                    'crossword__cell--highlighted': this.props.isHighlighted
+                    'crossword__cell--highlighted': this.props.isHighlighted,
+                    'crossword__cell--intersecting': this.props.intersectsFocussedEntry
                 })
             }),
             innerNodes
@@ -80,6 +81,7 @@ export default React.createClass({
                     cellProps.y = y;
                     cellProps.key = 'cell_' + x + '_' + y;
                     cellProps.isHighlighted = this.props.isHighlighted(x, y);
+                    cellProps.intersectsFocussedEntry = this.props.cellIntersectsFocussedEntry(x, y);
                     cellProps.isFocussed = this.props.focussedCell && x === this.props.focussedCell.x &&
                         y === this.props.focussedCell.y;
                     cells.push(Cell(cellProps));

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -368,6 +368,23 @@ var Crossword = React.createClass({
         let focussed = this.clueInFocus(),
             isHighlighted = (x, y) => focussed ? helpers.entryHasCell(focussed, x, y) : false;
 
+        // Deep equal version of _.intersection
+        let findIntersectingCells = (array1, array2) =>
+            array1.filter(cell1 => array2.some(cell2 => _.isEqual(cell1, cell2)));
+
+        let focussedCells = focussed ? helpers.cellsForEntry(focussed) : [];
+        let entryHasIntersectingCell = entry => {
+            let cells = helpers.cellsForEntry(entry);
+            let intersecting = findIntersectingCells(cells, focussedCells);
+            return !! intersecting.length;
+        };
+
+        let otherEntries = _.difference(this.props.data.entries, focussed ? [focussed] : []);
+        let intersectingEntries = otherEntries.filter(entryHasIntersectingCell);
+
+        let cellIntersectsFocussedEntry = (x, y) =>
+            intersectingEntries.some(entry => helpers.entryHasCell(entry, x, y));
+
         return React.DOM.div({
             className: 'crossword__container'
         },
@@ -381,6 +398,7 @@ var Crossword = React.createClass({
             setCellValue: this.setCellValue,
             onSelect: this.onSelect,
             isHighlighted: isHighlighted,
+            cellIntersectsFocussedEntry,
             focussedCell: this.state.cellInFocus,
             ref: 'grid'
         }),

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -369,20 +369,20 @@ var Crossword = React.createClass({
             isHighlighted = (x, y) => focussed ? helpers.entryHasCell(focussed, x, y) : false;
 
         // Deep equal version of _.intersection
-        let findIntersectingCells = (array1, array2) =>
+        const findIntersectingCells = (array1, array2) =>
             array1.filter(cell1 => array2.some(cell2 => _.isEqual(cell1, cell2)));
 
-        let focussedCells = focussed ? helpers.cellsForEntry(focussed) : [];
-        let entryHasIntersectingCell = entry => {
-            let cells = helpers.cellsForEntry(entry);
-            let intersecting = findIntersectingCells(cells, focussedCells);
+        const focussedCells = focussed ? helpers.cellsForEntry(focussed) : [];
+        const entryHasIntersectingCell = entry => {
+            const cells = helpers.cellsForEntry(entry);
+            const intersecting = findIntersectingCells(cells, focussedCells);
             return !! intersecting.length;
         };
 
-        let otherEntries = _.difference(this.props.data.entries, focussed ? [focussed] : []);
-        let intersectingEntries = otherEntries.filter(entryHasIntersectingCell);
+        const otherEntries = _.difference(this.props.data.entries, focussed ? [focussed] : []);
+        const intersectingEntries = otherEntries.filter(entryHasIntersectingCell);
 
-        let cellIntersectsFocussedEntry = (x, y) =>
+        const cellIntersectsFocussedEntry = (x, y) =>
             intersectingEntries.some(entry => helpers.entryHasCell(entry, x, y));
 
         return React.DOM.div({

--- a/static/src/stylesheets/module/crosswords/_grid.scss
+++ b/static/src/stylesheets/module/crosswords/_grid.scss
@@ -8,6 +8,10 @@
     fill: #ffffff;
 }
 
+.crossword__cell--intersecting {
+    fill: hsl(0, 0%, 80%);
+}
+
 .crossword__cell--highlighted {
     fill: lighten(colour(crosswordAccent2), 30%);
 }

--- a/static/src/stylesheets/module/crosswords/_grid.scss
+++ b/static/src/stylesheets/module/crosswords/_grid.scss
@@ -9,7 +9,7 @@
 }
 
 .crossword__cell--intersecting {
-    fill: hsl(0, 0%, 80%);
+    fill: colour(neutral-3);
 }
 
 .crossword__cell--highlighted {


### PR DESCRIPTION
As per the designs.

This is my first dive into crosswords. There could be existing functions I should be re-using, or I may have put things in the wrong place. Please shout if that's the case.

Merging into @sndrs’s `xwords` branch because I'm based off that and it's not yet in master.

![image](https://cloud.githubusercontent.com/assets/921609/6900622/b4549eaa-d6ff-11e4-9047-bc4a1881e2d5.png)
