### PR TITLE
Add server-based ab tests to dashboard

### DIFF
--- a/admin/app/views/abtests.scala.html
+++ b/admin/app/views/abtests.scala.html
@@ -17,6 +17,8 @@
 
     <div class="abtests-audience"></div>
 
+    @fragments.serverBasedTests()
+
     <div class="abtests-active"></div>
 
     <h2 class="abtests-expired-title">Expired <a href="#">show</a></h2>

--- a/admin/app/views/fragments/abtestItem.scala.html
+++ b/admin/app/views/fragments/abtestItem.scala.html
@@ -2,15 +2,15 @@
 <div class="abtest-item">
     <div class="abtest-item__titlebar">
         <span class="label label-success abtest-item__active-label">active</span>
-        <span class="label label-important abtest-item__expired-label">expired</span>
+        <span class="label label-danger abtest-item__expired-label">expired</span>
         <span class="label label-success abtest-item__switched-on-label">on</span>
-        <span class="label label-important abtest-item__switched-off-label">off</span>
+        <span class="label label-danger abtest-item__switched-off-label">off</span>
         <span class="abtest-item__name"></span>
         <span class="abtest-item__description"></span>
     </div>
     <div class="abtest-item__participation"></div>
-    <div class="row-fluid">
-        <div class="span3 abtest__details">
+    <div class="row">
+        <div class="col-md-3 abtest__details">
             <table class="abtest__table table table-r table-bordered table-hover">
                 <thead>
                 <th colspan="2">Details</th>
@@ -31,7 +31,7 @@
                 </tbody>
             </table>
         </div>
-        <div class="span9">
+        <div class="col-md-9">
             <table class="table table-r table-bordered table-condensed">
                 <thead><tr><th>Chart</th></tr></thead>
                 <tbody>

--- a/admin/app/views/fragments/abtestItem.scala.html
+++ b/admin/app/views/fragments/abtestItem.scala.html
@@ -1,11 +1,11 @@
 @()
 <div class="abtest-item">
     <div class="abtest-item__titlebar">
+        <h3 class="abtest-item__name"></h3>
         <span class="label label-success abtest-item__active-label">active</span>
         <span class="label label-danger abtest-item__expired-label">expired</span>
         <span class="label label-success abtest-item__switched-on-label">on</span>
         <span class="label label-danger abtest-item__switched-off-label">off</span>
-        <span class="abtest-item__name"></span>
         <span class="abtest-item__description"></span>
     </div>
     <div class="abtest-item__participation"></div>

--- a/admin/app/views/fragments/audience.scala.html
+++ b/admin/app/views/fragments/audience.scala.html
@@ -1,10 +1,9 @@
 @()
 <div class="audience-breakdown">
-    <h2 class="abtest-item__titlebar">Summary</h2>
+    <h3 class="abtest-item__titlebar">Breakdown</h3>
 
     <div class="row">
-        <div class="col-md-2"></div>
-        <div class="col-md-8">
+        <div class="col-md-12">
             <table class="table table-bordered ">
                 <thead>
                     <th class="audience-breakdown__ruler-division">0%</th>
@@ -16,6 +15,5 @@
                 </tbody>
             </table>
         </div>
-        <div class="col-md-2"></div>
     </div>
 </div>

--- a/admin/app/views/fragments/serverBasedTests.scala.html
+++ b/admin/app/views/fragments/serverBasedTests.scala.html
@@ -1,0 +1,44 @@
+@()
+@import mvt.ActiveTests.tests
+@import mvt.TestDefinition
+
+<div class="abtests-server-based">
+    <h3 class="abtest-item__titlebar">Server-based AB tests</h3>
+
+    <div class="row">
+        <div class="col-md-7">
+            <table class="table table-bordered ">
+                <thead>
+                    <th colspan="4">Name</th>
+                    <th colspan="3">Allocated variants</th>
+                </thead>
+                <tbody>
+                    @tests.map { test =>
+                        <tr>
+                            <td colspan="4">@status(test) @test.name </td>
+                            <td colspan="3">@{test.variants.map(_.name).sorted.mkString(", ")}</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+@status(test: TestDefinition) = {
+    @if(test.switch.hasExpired) {
+        <span class="abtest-server-label label label-danger">expired</span>
+    } else {
+        @if(test.switch.expiresSoon) {
+            <span class="abtest-server-label label label-success">active</span>
+        } else {
+            <span class="abtest-server-label label label-warning">expires soon</span>
+        }
+
+        @if(test.switch.isSwitchedOn) {
+            <span class="abtest-server-label label label-success">on</span>
+        } else {
+            <span class="abtest-server-label label label-danger">off</span>
+        }
+    }
+}

--- a/admin/app/views/fragments/serverBasedTests.scala.html
+++ b/admin/app/views/fragments/serverBasedTests.scala.html
@@ -15,7 +15,7 @@
                 <tbody>
                     @tests.map { test =>
                         <tr>
-                            <td colspan="4">@status(test) @test.name </td>
+                            <td colspan="4">@test.name @status(test)</td>
                             <td colspan="3">@{test.variants.map(_.name).sorted.mkString(", ")}</td>
                         </tr>
                     }

--- a/admin/public/css/abtests.css
+++ b/admin/public/css/abtests.css
@@ -19,7 +19,6 @@
 }
 
 .abtest-item__titlebar {
-    border-bottom: 1px solid #ccc;
     margin-top: 10px;
     margin-bottom: 10px;
     padding-bottom: 4px;
@@ -50,15 +49,20 @@
     display: none;
 }
 
+.abtest-item--active .abtest-item__active-label,
 .abtest-item--expired .abtest-item__expired-label,
 .abtest-item--switched-on .abtest-item__switched-on-label,
-.abtest-item--switched-off .abtest-item__switched-off-label
-{
+.abtest-item--switched-off .abtest-item__switched-off-label {
     display: inline-block;
     position: relative;
     top: -5px;
 }
 
+.abtest-server-label {
+    display: inline-block;
+    position: relative;
+    top: -2px;
+}
 
 .abtest-item__participation {
     margin-bottom: 12px;

--- a/admin/public/css/abtests.css
+++ b/admin/public/css/abtests.css
@@ -24,16 +24,6 @@
     padding-bottom: 4px;
 }
 
-.abtest-item__name {
-    font-size: 28px;
-    font-weight: bold;
-}
-
-.abtest-item__description {
-    display: inline-block;
-    margin-left: 10px;
-}
-
 .abtest-item--expired .abtest-item__expiry {
     color: #a55;
 }
@@ -52,12 +42,7 @@
 .abtest-item--active .abtest-item__active-label,
 .abtest-item--expired .abtest-item__expired-label,
 .abtest-item--switched-on .abtest-item__switched-on-label,
-.abtest-item--switched-off .abtest-item__switched-off-label {
-    display: inline-block;
-    position: relative;
-    top: -5px;
-}
-
+.abtest-item--switched-off .abtest-item__switched-off-label,
 .abtest-server-label {
     display: inline-block;
     position: relative;

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -40,6 +40,8 @@ trait SwitchTrait extends Switchable with Initializable[SwitchTrait] {
 
   def expiresSoon = daysToExpiry < 7
 
+  def hasExpired = daysToExpiry == 0
+
   Switch.switches.send(this :: _)
 }
 


### PR DESCRIPTION
Fix a few styling issues with the labels, reinstate the row columns for graphs, and add a new fragment for server-based tests.
![screen shot 2015-04-17 at 13 29 59](https://cloud.githubusercontent.com/assets/4549425/7201975/a1495274-e505-11e4-84e0-bf5c362cd134.png)
