### PR TITLE
Change PressedPage analyticsName

### DIFF
--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -81,7 +81,15 @@ case class PressedPage(id: String,
   override lazy val description: Option[String] = seoData.description
   override lazy val section: String = seoData.navSection
   lazy val navSection: String = section
-  override lazy val analyticsName: String = s"GFE:${seoData.webTitle.capitalize}"
+
+  //For network fronts we want the string "Network Front"
+  //This allows us to change webTitle in tool easily on fronts
+  override lazy val analyticsName: String =
+    if (isNetworkFront)
+      s"GFE:${GuardianContentTypes.NetworkFront}"
+    else
+      s"GFE:${seoData.webTitle.capitalize}"
+
   override lazy val webTitle: String = seoData.webTitle
   override lazy val title: Option[String] = seoData.title
 


### PR DESCRIPTION
#### Problem

In `RSS`, we currently use `webTitle` from `facia-tool`. 
For network fronts, this is currently `Network Front` and cannot be changed in `facia-tool` because if it is changed it will break Omniture tracking.

This static string gives a poor `RSS` experience in that it gives no indication as to what network front it is:

![rssexperience](https://cloud.githubusercontent.com/assets/445472/8081103/cfd72358-0f69-11e5-92dd-33482b55495a.png)
#### Fix

For network fronts, we will always set `GFE:Network Front` regardless of what it in `webTitle`. This will allow us to change `webTitle` in `facia-tool` to something more friendly for `RSS`. (And just allow us to change network front web titles in any case).
