### PR TITLE
Liveblog fronts test: rename

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -576,7 +576,7 @@ object Switches {
 
   val ABLiveblogFrontUpdates = Switch("A/B Tests", "ab-liveblog-front-updates",
     "Switch for the latest liveblog updates on fronts A/B test.",
-    safeState = Off, sellByDate = new LocalDate(2015, 4, 23)
+    safeState = On, sellByDate = new LocalDate(2015, 4, 23)
   )
 
   val ABHeadlineSwitches = (1 to 10) map { n =>

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -576,7 +576,7 @@ object Switches {
 
   val ABLiveblogFrontUpdates = Switch("A/B Tests", "ab-liveblog-front-updates",
     "Switch for the latest liveblog updates on fronts A/B test.",
-    safeState = On, sellByDate = new LocalDate(2015, 4, 23)
+    safeState = Off, sellByDate = new LocalDate(2015, 4, 23)
   )
 
   val ABHeadlineSwitches = (1 to 10) map { n =>

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -576,7 +576,7 @@ object Switches {
 
   val ABLiveblogFrontUpdates = Switch("A/B Tests", "ab-liveblog-front-updates",
     "Switch for the latest liveblog updates on fronts A/B test.",
-    safeState = Off, sellByDate = new LocalDate(2015, 4, 23)
+    safeState = Off, sellByDate = new LocalDate(2015, 5, 21)
   )
 
   val ABHeadlineSwitches = (1 to 10) map { n =>

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -574,8 +574,8 @@ object Switches {
     safeState = Off, sellByDate = never
   )
 
-  val ABLiveblogBlocksOnFronts = Switch("A/B Tests", "ab-liveblog-blocks-on-fronts",
-    "Switch for the latest liveblog blocks on fronts A/B test.",
+  val ABLiveblogFrontUpdates = Switch("A/B Tests", "ab-liveblog-front-updates",
+    "Switch for the latest liveblog updates on fronts A/B test.",
     safeState = Off, sellByDate = new LocalDate(2015, 4, 23)
   )
 

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -11,7 +11,7 @@
 @import views.support.ImgSrc
 @import layout.{LatestSnap, FaciaWidths}
 @import Function.const
-@import conf.Switches.ABLiveblogBlocksOnFronts
+@import conf.Switches.ABLiveblogFrontUpdates
 
 <div class="@GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(!isList){js-snappable}"
     @if(item.discussionSettings.isCommentable) {
@@ -119,7 +119,7 @@ data-test-id="facia-card"
             }
         </div>
 
-        @if(ABLiveblogBlocksOnFronts.isSwitchedOn && item.isLive) {
+        @if(ABLiveblogFrontUpdates.isSwitchedOn && item.isLive) {
             <div class="js-liveblog-blocks" data-article-id="@item.id">
                 @item.trailText.filter(const(item.showStandfirst)).map { text =>
                     <div class="fc-item__standfirst">@Html(text)</div>

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -6,7 +6,7 @@ define([
     'common/utils/mediator',
     'common/utils/storage',
     'common/modules/analytics/mvt-cookie',
-    'common/modules/experiments/tests/liveblog-blocks-on-fronts',
+    'common/modules/experiments/tests/liveblog-front-updates',
     'common/modules/experiments/tests/high-commercial-component',
     'common/modules/experiments/tests/identity-social-oauth',
     'common/modules/experiments/tests/mt-master',
@@ -28,7 +28,7 @@ define([
     mediator,
     store,
     mvtCookie,
-    LiveblogBlocksOnFronts,
+    LiveblogFrontUpdates,
     HighCommercialComponent,
     IdentitySocialOAuth,
     MtMaster,
@@ -46,7 +46,7 @@ define([
 
     var ab,
         TESTS = _.flatten([
-            new LiveblogBlocksOnFronts(),
+            new LiveblogFrontUpdates(),
             new HighCommercialComponent(),
             new IdentitySocialOAuth(),
             new MtMaster(),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-front-updates.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-front-updates.js
@@ -9,7 +9,7 @@ define([
 ) {
 
     return function () {
-        this.id = 'LiveblogBlocksOnFronts';
+        this.id = 'LiveblogFrontUpdates';
         this.start = '2015-04-08';
         this.expiry = '2015-04-23';
         this.author = 'Stephan Fowler';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-front-updates.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/liveblog-front-updates.js
@@ -10,8 +10,8 @@ define([
 
     return function () {
         this.id = 'LiveblogFrontUpdates';
-        this.start = '2015-04-08';
-        this.expiry = '2015-04-23';
+        this.start = '2015-04-21';
+        this.expiry = '2015-05-21';
         this.author = 'Stephan Fowler';
         this.description = 'Checking effect of showing the latest liveblog blocks on fronts';
         this.audience = 0.3;


### PR DESCRIPTION
Because adding or renaming variants corrupts the historical data.
