### PR TITLE
Set Up New Commercial Integration Test Configuration

### DIFF
--- a/integrated-tests/src/test/scala/integration/commercial/AdsTest.scala
+++ b/integrated-tests/src/test/scala/integration/commercial/AdsTest.scala
@@ -1,6 +1,7 @@
-package integration
+package integration.commercial
 
-import Config.baseUrl
+import integration.SharedWebDriver
+import integration.driver.Config.baseUrl
 import org.scalatest.tags.Retryable
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 

--- a/integrated-tests/src/test/scala/integration/commercial/CommercialTestSuite.scala
+++ b/integrated-tests/src/test/scala/integration/commercial/CommercialTestSuite.scala
@@ -1,0 +1,6 @@
+package integration.commercial
+
+import integration.SingleWebDriver
+import org.scalatest.Suites
+
+class CommercialTestSuite extends Suites(new AdsTest) with SingleWebDriver

--- a/integrated-tests/src/test/scala/integration/common/MostPopularTest.scala
+++ b/integrated-tests/src/test/scala/integration/common/MostPopularTest.scala
@@ -1,5 +1,6 @@
-package integration
+package integration.common
 
+import integration.SharedWebDriver
 import org.scalatest.tags.Retryable
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 

--- a/integrated-tests/src/test/scala/integration/common/SslCertTest.scala
+++ b/integrated-tests/src/test/scala/integration/common/SslCertTest.scala
@@ -1,11 +1,12 @@
-package integration
+package integration.common
 
-import org.scalatest.{DoNotDiscover, FlatSpec}
-import javax.net.ssl._
-import java.security.{cert, SecureRandom}
-import java.net.{ProtocolException, MalformedURLException, URL}
-import org.joda.time.{Days, DateTime}
 import java.io.IOException
+import java.net.{MalformedURLException, ProtocolException, URL}
+import java.security.{SecureRandom, cert}
+import javax.net.ssl._
+
+import org.joda.time.{DateTime, Days}
+import org.scalatest.{DoNotDiscover, FlatSpec}
 import sun.security.x509.X509CertImpl
 
 @DoNotDiscover class SslCertTest extends FlatSpec {
@@ -46,7 +47,7 @@ import sun.security.x509.X509CertImpl
 
         conn.connect()
         val certs = conn.getServerCertificates
-        certs.headOption.map { cert =>
+        certs.headOption.foreach { cert =>
           val x = cert.asInstanceOf[X509CertImpl]
           val expiry = x.getNotAfter.getTime
           val daysleft = Days.daysBetween(new DateTime(), new DateTime(expiry.toLong)).getDays

--- a/integrated-tests/src/test/scala/integration/driver/Config.scala
+++ b/integrated-tests/src/test/scala/integration/driver/Config.scala
@@ -1,6 +1,6 @@
-package integration
+package integration.driver
 
-import java.io.{FileInputStream, File}
+import java.io.{File, FileInputStream}
 import java.util.Properties
 
 object Config {
@@ -22,7 +22,7 @@ object Config {
     props
   }
 
-  val remoteMode = optionalProperty("tests.mode").exists(_ == "remote")
+  val remoteMode = optionalProperty("tests.mode").contains("remote")
   val baseUrl = optionalProperty("tests.baseUrl").getOrElse("http://www.theguardian.com")
   val profileBaseUrl = optionalProperty("tests.profileBaseUrl").getOrElse("https://profile.theguardian.com")
 

--- a/integrated-tests/src/test/scala/integration/facia/ShowMoreTest.scala
+++ b/integrated-tests/src/test/scala/integration/facia/ShowMoreTest.scala
@@ -1,5 +1,6 @@
-package integration
+package integration.facia
 
+import integration.SharedWebDriver
 import org.scalatest.tags.Retryable
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 

--- a/integrated-tests/src/test/scala/integration/profile/ProfileCommentsTest.scala
+++ b/integrated-tests/src/test/scala/integration/profile/ProfileCommentsTest.scala
@@ -1,6 +1,7 @@
-package integration
+package integration.profile
 
-import Config.profileBaseUrl
+import integration.SharedWebDriver
+import integration.driver.Config
 import org.scalatest.tags.Retryable
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 
@@ -8,7 +9,7 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 
   "Profile pages" should "show user comments" in {
     webDriver.get(profileTheguardian("/user/id/4383032"))
-    implicitlyWait(5);
+    implicitlyWait(5)
 
     $("[itemtype='http://schema.org/UserComments']") should not be empty
     $("[itemtype='http://schema.org/Comment']") should not be empty
@@ -28,5 +29,5 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
     $("[itemtype='http://schema.org/Comment']") should not be empty
   }
 
-  protected def profileTheguardian(path: String) = s"$profileBaseUrl$path"
+  protected def profileTheguardian(path: String) = s"${Config.profileBaseUrl}$path"
 }

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -1,13 +1,12 @@
 package com.gu
 
-import sbt._
-import sbt.Keys._
-import play.Play.autoImport._
-import PlayKeys._
-import play._
-import play.twirl.sbt.Import._
+import com.gu.Dependencies._
 import com.typesafe.sbt.web.Import._
-import Dependencies._
+import play.Play.autoImport._
+import play.PlayImport.PlayKeys._
+import play.twirl.sbt.Import._
+import sbt.Keys._
+import sbt._
 
 object Frontend extends Build with Prototypes {
 
@@ -188,6 +187,8 @@ object Frontend extends Build with Prototypes {
   val integrationTests = Project("integrated-tests", file("integrated-tests"))
     .settings(frontendCompilationSettings:_*)
     .settings(frontendIntegrationTestsSettings:_*)
+    .configs(commercialIntegrationTests)
+    .settings(inConfig(commercialIntegrationTests)(Defaults.testTasks): _*)
 
   val pngResizer = application("png-resizer")
     .dependsOn(commonWithTests)

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -1,12 +1,12 @@
 package com.gu
 
+import com.gu.Dependencies._
 import com.gu.versioninfo.VersionInfo
-import sbt._
-import sbt.Keys._
-import com.typesafe.sbt.web.SbtWeb.autoImport._
 import com.typesafe.sbt.SbtNativePackager._
+import com.typesafe.sbt.web.SbtWeb.autoImport._
 import play.twirl.sbt.Import._
-import Dependencies._
+import sbt.Keys._
+import sbt._
 
 trait Prototypes {
   val version = "1-SNAPSHOT"
@@ -27,9 +27,21 @@ trait Prototypes {
     }
   )
 
+  val commercialIntegrationTests = config("commercial-integration") extend Test
+
+  def commercialTestFilter(name: String): Boolean = name startsWith "integration.commercial"
+  def allTestFilter(name: String): Boolean = !commercialTestFilter(name)
+
   val frontendIntegrationTestsSettings = Seq (
     concurrentRestrictions in ThisProject := List(Tags.limit(Tags.Test, 1)),
-    testOptions in Test += Tests.Argument("-oDF"),
+    testOptions in Test ++= Seq(
+      Tests.Argument("-oDF"),
+      Tests.Filter(allTestFilter)
+    ),
+    testOptions in commercialIntegrationTests := Seq(
+      Tests.Argument("-oDF"),
+      Tests.Filter(commercialTestFilter)
+    ),
     resolvers ++= Seq(Resolver.typesafeRepo("releases")),
     libraryDependencies ++= Seq(
       scalaTestPlus,


### PR DESCRIPTION
This enables a new SBT command: `commercial-integration:test`
which will be used in the new Teamcity build configuration.

Also:
- webdriver uses ChromeDriver in local mode
- packages have been put under an integration package

/cc @rich-nguyen 
