### PR TITLE
Liveblogs on fronts: item meta 

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-blocks-on-fronts.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-blocks-on-fronts.js
@@ -22,7 +22,7 @@ define([
         this.idealOutcome = 'Higher engagement, measured as increased onward journeys to ANY content on the affected front, or increased dewll time on that front';
 
         this.canRun = function () {
-            return ['Network Front', 'Section'].indexOf(config.page.contentType) > -1;
+            return true;
         };
 
         this.variants = [

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -85,17 +85,7 @@
     height: 78px; // 2 * block height - 2px margin
     overflow: hidden;
     margin-right: -1 * $gs-gutter / 4;
-
-    .fc-item--has-metadata & {
-        margin-bottom: -1 * $gs-baseline * 2;
-    }
-
-    .fc-item--has-sublinks-1 &,
-    .fc-item--has-sublinks-2 &,
-    .fc-item--has-sublinks-3 &,
-    .fc-item--has-sublinks-4 & {
-        margin-bottom: 0;
-    }
+    margin-bottom: $gs-baseline / 2;
 }
 
 .fc-item__liveblog-message {


### PR DESCRIPTION
Fix overlapping with comment count & item time. Run on tags pages too.

![liveblog-w-comment-count](https://cloud.githubusercontent.com/assets/1147913/7205144/083dbd08-e51f-11e4-8e6b-2061b20ac2d1.png)
