### PR TITLE
change the short url sent to save to later

### DIFF
--- a/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
@@ -25,7 +25,7 @@ define([
     }
 
     SaveForLater.prototype.init = function () {
-        if (identity.isUserLoggedIn()) {                                                                                                  1
+        if (identity.isUserLoggedIn()) {
             this.getSavedArticles();
         } else {
             var url = config.page.idUrl + '/prefs/save-content?returnUrl=' + encodeURIComponent(document.location.href) +

--- a/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
@@ -21,7 +21,7 @@ define([
         this.pageId = config.page.pageId;
         this.$saver = bonzo(this.saveLinkHolder);
         this.savedArticlesUrl = config.page.idUrl + '/saved-articles';
-        this.shortUrl = config.page.shortUrl.replace('http:/', '');   //  Keep the fitst trailing slash
+        this.shortUrl = config.page.shortUrl.replace('http://gu.com', '');   //  Keep the fitst trailing slash
     }
 
     SaveForLater.prototype.init = function () {

--- a/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
@@ -21,14 +21,15 @@ define([
         this.pageId = config.page.pageId;
         this.$saver = bonzo(this.saveLinkHolder);
         this.savedArticlesUrl = config.page.idUrl + '/saved-articles';
+        this.shortUrl = config.page.shortUrl.replace('http:/', '');   //  Keep the fitst trailing slash
     }
 
     SaveForLater.prototype.init = function () {
-        if (identity.isUserLoggedIn()) {
+        if (identity.isUserLoggedIn()) {                                                                                                  1
             this.getSavedArticles();
         } else {
             var url = config.page.idUrl + '/prefs/save-content?returnUrl=' + encodeURIComponent(document.location.href) +
-                '&shortUrl=' + config.page.shortUrl;
+                '&shortUrl=' + this.shortUrl;
             this.$saver.html(
                 '<a href="' + url + ' "data-link-name="meta-save-for-later" data-component=meta-save-for-later">Save for later</a>'
             );
@@ -70,7 +71,7 @@ define([
         var self = this,
             //Identity api needs a string in the format yyyy-mm-ddThh:mm:ss+hh:mm  otherwise it barfs
             date = new Date().toISOString().replace(/\.[0-9]+Z/, '+00:00'),
-            newArticle = {id: self.pageId, shortUrl: config.page.shortUrl, date: date, read: false  };
+            newArticle = {id: self.pageId, shortUrl: self.shortUrl, date: date, read: false  };
 
         self.userData.articles.push(newArticle);
 


### PR DESCRIPTION
Change the data we send to the identity api so that the shortUrl is just a path ( with a leading slash )

``` json
{
    "version": "2015-04-01T00:09:06+11:00,
    "articles": [
        {
            "id": "world/2015/mar/31/death-sentence-killer-british-medical-students-borneo-zulkipli-abdullah",
            "shortUrl": "/gu.com/p/475ajj",
            "date": "2015-04-01T00:09:06+11:00",
            "read": false
        }
    ]
}
```

Instead of

``` json
{
    "version": "2015-04-01T00:09:06+11:00,
    "articles": [
        {
            "id": "http://m.thegulocal.com/world/2015/mar/31/death-sentence-killer-british-medical-students-borneo-zulkipli-abdullah",
            "shortUrl": "http://gu.com/p/475ajj",
            "date": "2015-04-01T00:09:06+11:00",
            "read": false
        }
    ]
}
```
