### PR TITLE
Show slideshow only on large card types

### DIFF
--- a/common/app/cards/CardType.scala
+++ b/common/app/cards/CardType.scala
@@ -33,6 +33,11 @@ sealed trait CardType {
     case Fluid | FullMedia100 | FullMedia75 | FullMedia50 | Half | ThreeQuarters | ThreeQuartersRight | Standard => true
     case _ => false
   }
+
+  def canShowSlideshow = this match {
+    case Half | ThreeQuarters | ThreeQuartersRight | ThreeQuartersTall | FullMedia50 | FullMedia75 | FullMedia100 => true
+    case _ => false
+  }
 }
 
 /** This is called ListItem because List is already taken */

--- a/common/app/layout/Column.scala
+++ b/common/app/layout/Column.scala
@@ -25,6 +25,7 @@ case class ItemClasses(mobile: CardType, tablet: CardType, desktop: Option[CardT
   def showVideoEndSlate = allTypes.exists(_.videoPlayer.showEndSlate)
 
   def showCutOut = allTypes.exists(_.showCutOut)
+  def canShowSlideshow = allTypes.exists(_.canShowSlideshow)
 }
 case class SliceLayout(cssClassName: String, columns: Seq[Column]) {
   def numItems = columns.map(_.numItems).sum

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -198,7 +198,7 @@ object FaciaCard {
       faciaContent.headline,
       FaciaCardHeader.fromTrailAndKicker(faciaContent, maybeKicker, Some(config)),
       getByline(faciaContent).filterNot(Function.const(suppressByline)),
-      FaciaDisplayElement.fromFaciaContent(faciaContent),
+      FaciaDisplayElement.fromFaciaContentAndCardType(faciaContent, cardTypes),
       CutOut.fromTrail(faciaContent),
       faciaContent.cardStyle,
       cardTypes,

--- a/common/app/model/FaciaDisplayElement.scala
+++ b/common/app/model/FaciaDisplayElement.scala
@@ -5,9 +5,10 @@ import conf.Switches
 import implicits.FaciaContentImplicits._
 import implicits.FaciaContentFrontendHelpers._
 import conf.{Switches,Configuration}
+import layout.ItemClasses
 
 object FaciaDisplayElement {
-  def fromFaciaContent(faciaContent: FaciaContent): Option[FaciaDisplayElement] = {
+  def fromFaciaContentAndCardType(faciaContent: FaciaContent, itemClasses: ItemClasses): Option[FaciaDisplayElement] = {
     faciaContent.mainVideo match {
       case Some(videoElement) if faciaContent.showMainVideo =>
         Some(InlineVideo(
@@ -18,7 +19,7 @@ object FaciaDisplayElement {
         ))
       case _ if faciaContent.isCrossword && Switches.CrosswordSvgThumbnailsSwitch.isSwitchedOn =>
         Some(CrosswordSvg(faciaContent.id))
-      case _ if faciaContent.imageSlideshowReplace =>
+      case _ if faciaContent.imageSlideshowReplace && itemClasses.canShowSlideshow =>
         InlineSlideshow.fromFaciaContent(faciaContent)
       case _ => InlineImage.fromFaciaContent(faciaContent)
     }


### PR DESCRIPTION
When the slot is third or below, show the default image instead of the slideshow.

@janua :laughing: it works!!
