### PR TITLE
Xwords: fix source map sources paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,6 +85,10 @@ module.exports = function (grunt) {
             grunt.task.run('shell:jspmBundleStatic');
         }
 
+        if (options.isDev) {
+            grunt.task.run('replace:cssSourceMaps');
+        }
+
         grunt.task.run(['concurrent:requireJS', 'copy:javascript']);
         if (!options.isDev) {
             grunt.task.run('uglify:javascript');

--- a/grunt-configs/replace.js
+++ b/grunt-configs/replace.js
@@ -7,6 +7,14 @@ module.exports = function(grunt, options) {
                 from: '../../src/stylesheets/',
                 to: './'
             }]
+        },
+        jspmSourceMaps: {
+            src: [options.staticTargetDir + 'bundles/*.js.map'],
+            overwrite: true,
+            replacements: [{
+                from: '../../src/',
+                to: '../'
+            }]
         }
     };
 };


### PR DESCRIPTION
This fixes the paths in the source map `sources`, so we can use the source maps in production.
