### PR TITLE
Show name and build ID for all boxes

### DIFF
--- a/admin/public/css/radiator.css
+++ b/admin/public/css/radiator.css
@@ -12,12 +12,9 @@ header {
     font-size: 18px;
 }
 .navbar { display: none; }
-#pingdom li, #riffraff li, #sell-by-date li { font-size: 30px; line-height: 30px; } 
+#pingdom li, #riffraff li, #sell-by-date li { font-size: 30px; line-height: 30px; }
 #pingdom small, #riffraff small { font-size: 20px; }
-.up, .Completed {
-    color: #B8FAA0;
 
-} 
 .down, .Failed { color: red; }
 .Running { color: orange; }
 ul {
@@ -41,6 +38,13 @@ ul {
     margin: 5px 5px 0 0;
 }
 
+.riffraff li {
+    font-size: 9px;
+    color: #000000;
+    text-align: center;
+    line-height: 10px;
+}
+
 #pingdom li.up, .riffraff li.Completed {
     background-color: #B8FAA0;
 }
@@ -55,13 +59,6 @@ ul {
 
 .riffraff li.Behind {
     background-color: #21fa41;
-}
-
-.riffraff li.Behind, .riffraff li.Failed,  .riffraff li.Running {
-    color: #000000;
-    font-size: 9px;
-    text-align: center;
-    line-height: 10px;
 }
 
 .expiry-days-0, .expiry-days-1, .expiry-days-2 {

--- a/static/src/javascripts/projects/admin/bootstraps/radiator.js
+++ b/static/src/javascripts/projects/admin/bootstraps/radiator.js
@@ -82,14 +82,13 @@ define([
 
                         var li = document.createElement('li');
                         li.className = d.status;
-                        li.innerHTML = nameAbbreviation;
+                        li.innerHTML = nameAbbreviation + ' ' + d.build;
                         li.setAttribute('title', d.projectName);
                         link.appendChild(li);
 
                         if (latestDeployments['CODE'][deployment] && stage === 'PROD' && d.status === 'Completed') {
                             var codeBuild = (latestDeployments['CODE'][deployment] || {}).build;
                             if (codeBuild !== d.build){
-                                li.innerHTML = nameAbbreviation + ' ' + codeBuild;
                                 li.className = 'Behind';
                             }
                         }


### PR DESCRIPTION
This is a small change to Radiator to always show the application name and build ID for all deployments.

Beforehand, the interface was quite confusing. When PROD was behind, the build ID of CODE would appear inside the PROD deployment box. I developed a habit of clicking the box to discover the build ID of PROD. (I use this information to manually evaluate the difference between the two builds, so I know exactly how far behind PROD is. Ideally it would only be one build behind, but this is almost never the case.)

This change makes it much easier to read the build IDs.

/cc @rich-nguyen 

Before
![image](https://cloud.githubusercontent.com/assets/921609/6942733/612ae0bc-d881-11e4-8520-f15e1b7f515c.png)
After
![image](https://cloud.githubusercontent.com/assets/921609/6942740/6830280e-d881-11e4-83d0-36fe7409653e.png)
