### PR TITLE
Curl plugin: fix icon classes: correct image type detection

### DIFF
--- a/static/src/javascripts/projects/common/utils/inlineSvg.js
+++ b/static/src/javascripts/projects/common/utils/inlineSvg.js
@@ -12,15 +12,11 @@ define([
 
         load: function (name, req, onLoad, config) {
             var prefix = "inline-",
-                data = name.split("!"),
-
-                path = data[0],
-                imageType = data[1] || "",
-
-                dirs = path.split("/"),
+                dirs = name.split("/"),
+                imageType = dirs[1],
                 fileName = dirs.pop();
 
-            text.get(req.toUrl(dirs.join("/") + "/" + (imageType ? imageType + "/" : "") + fileName + ".svg"), function (svg) {
+            text.get(req.toUrl(dirs.join("/") + "/" + fileName + ".svg"), function (svg) {
 
                 svg = "<span class=\"" + prefix + fileName + " " + (imageType !== "" ? prefix + imageType : "") + "\">" + svg + "</span>";
 


### PR DESCRIPTION
[We changed the module IDs for SVGs in `common/views/svgs`](https://github.com/guardian/frontend/pull/9005/files#diff-9dea3df0fd90248d5685837d8d7392ebL7), but we didn't update the Curl plugin to use the new module ID format, which meant the `inline-{icon,logo,commercial}` classes were not being applied to their corresponding icons.

![image](https://cloud.githubusercontent.com/assets/921609/7372568/6a11e376-edbf-11e4-8e11-04bee2413dd6.png)
