### PR TITLE
Keep a Count of First Ad Rendered on Page

### DIFF
--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -20,6 +20,7 @@ object Metric extends Logging {
     ("pva", CountMetric("kpis-analytics-page-views")), // page view fires after analytics
 
     ("ads-blocked", CountMetric("ads-blocked")),
+    ("ad-render", CountMetric("first-ad-rendered")),
 
     // error pages
     ("50x", CountMetric("kpis-user-50x")),             // beacon on the 50x page that tells us that real users are getting 500 errors

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -130,7 +130,9 @@ define([
             });
         },
 
-        recordFirstAdRendered = _.once(beacon.beaconCounts('ad-render')),
+        recordFirstAdRendered = _.once(function () {
+            beacon.beaconCounts('ad-render');
+        }),
 
         /**
          * Initial commands

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -135,7 +135,7 @@ define([
                 rendered = true;
 
                 // record first ad on page rendered
-                _.once((new Image()).src = guardian.config.page.beaconUrl + '/count/ad-render.gif');
+                _.once((new Image()).src = config.page.beaconUrl + '/count/ad-render.gif');
 
                 mediator.emit('modules:commercial:dfp:rendered', event);
                 parseAd(event);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -16,7 +16,8 @@ define([
     'common/modules/commercial/ads/sticky-mpu',
     'common/modules/commercial/build-page-targeting',
     'common/modules/onward/geo-most-popular',
-    'common/modules/experiments/ab'
+    'common/modules/experiments/ab',
+    'common/modules/analytics/beacon'
 ], function (
     bean,
     bonzo,
@@ -34,7 +35,8 @@ define([
     StickyMpu,
     buildPageTargeting,
     geoMostPopular,
-    ab
+    ab,
+    beacon
 ) {
     /**
      * Right, so an explanation as to how this works...
@@ -127,16 +129,16 @@ define([
                 });
             });
         },
+
+        recordFirstAdRendered = _.once(beacon.beaconCounts('ad-render')),
+
         /**
          * Initial commands
          */
         setListeners = function () {
             googletag.pubads().addEventListener('slotRenderEnded', raven.wrap(function (event) {
                 rendered = true;
-
-                // record first ad on page rendered
-                _.once((new Image()).src = config.page.beaconUrl + '/count/ad-render.gif');
-
+                recordFirstAdRendered();
                 mediator.emit('modules:commercial:dfp:rendered', event);
                 parseAd(event);
             }));

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -133,6 +133,10 @@ define([
         setListeners = function () {
             googletag.pubads().addEventListener('slotRenderEnded', raven.wrap(function (event) {
                 rendered = true;
+
+                // record first ad on page rendered
+                _.once((new Image()).src = guardian.config.page.beaconUrl + '/count/ad-render.gif');
+
                 mediator.emit('modules:commercial:dfp:rendered', event);
                 parseAd(event);
             }));


### PR DESCRIPTION
New Cloudwatch diagnostic metric to allow us to compare count of page-views with count of page-views that have had at least one ad rendered.
