### PR TITLE
Use context require in enhancer

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
       "bonzo": "npm:bonzo@^1.4.0",
       "classnames": "npm:classnames@^1.2.0",
       "domready": "npm:domready@^1.0.7",
-      "enhancer": "github:guardian/enhancer@0.1.3",
+      "enhancer": "github:guardian/enhancer@0.1.4",
       "fastclick": "npm:fastclick@1.0.6",
       "fastdom": "github:wilsonpage/fastdom@^0.8.6",
       "fence": "github:guardian/fence@~0.2.11",

--- a/static/src/javascripts/bower.json
+++ b/static/src/javascripts/bower.json
@@ -12,7 +12,7 @@
     "qwery": "3.4.2",
     "react": "0.11.2",
     "reqwest": "1.1.5",
-    "enhancer": "0.1.3",
+    "enhancer": "0.1.4",
     "videojs": "guardian/video.js#158221b5d997a184972fbf038c9eebdb676d30c8",
     "videojs-contrib-ads": "videojs/videojs-contrib-ads#f44387a4d2fd939f9a665762917e2fa6fc8838d7",
     "videojs-persistvolume": "~0.1.0",

--- a/static/src/javascripts/components/enhancer/enhancer.js
+++ b/static/src/javascripts/components/enhancer/enhancer.js
@@ -1,4 +1,8 @@
-define(function () {
+define([
+    'require'
+], function (
+    require
+) {
 
     /**
      * Render a DOM Node that supports progressive enhancement via a

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -42,7 +42,7 @@ System.config({
     "bonzo": "npm:bonzo@1.4.0",
     "classnames": "npm:classnames@1.2.0",
     "domready": "npm:domready@1.0.7",
-    "enhancer": "github:guardian/enhancer@0.1.3",
+    "enhancer": "github:guardian/enhancer@0.1.4",
     "fastclick": "npm:fastclick@1.0.6",
     "fastdom": "github:wilsonpage/fastdom@0.8.6",
     "fence": "github:guardian/fence@0.2.11",


### PR DESCRIPTION
I'm reinstating the context based require, because system js now normalises dynamic requires when using this load style.
