### PR TITLE
Performance link point to ophan summary

### DIFF
--- a/facia-tool/public/js/constants/defaults.js
+++ b/facia-tool/public/js/constants/defaults.js
@@ -66,7 +66,7 @@ export default {
 
     latestSnapPrefix:      'Latest from ',
 
-    ophanBase:             'http://dashboard.ophan.co.uk/graph/breakdown',
+    ophanBase:             'http://dashboard.ophan.co.uk/summary',
     ophanFrontBase:        'http://dashboard.ophan.co.uk/info?path=',
 
     internalContentPrefix: 'internal-code/content/',


### PR DESCRIPTION
In facia tool the performance link is pointing to the breakdown graph.
It's more useful to point to the summary page of each article, that anyway includes the performance graph in it.
