### PR TITLE
Protect in-memory most-viewed videos if ophan request times out

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -124,7 +124,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   object ophanApi {
     lazy val key = configuration.getStringProperty("ophan.api.key")
     lazy val host = configuration.getStringProperty("ophan.api.host")
-    lazy val timeout = configuration.getIntegerProperty("content.api.timeout.millis").getOrElse(2000)
   }
 
   object ophan {

--- a/common/app/services/OphanApi.scala
+++ b/common/app/services/OphanApi.scala
@@ -25,7 +25,7 @@ object OphanApi extends ExecutionContexts with Logging with implicits.WSRequests
         } mkString "&"
         val url = s"$host/$path?$queryString&api-key=$key"
         log.info(s"Making request to Ophan API: $url")
-        WS.url(url) withRequestTimeout ophanApi.timeout getOKResponse() map (_.json)
+        WS.url(url).withRequestTimeout(10000).getOKResponse().map(_.json)
       }
 
     maybeJson getOrElse {

--- a/onward/app/feed/MostViewedVideoAgent.scala
+++ b/onward/app/feed/MostViewedVideoAgent.scala
@@ -39,7 +39,7 @@ object MostViewedVideoAgent extends Logging with ExecutionContexts {
         val videos = contentSeq.toSeq.collect {
           case Some(video: Video) => video
         }
-        agent alter videos
+        if(videos.nonEmpty) agent.alter(videos)
       }
     }
   }


### PR DESCRIPTION
It appears that requests to ophan for most-viewed videos can time out, which is fine except that we were allowing an empty set to replace what we already had in memory which resulted in the content disappearing from the site.

So now we test that the results we receive are non-empty before replacing the stored set. Also, we've upped the timeout to ten seconds as the agent is asynchronous and should be able to afford to wait a bit longer.

cc @OliverJAsh
