### PR TITLE
Our own proxy for commenting

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -243,6 +243,8 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   object discussion {
     lazy val apiRoot = configuration.getMandatoryStringProperty("discussion.apiRoot")
     lazy val secureApiRoot = configuration.getMandatoryStringProperty("discussion.secureApiRoot")
+    lazy val apiRootProxy = configuration.getMandatoryStringProperty("discussion.apiRootProxy")
+    lazy val secureApiRootProxy = configuration.getMandatoryStringProperty("discussion.secureApiRootProxy")
     lazy val apiTimeout = configuration.getMandatoryStringProperty("discussion.apiTimeout")
     lazy val apiClientHeader = configuration.getMandatoryStringProperty("discussion.apiClientHeader")
     lazy val url = configuration.getMandatoryStringProperty("discussion.url")
@@ -310,6 +312,8 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       "idOAuthUrl" -> id.oauthUrl,
       "discussionApiRoot" -> discussion.apiRoot,
       ("secureDiscussionApiRoot", discussion.secureApiRoot),
+      ("discussionApiRootProxy", discussion.apiRootProxy),
+      ("secureDiscussionApiRootProxy", discussion.secureApiRootProxy),
       "discussionApiClientHeader" -> discussion.apiClientHeader,
       ("ophanJsUrl", ophan.jsLocation),
       ("ophanEmbedJsUrl", ophan.embedJsLocation),

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -535,6 +535,11 @@ object Switches {
     safeState = Off, sellByDate = new LocalDate(2015, 5, 15)
   )
 
+  val DiscussionApiProxySwitch = Switch("Feature", "discussion-use-api-proxy",
+    "When switched ON all discussion traffic will be relayed via theguardian.com/discussion/proxy",
+    safeState = Off, sellByDate = new LocalDate(2015, 6, 11)
+  )
+
   // A/B Tests
   val ABMtLzAdsDepth = Switch("A/B Tests", "ab-mt-lz-ads-depth", "Depth for lazy loaded ads.",
     safeState = Off, sellByDate = new LocalDate(2015, 5, 15)

--- a/discussion/app/controllers/DiscussionProxyController.scala
+++ b/discussion/app/controllers/DiscussionProxyController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import conf.Configuration
+import play.api.libs.json.Json
 import play.api.libs.ws.WS
 import play.api.mvc.Action
 
@@ -10,8 +11,8 @@ object DiscussionProxyController extends DiscussionController {
 
     log.info(s"### RELAY!!")
 
-    val headers = request.headers.toSimpleMap.toSeq
-    val payload = request.body.asJson.get
+    val headers = (request.headers.toSimpleMap ++ Map("X-Forwarded-For" -> request.remoteAddress)).toSeq
+    val payload = request.body.asJson.getOrElse(Json.parse("{}"))
     val timeout = Configuration.discussion.apiTimeout.toInt
     val apiRoot = request.isSecure match {
       case true => Configuration.discussion.secureApiRoot

--- a/discussion/app/controllers/DiscussionProxyController.scala
+++ b/discussion/app/controllers/DiscussionProxyController.scala
@@ -1,0 +1,32 @@
+package controllers
+
+import conf.Configuration
+import play.api.libs.ws.WS
+import play.api.mvc.Action
+
+object DiscussionProxyController extends DiscussionController {
+  def relay(path: String) = Action.async { implicit request =>
+    import play.api.Play.current
+
+    log.info(s"### RELAY!!")
+
+    val headers = request.headers.toSimpleMap.toSeq
+    val payload = request.body.asJson.get
+    val timeout = Configuration.discussion.apiTimeout.toInt
+    val apiRoot = request.isSecure match {
+      case true => Configuration.discussion.secureApiRoot
+      case _ => Configuration.discussion.apiRoot
+    }
+
+    log.info(s"### proxied comment call to: ${apiRoot + path}")
+
+    WS.url(apiRoot + path)
+      .withHeaders(headers: _*)
+      .withMethod(request.method)
+      .withRequestTimeout(timeout)
+      .post(payload).map{ response =>
+        Ok(response.json)
+      }
+
+  }
+}

--- a/discussion/conf/routes
+++ b/discussion/conf/routes
@@ -30,3 +30,5 @@ GET         /discussion/profile/:id/picks.json                                  
 GET         /discussion/profile/:id/witness.json                                controllers.WitnessActivityController.witnessActivity(id: String)
 
 GET         /open/cta/article/*discussionKey.json                               controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)
+
+POST        /discussion/proxy/*path                                             controllers.DiscussionProxyController.relay(path)

--- a/static/src/javascripts/projects/common/modules/discussion/api.js
+++ b/static/src/javascripts/projects/common/modules/discussion/api.js
@@ -34,21 +34,18 @@ define([
             data.GU_U = cookies.get('GU_U');
         }
 
-        var useProxy = vars.model.switches()['discussionUseApiProxy'];
-
-        console.log("useProxy?" + ((useProxy) ? Api.proxy : Api.root) + endpoint);
-
-        var request = ajax({
-            url: ((useProxy) ? Api.proxy : Api.root) + endpoint,
-            type: (method === 'get') ? 'jsonp' : 'json',
-            method: method,
-            crossOrigin: (useProxy) ? false : true,
-            data: data,
-            headers: {
-                'D2-X-UID': 'zHoBy6HNKsk',
-                'GU-Client': Api.clientHeader
-            }
-        });
+        var useProxy = config.page.switches.discussionUseApiProxy,
+            request = ajax({
+                url: ((useProxy) ? Api.proxy : Api.root) + endpoint,
+                type: (method === 'get') ? 'jsonp' : 'json',
+                method: method,
+                crossOrigin: (useProxy) ? false : true,
+                data: data,
+                headers: {
+                    'D2-X-UID': 'zHoBy6HNKsk',
+                    'GU-Client': Api.clientHeader
+                }
+            });
 
         return request;
     };

--- a/static/src/javascripts/projects/common/modules/discussion/api.js
+++ b/static/src/javascripts/projects/common/modules/discussion/api.js
@@ -16,6 +16,9 @@ define([
         root: (document.location.protocol === 'https:')
                 ? config.page.secureDiscussionApiRoot
                 : config.page.discussionApiRoot,
+        proxy: (document.location.protocol === 'https:')
+            ? config.page.secureDiscussionApiRootProxy
+            : config.page.discussionApiRootProxy,
         clientHeader: config.page.discussionApiClientHeader
     };
 
@@ -31,11 +34,15 @@ define([
             data.GU_U = cookies.get('GU_U');
         }
 
+        var useProxy = vars.model.switches()['discussionUseApiProxy'];
+
+        console.log("useProxy?" + ((useProxy) ? Api.proxy : Api.root) + endpoint);
+
         var request = ajax({
-            url: Api.root + endpoint,
+            url: ((useProxy) ? Api.proxy : Api.root) + endpoint,
             type: (method === 'get') ? 'jsonp' : 'json',
             method: method,
-            crossOrigin: true,
+            crossOrigin: (useProxy) ? false : true,
             data: data,
             headers: {
                 'D2-X-UID': 'zHoBy6HNKsk',

--- a/static/src/javascripts/test/spec/common/discussion/comment-box.spec.js
+++ b/static/src/javascripts/test/spec/common/discussion/comment-box.spec.js
@@ -6,6 +6,14 @@ import validCommentText from 'fixtures/discussion/comment-valid';
 import apiPostValidCommentResp from 'fixtures/discussion/api-post-comment-valid';
 import CommentBox from 'common/modules/discussion/comment-box';
 
+var config = {
+    page: {
+        switches: {
+            discussionUseApiProxy: true
+        }
+    }
+};
+
 describe('Comment box', function() {
     var server,
         fixturesId = 'comment-box',
@@ -66,6 +74,9 @@ describe('Comment box', function() {
     beforeEach(function() {
         server = sinon.fakeServer.create();
         fixtures.render(fixture);
+        config.page.switches = {
+            discussionUseApiProxy: true
+        };
         commentBox = new CommentBox({
             discussionId: discussionId,
             maxLength: maxCommentLength,


### PR DESCRIPTION
!PLEASE DON'T MERGE YET!

We've seen comment submissions fail due to a breakdown of CORS when the commenter is behind an HTTP 1.0 proxy. This change sets up a route that lets us do the proxying to the discussion API from within our own domain.

However, this code is untested because I've not yet been able to authenticate myself with the identity service when running from localhost and using CODE as the source of articles / comments etc, and so I'm unable to actually try to add a comment.

Please can someone take a look and let me know what glaring errors are lurking here (a lot of this is the result of guesswork on my part) because I may have to merge to master in order to test it on the code environment. In which case I at least need to know for sure that the feature switch logic will work as expected.

Thanks,
Justin.
