### PR TITLE
Put all kerning/ligatures etc behind a swtich, with hash overides

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -719,6 +719,15 @@ object Switches {
     exposeClientSide = true
   )
 
+  val FontKerningSwitch = Switch(
+    "Feature",
+    "font-kerning",
+    "If this is switched on then fonts will be kerned/optimised for legibility.",
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
   val SearchSwitch = Switch(
     "Feature",
     "google-search",

--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -204,6 +204,17 @@
             if (testCssSupport('position', 'fixed')) {
                 docClass += ' has-fixed';
             }
+
+            @if(FontKerningSwitch.isSwitchedOn) {
+                if (window.location.hash !== '#no-kern') {
+                    docClass += ' should-kern';
+                }
+            } else {
+                if (window.location.hash === '#kern') {
+                    docClass += ' should-kern';
+                }
+            }
+
             docClass = docClass.replace(/\bis-not-modern\b/g, 'is-modern');
         }
     })(guardian.isModernBrowser);

--- a/static/src/stylesheets/base/_type.scss
+++ b/static/src/stylesheets/base/_type.scss
@@ -20,6 +20,10 @@ body {
 html,
 body {
     text-rendering: optimizeSpeed;
+}
+
+.should-kern body {
+    text-rendering: optimizeLegibility;
     font-feature-settings: 'kern';
     font-kerning: normal; // Safari 7+, Firefox 24+, Chrome 33(?)+, Opera 21
     font-variant-ligatures: common-ligatures;


### PR DESCRIPTION
So #9309 didn't have the effect I was hoping. Turns out the other options we use (`font-kerning`, `font-variant-ligatures` etc) appear to kick in some of the same features as `optimizeLegibility`, depending on the browser.

This puts the whole font rendering upgrade behind a switch, so we can disable it for a day to see if @michaelwmcnamara and @ScottPainterGNM's iOS crash metrics change.

Both switch states have a hash override (`#kern`/`#no-kern`) so we can run proper webpagetests on it too. 

The default is to leave things as they were before #9309 switched to `optimizeSpeed`.
