### PR TITLE
Fix broken relative link in nginx doc

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -20,7 +20,7 @@ Add the following to your ```/etc/hosts```:
     127.0.0.1   m.thegulocal.com
 
 
-## Now run the frontend setup script for nginx [setup.sh](nginx/setup.sh):
+## Now run the frontend setup script for nginx [setup.sh](setup.sh):
 
     sh setup.sh
 


### PR DESCRIPTION
[GitHub renders the previous version of the setup.sh link](https://github.com/guardian/frontend/tree/304c420e51/nginx#now-run-the-frontend-setup-script-for-nginx-setupsh) as a broken link to:

https://github.com/guardian/frontend/blob/master/nginx/nginx/setup.sh

..there are two `/ngnix` in the link, because the `nginx/README.md` is already one folder down - the link doesn't work, we need to remove one of those `/ngnix`
