### PR TITLE
Add Membership bootstrap to curl paths

### DIFF
--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -49,6 +49,7 @@
                 'bootstraps/facia':         '@Static("javascripts/bootstraps/facia.js")',
                 'bootstraps/football':      '@Static("javascripts/bootstraps/football.js")',
                 'bootstraps/image-content': '@Static("javascripts/bootstraps/image-content.js")',
+                'bootstraps/membership':    '@Static("javascripts/bootstraps/membership.js")',
                 'bootstraps/sudoku':        '@Static("javascripts/bootstraps/sudoku.js")',
                 'bootstraps/video-player':  '@Static("javascripts/bootstraps/video-player.js")'
             }


### PR DESCRIPTION
Additionally, can't find any usage of sending [`curlPaths` to `main.scala.html`](https://github.com/guardian/frontend/blob/master/common/app/views/main.scala.html#L1) as a param.

Loading this Membership bootstrap was the final occurrence of doing so ([deleted here](https://github.com/guardian/frontend/commit/5b8398e41a68b2338b1e476a24653abdc591c709#diff-66de0b87a5f14f6528516725df53257aL6)) — is this now deprecated (should be removed)?
