### PR TITLE
Robust/fastdom all the things

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -191,6 +191,11 @@ object Switches {
     safeState = Off, sellByDate = never
   )
 
+  val RobustFastdom = Switch("Performance", "robust-fastdom",
+    "If this switch is on robust defers module loading using fastdom",
+    safeState = Off, sellByDate = new LocalDate(2015, 5, 20)
+  )
+
   // Commercial
   val DfpCachingSwitch = Switch("Commercial", "dfp-caching",
     "Have Admin will poll DFP to precache adserving data.",

--- a/static/src/javascripts/bootstraps/app.js
+++ b/static/src/javascripts/bootstraps/app.js
@@ -4,6 +4,7 @@ define([
     'common/utils/config',
     'common/utils/detect',
     'common/utils/mediator',
+    'common/utils/robust',
     'common/utils/user-timing',
     'bootstraps/article',
     'bootstraps/common',
@@ -18,6 +19,7 @@ define([
     config,
     detect,
     mediator,
+    robust,
     userTiming,
     article,
     common,
@@ -29,11 +31,15 @@ define([
 ) {
 
     var bootstrapContext = function (featureName, boostrap) {
-            raven.context(
-                { tags: { feature: featureName } },
-                boostrap.init,
-                []
-            );
+            if (config.switches.robustFastdom) {
+                robust(featureName, boostrap.init);
+            } else {
+                raven.context(
+                    { tags: { feature: featureName } },
+                    boostrap.init,
+                    []
+                );
+            }
         },
 
         routes = function () {

--- a/static/src/javascripts/bootstraps/app.js
+++ b/static/src/javascripts/bootstraps/app.js
@@ -1,6 +1,7 @@
 define([
     'qwery',
     'raven',
+    'fastdom',
     'common/utils/config',
     'common/utils/detect',
     'common/utils/mediator',
@@ -16,6 +17,7 @@ define([
 ], function (
     qwery,
     raven,
+    fastdom,
     config,
     detect,
     mediator,
@@ -119,7 +121,13 @@ define([
             }
 
             // Mark the end of synchronous execution.
-            userTiming.mark('App End');
+            if (config.switches.robustFastdom) {
+                fastdom.defer(function () {
+                    userTiming.mark('App End');
+                });
+            } else {
+                userTiming.mark('App End');
+            }
         };
 
     return {

--- a/static/src/javascripts/projects/common/utils/robust.js
+++ b/static/src/javascripts/projects/common/utils/robust.js
@@ -5,9 +5,13 @@
     For example "comments throwing an exception should not stop auto refresh"
  */
 define([
-    'raven'
+    'raven',
+    'fastdom',
+    'common/utils/config'
 ], function (
-    raven
+    raven,
+    fastdom,
+    config
 ) {
     function Robust(name, block, reporter) {
 
@@ -15,10 +19,18 @@ define([
             reporter = raven.captureException;
         }
 
-        try {
-            block();
-        } catch (e) {
-            reporter(e, { tags: { module: name } });
+        var run = function () {
+            try {
+                block();
+            } catch (e) {
+                reporter(e, { tags: { module: name } });
+            }
+        };
+
+        if (config.switches.robustFastdom) {
+            fastdom.defer(run);
+        } else {
+            run();
         }
     }
 

--- a/static/test/javascripts/spec/common/utils/robust.spec.js
+++ b/static/test/javascripts/spec/common/utils/robust.spec.js
@@ -7,7 +7,7 @@ define([
 ) {
     describe('Robust', function() {
         it('should complete successfully', function (success) {
-            robust('test', function () { success() });
+            robust('test', function () { success(); });
         });
 
         it('should log and swallow exceptions', function (success) {


### PR DESCRIPTION
Use `robust` inside `facia` and `app`, but the key change is that  robust now uses `fastdom.defer` to schedule each module initialisation in its own frame.

This should make loading more robust (quite sure) and smoother (would like a second opinion on this).

I took some measure in dev tool timeline, and the fps is much better. (I can share them but they're huge)

Other measures:

| Main script execution block | Before changes | With fastdom |
| --- | --- | --- |
| `core.js` | 40ms | 40ms |
| `app.js` | 65ms | 36ms |
| `facia.js` | 12ms | 3ms |

Blocks are smaller because there are a bunch of intervals scheduled for later.

I tested this on a copy of `/uk` front, so a big front.

Drawback might be that the page load is delayed (when JS stops running).

I've also tried to use `fastdom.read` / `write` instead of `defer` but multiple blocks run in the same frame, and it's way more likely that the 60fps is not respected.

Would be nice to have opinions on this, or maybe A/B test it.

@phamann @robertberry ?
