### PR TITLE
Make sure infinite ads run in both AB tests

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -67,9 +67,11 @@ define([
     }
 
     function isMtRecTest() {
-        var MtRec2Test = ab.getParticipations().MtRec2;
+        var MtRec1Test = ab.getParticipations().MtRec1,
+            MtRec2Test = ab.getParticipations().MtRec2;
 
-        return ab.testCanBeRun('MtRec2') && MtRec2Test && MtRec2Test.variant === 'A';
+        return ab.testCanBeRun('MtRec1') && MtRec1Test && MtRec1Test.variant === 'A' ||
+            ab.testCanBeRun('MtRec2') && MtRec2Test && MtRec2Test.variant === 'A';
     }
 
     var ads = [],


### PR DESCRIPTION
We want infinite ads to run in both viewability tests.
