### PR TITLE
Add A/B VariantTest test

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -564,6 +564,11 @@ object Switches {
     safeState = Off, sellByDate = new LocalDate(2015, 5, 17)
   )
 
+  val ABVariantTest = Switch("A/B Tests", "ab-variant-test",
+    "Switch for the Variant Test A/B test.",
+    safeState = Off, sellByDate = new LocalDate(2015, 5, 1)
+  )
+
   val ABSaveForLaterSwitch = Switch("A/B Tests", "ab-save-for-later",
     "It this switch is turned on, user are able to save article. Turn off if the identity API barfs" ,
     safeState = Off, sellByDate = never

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -6,6 +6,7 @@ define([
     'common/utils/mediator',
     'common/utils/storage',
     'common/modules/analytics/mvt-cookie',
+    'common/modules/experiments/tests/variant-test',
     'common/modules/experiments/tests/liveblog-front-updates',
     'common/modules/experiments/tests/high-commercial-component',
     'common/modules/experiments/tests/identity-social-oauth',
@@ -29,6 +30,7 @@ define([
     mediator,
     store,
     mvtCookie,
+    VariantTest,
     LiveblogFrontUpdates,
     HighCommercialComponent,
     IdentitySocialOAuth,
@@ -48,6 +50,7 @@ define([
 
     var ab,
         TESTS = _.flatten([
+            new VariantTest(),
             new LiveblogFrontUpdates(),
             new HighCommercialComponent(),
             new IdentitySocialOAuth(),

--- a/static/src/javascripts/projects/common/modules/experiments/tests/variant-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/variant-test.js
@@ -1,0 +1,40 @@
+define(function () {
+
+    return function () {
+        this.id = 'VariantTest';
+        this.start = '2015-04-24';
+        this.expiry = '2015-05-01';
+        this.author = 'Oliver Ash';
+        this.description = 'Test for the test framework to see whether the variant traffic distribution is correct.';
+        this.audience = 0.2;
+        this.audienceOffset = 0.5;
+        this.successMeasure = 'Traffic distribution is equal across variants';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'Traffic distribution is equal across variants';
+
+        this.canRun = function () {
+            return true;
+        };
+
+        this.variants = [
+            {
+                id: 'A',
+                test: function () {}
+            },
+            {
+                id: 'B',
+                test: function () {}
+            },
+            {
+                id: 'C',
+                test: function () {}
+            },
+            {
+                id: 'D',
+                test: function () {}
+            }
+        ];
+    };
+
+});


### PR DESCRIPTION
To continue my theme of reverting reverts, I'm now testing the tests.

Background: we are seeing very odd traffic distribution in my `FacebookLikePrompt` test. The control group size is about 4x larger than each of the other variants. This test is just to make sure the A/B test framework is still behaving as it should.
