### PR TITLE
Extend JspmTest by a month

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -21,7 +21,7 @@ object JspmTest extends TestDefinition(
   List(Variant0),
   "jspm-test",
   "Tests our new JSPM jsavscript configuration",
-  new LocalDate(2015, 5, 30)
+  new LocalDate(2015, 6, 30)
 )
 
 object CMHRTest extends TestDefinition(


### PR DESCRIPTION
We need to enable CORS for assets-secure.guim so the interactive team can preview their work using preview.gutools

SystemJS downloads via XHR, which requires CORS for cross-domain.
