### PR TITLE
Flex nowrap fix

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/navListContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/navListContainer.scala.html
@@ -11,9 +11,7 @@
             @collectionDefinition.collectionEssentials.items.zipWithIndex.map { case (item, index) =>
             <li class="fc-slice__item--nav-list">
                 <div class="fc-item fc-item--list-compact">
-                    <div class="fc-item__container">
-                        <a href="@LinkTo(item)" data-link-name=" | article | @index">@item.headline</a>
-                    </div>
+                    <a href="@LinkTo(item)" data-link-name=" | article | @index">@item.headline</a>
                 </div>
             </li>
         }

--- a/common/app/views/fragments/containers/facia_cards/navMediaListContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/navMediaListContainer.scala.html
@@ -16,7 +16,7 @@
                     @InlineImage.fromTrail(item).map { imageContainer =>
                         @image(imageContainer.imageContainer)
                     }
-                    <div class="fc-item__container">@item.headline</div>
+                    @item.headline
                 </a>
             </li>
         }

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -77,18 +77,6 @@ $fc-item-gutter: $gs-gutter / 4;
     @include mq(tablet) {
         .has-flex & {
             @include flex(1);
-            // see: http://stackoverflow.com/questions/7813783/firefox-and-flexbox-when-using-white-space-nowrap-on-child-element-the-flexib
-            // width:0 fixes child elements with white-space:nowrap below flex
-            width: 0;
-        }
-
-        // Temporary fix for the above! - for video most popular
-        .has-flex .most-viewed--media & {
-            width: 50%;
-
-            @include mq($until: desktop) {
-                width: 33.3%;
-            }
         }
 
         .has-flex-wrap & {
@@ -111,6 +99,9 @@ $fc-item-gutter: $gs-gutter / 4;
             @include flex-direction(column);
             @include flex-display;
             @include flex(1);
+            // see: http://stackoverflow.com/questions/7813783/firefox-and-flexbox-when-using-white-space-nowrap-on-child-element-the-flexib
+            // width:0 fixes child elements with white-space:nowrap below flex
+            width: 0;
         }
     }
 }

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -99,7 +99,7 @@ $fc-item-gutter: $gs-gutter / 4;
             @include flex-direction(column);
             @include flex-display;
             @include flex(1);
-            // see: http://stackoverflow.com/questions/7813783/firefox-and-flexbox-when-using-white-space-nowrap-on-child-element-the-flexib
+            // see: http://stackoverflow.com/a/9737602/802472
             // width:0 fixes child elements with white-space:nowrap below flex
             width: 0;
         }


### PR DESCRIPTION
`width: 0` fix for `white-space: nowrap` elements within flex layouts, that bust Firefox. ([Stack Overflow](http://stackoverflow.com/a/9737602/802472))

Browserstack: [/uk](http://www.browserstack.com/screenshots/5259a9eb4bca8c18e42ef0a54e78f878a57f0483), [/careers](http://www.browserstack.com/screenshots/8496f4257113c480178be5c9735ba07e068c7221), [/a-video-page](http://www.browserstack.com/screenshots/9290af373cc380ba2c28e01b0a79142ffcce21fa)

@sndrs 
