### PR TITLE
Only show global most popular container within the info section

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -203,7 +203,6 @@ GET         /metrics/afg                                                        
 GET         /radiator                                                                                                controllers.admin.RadiatorController.renderRadiator()
 GET         /radiator/pingdom                                                                                        controllers.admin.RadiatorController.pingdom()
 GET         /radiator/commit/*hash                                                                                   controllers.admin.RadiatorController.commitDetail(hash)
-GET         /troubleshoot/football                                                                                   controllers.admin.FootballTroubleshooterController.renderFootballTroubleshooter()
 GET         /troubleshoot/pages                                                                                      controllers.admin.TroubleshooterController.index()
 GET         /troubleshoot/test                                                                                       controllers.admin.TroubleshooterController.test(id, testPath)
 GET         /redirects                                                                                               controllers.admin.RedirectController.redirect()

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -203,6 +203,8 @@ GET         /metrics/afg                                                        
 GET         /radiator                                                                                                controllers.admin.RadiatorController.renderRadiator()
 GET         /radiator/pingdom                                                                                        controllers.admin.RadiatorController.pingdom()
 GET         /radiator/commit/*hash                                                                                   controllers.admin.RadiatorController.commitDetail(hash)
+GET         /troubleshoot/football                                                                                   controllers.admin.SportTroubleshooterController.renderFootballTroubleshooter()
+GET         /troubleshoot/cricket                                                                                    controllers.admin.SportTroubleshooterController.renderCricketTroubleshooter()
 GET         /troubleshoot/pages                                                                                      controllers.admin.TroubleshooterController.index()
 GET         /troubleshoot/test                                                                                       controllers.admin.TroubleshooterController.test(id, testPath)
 GET         /redirects                                                                                               controllers.admin.RedirectController.redirect()

--- a/static/src/javascripts/projects/common/modules/onward/popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/popular.js
@@ -19,8 +19,13 @@ define([
 ) {
 
     function MostPopular() {
+        // This is not going to evolve into a random list of sections. If anyone wants more than these 2 then 
+        // they get to comission the work to have it go through the entire tooling chain so that a section has a
+        // property that tells us whether it shows most popular or not.
+        // Don't even come ask...
+        var sectionsWithoutPopular = ['info', 'global'];
         mediator.emit('register:begin', 'popular-in-section');
-        this.hasSection = config.page && config.page.section && !_.contains(['info', 'global'], config.page.section);
+        this.hasSection = config.page && config.page.section && !_.contains(sectionsWithoutPopular, config.page.section);
         this.endpoint = '/most-read' + (this.hasSection ? '/' + config.page.section : '') + '.json';
     }
 

--- a/static/src/javascripts/projects/common/modules/onward/popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/popular.js
@@ -19,7 +19,7 @@ define([
 ) {
 
     function MostPopular() {
-        // This is not going to evolve into a random list of sections. If anyone wants more than these 2 then 
+        // This is not going to evolve into a random list of sections. If anyone wants more than these 2 then
         // they get to comission the work to have it go through the entire tooling chain so that a section has a
         // property that tells us whether it shows most popular or not.
         // Don't even come ask...

--- a/static/src/javascripts/projects/common/modules/onward/popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/popular.js
@@ -1,4 +1,5 @@
 define([
+    'common/utils/_',
     'qwery',
     'common/utils/$',
     'common/utils/config',
@@ -7,6 +8,7 @@ define([
     'common/modules/commercial/create-ad-slot',
     'common/modules/commercial/dfp'
 ], function (
+    _,
     qwery,
     $,
     config,
@@ -18,7 +20,7 @@ define([
 
     function MostPopular() {
         mediator.emit('register:begin', 'popular-in-section');
-        this.hasSection = config.page && config.page.section && config.page.section !== 'global';
+        this.hasSection = config.page && config.page.section && !_.contains(['info', 'global'], config.page.section);
         this.endpoint = '/most-read' + (this.hasSection ? '/' + config.page.section : '') + '.json';
     }
 

--- a/static/test/javascripts/spec/common/onward/popular.spec.js
+++ b/static/test/javascripts/spec/common/onward/popular.spec.js
@@ -60,6 +60,19 @@ define([
                     new Popular().init();
                 });
 
+                it("should only request global most popular for blacklisted sections", function (done) {
+                    mocks.store['common/utils/config'].page.section = 'info';
+
+                    server.respondWith('/most-read.json', [200, {}, '{ "html": "' + html + '" }']);
+                    mocks.store['common/utils/mediator'].once('modules:popular:loaded', function (el) {
+                        var innerHtml = el.innerHTML;
+                        expect(innerHtml).toBe('popular');
+                        done();
+                    });
+
+                    new Popular().init();
+                });
+
             });
 
         });


### PR DESCRIPTION
As requested form editorial and central production: they don't want the section specific content to appear on any content within the info section.

/cc @gklopper 
