### PR TITLE
Update ondemand endpoints

### DIFF
--- a/facia-press/app/controllers/Application.scala
+++ b/facia-press/app/controllers/Application.scala
@@ -1,9 +1,8 @@
 package controllers
 
 import common.ExecutionContexts
-import frontpress.LiveFapiFrontPress
+import frontpress.{DraftFapiFrontPress, LiveFapiFrontPress, FrontPress}
 import conf.Configuration
-import frontpress.FrontPress
 import model.NoCache
 import play.api.libs.json.Json
 import play.api.mvc.{Result, Action, Controller}
@@ -52,10 +51,10 @@ object Application extends Controller with ExecutionContexts {
       Future.successful(NoCache(ServiceUnavailable))}
 
   def pressLiveForPath(path: String) = Action.async {
-    handlePressRequest(path, "live")(FrontPress.pressLiveByPathId)
+    handlePressRequest(path, "live")(LiveFapiFrontPress.pressByPathId)
   }
 
   def pressDraftForPath(path: String) = Action.async {
-    handlePressRequest(path, "draft")(FrontPress.pressDraftByPathId)
+    handlePressRequest(path, "draft")(DraftFapiFrontPress.pressByPathId)
   }
 }

--- a/facia-press/app/controllers/Application.scala
+++ b/facia-press/app/controllers/Application.scala
@@ -1,13 +1,13 @@
 package controllers
 
 import common.ExecutionContexts
-import frontpress.{DraftFapiFrontPress, LiveFapiFrontPress, FrontPress}
 import conf.Configuration
+import conf.Switches.FaciaPressOnDemand
+import frontpress.{DraftFapiFrontPress, LiveFapiFrontPress}
 import model.NoCache
 import play.api.libs.json.Json
-import play.api.mvc.{Result, Action, Controller}
+import play.api.mvc.{Action, Controller, Result}
 import services.ConfigAgent
-import conf.Switches.FaciaPressOnDemand
 
 import scala.concurrent.Future
 


### PR DESCRIPTION
This updates the **press-on-demand** endpoints in `facia-press` to use the new format.

@robertberry 
