### PR TITLE
Live blog contributor images are here to stay. Kill the switch.

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -233,12 +233,6 @@ object Switches {
     safeState = On, sellByDate = never
   )
 
-  val LiveBlogContributorImagesSwitch = Switch("Feature", "liveblog-contributor-image",
-    "Show contributor byline images in live blog blocks",
-    safeState = Off,
-    sellByDate = new LocalDate(2015, 5, 28)
-  )
-
   val ElectionLiveBadgeSwitch = Switch("Feature", "election-2015-badging",
     "Display Election Live 2015 Badge",
     safeState = On,

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -294,7 +294,7 @@ case class LiveBlogDateFormatter(isLiveBlog: Boolean)(implicit val request: Requ
 
 case class BloggerBylineImage(article: Article)(implicit val request: RequestHeader) extends HtmlCleaner  {
   def clean(body: Document): Document = {
-    if (article.isLiveBlog && LiveBlogContributorImagesSwitch.isSwitchedOn) {
+    if (article.isLiveBlog) {
       body.select(".block").foreach { el =>
         val contributorId = el.attributes().get("data-block-contributor")
         if (contributorId.nonEmpty) {


### PR DESCRIPTION
There should be no need to turn this feature off, so let's remove the switch.

Before;
![screen shot 2015-05-14 at 15 44 28](https://cloud.githubusercontent.com/assets/690395/7633922/79ca1760-fa4f-11e4-86bf-88f6db8c8daf.png)

After;
![screen shot 2015-05-14 at 15 42 47](https://cloud.githubusercontent.com/assets/690395/7633896/4f445b22-fa4f-11e4-92dd-2b2373168cf9.png)

Nice.
