### PR TITLE
Change treats link to use SupportedUrl instead of LinkTo

### DIFF
--- a/common/app/views/fragments/nav/treats.scala.html
+++ b/common/app/views/fragments/nav/treats.scala.html
@@ -4,11 +4,12 @@
 @import implicits.FaciaContentImplicits._
 @import crosswords.{CrosswordGrid, CrosswordPreview, TodaysCrosswordGrid}
 @import views.support.{Treat, CrosswordTreat, SnappableTreat, ClimateTreat, NormalTreat}
+@import model.SupportedUrl
 
 @if(containerDefinition.collectionEssentials.treats.nonEmpty) {
     <ul class="treats__container">
     @containerDefinition.collectionEssentials.treats.zipWithIndex.map { case (treat, index) =>
-        @defining(LinkTo.hrefOrId(treat)) { link =>
+        @defining(SupportedUrl.fromFaciaContent(treat)) { link =>
             <li class="treats__list-item">
                 @Treat.fromUrl(link) match {
                     case CrosswordTreat => {


### PR DESCRIPTION
This makes the treats have the same behaviour as `ContentCard` through the use of `SupportedUrl`. Although in `ContentCard` they are wrapped in `EditionalisedLink`.

`LinkTo.hrefOrId` isn't good enough.

@robertberry 
