### PR TITLE
Remove logging of ab participations

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -253,7 +253,6 @@ define([
 
                 if (config.switches.ophan) {
                     require(['ophan/ng'], function (ophan) {
-                        ophan.record({ab: ab.getParticipations()});
 
                         if (config.switches.scrollDepth) {
                             mediator.on('scrolldepth:data', ophan.record);


### PR DESCRIPTION
This is the removal of a redundant additional log of the ab participations. It is already passed in through the register system.
