### PR TITLE
Version 2 of 'Ad feature MPU large' template

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
@@ -6,6 +6,7 @@ define([
     // require templates, so they're bundled up as part of the build
     'text!common/views/commercial/creatives/ad-feature-mpu.html',
     'text!common/views/commercial/creatives/ad-feature-mpu-large.html',
+    'text!common/views/commercial/creatives/ad-feature-mpu-large-v2.html',
     'text!common/views/commercial/creatives/logo-ad-feature.html',
     'text!common/views/commercial/creatives/logo-sponsored.html',
     'text!common/views/commercial/creatives/manual-inline.html',

--- a/static/src/javascripts/projects/common/views/commercial/creatives/ad-feature-mpu-large-v2.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/ad-feature-mpu-large-v2.html
@@ -1,0 +1,13 @@
+<div class="creative--ad-feature-mpu-large creative--ad-feature-mpu-large-v2" data-link-name="creative | ad feature mpu large">
+    <a class="creative__article" href="{{clickMacro}}{{articleUrl}}" data-link-name="article">
+        <div class="creative__article__image-container">
+        	<img class="creative__article__image" src="{{articleImage}}">
+        </div>
+        <h2 class="creative__article__title">{{articleHeaderText}}</h2>
+    </a>
+    <p class="creative__logo-text">Brought to you by:</p>
+    <a class="creative__logo" href="{{clickMacro}}{{logoUrl}}" data-link-name="logo">
+        <img src="{{logoImage}}" />
+    </a>
+    <a class="creative__logo-info" href="{{clickMacro}}{{infoUrl}}" data-link-name="info">About this content</a>
+</div>

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -647,6 +647,36 @@
         display: block;
         clear: left;
     }
+
+    &.creative--ad-feature-mpu-large-v2 {
+        padding: 0 0 $gs-baseline / 2;
+
+        .creative__article {
+            padding: 0;
+
+            h2 {
+                padding: $gs-baseline / 2;
+                font-size: 18px;
+                line-height: 22px;
+                height: 44px;
+            }
+        }
+
+        .creative__logo-text,
+        .creative__logo-info {
+            margin-left: $gs-baseline / 2;
+        }
+
+        .creative__logo {
+            margin-right: $gs-baseline / 2;
+        }
+
+        .creative__article__image-container {
+            max-height: 150px;
+            overflow: hidden;
+        }
+
+    }
 }
 
 @keyframes textanimation {

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -656,8 +656,8 @@
 
             h2 {
                 padding: $gs-baseline / 2;
-                font-size: 18px;
-                line-height: 22px;
+                font-size: get-font-size(bodyHeading, 3);
+                line-height: get-line-height(bodyHeading, 1);
                 height: 44px;
             }
         }

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -648,35 +648,36 @@
         clear: left;
     }
 
-    &.creative--ad-feature-mpu-large-v2 {
-        padding: 0 0 $gs-baseline / 2;
+}
 
-        .creative__article {
-            padding: 0;
+.creative--ad-feature-mpu-large-v2 {
+    padding: 0 0 $gs-baseline / 2;
 
-            h2 {
-                padding: $gs-baseline / 2;
-                font-size: get-font-size(bodyHeading, 3);
-                line-height: get-line-height(bodyHeading, 1);
-                height: 44px;
-            }
+    .creative__article {
+        padding: 0;
+
+        h2 {
+            padding: $gs-baseline / 2;
+            font-size: get-font-size(bodyHeading, 3);
+            line-height: get-line-height(bodyHeading, 1);
+            height: 44px;
         }
-
-        .creative__logo-text,
-        .creative__logo-info {
-            margin-left: $gs-baseline / 2;
-        }
-
-        .creative__logo {
-            margin-right: $gs-baseline / 2;
-        }
-
-        .creative__article__image-container {
-            max-height: 150px;
-            overflow: hidden;
-        }
-
     }
+
+    .creative__logo-text,
+    .creative__logo-info {
+        margin-left: $gs-baseline / 2;
+    }
+
+    .creative__logo {
+        margin-right: $gs-baseline / 2;
+    }
+
+    .creative__article__image-container {
+        max-height: 156px;
+        overflow: hidden;
+    }
+
 }
 
 @keyframes textanimation {


### PR DESCRIPTION
Design tweaks to 'Ad feature MPU large' template based on this design:

![commercial-item-in-container 1](https://cloud.githubusercontent.com/assets/3763718/7961763/65c486ee-0a01-11e5-8c3f-eb68e1770514.png)

Old template looks like this:

![screen shot 2015-06-03 at 15 03 03](https://cloud.githubusercontent.com/assets/3763718/7961809/b3e8aa76-0a01-11e5-8fab-eb752b040638.png)

Changes include:
1. Removing padding around image
2. Reducing padding/margin around text
3. Fixing image height to 150px
4. Fixing heading height to allow up to 2 lines of text
