### PR TITLE
Fix add alignment

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -85,6 +85,10 @@
         transform: translateZ(0);
         transition: height 1s cubic-bezier(0, 0, 0, .985);
     }
+
+    > div {
+        margin: 0 auto;
+    }
 }
 .top-banner-ad-container--above-nav {
     @include mq(tablet) {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -85,10 +85,6 @@
         transform: translateZ(0);
         transition: height 1s cubic-bezier(0, 0, 0, .985);
     }
-
-    > div {
-        margin: 0 auto;
-    }
 }
 .top-banner-ad-container--above-nav {
     @include mq(tablet) {
@@ -204,6 +200,11 @@
         float: right;
         margin-top: $gs-baseline/3;
         margin-left: $gs-gutter;
+    }
+}
+.ad-slot__content {
+    > div {
+        margin: 0 auto;            
     }
 }
 .ad-slot--container-inline {


### PR DESCRIPTION
Sometimes ads are outside of the iframe and it mess their alignment (they stick to the left side):
![screen shot 2015-05-27 at 12 30 30](https://cloud.githubusercontent.com/assets/2579465/7834906/3416066c-046c-11e5-883a-523efcc26289.png)

This PR is solving that by adding margin: 0 auto on the first div child (as we don't have access to its classes) of the ad wrapper:
![screen shot 2015-05-27 at 12 30 53](https://cloud.githubusercontent.com/assets/2579465/7834919/5c079582-046c-11e5-85f3-16a059b9622b.png)
