### PR TITLE
Improve display of xword thumbnails

### DIFF
--- a/static/src/javascripts/es6/projects/common/modules/crosswords/thumbnails.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/thumbnails.js
@@ -3,12 +3,14 @@ import $ from 'common/utils/$';
 import bonzo from 'bonzo';
 import qwery from 'qwery';
 import ajax from 'common/utils/ajax';
+import fastdom from 'fastdom';
 
-import helpers from 'es6/projects/common/modules/crosswords/helpers';
-import persistence from 'es6/projects/common/modules/crosswords/persistence';
+import helpers from './helpers';
+import persistence from './persistence';
+import loadFont from './font';
 
 const textXOffset = 15;
-const textYOffset = 19;
+const textYOffset = 16;
 
 function makeTextCells(savedState) {
     const columns = savedState.length;
@@ -36,25 +38,32 @@ function makeTextCells(savedState) {
 }
 
 function init() {
-    _.forEach(qwery('.js-crossword-thumbnail'), (elem) => {
-        const $elem = bonzo(elem);
-        const savedState = persistence.loadGridState($elem.attr('data-crossword-id'));
+    const thumbnails = qwery('.js-crossword-thumbnail');
 
-        if (savedState) {
-            ajax({
-                url: $elem.attr('src'),
-                type: 'xml',
-                method: 'get',
-                crossOrigin: true,
-                success (data) {
-                    const cells = makeTextCells(savedState);
-                    const svg = qwery('svg', data)[0];
-                    bonzo(svg).append(cells);
-                    $elem.replaceWith(svg);
-                }
-            });
-        }
-    });
+    if(thumbnails.length) {
+        loadFont();
+        _.forEach(thumbnails, (elem) => {
+            const $elem = bonzo(elem);
+            const savedState = persistence.loadGridState($elem.attr('data-crossword-id'));
+
+            if (savedState) {
+                ajax({
+                    url: $elem.attr('src'),
+                    type: 'xml',
+                    method: 'get',
+                    crossOrigin: true,
+                    success (data) {
+                        const cells = makeTextCells(savedState);
+                        const svg = qwery('svg', data)[0];
+                        bonzo(svg).append(cells);
+                        fastdom.write(function () {
+                            $elem.replaceWith(svg);
+                        });
+                    }
+                });
+            }
+        });
+    }
 }
 
 export default {


### PR DESCRIPTION
before:

![screen shot 2015-05-12 at 17 18 32](https://cloud.githubusercontent.com/assets/867233/7592443/14c579f2-f8cb-11e4-8e02-3ff938279274.png)

after:

![screen shot 2015-05-12 at 17 18 45](https://cloud.githubusercontent.com/assets/867233/7592449/1aca4bfc-f8cb-11e4-873c-5d80893528e1.png)

nb this doesn't address the previews not showing on code. that's a JSPM thing...
