### PR TITLE
Use Press fromSetOfIdsWithForceConfig on collection update

### DIFF
--- a/facia-tool/app/controllers/CollectionController.scala
+++ b/facia-tool/app/controllers/CollectionController.scala
@@ -29,7 +29,7 @@ object CollectionController extends Controller with PanDomainAuthActions {
       case Some(CollectionRequest(frontIds, collection)) =>
         val identity = request.user
         val collectionId = UpdateManager.addCollection(frontIds, collection, identity)
-        Press.fromSetOfIds(Set(collectionId))
+        Press.fromSetOfIdsWithForceConfig(Set(collectionId))
         Ok(Json.toJson(CreateCollectionResponse(collectionId)))
 
       case None => BadRequest
@@ -41,7 +41,7 @@ object CollectionController extends Controller with PanDomainAuthActions {
       case Some(CollectionRequest(frontIds, collection)) =>
         val identity = request.user
         UpdateManager.updateCollection(collectionId, frontIds, collection, identity)
-        Press.fromSetOfIds(Set(collectionId))
+        Press.fromSetOfIdsWithForceConfig(Set(collectionId))
         Ok
 
       case None => BadRequest


### PR DESCRIPTION
We also want to force a `config` update on `facia-press` boxes for updates to a `collection` in the `config` editor.

@robertberry @piuccio 
