### PR TITLE
Remove FaciaTreats switch

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -587,11 +587,6 @@ object Switches {
     safeState = Off, sellByDate = never
   )
 
-  val FaciaTreats = Switch("Facia", "facia-treats",
-    "If this switch is on then treats will be available to edit in the tool and will be pressed",
-    safeState = Off, sellByDate = never
-  )
-
   val IphoneConfidence = Switch("Performance", "iphone-confidence",
     "If this switch is on then some beacons will be dropped to gauge iPhone confidence",
     safeState = Off, sellByDate = new LocalDate(2015, 4, 30)

--- a/facia-press/app/frontpress/ParseCollection.scala
+++ b/facia-press/app/frontpress/ParseCollection.scala
@@ -3,7 +3,7 @@ package services
 import com.gu.facia.client.models.{Trail, _}
 import com.gu.contentapi.client.model.{Content => ApiContent}
 import common._
-import conf.Switches.{FaciaToolCachedContentApiSwitch, FaciaTreats}
+import conf.Switches.FaciaToolCachedContentApiSwitch
 import conf.{Configuration, LiveContentApi}
 import contentapi.{ContentApiClient, QueryDefaults}
 import fronts.FrontsApi
@@ -81,13 +81,10 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
     }
 
     val treatsFuture: Future[Seq[Content]] =
-      if (FaciaTreats.isSwitchedOn)
-          collection.flatMap { collectionOption =>
-            val items: Seq[Trail] =
-              collectionOption.flatMap(_.treats).getOrElse(Nil)
-            getArticles(items, edition)}
-      else
-        Future.successful(Nil)
+      collection.flatMap { collectionOption =>
+        val items: Seq[Trail] =
+          collectionOption.flatMap(_.treats).getOrElse(Nil)
+        getArticles(items, edition)}
 
     val executeDraftContentApiQuery: Future[Result] =
       config.apiQuery.map(executeContentApiQueryViaCache(_, edition)).getOrElse(Future.successful(Result.empty))

--- a/facia-tool/app/views/admin_main.scala.html
+++ b/facia-tool/app/views/admin_main.scala.html
@@ -3,7 +3,6 @@
 @import slices.{FixedContainers, DynamicContainers, IdsJson}
 @import IdsJson.{fixed, dynamic}
 @import conf.Configuration
-@import conf.Switches.FaciaTreats
 
 <!DOCTYPE html>
 

--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -278,10 +278,8 @@
                             &middot;
                             <a class='tool--content' data-bind="attr: {href: '/@{priority}?layout=latest,front:' + id()}">edit content</a>
                             &middot;
-                            @if(Switches.FaciaTreats.isSwitchedOn) {
                             <a class='tool--content' data-bind="attr: {href: '/@{priority}?treats=please&amp;front=' + id()}">edit treats</a>
                             &middot;
-                            }
                             <a class='tool--live' data-bind="attr: {href: '@urlBase(env)' + id()}" target="_blank">view live</a>
                             &middot;
                             <a class='tool--live' data-bind="attr: {href: ophanPerformances()}" target="_blank">view performance</a>

--- a/facia-tool/public/js/utils/layout-from-url.js
+++ b/facia-tool/public/js/utils/layout-from-url.js
@@ -1,10 +1,8 @@
 define([
     'underscore',
-    'modules/vars',
     'utils/parse-query-params'
 ], function (
     _,
-    vars,
     parseQueryParams
 ) {
     function get () {
@@ -16,7 +14,7 @@ define([
             queryParams = parseQueryParams(window.location.search),
             configFromURL = queryParams.layout;
 
-        if (queryParams.treats === 'please' && vars.model.switches()['facia-treats']) {
+        if (queryParams.treats === 'please') {
             columns = [{
                 type: 'clipboard'
             }, {


### PR DESCRIPTION
Treats are here to stay, there's no reason to keep them behind a switch
