### PR TITLE
Incorporate test for currentSrc support from picturefill 2.3.1

### DIFF
--- a/static/src/javascripts/projects/common/utils/picturefill.js
+++ b/static/src/javascripts/projects/common/utils/picturefill.js
@@ -82,7 +82,7 @@ define([
         (function () {
             pf.srcsetSupported = 'srcset' in image;
             pf.sizesSupported = 'sizes' in image;
-            pf.curSrcSupported = "currentSrc" in image;
+            pf.curSrcSupported = 'currentSrc' in image;
         })();
 
         // just a string trim workaround
@@ -361,7 +361,7 @@ define([
                         picImg.src = bestCandidate.url;
                         // currentSrc attribute and property to match
                         // http://picture.responsiveimages.org/#the-img-element
-                        if ( !pf.curSrcSupported ) {
+                        if (!pf.curSrcSupported) {
                             picImg.currentSrc = picImg.src;
                         }
                     });

--- a/static/src/javascripts/projects/common/utils/picturefill.js
+++ b/static/src/javascripts/projects/common/utils/picturefill.js
@@ -82,6 +82,7 @@ define([
         (function () {
             pf.srcsetSupported = 'srcset' in image;
             pf.sizesSupported = 'sizes' in image;
+            pf.curSrcSupported = "currentSrc" in image;
         })();
 
         // just a string trim workaround
@@ -360,7 +361,9 @@ define([
                         picImg.src = bestCandidate.url;
                         // currentSrc attribute and property to match
                         // http://picture.responsiveimages.org/#the-img-element
-                        picImg.currentSrc = picImg.src;
+                        if ( !pf.curSrcSupported ) {
+                            picImg.currentSrc = picImg.src;
+                        }
                     });
                 }
             }


### PR DESCRIPTION
Adds updates from https://github.com/scottjehl/picturefill/releases/tag/2.3.1 ([full story](https://css-tricks.com/please-update-picturefill)).
# Testing

@ScottPainterGNM – screenshot smoke tests [seems ok](https://www.browserstack.com/screenshots/4d69cf92af61b6941a0850cd78718648addeba67), but a quick browser check would be useful, namely just that:
- [x] images appear as normal on fronts
