### PR TITLE
Remove css3 mixins - pt5

### DIFF
--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -237,13 +237,6 @@
     @include absolute-center;
 }
 
-@mixin input-placeholder {
-    &::-webkit-input-placeholder { @content; }
-    &:-moz-placeholder { @content; }
-    &::-moz-placeholder { @content; }
-    &:-ms-input-placeholder { @content; }
-}
-
 // convert a given width to one available in _vars.scss if it's within the tolerance
 @function normalize-width($width) {
     $tolerance: 10px;

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -26,8 +26,6 @@
         $to: transparentize($from, 1);
     }
     background-color: $from;
-    background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from($from), to($to));
-    background-image: -webkit-linear-gradient($from, $to);
     background-image: linear-gradient(to bottom, $from, $to);
 }
 

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -15,12 +15,6 @@
 // CSS helpers
 // =============================================================================
 
-// Transparent background with fallback for older browsers
-@mixin transparent-background($color, $opacity) {
-    background-color: $color;
-    background-color: rgba($color, $opacity);
-}
-
 // Vertical linear gradient with a plain fallback for older browsers
 @mixin simple-gradient($from, $to) {
     // Fix for browsers not understanding transparent
@@ -176,27 +170,6 @@
     width: $size;
     height: $size;
     font-size: $size/6 // play triangle is em based so this scales it;
-}
-
-@mixin align-items--start {
-    -webkit-box-align: start;
-    -webkit-align-items: flex-start;
-    -ms-flex-align: start;
-    align-items: flex-start;
-}
-
-@mixin align-items--end {
-    -webkit-box-align: end;
-    -webkit-align-items: flex-end;
-    -ms-flex-align: end;
-    align-items: flex-end;
-}
-
-@mixin align-items--stretch {
-    -webkit-box-align: stretch;
-    -webkit-align-items: stretch;
-    -ms-flex-align: stretch;
-    align-items: stretch;
 }
 
 // note that if using this in a media query, the fallback needs to

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -178,31 +178,6 @@
     font-size: $size/6 // play triangle is em based so this scales it;
 }
 
