### PR TITLE
Supporter banner AB test

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1018,7 +1018,7 @@ object Switches {
     "A/B Tests",
     "ab-supporter",
     "Switch for the Supporter Message A/B test.",
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2015, 6, 28),
     exposeClientSide = true
   )

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1019,7 +1019,7 @@ object Switches {
     "ab-supporter",
     "Switch for the Supporter Message A/B test.",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 6, 6),
+    sellByDate = new LocalDate(2015, 6, 11),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1019,7 +1019,7 @@ object Switches {
     "ab-supporter",
     "Switch for the Supporter Message A/B test.",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 6, 28),
+    sellByDate = new LocalDate(2015, 6, 6),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1014,6 +1014,15 @@ object Switches {
     )
   }
 
+  val ABSupporterMessage = Switch(
+    "A/B Tests",
+    "ab-supporter",
+    "Switch for the Supporter Message A/B test.",
+    safeState = On,
+    sellByDate = new LocalDate(2015, 6, 28),
+    exposeClientSide = true
+  )
+
   val FootballFeedRecorderSwitch = Switch(
     "Feature",
     "football-feed-recorder",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -13,7 +13,8 @@ define([
     'common/modules/experiments/tests/save-for-later',
     'common/modules/experiments/tests/cookie-refresh',
     'common/modules/experiments/headlines',
-    'common/modules/experiments/tests/defer-spacefinder'
+    'common/modules/experiments/tests/defer-spacefinder',
+    'common/modules/experiments/tests/supporter-message'
 ], function (
     raven,
     _,
@@ -29,7 +30,8 @@ define([
     SaveForLater,
     CookieRefresh,
     Headline,
-    DeferSpacefinder
+    DeferSpacefinder,
+    SupporterMessage
     ) {
 
     var ab,
@@ -41,6 +43,7 @@ define([
             new SaveForLater(),
             new CookieRefresh(),
             new DeferSpacefinder(),
+            new SupporterMessage(),
             _.map(_.range(1, 10), function (n) {
                 return new Headline(n);
             })

--- a/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
@@ -1,0 +1,66 @@
+define([
+    'common/utils/config',
+    'common/utils/detect',
+    'common/utils/template',
+    'common/modules/ui/message',
+    'common/modules/identity/api',
+    'text!common/views/supporter-message.html'
+], function (
+    config,
+    detect,
+    template,
+    Message,
+    idApi,
+    supporterMessageTmpl
+) {
+
+    return function () {
+
+        this.id = 'Supporter';
+        this.start = '2015-06-02';
+        this.expiry = '2015-06-21';
+        this.author = 'David Rapson';
+        this.description = 'Test if logged in users are encouraged to become a Supporter';
+        this.audience = 1.0;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Users will be interested in Supporter tier';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = 'supporter message, hide, read more';
+        this.idealOutcome = 'Users will sign up as a Supporter';
+
+        this.canRun = function () {
+            return config.page.contentType == 'Article' && detect.getBreakpoint() !== 'mobile' && idApi.isUserLoggedIn();
+        };
+
+        this.variants = [{
+            id: 'A',
+            test: function () {
+                new Message('supporter', {
+                    pinOnHide: false,
+                    siteMessageLinkName: 'supporter message',
+                    siteMessageCloseBtn: 'hide'
+                }).show(template(supporterMessageTmpl, {
+                    supporterLink: 'https://membership.theguardian.com/about/supporter',
+                    messageText: 'Not already a supporter? Why not become one today',
+                    linkText: 'Become a supporter today'
+                }));
+            }
+        },
+        {
+            id: 'B',
+            test: function () {
+                new Message('supporter', {
+                    pinOnHide: false,
+                    siteMessageLinkName: 'supporter message',
+                    siteMessageCloseBtn: 'hide'
+                }).show(template(supporterMessageTmpl, {
+                    supporterLink: 'https://membership.theguardian.com/about/supporter',
+                    messageText: 'Interested in becoming a supporter?',
+                    linkText: 'Become a supporter today'
+                }));
+            }
+        }];
+
+    };
+
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
@@ -17,8 +17,8 @@ define([
     return function () {
 
         this.id = 'Supporter';
-        this.start = '2015-06-03';
-        this.expiry = '2015-06-08';
+        this.start = '2015-06-04';
+        this.expiry = '2015-06-06';
         this.author = 'David Rapson';
         this.description = 'Test if logged in users are encouraged to become a Supporter';
         this.audience = 0.2;
@@ -41,7 +41,7 @@ define([
                     siteMessageCloseBtn: 'hide'
                 }).show(template(supporterMessageTmpl, {
                     supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=SUPPORTER_BANNER_TEST_A',
-                    messageText: 'Not already a member? Start supporting us today',
+                    messageText: 'Not already a Guardian Member? Start supporting us today',
                     linkText: 'Become a supporter'
                 }));
             }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
@@ -40,7 +40,7 @@ define([
                     siteMessageLinkName: 'supporter message',
                     siteMessageCloseBtn: 'hide'
                 }).show(template(supporterMessageTmpl, {
-                    supporterLink: 'https://membership.theguardian.com/about/supporter',
+                    supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=SUPPORTER_BANNER_TEST_A',
                     messageText: 'Not already a member? Start supporting us today',
                     linkText: 'Become a supporter'
                 }));
@@ -54,7 +54,7 @@ define([
                     siteMessageLinkName: 'supporter message',
                     siteMessageCloseBtn: 'hide'
                 }).show(template(supporterMessageTmpl, {
-                    supporterLink: 'https://membership.theguardian.com/about/supporter',
+                    supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=SUPPORTER_BANNER_TEST_B',
                     messageText: 'Become a Guardian Member and support fearless investigative journalism',
                     linkText: 'Become a supporter'
                 }));

--- a/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
@@ -18,11 +18,11 @@ define([
 
         this.id = 'Supporter';
         this.start = '2015-06-04';
-        this.expiry = '2015-06-06';
+        this.expiry = '2015-06-11';
         this.author = 'David Rapson';
         this.description = 'Test if logged in users are encouraged to become a Supporter';
         this.audience = 0.1;
-        this.audienceOffset = 0;
+        this.audienceOffset = 0.25;
         this.successMeasure = 'Users will be interested in Supporter tier';
         this.audienceCriteria = '10% of logged in users, only on article pages';
         this.dataLinkNames = 'supporter message, hide, read more';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
@@ -17,11 +17,11 @@ define([
     return function () {
 
         this.id = 'Supporter';
-        this.start = '2015-06-02';
-        this.expiry = '2015-06-21';
+        this.start = '2015-06-03';
+        this.expiry = '2015-06-08';
         this.author = 'David Rapson';
         this.description = 'Test if logged in users are encouraged to become a Supporter';
-        this.audience = 1.0;
+        this.audience = 0.2;
         this.audienceOffset = 0;
         this.successMeasure = 'Users will be interested in Supporter tier';
         this.audienceCriteria = 'All users';
@@ -29,7 +29,7 @@ define([
         this.idealOutcome = 'Users will sign up as a Supporter';
 
         this.canRun = function () {
-            return config.page.contentType == 'Article' && detect.getBreakpoint() !== 'mobile' && idApi.isUserLoggedIn();
+            return config.page.contentType === 'Article' && detect.getBreakpoint() !== 'mobile' && idApi.isUserLoggedIn();
         };
 
         this.variants = [{
@@ -41,8 +41,8 @@ define([
                     siteMessageCloseBtn: 'hide'
                 }).show(template(supporterMessageTmpl, {
                     supporterLink: 'https://membership.theguardian.com/about/supporter',
-                    messageText: 'Not already a supporter? Why not become one today',
-                    linkText: 'Become a supporter today'
+                    messageText: 'Not already a member? Start supporting us today',
+                    linkText: 'Become a supporter'
                 }));
             }
         },
@@ -55,8 +55,8 @@ define([
                     siteMessageCloseBtn: 'hide'
                 }).show(template(supporterMessageTmpl, {
                     supporterLink: 'https://membership.theguardian.com/about/supporter',
-                    messageText: 'Interested in becoming a supporter?',
-                    linkText: 'Become a supporter today'
+                    messageText: 'Become a Guardian Member and support fearless investigative journalism',
+                    linkText: 'Become a supporter'
                 }));
             }
         }];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/supporter-message.js
@@ -21,10 +21,10 @@ define([
         this.expiry = '2015-06-06';
         this.author = 'David Rapson';
         this.description = 'Test if logged in users are encouraged to become a Supporter';
-        this.audience = 0.2;
+        this.audience = 0.1;
         this.audienceOffset = 0;
         this.successMeasure = 'Users will be interested in Supporter tier';
-        this.audienceCriteria = 'All users';
+        this.audienceCriteria = '10% of logged in users, only on article pages';
         this.dataLinkNames = 'supporter message, hide, read more';
         this.idealOutcome = 'Users will sign up as a Supporter';
 

--- a/static/src/javascripts/projects/common/views/supporter-message.html
+++ b/static/src/javascripts/projects/common/views/supporter-message.html
@@ -1,0 +1,9 @@
+<p class="site-message__message" id="site-message__message">
+    {{messageText}}
+</p>
+<ul class="site-message__actions u-unstyled">
+    <li class="site-message__actions__item">
+        <i class="i i-arrow-white-right"></i>
+        <a href="{{supporterLink}}" target="_blank" data-link-name="read more">{{linkText}}</a>
+    </li>
+</ul>

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -429,6 +429,10 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     background: colour(news-support-2);
 }
 
+.site-message--supporter {
+    background: colour(news-main-2);
+}
+
 .site-message--panel-mtrec1,
 .site-message--panel-mtrec2 {
     background: colour(neutral-2);


### PR DESCRIPTION
This PR sets up a new AB test to promote the Supporter tier of Membership to logged in users.

**A variant**
![screen shot 2015-06-04 at 11 18 45](https://cloud.githubusercontent.com/assets/123386/7982137/66bc16ba-0aac-11e5-8563-6f1f49136d7e.png)

**B variant**
![screen shot 2015-06-04 at 11 18 33](https://cloud.githubusercontent.com/assets/123386/7982138/66bd741a-0aac-11e5-90fa-8681ade00c06.png)

**Test criteria:**
- 10% of audience
- Logged in users
- Only shown on article pages

Awaiting confirmation that we're OK to run this test before merging, but is in a position to be code reviewed.

@dominickendrick @mattandrews @crifmulholland
