### PR TITLE
remove the tech-feedback switch

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -352,11 +352,6 @@ object Switches {
     safeState = Off, never
   )
 
-  val FeedbackLink = Switch("Monitoring", "tech-feedback",
-    "decide by now if it's worth keeping the link in the footer soliciting clicks for technical problems",
-    safeState = Off, new LocalDate(2015, 5, 23)
-  )
-
 
   // Features
   val ABTestHeadlines = Switch(

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -51,9 +51,6 @@ object Metric extends Logging {
     ("comment-post-success", CountMetric("comment-post-success"))
   ) ++ iPhoneMetrics
 
-  lazy val techFeedback = Switches.FeedbackLink // remove tech-feedback metric when this switch is removed.
-
-
   private val iPhoneMetrics: Seq[(String, CountMetric)] = Seq(4, 6).flatMap( model =>
     Seq(
       s"iphone-$model-start" -> CountMetric(s"iphone-$model-start"),


### PR DESCRIPTION
After extending the switch too many time it's time to remove it.

Tech feedback is recording some useful info although we need to iterate on it to make it something more useful rather than a proof of concept.

The next idea is to move the target to theguardian.com and let ophan record the stats about the pages so we can gather some better intelligence about who's having problems.
