### PR TITLE
add appindexing to the json linked data stuff

### DIFF
--- a/article/test/ArticleMetaDataTest.scala
+++ b/article/test/ArticleMetaDataTest.scala
@@ -18,10 +18,14 @@ import play.api.test.Helpers._
     script.size() should be(1)
 
     val data: JsValue = Json.parse(script.first().html())
-    (data \ "name").as[String] should be("The Guardian")
-    (data \ "logo").as[String] should include("152x152.png")
+    val organisation = data.asInstanceOf[JsArray](0)
+    val appIndexer = data.asInstanceOf[JsArray](1)
+    (organisation \ "name").as[String] should be("The Guardian")
+    (organisation \ "logo").as[String] should include("152x152.png")
 
-    val socialNetworks = (data \ "sameAs").as[List[String]]
+    (appIndexer \ "potentialAction" \ "target").as[String] should include(articleUrl)
+
+    val socialNetworks = (organisation \ "sameAs").as[List[String]]
 
     socialNetworks.size should be(4)
   }

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -13,7 +13,7 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
   lazy val section: String = id
 
   lazy val id: String = delegate.id
-  lazy val webUrl: String = delegate.webUrl
+  override lazy val webUrl: String = delegate.webUrl
   lazy val webTitle: String = delegate.webTitle
 
   lazy val keywordIds: Seq[String] = frontKeywordIds(id)

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -16,7 +16,7 @@ case class Tag(private val delegate: ApiTag, override val pagination: Option[Pag
   // some tags e.g. tone do not have an explicit section
   lazy val section: String = delegate.sectionId.getOrElse("global")
 
-  lazy val webUrl: String = delegate.webUrl
+  override lazy val webUrl: String = delegate.webUrl
   lazy val webTitle: String = delegate.webTitle
   lazy val sectionName: String = delegate.sectionName.getOrElse("global")
   override lazy val description = delegate.description

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -40,7 +40,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   lazy val internalContentCode: String = delegate.safeFields("internalContentCode")
   lazy val shortUrl: String = delegate.safeFields("shortUrl")
   lazy val shortUrlId: String = delegate.safeFields("shortUrl").replace("http://gu.com", "")
-  lazy val webUrl: String = delegate.webUrl
+  override lazy val webUrl: String = delegate.webUrl
   lazy val standfirst: Option[String] = fields.get("standfirst")
   lazy val contributorBio: Option[String] = fields.get("contributorBio")
   lazy val starRating: Option[Int] = fields.get("starRating").flatMap(s => Try(s.toInt).toOption)

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -3,14 +3,19 @@ package model
 import common.{NavItem, Edition, ManifestData, Pagination}
 import conf.Configuration
 import dfp.DfpAgent
+import model.meta.{PotentialAction, WebPage, LinkedData, Guardian}
 import play.api.libs.json.{JsBoolean, JsValue, JsString}
 
+/**
+ * MetaData represents a page on the site, whether facia or content
+ */
 trait MetaData extends Tags {
   def id: String
   def section: String
   def webTitle: String
   def analyticsName: String
   def url: String  = s"/$id"
+  def webUrl: String = s"${Configuration.site.host}$url"
   def linkText: String = webTitle
   def pagination: Option[Pagination] = None
   def description: Option[String] = None
@@ -67,7 +72,7 @@ trait MetaData extends Tags {
     "og:site_name" -> "the Guardian",
     "fb:app_id"    -> Configuration.facebook.appId,
     "og:type"      -> "website",
-    "og:url"       -> s"${Configuration.site.host}$url"
+    "og:url"       -> webUrl
   )
 
   def openGraphImages: Seq[String] = Seq()
@@ -78,6 +83,11 @@ trait MetaData extends Tags {
     "twitter:app:id:iphone" -> "409128287",
     "twitter:app:name:googleplay" -> "The Guardian",
     "twitter:app:id:googleplay" -> "com.guardian"
+  )
+
+  def linkedData: List[LinkedData] = List(
+    Guardian(),
+    WebPage(webUrl, PotentialAction(target = webUrl.replace("://", "/")))
   )
 
   def cacheSeconds = 60
@@ -92,6 +102,10 @@ trait MetaData extends Tags {
     DfpAgent.isExpiredAdvertisementFeature(id, tags, Some(section))
   lazy val sponsorshipTag: Option[Tag] = DfpAgent.sponsorshipTag(tags, Some(section))
 }
+
+
+
+
 
 class Page(
   val id: String,
@@ -247,6 +261,9 @@ trait Elements {
   }
 }
 
+/**
+ * Tags lets you extract meaning from tags on a page.
+ */
 trait Tags {
   def tags: Seq[Tag] = Nil
   def contributorAvatar: Option[String] = tags.flatMap(_.contributorImagePath).headOption

--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -1,5 +1,7 @@
 package model.meta
 
+import conf.Static
+
 class LinkedData(
                        val `@type`: String,
                        val `@context`: String = "http://schema.org")
@@ -17,7 +19,7 @@ object LinkedData {
 case class Guardian(
                      name: String = "The Guardian",
                      url: String = "http://www.theguardian.com/",
-                     logo: String = "http://assets.guim.co.uk/images/favicons/451963ac2e23633472bf48e2856d3f04/152x152.png",
+                     logo: String = Static("images/favicons/152x152.png").path,
                      sameAs: List[String] = List(
                        "https://www.facebook.com/theguardian",
                        "https://twitter.com/guardian",

--- a/common/app/model/meta/LinkedData.scala
+++ b/common/app/model/meta/LinkedData.scala
@@ -1,0 +1,38 @@
+package model.meta
+
+class LinkedData(
+                       val `@type`: String,
+                       val `@context`: String = "http://schema.org")
+
+object LinkedData {
+
+  import org.json4s._
+  import org.json4s.native.Serialization.write
+
+  implicit val formats = DefaultFormats + FieldSerializer[LinkedData]()
+
+  def toJson(list: List[LinkedData]) = write(list)
+}
+
+case class Guardian(
+                     name: String = "The Guardian",
+                     url: String = "http://www.theguardian.com/",
+                     logo: String = "http://assets.guim.co.uk/images/favicons/451963ac2e23633472bf48e2856d3f04/152x152.png",
+                     sameAs: List[String] = List(
+                       "https://www.facebook.com/theguardian",
+                       "https://twitter.com/guardian",
+                       "https://plus.google.com/+theGuardian",
+                       "https://www.youtube.com/user/TheGuardian"
+                     )
+                     ) extends LinkedData("Organization")
+
+// https://developers.google.com/app-indexing/webmasters/server#schemaorg-markup-for-viewaction
+case class WebPage(
+                    `@id`: String,
+                    potentialAction: PotentialAction
+                    ) extends LinkedData("WebPage")
+
+case class PotentialAction(
+                            `@type`: String = "ViewAction",
+                            target: String
+                            )

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -3,6 +3,7 @@
 @import common.AnalyticsHost
 @import common._
 @import conf._
+@import model.meta.LinkedData
 @import play.api.Play
 @import play.api.Play.current
 @import views.support._
@@ -110,17 +111,5 @@
 <meta name="google-site-verification" content="LR-FN6c2gIEUoo3k049w1nxyHykmac5ZE3SaUOiKc30" />
 
 <script data-schema="organization" type="application/ld+json">
-    {
-        "@@context" : "http://schema.org",
-        "@@type" : "Organization",
-        "name" : "The Guardian",
-        "url" : "http://www.theguardian.com/",
-        "logo" : "@Static("images/favicons/152x152.png")",
-        "sameAs" : [
-            "https://www.facebook.com/theguardian",
-            "https://twitter.com/guardian",
-            "https://plus.google.com/+theGuardian",
-            "https://www.youtube.com/user/TheGuardian"
-        ]
-    }
+@Html(LinkedData.toJson(item.linkedData))
 </script>


### PR DESCRIPTION
We would like to add app indexing to the site so google can suggest to install the app if users don't have it, and ensure coverage of all our pages to let users open on app or web from search.
For the tech info see https://developers.google.com/app-indexing/webmasters/server#schemaorg-markup-for-viewaction
The output is not formatted, but an example formats to this:

```
[
  {
    "name": "The Guardian",
    "url": "http://www.theguardian.com/",
    "logo": "http://assets.guim.co.uk/images/favicons/451963ac2e23633472bf48e2856d3f04/152x152.png",
    "sameAs": [
      "https://www.facebook.com/theguardian",
      "https://twitter.com/guardian",
      "https://plus.google.com/+theGuardian",
      "https://www.youtube.com/user/TheGuardian"
    ],
    "@type": "Organization",
    "@context": "http://schema.org"
  },
  {
    "@id": "http://www.theguardian.com/politics/live/2015/apr/17/election-2015-live-ed-miliband-nicola-sturgeon-david-cameron-snp-labour",
    "potentialAction": {
      "@type": "ViewAction",
      "target": "http/www.theguardian.com/politics/live/2015/apr/17/election-2015-live-ed-miliband-nicola-sturgeon-david-cameron-snp-labour"
    },
    "@type": "WebPage",
    "@context": "http://schema.org"
  }
]
```

You can validate it here:
https://developers.google.com/structured-data/testing-tool/
fyi @mohammad-haque
