### PR TITLE
Weather & Breaking News for International edition

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -65,8 +65,8 @@ define([
                         collection.href = collection.href.toLowerCase();
                         return collection;
                     }),
-
-                    edition = (page.edition || '').toLowerCase(),
+                    treatAsInternationalForAlerts = page.internationalEdition === 'international',
+                    edition = treatAsInternationalForAlerts ? 'intl' : (page.edition || '').toLowerCase(),
                     section = supportedSections[page.section],
 
                     articles = _.flatten([

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -56,7 +56,7 @@ define([
         },
 
         isNetworkFront: function () {
-            return _.contains(['uk', 'us', 'au'], config.page.pageId);
+            return _.contains(['uk', 'us', 'au', 'international'], config.page.pageId);
         },
 
         /**


### PR DESCRIPTION
International front will now show weather.

International users will now only see Global alerts (and section alerts).

cc @stephanfowler @robertberry
