### PR TITLE
Add channel prop to tracked vars in omniture media report

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -86,7 +86,7 @@ define([
             s.loadModule('Media');
             s.Media.autoTrack = false;
             s.Media.trackWhilePlaying = false;
-            s.Media.trackVars = 'events,eVar7,eVar43,eVar44,prop44,eVar47,eVar61';
+            s.Media.trackVars = 'events,eVar7,eVar43,eVar44,prop44,eVar47,eVar61,channel';
             s.Media.trackEvents = 'event17,event18,event19,event20,event21,event22,event23,event57,event59,event64,event96,event97,event98';
             s.Media.segmentByMilestones = false;
             s.Media.trackUsingContextData = false;


### PR DESCRIPTION
As requested from @mkopka

Added channel to media events to make our guardian core segment (which is defined based on site sections) compatible with video events

s.linkTrackVars = 'events,eVar11,prop41,eVar43,prop43,eVar44,prop44,prop9,channel';
