### PR TITLE
Remove importance from facia tool

### DIFF
--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -152,12 +152,6 @@
                 <input type="checkbox" data-bind="
                     checked: meta.uneditable" />
 
-                <label>Importance</label>
-                <select data-bind="options: props.optionsImportance,
-                    optionsCaption: 'default',
-                    value: meta.importance,
-                    valueAllowUnset: true"></select>
-
                 <div class="tools">
                     <button class="tool" data-bind="
                         click: save">Save container</button>

--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -50,16 +50,9 @@ define([
             'showDateHeader',
             'showLatestUpdate',
             'excludeFromRss',
-            'apiQuery',
-            'importance']);
+            'apiQuery']);
 
         populateObservables(this.meta, opts);
-
-        this.props = {
-            optionsImportance: [
-                'critical', 'important'
-            ]
-        };
 
         this.state = asObservableProps([
             'isOpen',

--- a/facia-tool/test/config/TransformationsSpec.scala
+++ b/facia-tool/test/config/TransformationsSpec.scala
@@ -49,7 +49,6 @@ import test.ConfiguredTestSuite
     None,
     None,
     None,
-    None,
     None
   )
 

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -142,11 +142,10 @@ trait FrontJson extends ExecutionContexts with Logging {
       showSections    = (json \ "showSections").asOpt[Boolean],
       uneditable      = (json \ "uneditable").asOpt[Boolean],
       hideKickers     = (json \ "hideKickers").asOpt[Boolean],
-      showDateHeader =  (json \ "showDateHeader").asOpt[Boolean],
+      showDateHeader  =  (json \ "showDateHeader").asOpt[Boolean],
       showLatestUpdate = (json \ "showLatestUpdate").asOpt[Boolean],
-      excludeFromRss = (json \ "excludeFromRss").asOpt[Boolean],
-      showTimestamps = (json \ "showTimestamps").asOpt[Boolean],
-      importance = (json \ "importance").asOpt[String]
+      excludeFromRss  = (json \ "excludeFromRss").asOpt[Boolean],
+      showTimestamps  = (json \ "showTimestamps").asOpt[Boolean]
     )
 
   private def parsePressedJson(j: String): Option[FaciaPage] = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val crosswordsApiClient = "com.gu" %% "crosswords-api-client" % "0.5"
   val dfpAxis = "com.google.api-ads" % "dfp-axis" % "1.38.0"
   val exactTargetClient = "com.gu" %% "exact-target-client" % "2.24"
-  val faciaScalaClient = "com.gu" %% "facia-json" % "0.29"
+  val faciaScalaClient = "com.gu" %% "facia-json" % "0.30"
   val flexibleContentBlockToText = "com.gu" %% "flexible-content-block-to-text" % "0.4"
   val flexibleContentBodyParser = "com.gu" %% "flexible-content-body-parser" % "0.6"
   val googleSheetsApi = "com.google.gdata" % "core" % "1.47.1"


### PR DESCRIPTION
Because it's apparently useless now. Canonical containers do the job.

@janua important should also be removed from `facia-scala-client`
