### PR TITLE
Reorder the filtering of empty collections to ensure first-container is valid

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -393,7 +393,7 @@ object Front extends implicits.Collections {
     import scalaz.syntax.traverse._
 
     Front(
-      pressedPage.collections.zipWithIndex.mapAccumL(
+      pressedPage.collections.filterNot(_.all.isEmpty).zipWithIndex.mapAccumL(
         (Set.empty[TrailUrl], initialContext)
       ) { case ((seenTrails, context), (pressedCollection, index)) =>
         val container = Container.fromPressedCollection(pressedCollection)
@@ -420,7 +420,7 @@ object Front extends implicits.Collections {
             None
           ))
         }
-      }._2.filterNot(_.items.isEmpty)
+      }._2
     )
 
   }


### PR DESCRIPTION
Filters out empty collections sooner, so they won't be indexed at all. This means the `fc-container--first` is consistent. It also means the data link names for containers are sensibly labelled, with respect to the visible facia containers.

Fixes #9378
