### PR TITLE
Extending switches

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -935,7 +935,7 @@ object Switches {
     "ab-mt-rec1",
     "Viewability results - Recommendation option 1",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 6, 2),
+    sellByDate = new LocalDate(2015, 6, 16),
     exposeClientSide = true
   )
 
@@ -944,7 +944,7 @@ object Switches {
     "ab-mt-rec2",
     "Viewability results - Recommendation option 2",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 6, 2),
+    sellByDate = new LocalDate(2015, 6, 16),
     exposeClientSide = true
   )
 
@@ -971,7 +971,7 @@ object Switches {
     "ab-defer-spacefinder",
     "A/B test to defer execution of spacefinder until images and richlinks have been loaded.",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 6, 2),
+    sellByDate = new LocalDate(2015, 6, 16),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/defer-spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/defer-spacefinder.js
@@ -3,7 +3,7 @@ define(function () {
     return function () {
         this.id = 'DeferSpacefinder';
         this.start = '2015-04-30';
-        this.expiry = '2015-06-02';
+        this.expiry = '2015-06-16';
         this.author = 'Zofia Korcz';
         this.description = 'Defer execution of spacefinder until images and richlinks have been loaded.';
         this.audience = 0.02;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/mt-rec1.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/mt-rec1.js
@@ -18,7 +18,7 @@ define([
     return function () {
         this.id = 'MtRec1';
         this.start = '2015-05-12';
-        this.expiry = '2015-06-02';
+        this.expiry = '2015-06-16';
         this.author = 'Zofia Korcz';
         this.description = 'Viewability results - Recommendation option 1';
         this.audience = 0.02;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/mt-rec2.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/mt-rec2.js
@@ -18,7 +18,7 @@ define([
     return function () {
         this.id = 'MtRec2';
         this.start = '2015-05-12';
-        this.expiry = '2015-06-02';
+        this.expiry = '2015-06-16';
         this.author = 'Steve Vadocz';
         this.description = 'Viewability results - Recommendation option 2';
         this.audience = 0.02;


### PR DESCRIPTION
Extending AB testing switches for another 2 weeks.

I will merge defer-spacefinder with other two tests (Rec1 and Rec2) in next PR but I want to be sure that it won't break build tomorrow if it won't go out today for some unexpected reason.

Rec1 and Rec2 are still on test.
