### PR TITLE
Fix rich links

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -103,7 +103,7 @@ define([
 
                 mediator.emit('modules:commercial:creatives:commercial-component:loaded');
             }.bind(this),
-            error: function (err) {
+            error: function () {
                 this.$adSlot.hide();
             }.bind(this)
         }).load();

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -102,6 +102,9 @@ define([
                 this.postLoadEvents[this.type] && this.postLoadEvents[this.type](this.$adSlot);
 
                 mediator.emit('modules:commercial:creatives:commercial-component:loaded');
+            }.bind(this),
+            error: function (err) {
+                this.$adSlot.hide();
             }.bind(this)
         }).load();
 


### PR DESCRIPTION
Fixing the weird blank space caused by commercial components.

![screen shot 2015-06-05 at 15 36 15](https://cloud.githubusercontent.com/assets/2579465/8008174/5baa41e2-0b98-11e5-9809-4a0bf1560f7e.png)

I started to write unit test but I noticed that whole unit tests for this module are turned off because of the move to jspm. I am adding to the backlog to look at these tests next week.

@kelvin-chappell @kenlim @johnduffell 
