### PR TITLE
Update URL to work in all environments

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
@@ -10,7 +10,7 @@ define([
     urlUtils
 ) {
 
-    var gatewayUrl = '//pq-direct.revsci.net/pql',
+    var gatewayUrl = 'http://pq-direct.revsci.net/pql',
         storageKey = 'gu.ads.audsci-gateway',
         sectionPlacements = {
             sport:        ['FKSWod', '2xivTZ', 'MTLELH'],


### PR DESCRIPTION
Relative URLs will not be mapped correctly in SystemJS land (until we upgrade to System v0.17.0).

This change just makes the URL work for both RequireJS and SystemJS.
