### PR TITLE
Facia; Press on demand

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -686,6 +686,11 @@ object Switches {
     safeState = Off, sellByDate = new LocalDate(2015, 8, 31)
   )
 
+  val FaciaPressOnDemand = Switch("Facia", "facia-press-on-demand",
+    "If this is switched on, you can force facia to press on demand (Leave off)",
+    safeState = Off, sellByDate = new LocalDate(2015, 6, 30)
+  )
+
   // Server-side A/B Tests
 
   val ServerSideTests = {

--- a/facia-press/app/controllers/Application.scala
+++ b/facia-press/app/controllers/Application.scala
@@ -24,12 +24,12 @@ object Application extends Controller with ExecutionContexts {
       .map(Ok.apply(_))
       .map(NoCache.apply)}
 
-  def pressForPath(path: String) = Action.async { request =>
+  def pressLiveForPath(path: String) = Action.async { request =>
     if (FaciaPressOnDemand.isSwitchedOn) {
       FrontPress.pressLiveByPathId(path)
-        .map(_ => Ok(s"Successfully pressed $path on live"))
-        .recover { case t => InternalServerError(t.getMessage)}}
+        .map(_ => NoCache(Ok(s"Successfully pressed $path on live")))
+        .recover { case t => NoCache(InternalServerError(t.getMessage))}}
     else {
-      Future.successful(ServiceUnavailable)}
+      Future.successful(NoCache(ServiceUnavailable))}
   }
 }

--- a/facia-press/conf/routes
+++ b/facia-press/conf/routes
@@ -2,7 +2,7 @@ GET        /_healthcheck        conf.HealthCheck.healthcheck()
 GET        /                    controllers.Application.index
 GET        /debug/config        controllers.Application.showCurrentConfig
 
-GET        /pressed/live/*id    controllers.Application.generateLivePressedFor(id)
+GET        /pressed/live/*path    controllers.Application.generateLivePressedFor(path)
 
 GET        /press/live/*path    controllers.Application.pressLiveForPath(path)
 GET        /press/draft/*path   controllers.Application.pressDraftForPath(path)

--- a/facia-press/conf/routes
+++ b/facia-press/conf/routes
@@ -2,4 +2,6 @@ GET        /_healthcheck        conf.HealthCheck.healthcheck()
 GET        /                    controllers.Application.index
 GET        /debug/config        controllers.Application.showCurrentConfig
 
-GET        /pressed/live/*id      controllers.Application.generateLivePressedFor(id)
+GET        /pressed/live/*id    controllers.Application.generateLivePressedFor(id)
+
+GET        /press/*path         controllers.Application.pressLiveForPath(path)

--- a/facia-press/conf/routes
+++ b/facia-press/conf/routes
@@ -4,4 +4,5 @@ GET        /debug/config        controllers.Application.showCurrentConfig
 
 GET        /pressed/live/*id    controllers.Application.generateLivePressedFor(id)
 
-GET        /press/*path         controllers.Application.pressLiveForPath(path)
+GET        /press/live/*path    controllers.Application.pressLiveForPath(path)
+GET        /press/draft/*path   controllers.Application.pressDraftForPath(path)


### PR DESCRIPTION
Without `SQS`, there is no way to trigger a press in `facia-press`, and it can continue it's work without `SQS`.

This gives us the ability to press on demand.

In case you are wondering; what `SQS` delivers is just paths, such as `"uk"` or `"au/culture"`.

@robertberry @gklopper @stephanfowler 
