### PR TITLE
Do not initialize save for later JS - fix for broken avatar features

### DIFF
--- a/static/src/javascripts/bootstraps/identity.js
+++ b/static/src/javascripts/bootstraps/identity.js
@@ -132,7 +132,7 @@ define([
             modules.validationEmail();
             modules.tabs();
             modules.accountProfile();
-            modules.savedForLater();
+            //modules.savedForLater();
 
             mediator.emit('page:identity:ready', config);
         };


### PR DESCRIPTION
We've been seeing issues with avatars and tracked down the regression to the "save for later" feature being introduced.

It prevents JS related to avatar display and upload ever being executed.

We are still tracking down the exact cause, but in order to bring back the avatar functionality, we would like to disable this feature for now. 
