### PR TITLE
Remove Ad-Impression Counting Switch

### DIFF
--- a/admin/app/jobs/AdImpressionCounter.scala
+++ b/admin/app/jobs/AdImpressionCounter.scala
@@ -2,7 +2,7 @@ package jobs
 
 import common.{ExecutionContexts, Logging}
 import conf.Configuration.environment
-import conf.Switches.{AdImpressionCountingSwitch, MetricsSwitch}
+import conf.Switches.MetricsSwitch
 import layout.{Breakpoint, Desktop, Mobile}
 import model.commercial._
 import model.diagnostics.CloudWatch
@@ -44,8 +44,7 @@ object AdImpressionCounter extends ExecutionContexts with Logging {
       }
     }
 
-    if ((environment.isProd || MetricsSwitch.isSwitchedOn) &&
-      AdImpressionCountingSwitch.isSwitchedOn) {
+    if (environment.isProd || MetricsSwitch.isSwitchedOn) {
 
       val countriesToMonitor = Seq("gb", "us", "au")
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -311,9 +311,6 @@ object Switches {
     "If this switch is on, Apple ads will appear below nav on the tech section front.",
     safeState = Off, sellByDate = new LocalDate(2015, 5, 6))
 
-  val AdImpressionCountingSwitch = Switch("Commercial", "ad-impression-counting",
-    "If this switch is on, ad impression counts will be kept in Cloudwatch.",
-    safeState = Off, sellByDate = new LocalDate(2015, 4, 15))
 
   // Monitoring
 


### PR DESCRIPTION
Because counting has been running for a few weeks now without incident.
