### PR TITLE
Right align front description text

### DIFF
--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -238,6 +238,7 @@ $header-image-size-desktop: 100px;
     @include fs-headline(2);
     padding-bottom: $gs-baseline / 2;
     color: colour(neutral-2);
+    text-align: right;
 
     @include mq(tablet) {
         padding-bottom: $gs-baseline;
@@ -248,6 +249,7 @@ $header-image-size-desktop: 100px;
         clear: left;
         float: left;
         margin-top: 0;
+        text-align: left;
     }
 
     @include mq(wide) {

--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -104,9 +104,11 @@ $header-image-size-desktop: 100px;
     @include mq($until: tablet) {
         overflow: hidden;
 
-        .fc-container__header__title,
-        .fc-container__header__description {
+        .fc-container__header__title {
             float: left;
+        }
+        .fc-container__header__description {
+            float: right;
         }
         .fc-container__header__title {
             padding-right: $gs-gutter / 4;


### PR DESCRIPTION
Front descriptions should be right-aligned on all breakpoints except desktop. Now they are.
![screen shot 2015-04-23 at 14 16 00](https://cloud.githubusercontent.com/assets/690395/7297839/7656a48c-e9c3-11e4-9267-468a6b0b1ead.png)

Fixes this issue: https://github.com/guardian/frontend/issues/8974
