### PR TITLE
optimizeSpeed, not optimizeLegibility

### DIFF
--- a/static/src/stylesheets/base/_type.scss
+++ b/static/src/stylesheets/base/_type.scss
@@ -19,7 +19,7 @@ body {
 
 html,
 body {
-    text-rendering: optimizeLegibility; // optional: for older browsers
+    text-rendering: optimizeSpeed;
     font-feature-settings: 'kern';
     font-kerning: normal; // Safari 7+, Firefox 24+, Chrome 33(?)+, Opera 21
     font-variant-ligatures: common-ligatures;


### PR DESCRIPTION
`text-rendering: optimizeLegibility` is very expensive, in terms of paint time and CPU, for not a huge amount of gain. 

It's especially expensive on low-powered devices.

This swaps it for `optimizeSpeed`. It's hard to get paint time stats from local, but once this goes to code (and before prod), I'll get some webpagetest comparisons of prod vs code. But given we set it on the body, it's likely to be quite a lot slower.

For @paperboyo's sake, here are some desktop comparisons:

| Browser | optimizeSpeed | optimizeLegibility (current) |
| --- | --- | --- |
| firefox | ![screen shot 2015-05-28 at 17 55 14](https://cloud.githubusercontent.com/assets/867233/7865839/6ff9110e-0563-11e5-818b-7e5e4db60d19.png) | ![screen shot 2015-05-28 at 18 02 43](https://cloud.githubusercontent.com/assets/867233/7865905/cfd89b9e-0563-11e5-8fe8-ea3fb929e9e0.png) |
| safari 8 | ![screen shot 2015-05-28 at 17 55 41](https://cloud.githubusercontent.com/assets/867233/7865848/8082a29c-0563-11e5-805c-299a5d58d130.png) | ![screen shot 2015-05-28 at 18 03 28](https://cloud.githubusercontent.com/assets/867233/7865922/de2267a2-0563-11e5-943d-164dab476a56.png) |
| chrome | ![screen shot 2015-05-28 at 17 55 57](https://cloud.githubusercontent.com/assets/867233/7865857/8c01c490-0563-11e5-8e38-2b7c3bea91a1.png) | ![screen shot 2015-05-28 at 18 03 54](https://cloud.githubusercontent.com/assets/867233/7865938/f0708ace-0563-11e5-8d7b-ecfb6339d513.png) |

We need to see what difference to speed it makes in practise, but I'm struggling to spot anything too deleterious to legibility here to take the (expected) perf hit...
