### PR TITLE
Move star rating schema to article template

### DIFF
--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -30,8 +30,13 @@
                     <span class="content__head__illustration hide-on-mobile"><i class="i i-illustration-letters"></i></span>
                 }
 
-                @content.starRating.map { s =>
-                    @fragments.items.elements.starRating(s)
+                @content.starRating.map { rating =>
+                    <span class="u-h" itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">
+                        <meta itemprop="worstRating" content="1" />
+                        <span itemprop="ratingValue">@rating</span> /
+                        <span itemprop="bestRating">5</span> stars
+                    </span>
+                    @fragments.items.elements.starRating(rating)
                 }
 
                 @if(showBadge) {

--- a/common/app/views/fragments/items/elements/starRating.scala.html
+++ b/common/app/views/fragments/items/elements/starRating.scala.html
@@ -1,10 +1,5 @@
 @(rating: Int)(implicit request: RequestHeader)
 
-<span class="u-h" itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">
-    <meta itemprop="worstRating" content="1" />
-    <span itemprop="ratingValue">@rating</span> /
-    <span itemprop="bestRating">5</span> stars
-</span>
 <div class="stars" role="presentation">
     @List(1,2,3,4,5).map{ i =>
         @fragments.inlineSvg("star", "icon", List("star__item", if(i <= rating){ "star__item--golden" }else{ "star__item--grey" }))


### PR DESCRIPTION
This was causing [schema errors](https://developers.google.com/webmasters/structured-data/testing-tool?url=http%253A%252F%252Fwww.theguardian.com%252Fuk) on the front. As we do not have the `Article` schema in scope for items on fronts and `reviewRating` is not a valid prop of `WebPage` which is in scope.

/cc @gklopper 
