### PR TITLE
New versions of fluid 250 and scrollable MPU ad templates

### DIFF
--- a/static/src/javascripts/bootstraps/creatives.js
+++ b/static/src/javascripts/bootstraps/creatives.js
@@ -4,8 +4,10 @@ define([
     'common/modules/commercial/creatives/expandable',
     'common/modules/commercial/creatives/expandable-v2',
     'common/modules/commercial/creatives/fluid250',
+    'common/modules/commercial/creatives/fluid250-v3',
     'common/modules/commercial/creatives/fluid250GoogleAndroid',
     'common/modules/commercial/creatives/foundation-funded-logo',
     'common/modules/commercial/creatives/scrollable-mpu',
+    'common/modules/commercial/creatives/scrollable-mpu-v2',
     'common/modules/commercial/creatives/template'
 ], function () {});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250-v3.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250-v3.js
@@ -1,0 +1,107 @@
+define([
+    'bean',
+    'bonzo',
+    'fastdom',
+    'common/utils/_',
+    'common/utils/$',
+    'common/utils/detect',
+    'common/utils/mediator',
+    'common/utils/storage',
+    'common/utils/template',
+    'text!common/views/commercial/creatives/fluid250-v3.html'
+], function (
+    bean,
+    bonzo,
+    fastdom,
+    _,
+    $,
+    detect,
+    mediator,
+    storage,
+    template,
+    fluid250Tpl
+) {
+    var Fluid250 = function ($adSlot, params) {
+        this.$adSlot = $adSlot;
+        this.params = params;
+    };
+
+    Fluid250.hasScrollEnabled = !detect.isIOS() && !detect.isAndroid();
+
+    Fluid250.isModernBrowser = detect.isModernBrowser();
+
+    Fluid250.isIE9OrLess = detect.getUserAgent.browser === 'MSIE' && (detect.getUserAgent.version === '9' || detect.getUserAgent.version === '8');
+
+    Fluid250.prototype.updateBgPosition = function () {
+        switch (this.params.backgroundImagePType) {
+            case 'fixed':
+                break;
+            case 'parallax':
+                fastdom.read(function () {
+                    this.scrollAmount = Math.ceil((window.pageYOffset - this.$adSlot.offset().top) * 0.3 * -1) + 20;
+                    this.scrollAmountP = this.scrollAmount + '%';
+                }.bind(this));
+                fastdom.write(function () {
+                    $('.ad-scrolling-bg', $(this.$adSlot)).addClass('ad-scrolling-bg-parallax').css('background-position', '50%' + this.scrollAmountP);
+                }.bind(this));
+                break;
+        }
+
+        this.layer2Animation();
+    };
+
+    Fluid250.prototype.layer2Animation = function () {
+        var inViewB;
+        if (this.params.layerTwoAnimation === 'enabled' && Fluid250.isModernBrowser && !Fluid250.isIE9OrLess) {
+            fastdom.read(function () {
+                inViewB = (window.pageYOffset + bonzo.viewport().height) > this.$adSlot.offset().top;
+            }.bind(this));
+            fastdom.write(function () {
+                $('.hide-until-tablet .fluid250_layer2', $(this.$adSlot)).addClass('ad-scrolling-text-hide');
+                if (inViewB) {
+                    $('.hide-until-tablet .fluid250_layer2', $(this.$adSlot)).addClass('ad-scrolling-text-animate');
+                }
+            }.bind(this));
+        }
+    };
+
+    Fluid250.prototype.create = function () {
+        var templateOptions = {
+                showLabel: (this.params.showAdLabel === 'hide') ?
+                'creative__label--hidden' : '',
+
+                layerTwoBGProperties: (!this.params.layerTwoAnimation || this.params.layerTwoAnimation === '' || this.params.layerTwoAnimation === 'disabled' || (!Fluid250.isModernBrowser && this.params.layerTwoAnimation === 'enabled')) ?
+                ' background-position: ' + this.params.layerTwoBGPosition + ';' : ''
+            },
+            leftPosition = (this.params.videoPositionH === 'left' ?
+                ' left: ' + this.params.videoHorizSpace + 'px;' : ''
+            ),
+            rightPosition = (this.params.videoPositionH === 'right' ?
+                ' right: ' + this.params.videoHorizSpace + 'px;' : ''
+            ),
+            videoDesktop = {
+                video: (this.params.videoURL !== '') ?
+                    '<iframe width="409px" height="230px" src="' + this.params.videoURL + '?rel=0&amp;controls=0&amp;showinfo=0&amp;title=0&amp;byline=0&amp;portrait=0" frameborder="0" class="fluid250_video fluid250_video--desktop fluid250_video--vert-pos-' + this.params.videoPositionV + ' fluid250_video--horiz-pos-' + this.params.videoPositionH + '" style="' + leftPosition + rightPosition + '"></iframe>' : ''
+            },
+            scrollingbg = {
+                scrollbg: (this.params.backgroundImagePType !== '' || this.params.backgroundImagePType !== 'none') ?
+                    '<div class="ad-scrolling-bg" style="background-image: url(' + this.params.backgroundImageP + '); background-position: 50% 0; background-repeat: ' + this.params.backgroundImagePRepeat + ';"></div>' : ''
+            };
+
+        $.create(template(fluid250Tpl, _.merge(this.params, templateOptions, videoDesktop, scrollingbg))).appendTo(this.$adSlot);
+
+        if (this.params.trackingPixel) {
+            this.$adSlot.before('<img src="' + this.params.trackingPixel + this.params.cacheBuster + '" class="creative__tracking-pixel" height="1px" width="1px"/>');
+        }
+        if (Fluid250.hasScrollEnabled) {
+            // update bg position
+            this.updateBgPosition();
+            mediator.on('window:scroll', this.updateBgPosition.bind(this));
+            // to be safe, also update on window resize
+            mediator.on('window:resize', this.updateBgPosition.bind(this));
+        }
+    };
+
+    return Fluid250;
+
+});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/scrollable-mpu-v2.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/scrollable-mpu-v2.js
@@ -1,0 +1,79 @@
+define([
+    'fastdom',
+    'common/utils/$',
+    'common/utils/detect',
+    'common/utils/mediator',
+    'common/utils/template',
+    'text!common/views/commercial/creatives/scrollable-mpu-v2.html'
+], function (
+    fastdom,
+    $,
+    detect,
+    mediator,
+    template,
+    scrollableMpuTpl
+) {
+
+    /**
+     * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10026567
+     */
+    var ScrollableMpu = function ($adSlot, params) {
+        this.$adSlot = $adSlot;
+        this.params  = params;
+    };
+
+    /**
+     * TODO: rather blunt instrument this, due to the fact *most* mobile devices don't have a fixed
+     * background-attachment - need to make this more granular
+     */
+    ScrollableMpu.hasScrollEnabled = !detect.isIOS() && !detect.isAndroid();
+
+    ScrollableMpu.prototype.updateBgPosition = function () {
+
+        switch (this.params.backgroundImagePType) {
+            case 'fixed matching fluid250':
+                fastdom.write(function () {
+                    $('.creative--scrollable-mpu-image', $(this.$adSlot)).addClass('creative--scrollable-mpu-image-fixed');
+                }.bind(this));
+                break;
+            case 'parallax':
+                fastdom.read(function () {
+                    this.scrollAmount = Math.ceil((window.pageYOffset - this.$adSlot.offset().top) * 0.3 * -1) + 20;
+                    this.scrollAmountP = this.scrollAmount + '%';
+                }.bind(this));
+                fastdom.write(function () {
+                    $('.creative--scrollable-mpu-image', $(this.$adSlot)).addClass('creative--scrollable-mpu-image-parallax').css('background-position', '50%' + this.scrollAmountP);
+                }.bind(this));
+                break;
+            default:
+                fastdom.write(function () {
+                    $('.creative--scrollable-mpu-image', $(this.$adSlot)).css('background-position', '100%' + (window.pageYOffset - this.$scrollableMpu.offset().top) + 'px');
+                }.bind(this));
+        }
+    };
+
+    ScrollableMpu.prototype.create = function () {
+        var templateOptions = {
+            clickMacro:       this.params.clickMacro,
+            destination:      this.params.destination,
+            layer1Image:      ScrollableMpu.hasScrollEnabled ? this.params.layer1Image : this.params.mobileImage,
+            backgroundImage:       ScrollableMpu.hasScrollEnabled && this.params.backgroundImage ?
+                '<div class="creative--scrollable-mpu-image" style="background-image: url(' + this.params.backgroundImage + ');"></div>' : '',
+            trackingPixelImg: this.params.trackingPixel ?
+                '<img src="' + this.params.trackingPixel + '" width="1" height="1" />' : ''
+        };
+        this.$scrollableMpu = $.create(template(scrollableMpuTpl, templateOptions)).appendTo(this.$adSlot);
+
+        if (ScrollableMpu.hasScrollEnabled) {
+            // update bg position
+            this.updateBgPosition();
+
+            mediator.on('window:scroll', this.updateBgPosition.bind(this));
+            // to be safe, also update on window resize
+            mediator.on('window:resize', this.updateBgPosition.bind(this));
+        }
+    };
+
+    return ScrollableMpu;
+
+});

