### PR TITLE
Election 2015 badging tweaks

### DIFF
--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -5,8 +5,7 @@
 
 @defining(
     ElectionLiveBadgeSwitch.isSwitchedOn &&
-    (content.tags.indexWhere(_.id == "politics/general-election-2015") == 0 ||
-    content.tags.indexWhere(_.id == "politics/series/election-live-2015") == 0) &&
+    content.tags.exists(_.id == "politics/general-election-2015") &&
     !(content.isSponsored(Some(Edition(request))) ||
         content.isAdvertisementFeature ||
         content.isFoundationSupported)

--- a/static/src/stylesheets/module/experiments/election-badge.scss
+++ b/static/src/stylesheets/module/experiments/election-badge.scss
@@ -15,7 +15,9 @@
 
 .content__section-label--election,
 .content__series-label--election {
-    @include mq($until: desktop) {
+    margin-top: 0;
+
+    @include mq(mobileLandscape, desktop) {
         margin-top: $gs-baseline;
     }
 }


### PR DESCRIPTION
- As requested from Katie, now apply badge across all content tagged with "politics/general-election-2015" not just those with keyword tag.
- Fix styling issue on smaller mobile breakpoints

/cc @robertberry @stephanfowler @JustinPinner 
