### PR TITLE
Google site verification

### DIFF
--- a/applications/app/controllers/SiteVerificationController.scala
+++ b/applications/app/controllers/SiteVerificationController.scala
@@ -1,0 +1,21 @@
+package controllers
+
+import play.api.mvc.{Action, Controller}
+import scala.concurrent.duration._
+
+object SiteVerificationController extends Controller {
+
+  // A list of accepted accounts. Note, the main guardian.com youtube account
+  // is not present here, it was already verified using an alternative method (domain).
+  private val acceptedGoogleAccounts = List(
+    "367bc8736b2b40ff" // Owen Jones
+  )
+
+  def googleSiteVerify(account: String) = Action { implicit request =>
+      if (acceptedGoogleAccounts.contains(account)) {
+        model.Cached(7.days)(Ok(s"google-site-verification: google$account.html"))
+      } else {
+        model.Cached(5.minutes)(NotFound)
+      }
+  }
+}

--- a/applications/app/controllers/SiteVerificationController.scala
+++ b/applications/app/controllers/SiteVerificationController.scala
@@ -8,7 +8,13 @@ object SiteVerificationController extends Controller {
   // A list of accepted accounts. Note, the main guardian.com youtube account
   // is not present here, it was already verified using an alternative method (domain).
   private val acceptedGoogleAccounts = List(
-    "367bc8736b2b40ff" // Owen Jones
+    "f2ddac7ca1547968", // Main Guardian channel - https://www.youtube.com/user/TheGuardian
+    "bbb4e09fa25b64ba"  // Used by:
+      // Football channel - https://www.youtube.com/user/GuardianFootball
+      // Owen Jones channel - https://www.youtube.com/channel/UCSYCo8uRGF39qDCxF870K5Q
+      // Music channel - https://www.youtube.com/user/GuardianMusic
+      // Culture & arts channel - https://www.youtube.com/user/GuardianCultureArts
+      // Science & technology channel - https://www.youtube.com/user/gdntech
   )
 
   def googleSiteVerify(account: String) = Action { implicit request =>

--- a/applications/app/controllers/SiteVerificationController.scala
+++ b/applications/app/controllers/SiteVerificationController.scala
@@ -5,8 +5,7 @@ import scala.concurrent.duration._
 
 object SiteVerificationController extends Controller {
 
-  // A list of accepted accounts. Note, the main guardian.com youtube account
-  // is not present here, it was already verified using an alternative method (domain).
+  // A list of accepted accounts.
   private val acceptedGoogleAccounts = List(
     "f2ddac7ca1547968", // Main Guardian channel - https://www.youtube.com/user/TheGuardian
     "bbb4e09fa25b64ba"  // Used by:

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -62,3 +62,6 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                             
 
 # Tag combiners
 GET        /$leftSide<[^+]+>+*rightSide                                         controllers.IndexController.renderCombiner(leftSide, rightSide)
+
+# Google site verification
+GET        /google$account<[\w\d-]*>.html                                       controllers.SiteVerificationController.googleSiteVerify(account)

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -108,12 +108,11 @@
 @*
     this script allows you to hook up an external debugger for mobile devices
     see: http://people.apache.org/~pmuellr/weinre/docs/latest/
+
 *@
 @if(play.Play.isDev()) {
     @Configuration.javascript.pageData.get("guardian.page.iphoneDebugger").map{ scriptUrl => <script src="@scriptUrl"></script> }
 }
-
-<meta name="google-site-verification" content="LR-FN6c2gIEUoo3k049w1nxyHykmac5ZE3SaUOiKc30" />
 
 @item.linkedData.map { linkedData =>
     <script data-schema="@{linkedData.`@type`}" type="application/ld+json">


### PR DESCRIPTION
Add a controller that returns verification content for google (youtube accounts). This allows multimedia team to link to the guardian from videos on guardian channels (there are several channels now).
