### PR TITLE
temporarily remove US min usage check in caniuse-db

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -10,6 +10,6 @@ Android >= 2
 BlackBerry >= 6
 ExplorerMobile >= 7
 
-> 2% in US
+# > 2% in US
 > 2% in AU
 > 2% in GB


### PR DESCRIPTION
- only until https://github.com/Fyrd/caniuse/issues/966 is resolved

this is just a nice-to-have – our min browser spec is captured manually. we can safely remove it temporarily
