### PR TITLE
Test Commercial Components on Prod

### DIFF
--- a/integrated-tests/src/test/scala/commercial/AdsTest.scala
+++ b/integrated-tests/src/test/scala/commercial/AdsTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 class AdsTest extends FlatSpec with Matchers with SharedWebDriver {
 
   override protected def get(path: String): Unit = {
-    webDriver.get(s"http://m.code.dev-theguardian.com/$path?test=test#gu.prefs.switchOn=adverts")
+    webDriver.get(s"${Config.baseUrl}/$path?test=test#gu.prefs.switchOn=adverts")
     webDriver.navigate().refresh()
   }
 


### PR DESCRIPTION
Rather than on Code because it's unstable, switches are often in a testing state and it's extremely unlikely we're going to catch any problems there.  It gives too many red integration tests because of switch states.
