### PR TITLE
Fixing missing arrow on branded component

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/branded-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/branded-component.js
@@ -25,13 +25,15 @@ define([
                 template: brandedComponentJobsTpl,
                 config:   {
                     imgUrl: config.images.commercial.brandedComponentJobs,
-                    marque36icon: svgs('marque36icon', ['creative__marque'])
+                    marque36icon: svgs('marque36icon', ['creative__marque']),
+                    arrowRight: svgs('arrowRight', ['i-right'])
                 }
             },
             membership: {
                 template: brandedComponentMembershipTpl,
                 config:   {
-                    marque36icon: svgs('marque36icon', ['creative__marque'])
+                    marque36icon: svgs('marque36icon', ['creative__marque']),
+                    arrowRight: svgs('arrowRight', ['i-right'])
                 }
             },
             soulmates: {


### PR DESCRIPTION
Adding svg icon to the config to fix this bug on jobs and membership branded component.

Before:
![screen shot 2015-05-12 at 15 48 20](https://cloud.githubusercontent.com/assets/3763718/7590087/90eacd1e-f8be-11e4-8826-1b49d797276e.png)

![screen shot 2015-05-12 at 15 48 40](https://cloud.githubusercontent.com/assets/3763718/7590101/a26503a2-f8be-11e4-9dc2-7737ccea9695.png)

After:
![screen shot 2015-05-12 at 15 48 31](https://cloud.githubusercontent.com/assets/3763718/7590096/9ccff492-f8be-11e4-980c-bc279c2dd230.png)

![screen shot 2015-05-12 at 15 48 47](https://cloud.githubusercontent.com/assets/3763718/7590105/a99c0328-f8be-11e4-8001-f33ab2e1ce13.png)
