### PR TITLE
Remove css3 mixins - pt3

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -80,7 +80,7 @@ $fc-item-gutter: $gs-gutter / 4;
         }
 
         .has-flex-wrap & {
-            @include flex-display;
+            display: flex;
         }
 
         .has-no-flex-wrap & {
@@ -97,7 +97,7 @@ $fc-item-gutter: $gs-gutter / 4;
     @include mq(tablet) {
         .has-flex-wrap & {
             @include flex-direction(column);
-            @include flex-display;
+            display: flex;
             flex: 1 1 auto;
             // see: http://stackoverflow.com/a/9737602/802472
             // width:0 fixes child elements with white-space:nowrap below flex

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -33,21 +33,21 @@ $fc-item-gutter: $gs-gutter / 4;
         }
 
         .fc-item__media-wrapper {
-            @include flex-basis($media-width);
+            flex-basis: $media-width;
         }
 
         .fc-item__video-fallback {
-            @include flex-basis($media-width);
+            flex-basis: $media-width;
         }
 
         .fc-item__content {
-            @include flex-basis(100% - $media-width);
+            flex-basis: (100% - $media-width);
             // DAMN YOU IE10/11 FLEXWRAP BOX SIZING BUG
-            max-width: 100% - $media-width;
+            max-width: (100% - $media-width);
         }
 
         .fc-item__footer--horizontal {
-            @include flex-basis(100%);
+            flex-basis: 100%;
         }
     }
 

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -76,7 +76,7 @@ $fc-item-gutter: $gs-gutter / 4;
 
     @include mq(tablet) {
         .has-flex & {
-            @include flex(1);
+            flex: 1 1 auto;
         }
 
         .has-flex-wrap & {
@@ -98,7 +98,7 @@ $fc-item-gutter: $gs-gutter / 4;
         .has-flex-wrap & {
             @include flex-direction(column);
             @include flex-display;
-            @include flex(1);
+            flex: 1 1 auto;
             // see: http://stackoverflow.com/a/9737602/802472
             // width:0 fixes child elements with white-space:nowrap below flex
             width: 0;

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -29,7 +29,7 @@
 
     @include mq(tablet) {
         .has-flex & {
-            @include flex-display;
+            display: flex;
         }
     }
 

--- a/static/src/stylesheets/module/facia/_l-list.scss
+++ b/static/src/stylesheets/module/facia/_l-list.scss
@@ -28,7 +28,7 @@
                     float: left;
 
                     .has-flex & {
-                        @include flex($span);
+                        flex: $span 1 auto;
                     }
                 }
             }

--- a/static/src/stylesheets/module/facia/_l-list.scss
+++ b/static/src/stylesheets/module/facia/_l-list.scss
@@ -3,7 +3,7 @@
 
     @include mq(tablet) {
         .has-flex-wrap & {
-            @include flex-display;
+            display: flex;
             @include flex-wrap(wrap);
         }
     }

--- a/static/src/stylesheets/module/facia/_l-list.scss
+++ b/static/src/stylesheets/module/facia/_l-list.scss
@@ -14,7 +14,7 @@
 
     .has-flex-wrap & {
         @include flex-grow(0);
-        @include flex-basis(100%);
+        flex-basis: 100%;
     }
 }
 
@@ -55,7 +55,7 @@
                 }
 
                 .has-flex-wrap & {
-                    @include flex-basis(100% / $column);
+                    flex-basis: (100% / $column);
                 }
             }
         }

--- a/static/src/stylesheets/module/facia/_linkslist.scss
+++ b/static/src/stylesheets/module/facia/_linkslist.scss
@@ -81,11 +81,11 @@
         .fc-slice__item {
             @include mq(tablet) {
                 @include flex-grow(0);
-                @include flex-basis(50%);
+                flex-basis: 50%;
             }
 
             @include mq(desktop) {
-                @include flex-basis(100% / 3);
+                flex-basis: (100% / 3);
             }
         }
     }

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -142,7 +142,7 @@ Hence why a greater depth of selector specificity is needed.
             }
 
             &:first-child {
-                @include flex(1);
+                flex: 1 1 auto;
                 width: 50%;
 
                 .fc-slice__item {
@@ -181,7 +181,7 @@ Hence why a greater depth of selector specificity is needed.
             width: 25% !important;
 
             &:last-child {
-                @include flex(2);
+                flex: 2 1 auto;
                 width: 50% !important;
             }
         }

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -146,7 +146,7 @@ Hence why a greater depth of selector specificity is needed.
                 width: 50%;
 
                 .fc-slice__item {
-                    @include flex-basis(100%);
+                    flex-basis: 100%;
                 }
                 .fc-slice__item:nth-child(5) {
                     padding-bottom: $gs-baseline;

--- a/static/src/stylesheets/module/facia/_sublinks.scss
+++ b/static/src/stylesheets/module/facia/_sublinks.scss
@@ -39,7 +39,7 @@
             @include flex-display;
         }
         .fc-sublink {
-            @include flex(1, 1, 100%);
+            flex: 1 1 100%;
 
             & + * {
                 margin-left: $gs-gutter;

--- a/static/src/stylesheets/module/facia/_sublinks.scss
+++ b/static/src/stylesheets/module/facia/_sublinks.scss
@@ -36,7 +36,7 @@
 @mixin fc-sublinks--horizontal {
     .has-flex-wrap & {
         .fc-sublinks {
-            @include flex-display;
+            display: flex;
         }
         .fc-sublink {
             flex: 1 1 100%;

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-100.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-100.scss
@@ -85,6 +85,6 @@ x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x
     }
 
     .fc-item__footer--horizontal {
-        @include flex-basis(auto);
+        flex-basis: auto;
     }
 }

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-50.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-50.scss
@@ -72,7 +72,7 @@ Full item with 50% width media.
             }
 
             .has-flex-wrap & {
-                @include flex-basis(auto);
+                flex-basis: auto;
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-75.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-75.scss
@@ -73,7 +73,7 @@ Full item with 75% width media.
             }
 
             .has-flex-wrap & {
-                @include flex-basis(auto);
+                flex-basis: auto;
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--half.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--half.scss
@@ -102,7 +102,7 @@ x x x x x x x x x x x x x x x x x x
     }
 
     .fc-item__footer--horizontal {
-        @include flex-basis(auto);
+        flex-basis: auto;
     }
 
     .vjs-big-play-button > span {

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--half.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--half.scss
@@ -92,7 +92,7 @@ x x x x x x x x x x x x x x x x x x
 
         .has-flex-wrap &.fc-item--has-cutout {
             .fc-item__content {
-                @include flex(0);
+                flex: 0 1 auto;
             }
         }
     }

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
@@ -77,7 +77,7 @@ Three quarter item. Looks like a wide standard, a bit like this:
             }
 
             .has-flex-wrap & {
-                @include flex-basis(auto);
+                flex-basis: auto;
             }
         }
     }


### PR DESCRIPTION
only diff from master after compilation is reversing some prefixed attributes:

``` css
display: -ms-flexbox;
display: -webkit-flex;
```

becomes

``` css
display: -webkit-flex;
display: -ms-flexbox;
```
