### PR TITLE
Add value for iPad2 or iPad mini to cloudwatch monitoring

### DIFF
--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -243,7 +243,7 @@
                 ipad1 & 2 (unfortunately this also includes ipad mini) - mitigate that by checking older ios version too.
                 Apple seems to purposefully make this a difficult thing to do.
             *@
-            var isOlderIpad = !isIphone && window.devicePixelRatio === 1 || /.*iPad; CPU OS ([345])_\d+.*/.test(navigator.userAgent);
+            var isOlderIpad = !isIphone && window.devicePixelRatio === 1 || /.*iPad; CPU OS ([3456])_\d+.*/.test(navigator.userAgent);
 
 
             if ( isOlderIpad ) {

--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -243,11 +243,15 @@
                 ipad1 & 2 (unfortunately this also includes ipad mini) - mitigate that by checking older ios version too.
                 Apple seems to purposefully make this a difficult thing to do.
             *@
-            var isOlderIpad = !isIphone && window.devicePixelRatio === 1 || /.*iPad; CPU OS ([3456])_\d+.*/.test(navigator.userAgent);
-
+            var isOlderIpad = !isIphone && window.devicePixelRatio === 1 && /.*iPad; CPU OS ([345])_\d+.*/.test(navigator.userAgent);
+            var isIpad2orMini = !isIphone && window.devicePixelRatio === 1 && /.*iPad; CPU OS ([678])_\d+.*/.test(navigator.userAgent);
 
             if ( isOlderIpad ) {
                 logDevice ( 'old', 'ipad' );
+            }
+
+            if ( isIpad2orMini ) {
+                logDevice ( '2orMini', 'ipad' );
             }
 
             if ( isIphone6 ) {

--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -244,7 +244,7 @@
                 Apple seems to purposefully make this a difficult thing to do.
             *@
             var isOlderIpad = !isIphone && window.devicePixelRatio === 1 || /.*iPad; CPU OS ([345])_\d+.*/.test(navigator.userAgent);
-            console.log("ipad indicator" + isOlderIpad)
+
 
             if ( isOlderIpad ) {
                 logDevice ( 'old', 'ipad' );

--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -243,7 +243,8 @@
                 ipad1 & 2 (unfortunately this also includes ipad mini) - mitigate that by checking older ios version too.
                 Apple seems to purposefully make this a difficult thing to do.
             *@
-            var isOlderIpad = !isIphone && window.devicePixelRatio === 1 && /.*iPad; CPU OS ([345])_\d+.*/.test(navigator.userAgent);
+            var isOlderIpad = !isIphone && window.devicePixelRatio === 1 || /.*iPad; CPU OS ([345])_\d+.*/.test(navigator.userAgent);
+            console.log("ipad indicator" + isOlderIpad)
 
             if ( isOlderIpad ) {
                 logDevice ( 'old', 'ipad' );

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -38,6 +38,8 @@ object Metric extends Logging {
 
     ("ipad-old-start", CountMetric(s"ipad-old-start")),
     ("ipad-old-after-5", CountMetric(s"ipad-old-after-5")),
+    ("ipad-2orMini-start", CountMetric(s"ipad-2orMini-start")),
+    ("ipad-2orMini-after-5", CountMetric(s"ipad-2orMini-after-5")),
 
     ("tech-feedback", CountMetric("tech-feedback"))
   ) ++ iPhoneMetrics


### PR DESCRIPTION
Currently in terms of identifying what kinds of iPads are visiting our site we are flying blind.
We have a figure for how many ipads in total visit us, and we have an idea of how many iPad1's visit us (any iPad with iOS version 5 or less is almost certain to be an iPad1 as they are the only iPad that cant upgrade beyond iOS5.1.1). However we have no idea how many iPad2 or iPad mini's are visiting us.
This is important as we have a number of issues with iPad2 and the capability of that device is poorer than later generations - so if there are significant numbers of them hitting our site they become more important to test.

We currently have a value for cloudwatch monitoring that tracks how many iPad1's visit the site and how many remain after 5 seconds, to get a rough idea of the crash rate on this device.

This change is to add a new value for cloudwatch monitoring that will track how many devices likely to be an iPad2 or iPad mini's visit the site. This is calculated by the fact that they have a devicePixelRation equal to 1 (all later generation device have a higer DevicePixelRatio) and they have an iOS version later than 5 (the cutoff point for iPad1's).

This value will only be used in sending monitoring to cloudwatch so will have no impact elsewhere.
