### PR TITLE
Add RSS link to facia pages

### DIFF
--- a/facia/app/views/fragments/frontHead.scala.html
+++ b/facia/app/views/fragments/frontHead.scala.html
@@ -4,3 +4,4 @@
 
 <meta name="twitter:url" content="@LinkTo(request.uri)" />
 <meta property="og:title" content="@views.support.Title(page)" />
+<link rel="alternate" href="@LinkTo(request.uri)/rss" type="application/rss+xml" >

--- a/facia/app/views/fragments/frontHead.scala.html
+++ b/facia/app/views/fragments/frontHead.scala.html
@@ -4,4 +4,4 @@
 
 <meta name="twitter:url" content="@LinkTo(request.uri)" />
 <meta property="og:title" content="@views.support.Title(page)" />
-<link rel="alternate" href="@LinkTo(request.uri)/rss" type="application/rss+xml" >
+<link rel="alternate" href="@LinkTo(request.uri)/rss" title="RSS" type="application/rss+xml" >


### PR DESCRIPTION
We are missing any links to `/rss` pages on our fronts.

This adds an `alternative` link to `/rss` for a given `facia` page.
All `facia` pages have got `rss`.

Maybe we should add a `title` to the element?

@gklopper @OliverJAsh @sndrs 
