### PR TITLE
Make sure the quote icon is always last

### DIFF
--- a/common/app/views/fragments/items/elements/facia_cards/title.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/title.scala.html
@@ -6,12 +6,11 @@
 @import views.support._
 
 @icon = {
-    @* TODO refactor to some kind of case match *@
-    @if(header.quoted) { @fragments.inlineSvg("quote", "icon") }
     @if(header.isExternal) { @fragments.inlineSvg("external-link", "icon") }
     @if(header.isVideo) { @fragments.inlineSvg("video-icon", "icon") }
     @if(header.isGallery) { @fragments.inlineSvg("camera", "icon") }
     @if(header.isAudio) { @fragments.inlineSvg("volume-high", "icon") }
+    @if(header.quoted) { @fragments.inlineSvg("quote", "icon") }
 }
 
 @headline() = {


### PR DESCRIPTION
The quote icon was being displayed before the video icon, which looked weird. I've made the quote icon the last to be considered so it should make sense regardless of any other icons chosen before it (I think).

And at last I've got a local version of the live fronts visible so I can see how they compare after this tweak (local on the left, live on the right);

![screen shot 2015-04-21 at 16 46 52](https://cloud.githubusercontent.com/assets/690395/7256234/ce001620-e845-11e4-8b5f-5e03f8b4ee37.png)
