### PR TITLE
Save for later use path

### DIFF
--- a/identity/app/controllers/SaveContentController.scala
+++ b/identity/app/controllers/SaveContentController.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import java.net.URI
+
 import com.google.inject.Inject
 import common.ExecutionContexts
 import idapiclient.IdApiClient
@@ -23,13 +25,13 @@ class SaveContentController @Inject() ( api: IdApiClient,
     val idRequest = identityRequestParser(request)
     val userId = request.user.getId()
 
-    (idRequest.returnUrl, idRequest.shortUrl) match {
-      case (Some(returnUrl), Some(shortUrl) ) => {
+    (idRequest.returnUrl, idRequest.shortUrl, idRequest.pageId) match {
+      case (Some(returnUrl), Some(shortUrl), Some(pageId) ) => {
         val prefsResponse = api.syncedPrefs(request.user.auth)
         savedArticleService.getOrCreateArticlesList(prefsResponse) map {
           case Right(prefs) =>
             if (!prefs.contains(shortUrl)) {
-              val savedArticles = prefs.addArticle(returnUrl, shortUrl)
+              val savedArticles = prefs.addArticle(pageId, shortUrl)
               api.saveArticle(userId, request.user.auth, savedArticles)
             }
           case Left(errors) => logger.error(errors.toString)

--- a/identity/app/services/IdRequestParser.scala
+++ b/identity/app/services/IdRequestParser.scala
@@ -1,11 +1,11 @@
 package services
 
-import com.google.inject.{Inject, Singleton}
-import conf.Switches
 import idapiclient.TrackingData
-import jobs.TorExitNodeList
 import play.api.mvc.RequestHeader
+import com.google.inject.{Inject, Singleton}
 import utils.RemoteAddress
+import jobs.TorExitNodeList
+import conf.Switches
 
 @Singleton
 class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends RemoteAddress {

--- a/identity/app/services/IdRequestParser.scala
+++ b/identity/app/services/IdRequestParser.scala
@@ -14,8 +14,9 @@ class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends Re
     val ip = clientIp(request)
     val skipConfirmation = request.getQueryString("skipConfirmation").map(_ == "true")
     val shortUrl = request.getQueryString("shortUrl")
+    val pageId = request.getQueryString("pageId")
     IdentityRequest(
-      TrackingData(
+    TrackingData(
         returnUrl,
         request.getQueryString("type"),
         request.cookies.get("S_VI").map(_.value),
@@ -26,7 +27,8 @@ class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends Re
       returnUrl,
       ip,
       skipConfirmation,
-      shortUrl
+      shortUrl,
+      pageId
     )
   }
 }
@@ -48,4 +50,4 @@ class TorNodeLoggingIdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifi
   }
 }
 
-case class IdentityRequest(trackingData: TrackingData, returnUrl: Option[String], clientIp: Option[String], skipConfirmation: Option[Boolean], shortUrl: Option[String] = None)
+case class IdentityRequest(trackingData: TrackingData, returnUrl: Option[String], clientIp: Option[String], skipConfirmation: Option[Boolean], shortUrl: Option[String] = None, pageId: Option[String] = None)

--- a/identity/app/services/IdRequestParser.scala
+++ b/identity/app/services/IdRequestParser.scala
@@ -15,7 +15,7 @@ class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends Re
     val skipConfirmation = request.getQueryString("skipConfirmation").map(_ == "true")
     val shortUrl = request.getQueryString("shortUrl")
     IdentityRequest(
-    TrackingData(
+      TrackingData(
         returnUrl,
         request.getQueryString("type"),
         request.cookies.get("S_VI").map(_.value),

--- a/identity/app/services/IdRequestParser.scala
+++ b/identity/app/services/IdRequestParser.scala
@@ -1,11 +1,11 @@
 package services
 
-import idapiclient.TrackingData
-import play.api.mvc.RequestHeader
 import com.google.inject.{Inject, Singleton}
-import utils.RemoteAddress
-import jobs.TorExitNodeList
 import conf.Switches
+import idapiclient.TrackingData
+import jobs.TorExitNodeList
+import play.api.mvc.RequestHeader
+import utils.RemoteAddress
 
 @Singleton
 class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends RemoteAddress {
@@ -14,7 +14,6 @@ class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends Re
     val ip = clientIp(request)
     val skipConfirmation = request.getQueryString("skipConfirmation").map(_ == "true")
     val shortUrl = request.getQueryString("shortUrl")
-    val pageId = request.getQueryString("pageId")
     IdentityRequest(
     TrackingData(
         returnUrl,
@@ -27,8 +26,7 @@ class IdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifier) extends Re
       returnUrl,
       ip,
       skipConfirmation,
-      shortUrl,
-      pageId
+      shortUrl
     )
   }
 }
@@ -50,4 +48,4 @@ class TorNodeLoggingIdRequestParser @Inject()(returnUrlVerifier: ReturnUrlVerifi
   }
 }
 
-case class IdentityRequest(trackingData: TrackingData, returnUrl: Option[String], clientIp: Option[String], skipConfirmation: Option[Boolean], shortUrl: Option[String] = None, pageId: Option[String] = None)
+case class IdentityRequest(trackingData: TrackingData, returnUrl: Option[String], clientIp: Option[String], skipConfirmation: Option[Boolean], shortUrl: Option[String] = None)

--- a/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
@@ -28,9 +28,9 @@ define([
             this.getSavedArticles();
         } else {
             var url = config.page.idUrl + '/prefs/save-content?returnUrl=' + encodeURIComponent(document.location.href) +
-                '&shortUrl=' + config.page.shortUrl + '&pageId=' + this.pageId;
+                '&shortUrl=' + config.page.shortUrl;
             this.$saver.html(
-                '<a href="' + url + ' "data-link-name="meta-save-for-later" data-component=meta-save-for-later">Saver for later</a>'
+                '<a href="' + url + ' "data-link-name="meta-save-for-later" data-component=meta-save-for-later">Save for later</a>'
             );
         }
     };

--- a/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
@@ -18,7 +18,7 @@ define([
     function SaveForLater() {
         this.saveLinkHolder = qwery('.meta__save-for-later')[0];
         this.userData = null;
-        this.encodedPageUrl = encodeURIComponent(document.location.href);
+        this.pageId = config.page.pageId;
         this.$saver = bonzo(this.saveLinkHolder);
         this.savedArticlesUrl = config.page.idUrl + '/saved-articles';
     }
@@ -27,9 +27,10 @@ define([
         if (identity.isUserLoggedIn()) {
             this.getSavedArticles();
         } else {
-            var url = config.page.idUrl + '/prefs/save-content?returnUrl=' + this.encodedPageUrl + '&shortUrl=' + config.page.shortUrl;
+            var url = config.page.idUrl + '/prefs/save-content?returnUrl=' + encodeURIComponent(document.location.href) +
+                '&shortUrl=' + config.page.shortUrl + '&pageId=' + this.pageId;
             this.$saver.html(
-                '<a href="' + url + ' "data-link-name="meta-save-for-later" data-component=meta-save-for-later">Save for later</a>'
+                '<a href="' + url + ' "data-link-name="meta-save-for-later" data-component=meta-save-for-later">Saver for later</a>'
             );
         }
     };
@@ -69,7 +70,7 @@ define([
         var self = this,
             //Identity api needs a string in the format yyyy-mm-ddThh:mm:ss+hh:mm  otherwise it barfs
             date = new Date().toISOString().replace(/\.[0-9]+Z/, '+00:00'),
-            newArticle = {id: document.location.href, shortUrl: config.page.shortUrl, date: date, read: false  };
+            newArticle = {id: self.pageId, shortUrl: config.page.shortUrl, date: date, read: false  };
 
         self.userData.articles.push(newArticle);
 


### PR DESCRIPTION
Change the format of the data sent to the Identiy api for save for later, so we use pageId instead of href

So we send

``` json
{
    "version": "2015-04-01T00:09:06+11:00,
    "articles": [
        {
            "id": "world/2015/mar/31/death-sentence-killer-british-medical-students-borneo-zulkipli-abdullah",
            "shortUrl": "http://gu.com/p/475ajj",
            "date": "2015-04-01T00:09:06+11:00",
            "read": false
        }
    ]
}
```

Instead of

``` json
{
    "version": "2015-04-01T00:09:06+11:00,
    "articles": [
        {
            "id": "http://m.thegulocal.com/world/2015/mar/31/death-sentence-killer-british-medical-students-borneo-zulkipli-abdullah",
            "shortUrl": "http://gu.com/p/475ajj",
            "date": "2015-04-01T00:09:06+11:00",
            "read": false
        }
    ]
}
```
