### PR TITLE
Remove trailing slash

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -81,7 +81,7 @@
             }
 
         <li class="colophon__item">
-            <a data-link-name="tech feedback" href="@LinkTo{/info/tech-feedback/}">
+            <a data-link-name="tech feedback" href="@LinkTo{/info/tech-feedback}">
                 report technical issue
             </a>
         </li>

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -109,7 +109,7 @@ GET         /video/end-slate/section/*sectionId.json                            
 GET         /embed/card/*path.json                                                                                   controllers.RichLinkController.render(path)
 GET         /embed/card/*path                                                                                        controllers.RichLinkController.renderHtml(path)
 # User tech feedback
-GET        /info/tech-feedback/                                                                                      controllers.TechFeedbackController.techFeedback(path = "")
+GET        /info/tech-feedback                                                                                       controllers.TechFeedbackController.techFeedback(path = "")
 GET        /info/tech-feedback/*path                                                                                 controllers.TechFeedbackController.techFeedback(path)
 
 # Sport

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -27,7 +27,7 @@
                                             <p>Please tell us more by choosing one of the options below.  We will record your choice and give you more options on a new page.</p>
                                             <ul>
                                                 @links.map { link =>
-                                                    <li><a data-link-name="tech feedback : @link._1" href="@link._1">@link._2</a></li>
+                                                    <li><a data-link-name="tech feedback : @link._1" href="tech-feedback/@link._1">@link._2</a></li>
                                                 }
                                             </ul>
                                         }

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -53,5 +53,5 @@ GET        /series/*path.json                         controllers.SeriesControll
 GET        /business-data/stocks.json                 controllers.StocksController.stocks
 
 # User tech feedback
-GET        /info/tech-feedback/                       controllers.TechFeedbackController.techFeedback(path = "")
+GET        /info/tech-feedback                        controllers.TechFeedbackController.techFeedback(path = "")
 GET        /info/tech-feedback/*path                  controllers.TechFeedbackController.techFeedback(path)


### PR DESCRIPTION
So the router removes trailing slashes from urls, meaning we get a 404 for tech-feedback.  This is a hack so it still works correctly without the slash.
