### PR TITLE
Only load bundle subresource if not in dev

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -26,8 +26,8 @@
 <link rel="dns-prefetch" href="//oas.theguardian.com" />
 <link rel="dns-prefetch" href="@Configuration.debug.beaconUrl" />
 
-@Static.js.jspmFile(item.section).map { file =>
-    @if(!play.Play.isDev()) {
+@if(!play.Play.isDev()) {
+    @Static.js.jspmFile(item.section).map { file =>
         <link rel="subresource" href="@Static(file)" />
     }
 }

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -27,7 +27,9 @@
 <link rel="dns-prefetch" href="@Configuration.debug.beaconUrl" />
 
 @Static.js.jspmFile(item.section).map { file =>
-    <link rel="subresource" href="@Static(file)" />
+    @if(!play.Play.isDev()) {
+        <link rel="subresource" href="@Static(file)" />
+    }
 }
 
 


### PR DESCRIPTION
Currently, if you run `grunt compile --dev`, the crossword pages will 500 because the bundle cannot be found in the asset map.
