### PR TITLE
Update omniture.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -173,7 +173,7 @@ define([
         this.s.channel   = this.getChannel();
         this.s.prop4     = config.page.keywords || '';
         this.s.prop6     = config.page.author || '';
-        this.s.prop7     = config.page.webPublicationDate || '';
+        this.s.prop7     = config.page.webPublicationDate || '';  //BROKEN
         this.s.prop8     = config.page.pageCode || '';
         this.s.prop9     = config.page.contentType || '';
         this.s.prop10    = config.page.tones || '';


### PR DESCRIPTION
s.prop7 captures the web publication date.

  this.s.prop7     = config.page.webPublicationDate || '';

However the captured values are the moment are sending in the below so is broken.  Important variable for the data analysts.

1427891341000
1428940657000
1426243969000
1428922650000
1421948315000
1423151884000
1424814235000
