### PR TITLE
Remove css3 border radius mixin

### DIFF
--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -22,7 +22,7 @@
 }
 
 @mixin circular {
-    border-radius: 1000px;
+    border-radius: 1000px; // Android 2.3 cannot deal with '50%'
 }
 
 // Vertical linear gradient with a plain fallback for older browsers

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -21,6 +21,10 @@
     background-color: rgba($color, $opacity);
 }
 
+@mixin circular {
+    border-radius: 1000px;
+}
+
 // Vertical linear gradient with a plain fallback for older browsers
 @mixin simple-gradient($from, $to) {
     // Fix for browsers not understanding transparent

--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -58,7 +58,7 @@
     &:before {
         display: inline-block;
         content: '';
-        @include border-radius(6px);
+        border-radius: 6px;
         height: 12px;
         width: 12px;
         margin-right: $right-space;
@@ -145,7 +145,7 @@
     cursor: pointer;
     width: $buttonSize;
     height: $buttonSize;
-    @include border-radius($buttonSize);
+    border-radius: $buttonSize;
     position: relative;
     display: block;
 

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -733,7 +733,7 @@ $comment-recommend-button-size: 19px;
     left: 0;
     width: $comment-recommend-button-size;
     height: $comment-recommend-button-size;
-    @include border-radius(18px);
+    border-radius: 18px;
     background-color: colour(neutral-7);
 }
 .d-comment__recommend-count {

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -404,7 +404,7 @@ $avatarPadding: $gs-gutter / 2;
 
 .d-comment__avatar,
 .user-avatar__image {
-    @include border-radius(50%);
+    @include circular;
 }
 
 .d-comment__meta-text,
@@ -1088,7 +1088,7 @@ $comment-recommend-button-size: 19px;
     @include fs-textSans(2, true);
 }
 .person__avatar {
-    @include border-radius(50%);
+    @include circular;
     overflow: hidden;
     float: left;
     height: 36px;

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -119,7 +119,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     @include fs-textSans(2);
     color: #ffffff;
     border: 1px solid rgba(#ffffff, .3);
-    @include border-radius(50%);
+    @include circular;
 
     @include mq(tablet) {
         float: right;
@@ -167,7 +167,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     @include fs-textSans(2);
     background: transparent;
     border: 1px solid rgba(#ffffff, .3);
-    @include border-radius(50%);
+    @include circular;
     color: #ffffff;
 
     &:hover,
@@ -225,7 +225,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         width: $gs-gutter;
         height: $gs-gutter;
         background-color: colour(neutral-1);
-        @include border-radius(50%);
+        @include circular;
         box-shadow: 0px 1px 0px colour(neutral-3);
 
         &:before {

--- a/static/src/stylesheets/module/_rounded-icon.scss
+++ b/static/src/stylesheets/module/_rounded-icon.scss
@@ -3,5 +3,5 @@
     display: inline-block;
     vertical-align: middle;
     position: relative;
-    @include border-radius(50%);
+    @include circular;
 }

--- a/static/src/stylesheets/module/_search.scss
+++ b/static/src/stylesheets/module/_search.scss
@@ -45,7 +45,7 @@ td.gsc-search-button {
     padding: 5px 0 0 !important;
 }
 .gsc-search-button-v2 {
-    @include border-radius(0 !important);
+    border-radius: 0 !important;
     margin: 0 !important;
     padding: 7px 9px 8px !important;
 }

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -249,7 +249,7 @@
         position: absolute;
         top: 0;
         right: 0;
-        @include border-radius(100px);
+        border-radius: 100px;
         border: 1px solid #ffffff;
         background-color: #000000;
         margin: 5px;
@@ -305,7 +305,7 @@
         margin-left: $gs-gutter*-1.5;
         text-align: center;
         @include fs-textSans(1);
-        @include border-radius($gs-gutter $gs-gutter 0 0);
+        border-radius: $gs-gutter $gs-gutter 0 0;
 
         .inline-arrow-down {
             @include transition(all 1s ease);

--- a/static/src/stylesheets/module/commercial/_facia-container.scss
+++ b/static/src/stylesheets/module/commercial/_facia-container.scss
@@ -167,7 +167,7 @@
 }
 .commercial__search__input {
     box-sizing: border-box;
-    @include border-radius(18px);
+    border-radius: 18px;
     @include fs-textSans(2);
     background-color: rgba(#ffffff, .9);
     border: 0;

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -180,7 +180,7 @@
 
 .share-modal__close {
     border: 1px solid colour(neutral-2);
-    @include border-radius(50%);
+    @include circular;
     width: 40px;
     height: 40px;
     padding: 0;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -439,7 +439,7 @@
     height: 60px; //Intentionally off grid
     margin: $gs-baseline/2 0;
     overflow: hidden;
-    @include border-radius(50%);
+    @include circular;
     background-color: colour(neutral-7);
 
     // fixes for webkit not properly scaling/clipping the child element (still broken on some android browsers...)

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -92,7 +92,7 @@ $block-padding-right: $gs-gutter;
 .live-pulse-icon:before {
     display: inline-block;
     position: relative;
-    @include border-radius(50%);
+    @include circular;
     $size: .75em;
     background-color: #ffffff;
     width: $size;
@@ -138,7 +138,7 @@ $block-padding-right: $gs-gutter;
         height: $size;
         margin-bottom: -1px;
         margin-right: 3px;
-        @include border-radius(50%);
+        @include circular;
         animation: live-pulse 2s infinite;
     }
 
@@ -635,7 +635,7 @@ $timeline-width: 15px;
             left: ($timeline-width/2)*-1;
             width: $timeline-width;
             height: $timeline-width;
-            @include border-radius(50%);
+            @include circular;
             background-color: colour(neutral-3);
         }
 

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -128,7 +128,7 @@ $ima-controls-height: 70px;
             margin-left: -.9em; /* [1] */
 
             @include mq(tablet) { // 0 border radius on mobile because stock android has a render bug with it here
-                @include border-radius(.2em);
+                border-radius: .2em;
             }
 
             .gu-media-wrapper:hover &,

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -95,7 +95,7 @@ $ima-controls-height: 70px;
         display: inline-block;
         vertical-align: middle;
         position: relative;
-        @include border-radius(50%);
+        @include circular;
         @include video-play-button-size($vjs-small-button-size);
         @include mq(mobileLandscape) {
             @include video-play-button-size($vjs-large-button-size);
@@ -523,7 +523,7 @@ $ima-controls-height: 70px;
     text-indent: -9999px;
     background: transparent;
     border: 1px solid rgba(#ffffff, .3);
-    @include border-radius(50%);
+    @include circular;
 
     &:hover {
         border-color: #ffffff;

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -612,7 +612,7 @@ $header-image-size-desktop: 100px;
 }
 
 .index-page-header__image-wrapper--contributor-circle {
-    @include border-radius(50%);
+    @include circular;
 }
 
 .fc-container--lazy-load {

--- a/static/src/stylesheets/module/facia/_treats.scss
+++ b/static/src/stylesheets/module/facia/_treats.scss
@@ -29,7 +29,7 @@
 .treats__treat {
     @include fs-textSans(1);
     @include button-height($base-size * 4);
-    @include border-radius(50%);
+    @include circular;
     box-sizing: border-box;
     display: inline-block;
     vertical-align: top;

--- a/static/src/stylesheets/module/football/_match-stat.scss
+++ b/static/src/stylesheets/module/football/_match-stat.scss
@@ -22,11 +22,11 @@
     height: 14px;
     top: 2px;
     width: 2px;
-    @include border-radius(0);
+    border-radius: 0;
 }
 
 @mixin team-result--shrink {
-    @include border-radius(8px);
+    border-radius: 8px;
     height: 4px;
     margin-left: ($gs-gutter/4)+3;
     width: 4px;
@@ -58,7 +58,7 @@
     display: inline-block;
     top: 0;
     vertical-align: middle;
-    @include border-radius(4px);
+    border-radius: 4px;
     height: 8px;
     margin-left: ($gs-gutter/4)+3;
     width: 8px;

--- a/static/src/stylesheets/module/football/_match-summary.scss
+++ b/static/src/stylesheets/module/football/_match-summary.scss
@@ -113,7 +113,7 @@ $football-crest--large: 60px;
     display: inline-block;
     height: $football-crest--small;
     width: $football-crest--small;
-    @include border-radius(24px);
+    border-radius: 24px;
     border: 2px dotted colour(neutral-2);
     @include fs-textSans(2);
     line-height: $football-crest--small - 3; // account for the border

--- a/static/src/stylesheets/module/football/_player-card.scss
+++ b/static/src/stylesheets/module/football/_player-card.scss
@@ -25,7 +25,7 @@ $player-card-avatar: (
     float: right;
 }
 .player-card__image {
-    @include border-radius(50%);
+    @include circular;
     height: map-get($player-card-avatar, default);
     width: map-get($player-card-avatar, default);
     float: right;

--- a/static/src/stylesheets/module/identity/_disc.scss
+++ b/static/src/stylesheets/module/identity/_disc.scss
@@ -53,7 +53,7 @@ $disc-avatar-size: 44px;
 .disc-comment__recommend-button {
     display: inline-block;
     vertical-align: middle;
-    @include border-radius(50%);
+    @include circular;
     height: 19px;
     width: 18px;
     background-color: colour(neutral-2-contrasted);
@@ -95,7 +95,7 @@ $disc-avatar-size: 44px;
 .disc-profile__avatar {
     float: left;
     overflow: hidden;
-    @include border-radius(50%);
+    @include circular;
     height: $disc-avatar-size;
     width: $disc-avatar-size;
 }


### PR DESCRIPTION
this needed a new mixin to be added, for when we use radius of 50% - which is not supported in old webkit. 

only diff with master is missing leading zero
