### PR TITLE
Add ab params to dfp targeting and omniture

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -24,8 +24,15 @@ object JspmTest extends TestDefinition(
   new LocalDate(2015, 5, 30)
 )
 
+object CMtest extends TestDefinition(
+  List(Variant1),
+  "cm-test",
+  "Tests our new JSPM jsavscript configuration",
+  new LocalDate(2015, 5, 30)
+)
+
 object ActiveTests extends Tests {
-  val tests: Seq[TestDefinition] = List(JspmTest)
+  val tests: Seq[TestDefinition] = List(JspmTest, CMtest)
 
   def getJavascriptConfig(implicit request: RequestHeader): String = {
     val configEntries = List(InternationalEditionVariant(request).map{ international => s""""internationalEditionVariant" : "$international" """}) ++

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -24,15 +24,8 @@ object JspmTest extends TestDefinition(
   new LocalDate(2015, 5, 30)
 )
 
-object CMtest extends TestDefinition(
-  List(Variant1),
-  "cm-test",
-  "Tests our new JSPM jsavscript configuration",
-  new LocalDate(2015, 5, 30)
-)
-
 object ActiveTests extends Tests {
-  val tests: Seq[TestDefinition] = List(JspmTest, CMtest)
+  val tests: Seq[TestDefinition] = List(JspmTest)
 
   def getJavascriptConfig(implicit request: RequestHeader): String = {
     val configEntries = List(InternationalEditionVariant(request).map{ international => s""""internationalEditionVariant" : "$international" """}) ++

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -4,7 +4,7 @@
 
 GET         /humans.txt                                                                                              dev.DevAssetsController.humans()
 GET         /surveys/*file                                                                                           dev.DevAssetsController.surveys(file)
-GET         /commercial/test-page                                                                                    controllers.commercial.CreativeTestPage.allComponents
+GET         /commercial/test-page                                     												 controllers.commercial.CreativeTestPage.allComponents(k: List[String])
 
 # For dev machines
 GET         /assets/internal/*file                                                                                   controllers.Assets.at(path="/public", file)

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -66,8 +66,6 @@ define([
                 }
             });
 
-            console.log(abParams);
-
             return abParams;
         };
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -55,9 +55,16 @@ define([
                 abParticipations = ab.getParticipations();
 
             _.forIn(abParticipations, function (n, key) {
-                if (key.indexOf('Mt') > -1 && n.variant &&
-                    n.variant !== 'notintest') {
+                if (n.variant && n.variant !== 'notintest') {
                     abParams.push(key + '-' + n.variant.substring(0, 1));
+                }
+            });
+
+            _.forIn(_.keys(config.tests), function (n, key) {
+                console.log(key.match(/^CM\s/));
+                if (key.match(/^CM\s/)) {
+                    console.log(n, key);
+                    abParams.push(key + '-' + n);
                 }
             });
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -60,7 +60,7 @@ define([
                 }
             });
 
-            _.forIn(_.keys(config.tests), function (n, key) {
+            _.forIn(_.keys(config.tests), function (n) {
                 if (n.match(/^cm/)) {
                     abParams.push(n);
                 }

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -61,12 +61,12 @@ define([
             });
 
             _.forIn(_.keys(config.tests), function (n, key) {
-                console.log(key.match(/^CM\s/));
-                if (key.match(/^CM\s/)) {
-                    console.log(n, key);
-                    abParams.push(key + '-' + n);
+                if (n.match(/^cm/)) {
+                    abParams.push(n);
                 }
             });
+
+            console.log(abParams);
 
             return abParams;
         };

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -61,7 +61,7 @@ define([
             });
 
             _.forIn(_.keys(config.tests), function (n) {
-                if (n.match(/^cm/)) {
+                if (n.toLowerCase().match(/^cm/)) {
                     abParams.push(n);
                 }
             });

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -136,6 +136,13 @@ define([
             }
         });
 
+        _.forEach(_.keys(config.tests), function (k) {
+            if (k.match(/^CM\s/)) {
+                console.log(k);
+                tag.push(['AB', k, 'variant'].join(' | '));
+            }
+        });
+
         if (config.tests.internationalEditionVariant) {
             tag.push(['AB', 'InternationalEditionTest', config.tests.internationalEditionVariant].join(' | '));
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -137,7 +137,7 @@ define([
         });
 
         _.forEach(_.keys(config.tests), function (k) {
-            if (k.match(/^cm/)) {
+            if (k.toLowerCase().match(/^cm/)) {
                 tag.push(['AB', k, 'variant'].join(' | '));
             }
         });

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -137,8 +137,7 @@ define([
         });
 
         _.forEach(_.keys(config.tests), function (k) {
-            if (k.match(/^CM\s/)) {
-                console.log(k);
+            if (k.match(/^cm/)) {
                 tag.push(['AB', k, 'variant'].join(' | '));
             }
         });


### PR DESCRIPTION
For some commercial server side AB testing we need to track tests.

In omniture:
![screen shot 2015-05-21 at 11 40 00](https://cloud.githubusercontent.com/assets/2579465/7747105/9cba0748-ffaf-11e4-952d-3de390d8ade7.png)

And DFP:
![screen shot 2015-05-21 at 11 39 09](https://cloud.githubusercontent.com/assets/2579465/7747108/a897314e-ffaf-11e4-8ac3-d38b336ad33e.png)

We also start to use `cm` prefix so we can clearly see (and send to DFP) only commercial tests.

CC @Calanthe @kenlim @kelvin-chappell 
