### PR TITLE
Fix for the Pullizer text - sticky nav burger AB test

### DIFF
--- a/static/src/stylesheets/layout/_header.scss
+++ b/static/src/stylesheets/layout/_header.scss
@@ -107,6 +107,10 @@ $c-guardian-services-action: #ffffff;
         color: #aad8f1; // To match custom colour of 'the' in logotype. Shouldn't be used elsewhere
         font-weight: bold;
         white-space: nowrap;
+
+        .l-header--is-slim-ab & {
+            display: none !important;
+        }
     }
 
     .no-svg & {


### PR DESCRIPTION
I know its ugly, but there is no other way to overwrite !important. 
