### PR TITLE
Make sure we have access to ophan.viewId

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -132,7 +132,8 @@ define([
             if (config.switches.ophan && config.switches.ophanViewId) {
                 require(['ophan/ng'],
                     function (ophan) {
-                        setTarget({viewId: ophan.viewId});
+                        var viewId = (ophan || {}).viewId;
+                        setTarget({viewId: viewId});
                     },
                     function (err) {
                         raven.captureException(new Error('Error retrieving ophan (' + err + ')'), {


### PR DESCRIPTION
This seems to be still failing. So we need to make sure that we definitely have access to ophan object.

CC @kenlim @kelvin-chappell 
