### PR TITLE
Update become a member return url to Friend enter details

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -19,7 +19,7 @@
                         <div class="brand-bar__item brand-bar__item--profile
                                     brand-bar__item--has-control brand-bar__item--register
                                     popup-container has-popup js-profile-register">
-                            <a href="@Configuration.id.url/register?skipConfirmation=true&INTCMP=HEADER_GU_REG&returnUrl=@URLEncode("https://membership.theguardian.com/about")"
+                            <a href="@Configuration.id.url/register?skipConfirmation=true&INTCMP=HEADER_GU_REG&returnUrl=@URLEncode("https://membership.theguardian.com/join/friend/enter-details")"
                                data-link-name="Register link"
                                class="brand-bar__item--action">
                                 @fragments.inlineSvg("profile-add-36", "icon", List("rounded-icon", "control__icon-wrapper"))


### PR DESCRIPTION
![screen shot 2015-05-12 at 17 09 09](https://cloud.githubusercontent.com/assets/123386/7592191/e2d98574-f8c9-11e4-811c-42dde4dde99c.png)

Updates the return url for the become a member link to go to the [Friend enter details page](https://membership.theguardian.com/join/friend/enter-details) instead of [About](https://membership.theguardian.com/about) to match the expectation that you are signing up for a Membership account.

// @mattandrews 
