### PR TITLE
Added User 50x graph to radiator

### DIFF
--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -37,7 +37,7 @@ object RadiatorController extends Controller with Logging with AuthLogging with 
       NoCache(Ok(c.body).withHeaders("Content-Type" -> "application/json; charset=utf-8"))
     }
   }
-  def renderRadiator(external: Boolean = false) = AuthActions.AuthActionTest.async { implicit request =>
+  def renderRadiator() = AuthActions.AuthActionTest.async { implicit request =>
 
     // Some features do not work outside our network
     // /radiator?features=external disables these

--- a/admin/app/tools/CloudWatch.scala
+++ b/admin/app/tools/CloudWatch.scala
@@ -234,6 +234,17 @@ object CloudWatch extends Logging with ExecutionContexts {
       .withDimensions(stage)))
   } yield new AwsLineChart("ophan-percent-conversion", Seq("Time", "%"), ChartFormat.SingleLineBlue, metric)
 
+  def user50x = for {
+    metric <- withErrorLogging(euWestClient.getMetricStatisticsFuture(new GetMetricStatisticsRequest()
+      .withStartTime(new DateTime().minusMinutes(60).toDate)
+      .withEndTime(new DateTime().toDate)
+      .withPeriod(60)
+      .withStatistics("Sum")
+      .withNamespace("Diagnostics")
+      .withMetricName("kpis-user-50x")
+      .withDimensions(stage)))
+  } yield new AwsLineChart("User 50x", Seq("Time", "50x/min"), ChartFormat.SingleLineRed, metric)
+
   def ratioConfidence = for {
     metric <- withErrorLogging(euWestClient.getMetricStatisticsFuture(new GetMetricStatisticsRequest()
       .withStartTime(new DateTime().minusWeeks(2).toDate)

--- a/admin/app/tools/CloudWatch.scala
+++ b/admin/app/tools/CloudWatch.scala
@@ -236,7 +236,7 @@ object CloudWatch extends Logging with ExecutionContexts {
 
   def user50x = for {
     metric <- withErrorLogging(euWestClient.getMetricStatisticsFuture(new GetMetricStatisticsRequest()
-      .withStartTime(new DateTime().minusMinutes(60).toDate)
+      .withStartTime(new DateTime().minusHours(2).toDate)
       .withEndTime(new DateTime().toDate)
       .withPeriod(60)
       .withStatistics("Sum")

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -31,6 +31,7 @@
                     <ul>
                         <li><a href="/dev/switchboard">Switchboard</a></li>
                         <li><a href="@controllers.admin.routes.RadiatorController.renderRadiator()">Radiator</a></li>
+                        <li><a href="@controllers.admin.routes.RadiatorController.renderRadiator()?features=external">Radiator (external)</a></li>
                         <li><a href="@controllers.admin.routes.RedirectController.redirect()">Redirects</a></li>
                         <li><a href="@controllers.admin.routes.CssReportController.entry()">CSS Selector Usage</a></li>
                     </ul>

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -2,7 +2,8 @@
     hitMissCharts: Seq[tools.AwsLineChart],
     cost: tools.MaximumMetric,
     switches: Seq[conf.SwitchTrait],
-    env: String)
+    env: String,
+    external: Boolean)
 
 @import org.joda.time.{DateTime, Days}
 
@@ -21,13 +22,16 @@
     </div>
 
     <div class="build-wrapper">
-        <h2>Teamcity builds</h2>
-        @*
+        @if(!external) {
+            <h2>Teamcity builds</h2>
+            @*
             To add another build just append another &buildTypeId=XXXXXX
             Note, it will not show unless you enable the "External status widget" for the build in Teamcity
-        *@
-        <script type="text/javascript" src="https://teamcity.gutools.co.uk/externalStatus.html?js=1&buildTypeId=bt1304&buildTypeId=Frontend_IntegrationTests&buildTypeId=Frontend_SanityTests"></script>
+            *@
+            <script type="text/javascript" src="https://teamcity.gutools.co.uk/externalStatus.html?js=1&buildTypeId=bt1304&buildTypeId=Frontend_IntegrationTests&buildTypeId=Frontend_SanityTests"></script>
+        }
     </div>
+
 
     <div class="expiring-wrapper">
         <h2>Expiring features</h2>
@@ -48,16 +52,18 @@
     </div>
 
     <div class="monitoring-wrapper">
-        <div class="riffraff-wrapper">
-            <h2>CODE Deployments</h2>
-            <ul class="riffraff" id="riffraffCODE"></ul>
-            <ul class="deployers" id="deployersCODE"></ul>
-        </div>
-        <div class="riffraff-wrapper">
-            <h2>PROD Deployments</h2>
-            <ul class="riffraff" id="riffraffPROD"></ul>
-            <ul class="deployers" id="deployersPROD"></ul>
-        </div>
+        @if(!external) {
+            <div class="riffraff-wrapper">
+                <h2>CODE Deployments</h2>
+                <ul class="riffraff" id="riffraffCODE"></ul>
+                <ul class="deployers" id="deployersCODE"></ul>
+            </div>
+            <div class="riffraff-wrapper">
+                <h2>PROD Deployments</h2>
+                <ul class="riffraff" id="riffraffPROD"></ul>
+                <ul class="deployers" id="deployersPROD"></ul>
+            </div>
+        }
     </div>
 
     @charts.map{ chart => @fragments.lineChart(chart)  }


### PR DESCRIPTION
These are populated by a beacon on the 50x page. This means there is a really good chance a user has seen an error page.

Giving it a high prominence because, well, a user has seen an error page.

Also add an **_external**_ mode to the radiator. This disables any features that cannot be reached outside the Guardian network (e.g. build status and deploy status)

cc @phamann @rich-nguyen @robertberry 
![5xx](https://cloud.githubusercontent.com/assets/76709/7214711/d3305f58-e5af-11e4-87df-91115ce054c3.png)
