### PR TITLE
Update Membership message A/B test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message.js
@@ -45,20 +45,6 @@ define([
                     linkText: 'Become a supporter'
                 }));
             }
-        },
-        {
-            id: 'B',
-            test: function () {
-                new Message('membership-message', {
-                    pinOnHide: false,
-                    siteMessageLinkName: 'membership message',
-                    siteMessageCloseBtn: 'hide'
-                }).show(template(messageTmpl, {
-                    supporterLink: 'https://membership.theguardian.com/about?INTCMP=MEMBERSHIP_BANNER_TEST_B',
-                    messageText: 'Become a Guardian Member and support fearless investigative journalism',
-                    linkText: 'Become a partner'
-                }));
-            }
         }];
 
     };


### PR DESCRIPTION
Removes B variant of membership message test due to low conversion rate for B variant (45 Supporters for A vs. 2 Partners for B variant).

![screen shot 2015-06-11 at 17 04 53](https://cloud.githubusercontent.com/assets/123386/8111917/78247e1e-105c-11e5-9797-bafd0a47e3b8.png)

cc @dominickendrick 
