### PR TITLE
Increase test timeout

### DIFF
--- a/integrated-tests/src/test/scala/commercial/AdsTest.scala
+++ b/integrated-tests/src/test/scala/commercial/AdsTest.scala
@@ -14,7 +14,7 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
     // This is an essential sleep, because the implicitlyWait isn't sufficient to ensure that
     // the js application has completed, since the dfp-ad classes exist on page load.
     Thread.sleep(10000)
-    implicitlyWait(10)
+    implicitlyWait(20)
 
     withClue("Should display top banner ad") {
       $("#dfp-ad--top-above-nav > *").size should be > 0

--- a/integrated-tests/src/test/scala/common/MostPopularTest.scala
+++ b/integrated-tests/src/test/scala/common/MostPopularTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
   "Content pages" should "have functioning most popular components" in {
 
     get("/books/2014/oct/15/dylan-thomas-in-fitzrovia-griff-rhys-jones")
-    implicitlyWait(5)
+    implicitlyWait(20)
 
     withClue("Should show the 'most popular' component") {
       first("[data-test-id='popular-in']").isDisplayed should be (true)


### PR DESCRIPTION
We are having problems with the most popular integration test (?!). Adding timeout
