### PR TITLE
Tweak linked data on liveblogs

### DIFF
--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -72,7 +72,7 @@
                             @fragments.liveFilter(article.isLive)
 
                             <div class="js-liveblog-body u-cf from-content-api js-blog-blocks @if(article.isLive) {live-blog}" data-test-id="live-blog-blocks"
-                                itemprop="@if(article.isReview) {reviewBody} else {@if(article.isLive) {liveBlogUpdate} else {articleBody}}">
+                                itemprop="@if(article.isReview) {reviewBody} else {articleBody}">
                                 @BodyCleaner(article, article.body)
                             </div>
                         </div>

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -297,6 +297,7 @@ case class LiveBlogLinkedData(isLiveBlog: Boolean)(implicit val request: Request
     if (isLiveBlog) {
       body.select(".block").foreach { el =>
         val id = el.id()
+        el.attr("itemprop", "liveBlogUpdate")
         el.attr("itemscope", "")
         el.attr("itemtype", "http://schema.org/BlogPosting")
         el.select(".block-time.published-time time").foreach { time =>


### PR DESCRIPTION
Apparently for validity the liveBlogUpdate tag should be on each element rather than the whole block.
