### PR TITLE
Liveblog switches per network front

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -510,8 +510,23 @@ object Switches {
     "If switched on, any user registrations from a known tor esit node will be logged",
     safeState = On, sellByDate = never)
 
-  val LiveblogFrontUpdates = Switch("Feature", "liveblog-front-updates",
-    "Switch for the latest liveblog updates on fronts",
+  val LiveblogUkFrontUpdates = Switch("Feature", "liveblog-uk-front-updates",
+    "Switch for the latest liveblog updates on the UK network front",
+    safeState = Off, sellByDate = never
+  )
+
+  val LiveblogUsFrontUpdates = Switch("Feature", "liveblog-us-front-updates",
+    "Switch for the latest liveblog updates on the US network front",
+    safeState = Off, sellByDate = never
+  )
+
+  val LiveblogAuFrontUpdates = Switch("Feature", "liveblog-au-front-updates",
+    "Switch for the latest liveblog updates on the AU network front",
+    safeState = Off, sellByDate = never
+  )
+
+  val LiveblogOtherFrontUpdates = Switch("Feature", "liveblog-other-front-updates",
+    "Switch for the latest liveblog updates on non-network fronts",
     safeState = Off, sellByDate = never
   )
 

--- a/static/src/javascripts/bootstraps/facia.js
+++ b/static/src/javascripts/bootstraps/facia.js
@@ -82,9 +82,14 @@ define([
             },
 
             showLiveblogUpdates: function () {
-                var isSport = _.contains(['sport', 'football'], config.page.section);
+                var pageId = config.page.pageId,
+                    isNetFront = _.contains(['uk', 'us', 'au'], pageId),
+                    isSport = _.contains(['sport', 'football'], config.page.section);
 
-                if (config.switches.liveblogFrontUpdates && !isSport ||
+                if (config.switches.liveblogOtherFrontUpdates && !isSport && !isNetFront ||
+                    config.switches.liveblogUkFrontUpdates && pageId === 'uk' ||
+                    config.switches.liveblogUsFrontUpdates && pageId === 'us' ||
+                    config.switches.liveblogAuFrontUpdates && pageId === 'au' ||
                     config.switches.abLiveblogSportFrontUpdates && isSport && ab.getTestVariant('LiveblogSportFrontUpdates') === 'updates') {
                     mediator.on('page:front:ready', function () {
                         liveblogUpdates.show();


### PR DESCRIPTION
Until we add an option in the Fronts Tool for switching updates on/off per liveblog, these switches allow them to be turned on/off per network front.

(Context: Australia wanted them off today.)
