### PR TITLE
Liveblog playables - fewer blocks on smaller cards

### DIFF
--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list.scss
@@ -37,8 +37,4 @@ x x x x x x x x x x x x x x x x x x x x x x x x
         margin: 0;
         @include fs-header(1);
     }
-
-    .fc-item__liveblog-blocks {
-        height: 38px; // 1 * block height - 2px margin
-    }
 }

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--three-quarters.scss
@@ -45,6 +45,7 @@ Three quarter item. Looks like a wide standard, a bit like this:
     .fc-item__liveblog-blocks {
         @include mq(tablet) {
             padding-right: 0;
+            height: 78px; // 2 * block height - 2px margin
         }
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -85,6 +85,7 @@
     height: 38px; // 1 * block height - 2px margin
     overflow: hidden;
     margin-top: -1 * $gs-baseline / 2;
+    margin-bottom: $gs-baseline / 2;
 }
 
 .fc-item__liveblog-blocks__inner {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -82,10 +82,9 @@
 }
 
 .fc-item__liveblog-blocks {
-    height: 78px; // 2 * block height - 2px margin
+    height: 38px; // 1 * block height - 2px margin
     overflow: hidden;
-    margin-right: -1 * $gs-gutter / 4;
-    margin-bottom: $gs-baseline / 2;
+    margin-top: -1 * $gs-baseline / 2;
 }
 
 .fc-item__liveblog-blocks__inner {


### PR DESCRIPTION
Only show one liveblog update, unless the card is three-quarters or full width.

![liveblog-updates](https://cloud.githubusercontent.com/assets/1147913/7429359/da25c904-eff7-11e4-8e12-37b872ac97e1.png)
