### PR TITLE
check the data contains the next-gen shortUrl

### DIFF
--- a/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
@@ -63,7 +63,7 @@ define([
 
     SaveForLater.prototype.hasUserSavedArticle = function (articles, shortUrl) {
         return _.some(articles, function (article) {
-            return article.shortUrl.contains(shortUrl);
+            return article.shortUrl.indexOf(shortUrl) > -1;
         });
     };
 

--- a/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
@@ -63,7 +63,7 @@ define([
 
     SaveForLater.prototype.hasUserSavedArticle = function (articles, shortUrl) {
         return _.some(articles, function (article) {
-            return article.shortUrl === shortUrl;
+            return article.shortUrl.contains(shortUrl);
         });
     };
 


### PR DESCRIPTION
This makes sure that save-for-later works on IOS and Android. Turns out there's a slight descrepency in the data - so that an android list of synced articles and a iPhone one store slightly different values: 

Because my code uses the shortUrl value to determine whether or not a user has already saved an article, it doesn't work on android but does on IOS

IOS: 

``` json
    "savedArticles" : {
        "version" : "1429104137137",
        "articles" : [
            {
                "id" : "world/2015/apr/15/migrant-boat-sinks-mediterranean-passengers",
                "shortUrl" : "/p/47gt3",
                "date" : ISODate("2015-04-15T13:22:17Z"),
                "read" : false
            }
        ]
    }
```

Android

``` json
    "savedArticles" : {
        "version" : "1429104137137",
        "articles" : [
            {
                "id" : "world/2015/apr/15/migrant-boat-sinks-mediterranean-passengers",
                "shortUrl" : "http://gu.com/p/47gt3",
                "date" : ISODate("2015-04-15T13:22:17Z"),
                "read" : false
            }
        ]
    }
```
