### PR TITLE
Weather – Target the headlines container rather than the first container

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -197,7 +197,7 @@ define([
         },
 
         attachToDOM: function (tmpl, city) {
-            $holder = $('.js-container--first .js-container__header');
+            $holder = $('#headlines .js-container__header');
             $('.js-weather', $holder).remove();
             $holder.append(tmpl.replace(new RegExp('{{city}}', 'g'), city));
         },

--- a/static/test/javascripts/spec/facia/weather.spec.js
+++ b/static/test/javascripts/spec/facia/weather.spec.js
@@ -22,7 +22,7 @@ define([
 
                 beforeEach(function () {
                     container = bonzo.create(
-                        '<div class="js-container--first"><div class="js-container__header"></div></div>'
+                        '<div id="headlines"><div class="js-container__header"></div></div>'
                     )[0];
 
                     $('body').append(container);


### PR DESCRIPTION
Targets `#headlines` container rather than `.js-container--first` for weather. This is for the new `dynamic/package` container that will precede the existing headlines container and shouldn't have weather in it.
