### PR TITLE
Remove global lang property from <html> element

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -5,7 +5,7 @@
 @import views.support.RenderClasses
 
 <!DOCTYPE html>
-<html id="js-context" class="js-off is-not-modern id--signed-out" lang="en-GB" data-page-path="@request.path">
+<html id="js-context" class="js-off is-not-modern id--signed-out" data-page-path="@request.path">
 <head>
     @fragments.head(metaData, projectName, head, curlPaths)
 </head>


### PR DESCRIPTION
As it was causes validation issues with the open-graph rdf schema.

See schema linter for further results:
http://linter.structured-data.org/?url=http:%2F%2Fwww.theguardian.com%2Fuk

Also related to this PR in our sanity tests:
https://github.com/guardian/frontend-sanity-tests/pull/11

It is also not really used:
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang

/cc @gklopper 
