### PR TITLE
New: specify keywords to use in the Ad Test Page

### DIFF
--- a/commercial/app/controllers/commercial/CreativeTestPage.scala
+++ b/commercial/app/controllers/commercial/CreativeTestPage.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.{JsString, JsValue}
 import play.api.mvc._
 import conf.Configuration
 
-object TestPage extends model.MetaData  {
+class TestPage(specifiedKeywords : List[String] = Nil) extends model.MetaData  {
 
   override lazy val id: String = "1234567"
   override lazy val description: Option[String] = None
@@ -21,9 +21,15 @@ object TestPage extends model.MetaData  {
   lazy val faciaPageMetaData: Map[String, JsValue] = newMetaData
 
   lazy val newMetaData: Map[String, JsValue] = Map(
-    "keywords" -> JsString(webTitle.capitalize),
+    "keywords" -> JsString(capitalisedKeywords),
+    "keywordIds" -> JsString(lowerCaseKeywords),
     "contentType" -> JsString(contentType)
   )
+
+  lazy val allTheKeywords = webTitle :: specifiedKeywords
+
+  def capitalisedKeywords = (allTheKeywords).map(_.capitalize).mkString(",")
+  def lowerCaseKeywords = (allTheKeywords).map(_.toLowerCase).mkString(",")
 
   val isNetworkFront: Boolean = false
 
@@ -32,9 +38,9 @@ object TestPage extends model.MetaData  {
 }
 
 object CreativeTestPage extends Controller {
-  def allComponents() = Action{ implicit request =>
+  def allComponents(keyword : List[String]) = Action{ implicit request =>
     if(Configuration.environment.stage == "dev" || Configuration.environment.stage == "code") {
-      Ok(views.html.debugger.allcreatives(TestPage))
+      Ok(views.html.debugger.allcreatives(new TestPage(keyword)))
     } else {
       NotFound
     }

--- a/commercial/app/controllers/commercial/CreativeTestPage.scala
+++ b/commercial/app/controllers/commercial/CreativeTestPage.scala
@@ -28,8 +28,8 @@ class TestPage(specifiedKeywords : List[String] = Nil) extends model.MetaData  {
 
   lazy val allTheKeywords = webTitle :: specifiedKeywords
 
-  def capitalisedKeywords = (allTheKeywords).map(_.capitalize).mkString(",")
-  def lowerCaseKeywords = (allTheKeywords).map(_.toLowerCase).mkString(",")
+  lazy val capitalisedKeywords = (allTheKeywords).map(_.capitalize).mkString(",")
+  lazy val lowerCaseKeywords = (allTheKeywords).map(_.toLowerCase).mkString(",")
 
   val isNetworkFront: Boolean = false
 

--- a/commercial/app/controllers/commercial/JobAds.scala
+++ b/commercial/app/controllers/commercial/JobAds.scala
@@ -23,20 +23,4 @@ object JobAds extends Controller with implicits.Requests {
       }
     }
   }
-
-  def renderJobsHtml = MemcachedAction { implicit request =>
-    Future.successful {
-      (JobsAgent.specificJobs(specificIds) ++ JobsAgent.jobsTargetedAt(segment)).distinct match {
-        case Nil => NoCache(jsonFormat.nilResult)
-        case jobs => Cached(componentMaxAge) {
-          val clickMacro = request.getParameter("clickMacro")
-          val omnitureId = request.getParameter("omnitureId")
-
-          htmlFormat.result(views.html.jobs.jobs(jobs.take(2), omnitureId, clickMacro))
-        }
-      }
-    }
-  }
-
-
 }

--- a/commercial/app/controllers/commercial/JobAds.scala
+++ b/commercial/app/controllers/commercial/JobAds.scala
@@ -24,4 +24,19 @@ object JobAds extends Controller with implicits.Requests {
     }
   }
 
+  def renderJobsHtml = MemcachedAction { implicit request =>
+    Future.successful {
+      (JobsAgent.specificJobs(specificIds) ++ JobsAgent.jobsTargetedAt(segment)).distinct match {
+        case Nil => NoCache(jsonFormat.nilResult)
+        case jobs => Cached(componentMaxAge) {
+          val clickMacro = request.getParameter("clickMacro")
+          val omnitureId = request.getParameter("omnitureId")
+
+          htmlFormat.result(views.html.jobs.jobs(jobs.take(2), omnitureId, clickMacro))
+        }
+      }
+    }
+  }
+
+
 }

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -4,7 +4,7 @@
 
 # For dev machines
 GET        /assets/*path                                             dev.DevAssetsController.at(path)
-GET        /commercial/test-page                                     controllers.commercial.CreativeTestPage.allComponents
+GET        /commercial/test-page                                     controllers.commercial.CreativeTestPage.allComponents(k: List[String])
 GET        /_healthcheck                                             conf.HealthCheck.healthcheck()
 
 
@@ -13,7 +13,6 @@ GET        /commercial/travel/offers.json                            controllers
 
 # Jobs
 GET        /commercial/jobs.json                                     controllers.commercial.JobAds.renderJobs
-GET        /commercial/jobs.html                                     controllers.commercial.JobAds.renderJobsHtml
 
 # Masterclasses
 GET        /commercial/masterclasses.json                            controllers.commercial.MasterClasses.renderMasterclasses

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -13,6 +13,7 @@ GET        /commercial/travel/offers.json                            controllers
 
 # Jobs
 GET        /commercial/jobs.json                                     controllers.commercial.JobAds.renderJobs
+GET        /commercial/jobs.html                                     controllers.commercial.JobAds.renderJobsHtml
 
 # Masterclasses
 GET        /commercial/masterclasses.json                            controllers.commercial.MasterClasses.renderMasterclasses


### PR DESCRIPTION
The Ad Test page is handy for looking at the components, but they don't allow you to test targeting. 

This PR will allow you to bake keywords into the page model so that you can see if your components are targeting correctly. 

just add a param with the key value of "k" like this:

commercial/test-page?k=environment
