### PR TITLE
Rename img object contentUrl schema property

### DIFF
--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -58,7 +58,7 @@
         srcset="@ImgSrc.srcset(picture, widths)"
         sizes="@widths.sizes"
         class="maxed responsive-img"
-        itemprop="contentURL representativeOfPage"
+        itemprop="contentUrl representativeOfPage"
         alt="@ImgSrc.getFallbackAsset(picture).flatMap(_.altText).getOrElse("")" />
 
 }


### PR DESCRIPTION
Turns out schema is case-sensitive...

`contentURL !== contentUrl`

https://schema.org/contentUrl

/cc @gklopper 
