### PR TITLE
Drag images in their textarea

### DIFF
--- a/facia-tool/app/views/collections.scala.html
+++ b/facia-tool/app/views/collections.scala.html
@@ -36,7 +36,11 @@
                             placeholder: field() || (label + '...'),
                             title: label
                         },
+                        css: {
+                            'underDrag': underDrag
+                        },
                         autoResize: true,
+                        dropImage: dropImage,
                         tabbableFormField: true,
                         textInput: overrideOrVal"></textarea>
 

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1191,6 +1191,13 @@ select {
     width: 15px;
 }
 
+.editor .underDrag {
+    background-color: #999999;
+}
+.editor .underDrag.active {
+    background-color: #999999;
+}
+
 .element {
     display: inline-block;
     margin: 0 0 3px 0;

--- a/facia-tool/public/js/modules/droppable.js
+++ b/facia-tool/public/js/modules/droppable.js
@@ -50,7 +50,7 @@ define([
             }
 
             try {
-                source = draggableElement(event.dataTransfer, sourceGroup);
+                source = draggableElement.getItem(event.dataTransfer, sourceGroup);
             } catch (ex) {
                 targetGroup.unsetAsTarget();
                 alert(ex.message);

--- a/facia-tool/public/js/utils/draggable-element.js
+++ b/facia-tool/public/js/utils/draggable-element.js
@@ -7,19 +7,8 @@ define([
     deepGet,
     parseQueryParams
 ) {
-    function getItem(dataTransfer, sourceGroup) {
-        var id = dataTransfer.getData('Text'),
-            mediaItem = dataTransfer.getData('application/vnd.mediaservice.crops+json'),
-            sourceItem = dataTransfer.getData('sourceItem'),
-            knownQueryParams = parseQueryParams(id, {
-                namespace: 'gu-',
-                excludeNamespace: false,
-                stripNamespace: true
-            }),
-            unknownQueryParams = parseQueryParams(id, {
-                namespace: 'gu-',
-                excludeNamespace: true
-            });
+    function getMediaItem(dataTransfer) {
+        var mediaItem = dataTransfer.getData('application/vnd.mediaservice.crops+json');
 
         if (mediaItem) {
             try {
@@ -42,7 +31,25 @@ define([
                 throw new Error('Sorry, a suitable crop size does not exist for this image');
             }
 
-        } else if (!id) {
+        }
+        return mediaItem;
+    }
+
+    function getItem(dataTransfer, sourceGroup) {
+        var id = dataTransfer.getData('Text'),
+            mediaItem = getMediaItem(dataTransfer),
+            sourceItem = dataTransfer.getData('sourceItem'),
+            knownQueryParams = parseQueryParams(id, {
+                namespace: 'gu-',
+                excludeNamespace: false,
+                stripNamespace: true
+            }),
+            unknownQueryParams = parseQueryParams(id, {
+                namespace: 'gu-',
+                excludeNamespace: true
+            });
+
+        if (!mediaItem && !id) {
             throw new Error('Sorry, you can\'t add that to a front');
         }
 
@@ -71,5 +78,8 @@ define([
         };
     }
 
-    return getItem;
+    return {
+        getMediaItem: getMediaItem,
+        getItem: getItem
+    };
 });


### PR DESCRIPTION
You can now drag and drop images into any image textarea (slideshow, cutout, replace).

Works dragging from the grid, or any image url (however once validated, the url must be guim.co.uk)

@stephanfowler 
fyi @theefer 
