### PR TITLE
Xword template harmony and cell number size

### DIFF
--- a/applications/app/crosswords/CrosswordSvg.scala
+++ b/applications/app/crosswords/CrosswordSvg.scala
@@ -37,7 +37,7 @@ case class Grid(columns: Int, rows: Int, cells: Map[Position, Cell])
 
 object CrosswordSvg {
   val BorderSize = 1
-  val CellSize = 30
+  val CellSize = 31
 
   implicit val positionOrdering = Ordering.by[Position, (Int, Int)](position => (position.y, position.x))
 
@@ -51,7 +51,7 @@ object CrosswordSvg {
     cell.number map { n =>
       <g>
         {cellRect}
-        <text x={(x + 1).toString} y={(y + 8).toString} class="crossword__cell-number">{n}</text>
+        <text x={(x + 1).toString} y={(y + 9).toString} class="crossword__cell-number">{n}</text>
       </g>
     } getOrElse cellRect
   }
@@ -64,13 +64,7 @@ object CrosswordSvg {
 
     val viewBoxHeight = if (trim) width * 0.6 else height
 
-    <svg xmlns="http://www.w3.org/2000/svg"
-         xmlns:xlink="http://www.w3.org/1999/xlink"
-         viewBox={s"0, 0, $width, $viewBoxHeight"}
-         preserveAspectRatio="none"
-         width={boxWidth.getOrElse(width + "px")}
-         height={boxHeight.getOrElse(width + "px")}
-         style="font-size: 10px">
+    <svg viewBox={s"0, 0, $width, $viewBoxHeight"} class="crossword__grid">
       <rect x="0" y="0" width={width.toString} height={height.toString} style="fill: #000000" />
       {
         for {

--- a/applications/app/views/crossword.scala.html
+++ b/applications/app/views/crossword.scala.html
@@ -28,19 +28,24 @@
                         <div class="js-crossword"
                              data-crossword-data="@Json.stringify(Json.toJson(crosswordPage.crossword))">
 
-                            @* The following is a fallback for when JavaScript is not enabled *@
-                            <div style="@crosswordPage.fallbackDimensions.styleString">
-                                @svg
-                            </div>
+                            <div class="crossword__container crossword__container--@crosswordPage.crossword.crosswordType.toString.toLowerCase()">
 
-                            <div class="crossword__clues">
-                                <h3 class="crossword__clues-header">Across</h3>
+                                @* The following is a fallback for when JavaScript is not enabled *@
+                                <div class="crossword__grid-wrapper">
+                                    @svg
+                                </div>
 
-                                @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction == Across))
+                                <div class="crossword__clues">
+                                    <div class="crossword__clues--across">
+                                        <h3 class="crossword__clues-header">Across</h3>
+                                        @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction == Across))
+                                    </div>
 
-                                <h3 class="crossword__clues-header">Down</h3>
-
-                                @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction == Down))
+                                    <div class="crossword__clues--down">
+                                        <h3 class="crossword__clues-header">Down</h3>
+                                        @crosswordEntries(crosswordPage.crossword.entries.filter(_.direction == Down))
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/applications/app/views/fragments/crosswordEntries.scala.html
+++ b/applications/app/views/fragments/crosswordEntries.scala.html
@@ -1,7 +1,7 @@
 @(entries: Seq[crosswords.CrosswordEntry])
 
 @if(entries.nonEmpty) {
-    <ol>
+    <ol class="crossword__clues-list">
     @for(entry <- entries) {
         <li value="@entry.number" class="crossword__clue">@Html(entry.clue)</li>
     }

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/constants.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/constants.js
@@ -1,7 +1,7 @@
 export default {
     cellSize: 31,
     borderSize: 1,
-    numberSize: 7,
+    numberSize: 9,
     entrySize: 10
 };
 

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/grid.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/grid.js
@@ -24,7 +24,7 @@ const Cell = React.createClass({
             innerNodes.push(
                 React.DOM.text({
                     x: left + 1,
-                    y: top + constants.numberSize + 1,
+                    y: top + constants.numberSize,
                     key: 'number',
                     className: 'crossword__cell-number'
                 }, this.props.number)

--- a/static/src/stylesheets/module/crosswords/_grid.scss
+++ b/static/src/stylesheets/module/crosswords/_grid.scss
@@ -24,7 +24,7 @@
 
 .crossword__cell-number {
     font-family: $f-sans-serif-text;
-    font-size: 8px;
+    font-size: 10px;
 }
 
 .crossword__cell-text {


### PR DESCRIPTION
Bumps the grid cell id size and brings the `scala.html` templates for crosswords into harmony with recent changes to `jsx` templates, reducing the effect of the re-render.

there's still a flash though, on the initial `React.renderComponent` call that needs ironing out, somehow...

cc @robertberry 
