### PR TITLE
Change the max number of fronts

### DIFF
--- a/facia-tool/app/views/config.scala.html
+++ b/facia-tool/app/views/config.scala.html
@@ -260,7 +260,9 @@
                             valueAllowUnset: true"></select>
 
                         <div class="tools action-buttons">
-                            <span class="tool" data-bind="click: saveProps">Save metadata</span>
+                            <button class="tool" data-bind="
+                                enable: state.isValidMetadata() !== false,
+                                click: saveProps">Save metadata</button>
                         </div>
                     </div>
                 <!-- /ko -->

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1441,6 +1441,14 @@ button {
     background: #148ad2;
 }
 
+.tools .tool:first-child:disabled {
+    background: #ccc;
+    cursor: default;
+}
+.tools .tool:first-child:hover:disabled {
+    background: #ccc;
+}
+
 .tools .tool.draft-publish {
     background: #ffc107;
 }

--- a/facia-tool/public/js/constants/defaults.js
+++ b/facia-tool/public/js/constants/defaults.js
@@ -31,7 +31,12 @@ export default {
 
     detectPendingChangesInClipboard: 4000,
 
-    maxFronts: 500,
+    defaultPriority: 'editorial',
+    maxFronts: {
+        'editorial': 200,
+        'commercial': 350,
+        'training': 50
+    },
 
     filterTypes: {
         section: { display: 'in section:', param: 'section', path: 'sections', placeholder: 'e.g. news' },

--- a/facia-tool/public/js/models/config/front.js
+++ b/facia-tool/public/js/models/config/front.js
@@ -9,6 +9,7 @@ define([
     'utils/as-observable-props',
     'utils/populate-observables',
     'utils/find-first-by-id',
+    'utils/front-count',
     'utils/validate-image-src'
 ], function(
     ko,
@@ -21,12 +22,14 @@ define([
     asObservableProps,
     populateObservables,
     findFirstById,
+    frontCount,
     validateImageSrc
 ) {
     asObservableProps = asObservableProps.default;
     findFirstById = findFirstById.default;
     populateObservables = populateObservables.default;
     validateImageSrc = validateImageSrc.default;
+    frontCount = frontCount.default;
 
     function Front(opts) {
         var self = this;
@@ -58,13 +61,17 @@ define([
 
         this.state = asObservableProps([
             'isOpen',
-            'isOpenProps']);
+            'isOpenProps',
+            'isValidMetadata']);
+        this.state.isValidMetadata(true);
 
         this.state.withinPriority = ko.computed(function() {
             return this.props.priority() === vars.priority || this.state.isOpenProps(); // last clause allows priority change
         }, this);
 
         this.applyConstraints();
+
+        this.props.priority.subscribe(this.onChangePriority.bind(this));
 
         this.collections = new Group({
             parent: self,
@@ -229,6 +236,17 @@ define([
         if (this.props.priority() === 'training') {
             this.state.isTypeLocked = true;
             this.props.isHidden(true);
+        }
+    };
+
+    Front.prototype.onChangePriority = function (newPriority) {
+        var num = frontCount(vars.state.config.fronts, newPriority);
+
+        if (num.count >= num.max) {
+            this.state.isValidMetadata(false);
+            window.alert('The maximum number of fronts (' + num.max + ') has been exceeded. Please delete one first, by removing all its collections.');
+        } else {
+            this.state.isValidMetadata(true);
         }
     };
 

--- a/facia-tool/public/js/models/config/main.js
+++ b/facia-tool/public/js/models/config/main.js
@@ -11,12 +11,13 @@ import Front from 'models/config/front';
 import Collection from 'models/config/collection';
 import newItems from 'models/config/new-items';
 import persistence from 'models/config/persistence';
+import frontCount from 'utils/front-count';
 
 export default function() {
     var model = {};
     vars.setModel(model);
 
-    model.title = ko.observable((vars.priority || 'editorial') + ' fronts configuration');
+    model.title = ko.observable((vars.priority || vars.CONST.defaultPriority) + ' fronts configuration');
 
     model.switches = ko.observable();
 
@@ -39,15 +40,15 @@ export default function() {
     });
 
     model.createFront = function() {
-        var front;
+        var front, num = frontCount(vars.state.config.fronts, vars.priority);
 
-        if (vars.model.fronts().length <= vars.CONST.maxFronts) {
+        if (num.count < num.max) {
             front = new Front({priority: vars.priority, isHidden: true});
             front.setOpen(true);
             model.pinnedFront(front);
             model.fronts.unshift(front);
         } else {
-            window.alert('The maximum number of fronts (' + vars.CONST.maxFronts + ') has been exceeded. Please delete one first, by removing all its collections.');
+            window.alert('The maximum number of fronts (' + num.max + ') has been exceeded. Please delete one first, by removing all its collections.');
         }
     };
 

--- a/facia-tool/public/js/modules/vars.js
+++ b/facia-tool/public/js/modules/vars.js
@@ -3,7 +3,7 @@ import _ from 'underscore';
 
 export const priority = (function (pathname) {
     let priority = pathname.match(/^\/?([^\/]+)/);
-    if (priority && priority[1] !== 'editorial') {
+    if (priority && priority[1] !== CONST.defaultPriority) {
         return priority[1];
     }
 })(window.location.pathname);

--- a/facia-tool/public/js/utils/fetch-lastmodified.js
+++ b/facia-tool/public/js/utils/fetch-lastmodified.js
@@ -1,11 +1,11 @@
 import Promise from 'Promise';
 import authedAjax from 'modules/authed-ajax';
-import * as vars from 'modules/vars';
+import {priority, CONST} from 'modules/vars';
 import humanTime from 'utils/human-time';
 
 function getFrontAgeAlertMs(front) {
-    return vars.CONST.frontAgeAlertMs[
-        vars.CONST.highFrequencyPaths.indexOf(front) > -1 ? 'front' : vars.priority || 'editorial'
+    return CONST.frontAgeAlertMs[
+        CONST.highFrequencyPaths.indexOf(front) > -1 ? 'front' : priority || CONST.defaultPriority
     ] || 600000;
 }
 

--- a/facia-tool/public/js/utils/front-count.js
+++ b/facia-tool/public/js/utils/front-count.js
@@ -1,0 +1,13 @@
+import {CONST} from 'modules/vars';
+import _ from 'underscore';
+
+export default function countFronts (fronts, priority) {
+    priority = priority || CONST.defaultPriority;
+
+    return {
+        count: _.countBy(_.values(fronts), function (front) {
+            return front.priority || CONST.defaultPriority;
+        })[priority],
+        max: CONST.maxFronts[priority] || Infinity
+    };
+}

--- a/facia-tool/test/public/spec/front.count.spec.js
+++ b/facia-tool/test/public/spec/front.count.spec.js
@@ -1,0 +1,45 @@
+import {CONST} from 'modules/vars';
+import count from 'utils/front-count';
+
+describe('utils/front-count', function () {
+    var fronts = {
+        'a': {},
+        'b': {},
+        'c': { priority: 'commercial' },
+        'd': { priority: 'editorial' },
+        'e': { priority: 'whatever' },
+        'f': { priority: 'whatever' }
+    };
+
+    it('counts fronts without priority', function () {
+        var result = count(fronts, 'editorial');
+        expect(result).toEqual({
+            count: 3,
+            max: CONST.maxFronts.editorial
+        });
+    });
+
+    it('defaults to editorial priority', function () {
+        var result = count(fronts);
+        expect(result).toEqual({
+            count: 3,
+            max: CONST.maxFronts.editorial
+        });
+    });
+
+    it('counts fronts with any priority', function () {
+        var result = count(fronts, 'commercial');
+        expect(result).toEqual({
+            count: 1,
+            max: CONST.maxFronts.commercial
+        });
+    });
+
+    it('counts fronts with no limits', function () {
+        var result = count(fronts, 'whatever');
+        expect(result).toEqual({
+            count: 2,
+            max: Infinity
+        });
+    });
+});


### PR DESCRIPTION
Have different max value per priority. This allows commercial and editorial front to be independent.

cc @stephanfowler @rrees 
