### PR TITLE
Make beacon URL relative

### DIFF
--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -96,7 +96,7 @@ standalone.oauth.clientid=768784040766-1eq1drssgu65vrs4oi1hjh70d9b30fti.apps.goo
 standalone.oauth.callback=http://localhost:9000/oauth2callback
 
 # Beacon diagnostics
-beacon.url=//localhost:9000
+beacon.url=
 
 # Push Notifications
 push_notifications.host=https://guardian-proxy.appspot.com


### PR DESCRIPTION
I switch between using `localhost:<port>` and `m.thegulocal.com` (via nginx) and each time I get console errors because I've forgotten to update the beacon URL to match. We don't need to set this in dev—it can be relative to the base URL.
