### PR TITLE
Membership event embed

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -24,6 +24,7 @@ object BodyCleaner {
         DropCaps(article.isComment || article.isFeature),
         FigCaptionCleaner,
         RichLinkCleaner,
+        MembershipEventCleaner,
         BlockquoteCleaner,
         CmpParamCleaner
       )

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -526,3 +526,15 @@ object RichLinkCleaner extends HtmlCleaner {
     document
   }
 }
+
+object MembershipEventCleaner extends HtmlCleaner {
+  override def clean(document: Document): Document = {
+    val membershipEvents = document.getElementsByClass("element-membership")
+    membershipEvents
+      .addClass("element-membership--not-upgraded")
+      .attr("data-component", "membership-events")
+      .zipWithIndex.map{ case (el, index) => el.attr("data-link-name", s"membership-event-${membershipEvents.length} | ${index+1}") }
+
+    document
+  }
+}

--- a/static/src/javascripts/bootstraps/article.js
+++ b/static/src/javascripts/bootstraps/article.js
@@ -7,6 +7,7 @@ define([
     'common/utils/mediator',
     'common/utils/url',
     'common/modules/article/rich-links',
+    'common/modules/article/membership-events',
     'common/modules/article/open-module',
     'common/modules/article/truncate',
     'common/modules/article/twitter',
@@ -23,6 +24,7 @@ define([
     mediator,
     urlutils,
     richLinks,
+    membershipEvents,
     openModule,
     truncate,
     twitter,
@@ -92,6 +94,7 @@ define([
             modules.initCmpParam();
             richLinks.upgradeRichLinks();
             richLinks.insertTagRichLink();
+            membershipEvents.upgradeEvents();
             openModule.init();
 
             mediator.emit('page:article:ready');

--- a/static/src/javascripts/projects/common/modules/article/membership-events.js
+++ b/static/src/javascripts/projects/common/modules/article/membership-events.js
@@ -1,28 +1,19 @@
 define([
     'fastdom',
-    'qwery',
-    'Promise',
-    'common/utils/_',
+    'common/utils/config',
     'common/utils/$',
     'common/utils/ajax-promise'
-], function (
-    fastdom,
-    qwery,
-    Promise,
-    _,
-    $,
-    ajax
-) {
+], function (fastdom, config, $, ajax) {
 
     var ELEMENT_INITIAL_CLASS = 'element-membership--not-upgraded',
         ELEMENT_UPGRADED_CLASS = 'element-membership--upgraded';
 
     function upgradeEvent(el) {
         var href = $('a', el).attr('href'),
-            matches = href.match(/https:\/\/membership.theguardian.com/);
+            matches = (href.indexOf(config.page.membershipUrl) > -1);
 
         if (matches) {
-            return ajax({
+            ajax({
                 url: href + '/card',
                 crossOrigin: true
             }).then(function (resp) {
@@ -34,8 +25,6 @@ define([
                     });
                 }
             });
-        } else {
-            return Promise.resolve(null);
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/article/membership-events.js
+++ b/static/src/javascripts/projects/common/modules/article/membership-events.js
@@ -1,16 +1,15 @@
 define([
     'fastdom',
-    'common/utils/config',
     'common/utils/$',
     'common/utils/ajax-promise'
-], function (fastdom, config, $, ajax) {
+], function (fastdom, $, ajax) {
 
     var ELEMENT_INITIAL_CLASS = 'element-membership--not-upgraded',
         ELEMENT_UPGRADED_CLASS = 'element-membership--upgraded';
 
     function upgradeEvent(el) {
         var href = $('a', el).attr('href'),
-            matches = (href.indexOf(config.page.membershipUrl) > -1);
+            matches = href.match(/https:\/\/membership.theguardian.com/);
 
         if (matches) {
             ajax({

--- a/static/src/javascripts/projects/common/modules/article/membership-events.js
+++ b/static/src/javascripts/projects/common/modules/article/membership-events.js
@@ -1,0 +1,50 @@
+define([
+    'fastdom',
+    'qwery',
+    'Promise',
+    'common/utils/_',
+    'common/utils/$',
+    'common/utils/ajax-promise'
+], function (
+    fastdom,
+    qwery,
+    Promise,
+    _,
+    $,
+    ajax
+) {
+
+    var ELEMENT_INITIAL_CLASS = 'element-membership--not-upgraded',
+        ELEMENT_UPGRADED_CLASS = 'element-membership--upgraded';
+
+    function upgradeEvent(el) {
+        var href = $('a', el).attr('href'),
+            matches = href.match(/https:\/\/membership.theguardian.com/);
+
+        if (matches) {
+            return ajax({
+                url: href + '/card',
+                crossOrigin: true
+            }).then(function (resp) {
+                if (resp.html) {
+                    fastdom.write(function () {
+                        $(el).html(resp.html)
+                            .removeClass(ELEMENT_INITIAL_CLASS)
+                            .addClass(ELEMENT_UPGRADED_CLASS);
+                    });
+                }
+            });
+        } else {
+            return Promise.resolve(null);
+        }
+    }
+
+    function upgradeEvents() {
+        $('.' + ELEMENT_INITIAL_CLASS).each(upgradeEvent);
+    }
+
+    return {
+        upgradeEvent: upgradeEvent,
+        upgradeEvents: upgradeEvents,
+    };
+});

--- a/static/src/javascripts/projects/common/modules/article/membership-events.js
+++ b/static/src/javascripts/projects/common/modules/article/membership-events.js
@@ -45,6 +45,6 @@ define([
 
     return {
         upgradeEvent: upgradeEvent,
-        upgradeEvents: upgradeEvents,
+        upgradeEvents: upgradeEvents
     };
 });

--- a/static/src/stylesheets/global.scss
+++ b/static/src/stylesheets/global.scss
@@ -63,6 +63,7 @@
 @import 'module/_submeta';
 
 @import 'module/_rich-links';
+@import 'module/_membership-events';
 
 /* ==========================================================================
    External modules

--- a/static/src/stylesheets/module/_membership-events.scss
+++ b/static/src/stylesheets/module/_membership-events.scss
@@ -41,3 +41,10 @@
         }
     }
 }
+
+.element-membership--upgraded {
+    float: left;
+    clear: both;
+    margin: 5px $gs-gutter $gs-baseline  0;
+    width: gs-span(2);
+}

--- a/static/src/stylesheets/module/_membership-events.scss
+++ b/static/src/stylesheets/module/_membership-events.scss
@@ -1,0 +1,43 @@
+/**
+ * Membership event embed
+ * Not-upgraded style (no-js / failures)
+ *
+ * Full, enhanced styles provided directly by card endpoint,
+ * e.g. https://membership.theguardian.com/event/the-observer-election-countdown-16253236869/card
+ */
+.element-membership--not-upgraded {
+    border-top: 1px dotted colour(neutral-3);
+    border-bottom: 1px dotted colour(neutral-3);
+    margin-bottom: $gs-baseline / 1.5;
+
+    @include mq(mobileLandscape) {
+        float: left;
+        width: gs-span(3);
+        margin: $gs-baseline / 3 $gs-gutter $gs-baseline / 2 0;
+    }
+
+    p {
+        margin: 0;
+    }
+
+    span {
+        display: block;
+        @include fs-textSans(1);
+        color: colour(neutral-2);
+        padding: $gs-baseline/4 0;
+    }
+
+    a {
+        @include fs-headline(2);
+        font-weight: 500;
+        display: block;
+        padding: 0;
+        color: colour(neutral-1);
+        border: 0;
+        padding-bottom: $gs-baseline * 1.5;
+
+        &:hover {
+            text-decoration: underline !important;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new element type for enhancing embedded Membership events, based on `rich-links`.
- Markup and styles for enhanced version provided by an endpoint on Membership: https://membership.theguardian.com/event/the-observer-election-countdown-16253236869/card (See https://github.com/guardian/membership-frontend/pull/477)

**Enhanced version**
![event-embed-enhanced](https://cloud.githubusercontent.com/assets/123386/7186074/20a4e666-e45f-11e4-9f7f-a556ad34a4dc.png)

**Default appearance**
![event-embed-unsupported](https://cloud.githubusercontent.com/assets/123386/7186086/312a325c-e45f-11e4-9a45-c0747a39228e.png)

This is my first PR so let me know if you need any more information or I've missed some steps.

@mattandrews @phamann 
