### PR TITLE
Remove Book Lookup Switch

### DIFF
--- a/commercial/app/model/commercial/books/Book.scala
+++ b/commercial/app/model/commercial/books/Book.scala
@@ -1,7 +1,6 @@
 package model.commercial.books
 
 import common.ExecutionContexts
-import conf.Switches.LookUpBooksInBookshopCatalogue
 import model.commercial._
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
@@ -58,17 +57,9 @@ object BestsellersAgent extends MerchandiseAgent[Book] with ExecutionContexts {
   def getSpecificBook(isbn: String) = available find (_.isbn == isbn)
 
   def getSpecificBooks(isbns: Seq[String]): Future[Seq[Book]] = {
-
-    def lookUpInAllBooks: Future[Seq[Book]] = Future.sequence {
+    Future.sequence {
       isbns map (BookFinder.findByIsbn(_))
     } map (_.flatten.sortBy(book => isbns.indexOf(book.isbn)))
-
-    def lookUpInBestsellers: Future[Seq[Book]] = Future.successful {
-      available filter (isbns contains _.isbn)
-    }
-
-    if (LookUpBooksInBookshopCatalogue.isSwitchedOn) lookUpInAllBooks
-    else lookUpInBestsellers
   }
 
   def bestsellersTargetedAt(segment: Segment): Seq[Book] = {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -332,10 +332,6 @@ object Switches {
     "If switched on then all ads are lazy loaded",
     safeState = Off, sellByDate = never)
 
-  val LookUpBooksInBookshopCatalogue = Switch("Commercial", "look-up-books-in-catalogue",
-    "Looks up books in bookshop catalogue, rather than in bestsellers list.",
-    safeState = Off, sellByDate = new LocalDate(2015, 5, 13))
-
 
   // Monitoring
 


### PR DESCRIPTION
Looking up specified books seems to work without any noticeable increase in errors or latency so seems safe to remove the switch.
