### PR TITLE
extend quiz scores switch

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -499,7 +499,7 @@ object Switches {
 
   val QuizScoresService = Switch("Feature", "quiz-scores-service",
     "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
-    safeState = Off, sellByDate = new LocalDate(2015, 5, 16))
+    safeState = Off, sellByDate = new LocalDate(2015, 8, 16))
 
   val IdentityLogRegistrationsFromTor = Switch("Feature", "id-log-tor-registrations",
     "If switched on, any user registrations from a known tor esit node will be logged",


### PR DESCRIPTION
We are still using the quiz scores service and it's not ready to put into CAPI as we're actively working on quizzes, so extending for a few months.
We don't think it's useful for personality quizzes but it is still needed for knowledge quizzes.
