### PR TITLE
Fix console error in DEV

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -62,7 +62,8 @@ define([
                 var collections = (resp.collections || [])
                     .filter(function (collection) { return _.isArray(collection.content) && collection.content.length; })
                     .map(function (collection) {
-                        collection.href = collection.href.toLowerCase();
+                        // collection.href is string or null
+                        collection.href = (collection.href || '').toLowerCase();
                         return collection;
                     }),
                     treatAsInternationalForAlerts = page.internationalEdition === 'international',


### PR DESCRIPTION
In the data at `http://localhost:9000/breaking-news/lite.json`, `collections[].href` is `null` (which is valid), therefore resorting in:

```
Uncaught TypeError: Cannot read property 'toLowerCase' of null
```

Let's clear our console of silly errors like this :smile: 
