### PR TITLE
Use global require for enhancer

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
       "bonzo": "npm:bonzo@^1.4.0",
       "classnames": "npm:classnames@^1.2.0",
       "domready": "npm:domready@^1.0.7",
-      "enhancer": "github:guardian/enhancer@0.1.2",
+      "enhancer": "github:guardian/enhancer@0.1.3",
       "fastclick": "npm:fastclick@1.0.6",
       "fastdom": "github:wilsonpage/fastdom@^0.8.6",
       "fence": "github:guardian/fence@~0.2.11",

--- a/static/src/javascripts/bower.json
+++ b/static/src/javascripts/bower.json
@@ -12,7 +12,7 @@
     "qwery": "3.4.2",
     "react": "0.11.2",
     "reqwest": "1.1.5",
-    "enhancer": "0.1.2",
+    "enhancer": "0.1.3",
     "videojs": "guardian/video.js#158221b5d997a184972fbf038c9eebdb676d30c8",
     "videojs-contrib-ads": "videojs/videojs-contrib-ads#f44387a4d2fd939f9a665762917e2fa6fc8838d7",
     "videojs-persistvolume": "~0.1.0",

--- a/static/src/javascripts/components/enhancer/enhancer.js
+++ b/static/src/javascripts/components/enhancer/enhancer.js
@@ -1,8 +1,4 @@
-define([
-    'require'
-], function (
-    require
-) {
+define(function () {
 
     /**
      * Render a DOM Node that supports progressive enhancement via a

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -40,7 +40,7 @@ System.config({
     "bonzo": "npm:bonzo@1.4.0",
     "classnames": "npm:classnames@1.2.0",
     "domready": "npm:domready@1.0.7",
-    "enhancer": "github:guardian/enhancer@0.1.2",
+    "enhancer": "github:guardian/enhancer@0.1.3",
     "fastclick": "npm:fastclick@1.0.6",
     "fastdom": "github:wilsonpage/fastdom@0.8.6",
     "fence": "github:guardian/fence@0.2.11",


### PR DESCRIPTION
This change is in order to use the global require rather than the context provided one, which resolves an issue in SystemJs.
