### PR TITLE
Config tool: remove editors picks

### DIFF
--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -187,7 +187,7 @@ define([
         cc = checkCount;
 
         apiQuery += apiQuery.indexOf('?') < 0 ? '?' : '&';
-        apiQuery += 'show-editors-picks=true&show-fields=headline';
+        apiQuery += 'show-fields=headline';
 
         contentApi.fetchContent(apiQuery)
         .done(function(results) {


### PR DESCRIPTION
Mirrors https://github.com/guardian/frontend/pull/9257 in the config tool's Capi query previewer. 

@janua @piuccio 
