### PR TITLE
Turn off showEditorsPicks

### DIFF
--- a/facia-press/app/frontpress/ParseCollection.scala
+++ b/facia-press/app/frontpress/ParseCollection.scala
@@ -288,7 +288,6 @@ trait ParseCollection extends ExecutionContexts with QueryDefaults with Logging 
         case Path(id) =>
           val search = client.item(id, edition)
             .showElements("all")
-            .showEditorsPicks(true)
             .pageSize(20)
           val newSearch = queryParamsWithEdition.foldLeft(search) {
             case (query, (key, value)) => query.stringParam(key, value)


### PR DESCRIPTION
This turns off `showEditorsPicks` for search queries in `ParseCollection`.

This is in the old way of requesting content. For any `path` queries we always asked with `show-editors-picks=true`.

The new method of requesting through `facia-scala-client` already does not use `show-editors-picks=true`.

@stephanfowler 
