### PR TITLE
Fix the validation of new articles in breaking news

### DIFF
--- a/facia-tool/public/js/models/collections/collection.js
+++ b/facia-tool/public/js/models/collections/collection.js
@@ -183,15 +183,14 @@ define([
             addedInDraft = this.front.confirmSendingAlert() ? this.addedInDraft() : [];
 
         if (addedInDraft.length) {
-            var sendingAlertFor = this.addedInDraft(),
-                isMajorAlert = !!_.find(sendingAlertFor, function (article) {
+            var isMajorAlert = !!_.find(addedInDraft, function (article) {
                     return article.group.index === 1;
                 });
 
             modalDialog.confirm({
                 name: 'confirm_breaking_changes',
                 data: {
-                    articles: sendingAlertFor,
+                    articles: addedInDraft,
                     target: this.configMeta.displayName(),
                     targetGroup: isMajorAlert ? 'APP & WEB' : 'WEB',
                     targetGroupClass: isMajorAlert ? 'major-alert' : 'minor-alert'

--- a/facia-tool/public/js/widgets/fronts.js
+++ b/facia-tool/public/js/widgets/fronts.js
@@ -327,13 +327,16 @@ define([
         mediator.emit('front:disposed', this);
     };
 
-    function isOnlyArticle(item, front) {
-        var only = true;
-        _.find(front.collections(), function (collection) {
-            collection.eachArticle(function (article) {
-                only = only && article.id() === item.id();
+    function isOnlyArticle (item, front) {
+        var only = true,
+            containingCollection = _.find(front.collections(), function (collection) {
+                return _.find(collection.groups, function (group) {
+                    return group === item.group;
+                });
             });
-            return !only;
+
+        containingCollection.eachArticle(function (article) {
+            only = only && article.id() === item.id();
         });
         return only;
     }


### PR DESCRIPTION
The previous logic was enforcing one article per front, now it's instead one article per collection.
