### PR TITLE
Fix Karma tests when running in Chrome

### DIFF
--- a/static/src/javascripts/test/spec/common/analytics/beacon.spec.js
+++ b/static/src/javascripts/test/spec/common/analytics/beacon.spec.js
@@ -34,13 +34,17 @@ describe('Beacon', function () {
     it('should create correct img element when counting', function () {
         var img = beacon.counts('blocked-ads');
 
-        expect(bonzo(img).attr('src')).toBe('//beacon.guim.co.uk/counts.gif?c=blocked-ads');
+        if (!navigator.sendBeacon) {
+            expect(bonzo(img).attr('src')).toBe('//beacon.guim.co.uk/counts.gif?c=blocked-ads');
+        }
     });
 
     it('should create correct img element when counting more than one', function () {
         var img = beacon.counts(['blocked-ads', 'localStorage-supported']);
 
-        expect(bonzo(img).attr('src'))
-            .toBe('//beacon.guim.co.uk/counts.gif?c=blocked-ads&c=localStorage-supported');
+        if (!navigator.sendBeacon) {
+            expect(bonzo(img).attr('src'))
+                .toBe('//beacon.guim.co.uk/counts.gif?c=blocked-ads&c=localStorage-supported');
+        }
     });
 });

--- a/static/src/javascripts/test/spec/common/commercial/article-body-adverts.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/article-body-adverts.spec.js
@@ -16,7 +16,8 @@ describe('Article Body Adverts', function () {
             ]
         },
         injector = new Injector(),
-        articleBodyAdverts, config, detect, spacefinder;
+        articleBodyAdverts, config, detect, spacefinder, ab, getParticipationsStub,
+        testCanBeRunStub;
 
     beforeEach(function (done) {
 

--- a/static/src/javascripts/test/spec/common/onward/popular.spec.js
+++ b/static/src/javascripts/test/spec/common/onward/popular.spec.js
@@ -11,7 +11,7 @@ describe('Most popular', function () {
         html = '<b>popular</b>',
         server,
         injector = new Injector(),
-        Popular, config, mediator;
+        Popular, config, mediator, $fixturesContainer;
 
     beforeEach(function (done) {
         injector.mock({


### PR DESCRIPTION
The Karma tests fail when running in Chrome.

This is because the tests now run using SystemJS, which forces all files into strict mode (yay!). Strict mode = more errors = win. It is also because Chrome is way more up to date than Phantom, and has `navigator.sendBeacon`.
