### PR TITLE
Remove dedupe exceptions

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -278,9 +278,6 @@ object Front extends implicits.Collections {
   def itemsVisible(containerDefinition: ContainerDefinition) =
     containerDefinition.slices.flatMap(_.layout.columns.map(_.numItems)).sum
 
-  // Never de-duplicate snaps.
-  def participatesInDeduplication(trail: Trail) = !trail.snapType.isDefined
-
   /** Given a set of already seen trail URLs, a container type, and a set of trails, returns a new set of seen urls
     * for further de-duplication and the sequence of trails in the order that they ought to be shown for that
     * container.
@@ -314,9 +311,9 @@ object Front extends implicits.Collections {
         /** Fixed Containers participate in de-duplication.
           */
         val nToTake = itemsVisible(containerDefinition)
-        val notUsed = trails.filter(trail => !seen.contains(trail.url) || !participatesInDeduplication(trail))
+        val notUsed = trails.filter(trail => !seen.contains(trail.url))
           .distinctBy(_.url)
-        (seen ++ notUsed.take(nToTake).filter(participatesInDeduplication).map(_.url), notUsed)
+        (seen ++ notUsed.take(nToTake).map(_.url), notUsed)
 
       case _ =>
         /** Nav lists and most popular do not participate in de-duplication at all */

--- a/common/test/layout/FrontTest.scala
+++ b/common/test/layout/FrontTest.scala
@@ -149,33 +149,4 @@ class FrontTest extends FlatSpec with Matchers {
 
     nowSeen shouldEqual Set("one", "two")
   }
-
-  it should "not deduplicate dream snaps" in {
-    val (_, dedupedTrails) = Front.deduplicate(Set("one", "two"), Fixed(FixedContainers.fixedMediumFastXI), Seq(
-      dreamSnapWithUrl("one")
-    ))
-
-    dedupedTrails.map(_.webUrl) shouldEqual Seq("one")
-  }
-
-  it should "not skip dream snaps when considering items visible to be added to the set of seen urls" in {
-    val (nowSeen, _) = Front.deduplicate(Set.empty, Fixed(FixedContainers.fixedSmallSlowIV), Seq(
-      dreamSnapWithUrl("one"),
-      dreamSnapWithUrl("two"),
-      trailWithUrl("three"),
-      trailWithUrl("four"),
-      trailWithUrl("five"),
-      trailWithUrl("six")
-    ))
-
-    nowSeen shouldEqual Set("three", "four")
-  }
-
-  it should "not include dream snaps in the seen urls" in {
-    val (nowSeen, _) = Front.deduplicate(Set.empty, Fixed(FixedContainers.fixedMediumFastXI), Seq(
-      dreamSnapWithUrl("one")
-    ))
-
-    nowSeen shouldEqual Set()
-  }
 }


### PR DESCRIPTION
Snap were exempt from de-duping. The current fashion to NOT exempt them. Fashion changes, of course.   
