### PR TITLE
Remove education and media from UK all sections nav

### DIFF
--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -93,8 +93,6 @@ object Uk extends Edition(
       NavItem(travel, Seq(uktravel, europetravel, usTravel)),
       NavItem(money, Seq(property, savings, pensions, borrowing, workAndCareers)),
       NavItem(science),
-      NavItem(education, Seq(students, teachersNetwork)),
-      NavItem(media),
       NavItem(guardianProfessional),
       NavItem(observer),
       NavItem(todaysPaper, Seq(editorialsandletters, obituaries, g2, weekend, theGuide, saturdayreview)),

--- a/common/test/common/NavigationTest.scala
+++ b/common/test/common/NavigationTest.scala
@@ -37,4 +37,7 @@ class NavigationTest extends FlatSpec with Matchers with OptionValues {
   "AU full nav" should "not contain 'membership'" in {
     Au.navigation.filter(_.name.title == "membership").isEmpty shouldEqual true
   }
+  "UK full nav" should "not contain 'education' or 'media'" in {
+    Uk.navigation.filter(n => n.name.title == "education" || n.name.title == "media").isEmpty shouldEqual true
+  }
 }


### PR DESCRIPTION
The UK navigation refresh should have removed the education and media sections from the all sections menu.