--- a/static/src/javascripts/projects/common/views/commercial/creatives/fluid250-v3.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/fluid250-v3.html
@@ -1,0 +1,55 @@
+<div class="creative--fluid250-bg-container">
+
+    <div class="ad-slot__label creative--fluid250__label fc-container--layout-front {{showLabel}}" data-test-id="ad-slot-label">
+        <div class="fc-container__inner">Advertisement</div>
+    </div>
+
+    <div class="creative--fluid250 l-side-margins hide-until-tablet creative--fluid250__height--{{creativeHeight}}" style="
+            background-color: {{backgroundColor}};
+            background-image: url({{backgroundImage}});
+            background-position: {{backgroundPosition}};
+            background-repeat: {{backgroundRepeat}};
+        ">
+        {{scrollbg}}
+        <a href="{{clickMacro}}{{link}}" target="_blank">
+            <div class="gs-container">
+                {{video}}
+                <div class="fluid250_layer fluid250_layer1" style="
+                    background-image: url({{layerOneBGImage}});
+                    background-position: {{layerOneBGPosition}};
+                "></div>
+                <div class="fluid250_layer fluid250_layer2" style="
+                    background-image: url({{layerTwoBGImage}});
+                    {{layerTwoBGProperties}}
+                "></div>
+                <div class="fluid250_layer fluid250_layer3" style="
+                    background-image: url({{layerThreeBGImage}});
+                    background-position: {{layerThreeBGPosition}};
+                "></div>
+            </div>
+        </a>
+    </div>
+    <div class="creative--fluid250 l-side-margins mobile-only" style="
+            background-color: {{backgroundColor}};
+            background-image: url({{backgroundImageM}});
+            background-position: {{backgroundPositionM}};
+            background-repeat: {{backgroundRepeatM}};
+        ">
+        <a href="{{link}}" target="_blank">
+            <div class="gs-container">
+                <div class="fluid250_layer fluid250_layer1" style="
+                    background-image: url({{layerOneBGImageM}});
+                    background-position: {{layerOneBGPositionM}};
+                "></div>
+                <div class="fluid250_layer fluid250_layer2" style="
+                    background-image: url({{layerTwoBGImageM}});
+                    background-position: {{layerTwoBGPositionM}};
+                "></div>
+                <div class="fluid250_layer fluid250_layer3" style="
+                    background-image: url({{layerThreeBGImageM}});
+                    background-position: {{layerThreeBGPositionM}};
+                "></div>
+            </div>
+        </a>
+    </div>
+</div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/scrollable-mpu-v2.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/scrollable-mpu-v2.html
@@ -1,0 +1,9 @@
+<a class="creative--scrollable-mpu"
+    href="{{clickMacro}}{{destination}}"
+    target="_new">
+    <div class="creative--scrollable-mpu-inner">
+    	{{backgroundImage}}
+    	<div class="creative--scrollable-mpu-static-image" style="background-image: url('{{layer1Image}}');"></div>
+    </div>
+</a>
+{{trackingPixelImg}}

