### PR TITLE
Update omnitureMedia.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -63,7 +63,7 @@ define([
                 // Any event after 'video:preroll:play' should be tagged with this value.
                 s.prop41 = 'PrerollMilestone';
             }
-            s.linkTrackVars = 'events,eVar11,prop41,eVar43,prop43,eVar44,prop44,prop9';
+            s.linkTrackVars = 'events,eVar11,prop41,eVar43,prop43,eVar44,prop44,prop9,channel';
             s.linkTrackEvents = values(events).join(',');
             s.events = event;
             s.tl(true, 'o', eventName || event);


### PR DESCRIPTION
Added channel to media events to make our guardian core segment (which is defined based on site sections) compatible with video events

s.linkTrackVars = 'events,eVar11,prop41,eVar43,prop43,eVar44,prop44,prop9,channel';
