### PR TITLE
Arrow SVG icon fixed

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
@@ -29,6 +29,7 @@ define([
 
         this.params.marque36icon = svgs('marque36icon');
         this.params.marque54icon = svgs('marque54icon');
+        this.params.arrowRight = svgs('arrowRight', ['i-right']);
         this.params.logoguardian = svgs('logoguardian');
         this.params.marque36iconCreativeMarque = svgs('marque36icon', ['creative__marque']);
     };

--- a/static/src/javascripts/projects/common/views/commercial/creatives/branded-component-jobs.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/branded-component-jobs.html
@@ -8,7 +8,7 @@
         <p class="creative__title">Finding quality jobs just got easier</p>
         <p class="creative__text">Introducing the next-generation Guardian Jobs website, designed to work whatever your device</p>
         <a class="button button--primary" href="{{clickMacro}}http://jobs.theguardian.com/" data-link-name="link">
-            Browse jobs<i class="i i-arrow-white-right i-right"></i>
+            Browse jobs{{arrowRight}}
         </a>
     </div>
 </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/branded-component-membership.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/branded-component-membership.html
@@ -7,7 +7,7 @@
         <p class="creative__title">The open exchange of ideas and opinions has the power to change the world</p>
         <p class="creative__text">Join the community for those who share this belief</p>
         <a class="button" href="{{clickMacro}}https://membership.theguardian.com/" data-link-name="link">
-            Find out more<i class="i i-arrow-white-right i-right"></i>
+            Find out more{{arrowRight}}
         </a>
     </div>
 </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/manual-inline.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/manual-inline.html
@@ -13,7 +13,7 @@
         </a>
         <p class="lineitem__meta">{{offer_meta}}</p>
         <a href="{{clickMacro}}{{offer_url}}" class="button button--primary button--small" data-link-name="click here">
-            Click here<i class="i i-arrow-white-right i-right"></i>
+            Click here{{arrowRight}}
         </a>
     </div>
 </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/manual-multiple.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/manual-multiple.html
@@ -12,7 +12,7 @@
                 <a class="commercial__cta button button--tertiary button--large"
                    href="{{clickMacro}}{{base__url}}"
                    data-link-name="viewall">
-                    <i class="i i-arrow-white-right i-right"></i>
+                    {{arrowRight}}
                     <span class="commercial__cta__label">{{viewalltext}}</span>
                 </a>
             </div>
@@ -30,7 +30,7 @@
                         <h4 class="lineitem__title">{{offer1title}}</h4>
                         <p class="lineitem__meta">{{offer1meta}}</p>
                         <p class="lineitem__cta button button--primary button--small">
-                            {{offerlinktext}}<i class="i i-arrow-white-right i-right"></i>
+                            {{offerlinktext}}{{arrowRight}}
                         </p>
                     </a>
                 </li>
@@ -44,7 +44,7 @@
                         <h4 class="lineitem__title">{{offer2title}}</h4>
                         <p class="lineitem__meta">{{offer2meta}}</p>
                         <p class="lineitem__cta button button--primary button--small">
-                            {{offerlinktext}}<i class="i i-arrow-white-right i-right"></i>
+                            {{offerlinktext}}{{arrowRight}}
                         </p>
                     </a>
                 </li>
@@ -58,7 +58,7 @@
                         <h4 class="lineitem__title">{{offer3title}}</h4>
                         <p class="lineitem__meta">{{offer3meta}}</p>
                         <p class="ineitem__cta button button--primary button--small">
-                            {{offerlinktext}}<i class="i i-arrow-white-right i-right"></i>
+                            {{offerlinktext}}{{arrowRight}}
                         </p>
                     </a>
                 </li>
@@ -72,7 +72,7 @@
                         <h4 class="lineitem__title">{{offer4title}}</h4>
                         <p class="lineitem__meta">{{offer4meta}}</p>
                         <p class="ineitem__cta button button--primary button--small">
-                            {{offerlinktext}}<i class="i i-arrow-white-right i-right"></i>
+                            {{offerlinktext}}{{arrowRight}}
                         </p>
                     </a>
                 </li>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/manual-single.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/manual-single.html
@@ -26,14 +26,14 @@
                         <a class="lineitem__cta button button--tertiary button--small"
                            href="{{clickMacro}}{{offerUrl}}"
                            data-link-name="merchandising-{{offerTitle}}-link">
-                            {{offerLinkText}}<i class="i i-arrow-black-right i-right"></i>
+                            {{offerLinkText}}{{arrowRight}}
                         </a>
                     </div>
                     <div class="lineitem--dfp-single__cta hide-on-mobile {{showCtaLink}}">
                         <a class="commercial__cta button button--primary button--large"
                            href="{{clickMacro}}{{seeMoreUrl}}"
                            data-link-name="merchandising-viewall">
-                            {{viewAllText}}<i class="i i-arrow-white-right i-right"></i>
+                            {{viewAllText}}{{arrowRight}}
                         </a>
                     </div>
                 </div>

--- a/static/src/javascripts/projects/common/views/svgs.js
+++ b/static/src/javascripts/projects/common/views/svgs.js
@@ -15,7 +15,8 @@ define([
     'inlineSvg!svgs/logo/logo-guardian',
     'inlineSvg!svgs/commercial/logo-soulmates',
     'inlineSvg!svgs/icon/close-central',
-    'inlineSvg!svgs/icon/arrow-white-right'
+    'inlineSvg!svgs/icon/arrow-white-right',
+    'inlineSvg!svgs/icon/arrow-right'
 ], function (
     _,
     commentCount16icon,
@@ -29,7 +30,8 @@ define([
     logoguardian,
     logosoulmates,
     closeCentralIcon,
-    arrowWhiteRight
+    arrowWhiteRight,
+    arrowRight
 ) {
     var svgs = {
         commentCount16icon: commentCount16icon,
@@ -43,7 +45,8 @@ define([
         logoguardian: logoguardian,
         logosoulmates: logosoulmates,
         closeCentralIcon: closeCentralIcon,
-        arrowWhiteRight: arrowWhiteRight
+        arrowWhiteRight: arrowWhiteRight,
+        arrowRight: arrowRight
     };
 
     return function (name, classes, title) {


### PR DESCRIPTION
Updating arrow markup on js-created components to use inline svg.

This is an example of where these arrows were missing:
![screen shot 2015-05-05 at 11 17 31](https://cloud.githubusercontent.com/assets/3763718/7470858/6aaddb10-f318-11e4-893f-0a8cda20faa6.png)

After the fix was applied:
![screen shot 2015-05-05 at 11 19 33](https://cloud.githubusercontent.com/assets/3763718/7470888/a6d3b092-f318-11e4-8de5-5f9578bab9ee.png)
