### PR TITLE
Add notification routes to preview for Google demo

### DIFF
--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -1,4 +1,12 @@
 # Paths specific to "preview"
+
+# Simply for the Google IO demo, because preview has a valid HTTPS cert and the page has no mixed content.
+GET        /2015-05-19-service-worker.js        controllers.WebAppController.serviceWorker()
+GET        /2015-05-26-manifest.json            controllers.WebAppController.manifest()
+GET        /$path<international>                controllers.FaciaController.renderFront(path)
+GET        /preferences                         controllers.PreferencesController.indexPrefs()
+GET        /preferences/notifications           controllers.PreferencesController.notificationPrefs()
+
 GET     /_healthcheck               controllers.PreviewHealthCheck.healthcheck()
 GET     /responsive-viewer/*path    controllers.ResponsiveViewerController.preview(path)
 

--- a/preview/conf/routes
+++ b/preview/conf/routes
@@ -3,7 +3,6 @@
 # Simply for the Google IO demo, because preview has a valid HTTPS cert and the page has no mixed content.
 GET        /2015-05-19-service-worker.js        controllers.WebAppController.serviceWorker()
 GET        /2015-05-26-manifest.json            controllers.WebAppController.manifest()
-GET        /$path<international>                controllers.FaciaController.renderFront(path)
 GET        /preferences                         controllers.PreferencesController.indexPrefs()
 GET        /preferences/notifications           controllers.PreferencesController.notificationPrefs()
 


### PR DESCRIPTION
https://www.theguardian.com/preferences/notifications has mixed content. To fix this we need to use `assets.securePath` for all assets, which we started in https://github.com/guardian/frontend/pull/9265. However, this is a big change and for the sake of the Google demo tomorrow, we can just use preview which is already all served over valid HTTPS.

/cc @gklopper 
