### PR TITLE
Football snaps

### DIFF
--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -80,6 +80,7 @@ class Assets(base: String, assetMap: String = "assets/assets.map") extends Loggi
     private def css(project: String): String = {
 
       val suffix = project match {
+        case "footballSnaps" => "footballSnaps.css"
         case "facia" => "facia.css"
         case "identity" => "identity.css"
         case "football" => "football.css"

--- a/sport/app/football/views/fragments/componentStyles.scala.html
+++ b/sport/app/football/views/fragments/componentStyles.scala.html
@@ -1,0 +1,5 @@
+@()(implicit request: RequestHeader)
+
+<style>
+    @Html(Static.css.head("footballSnaps"))
+</style>

--- a/sport/app/football/views/matchList/matchesComponent.scala.html
+++ b/sport/app/football/views/matchList/matchesComponent.scala.html
@@ -3,6 +3,9 @@
 @import football.model._
 
 <div data-component="football-matches-embed" class="c-football-matches">
+
+    @football.views.html.fragments.componentStyles()
+
     @matchesList.matchesGroupedByDateAndCompetition.zipWithRowInfo.map { case ((date, competitionMatches), dateRow) =>
         <div class="football-matches__day">
             @competitionMatches.zipWithRowInfo.map { case ((competition, matches), matchRow) =>

--- a/sport/app/football/views/tablesList/tablesComponent.scala.html
+++ b/sport/app/football/views/tablesList/tablesComponent.scala.html
@@ -1,6 +1,10 @@
 @(competition: model.Competition, group: Group, highlightTeamId: Option[String] = None, multiGroup: Boolean = false)(implicit request: RequestHeader)
+
 @if(!multiGroup) {
 <div data-component="football-table-embed" class="c-football-table table--hide-from-importance-1">
+
+    @football.views.html.fragments.componentStyles()
+
     @tableView(competition, group,
         highlightTeamId = highlightTeamId,
         heading = Some(competition.fullName),

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -309,3 +309,30 @@
 
     @return $width;
 }
+
+// Table helpers (moved from 'base/_tables.scss')
+// =============================================================================
+@mixin table--hide-none {
+    th, td { display: table-cell !important; }
+}
+
+@mixin table--hide-from-importance-1 {
+    .table-column--importance-1 {
+        display: none;
+    }
+}
+
+@mixin table--hide-from-importance-2 {
+    .table-column--importance-1,
+    .table-column--importance-2 {
+        display: none;
+    }
+}
+
+@mixin table--hide-from-importance-3 {
+    .table-column--importance-1,
+    .table-column--importance-2,
+    .table-column--importance-3 {
+        display: none;
+    }
+}

--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -185,3 +185,11 @@ $available-image-widths: 140px, 220px, 300px, 460px, 620px, 700px, 860px, 940px,
 // =============================================================================
 
 $popup-toggle-arrow-size: 4px;
+
+// Tables
+// =============================================================================
+$table-baseline: 8px;
+$table-gutter: 8px;
+$table-breakpoint-importance-1: tablet;
+$table-breakpoint-importance-2: mobile;
+$table-breakpoint-importance-3: 220px;

--- a/static/src/stylesheets/base/_tables.scss
+++ b/static/src/stylesheets/base/_tables.scss
@@ -1,33 +1,3 @@
-$table-baseline: 8px;
-$table-gutter: 8px;
-$table-breakpoint-importance-1: tablet;
-$table-breakpoint-importance-2: mobile;
-$table-breakpoint-importance-3: 220px;
-
-@mixin table--hide-none {
-    th, td { display: table-cell !important; }
-}
-
-@mixin table--hide-from-importance-1 {
-    .table-column--importance-1 {
-        display: none;
-    }
-}
-
-@mixin table--hide-from-importance-2 {
-    .table-column--importance-1,
-    .table-column--importance-2 {
-        display: none;
-    }
-}
-
-@mixin table--hide-from-importance-3 {
-    .table-column--importance-1,
-    .table-column--importance-2,
-    .table-column--importance-3 {
-        display: none;
-    }
-}
 .table--hide-none { @include table--hide-none; }
 .table--hide-from-importance-1 { @include table--hide-from-importance-1; }
 .table--hide-from-importance-2 { @include table--hide-from-importance-2; }

--- a/static/src/stylesheets/global.scss
+++ b/static/src/stylesheets/global.scss
@@ -96,7 +96,6 @@
 @import 'module/facia/_facia-show-more';
 @import 'module/facia/_pagination';
 
-@import 'module/facia/snaps/_football';
 @import 'module/facia/_tag-meta';
 
 // card additions

--- a/static/src/stylesheets/head.footballSnaps.scss
+++ b/static/src/stylesheets/head.footballSnaps.scss
@@ -1,8 +1,6 @@
 @import '_vars';
 @import '_mixins';
 
-@import 'base/_tables';
-
 @import 'module/football/_tables';
 @import 'module/football/_match-stat';
 @import 'module/football/_match-summary';

--- a/static/src/stylesheets/head.footballSnaps.scss
+++ b/static/src/stylesheets/head.footballSnaps.scss
@@ -1,0 +1,11 @@
+@import '_vars';
+@import '_mixins';
+
+@import "base/_tables";
+
+@import 'module/football/_tables';
+@import 'module/football/_match-stat';
+@import 'module/football/_match-summary';
+@import 'module/football/_matches';
+
+@import 'module/facia/snaps/_football';

--- a/static/src/stylesheets/head.footballSnaps.scss
+++ b/static/src/stylesheets/head.footballSnaps.scss
@@ -1,7 +1,7 @@
 @import '_vars';
 @import '_mixins';
 
-@import "base/_tables";
+@import 'base/_tables';
 
 @import 'module/football/_tables';
 @import 'module/football/_match-stat';


### PR DESCRIPTION
Fixes the styling of football snaps components. After discussing with @sndrs and @stephanfowler we've also refactored the styles into their own encapsulated css file which then gets inlined into the components payload. I.e. we will only load the styles if the components are actually visible on the page rather than on every facia page regardless like before. Web Components anybody???
### Before

![google chrome](https://cloud.githubusercontent.com/assets/80089/7024294/9a923b3c-dd33-11e4-9123-e11d35bdeef9.png)
### After

![google chrome](https://cloud.githubusercontent.com/assets/80089/7024296/9c3896d4-dd33-11e4-92d0-83e81d9f5d05.png)
