### PR TITLE
Remove mainContentOfPage prop from all content types

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -9,7 +9,7 @@
             Map("content--advertisement-feature" -> gallery.isAdvertisementFeature),
             "content", "content--media", "content--gallery", "tonal", s"tonal--${articleToneClass(gallery)}"
         )"
-        itemprop="mainContentOfPage" itemscope itemtype="@gallery.schemaType" role="main">
+        itemscope itemtype="@gallery.schemaType" role="main">
 
         @fragments.headTonal(gallery)
 

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -26,7 +26,7 @@
                 ),
                 "content", "content--interactive", "tonal", s"tonal--${articleToneClass(interactive)}"
             )"
-            itemprop="mainContentOfPage" itemscope itemtype="@interactive.schemaType" role="main">
+            itemscope itemtype="@interactive.schemaType" role="main">
 
             @fragments.headDefault(interactive, showBadge = true)
 

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -14,7 +14,7 @@
             ),
             "content", "content--media", s"content--media--$mediaType", "tonal", s"tonal--${articleToneClass(media)}"
         )"
-        itemprop="mainContentOfPage" itemscope itemtype="@media.schemaType" role="main">
+        itemscope itemtype="@media.schemaType" role="main">
 
         @fragments.headTonal(media)
 

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -12,7 +12,7 @@
 <div class="l-side-margins">
     <article id="live-blog" data-test-id="live-blog"
         class="content content--liveblog tonal tonal--@articleToneClass(article) blog @if(article.isLive){is-live} section-@article.sectionName.toLowerCase"
-        itemprop="mainContentOfPage" itemscope itemtype="@article.schemaType" role="main">
+        itemscope itemtype="@article.schemaType" role="main">
 
         <header class="content__head tonal__head tonal__head--@articleToneClass(article)">
             @* UPPER HEADER *@


### PR DESCRIPTION
I missed this previously in #8884 and is causing the same validation error:

https://developers.google.com/webmasters/structured-data/testing-tool?url=http%253A%252F%252Fwww.theguardian.com%252Fsport%252Flive%252F2015%252Fapr%252F17%252Fwest-indies-england-first-test-day-five-live

/cc @gklopper 
