### PR TITLE
Dedupe most viewed videos

### DIFF
--- a/onward/app/controllers/MostViewedVideoController.scala
+++ b/onward/app/controllers/MostViewedVideoController.scala
@@ -10,7 +10,7 @@ object MostViewedVideoController extends Controller with Logging with ExecutionC
   def renderMostViewed() = Action { implicit request =>
 
     val size = request.getQueryString("size").getOrElse("6").toInt
-    val videos = MostViewedVideoAgent.mostViewedVideo()..take(size)
+    val videos = MostViewedVideoAgent.mostViewedVideo().take(size)
 
     Cached(900) {
       JsonComponent(

--- a/onward/app/controllers/MostViewedVideoController.scala
+++ b/onward/app/controllers/MostViewedVideoController.scala
@@ -10,7 +10,7 @@ object MostViewedVideoController extends Controller with Logging with ExecutionC
   def renderMostViewed() = Action { implicit request =>
 
     val size = request.getQueryString("size").getOrElse("6").toInt
-    val videos = MostViewedVideoAgent.mostViewedVideo().take(size)
+    val videos = MostViewedVideoAgent.mostViewedVideo()..take(size)
 
     Cached(900) {
       JsonComponent(


### PR DESCRIPTION
We don't have a service for looking up video by ID, so for each video entity in http://api.ophan.co.uk/api/video/mostviewed, we have to infer the canonical URL from one of the tracked `paths`—which sometimes results in duplicates.

This change dedupes the inferred canonical URLs.

Fixes #9018