-@mixin transition-duration($duration: 1s) {
-    -webkit-transition-duration: $duration;
-    transition-duration: $duration;
-}
-
-@mixin display-flex {
-    display: -webkit-box;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: -webkit-flex;
-    display: flex;
-}
-
-@mixin flex-wrap($wrap) {
-    -webkit-flex-wrap: $wrap;
-    -ms-flex-wrap: $wrap;
-    flex-wrap: $wrap;
-}
-
-@mixin flex-direction($direction) {
-    -webkit-flex-direction: $direction;
-    -ms-flex-direction: $direction;
-    flex-direction: $direction;
-}
-
 @mixin align-items--start {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
@@ -228,12 +203,7 @@
 // be windowed between breakpoints, because the nth-child is not reset
 @mixin columns($cols: 1, $gap: 0, $rule: false) {
     @if $browser-supports-columns {
-        -webkit-column-count: $cols;
-        -moz-column-count: $cols;
         column-count: $cols;
-
-        -webkit-column-gap: $gap;
-        -moz-column-gap: $gap;
         column-gap: $gap;
 
         @if $rule {
@@ -258,8 +228,6 @@
 }
 
 @mixin column-rule($style: 1px solid colour(neutral-5)) {
-    -webkit-column-rule: $style;
-    -moz-column-rule: $style;
     column-rule: $style;
 }
 

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -145,9 +145,6 @@
 
 .u-text-hyphenate {
     word-wrap: break-word;
-    -webkit-hyphens: auto;
-    -moz-hyphens: auto;
-    -ms-hyphens: auto;
     hyphens: auto;
 }
 

--- a/static/src/stylesheets/base/_helpers.scss
+++ b/static/src/stylesheets/base/_helpers.scss
@@ -182,7 +182,7 @@
 %u-underline {
     text-decoration: none !important;
     border-bottom: 1px solid colour(neutral-4);
-    @include transition(border-color .15s ease-out);
+    transition: border-color .15s ease-out;
 
     &:hover,
     &:focus {

--- a/static/src/stylesheets/base/_type.scss
+++ b/static/src/stylesheets/base/_type.scss
@@ -20,12 +20,8 @@ body {
 html,
 body {
     text-rendering: optimizeLegibility; // optional: for older browsers
-    -moz-font-feature-settings: 'kern=1'; // pre-Firefox 14+
-    -webkit-font-feature-settings: 'kern';
-    -moz-font-feature-settings: 'kern'; // Firefox 14+
     font-feature-settings: 'kern';
     font-kerning: normal; // Safari 7+, Firefox 24+, Chrome 33(?)+, Opera 21
-    -webkit-font-variant-ligatures: common-ligatures; // for iOS and Safari 6
     font-variant-ligatures: common-ligatures;
 }
 

--- a/static/src/stylesheets/layout/_side-margins.scss
+++ b/static/src/stylesheets/layout/_side-margins.scss
@@ -9,7 +9,6 @@
 @mixin side-margins-position($container-width) {
     &:before,
     &:after {
-        width: -webkit-calc((100% - #{rem($container-width + $gs-gutter * 2)}) / 2);
         width: calc((100% - #{rem($container-width + $gs-gutter * 2)}) / 2);
     }
 }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -83,7 +83,7 @@
     iframe {
         -webkit-transform: translateZ(0);
         transform: translateZ(0);
-        @include transition(height 1s cubic-bezier(0, 0, 0, .985));
+        transition: height 1s cubic-bezier(0, 0, 0, .985);
     }
 }
 .top-banner-ad-container--above-nav {
@@ -584,7 +584,7 @@
             height: 108px;
             -webkit-transform: translateZ(0);
             transform: translateZ(0);
-            @include transition(height 1s cubic-bezier(0, 0, 0, .985));
+            transition: height 1s cubic-bezier(0, 0, 0, .985);
 
             &.ad--responsive--open {
                 height: 250px;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -81,7 +81,6 @@
         }
     }
     iframe {
-        -webkit-transform: translateZ(0);
         transform: translateZ(0);
         transition: height 1s cubic-bezier(0, 0, 0, .985);
     }
@@ -582,7 +581,6 @@
     .ad--responsive {
         @include mq(tablet) {
             height: 108px;
-            -webkit-transform: translateZ(0);
             transform: translateZ(0);
             transition: height 1s cubic-bezier(0, 0, 0, .985);
 

--- a/static/src/stylesheets/module/_discussion-mixins.scss
+++ b/static/src/stylesheets/module/_discussion-mixins.scss
@@ -33,7 +33,5 @@
 }
 
 @mixin d-white-fade {
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, rgba(255, 255, 255, 0)), color-stop(80%, rgba(255, 255, 255, 1)), color-stop(100%, rgba(255, 255, 255, 1)));
-    background: -webkit-linear-gradient(top, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 80%, rgba(255, 255, 255, 1) 100%);
     background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 80%, rgba(255, 255, 255, 1) 100%);
 }

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -1185,16 +1185,12 @@ $comment-recommend-button-size: 19px;
     background: transparent;
     position: relative;
     z-index: 2;
-    .d-comment-box--top-level & {
-        @include input-placeholder {
-            color: colour(neutral-1);
-            font-weight: bold;
-        }
+    .d-comment-box--top-level &::placeholder {
+        color: colour(neutral-1);
+        font-weight: bold;
     }
-    .d-comment-box--top-level.d-comment-box--expanded & {
-        @include input-placeholder {
-            color: #ffffff;
-        }
+    .d-comment-box--top-level.d-comment-box--expanded &::placeholder {
+        color: #ffffff;
     }
     .discussion__comment-box--bottom & {
         margin-top: 0;

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -774,7 +774,7 @@ $comment-recommend-button-size: 19px;
 .d-comment__recommend--recommended {
     .d-comment__recommend-button,
     .d-comment__recommend-pulse {
-        @include transition(background-color .25s ease-in-out);
+        transition: background-color .25s ease-in-out;
         background-color: colour(news-main-2);
     }
     .d-comment__recommend-pulse {
@@ -789,7 +789,7 @@ $comment-recommend-button-size: 19px;
     .d-comment__recommend-count--old,
     .d-comment__recommend-count--new {
         top: -1 * $comment-recommend-button-size;
-        @include transition(top .15s .15s ease-in-out);
+        transition: top .15s .15s ease-in-out;
     }
 }
 

--- a/static/src/stylesheets/module/_headline-list.scss
+++ b/static/src/stylesheets/module/_headline-list.scss
@@ -100,8 +100,6 @@
     .headline-column {
         min-height: gs-height(11) - $gs-baseline;
         max-height: gs-height(12) - $gs-baseline;
-        -webkit-column-fill: auto;
-        -moz-column-fill: auto;
         column-fill: auto;
     }
 

--- a/static/src/stylesheets/module/_layout-hints.scss
+++ b/static/src/stylesheets/module/_layout-hints.scss
@@ -183,7 +183,7 @@ figure {
     }
 
     .u-responsive-ratio--letterbox {
-        @include transition(padding-bottom 1s);
+        transition: padding-bottom 1s;
 
         @include mq($until: desktop) {
             padding-bottom: aspect-ratio-height(5, 3);

--- a/static/src/stylesheets/module/_rich-links.scss
+++ b/static/src/stylesheets/module/_rich-links.scss
@@ -74,11 +74,11 @@
 }
 
 .rich-link__image-container {
-    @include transition(background-color .25s ease);
+    transition: background-color .25s ease;
     background-color: rgba(0, 0, 0, .1);
 
     .responsive-img {
-        @include transition(opacity .25s ease);
+        transition: opacity .25s ease;
     }
 }
 

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -198,7 +198,7 @@ category: Common
     padding-top: $gs-baseline / 3;
     opacity: 0;
     visibility: hidden;
-    @include transition(opacity .15s ease);
+    transition: opacity .15s ease;
 
     .social__item {
         padding: 0 $gs-gutter / 10;
@@ -221,7 +221,7 @@ category: Common
     width: 100%;
     opacity: 0;
     z-index: 10;
-    @include transition(bottom .4s ease);
+    transition: bottom .4s ease;
 }
 
 .social-fixed__item {

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -233,7 +233,7 @@
         height: 0;
         position: relative;
         overflow: hidden;
-        @include transition(height 1s);
+        transition: height 1s;
     }
     .ad-exp--expand .facia-container__inner {
         height: 100%;
@@ -258,7 +258,7 @@
         height: 32px;
         width: 32px;
         transform: rotate(45deg);
-        @include transition(all 1s ease);
+        transition: all 1s ease;
 
         @include mq(tablet) {
             right: $gs-gutter;
@@ -308,7 +308,7 @@
         @include border-radius($gs-gutter $gs-gutter 0 0);
 
         .inline-arrow-down {
-            @include transition(all 1s ease);
+            transition: all 1s ease;
             display: block;
             margin: -2px auto 2px;
         }

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -230,7 +230,7 @@
     }
 
     .block-share__item {
-        @include transition(opacity .15s linear);
+        transition: opacity .15s linear;
     }
 
     .block-share__item--facebook {

--- a/static/src/stylesheets/module/content/_gallery-lightbox.scss
+++ b/static/src/stylesheets/module/content/_gallery-lightbox.scss
@@ -70,11 +70,6 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
     margin: 0;
     white-space: nowrap;
     transition: transform 20ms;
-    -webkit-transition-property: -webkit-transform;
-    -moz-transition-property: -moz-transform;
-    transition-property: -webkit-transform;
-    transition-property: -moz-transform;
-    transition-property: transform;
 }
 
 .gallery-lightbox__swipe-container {

--- a/static/src/stylesheets/module/content/_gallery-lightbox.scss
+++ b/static/src/stylesheets/module/content/_gallery-lightbox.scss
@@ -69,7 +69,7 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
     box-sizing: border-box;
     margin: 0;
     white-space: nowrap;
-    @include transition(transform 20ms);
+    transition: transform 20ms;
     -webkit-transition-property: -webkit-transform;
     -moz-transition-property: -moz-transform;
     transition-property: -webkit-transform;
@@ -101,7 +101,7 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
 }
 
 .gallery-lightbox__item--img {
-    @include transition(padding-right .1s ease-in);
+    transition: padding-right .1s ease-in;
 }
 
 .gallery-lightbox__item--endslate {
@@ -175,7 +175,7 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
         padding-top: gs-height(2) + $gs-baseline - 2px;
         padding-right: $gs-gutter*2;
         padding-left: $gs-gutter;
-        @include transition(right .1s ease-in, opacity .1s ease-in);
+        transition: right .1s ease-in, opacity .1s ease-in;
         background-color: colour(media-background);
         right: (-1 * $gallery-lightbox-info-width-desktop) + $gallery-lightbox-sidebar-width;
         width: $gallery-lightbox-info-width-desktop;
@@ -279,14 +279,14 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
     outline: none;
     text-indent: -9999px;
 
-    @include transition(background-color .2s);
+    transition: background-color .2s;
     &:focus {
         background-color: lighten($c-gallery-lightbox-btn, 8%);
     }
 }
 
 .gallery-lightbox--hover .gallery-lightbox__btn:hover .gallery-lightbox__btn-body {
-    @include transition(none);
+    transition: none;
     background: $c-gallery-lightbox-btn--active;
 }
 
@@ -322,13 +322,13 @@ $gallery-lightbox-sidebar-breakpoint: desktop;
         }
     }
     .gallery-lightbox__btn--close-hitbox:hover & {
-        @include transition(none);
+        transition: none;
         background: $c-gallery-lightbox-btn--active;
     }
 }
 
 .gallery-lightbox__button-pulse .gallery-lightbox__btn-body {
-    @include transition(none);
+    transition: none;
     background-color: $c-gallery-lightbox-btn--active;
 }
 

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -201,7 +201,7 @@ $ima-controls-height: 70px;
     @include fs-textSans(1);
     font-weight: bold;
     height: $vjs-control-height;
-    @include transition(bottom .8s);
+    transition: bottom .8s;
     transition-delay: 1s;
 }
 
@@ -218,7 +218,7 @@ $ima-controls-height: 70px;
     .vjs-paused.vjs-has-started &,
     &:hover {
         bottom: 0;
-        @include transition(bottom 0s);
+        transition: bottom 0s;
         transition-delay: 0s;
     }
 
@@ -573,13 +573,13 @@ $ima-controls-height: 70px;
     padding: $gs-baseline/2;
     top: ($height + $gs-baseline) * -1;
     left: 0;
-    @include transition(top .8s);
+    transition: top .8s;
     transition-delay: .2s;
 
     .gu-media-wrapper:hover &,
     .vjs-paused & {
         top: 0;
-        @include transition(top 0s);
+        transition: top 0s;
         transition-delay: 0s;
     }
 }
@@ -696,7 +696,7 @@ $ima-controls-height: 70px;
     padding: $gs-baseline/2 $gs-gutter/2;
     @include fs-textSans(3);
     font-weight: bold;
-    @include transition(top .8s);
+    transition: top .8s;
     transition-delay: 1s;
     left: 0;
     top: $gs-baseline*-4;
@@ -706,7 +706,7 @@ $ima-controls-height: 70px;
     .vjs-paused &,
     &:hover {
         top: 0;
-        @include transition(top 0s);
+        transition: top 0s;
         transition-delay: 0s;
     }
 
@@ -986,7 +986,7 @@ $ima-controls-height: 70px;
     .vjs-mousemoved &,
     &:hover {
         bottom: 0;
-        @include transition(bottom 0s);
+        transition: bottom 0s;
         transition-delay: 0s;
     }
 }

--- a/static/src/stylesheets/module/crosswords/_grid.scss
+++ b/static/src/stylesheets/module/crosswords/_grid.scss
@@ -36,7 +36,7 @@
     -webkit-font-smoothing: subpixel-antialiased;
     fill: #3f4ac3; // biro blue
 
-    @include transition(opacity .15s ease-in);
+    transition: opacity .15s ease-in;
 }
 
 .crossword__cell-text--error {

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -375,7 +375,7 @@ $header-image-size-desktop: 100px;
     padding-top: $gs-baseline/2;
     padding-bottom: $gs-baseline;
     opacity: 1;
-    @include transition(opacity .25s linear); // Used to fade-in new updates
+    transition: opacity .25s linear; // Used to fade-in new updates
 
     @include mq(tablet) {
         padding-top: $gs-baseline / 4;
@@ -408,7 +408,7 @@ $header-image-size-desktop: 100px;
 
 .fc-container__body--is-hidden {
     opacity: 0;
-    @include transition(opacity .25s linear); // Used to fade-in new updates
+    transition: opacity .25s linear; // Used to fade-in new updates
 }
 
 .fc-container__toggle {

--- a/static/src/stylesheets/module/facia/_facia-show-more.scss
+++ b/static/src/stylesheets/module/facia/_facia-show-more.scss
@@ -14,7 +14,7 @@
 
 .show-more__error-message {
     @include fs-textSans(3);
-    @include transition(opacity 1.5s);
+    transition: opacity 1.5s;
     color: colour(status-negative);
     display: inline-block;
     padding-top: $gs-baseline / 2;

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -24,7 +24,7 @@ $fc-item-gutter: $gs-gutter / 4;
 
     .has-flex-wrap & {
         .fc-item__container {
-            @include flex-wrap(wrap);
+            flex-wrap: wrap;
             @if $media-align == right {
                 @include flex-direction(row-reverse);
             } @else {

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -26,9 +26,9 @@ $fc-item-gutter: $gs-gutter / 4;
         .fc-item__container {
             flex-wrap: wrap;
             @if $media-align == right {
-                @include flex-direction(row-reverse);
+                flex-direction: row-reverse;
             } @else {
-                @include flex-direction(row);
+                flex-direction: row;
             }
         }
 
@@ -96,7 +96,7 @@ $fc-item-gutter: $gs-gutter / 4;
 
     @include mq(tablet) {
         .has-flex-wrap & {
-            @include flex-direction(column);
+            flex-direction: column;
             display: flex;
             flex: 1 1 auto;
             // see: http://stackoverflow.com/a/9737602/802472

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -271,7 +271,7 @@
 
         .has-flex-wrap & {
             .fc-item__container {
-                @include flex-direction(row);
+                flex-direction: row;
             }
         }
 

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -52,10 +52,6 @@
     }
 }
 .fc-slice__item--no-mpu {
-    -webkit-box-flex: 0 !important;
-    -moz-box-flex: 0 !important;
-    -webkit-flex: 0 !important;
-    -ms-flex: 0 !important;
     flex: 0 !important;
 }
 

--- a/static/src/stylesheets/module/facia/_l-list.scss
+++ b/static/src/stylesheets/module/facia/_l-list.scss
@@ -13,7 +13,7 @@
     float: left;
 
     .has-flex-wrap & {
-        @include flex-grow(0);
+        flex-grow: 0;
         flex-basis: 100%;
     }
 }

--- a/static/src/stylesheets/module/facia/_l-list.scss
+++ b/static/src/stylesheets/module/facia/_l-list.scss
@@ -4,7 +4,7 @@
     @include mq(tablet) {
         .has-flex-wrap & {
             display: flex;
-            @include flex-wrap(wrap);
+            flex-wrap: wrap;
         }
     }
 }

--- a/static/src/stylesheets/module/facia/_linkslist.scss
+++ b/static/src/stylesheets/module/facia/_linkslist.scss
@@ -80,7 +80,7 @@
     .has-flex-wrap & {
         .fc-slice__item {
             @include mq(tablet) {
-                @include flex-grow(0);
+                flex-grow: 0;
                 flex-basis: 50%;
             }
 

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -16,7 +16,7 @@ Hence why a greater depth of selector specificity is needed.
 */
 .fc-slice--hl4-h {
     .has-flex & {
-        @include flex-direction(row-reverse);
+        flex-direction: row-reverse;
 
         .fc-slice__item:before {
             display: none;
@@ -108,7 +108,7 @@ Hence why a greater depth of selector specificity is needed.
 
 .fc-slice--h14-q-q {
     .has-flex & {
-        @include flex-direction(row-reverse);
+        flex-direction: row-reverse;
 
         .fc-slice__item:before {
             display: none;

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-50.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-50.scss
@@ -59,7 +59,7 @@ Full item with 50% width media.
             min-height: gs-height(5) + $gs-baseline * 3;
 
             .has-flex-wrap & {
-                @include flex-direction(row);
+                flex-direction: row;
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-75.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--full-media-75.scss
@@ -60,7 +60,7 @@ Full item with 75% width media.
             min-height: gs-height(5) + $gs-baseline * 3;
 
             .has-flex-wrap & {
-                @include flex-direction(row);
+                flex-direction: row;
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters-right.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters-right.scss
@@ -26,7 +26,7 @@ Three quarter item. Looks like a wide standard, a bit like this:
 
     .has-flex-wrap & {
         .fc-item__container {
-            @include flex-direction(row);
+            flex-direction: row;
         }
     }
 

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
@@ -59,7 +59,7 @@ Three quarter item. Looks like a wide standard, a bit like this:
             min-height: gs-height(7);
 
             .has-flex-wrap & {
-                @include flex-direction(row);
+                flex-direction: row;
             }
         }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -94,9 +94,6 @@
 
 .fc-item__liveblog-blocks__inner,
 .fc-item__liveblog-message__inner {
-    -webkit-transition: -webkit-transform .5s ease-in-out;
-    -moz-transition: -moz-transform .5s ease-in-out;
-    -o-transition: -o-transform .5s ease-in-out;
     transition: transform .5s ease-in-out;
 }
 

--- a/static/src/stylesheets/module/identity/_activity-stream.scss
+++ b/static/src/stylesheets/module/identity/_activity-stream.scss
@@ -165,7 +165,7 @@
 }
 .activity-stream__witness-content:hover {
     background: colour(neutral-6);
-    @include transition(.3s all);
+    transition: .3s all;
 }
 .activity-stream__witness-text {
     display: block;

--- a/static/src/stylesheets/module/nav/_brand-bar.scss
+++ b/static/src/stylesheets/module/nav/_brand-bar.scss
@@ -18,9 +18,6 @@
 // to context matching).
 
 .brand-bar__item {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
     @include fs-bodyHeading(1);
     float: left;

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -69,8 +69,6 @@ $c-navigation-expandable-background: colour(neutral-1);
     &:before {
         background: $c-navigation-background-side-bar;
         border-bottom: 1px solid $c-global-navigation-border;
-        -moz-background-clip: padding-box;
-        -webkit-background-clip: padding-box;
         background-clip: padding-box;
 
         .l-header--is-slim & {
@@ -689,8 +687,6 @@ $c-navigation-expandable-background: colour(neutral-1);
     line-height: $navigation-height;
     padding: 0 $gs-gutter / 2;
     background: $c-navigation-toggle-background;
-    -moz-background-clip: padding-box;
-    -webkit-background-clip: padding-box;
     background-clip: padding-box;
     text-align: left;
     // TODO: Why is this needed?

--- a/static/src/stylesheets/module/onward/_breaking-news.scss
+++ b/static/src/stylesheets/module/onward/_breaking-news.scss
@@ -34,7 +34,7 @@ $breaking-news-close-icon-width: 32px;
 }
 
 .breaking-news--fade-in {
-    @include transition(all .5s ease);
+    transition: all .5s ease;
 }
 
 .breaking-news--hidden {
@@ -46,7 +46,7 @@ $breaking-news-close-icon-width: 32px;
     display: block;
     padding: 0 0 $gs-baseline;
     background: fade-out(colour(live-default), 1 - .95);
-    @include transition(background-color .25s ease);
+    transition: background-color .25s ease;
 
     &:hover {
         background-color: darken(colour(live-default), 2%);
@@ -120,7 +120,7 @@ $breaking-news-close-icon-width: 32px;
     opacity: 1;
     z-index: 1;
     box-shadow: none;
-    @include transition(none);
+    transition: none;
 
     .breaking-news__items {
         visibility: hidden;


### PR DESCRIPTION
Final removal of mixin use for prefixes. Includes tidy up of our `_mixins.scss`, including removing unused mixins, and inlined prefixes too.

diffs with master css:
- no leading zeros
- removal of outdated prefixes e.g. `:-moz-placeholder`
- autoprefixer has a different prefix order in come cases, which seem better, e.g.

```
        -webkit-box-orient: horizontal;
        -webkit-box-direction: reverse;
        -webkit-flex-direction: row-reverse;
        -ms-flex-direction: row-reverse;
        flex-direction: row-reverse
```

instead of

```
        -webkit-flex-direction: row-reverse;
        -ms-flex-direction: row-reverse;
        -webkit-box-orient: horizontal;
        -webkit-box-direction: reverse;
        flex-direction: row-reverse
```
