### PR TITLE
Save for Later article button styling

### DIFF
--- a/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
@@ -30,7 +30,7 @@ define([
         this.shortUrl = config.page.shortUrl.replace('http://gu.com', '');   //  Keep the fitst trailing slash
     }
 
-    var bookmarkSvg = svgs('bookmark');
+    var bookmarkSvg = svgs('bookmark', ['i-left']);
 
     SaveForLater.prototype.init = function () {
         if (identity.isUserLoggedIn()) {

--- a/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
@@ -41,7 +41,8 @@ define([
             this.$saver.html(
                 template(saveForLaterTmpl, {
                     url: url,
-                    icon: bookmarkSvg
+                    icon: bookmarkSvg,
+                    state: "save"
                 })
             );
         }

--- a/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/loyalty/save-for-later.js
@@ -42,7 +42,7 @@ define([
                 template(saveForLaterTmpl, {
                     url: url,
                     icon: bookmarkSvg,
-                    state: "save"
+                    state: 'save'
                 })
             );
         }

--- a/static/src/javascripts/projects/common/views/loyalty/save-for-later.html
+++ b/static/src/javascripts/projects/common/views/loyalty/save-for-later.html
@@ -2,5 +2,5 @@
     {{icon}}
     <span class="save-for-later__label save-for-later__label--save">Save for later</span>
     <span class="save-for-later__label save-for-later__label--saved">Article saved</span>
-    <span class="save-for-later__label save-for-later__label--remove">Remove article?</span>
+    <span class="save-for-later__label save-for-later__label--remove">Remove?</span>
 </a>

--- a/static/src/javascripts/projects/common/views/loyalty/save-for-later.html
+++ b/static/src/javascripts/projects/common/views/loyalty/save-for-later.html
@@ -1,4 +1,6 @@
-<button class="button button--medium button--tertiary save-for-later__button js-save-for-later-button" data-test-id="show-more" data-link-name="more">
+<a class="button button--medium button--tertiary save-for-later__button js-save-for-later-button save-for-later--{{state}}" href="{{url}}"data-link-name="meta-save-for-later" data-component="meta-save-for-later">
     {{icon}}
-    <a href="{{url}}"data-link-name="meta-save-for-later" data-component="meta-save-for-later">Save for later</a>
-</button>
+    <span class="save-for-later__label save-for-later__label--save">Save for later</span>
+    <span class="save-for-later__label save-for-later__label--saved">Article saved</span>
+    <span class="save-for-later__label save-for-later__label--remove">Remove article?</span>
+</a>

--- a/static/src/javascripts/projects/common/views/loyalty/save-for-later.html
+++ b/static/src/javascripts/projects/common/views/loyalty/save-for-later.html
@@ -1,4 +1,4 @@
-<button class="button button--medium js-show-more-button" data-test-id="show-more" data-link-name="more">
+<button class="button button--medium button--tertiary save-for-later__button js-save-for-later-button" data-test-id="show-more" data-link-name="more">
     {{icon}}
     <a href="{{url}}"data-link-name="meta-save-for-later" data-component="meta-save-for-later">Save for later</a>
 </button>

--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -65,7 +65,6 @@
 @import 'module/nav/_has-localnav-overrides';
 @import 'module/nav/_navigation';
 @import 'module/_rounded-icon';
-@import 'module/_save-for-later';
 
 
 /* ==========================================================================

--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -65,6 +65,7 @@
 @import 'module/nav/_has-localnav-overrides';
 @import 'module/nav/_navigation';
 @import 'module/_rounded-icon';
+@import 'module/_save-for-later';
 
 
 /* ==========================================================================

--- a/static/src/stylesheets/global.scss
+++ b/static/src/stylesheets/global.scss
@@ -65,6 +65,8 @@
 @import 'module/_rich-links';
 @import 'module/_membership-events';
 
+@import 'module/_save-for-later';
+
 /* ==========================================================================
    External modules
    ========================================================================== */

--- a/static/src/stylesheets/module/_save-for-later.scss
+++ b/static/src/stylesheets/module/_save-for-later.scss
@@ -12,7 +12,8 @@
 
 .button.save-for-later__button {
     font-size: get-font-size(textSans, 1);
-    border: green !important;
+    width: gs-span(2) - $gs-gutter;
+    @include button-height(32px);
 
     @include button-colour(
         $fill-colour: colour(neutral-6),

--- a/static/src/stylesheets/module/_save-for-later.scss
+++ b/static/src/stylesheets/module/_save-for-later.scss
@@ -14,7 +14,6 @@
     font-size: get-font-size(textSans, 1);
     width: gs-span(2) - $gs-gutter;
     @include button-height(32px);
-
     @include button-colour(
         $fill-colour: colour(neutral-6),
         $border-color: colour(neutral-6),
@@ -26,6 +25,16 @@
     @include save-for-later-state(save, colour(neutral-2));
     @include save-for-later-state(saved, colour(news-accent));
     @include save-for-later-state(remove, colour(live-accent));
+
+    &.save-for-later--save {
+        @include button-colour(
+            $fill-colour: transparent,
+            $border-color: colour(neutral-6),
+            $text-colour: colour(neutral-1),
+            $hover-colour: colour(neutral-8),
+            $hover-border: colour(neutral-8)
+        );
+    }
 
     &:hover {
         background-color: colour(neutral-5);

--- a/static/src/stylesheets/module/_save-for-later.scss
+++ b/static/src/stylesheets/module/_save-for-later.scss
@@ -1,0 +1,13 @@
+.save-for-later__button {
+    color: colour(neutral-1);
+    @include fs-textSans(1);
+
+    .inline-icon {
+        fill: colour(neutral-1);
+        margin-left: 0;
+
+        svg {
+            width: 18px;
+        }
+    }
+}

--- a/static/src/stylesheets/module/_save-for-later.scss
+++ b/static/src/stylesheets/module/_save-for-later.scss
@@ -1,13 +1,46 @@
-.save-for-later__button {
-    color: colour(neutral-1);
-    @include fs-textSans(1);
+@mixin save-for-later-state($state, $c-accent) {
+    &.save-for-later--#{$state} {
+        .save-for-later__label--#{$state} {
+            display: inline;
+        }
+
+        &.button .inline-icon {
+            fill: $c-accent;
+        }
+    }
+}
+
+.button.save-for-later__button {
+    font-size: get-font-size(textSans, 1);
+    border: green !important;
+
+    @include button-colour(
+        $fill-colour: colour(neutral-6),
+        $border-color: colour(neutral-6),
+        $text-colour: colour(neutral-1),
+        $hover-colour: colour(neutral-5),
+        $hover-border: colour(neutral-5)
+    );
+
+    @include save-for-later-state(save, colour(neutral-2));
+    @include save-for-later-state(saved, colour(news-accent));
+    @include save-for-later-state(remove, colour(live-accent));
+
+    &:hover {
+        background-color: colour(neutral-5);
+    }
 
     .inline-icon {
         fill: colour(neutral-1);
         margin-left: 0;
+        margin: 0 4px 0 0;
 
         svg {
             width: 18px;
         }
     }
+}
+
+.save-for-later__label {
+    display: none;
 }

--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -124,7 +124,7 @@
 
 .meta__save-for-later {
     padding-top: $gs-baseline / 2;
-    padding-bottom: $gs-baseline;
+    padding-bottom: $gs-baseline / 2;
     margin-bottom: 0;
     border-top: 1px dotted colour(neutral-5);
 }

--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -42,7 +42,13 @@
     height: $gs-baseline * 3;
     padding: $gs-baseline / 2 0;
 
-    @include mq(mobileLandscape, leftCol) {
+    @include mq(mobile, mobileLandscape) {
+        position: absolute;
+        right: 0;
+        bottom: -2px;
+        border: 0;
+    }
+    @include mq(tablet, leftCol) {
         position: absolute;
         right: 0;
         top: 0;
@@ -127,6 +133,20 @@
     padding-bottom: $gs-baseline / 2;
     margin-bottom: 0;
     border-top: 1px dotted colour(neutral-5);
+    position: relative;
+
+    $social-width: 39px;
+
+    @include mq(mobileLandscape, leftCol) {
+        position: absolute;
+        top: 1px;
+        left: ($social-width * 6);
+        border-top: 0;
+    }
+    
+    @include mq(tablet, leftCol) {
+        left: ($social-width * 5);
+    }
 }
 
 .meta__number:not(.u-h) + .meta__number {

--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -123,7 +123,7 @@
 }
 
 .meta__save-for-later {
-    padding-top: $gs-baseline / 6;
+    padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline;
     margin-bottom: 0;
     border-top: 1px dotted colour(neutral-5);


### PR DESCRIPTION
Styling for the in-article save for later button.

Placement:
![button](https://cloud.githubusercontent.com/assets/1607666/7685230/8f26abae-fd84-11e4-996b-40471698dd9d.gif)

States:
![screen shot 2015-05-18 at 17 53 34](https://cloud.githubusercontent.com/assets/1607666/7685536/e74f5c20-fd86-11e4-99f6-4a3925537280.png)
![screen shot 2015-05-18 at 17 53 43](https://cloud.githubusercontent.com/assets/1607666/7685534/e74db5be-fd86-11e4-9152-0ebc6124aa94.png)
![screen shot 2015-05-18 at 17 54 06](https://cloud.githubusercontent.com/assets/1607666/7685535/e74e2b8e-fd86-11e4-902c-d1f3e00a9ef9.png)

Last state (remove) only appears on rollover of saved button. Might need beefing up but am reluctant to make a decision until we actually have the correct logic for this button in place.