--- a/static/src/javascripts/test/spec/common/commercial/creatives/fluid250-v3.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/creatives/fluid250-v3.spec.js
@@ -1,0 +1,42 @@
+import qwery from 'qwery'
+import $ from 'common/utils/$'
+import fixtures from 'helpers/fixtures'
+import Fluid250 from 'common/modules/commercial/creatives/fluid250-v3'
+
+var fixturesConfig = {
+    id: 'ad-slot',
+    fixtures: [
+        '<div class="ad-slot"></div>'
+    ]
+};
+
+describe('Fluid 250', function() {
+
+    var fluid250,
+        $fixturesContainer;
+
+    it('should exist', function() {
+        expect(Fluid250).toBeDefined();
+    });
+
+    it('should be defined', function() {
+        $fixturesContainer = fixtures.render(fixturesConfig);
+
+        fluid250 = new Fluid250($('.ad-slot', $fixturesContainer), {});
+        expect(fluid250).toBeDefined();
+    });
+
+    it('ad slot should have a video iframe with proper styles', function() {
+        $fixturesContainer = fixtures.render(fixturesConfig);
+
+        new Fluid250($('.ad-slot', $fixturesContainer), {
+            videoPositionH: 'left',
+            videoHorizSpace: 10,
+            videoPositionV: 'top',
+            videoURL: 'exampleVideoUrl'
+        }).create();
+        expect(qwery('.fluid250_video--vert-pos-top', '.ad-slot').length).toBe(1);
+        expect(qwery('.fluid250_video--horiz-pos-left', '.ad-slot').length).toBe(1);
+    });
+
+});

