### PR TITLE
restore namespace to crosswords SVG

### DIFF
--- a/applications/app/crosswords/CrosswordSvg.scala
+++ b/applications/app/crosswords/CrosswordSvg.scala
@@ -64,7 +64,7 @@ object CrosswordSvg {
 
     val viewBoxHeight = if (trim) width * 0.6 else height
 
-    <svg viewBox={s"0, 0, $width, $viewBoxHeight"} class="crossword__grid">
+    <svg viewBox={s"0, 0, $width, $viewBoxHeight"} class="crossword__grid" xmlns="http://www.w3.org/2000/svg">
       <rect x="0" y="0" width={width.toString} height={height.toString} style="fill: #000000" />
       {
         for {


### PR DESCRIPTION
since they're loaded as `src`s on the front, they need to be valid `xml`.

before:
![screen shot 2015-04-17 at 12 58 57](https://cloud.githubusercontent.com/assets/867233/7201663/b457a2fc-e501-11e4-85da-f18f2e117b77.png)

after:
![screen shot 2015-04-17 at 12 59 28](https://cloud.githubusercontent.com/assets/867233/7201665/b6b343d0-e501-11e4-9dc0-3fcdea539c06.png)
