### PR TITLE
Set inline logo size for slim header without SVG

### DIFF
--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -83,6 +83,13 @@ $c-guardian-services-action: #ffffff;
                 height: 30px;
             }
         }
+
+        .no-svg & {
+            .inline-logo {
+                width: 160px;
+                height: 30px;
+            }
+        }
     }
 
     .inline-logo {
@@ -108,13 +115,6 @@ $c-guardian-services-action: #ffffff;
                 width: 320px;
                 height: 60px;
             }
-        }
-    }
-
-    .no-svg .l-header--is-slim & {
-        .inline-logo {
-            width: 160px;
-            height: 30px;
         }
     }
 }

--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -110,6 +110,13 @@ $c-guardian-services-action: #ffffff;
             }
         }
     }
+
+    .no-svg .l-header--is-slim & {
+        .inline-logo {
+            width: 160px;
+            height: 30px;
+        }
+    }
 }
 
 


### PR DESCRIPTION
Sass ampersands twisting my melon, can't see a way to combine this with the rule above it?
