### PR TITLE
Increase search results z-index

### DIFF
--- a/static/src/stylesheets/module/_popup.scss
+++ b/static/src/stylesheets/module/_popup.scss
@@ -217,7 +217,7 @@ $control-offset: 36 + $gs-gutter/2;
    ========================================================================== */
 
 .popup--search {
-    z-index: 10;
+    z-index: 300;
     padding: 0;
     right: 0;
     padding-top: 5px; // manual amount, determined by google, not guss-grid-system


### PR DESCRIPTION
This is to ensure the search results are always visible above page furniture components.

Fixes: #9071
### Before:

![google chrome](https://cloud.githubusercontent.com/assets/80089/7471096/d824218e-f31a-11e4-9734-cfc4aa43daa7.png)
### After:

![google chrome](https://cloud.githubusercontent.com/assets/80089/7471098/dbcb76fc-f31a-11e4-9359-851a50da7f38.png)
