### PR TITLE
Amending adblock detection to include Firefox

### DIFF
--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -442,11 +442,11 @@ define([
         $.create('<div class="ad_unit"></div>').appendTo(document.body);
         displayed = $('.ad_unit').css('display');
         mozBinding = $('.ad_unit').css('-moz-binding');
-        if (mozBinding !== undefined) {
+        if (typeof mozBinding !== 'undefined') {
             mozBindingHidden = $('.ad_unit').css('-moz-binding').indexOf('elemhidehit');
         }
         $('.ad_unit').remove();
-        if (displayed === 'none' || (mozBinding !== undefined && mozBindingHidden !== -1)) {
+        if (displayed === 'none' || (typeof mozBinding !== 'undefined' && mozBindingHidden !== -1)) {
             isAdblock = true;
         }
         return isAdblock;

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -435,16 +435,20 @@ define([
 
     function adblockInUse() {
         var displayed = '',
-            isAdblock = false;
+            isAdblock = false,
+            mozBinding = '',
+            mozBindingHidden = -1;
 
         $.create('<div class="ad_unit"></div>').appendTo(document.body);
         displayed = $('.ad_unit').css('display');
+        mozBinding = $('.ad_unit').css('-moz-binding');
+        if (mozBinding !== undefined) {
+            mozBindingHidden = $('.ad_unit').css('-moz-binding').indexOf('elemhidehit');
+        }
         $('.ad_unit').remove();
-
-        if (displayed === 'none') {
+        if (displayed === 'none' || (mozBinding !== undefined && mozBindingHidden !== -1)) {
             isAdblock = true;
         }
-
         return isAdblock;
     }
 


### PR DESCRIPTION
Some adblock extensions for Firefox use -moz-binding as opposed to display property to hide ad containers. This change includes -moz-binding detection.
