### PR TITLE
add linked data to live blogs

### DIFF
--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -15,6 +15,8 @@
         class="content content--liveblog tonal tonal--@articleToneClass(article) blog @if(article.isLive){is-live} section-@article.sectionName.toLowerCase"
         itemscope itemtype="@article.schemaType" role="main">
 
+        <a itemprop="url" href=""/>
+
         <header class="content__head tonal__head tonal__head--@articleToneClass(article)">
             @* UPPER HEADER *@
             <div class="content__header tonal__header u-cf">
@@ -70,7 +72,7 @@
                             @fragments.liveFilter(article.isLive)
 
                             <div class="js-liveblog-body u-cf from-content-api js-blog-blocks @if(article.isLive) {live-blog}" data-test-id="live-blog-blocks"
-                                itemprop="@if(article.isReview) {reviewBody} else {articleBody}">
+                                itemprop="@if(article.isReview) {reviewBody} else {@if(article.isLive) {liveBlogUpdate} else {articleBody}}">
                                 @BodyCleaner(article, article.body)
                             </div>
                         </div>

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -20,6 +20,7 @@ object BodyCleaner {
         VideoEmbedCleaner(article),
         PictureCleaner(article),
         LiveBlogDateFormatter(article.isLiveBlog),
+        LiveBlogLinkedData(article.isLiveBlog),
         BloggerBylineImage(article),
         LiveBlogShareButtons(article),
         DropCaps(article.isComment || article.isFeature),

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -79,7 +79,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   }
 
   lazy val hasTonalHeaderIllustration: Boolean = isLetters
-  
+
   lazy val showCircularBylinePicAtSide: Boolean =
     cardStyle == Feature && hasLargeContributorImage && contributors.length == 1
 
@@ -429,6 +429,8 @@ private object ArticleSchemas {
     // http://schema.org/Review
     if (article.isReview)
       "http://schema.org/Review"
+    else if (article.isLive)
+      "http://schema.org/LiveBlogPosting"
     else
       "http://schema.org/NewsArticle"
   }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -279,12 +279,31 @@ case class LiveBlogDateFormatter(isLiveBlog: Boolean)(implicit val request: Requ
         el.select(".block-time.published-time time").foreach { time =>
           val datetime = DateTime.parse(time.attr("datetime"))
           val hhmm = Format(datetime, "HH:mm")
-          time.wrap(s"""<a href="#$id" class="block-time__link"></a>""")
+          time.wrap(s"""<a href="#$id" itemprop="url" class="block-time__link"></a>""")
           time.attr("data-relativeformat", "med")
           time.after( s"""<span class="block-time__absolute">$hhmm</span>""")
           if (datetime.isAfter(DateTime.now().minusDays(5))) {
             time.addClass("js-timestamp")
           }
+        }
+      }
+    }
+    body
+  }
+}
+
+case class LiveBlogLinkedData(isLiveBlog: Boolean)(implicit val request: RequestHeader) extends HtmlCleaner  {
+  def clean(body: Document): Document = {
+    if (isLiveBlog) {
+      body.select(".block").foreach { el =>
+        val id = el.id()
+        el.attr("itemscope", "")
+        el.attr("itemtype", "http://schema.org/BlogPosting")
+        el.select(".block-time.published-time time").foreach { time =>
+          time.attr("itemprop", "datePublished")
+        }
+        el.select(".block-elements").foreach { body =>
+          body.attr("itemprop", "articleBody")
         }
       }
     }


### PR DESCRIPTION
Live blogs could do with being marked up with the liveblog schema for better SEOness.  This adds most of the fields we already have info for.

Unfortunately this doesn't validate yet due to the schema.org for live blogs not being up yet so the sainty tests will be failing =(  I will try to hack them to get around this problem.
