### PR TITLE
Server-side AB testing

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -73,7 +73,7 @@ object Switches {
 
   // Switch names can be letters numbers and hyphens only
 
-  private lazy val never = new LocalDate(2100, 1, 1)
+  lazy val never = new LocalDate(2100, 1, 1)
 
   // Performance
   val LazyLoadContainersSwitch = Switch("Performance", "lazy-load-containers",
@@ -497,6 +497,10 @@ object Switches {
   val QuizScoresService = Switch("Feature", "quiz-scores-service",
     "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
     safeState = Off, sellByDate = new LocalDate(2015, 5, 16))
+
+  val ServerSideTests = Switch("Feature", "server-side-tests",
+    "Enables the server side testing system",
+    safeState = Off, sellByDate = never)
 
   val IdentityLogRegistrationsFromTor = Switch("Feature", "id-log-tor-registrations",
     "If switched on, any user registrations from a known tor esit node will be logged",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -498,10 +498,6 @@ object Switches {
     "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
     safeState = Off, sellByDate = new LocalDate(2015, 5, 16))
 
-  val ServerSideTests = Switch("Feature", "server-side-tests",
-    "Enables the server side testing system",
-    safeState = Off, sellByDate = never)
-
   val IdentityLogRegistrationsFromTor = Switch("Feature", "id-log-tor-registrations",
     "If switched on, any user registrations from a known tor esit node will be logged",
     safeState = On, sellByDate = never)
@@ -658,6 +654,17 @@ object Switches {
     "If this switch is on, facia-tool will directly archive to DynamoDB. When this is about to expire, please check the DB size.",
     safeState = Off, sellByDate = new LocalDate(2015, 8, 31)
   )
+
+  // Server-side A/B Tests
+
+  val ServerSideTests = {
+    // It's for the side effect. Blame agents.
+    val tests = mvt.ActiveTests.tests
+
+    Switch("Server-side A/B Tests", "server-side-tests",
+      "Enables the server side testing system",
+      safeState = Off, sellByDate = never)
+  }
 
   def all: Seq[SwitchTrait] = Switch.allSwitches
 

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -36,11 +36,9 @@ trait Requests {
 
     // see http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html#x-forwarded-proto
     lazy val isSecure: Boolean = r.headers.get("X-Forwarded-Proto").exists(_.equalsIgnoreCase("https"))
-  }
 
-  implicit class RichRequest[A](val request: RequestHeader) {
     //This is a header reliably set by jQuery for AJAX requests used in facia-tool
-    lazy val isXmlHttpRequest: Boolean = request.headers.get("X-Requested-With").exists(_ == "XMLHttpRequest")
+    lazy val isXmlHttpRequest: Boolean = r.headers.get("X-Requested-With").exists(_ == "XMLHttpRequest")
   }
 }
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -2,7 +2,7 @@ package mvt
 
 import MultiVariateTesting._
 import common.InternationalEditionVariant
-import conf.{Switches, Switch}
+import conf.Switch
 import org.joda.time.LocalDate
 import play.api.mvc.RequestHeader
 import views.support.CamelCase
@@ -11,7 +11,7 @@ object ChimneyTest extends TestDefinition(
   List(Variant9, Variant8),
   "chimney-test",
   "an example test that adds a chimney to the home icon",
-  Switches.never
+  new LocalDate(2015, 4, 30)
 )
 
 object ActiveTests extends Tests {

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -1,0 +1,74 @@
+package mvt
+
+import MultiVariateTesting._
+import conf.{Switches, Switch}
+import org.joda.time.LocalDate
+import play.api.mvc.RequestHeader
+
+object ActiveTests extends Tests {
+  object Test0 extends TestDefinition(
+    List(Variant9),
+    "Test0",
+    "an experiment test",
+    Switches.never
+  )
+
+  val tests = List(Test0)
+}
+
+case class TestDefinition (
+  variants: Seq[Variant],
+  name: String,
+  description: String,
+  sellByDate: LocalDate
+) {
+  val switch: Switch = Switch(
+    "Server-side A/B Tests",
+    name,
+    description,
+    conf.Off,
+    sellByDate)
+}
+
+trait Tests {
+
+  protected def tests: Seq[TestDefinition]
+
+  def getTest(request: RequestHeader): Option[TestDefinition] = {
+    getVariant(request).flatMap { variant =>
+      tests.find(_.variants.contains(variant))
+    }
+  }
+
+  def isPartOfATest(request: RequestHeader): Boolean = {
+    getTest(request).exists(_.switch.isSwitchedOn && conf.Switches.ServerSideTests.isSwitchedOn)
+  }
+}
+
+object MultiVariateTesting {
+
+  sealed case class Variant(name: String)
+
+  object Variant0 extends Variant("variant-0")
+  object Variant1 extends Variant("variant-1")
+  object Variant2 extends Variant("variant-2")
+  object Variant3 extends Variant("variant-3")
+  object Variant4 extends Variant("variant-4")
+  object Variant5 extends Variant("variant-5")
+  object Variant6 extends Variant("variant-6")
+  object Variant7 extends Variant("variant-7")
+  object Variant8 extends Variant("variant-8")
+  object Variant9 extends Variant("variant-9")
+
+  private val allVariants = List(
+    Variant0, Variant1, Variant2, Variant3, Variant4,
+    Variant5, Variant6, Variant7, Variant8, Variant9)
+
+  def getVariant(request: RequestHeader): Option[Variant] = {
+    val cdnVariant: Option[String] = request.headers.get("X-GU-mvt-variant")
+
+    cdnVariant.flatMap( variantName => {
+      allVariants.find(_.name == variantName)
+    })
+  }
+}

--- a/common/app/views/fragments/javaScriptConfig.scala.html
+++ b/common/app/views/fragments/javaScriptConfig.scala.html
@@ -10,7 +10,7 @@
         "switches" : { @{Html(conf.Switches.all.map{ switch =>
             s""""${CamelCase.fromHyphenated(switch.name)}":${switch.isSwitchedOn}"""}.mkString(","))}
         },
-        "tests": { @InternationalEditionVariant(request).map{ international => "internationalEditionVariant" : "@international" } },
+        "tests": { @Html(mvt.ActiveTests.getJavascriptConfig) },
         "modules": { },
         "images": {
             "commercial": {

--- a/common/app/views/fragments/nav/topNavigation.scala.html
+++ b/common/app/views/fragments/nav/topNavigation.scala.html
@@ -9,7 +9,7 @@
            data-link-name="nav : primary : home"
            title="Back to homepage">
             <span class="top-navigation__icon-wrapper">
-                <span class="top-navigation__icon top-navigation__icon--home"></span>
+                <span class="top-navigation__icon top-navigation__icon--home @if(mvt.ChimneyTest.isParticipating){top-navigation__icon--home--has-chimney}"></span>
             </span>
             <span class="u-h">home</span>
         </a>

--- a/common/test/common/MultiVariateTestingTest.scala
+++ b/common/test/common/MultiVariateTestingTest.scala
@@ -1,0 +1,60 @@
+package common
+
+import conf.Switches
+import mvt.MultiVariateTesting._
+import mvt.{TestDefinition, MultiVariateTesting, Tests}
+import org.scalatest.{Matchers, FlatSpec}
+import test.TestRequest
+
+class MultiVariateTestingTest extends FlatSpec with Matchers {
+
+  conf.Switches.ServerSideTests.switchOn
+
+  "active mvt tests" should "not have duplicate variants" in {
+    val variantsInUse = mvt.ActiveTests.tests.flatMap(_.variants)
+    variantsInUse.size should equal (variantsInUse.distinct.size)
+  }
+
+  "a request with a valid test header" should "be assigned to the appropriate test" in {
+    TestCases.Test1.switch.switchOn
+    val testRequest = TestRequest("/uk")
+      .withHeaders(
+        "X-GU-mvt-variant" -> "variant-2"
+      )
+    MultiVariateTesting.getVariant(testRequest) should be (Some(Variant2))
+    TestCases.isPartOfATest(testRequest) should be (true)
+    TestCases.getTest(testRequest) should be (Some(TestCases.Test1))
+    TestCases.Test1.switch.switchOff
+  }
+
+  "a request with an invalid test header" should "be ignored" in {
+    val testRequest = TestRequest("/uk")
+      .withHeaders(
+        "X-GU-mvt-variant" -> "variant-invalid"
+      )
+    MultiVariateTesting.getVariant(testRequest) should be (None)
+    TestCases.isPartOfATest(testRequest) should be (false)
+    TestCases.getTest(testRequest) should be (None)
+  }
+
+  "a test definition" should "have a default switch state to off" in {
+    TestCases.Test0.switch.isSwitchedOff should be (true)
+  }
+
+  object TestCases extends Tests {
+    object Test0 extends TestDefinition(
+      List(Variant0),
+      "Test0",
+      "an experiment test",
+      Switches.never
+    )
+    object Test1 extends TestDefinition(
+      List(Variant1, Variant2),
+      "Test1",
+      "an experiment test",
+      Switches.never
+    )
+
+    val tests = List(Test0, Test1)
+  }
+}

--- a/common/test/common/MultiVariateTestingTest.scala
+++ b/common/test/common/MultiVariateTestingTest.scala
@@ -22,8 +22,8 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
         "X-GU-mvt-variant" -> "variant-2"
       )
     MultiVariateTesting.getVariant(testRequest) should be (Some(Variant2))
-    TestCases.isPartOfATest(testRequest) should be (true)
-    TestCases.getTest(testRequest) should be (Some(TestCases.Test1))
+    TestCases.isParticipatingInATest(testRequest) should be (true)
+    TestCases.getParticipatingTest(testRequest) should be (Some(TestCases.Test1))
     TestCases.Test1.switch.switchOff
   }
 
@@ -33,8 +33,8 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
         "X-GU-mvt-variant" -> "variant-invalid"
       )
     MultiVariateTesting.getVariant(testRequest) should be (None)
-    TestCases.isPartOfATest(testRequest) should be (false)
-    TestCases.getTest(testRequest) should be (None)
+    TestCases.isParticipatingInATest(testRequest) should be (false)
+    TestCases.getParticipatingTest(testRequest) should be (None)
   }
 
   "a test definition" should "have a default switch state to off" in {

--- a/static/src/javascripts/projects/common/modules/analytics/mvt-cookie.js
+++ b/static/src/javascripts/projects/common/modules/analytics/mvt-cookie.js
@@ -6,21 +6,13 @@ define([
     var MULTIVARIATE_ID_COOKIE = 'GU_mvt_id',
         VISITOR_ID_COOKIE = 's_vi',
         BROWSER_ID_COOKIE = 'bwid',
-        // Nice manageable range :)
-        MAX_INT = 1000000;
-
-    function generateMvtCookie() {
-        if (!getMvtValue() || getMvtValue() > MAX_INT) {
-            var mvtId = generateRandomInteger(MAX_INT, 1);
-            cookies.add(MULTIVARIATE_ID_COOKIE, mvtId, 365);
-        }
-
-        // Temporary cleanup call for old cookie with incorrect domain.
-        cookies.cleanUp(['GU_mvtid']);
-    }
+        // The full mvt ID interval is [1, 1000000]
+        // Server side mvt IDs occupy [9000000, 1000000)
+        // So the client-side mvt interval is [1, 899999]
+        MAX_INT = 899999;
 
     function overwriteMvtCookie(testId) {
-        // For test purposes.
+        // For test purposes only.
         cookies.add(MULTIVARIATE_ID_COOKIE, testId, 365);
     }
 
@@ -57,7 +49,6 @@ define([
     }
 
     return {
-        generateMvtCookie: generateMvtCookie,
         getMvtFullId: getMvtFullId,
         getMvtValue: getMvtValue,
         getMvtNumValues: getMvtNumValues,

--- a/static/src/javascripts/projects/common/modules/analytics/mvt-cookie.js
+++ b/static/src/javascripts/projects/common/modules/analytics/mvt-cookie.js
@@ -44,10 +44,6 @@ define([
         return MAX_INT;
     }
 
-    function generateRandomInteger(min, max) {
-        return Math.floor(Math.random() * (max - min + 1) + min);
-    }
-
     return {
         getMvtFullId: getMvtFullId,
         getMvtValue: getMvtValue,

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -250,8 +250,6 @@ define([
         },
 
         segmentUser: function () {
-            mvtCookie.generateMvtCookie();
-
             var tokens,
                 forceUserIntoTest = /^#ab/.test(window.location.hash);
             if (forceUserIntoTest) {

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -319,6 +319,10 @@ $c-navigation-expandable-background: colour(neutral-1);
     }
 }
 
+.top-navigation__icon--home--has-chimney {
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAASCAQAAAAul0yEAAAAPklEQVR4AdXJwQqAMADD0H56/jxSxhji3FHw9dBDUlaMqJi1cTViscu48Mx3nHIxM+7RjO+IR5/lzP0kc8hckqrLSprJGHUAAAAASUVORK5CYII=');
+}
+
 /* Global navigation
    ========================================================================== */
 


### PR DESCRIPTION
Adding some helpers to assist in the creation of a server-side test. Note: it's known as a server-side test, because you can now vary behaviour within the play app:

https://github.com/guardian/frontend/commit/ca526a008a095c099511cc6f05bfef15548c120d#diff-d7ac06ce4049f42538bd64d9cbfb142cL12

But it also allows you to do client-side behaviour changes, using the guardian config object.

I've added the chimney test as an example.
