### PR TITLE
Front liveblogs: Safari animation fix

### DIFF
--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -90,7 +90,10 @@
 }
 
 .fc-item__liveblog-blocks__inner {
-    @include transition(all .5s ease-in-out);
+    -webkit-transition: -webkit-transform .5s ease-in-out;
+       -moz-transition: -moz-transform .5s ease-in-out;
+         -o-transition: -o-transform .5s ease-in-out;
+            transition: transform .5s ease-in-out;
 }
 
 .fc-item__liveblog-block {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -90,7 +90,7 @@
 }
 
 .fc-item__liveblog-blocks__inner {
-    @include transition(transform .5s ease-in-out);
+    @include transition(all .5s ease-in-out);
 }
 
 .fc-item__liveblog-block {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -91,9 +91,9 @@
 
 .fc-item__liveblog-blocks__inner {
     -webkit-transition: -webkit-transform .5s ease-in-out;
-       -moz-transition: -moz-transform .5s ease-in-out;
-         -o-transition: -o-transform .5s ease-in-out;
-            transition: transform .5s ease-in-out;
+    -moz-transition: -moz-transform .5s ease-in-out;
+    -o-transition: -o-transform .5s ease-in-out;
+    transition: transform .5s ease-in-out;
 }
 
 .fc-item__liveblog-block {


### PR DESCRIPTION
Because 
`@include transition(transform ...`
produces:
`-webkit-transition: transform ...`
whereas Safari seems to need: 
`-webkit-transition: -webkit-transform ...`

Using `all` rather than `transform` gets around it.
