### PR TITLE
Election 2015 badging

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -225,6 +225,12 @@ object Switches {
     safeState = On, sellByDate = never
   )
 
+  val ElectionLiveBadgeSwitch = Switch("Feature", "election-2015-badging",
+    "Display Election Live 2015 Badge",
+    safeState = On,
+    sellByDate = new LocalDate(2015, 5, 28)
+  )
+
   val LiveblogAdvertsSwitch = Switch("Commercial", "liveblog-adverts",
     "Show inline adverts on liveblogs",
     safeState = Off, sellByDate = never

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -3,10 +3,11 @@
 @import common.{LinkTo, Localisation}
 
 <div class="content__labels">
+    @fragments.meta.pseudoBadge(content)
+
     <div class="content__section-label">
         <a class="content__section-label__link" data-link-name="article section" href="@LinkTo {/@content.sectionLabelLink}">@Html(Localisation(content.sectionLabelName))</a>
     </div>
-
 
     @content.blogOrSeriesTag.map { series =>
         <div class="content__series-label">

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -1,23 +1,37 @@
 @(content: model.Content)(implicit request: RequestHeader)
 
 @import common.{LinkTo, Localisation}
+@import conf.Switches.ElectionLiveBadgeSwitch
 
-<div class="content__labels">
-    @fragments.meta.pseudoBadge(content)
+@defining(
+    ElectionLiveBadgeSwitch.isSwitchedOn &&
+    (content.tags.indexWhere(_.id == "politics/general-election-2015") == 0 ||
+    content.tags.indexWhere(_.id == "politics/series/election-live-2015") == 0) &&
+    !(content.isSponsored(Some(Edition(request))) ||
+        content.isAdvertisementFeature ||
+        content.isFoundationSupported)
+) { electionBadgingEnabled =>
 
-    <div class="content__section-label">
+    <div class="content__labels">
+
+        @if(electionBadgingEnabled) {
+            @fragments.meta.pseudoBadge()
+        }
+
+    <div class="content__section-label@if(electionBadgingEnabled) { content__section-label--election}">
         <a class="content__section-label__link" data-link-name="article section" href="@LinkTo {/@content.sectionLabelLink}">@Html(Localisation(content.sectionLabelName))</a>
     </div>
 
-    @content.blogOrSeriesTag.map { series =>
-        <div class="content__series-label">
-            <a class="content__series-label__link" href="@LinkTo{/@series.id}">@series.name</a>
+        @content.blogOrSeriesTag.map { series =>
+        <div class="content__series-label @if(electionBadgingEnabled) { content__series-label--election}">
+            <a class="content__series-label__link" href="@LinkTo {/@series.id}">@series.name</a>
         </div>
-    }.getOrElse{
-        @if(content.isFromTheObserver ) {
-            <div class="content__series-label">
-                <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>
-            </div>
+        }.getOrElse {
+            @if(content.isFromTheObserver) {
+                <div class="content__series-label">
+                    <a class="content__series-label__link" href="http://observer.theguardian.com">The Observer</a>
+                </div>
+            }
         }
-    }
-</div>
+    </div>
+}

--- a/common/app/views/fragments/meta/pseudoBadge.scala.html
+++ b/common/app/views/fragments/meta/pseudoBadge.scala.html
@@ -1,25 +1,12 @@
-@(content: model.Content)(implicit request: RequestHeader)
-@import common.Edition
-@import conf.Switches.ElectionLiveBadgeSwitch
+@()(implicit request: RequestHeader)
 
 @defining(
-    ElectionLiveBadgeSwitch.isSwitchedOn,
-    content.tags.indexWhere(_.id == "politics/general-election-2015") == 0 ||
-    content.tags.indexWhere(_.id == "politics/series/election-live-2015") == 0,
-    content.isSponsored(Some(Edition(request))) ||
-    content.isAdvertisementFeature ||
-    content.isFoundationSupported
-) { case (electionBadgingEnabled, isElectionTopTag, isCommercialContent) =>
-        @if(electionBadgingEnabled && isElectionTopTag && !isCommercialContent) {
-            @defining(
-                "ge15badge",
-                "http://i.guim.co.uk/static/w-90/h--/q-95/sys-images/Guardian/Pix/pictures/2015/4/1/1427904404288/election-2015-logo-160x160.png"
-            ){ case (name, badgePath) =>
-                @fragments.meta.pseudoBadgeSlot(name) {
-                    <div class="badge-slot--meta-badge__inner badge-slot__content--placeholder">
-                        <img src="@badgePath" />
-                    </div>
-                }
-            }
-        }
+    "ge15badge",
+    "http://i.guim.co.uk/static/w-90/h--/q-95/sys-images/Guardian/Pix/pictures/2015/4/1/1427904404288/election-2015-logo-160x160.png"
+){ case (name, badgePath) =>
+    @fragments.meta.pseudoBadgeSlot(name) {
+        <div class="badge-slot__inner badge-slot__content--placeholder">
+            <img class="badge-slot__img" src="@badgePath" />
+        </div>
     }
+}

--- a/common/app/views/fragments/meta/pseudoBadge.scala.html
+++ b/common/app/views/fragments/meta/pseudoBadge.scala.html
@@ -1,0 +1,20 @@
+@(content: model.Content)(implicit request: RequestHeader)
+@import common.Edition
+@import conf.Switches.ElectionLiveBadgeSwitch
+
+@defining(ElectionLiveBadgeSwitch.isSwitchedOn,
+            content.tags.indexWhere(_.id == "politics/general-election-2015") == 0 ||
+            content.tags.indexWhere(_.id == "politics/series/election-live-2015") == 0,
+            content.isSponsored(Some(Edition(request))) ||
+            content.isAdvertisementFeature ||
+            content.isFoundationSupported) { case (electionBadgingEnabled, isElectionTopTag, isCommercialContent) =>
+@if(electionBadgingEnabled && isElectionTopTag && !isCommercialContent) {
+        @defining("ge15badge", "TODO-path-to-badge-image.png") { case (name, badgePath) =>
+            @fragments.meta.pseudoBadgeSlot(name) {
+                <div class="badge-slot--meta-badge__inner badge-slot__content--placeholder">
+                    <img src="@badgePath" />
+                </div>
+            }
+        }
+    }
+}

--- a/common/app/views/fragments/meta/pseudoBadge.scala.html
+++ b/common/app/views/fragments/meta/pseudoBadge.scala.html
@@ -2,7 +2,7 @@
 
 @defining(
     "ge15badge",
-    "http://i.guim.co.uk/static/w-90/h--/q-95/sys-images/Guardian/Pix/pictures/2015/4/1/1427904404288/election-2015-logo-160x160.png"
+    "http://i.guim.co.uk/static/w-90/h--/q-95/sys-images/Guardian/Pix/pictures/2015/4/2/1427982061285/election2015logo160x160opt.png"
 ){ case (name, badgePath) =>
     @fragments.meta.pseudoBadgeSlot(name) {
         <div class="badge-slot__inner badge-slot__content--placeholder">

--- a/common/app/views/fragments/meta/pseudoBadge.scala.html
+++ b/common/app/views/fragments/meta/pseudoBadge.scala.html
@@ -2,19 +2,24 @@
 @import common.Edition
 @import conf.Switches.ElectionLiveBadgeSwitch
 
-@defining(ElectionLiveBadgeSwitch.isSwitchedOn,
-            content.tags.indexWhere(_.id == "politics/general-election-2015") == 0 ||
-            content.tags.indexWhere(_.id == "politics/series/election-live-2015") == 0,
-            content.isSponsored(Some(Edition(request))) ||
-            content.isAdvertisementFeature ||
-            content.isFoundationSupported) { case (electionBadgingEnabled, isElectionTopTag, isCommercialContent) =>
-@if(electionBadgingEnabled && isElectionTopTag && !isCommercialContent) {
-        @defining("ge15badge", "TODO-path-to-badge-image.png") { case (name, badgePath) =>
-            @fragments.meta.pseudoBadgeSlot(name) {
-                <div class="badge-slot--meta-badge__inner badge-slot__content--placeholder">
-                    <img src="@badgePath" />
-                </div>
+@defining(
+    ElectionLiveBadgeSwitch.isSwitchedOn,
+    content.tags.indexWhere(_.id == "politics/general-election-2015") == 0 ||
+    content.tags.indexWhere(_.id == "politics/series/election-live-2015") == 0,
+    content.isSponsored(Some(Edition(request))) ||
+    content.isAdvertisementFeature ||
+    content.isFoundationSupported
+) { case (electionBadgingEnabled, isElectionTopTag, isCommercialContent) =>
+        @if(electionBadgingEnabled && isElectionTopTag && !isCommercialContent) {
+            @defining(
+                "ge15badge",
+                "http://i.guim.co.uk/static/w-90/h--/q-95/sys-images/Guardian/Pix/pictures/2015/4/1/1427904404288/election-2015-logo-160x160.png"
+            ){ case (name, badgePath) =>
+                @fragments.meta.pseudoBadgeSlot(name) {
+                    <div class="badge-slot--meta-badge__inner badge-slot__content--placeholder">
+                        <img src="@badgePath" />
+                    </div>
+                }
             }
         }
     }
-}

--- a/common/app/views/fragments/meta/pseudoBadgeSlot.scala.html
+++ b/common/app/views/fragments/meta/pseudoBadgeSlot.scala.html
@@ -1,0 +1,9 @@
+@(name: String)(placeholderContent: Html)
+
+<div
+id="meta-badge--@name"
+class="badge-slot-meta-@name"
+data-link-name="meta badge slot @name"
+data-test-id="meta-badge-slot-@name"
+data-name="@name"
+>@placeholderContent</div>

--- a/static/src/stylesheets/head.content.scss
+++ b/static/src/stylesheets/head.content.scss
@@ -29,3 +29,4 @@
 // and may contain more specific selectors than we would usually like
 
 @import 'module/external/_from-content-api';
+@import 'module/experiments/election-badge';

--- a/static/src/stylesheets/module/experiments/election-badge.scss
+++ b/static/src/stylesheets/module/experiments/election-badge.scss
@@ -1,0 +1,21 @@
+.badge-slot-meta-ge15badge {
+    float: left;
+    width: 45px;
+    margin-right: $gs-gutter / 2;
+
+    @include mq(desktop) {
+        width: 90px;
+        float: none;
+    }
+
+    .badge-slot__img {
+        width: 100%;
+    }
+}
+
+.content__section-label--election,
+.content__series-label--election {
+    @include mq($until: desktop) {
+        margin-top: $gs-baseline;
+    }
+}


### PR DESCRIPTION
This is a temporary (for the next couple of months) hack, to introduce our election logo on all content tagged with the election tag as the primary keyword. This is so we have consistency across all mediums print, web app for our coverage. 

It's been a contentious debate, and we have settled as a feature switch being the most appropriate solution.
### Screenshots

![google chrome](https://cloud.githubusercontent.com/assets/80089/6963464/ad6d17d6-d937-11e4-9f1a-b67af01bd8a5.png)

![google chrome](https://cloud.githubusercontent.com/assets/80089/6963466/af601f8e-d937-11e4-98e1-bd8326b81fda.png)

![littlesnapper](https://cloud.githubusercontent.com/assets/80089/6963467/b0dc8d84-d937-11e4-8c29-8b58ce8312c4.png)

![google chrome](https://cloud.githubusercontent.com/assets/80089/6963469/b229f5e6-d937-11e4-8149-be9fb006d3e7.png)

/cc @JustinPinner @gklopper @stephanfowler 
