### PR TITLE
Include FB autosignin to `ab-id-social-oauth` AB test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/identity-social-oauth.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/identity-social-oauth.js
@@ -8,7 +8,7 @@ define([
     return function () {
         this.id = 'IdSocialOauth';
         this.start = '2015-03-26';
-        this.expiry = '2015-04-25';
+        this.expiry = '2015-05-06';
         this.author = 'Marc Hibbins';
         this.description = 'Directs social sign-in attempts to the Identity OAuth app, rather than the Webapp.';
         this.audience = 0.05;
@@ -33,6 +33,7 @@ define([
                     $('.social-signin__action').each(function (el) {
                         el.href = el.href.replace(config.page.idWebAppUrl, config.page.idOAuthUrl);
                     });
+                    config.page.idWebAppUrl = config.page.idOAuthUrl
                 }
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/identity-social-oauth.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/identity-social-oauth.js
@@ -33,7 +33,7 @@ define([
                     $('.social-signin__action').each(function (el) {
                         el.href = el.href.replace(config.page.idWebAppUrl, config.page.idOAuthUrl);
                     });
-                    config.page.idWebAppUrl = config.page.idOAuthUrl
+                    config.page.idWebAppUrl = config.page.idOAuthUrl;
                 }
             }
         ];


### PR DESCRIPTION
When we start redirecting traffic gradually to the new social signin app, we want to also include users that are signed in automatically with Facebook. 
