### PR TITLE
Live blog contributor images

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -20,6 +20,7 @@ object BodyCleaner {
         VideoEmbedCleaner(article),
         PictureCleaner(article),
         LiveBlogDateFormatter(article.isLiveBlog),
+        BloggerBylineImage(article),
         LiveBlogShareButtons(article),
         DropCaps(article.isComment || article.isFeature),
         FigCaptionCleaner,

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -192,7 +192,7 @@ object Switches {
   val LzAds = Switch("Commercial", "lz-ads", "Lazy loading ads.",
     safeState = Off, sellByDate = new LocalDate(2015, 5, 13)
   )
-  
+
   val DfpCachingSwitch = Switch("Commercial", "dfp-caching",
     "Have Admin will poll DFP to precache adserving data.",
     safeState = On, sellByDate = never
@@ -230,7 +230,7 @@ object Switches {
 
   val LiveBlogContributorImagesSwitch = Switch("Feature", "liveblog-contributor-image",
     "Show contributor byline images in live blog blocks",
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2015, 5, 28)
   )
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -225,6 +225,12 @@ object Switches {
     safeState = On, sellByDate = never
   )
 
+  val LiveBlogContributorImagesSwitch = Switch("Feature", "liveblog-contributor-image",
+    "Show contributor byline images in live blog blocks",
+    safeState = On,
+    sellByDate = new LocalDate(2015, 5, 28)
+  )
+
   val ElectionLiveBadgeSwitch = Switch("Feature", "election-2015-badging",
     "Display Election Live 2015 Badge",
     safeState = On,

--- a/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
+++ b/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
@@ -1,9 +1,8 @@
 @(profileTag: Tag)(implicit request: RequestHeader)
 
-@import views.support.Profile
-
 @profileTag.contributorImagePath.map{ src =>
-    <div class="liveblog-block-byline-img">
-        <img class="liveblog-block-byline-img__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
+    <div class="liveblog-block-byline">
+        <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
+        <p class="liveblog-block-byline__name">@profileTag.name</p>
     </div>
 }

--- a/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
+++ b/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
@@ -1,0 +1,9 @@
+@(profileTag: Tag)(implicit request: RequestHeader)
+
+@import views.support.Profile
+
+@profileTag.contributorImagePath.map{ src =>
+    <div class="liveblog-block-byline-img">
+        <img class="liveblog-block-byline-img__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
+    </div>
+}

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -299,7 +299,7 @@ case class BloggerBylineImage(article: Article)(implicit val request: RequestHea
         val contributorId = el.attributes().get("data-block-contributor")
         article.tags.find(_.id == contributorId).map{ contributorTag =>
           val html = views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
-          el.append(html.toString())
+          el.getElementsByClass("block-elements").prepend(html.toString())
         }
       }
     }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -297,9 +297,11 @@ case class BloggerBylineImage(article: Article)(implicit val request: RequestHea
     if (article.isLiveBlog && LiveBlogContributorImagesSwitch.isSwitchedOn) {
       body.select(".block").foreach { el =>
         val contributorId = el.attributes().get("data-block-contributor")
-        article.tags.find(_.id == contributorId).map{ contributorTag =>
-          val html = views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
-          el.getElementsByClass("block-elements").prepend(html.toString())
+        if (contributorId.nonEmpty) {
+          article.tags.find(_.id == contributorId).map{ contributorTag =>
+            val html = views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
+            el.getElementsByClass("block-elements").headOption.foreach(_.prepend(html.toString()))
+          }
         }
       }
     }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -292,6 +292,21 @@ case class LiveBlogDateFormatter(isLiveBlog: Boolean)(implicit val request: Requ
   }
 }
 
+case class BloggerBylineImage(article: Article)(implicit val request: RequestHeader) extends HtmlCleaner  {
+  def clean(body: Document): Document = {
+    if (article.isLiveBlog && LiveBlogContributorImagesSwitch.isSwitchedOn) {
+      body.select(".block").foreach { el =>
+        val contributorId = el.attributes().get("data-block-contributor")
+        article.tags.find(_.id == contributorId).map{ contributorTag =>
+          val html = views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
+          el.append(html.toString())
+        }
+      }
+    }
+    body
+  }
+}
+
 case class LiveBlogShareButtons(article: Article)(implicit val request: RequestHeader) extends HtmlCleaner  {
   def clean(body: Document): Document = {
     if (article.isLiveBlog) {

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -289,7 +289,7 @@ $block-padding-right: $gs-gutter;
             font-weight: normal;
             font-size: 16px;
             display: inline;
-            color: #333;
+            color: #333333;
         }
 
         /* Quotes

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -285,10 +285,9 @@ $block-padding-right: $gs-gutter;
             margin-right: $gs-gutter * .2;
         }
         .liveblog-block-byline__name {
-            @include fs-bodyCopy(2) {
-                display: inline;
-                color: colour($neutral-1);
-            }
+            @include fs-bodyCopy(2);
+            display: inline;
+            color: colour(neutral-1);
         }
 
         /* Quotes

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -271,6 +271,27 @@ $block-padding-right: $gs-gutter;
 
     .block-elements {
 
+        /* Bylines
+           ========================================================= */
+        .liveblog-block-byline {
+            border-bottom: 1px dotted #dcdcdc;
+            padding-bottom: 8px;
+        }
+        .liveblog-block-byline__img {
+            display: inline;
+            border-radius: 50%;
+            max-width: 36px;
+            vertical-align: middle;
+            margin-right: 4px;
+        }
+        .liveblog-block-byline__name {
+            font-family: 'EgyptianText', Georgia;
+            font-weight: normal;
+            font-size: 16px;
+            display: inline;
+            color: #333;
+        }
+
         /* Quotes
            ========================================================= */
         > blockquote,

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -275,21 +275,20 @@ $block-padding-right: $gs-gutter;
            ========================================================= */
         .liveblog-block-byline {
             border-bottom: 1px dotted #dcdcdc;
-            padding-bottom: 8px;
+            padding-bottom: $gs-baseline * .5;
         }
         .liveblog-block-byline__img {
             display: inline;
             border-radius: 50%;
             max-width: 36px;
             vertical-align: middle;
-            margin-right: 4px;
+            margin-right: $gs-gutter * .2;
         }
         .liveblog-block-byline__name {
-            font-family: 'EgyptianText', Georgia;
-            font-weight: normal;
-            font-size: 16px;
-            display: inline;
-            color: #333333;
+            @include fs-bodyCopy(2) {
+                display: inline;
+                color: colour($neutral-1);
+            }
         }
 
         /* Quotes

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -274,7 +274,7 @@ $block-padding-right: $gs-gutter;
         /* Bylines
            ========================================================= */
         .liveblog-block-byline {
-            border-bottom: 1px dotted #dcdcdc;
+            border-bottom: 1px dotted colour(neutral-4);
             padding-bottom: $gs-baseline * .5;
         }
         .liveblog-block-byline__img {


### PR DESCRIPTION
Display contributor's byline image and name on liveblog posts if available, and if the block is properly marked with data-block-contributor, and if the feature is switched on.

Styling is the same as was used for the liveblog coverage of the oscars (http://www.theguardian.com/film/filmblog/live/2015/feb/22/oscars-2015-live-red-carpet-and-arrivals-ceremony-and-winners).
