### PR TITLE
Set below the nav banner slot to 980px for new campaign

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -60,12 +60,12 @@
         border-bottom-width: 1px;
 
         .ad-slot--top-banner-ad {
-            width: 970px;
+            width: 980px;
             padding-left: 0;
         }
 
         .ad-slot__label {
-            width: 970px;
+            width: 980px;
         }
     }
 


### PR DESCRIPTION
It was set to 970px for previous campaign and it needs to be 980px now. It's very rare so quick PR changing it is the best solution.
