### PR TITLE
Moving lazy ads load test to society section

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -174,7 +174,7 @@ define([
         },
 
         dfpSwitchParam = function () {
-            return config.switches.lzAds && config.page.edition === 'US' && config.page.section === 'politics';
+            return config.switches.lzAds && config.page.edition === 'US' && config.page.section === 'society';
         },
 
         /**


### PR DESCRIPTION
Just moved it from politics to society which has comparable page views but is less hot before elections.
