### PR TITLE
Fix treats LinkTo

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -1,6 +1,6 @@
 package common
 
-import com.gu.facia.api.models.FaciaContent
+import com.gu.facia.api.models._
 import layout.ContentCard
 import play.twirl.api.Html
 import play.api.mvc.{Result, AnyContent, Request, RequestHeader}
@@ -55,7 +55,14 @@ trait LinkTo extends Logging {
   }
 
   def hrefOrId(faciaContent: FaciaContent)(implicit request: RequestHeader): String =
-    faciaContent.href.getOrElse(faciaContent.id)
+    faciaContent match {
+      case curatedContent: CuratedContent => curatedContent.href.getOrElse(curatedContent.id)
+      case supportingCuratedContent: SupportingCuratedContent => supportingCuratedContent.href.getOrElse(supportingCuratedContent.id)
+      //LinkSnap.id would be a snap id, which is a link to nothing
+      case linkSnap: LinkSnap => linkSnap.href.getOrElse("")
+      //LatestSnap.id would be the internal content code, so never use this
+      case latestSnap: LatestSnap => latestSnap.href.orElse(latestSnap.latestContent.map(_.id)).getOrElse("")
+    }
 
   def apply(faciaCard: ContentCard)(implicit request: RequestHeader): String =
     faciaCard.url.get(request)

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -54,7 +54,8 @@ trait LinkTo extends Logging {
     case t: Trail => Option(apply(t.url))
   }
 
-  def apply(faciaContent: FaciaContent)(implicit request: RequestHeader): Option[String] = faciaContent.href
+  def hrefOrId(faciaContent: FaciaContent)(implicit request: RequestHeader): String =
+    faciaContent.href.getOrElse(faciaContent.id)
 
   def apply(faciaCard: ContentCard)(implicit request: RequestHeader): String =
     faciaCard.url.get(request)

--- a/common/app/views/fragments/containers/facia_cards/navListContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/navListContainer.scala.html
@@ -12,7 +12,7 @@
             @collectionDefinition.collectionEssentials.items.zipWithIndex.map { case (item, index) =>
             <li class="fc-slice__item--nav-list">
                 <div class="fc-item fc-item--list-compact">
-                    <a href="@LinkTo(item)" data-link-name=" | article | @index">@item.headline</a>
+                    <a href="@LinkTo.hrefOrId(item)" data-link-name=" | article | @index">@item.headline</a>
                 </div>
             </li>
         }

--- a/common/app/views/fragments/containers/facia_cards/navMediaListContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/navMediaListContainer.scala.html
@@ -13,7 +13,7 @@
         <ul class="u-unstyled fc-slice fc-slice--nav-list--media">
         @containerDefinition.items.zipWithIndex.map { case (item, index) =>
             <li class="fc-slice__item--nav-list">
-                <a href="@LinkTo(item)" data-link-name=" | article | @index" class="fc-item fc-item--list-compact--media">
+                <a href="@LinkTo.hrefOrId(item)" data-link-name=" | article | @index" class="fc-item fc-item--list-compact--media">
                     @InlineImage.fromFaciaContent(item).map { imageContainer =>
                         @image(imageContainer.imageContainer)
                     }

--- a/common/app/views/fragments/linkText.scala.html
+++ b/common/app/views/fragments/linkText.scala.html
@@ -5,6 +5,6 @@
 @import views.support.RemoveOuterParaHtml
 @import implicits.FaciaContentImplicits._
 
-<a href="@LinkTo(trail)" data-link-name="@info.rowNum | text">
+<a href="@LinkTo.hrefOrId(trail)" data-link-name="@info.rowNum | text">
     @trail.maybeWebTitle.map(RemoveOuterParaHtml.apply)
 </a>

--- a/common/app/views/fragments/nav/treats.scala.html
+++ b/common/app/views/fragments/nav/treats.scala.html
@@ -1,8 +1,6 @@
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
 
 @import common.LinkTo
-@import common.ExternalLinks.internalPath
-@import crosswords.{CrosswordGrid, TodaysCrosswordGrid, CrosswordPreview}
 @import implicits.FaciaContentImplicits._
 @import crosswords.{CrosswordGrid, CrosswordPreview, TodaysCrosswordGrid}
 @import views.support.{Treat, CrosswordTreat, SnappableTreat, ClimateTreat, NormalTreat}
@@ -10,7 +8,7 @@
 @if(containerDefinition.collectionEssentials.treats.nonEmpty) {
     <ul class="treats__container">
     @containerDefinition.collectionEssentials.treats.zipWithIndex.map { case (treat, index) =>
-        @defining(LinkTo(treat).getOrElse("")) { link =>
+        @defining(LinkTo.hrefOrId(treat)) { link =>
             <li class="treats__list-item">
                 @Treat.fromUrl(link) match {
                     case CrosswordTreat => {


### PR DESCRIPTION
The `LinkTo` for `FaciaContent` is not returning the correct thing.

If `href` is not set, we fallback to the `id`. This covers the case for when there is no `href` set on `CuratedContent` in `treats.scala.html`.

`LinkSnap`s should have it's `href` set to what `facia-tool` has it set to. If it is not set, we output a empty `href` as we have no alternative.

`LatestSnap`s should always have a `href` set to the `id` of the content it's carrying. Again it may not carry a content and is set to an empty string in this instance.

@robertberry @stephanfowler 
