### PR TITLE
Bottom margin for flex blended component

### DIFF
--- a/static/src/stylesheets/module/commercial/_commercial--multi.scss
+++ b/static/src/stylesheets/module/commercial/_commercial--multi.scss
@@ -85,6 +85,10 @@ Multi component (AKA Frankenponent)
     @include guss-row('.lineitems');
     .lineitems {
         width: auto;
+
+        .commercial__body & {
+            margin-bottom: $gs-baseline/2;
+        }
     }
     
 


### PR DESCRIPTION
Adding a bottom margin to mirror the top margin so that the grey dividers don't extend all the way to the bottom.

Before:

![screen shot 2015-05-05 at 12 13 29](https://cloud.githubusercontent.com/assets/3763718/7471540/3641d716-f320-11e4-8ca8-f7bb68440e3f.png)

After:

![screen shot 2015-05-05 at 12 14 14](https://cloud.githubusercontent.com/assets/3763718/7471546/4a87b326-f320-11e4-94f6-c4bbe6b9aaf6.png)
