### PR TITLE
Do not suppress play error messages in dev mode

### DIFF
--- a/common/app/CorsErrorHandler.scala
+++ b/common/app/CorsErrorHandler.scala
@@ -9,11 +9,16 @@ trait CorsErrorHandler extends GlobalSettings with Results with common.Execution
   private val defaultVaryFields = varyFields.mkString(",")
 
   override def onError(request: RequestHeader, ex: Throwable) = {
-    val headers = request.headers
-    val vary = headers.get("Vary").fold(defaultVaryFields)(v => (v :: varyFields).mkString(","))
+    // Overriding onError in Dev can hide helpful Exception messages.
+    if (play.Play.isDev) {
+      super.onError(request, ex)
+    } else {
+      val headers = request.headers
+      val vary = headers.get("Vary").fold(defaultVaryFields)(v => (v :: varyFields).mkString(","))
 
-    Future.successful{
-      Cors(InternalServerError.withHeaders("Vary" -> vary))(request)
+      Future.successful {
+        Cors(InternalServerError.withHeaders("Vary" -> vary))(request)
+      }
     }
   }
 


### PR DESCRIPTION
We were not supplying dev messages because the Cors trait overrides the error handler.
