### PR TITLE
Hiding label for middle full width slot

### DIFF
--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -450,7 +450,7 @@
     }
 }
 
-.ad-slot--dfp.ad-slot--merchandising-high {
+.ad-slot--merchandising-high {
     .creative__label--hidden {
         display: none;
     }

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -450,6 +450,12 @@
     }
 }
 
+.ad-slot--dfp.ad-slot--merchandising-high {
+    .creative__label--hidden {
+        display: none;
+    }
+}
+
 .creative--fluid250 {
     height: 100px;
 


### PR DESCRIPTION
This hides the "Advertisement" label when it should be hidden and you are using the "Show Advert label" functionality in the DFP template.

Before;
![screen shot 2015-04-02 at 15 25 16](https://cloud.githubusercontent.com/assets/1303616/6965883/91042f2a-d94c-11e4-8493-a05f1133e248.png)

After;
![screen shot 2015-04-02 at 15 25 38](https://cloud.githubusercontent.com/assets/1303616/6965886/9824f654-d94c-11e4-972a-912f24833ac7.png)
