### PR TITLE
Update the path used to extract ab test metadata

### DIFF
--- a/grunt-configs/shell.js
+++ b/grunt-configs/shell.js
@@ -20,7 +20,7 @@ module.exports = function(grunt, options) {
 
         abTestInfo: {
             command: 'node tools/ab-test-info/ab-test-info.js ' +
-                     'static/src/javascripts/modules/experiments/tests ' +
+                     'static/src/javascripts/projects/common/modules/experiments/tests ' +
                      'static/abtests.json'
         },
 


### PR DESCRIPTION
This allows the data team to access the ab test metadata for our project from a public s3 file
