### PR TITLE
add another month for the quiz-scores service

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -473,7 +473,7 @@ object Switches {
 
   val QuizScoresService = Switch("Feature", "quiz-scores-service",
     "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
-    safeState = Off, sellByDate = new LocalDate(2015, 4, 16))
+    safeState = Off, sellByDate = new LocalDate(2015, 5, 16))
 
   val IdentityLogRegistrationsFromTor = Switch("Feature", "id-log-tor-registrations",
     "If switched on, any user registrations from a known tor esit node will be logged",


### PR DESCRIPTION
We suspended the quizzes experiment for the election stuff which should be over on 7th may(!) so the quiz scores thing is still needed as we haven't decided whether it's a useful thing or not.

Regardless of that it'll be going somewhere sensible in a proper implementation (ophan?) but we need it until either we make the quizzes properly implemented or we decide it doesn't encourage people to do quizzes.
