### PR TITLE
Imgix ajax

### DIFF
--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -32,7 +32,7 @@ trait Requests {
 
     lazy val isHealthcheck: Boolean = r.headers.keys.exists(_ equalsIgnoreCase  "X-Gu-Management-Healthcheck")
 
-    def isInImgixTest: Boolean = imgixTestSections.exists(r.path.startsWith) && Switches.ImgixSwitch.isSwitchedOn
+    def isInImgixTest: Boolean = Switches.ImgixSwitch.isSwitchedOn && (imgixTestSections.exists(r.path.startsWith) || getParameter("inImgixTest").nonEmpty)
 
     // see http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html#x-forwarded-proto
     lazy val isSecure: Boolean = r.headers.get("X-Forwarded-Proto").exists(_.equalsIgnoreCase("https"))

--- a/onward/app/views/fragments/rightMostPopular.scala.html
+++ b/onward/app/views/fragments/rightMostPopular.scala.html
@@ -1,5 +1,7 @@
 @(popular: Option[model.MostPopular])(implicit request: RequestHeader)
-
+@import views.support.ImgSrc
+@import implicits.Requests._
+@import conf.Switches.ImgixSwitch
 @popular.map { pop =>
     <div class="right-most-popular right-most-popular--image component--rhc hide-on-childrens-books-site" data-component="right-most-popular" data-importance="-1">
         <h3 class="content__meta-heading">Most popular</h3>
@@ -9,7 +11,7 @@
                     <a class="right-most-popular-item__url media u-cf" href="@LinkTo{@trail.url}">
                         @trail.trailPicture(5, 3).map{ image =>
                             <div class="right-most-popular-item__img media__img">
-                                <img class="responsiveimg" src="@Item120.bestFor(image)" alt="" />
+                                <img class="responsiveimg" src="@if(request.isInImgixTest && ImgixSwitch.isSwitchedOn) { @ImgSrc.getFallbackUrl(image) } else { @Item120.bestFor(image) }" alt="" />
                             </div>
                         }
                         <h4 class="right-most-popular-item__headline media__body">@trail.linkText</h4>

--- a/onward/app/views/fragments/rightMostPopularGeo.scala.html
+++ b/onward/app/views/fragments/rightMostPopularGeo.scala.html
@@ -1,5 +1,7 @@
 @(popular: model.MostPopular, country: Option[String], countryCode: String )(implicit request: RequestHeader)
-
+@import views.support.ImgSrc
+@import implicits.Requests._
+@import conf.Switches.ImgixSwitch
 @if(popular.trails.nonEmpty) {
     <div class="right-most-popular right-most-popular--image component--rhc hide-on-childrens-books-site" data-component="geo-most-popular" data-importance="-1" data-test-id="right-most-popular">
         <h3 class="content__meta-heading">Most popular @{country.map{ name => s"in ${name}"}}</h3>
@@ -9,7 +11,7 @@
                     <a class="right-most-popular-item__url media u-cf" href="@LinkTo{@trail.url}">
                          @trail.trailPicture(5, 3).map{ image =>
                             <div class="right-most-popular-item__img media__img">
-                                <img class="responsiveimg" src="@Item120.bestFor(image)" alt="" />
+                                <img class="responsiveimg" src="@if(request.isInImgixTest && ImgixSwitch.isSwitchedOn) { @ImgSrc.getFallbackUrl(image) } else { @Item120.bestFor(image) }" alt="" />
                             </div>
                          }
                          <h4 class="right-most-popular-item__headline media__body">@trail.linkText</h4>

--- a/static/src/javascripts/projects/common/utils/ajax.js
+++ b/static/src/javascripts/projects/common/utils/ajax.js
@@ -19,6 +19,11 @@ define([
             params.url = ajaxHost + params.url;
             params.crossOrigin = true;
         }
+
+        if(config.page.section === "money" && config.switches.imgix) {
+            if(!!params.data) { params.data.inImgixTest = true; } else { params.data = { inImgixTest: true }; }
+        }
+
         r = reqwest(params);
         raven.wrap({ deep: true }, r.then);
         return r;

--- a/static/src/javascripts/projects/common/utils/ajax.js
+++ b/static/src/javascripts/projects/common/utils/ajax.js
@@ -20,8 +20,12 @@ define([
             params.crossOrigin = true;
         }
 
-        if(config.page.section === "money" && config.switches.imgix) {
-            if(!!params.data) { params.data.inImgixTest = true; } else { params.data = { inImgixTest: true }; }
+        if (config.page.section === 'money' && config.switches.imgix) {
+            if (!!params.data) {
+                params.data.inImgixTest = true;
+            } else {
+                params.data = { inImgixTest: true };
+            }
         }
 
         r = reqwest(params);


### PR DESCRIPTION
As discussed with @gklopper, this adds a parameter to all ajax requests within the Money section. This is so we can serve images via the Imgix resizing service for ajax'ed content such as related content and most popular.

(Note: Had to hack around the most popular templates as they called a size directly.)

/cc @gklopper @rich-nguyen 
