### PR TITLE
Always use the spec reporter

### DIFF
--- a/grunt-configs/karma.js
+++ b/grunt-configs/karma.js
@@ -1,7 +1,7 @@
 module.exports = function(grunt, options) {
     return {
         options: {
-            reporters: options.isDev ? ['spec'] : ['progress'],
+            reporters: ['spec'],
             singleRun: options.singleRun,
             browserDisconnectTimeout: 10000,
             browserDisconnectTolerance: 3,


### PR DESCRIPTION
The karma spec reporter is better at reporting errors in our jasmine tests, i reckon.
