### PR TITLE
Remove dev flag to fix build

### DIFF
--- a/grunt-configs/shell.js
+++ b/grunt-configs/shell.js
@@ -29,7 +29,7 @@ module.exports = function(grunt, options) {
         },
 
         jspmInstallFaciaTool: {
-            command: 'node ../../node_modules/jspm/jspm.js install --dev',
+            command: 'node ../../node_modules/jspm/jspm.js install',
             options: {
                 execOptions: {
                     cwd: 'facia-tool/public'


### PR DESCRIPTION
jspm (facia-tool) is not installing all of its deps because of a change introduced in https://github.com/guardian/frontend/commit/7e855b4b3e417a1f531a49c64511638ab2988024.

We don't need `--dev`.
