### PR TITLE
Keep Ad Confidence Metric in Cloudwatch

### DIFF
--- a/admin/app/services/CloudWatch.scala
+++ b/admin/app/services/CloudWatch.scala
@@ -62,6 +62,8 @@ trait CloudWatch extends Logging with ExecutionContexts {
   def rawPageViews: Future[GetMetricStatisticsResult] = sanityData("kpis-page-views")
 
   def analyticsPageViews: Future[GetMetricStatisticsResult] = sanityData("kpis-analytics-page-views")
+
+  def pageViewsHavingAnAd: Future[GetMetricStatisticsResult] = sanityData("first-ad-rendered")
 }
 
 object CloudWatch extends CloudWatch


### PR DESCRIPTION
Ad confidence calculated in similar way to omniture and ophan confidence.
Can use this for an alarm.
