### PR TITLE
Private collections

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1197,6 +1197,15 @@ object Switches {
     exposeClientSide = false
   )
 
+  val FaciaToolPutPrivate = Switch(
+    "Facia",
+    "facia-tool-put-private",
+    "If this is switched on, facia tool will put collections to S3 as private",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 7, 30),
+    exposeClientSide = false
+  )
+
   // Server-side A/B Tests
   val ServerSideTests = {
     // It's for the side effect. Blame agents.

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -163,7 +163,7 @@ object S3FrontsApi extends S3 {
   def listConfigsIds: List[String] = getConfigIds(s"$location/config/")
   def listCollectionIds: List[String] = getCollectionIds(s"$location/collection/")
   def putCollectionJson(id: String, json: String) = {
-    val location: String = s"$location/collection/$id/collection.json", json, "application/json"
+    val location: String = s"$location/collection/$id/collection.json"
     if (Switches.FaciaToolPutPrivate.isSwitchedOn) {
       putPrivate(location, json, "application/json")}
     else {

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -2,7 +2,7 @@ package services
 
 import com.gu.googleauth.UserIdentity
 import com.gu.pandomainauth.model.User
-import conf.Configuration
+import conf.{Switches, Configuration}
 import common.Logging
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model._
@@ -162,8 +162,12 @@ object S3FrontsApi extends S3 {
   def getBlock(id: String) = get(s"$location/collection/$id/collection.json")
   def listConfigsIds: List[String] = getConfigIds(s"$location/config/")
   def listCollectionIds: List[String] = getCollectionIds(s"$location/collection/")
-  def putCollectionJson(id: String, json: String) =
-    putPublic(s"$location/collection/$id/collection.json", json, "application/json")
+  def putCollectionJson(id: String, json: String) = {
+    val location: String = s"$location/collection/$id/collection.json", json, "application/json"
+    if (Switches.FaciaToolPutPrivate.isSwitchedOn) {
+      putPrivate(location, json, "application/json")}
+    else {
+      putPublic(location, json, "application/json")}}
 
   def archive(id: String, json: String, identity: User) = {
     val now = DateTime.now

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -163,11 +163,11 @@ object S3FrontsApi extends S3 {
   def listConfigsIds: List[String] = getConfigIds(s"$location/config/")
   def listCollectionIds: List[String] = getCollectionIds(s"$location/collection/")
   def putCollectionJson(id: String, json: String) = {
-    val location: String = s"$location/collection/$id/collection.json"
+    val putLocation: String = s"$location/collection/$id/collection.json"
     if (Switches.FaciaToolPutPrivate.isSwitchedOn) {
-      putPrivate(location, json, "application/json")}
+      putPrivate(putLocation, json, "application/json")}
     else {
-      putPublic(location, json, "application/json")}}
+      putPublic(putLocation, json, "application/json")}}
 
   def archive(id: String, json: String, identity: User) = {
     val now = DateTime.now


### PR DESCRIPTION
This adds a switch to change the read access of `collection.json` files to `private`.

The only consumer of these collections should be `facia-scala-client`, which _CAPI_, _MAPI_ and _Ophan_ use, each with their own key.

`facia-tool` also reads these but not through the client.

@robertberry @piuccio @DiegoVazquezNanini @mchv @obrienm 
