### PR TITLE
update tech feedback wording to be clear we won't reply

### DIFF
--- a/onward/app/layout/Feedback.scala
+++ b/onward/app/layout/Feedback.scala
@@ -5,7 +5,7 @@ case class Feedback(problem: String, email: Boolean = false, links: Option[Seq[(
 object Feedback {
 
   val thanks = "Thanks for letting us know that"
-  val monitor = "We monitor the total number of reports so we know which areas you would like to see improved."
+  val monitor = "Your feedback helps us understand which areas of the site need attention."
 
   def apply(path: String): Feedback = path match {
     case "" => Feedback(

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -8,8 +8,8 @@
                     <div class="gs-container">
                         <div class="content__main-column">
                             @defining(feedback.links match {
-                                case None => "Thank you for leaving technical feedback"
-                                case _ => "Report technical feedback"
+                                case None => "Thank you for telling us about your issue"
+                                case _ => "Report a technical issue"
                             }) { headline =>
                                 <h1 itemprop="headline" class="content__headline">@headline</h1>
                             }
@@ -24,7 +24,7 @@
                                     <div class="from-content-api">
                                         <p>@feedback.problem</p>
                                         @feedback.links.map { links =>
-                                            <p>Please tell us more by choosing one of the options below.  We will record your choice and give you more options on a new page.</p>
+                                            <p>Please tell us more by choosing one of the options below.  We will record your choice, and give you more options on a new page.</p>
                                             <ul>
                                                 @links.map { link =>
                                                     <li><a data-link-name="tech feedback : @link._1" href="tech-feedback/@link._1">@link._2</a></li>
@@ -33,27 +33,22 @@
                                         }
                                         @if(feedback.email) {
                                             <p>
-                                                Want to attach more detail to your report?  Drop a message to
+                                                If you'd like to help us further, please tell our developers more about your issue by emailing
                                                 <a class="js-tech-feedback-mailto" data-link-name="tech feedback : mailto : dotcom" href="mailto:dotcom.feedback@@theguardian.com">
                                                     dotcom.feedback@@theguardian.com
-                                                </a>
+                                                </a>.
+                                                    <strong>We value all feedback but we are unable to respond directly.</strong>
                                             </p>
-                                            <p>
-                                                <em>We value all feedback, but if you need a reply please contact
-                                                    <a class="js-userhelp-mailto" data-link-name="tech feedback : mailto : userhelp" href="mailto:userhelp@@theguardian.com">
-                                                        userhelp@@theguardian.com
-                                                    </a>.
-                                                </em>
+                                            <p>If you need help from us with your issue please contact our user support desk at
+                                                <a class="js-userhelp-mailto" data-link-name="tech feedback : mailto : userhelp" href="mailto:userhelp@@theguardian.com">
+                                                    userhelp@@theguardian.com
+                                                </a> and someone should get back to you.
                                             </p>
                                             <p>Think you can fix it yourself?  <a href="http://developers.theguardian.com/">Work for us</a>!</p>
                                         } else {
-                                            <p>Need help, or want something else? For website queries contact
+                                            <p>Need help, or want something else? Contact our user support desk at
                                                 <a class="js-userhelp-mailto" data-link-name="tech feedback : mailto : userhelp" href="mailto:userhelp@@theguardian.com">
                                                     userhelp@@theguardian.com
-                                                </a>
-                                                or alternatively use our
-                                                <a data-link-name="tech feedback : contact-us" href="/help/contact-us">
-                                                    contact us page
                                                 </a>.
                                             </p>
                                         }


### PR DESCRIPTION
People are sending us useful feedback, but some of them suggest they would like a reply.

This could be partly because we are getting them to email us rather than using a form, but putting a feedback form on might conflict with our lines in the sand so we'll have to be creative.

Anyway the wording is updated to help matters.
![image](https://cloud.githubusercontent.com/assets/7304387/8083216/e4a8a066-0f7a-11e5-8422-e5edfe6810b4.png)
