### PR TITLE
The Erdoğan Fix

### DIFF
--- a/grunt-configs/webfontjson.js
+++ b/grunt-configs/webfontjson.js
@@ -165,7 +165,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-off/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
+                        file: options.webfontsDir + 'hinting-off/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
                         format: 'ttf'
                     },
                     // This weight contains only a certain set of chars
@@ -459,7 +459,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-cleartype/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
+                        file: options.webfontsDir + 'hinting-cleartype/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
                         format: 'ttf'
                     },
                     // This weight contains only a certain set of chars
@@ -753,7 +753,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-auto/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
+                        file: options.webfontsDir + 'hinting-auto/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
                         format: 'ttf'
                     },
                     // This weight contains only a certain set of chars

--- a/grunt-configs/webfontjson.js
+++ b/grunt-configs/webfontjson.js
@@ -97,7 +97,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-off/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff2',
+                        file: options.webfontsDir + 'hinting-off/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff2',
                         format: 'woff'
                     },
                     // This weight contains only a certain set of chars
@@ -131,7 +131,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-off/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff',
+                        file: options.webfontsDir + 'hinting-off/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff',
                         format: 'woff'
                     },
                     // This weight contains only a certain set of chars
@@ -165,7 +165,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-off/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
+                        file: options.webfontsDir + 'hinting-off/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
                         format: 'ttf'
                     },
                     // This weight contains only a certain set of chars
@@ -391,7 +391,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-cleartype/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff2',
+                        file: options.webfontsDir + 'hinting-cleartype/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff2',
                         format: 'woff'
                     },
                     // This weight contains only a certain set of chars
@@ -425,7 +425,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-cleartype/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff',
+                        file: options.webfontsDir + 'hinting-cleartype/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff',
                         format: 'woff'
                     },
                     // This weight contains only a certain set of chars
@@ -459,7 +459,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-cleartype/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
+                        file: options.webfontsDir + 'hinting-cleartype/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
                         format: 'ttf'
                     },
                     // This weight contains only a certain set of chars
@@ -685,7 +685,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-auto/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff2',
+                        file: options.webfontsDir + 'hinting-auto/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff2',
                         format: 'woff'
                     },
                     // This weight contains only a certain set of chars
@@ -719,7 +719,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-auto/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff',
+                        file: options.webfontsDir + 'hinting-auto/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.woff',
                         format: 'woff'
                     },
                     // This weight contains only a certain set of chars
@@ -753,7 +753,7 @@ module.exports = function(grunt, options) {
                     {
                         'font-family': '"Guardian Egyptian Web"',
                         'font-weight': '500',
-                        file: options.webfontsDir + 'hinting-auto/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
+                        file: options.webfontsDir + 'hinting-auto/kerning-on/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Medium.ttf',
                         format: 'ttf'
                     },
                     // This weight contains only a certain set of chars


### PR DESCRIPTION
Temporarily switch to original vs latin1 char set for 500 weight Guardian Egyptian Web, due to prevalence of "Erdoğan" on fronts.

This adds ~5k to the font weight in WOFF2.

@sndrs @paperboyo 
