### PR TITLE
Use standard require syntax instead of a thenable

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -240,16 +240,15 @@ define([
                                 events.bindPrerollEvents(player);
                                 player.adSkipCountdown(15);
 
-                                require(['//imasdk.googleapis.com/js/sdkloader/ima3!system-script'])
-                                    .then(function () {
-                                        player.ima({
-                                            id: mediaId,
-                                            adTagUrl: getAdUrl()
-                                        });
-                                        // Video analytics event.
-                                        player.trigger(events.constructEventName('preroll:request', player));
-                                        player.ima.requestAds();
+                                require(['http://imasdk.googleapis.com/js/sdkloader/ima3.js!system-script'], function () {
+                                    player.ima({
+                                        id: mediaId,
+                                        adTagUrl: getAdUrl()
                                     });
+                                    // Video analytics event.
+                                    player.trigger(events.constructEventName('preroll:request', player));
+                                    player.ima.requestAds();
+                                });
                             }
                         )();
                     } else {


### PR DESCRIPTION
This was causing a problem with our video analytics. An old-style require, which needed to be updated to standard require syntax in order to work with `System.amdRequire`.
