### PR TITLE
Don't forward requests for /favicon.ico to CAPI

### DIFF
--- a/standalone/app/controllers/FaviconController.scala
+++ b/standalone/app/controllers/FaviconController.scala
@@ -1,0 +1,15 @@
+package controllers
+
+import play.api.mvc.Controller
+
+/*
+ * Pointless controller, only here to work around a bug in the Play routes compiler.
+
+ * If you try to point directly to controller.Assets.at(...) in standalone.routes
+ * then you will get strange compilation errors like:
+ * - patterns after a variable pattern cannot match (SLS 8.1.1)
+ * - unreachable code due to variable pattern 'file'
+ */
+object FaviconController extends Controller {
+  def favicon = Assets.at(path="/public", file="favicon.ico")
+}

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -171,7 +171,7 @@ GET        /weatherapi/locations                                                
 GET        /*path.json                                                                         controllers.ArticleController.renderLatest(path, lastUpdate: Option[String])
 
 # Don't forward requests for favicon.ico to the Content API
-GET        /favicon.ico                                                                        controllers.Assets.at(path="/public", file="favicon.ico")
+GET        /favicon.ico                                                                        controllers.FaviconController.favicon
 
 # Any "item" from the Content API
 GET        /*path                                                                              controllers.ItemController.render(path)

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -170,5 +170,8 @@ GET        /weatherapi/locations                                                
 # Articles
 GET        /*path.json                                                                         controllers.ArticleController.renderLatest(path, lastUpdate: Option[String])
 
+# Don't forward requests for favicon.ico to the Content API
+GET        /favicon.ico                                                                        controllers.Default.notFound
+
 # Any "item" from the Content API
 GET        /*path                                                                              controllers.ItemController.render(path)

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -171,7 +171,7 @@ GET        /weatherapi/locations                                                
 GET        /*path.json                                                                         controllers.ArticleController.renderLatest(path, lastUpdate: Option[String])
 
 # Don't forward requests for favicon.ico to the Content API
-GET        /favicon.ico                                                                        controllers.Default.notFound
+GET        /favicon.ico                                                                        controllers.Assets.at(path="/public", file="favicon.ico")
 
 # Any "item" from the Content API
 GET        /*path                                                                              controllers.ItemController.render(path)


### PR DESCRIPTION
Intercept requests for `/favicon.ico` and return a 404 instead of forwarding the request to CAPI. It's a 404 on the CAPI side, and we get quite a lot of these requests, which screws with our CloudWatch monitoring.

On live, requests to this path never hit the frontend machines anyway, because they are handled by the router. So this change will only affect preview.
