### PR TITLE
representativeOfPage should be a boolean not a url

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -389,7 +389,7 @@ import collection.JavaConversions._
 //        import browser._
 //
 //        Then("the main picture should be shown")
-//        $("[itemprop='contentURL representativeOfPage']") should have size 1
+//        $("[itemprop='contentURL']") should have size 1
 //
 //        And("the embedded video should not have a poster when there are no images in the video element")
 //        findFirst("video").getAttribute("poster") should be("")
@@ -428,7 +428,7 @@ import collection.JavaConversions._
       goTo("/artanddesign/2013/apr/15/buildings-tall-architecture-guardianwitness") { browser =>
         import browser._
         Then("The main picture should be show")
-        $("[itemprop='contentUrl representativeOfPage']") should have size 1
+        $("[itemprop='contentUrl']") should have size 1
       }
     }
 

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -125,7 +125,7 @@ import collection.JavaConversions._
         ImageServerSwitch.switchOn()
 
         Then("I should see the article's image")
-        findFirst("[itemprop='contentUrl representativeOfPage']").getAttribute("src") should
+        findFirst("[itemprop='contentUrl']").getAttribute("src") should
           include("Gunnerside-village-Swaled")
 
         And("I should see the image caption")

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -15,6 +15,8 @@
     <figure itemprop="associatedMedia image" itemscope itemtype="http://schema.org/ImageObject" data-component="image"
         class="media-primary media-content@if(isShowcase){ media-primary--showcase}">
 
+        <meta itemprop="representativeOfPage" content="true">
+
         @if(isFeature && isShowcase) {
             @lightbox(picture, MainMedia.FeatureShowcase)
             <div class="gs-container">
@@ -58,7 +60,7 @@
         srcset="@ImgSrc.srcset(picture, widths)"
         sizes="@widths.sizes"
         class="maxed responsive-img"
-        itemprop="contentUrl representativeOfPage"
+        itemprop="contentUrl"
         alt="@ImgSrc.getFallbackAsset(picture).flatMap(_.altText).getOrElse("")" />
 
 }


### PR DESCRIPTION
In our main images, we set the main image element to be itemprop representativeOfPage.  However then it picks up the url of the image as the value, when it should be a boolean.

See https://schema.org/ImageObject for more information.

I found this because it is a validation error on the linter and thus failing the sanity tests: http://linter.structured-data.org/?url=http:%2F%2Fwww.theguardian.com%2Fpolitics%2F2015%2Ffeb%2F26%2Fed-balls-plays-down-prospect-of-labour-deal-with-snp

Oddly it was validating successfully before so I guess there was a bug in the validator that was fixed.
