### PR TITLE
Add placeholder <div> in facia for election night snap, behind a switch.

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -528,6 +528,11 @@ object Switches {
     safeState = Off, sellByDate = never
   )
 
+  val ElectionSnap = Switch("Feature", "election-snap",
+    "ONLY TOUCH THIS IF YOU KNOW WHAT IT DOES AND IMPLICATIONS: Switch to render a placeholder for the election snap.",
+    safeState = Off, sellByDate = new LocalDate(2015, 5, 15)
+  )
+
   // A/B Tests
   val ABMtLzAdsDepth = Switch("A/B Tests", "ab-mt-lz-ads-depth", "Depth for lazy loaded ads.",
     safeState = Off, sellByDate = new LocalDate(2015, 5, 15)

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -270,6 +270,11 @@ case class FaciaContainer(
   def addShowMoreClasses = useShowMore && containerLayout.exists(_.hasShowMore)
 
   def shouldLazyLoad = Switches.LazyLoadContainersSwitch.isSwitchedOn && index > 8
+
+  def isStoryPackage = container match {
+    case Dynamic(DynamicPackage) => true
+    case _ => false
+  }
 }
 
 object Front extends implicits.Collections {

--- a/common/app/slices/Container.scala
+++ b/common/app/slices/Container.scala
@@ -2,6 +2,7 @@ package slices
 
 import com.gu.facia.client.models.{CollectionConfigJson => CollectionConfig}
 import common.Logging
+import conf.Switches.ElectionSnap
 
 object Container extends Logging {
   /** This is THE top level resolver for containers */
@@ -30,8 +31,10 @@ object Container extends Logging {
     case _ => true
   }
 
+  private def hasElectionSnap:Option[String] = if(ElectionSnap.isSwitchedOn) Some("fc-container--has-election-snap") else None
+
   def customClasses(container: Container) = container match {
-    case Dynamic(DynamicPackage) => Set("fc-container--story-package")
+    case Dynamic(DynamicPackage) => List(Some("fc-container--story-package"), hasElectionSnap).flatten.toSet
     case Fixed(fixedContainer) => fixedContainer.customCssClasses
     case _ => Nil
   }

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -29,14 +29,10 @@
              data-component="@componentName"
              aria-expanded="true">
 
-             @containerDefinition.container match {
-                 case Dynamic(DynamicPackage) => {
-                     <style scoped>
-                        @Html(conf.Static.css.head(Some("story-package")))
-                     </style>
-                 }
-                 
-                 case _ => {}
+             @if(containerDefinition.isStoryPackage){
+                 <style scoped>
+                    @Html(conf.Static.css.head(Some("story-package")))
+                 </style>
              }
 
         <div class="fc-container__inner">

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -3,6 +3,7 @@
 @import common.Localisation
 @import views.html.fragments.containers.facia_cards.{containerHeader, slice, showMore, showMoreButton}
 @import views.support.RenderClasses
+@import conf.Switches.ElectionSnap
 
 @containerHeader(containerDefinition, frontProperties)
 
@@ -16,6 +17,16 @@
     ))"
          data-title="@Html(Localisation(containerDefinition.displayName getOrElse ""))"
          data-id="@containerDefinition.dataId">
+
+        @* Custom markup for the election night snap, will be removed afterwards. *@
+        @if(containerDefinition.isStoryPackage & ElectionSnap.isSwitchedOn) {
+            <div id="election-snap" class="election-snap">
+
+
+
+            </div>
+        }
+
         @for(sliceWithCards <- containerLayout.slices) {
             @slice(sliceWithCards, containerDefinition.index)
         }

--- a/static/src/stylesheets/head.story-package.scss
+++ b/static/src/stylesheets/head.story-package.scss
@@ -10,7 +10,7 @@
             color: $colour;
         }
     }
-    
+
     .tone-#{$tone}--sublink {
         .fc-sublink__kicker {
             color: $colour;
@@ -182,5 +182,15 @@
                 }
             }
         }
+    }
+
+    .js-on &.fc-container--has-election-snap {
+        .fc-item--full-media-50-tablet {
+            display: none;
+        }
+    }
+
+    .js-off & .election-snap {
+        display: none;
     }
 }


### PR DESCRIPTION
As requested by the interactive team, this adds custom placeholder markup for the election night results snap*. It is purposefully behind an expiring switch so we can turn off in an emergency and will fallback to the normal snap process if all fails. We still need to keep the original item within the tool and response so that non-js users, Google and the apps still can index.
### *Reasoning

The reason why this is needed the current snap loading process causes the page to jump and flash quite al lot, which is normally acceptable. But for such a high profile component we are willing to make tradeoffs, this will also ensure the async request for data is made earlier.

/cc @sammorrisdesign @gklopper @stephanfowler @wpf500 @robertberry 
