### PR TITLE
Exempt manifest from preview auth

### DIFF
--- a/standalone/app/Global.scala
+++ b/standalone/app/Global.scala
@@ -28,6 +28,7 @@ object FilterExemptions {
     FilterExemption("/assets"),
     FilterExemption("/favicon.ico"),
     FilterExemption("/_healthcheck"),
+    FilterExemption("/2015-05-26-manifest.json"),
     // the healthcheck url
     FilterExemption("/world/2012/sep/11/barcelona-march-catalan-independence"),
 


### PR DESCRIPTION
When Chrome requests the manifest, it does not send the cookies header, thus auth fails.

Will remove after Google demo.
