### PR TITLE
Sticky nav AB test fixes

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -83,6 +83,8 @@ define([
                     if ($adSlot.attr('data-mobile').indexOf('300,251') > -1) {
                         new StickyMpu($adSlot).create();
                     }
+                } else {
+                    placeUnderMostPopular($adSlot);
                 }
             },
             '1,1': function (event, $adSlot) {
@@ -94,16 +96,30 @@ define([
                         $parent.addClass('fc-slice__item--no-mpu');
                 }
             },
-            '300,1050': function () {
+            '300,1050': function (event, $adSlot) {
                 // remove geo most popular
                 geoMostPopular.whenRendered.then(function (geoMostPopular) {
                     fastdom.write(function () {
                         bonzo(geoMostPopular.elem).remove();
                     });
                 });
+                placeUnderMostPopular($adSlot);
+            },
+            '300,600': function (event, $adSlot) {
+                placeUnderMostPopular($adSlot);
             }
         },
 
+        placeUnderMostPopular = function ($adSlot) {
+            var mtStickyNavTest = ab.getParticipations().MtStickyNav,
+                $secondaryColumn = $('.js-secondary-column');
+
+            if (ab.testCanBeRun('MtStickyNav') &&
+                mtStickyNavTest && mtStickyNavTest.variant === 'variant' && $adSlot.hasClass('ad-slot--right')) {
+                $('.right-most-popular', $secondaryColumn).css('margin-top', '0').append($adSlot);
+                $('.component--rhc .open-cta', $secondaryColumn).css('margin-top', '0');
+            }
+        },
         /**
          * Initial commands
          */

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -112,13 +112,19 @@ define([
 
         placeUnderMostPopular = function ($adSlot) {
             var mtStickyNavTest = ab.getParticipations().MtStickyNav,
+                $secondaryColumn;
+
+            fastdom.read(function () {
                 $secondaryColumn = $('.js-secondary-column');
 
-            if (ab.testCanBeRun('MtStickyNav') &&
-                mtStickyNavTest && mtStickyNavTest.variant === 'variant' && $adSlot.hasClass('ad-slot--right')) {
-                $('.right-most-popular', $secondaryColumn).css('margin-top', '0').append($adSlot);
-                $('.component--rhc .open-cta', $secondaryColumn).css('margin-top', '0');
-            }
+                if (ab.testCanBeRun('MtStickyNav') &&
+                    mtStickyNavTest && mtStickyNavTest.variant === 'variant' && $adSlot.hasClass('ad-slot--right')) {
+                    fastdom.write(function () {
+                        $('.right-most-popular', $secondaryColumn).css('margin-top', '0').append($adSlot);
+                        $('.component--rhc .open-cta', $secondaryColumn).css('margin-top', '0');
+                    });
+                }
+            });
         },
         /**
          * Initial commands

--- a/static/src/javascripts/projects/common/modules/experiments/tests/mt-sticky-nav.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/mt-sticky-nav.js
@@ -140,7 +140,7 @@ define([
                             $header: $('.sticky-nav-mt-test .l-header__inner'),
                             $bannnerMobile: $('.top-banner-ad-container--mobile'),
                             $contentBelowMobile: $('#maincontent'),
-                            scrollThreshold: config.page.contentType === 'Video' ? 280 : 480
+                            scrollThreshold: config.page.contentType === 'Video' || config.page.contentType === 'Gallery' ? 280 : 480
                         };
 
                         fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/mt-sticky-nav.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/mt-sticky-nav.js
@@ -140,7 +140,7 @@ define([
                             $header: $('.sticky-nav-mt-test .l-header__inner'),
                             $bannnerMobile: $('.top-banner-ad-container--mobile'),
                             $contentBelowMobile: $('#maincontent'),
-                            scrollThreshold: 480
+                            scrollThreshold: config.page.contentType === "Video" ? 280 : 480
                         };
 
                         fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/mt-sticky-nav.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/mt-sticky-nav.js
@@ -140,7 +140,7 @@ define([
                             $header: $('.sticky-nav-mt-test .l-header__inner'),
                             $bannnerMobile: $('.top-banner-ad-container--mobile'),
                             $contentBelowMobile: $('#maincontent'),
-                            scrollThreshold: config.page.contentType === "Video" ? 280 : 480
+                            scrollThreshold: config.page.contentType === 'Video' ? 280 : 480
                         };
 
                         fastdom.write(function () {


### PR DESCRIPTION
Ads in the rhc are moved under the most popular component.
Also, the threshold (so the moment of stopping the ad being sticky) is smaller on video pages. 
