### PR TITLE
Allow groups for breaking news

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -249,7 +249,7 @@
 
     <script type="text/html" id="confirm_breaking_changes">
         <div class="modalDialog-message">
-            <h3>Confirm alert before sending</h3>
+            <h3>Confirm <span data-bind="text: targetGroup, css: targetGroupClass"></span> alert before sending</h3>
             <ul data-bind="foreach: articles">
                 <li data-bind="html: headline"></li>
             </ul>

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1978,6 +1978,13 @@ hr {
     background-color: #ddd;
 }
 
+.major-alert {
+    color: #d50000;
+}
+.minor-alert {
+    color: #304ffe;
+}
+
 .buttons button {
     height: 26px;
     margin: 0 4px;

--- a/facia-tool/public/js/models/collections/collection.js
+++ b/facia-tool/public/js/models/collections/collection.js
@@ -183,11 +183,18 @@ define([
             addedInDraft = this.front.confirmSendingAlert() ? this.addedInDraft() : [];
 
         if (addedInDraft.length) {
+            var sendingAlertFor = this.addedInDraft(),
+                isMajorAlert = !!_.find(sendingAlertFor, function (article) {
+                    return article.group.index === 1;
+                });
+
             modalDialog.confirm({
                 name: 'confirm_breaking_changes',
                 data: {
-                    articles: this.addedInDraft(),
-                    target: this.configMeta.displayName()
+                    articles: sendingAlertFor,
+                    target: this.configMeta.displayName(),
+                    targetGroup: isMajorAlert ? 'APP & WEB' : 'WEB',
+                    targetGroupClass: isMajorAlert ? 'major-alert' : 'minor-alert'
                 }
             })
             .done(function () {

--- a/facia-tool/public/js/modules/vars.js
+++ b/facia-tool/public/js/modules/vars.js
@@ -17,7 +17,8 @@ define([
         types: dynamicContainers.concat(fixedContainers).concat([
             {name: 'nav/list'},
             {name: 'nav/media-list'},
-            {name: 'news/most-popular'}
+            {name: 'news/most-popular'},
+            {name: 'breaking-news/not-for-other-fronts', groups: ['minor', 'major']}
         ]),
 
         typesDynamic: dynamicContainers,

--- a/facia-tool/public/js/widgets/fronts.js
+++ b/facia-tool/public/js/widgets/fronts.js
@@ -310,7 +310,7 @@ define([
             // return 'Sorry, you can only add links to treats.';
             return false;
         }
-        if (this.confirmSendingAlert() && item.group && (item.group.items().length !== 1 || item.group.items()[0] !== item)) {
+        if (this.confirmSendingAlert() && !isOnlyArticle(item, this)) {
             return 'You can only have one article in this collection.';
         }
     };
@@ -326,6 +326,17 @@ define([
         sparklines.unsubscribe(this);
         mediator.emit('front:disposed', this);
     };
+
+    function isOnlyArticle(item, front) {
+        var only = true;
+        _.find(front.collections(), function (collection) {
+            collection.eachArticle(function (article) {
+                only = only && article.id() === item.id();
+            });
+            return !only;
+        });
+        return only;
+    }
 
     return Front;
 });


### PR DESCRIPTION
The group is showed in the alert dialog and there can only be one article per collection, regardless of the group.

Looks like this
![screen shot 2015-04-13 at 17 12 51](https://cloud.githubusercontent.com/assets/680284/7120012/f905a37a-e201-11e4-83ef-3aa7c3c49f35.png)
![screen shot 2015-04-13 at 17 12 28](https://cloud.githubusercontent.com/assets/680284/7120034/1749ed6e-e202-11e4-914c-1069baed690b.png)
![screen shot 2015-04-13 at 17 12 44](https://cloud.githubusercontent.com/assets/680284/7120037/1e3ea0ba-e202-11e4-9a68-a7da4275b9a5.png)

@stephanfowler @rich-nguyen 

I'll do another PR tomorrow to show somewhere whether it's the first time we send the alert or not.
