### PR TITLE
Re-word social sign-in confirmation message

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/autosignin.js
+++ b/static/src/javascripts/projects/common/modules/identity/autosignin.js
@@ -85,8 +85,8 @@ function (
 
         this.welcome = function (name) {
             var msg = '<p class="site-message__message" data-test-id="facebook-auto-sign-in-banner">' +
-                          'Welcome ' + name + ', you’re signed into the Guardian using Facebook, or ' +
-                          '<a data-link-name="fb auto : sign out" href="' + config.page.idUrl + '/signout"/>sign out</a>.' +
+                          'Welcome ' + name + ', you’re signed in to the Guardian using Facebook. ' +
+                          '<a data-link-name="fb auto : sign out" href="' + config.page.idUrl + '/signout"/>Sign out</a>.' +
                       '</p>';
             new Message('fbauto', { important: true }).show(msg);
         };


### PR DESCRIPTION
When using social sign-in, a banner at the bottom of article pages informs
users that they're logged in with $socialprovider. The confirmation text
reads:

"Welcome $name, you're signed into the Guardian using Facebook, or sign
out".

Here's an example:

![screen shot 2015-05-14 at 15 58 20](https://cloud.githubusercontent.com/assets/683665/7634323/1b4237d8-fa52-11e4-88f9-ee26ab92d6d3.png)

That seemed a bit odd in terms of style, so this commit updates it to:

"Welcome $name, you're signed in to the Guardian using Facebook. Sign out."
