### PR TITLE
Ads z-index to variable

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -1,5 +1,5 @@
 .ad-slot {
-    z-index: 1000;
+    z-index: $zindex-ads;
     overflow: hidden;
 
     .js-off & {


### PR DESCRIPTION
This is the first PR moving z-indexes to our new z-index layering.

It also fixes the sticky navigation z-index issue as the z-index of the sticky components will be over 1000.

It should be ok but we might get some unexpected overlays.

[browserstack](https://www.browserstack.com/screenshots/b568fa1b9ef79e8e266b85185795966e51474857)
