### PR TITLE
tell old ipad users why they can't comment

### DIFF
--- a/discussion/app/views/discussionComments/discussionPage.scala.html
+++ b/discussion/app/views/discussionComments/discussionPage.scala.html
@@ -14,6 +14,7 @@
     <div class="gs-container">
         <div class="content__main-column">
             <h2 class="page-sub-header tone-colour">Comments</h2>
+            <div class="discussion__warning modern-hidden">Please note: posting and replying to comments requires a more recent browser.</div>
             @commentsList(page, true)
         </div>
     </div>

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -99,7 +99,7 @@
                     }
                 </div>
                 @if(!comment.isBlocked){
-                    <div class="d-comment__actions d-comment__actions--left">
+                    <div class="d-comment__actions d-comment__actions--left modern-visible">
                         <a class="d-comment__action d-comment__action--reply" href="https://profile.theguardian.com/signin?returnUrl=@Configuration.discussion.url/comment-permalink/@comment.id"
                                 data-link-name="reply to comment" data-comment-id="@comment.id" role="button">
                             <i class="i i-reply-blue"></i>Reply

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -87,7 +87,7 @@ $avatarPadding: $gs-gutter / 2;
 
 .discussion__warning {
     font-size: 20px;
-    margin-bottom: 20px;
+    margin-bottom: $gs-gutter;
 }
 
 .discussion--disabled {

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -85,6 +85,11 @@ $avatarPadding: $gs-gutter / 2;
     }
 }
 
+.discussion__warning {
+    font-size: 20px;
+    margin-bottom: 20px;
+}
+
 .discussion--disabled {
     min-height: $gs-baseline * 4;
 }


### PR DESCRIPTION
on ipads etc on ios 6 and before, trying to reply to a comment just took the users back to the signin page, because they are not modern and JS is needed to reply.

So I have made it display a message telling them that they need a more modern browser to post or reply.
![image](https://cloud.githubusercontent.com/assets/7304387/6965849/569ab6ba-d94c-11e4-8d64-035d039bed45.png)
