### PR TITLE
Fix for social buttons clashing when image has no caption

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -220,6 +220,11 @@ case class PictureCleaner(article: Article)(implicit request: RequestHeader) ext
       figure.addClass("fig--narrow-caption")
       figure.addClass("fig--has-shares")
 
+      val figcaption = figure.getElementsByTag("figcaption")
+      if(figcaption.length < 1) {
+        figure.addClass("fig--no-caption")
+      }
+
       val html = views.html.fragments.share.blockLevelSharing(hashSuffix, article.elementShares(Some(hashSuffix), crop.url), article.contentType)
       image.after(html.toString())
       image.wrap("<a href='" + article.url + "#img-" + linkIndex + "' class='article__img-container js-gallerythumbs' data-link-name='Launch Article Lightbox' data-is-ajax></a>")


### PR DESCRIPTION
I couldn't stay away for too long. 

This fixes the social buttons clashing with the text when an image has no caption.

![screen shot 2015-04-10 at 10 09 02](https://cloud.githubusercontent.com/assets/2236852/7084907/c4114f56-df69-11e4-807c-56ba8717840e.png)

fixed:

![screen shot 2015-04-10 at 10 10 33](https://cloud.githubusercontent.com/assets/2236852/7084916/e087f96e-df69-11e4-8402-828ac117db19.png)

cc @rich-nguyen, looks like you refactored this section recently, +1?
