### PR TITLE
change & to &amp; on our site

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -14,7 +14,7 @@
         ("js-container--fc-show-more", containerDefinition.addShowMoreClasses),
         ("fc-show-more--mobile-only", containerDefinition.hasMobileOnlyShowMore)
     ))"
-         data-title="@Html(Localisation(containerDefinition.displayName getOrElse ""))"
+         data-title="@Localisation(containerDefinition.displayName getOrElse "")"
          data-id="@containerDefinition.dataId">
 
         @for(sliceWithCards <- containerLayout.slices) {

--- a/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
@@ -16,10 +16,10 @@
                     "tone-colour" -> isContributor))">
                     @href.map { href =>
                     <a data-link-name="section heading" href="@LinkTo {/@href}">
-                        @Html(Localisation(title))
+                        @Localisation(title)
                     </a>
                     }.getOrElse {
-                        <span tabindex="0">@Html(Localisation(title))</span>
+                        <span tabindex="0">@Localisation(title)</span>
                     }
 
                     @if(containerDefinition.showDateHeader) {

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -50,7 +50,7 @@
                                 popup-container brand-bar__item--subscribe"
                          data-component="subscribe">
                         <a href="http://subscribe.theguardian.com/@if(Edition(request) != Uk) {@{Edition(request).id.toLowerCase}}?INTCMP=NGW_HEADER_@{Edition(request).id}_GU_SUBSCRIBE" class="brand-bar__item--action"
-                        data-link-name="@Edition(request) : topNav : subscribe" class="brand-bar__item--action">
+                        data-link-name="@Edition(request).id.toLowerCase : topNav : subscribe">
                             @fragments.inlineSvg("marque-36", "icon", List("rounded-icon", "control__icon-wrapper"))
                             <span class="control__info">subscribe</span>
                         </a>


### PR DESCRIPTION
we should't have any bare & in our html
although inline JS and CSS are a grey area

``` html
<div class="fc-container__header__title">
<span tabindex="0">pictures & video</span>
</div>
```

``` html
<div class="fc-container--rolled-up-hide fc-container__body fc-show-more--hidden js-container--fc-show-more" data-title="pictures & video" data-id="uk-alpha/special-other/special-story">
```

changes to

``` html
                <div class="fc-container__header__title">

                        <span tabindex="0">pictures &amp; video</span>





                </div>
```

and

``` html
    <div class="fc-container--rolled-up-hide fc-container__body fc-show-more--hidden js-container--fc-show-more"
         data-title="pictures &amp; video"
         data-id="uk-alpha/special-other/special-story">
```