--- a/static/src/javascripts/test/spec/common/commercial/creatives/scrollable-mpu-v2.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/creatives/scrollable-mpu-v2.spec.js
@@ -1,0 +1,9 @@
+import ScrollableMpu from 'common/modules/commercial/creatives/scrollable-mpu-v2'
+
+describe('Scrollable MPU', function() {
+
+    it('should exist', function() {
+        expect(ScrollableMpu).toBeDefined();
+    });
+
+});

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -17,11 +17,23 @@
         width: 300px;
         position: absolute;
         top: 0;
+        left: 0;
         box-sizing: border-box;
     }
     .creative--scrollable-mpu-image {
         border: 1px solid colour(neutral-5);
         background: none 0 0 repeat;
+
+        &.creative--scrollable-mpu-image-fixed {
+            background-attachment: fixed;
+            background-repeat: repeat;
+            background-position: 50% 0;
+        }
+        &.creative--scrollable-mpu-image-parallax {
+            background-attachment: scroll;
+            background-repeat: repeat-y;
+            height: 500px;
+        }
     }
     .creative--scrollable-mpu-static-image {
         z-index: 1;
@@ -457,6 +469,49 @@
     }
 }
 
+.creative--fluid250-bg-container {
+    position: relative;
+    overflow: hidden;
+    margin-bottom: 0 !important;
+
+    .ad-scrolling-bg {
+        position: absolute;
+        top: 0;
+        height: 500px;
+        width: 100%;
+        background-repeat: no-repeat;
+        background-attachment: fixed;
+    }
+
+    .ad-scrolling-bg-parallax {
+        background-attachment: scroll;
+    }
+
+    .fluid250_layer {
+
+        .is-modern & {
+            &.ad-scrolling-text-hide {
+                background-position: 0 -250px;
+            }
+            &.ad-scrolling-text-animate {
+                animation: textanimation 1.4s ease .4s;
+                animation-fill-mode: forwards;
+            }
+        }
+    }
+
+    .ad-slot__label {
+        position: relative;
+        text-align: left;
+    }
+
+    .fc-container__inner {
+        padding-top: 0;
+        border-top: 0;
+    }
+
+}
+
 .ad-slot--merchandising-high {
     .creative__label--hidden {
         display: none;
@@ -578,5 +633,19 @@
     .creative__logo-info {
         display: block;
         clear: left;
+    }
+}
+
+@keyframes textanimation {
+    0% { 
+        background-position: 0 -250px; 
+    }
+
+    75% { 
+        background-position: 0 0; 
+    }
+
+    100% { 
+        background-position: 0 0; 
     }
 }


### PR DESCRIPTION
1. New fluid 250 version with options for fixed and parallax background linking to new DFP creative template called Fluid 250 V3 (test).

![screen shot 2015-05-26 at 11 11 24](https://cloud.githubusercontent.com/assets/3763718/7810232/2277670e-0398-11e5-81a0-4f644986c563.png)

New options in DFP:

![screen shot 2015-05-26 at 11 12 01](https://cloud.githubusercontent.com/assets/3763718/7810238/2b871c0e-0398-11e5-8b12-fd33e22ac761.png)

and options for animating a layer (expected to be text layer) when the ad scrolls into view:

![screen shot 2015-05-26 at 11 13 11](https://cloud.githubusercontent.com/assets/3763718/7810250/3e35e042-0398-11e5-80d2-bb5a8fe24e3a.png)
1. New scrollable MPU version linking to new DFP creative template called Scrollable MPU v2 (test).

![screen shot 2015-05-26 at 11 13 55](https://cloud.githubusercontent.com/assets/3763718/7810261/5aef0600-0398-11e5-93bf-706cdc3c2a84.png)

The new features are the fixed and parallax background scrolling:

![screen shot 2015-05-26 at 11 14 55](https://cloud.githubusercontent.com/assets/3763718/7810277/8054fb2a-0398-11e5-903c-dc72fb31bfa9.png)

Existing options have been renamed to be clearer.

Both new formats can be seen on the example from DFP order and line item 'Fluid 250 v3 test parallax' running under test cookie adtest=ah9.
