### PR TITLE
fix error when cmd-click on tech feedback in safari

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -16,6 +16,7 @@ GET         /js.gif                                                             
 GET         /count/$prefix<.+>.gif                                                                                   controllers.DiagnosticsController.analytics(prefix)
 GET         /counts.gif                                                                                              controllers.DiagnosticsController.analyticsCounts()
 POST        /tech-feedback                                                                                           controllers.DiagnosticsController.techFeedback()
+GET         /tech-feedback                                                                                           controllers.DiagnosticsController.techFeedback()
 POST        /css                                                                                                     controllers.DiagnosticsController.css
 OPTIONS     /css                                                                                                     controllers.DiagnosticsController.cssOptions
 POST        /accept-beacon                                                                                           controllers.DiagnosticsController.acceptBeacon

--- a/diagnostics/app/controllers/DiagnosticsController.scala
+++ b/diagnostics/app/controllers/DiagnosticsController.scala
@@ -44,7 +44,8 @@ object DiagnosticsController extends Controller with Logging {
   }
 
   def techFeedback() = Action { implicit request =>
-    Analytics.report("tech-feedback")
+    if (request.method == "POST")
+      Analytics.report("tech-feedback")
     val uri = request.queryString.get("uri").map(_.fold("")(_+" "+_))
     val uriKV = uri.map(uri => ("URL", uri))
     val width = request.queryString.get("width").map(value => ("Browser width", value.fold("")(_+" "+_)))

--- a/diagnostics/conf/routes
+++ b/diagnostics/conf/routes
@@ -12,6 +12,7 @@ GET        /count/$path<.+>.gif             controllers.DiagnosticsController.an
 GET        /counts.gif                      controllers.DiagnosticsController.analyticsCounts()
 
 POST       /tech-feedback                   controllers.DiagnosticsController.techFeedback()
+GET        /tech-feedback                   controllers.DiagnosticsController.techFeedback()
 
 GET        /robots.txt                      controllers.Assets.at(path="/public", file="robots.txt")
 


### PR DESCRIPTION
Tech feedback in the footer will submit a form with POST, to avoid bots hitting the link.

If you cmd-click on a form submit in safari to open in a new tab, it will bizarrely do a GET instead of a POST.  This is clearly a bug, but it's useful to work around it, so if someone does a GET we just don't do the beacon but still display the success page.
@gklopper 
