### PR TITLE
Update omniture.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -198,7 +198,6 @@ define([
         this.s.prop60    = detect.isFireFoxOSApp() ? 'firefoxosapp' : null;
 
         this.s.prop19     = platform;
-        this.s.eVar19     = platform;
 
         this.s.prop31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
         this.s.eVar31    = id.getUserFromCookie() ? 'registered user' : 'guest user';


### PR DESCRIPTION
Removed line 201 which passed platform into evar19.  We now rely more on device type rather than using platform for reporting and we still have prop19 capturing the platform so no longer need and can free up evar19.

```
    this.s.eVar19     = platform;
```
