### PR TITLE
Add Another Ad-Counting Beacon

### DIFF
--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -22,6 +22,7 @@ object Metric extends Logging {
     ("ads-blocked", CountMetric("ads-blocked")),
     ("ad-render", CountMetric("first-ad-rendered")),
     ("ad-render-article", CountMetric("first-ad-rendered-article")),
+    ("ad-wrapper", CountMetric("first-ad-rendered-dfp")),
 
     // error pages
     ("50x", CountMetric("kpis-user-50x")),             // beacon on the 50x page that tells us that real users are getting 500 errors

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -22,7 +22,7 @@ object Metric extends Logging {
     ("ads-blocked", CountMetric("ads-blocked")),
     ("ad-render", CountMetric("first-ad-rendered")),
     ("ad-render-article", CountMetric("first-ad-rendered-article")),
-    ("ad-wrapper", CountMetric("first-ad-rendered-dfp")),
+    ("ad-wrapper", CountMetric("dfp-served-ad")),
 
     // error pages
     ("50x", CountMetric("kpis-user-50x")),             // beacon on the 50x page that tells us that real users are getting 500 errors


### PR DESCRIPTION
This one uses a DFP creative wrapper so it's potentially a more accurate count.
