### PR TITLE
Filter SFL test audience by logged in users and always load SFL for pre-existing users

### DIFF
--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -122,7 +122,7 @@ define([
 ### Detecting a user's bucket
 You can use this code to check anywhere in your JS whether you're in a test bucket.
 ```
-if (ab.getTestVariant('FaciaSlideshow') === 'slideshow') {
+if (ab.getTestVariantId('FaciaSlideshow') === 'slideshow') {
     ///...
 }
 ```

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -500,7 +500,6 @@ define([
         },
 
         ready = function () {
-
             robust('c-fonts',           modules.loadFonts);
             robust('c-identity',        modules.initId);
             robust('c-adverts',         modules.initUserAdTargeting);

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -16,7 +16,6 @@ define([
     'common/utils/url',
     'common/utils/robust',
     'common/utils/storage',
-    'common/modules/loyalty/save-for-later',
     'common/modules/analytics/foresee-survey',
     'common/modules/analytics/livestats',
     'common/modules/analytics/media-listener',
@@ -75,7 +74,6 @@ define([
     url,
     robust,
     storage,
-    SaveForLater,
     Foresee,
     liveStats,
     mediaListener,
@@ -498,31 +496,12 @@ define([
                         }).show(template(internationalControlMessage, {}));
                     }
                 }
-            },
-
-            initSaveForLater: function () {
-                // On top of the A/B test, we always want to give pre-existing SFL
-                // users the web feature.
-                mediator.on('module:identity:api:loaded', function () {
-                    id.getSavedArticles().then(function (resp) {
-                        var userHasSavedArticles = !! resp.savedArticles;
-
-                        var test = ab.getTest('SaveForLater');
-                        var participation = ab.isParticipating(test);
-                        var userIsNotInTest = !participation || !ab.getVariant(test, participation.variant);
-                        if (userIsNotInTest && userHasSavedArticles) {
-                            var saveForLater = new SaveForLater();
-                            saveForLater.init();
-                        }
-                    });
-                });
             }
         },
 
         ready = function () {
 
             robust('c-fonts',           modules.loadFonts);
-            robust('c-init-save-for-later', modules.initSaveForLater);
             robust('c-identity',        modules.initId);
             robust('c-adverts',         modules.initUserAdTargeting);
             robust('c-discussion',      modules.initDiscussion);

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -341,6 +341,7 @@ define([
         getActiveTests: getActiveTests,
         getTestVariantId: getTestVariantId,
         setTestVariant: setTestVariant,
+        getVariant: getVariant,
 
         /**
          * check if a test can be run (i.e. is not expired and switched on)

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -165,8 +165,7 @@ define([
             var variant = getVariant(test, variantId);
             if (variant) {
                 variant.test();
-            }
-            if (variantId === 'notintest' && test.notInTest) {
+            } else if (variantId === 'notintest' && test.notInTest) {
                 test.notInTest();
             }
         }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -34,24 +34,24 @@ define([
     Headline,
     DeferSpacefinder,
     SupporterMessage
-    ) {
+) {
 
-    var ab,
-        TESTS = _.flatten([
-            new FacebookMostViewed(),
-            new LiveblogNotifications(),
-            new HighCommercialComponent(),
-            new MtRec1(),
-            new MtRec2(),
-            new SaveForLater(),
-            new CookieRefresh(),
-            new DeferSpacefinder(),
-            new SupporterMessage(),
-            _.map(_.range(1, 10), function (n) {
-                return new Headline(n);
-            })
-        ]),
-        participationsKey = 'gu.ab.participations';
+    var TESTS = _.flatten([
+        new FacebookMostViewed(),
+        new LiveblogNotifications(),
+        new HighCommercialComponent(),
+        new MtRec1(),
+        new MtRec2(),
+        new SaveForLater(),
+        new CookieRefresh(),
+        new DeferSpacefinder(),
+        new SupporterMessage(),
+        _.map(_.range(1, 10), function (n) {
+            return new Headline(n);
+        })
+    ]);
+
+    var participationsKey = 'gu.ab.participations';
 
     function getParticipations() {
         return store.local.get(participationsKey) || {};
@@ -162,12 +162,10 @@ define([
         if (isParticipating(test) && testCanBeRun(test)) {
             var participations = getParticipations(),
                 variantId = participations[test.id].variant;
-            _.some(test.variants, function (variant) {
-                if (variant.id === variantId) {
-                    variant.test();
-                    return true;
-                }
-            });
+            var variant = getVariant(test, variantId);
+            if (variant) {
+                variant.test();
+            }
             if (variantId === 'notintest' && test.notInTest) {
                 test.notInTest();
             }
@@ -207,7 +205,7 @@ define([
         return config.switches['ab' + test.id];
     }
 
-    function getTestVariant(testId) {
+    function getTestVariantId(testId) {
         var participation = getParticipations()[testId];
         return participation && participation.variant;
     }
@@ -223,10 +221,16 @@ define([
 
     function shouldRunTest(id, variant) {
         var test = getTest(id);
-        return test && isParticipating(test) && ab.getTestVariant(id) === variant && testCanBeRun(test);
+        return test && isParticipating(test) && ab.getTestVariantId(id) === variant && testCanBeRun(test);
     }
 
-    ab = {
+    function getVariant(test, variantId) {
+        return _.find(test.variants, function (variant) {
+            return variant.id === variantId;
+        });
+    }
+
+    var ab = {
 
         addTest: function (test) {
             TESTS.push(test);
@@ -314,7 +318,7 @@ define([
             try {
                 _.forEach(getActiveTests(), function (test) {
                     if (isParticipating(test) && testCanBeRun(test)) {
-                        var variant = getTestVariant(test.id);
+                        var variant = getTestVariantId(test.id);
                         if (variant && variant !== 'notintest') {
                             abLogObject['ab' + test.id] = variant;
                         }
@@ -335,7 +339,7 @@ define([
         makeOmnitureTag: makeOmnitureTag,
         getExpiredTests: getExpiredTests,
         getActiveTests: getActiveTests,
-        getTestVariant: getTestVariant,
+        getTestVariantId: getTestVariantId,
         setTestVariant: setTestVariant,
 
         /**

--- a/static/src/javascripts/projects/common/modules/experiments/tests/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/save-for-later.js
@@ -69,7 +69,7 @@ define([
             // users the web feature.
             mediator.on('module:identity:api:loaded', function () {
                 id.getSavedArticles().then(function (resp) {
-                    var userHasSavedArticles = !! resp.savedArticles;
+                    var userHasSavedArticles = !!resp.savedArticles;
 
                     if (userHasSavedArticles) {
                         init();

--- a/static/src/javascripts/projects/common/modules/experiments/tests/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/save-for-later.js
@@ -5,6 +5,7 @@ define([
     'common/utils/config',
     'common/utils/mediator',
     'common/utils/template',
+    'common/modules/identity/api',
     'common/modules/loyalty/save-for-later',
     'text!common/views/identity/saved-for-later-profile-link.html',
     'common/modules/identity/api'
@@ -15,6 +16,7 @@ define([
     config,
     mediator,
     template,
+    id,
     SaveForLater,
     profileLinkTmp,
     Id
@@ -38,17 +40,18 @@ define([
             return Id.isUserLoggedIn();
         };
 
+        var init = function () {
+            if (!/Network Front|Section/.test(config.page.contentType)) {
+                var saveForLater = new SaveForLater();
+                saveForLater.init();
+            }
+        };
+
         this.variants = [
             {
                 id: 'variant',
                 test: function () {
-                    mediator.on('module:identity:api:loaded', function () {
-
-                        if (!/Network Front|Section/.test(config.page.contentType)) {
-                            var saveForLater = new SaveForLater();
-                            saveForLater.init();
-                        }
-                    });
+                    mediator.on('module:identity:api:loaded', init);
 
                     mediator.on('modules:profilenav:loaded', function () {
                         var popup = qwery('.popup--profile')[0];
@@ -60,5 +63,19 @@ define([
                 }
             }
         ];
+
+        this.notInTest = function () {
+            // On top of the A/B test, we always want to give pre-existing SFL
+            // users the web feature.
+            mediator.on('module:identity:api:loaded', function () {
+                id.getSavedArticles().then(function (resp) {
+                    var userHasSavedArticles = !! resp.savedArticles;
+
+                    if (userHasSavedArticles) {
+                        init();
+                    }
+                });
+            });
+        };
     };
 });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/save-for-later.js
@@ -6,7 +6,8 @@ define([
     'common/utils/mediator',
     'common/utils/template',
     'common/modules/loyalty/save-for-later',
-    'text!common/views/identity/saved-for-later-profile-link.html'
+    'text!common/views/identity/saved-for-later-profile-link.html',
+    'common/modules/identity/api'
 ], function (
     bonzo,
     qwery,
@@ -15,7 +16,8 @@ define([
     mediator,
     template,
     SaveForLater,
-    profileLinkTmp
+    profileLinkTmp,
+    Id
 ) {
 
     return function () {
@@ -33,7 +35,7 @@ define([
         this.showForSensitive = false;
 
         this.canRun = function () {
-            return true;
+            return Id.isUserLoggedIn();
         };
 
         this.variants = [

--- a/static/src/javascripts/projects/common/modules/ui/clickstream.js
+++ b/static/src/javascripts/projects/common/modules/ui/clickstream.js
@@ -108,7 +108,7 @@ define([
                 applicableTests = ab.getActiveTestsEventIsApplicableTo(clickSpec);
                 if (applicableTests !== undefined && applicableTests.length > 0) {
                     clickSpec.tag = _.map(applicableTests, function (test) {
-                        var variant = ab.getTestVariant(test);
+                        var variant = ab.getTestVariantId(test);
                         return 'AB,' + test + ',' + variant + ',' + clickSpec.tag;
                     }).join(',');
                 }

--- a/static/src/javascripts/projects/common/modules/ui/sticky-social.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky-social.js
@@ -77,7 +77,7 @@ define([
     }
 
     function init() {
-        var testVariant = ab.getTestVariant('ShareButtons2'),
+        var testVariant = ab.getTestVariantId('ShareButtons2'),
             socialContext;
 
         if (testVariant.indexOf('referrer') > -1) {

--- a/static/src/javascripts/test/spec/common/experiments/ab.spec.js
+++ b/static/src/javascripts/test/spec/common/experiments/ab.spec.js
@@ -217,7 +217,7 @@ describe('AB Testing', function () {
             var event = {};
             event.tag = 'most popular | The Guardian | trail | 1 | text';
 
-            expect(ab.getTestVariant('DummyTest')).toEqual('control')
+            expect(ab.getTestVariantId('DummyTest')).toEqual('control')
         });
 
         it('should generate a string for Omniture to tag the test(s) the user is in', function () {


### PR DESCRIPTION
We will track users with saved articles using a prop.
