### PR TITLE
Stop Refreshing Ads After Displaying Them

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -323,6 +323,10 @@ object Switches {
     "If this switch is on, Apple ads will appear below nav on the tech section front.",
     safeState = Off, sellByDate = new LocalDate(2015, 5, 6))
 
+  val RefreshAdsAfterDisplaySwitch = Switch("Commercial", "refresh-ads-after-display",
+    "If this switch is on, ads will be refreshed after they display.",
+    safeState = On, sellByDate = new LocalDate(2015, 5, 6))
+
 
   // Monitoring
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -248,7 +248,11 @@ define([
                         slot: defineSlot($adSlot)
                     };
                     googletag.display(slotId);
-                    refreshSlot($adSlot);
+
+                    if (config.switches.refreshAdsAfterDisplay) {
+                        refreshSlot($adSlot);
+                    }
+
                 };
             if (displayed && !slots[slotId]) { // dynamically add ad slot
                 // this is horrible, but if we do this before the initial ads have loaded things go awry


### PR DESCRIPTION
We are refreshing ads immediately after they are displayed.  This seems to cause intermittent errors in some slots where multiple ads appear.

It also seems completely pointless, but wrapping it in a switch in case it turns out not to be pointless at all.  I don't see any problems locally.

@Calanthe @kenlim 
