### PR TITLE
Fix `WARNING: news not found in either frontend or pasteup palette` error

### DIFF
--- a/static/src/stylesheets/module/facia/_icons.scss
+++ b/static/src/stylesheets/module/facia/_icons.scss
@@ -3,7 +3,7 @@
 
 .fc-container__header__title a {
     .inline-icon {
-        fill: colour(news);
+        fill: colour(news-main-1);
         position: relative;
         height: .7em;
         width: 1em;


### PR DESCRIPTION
@phamann think [this colour](https://github.com/guardian/frontend/commit/219c5e96c14bfac3f673920391f2071b222ddae7#diff-31f0e983a33c0cf479de74619f3ebc5fR6) is wrong?

![screen shot 2015-04-20 at 10 44 13](https://cloud.githubusercontent.com/assets/867233/7227684/76cbbca2-e74a-11e4-8451-be5402372b20.png)
