### PR TITLE
Track parent url for iframe video embeds

### DIFF
--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -57,7 +57,7 @@ guardian.page.dfpAccountId=59666047
 guardian.page.dfpAdUnitRoot=theguardian.com
 guardian.page.sentryPublicApiKey=344003a8d11c41d8800fbad8383fdc50
 guardian.page.sentryHost=app.getsentry.com/35463
-guardian.page.externalEmbedHost=https://embed.theguardian.com
+guardian.page.externalEmbedHost=/assets/
 guardian.page.weatherapiurl=/weatherapi/city
 guardian.page.locationapiurl=/weatherapi/locations?query=
 guardian.page.forecastsapiurl=/weatherapi/forecast

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -295,6 +295,11 @@ define([
 
         if (this.isEmbed) {
             this.s.eVar11 = this.s.prop11 = 'Embedded';
+
+            // Get iframe's parent url: http://www.nczonline.net/blog/2013/04/16/getting-the-url-of-an-iframes-parent
+            if (!!window.parent && window.parent !== window) {
+                this.s.referrer = document.referrer;
+            }
         }
     };
 


### PR DESCRIPTION
We can pass the parent url to omniture for superior trackability.
