### PR TITLE
Fix navlist links

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -54,16 +54,6 @@ trait LinkTo extends Logging {
     case t: Trail => Option(apply(t.url))
   }
 
-  def hrefOrId(faciaContent: FaciaContent)(implicit request: RequestHeader): String =
-    faciaContent match {
-      case curatedContent: CuratedContent => curatedContent.href.getOrElse(curatedContent.id)
-      case supportingCuratedContent: SupportingCuratedContent => supportingCuratedContent.href.getOrElse(supportingCuratedContent.id)
-      //LinkSnap.id would be a snap id, which is a link to nothing
-      case linkSnap: LinkSnap => linkSnap.href.getOrElse("")
-      //LatestSnap.id would be the internal content code, so never use this
-      case latestSnap: LatestSnap => latestSnap.href.orElse(latestSnap.latestContent.map(_.id)).getOrElse("")
-    }
-
   def apply(faciaCard: ContentCard)(implicit request: RequestHeader): String =
     faciaCard.url.get(request)
 

--- a/common/app/views/fragments/containers/facia_cards/navListContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/navListContainer.scala.html
@@ -3,6 +3,7 @@
 @import common.LinkTo
 @import views.html.fragments.containers.facia_cards.containerHeader
 @import implicits.FaciaContentImplicits._
+@import model.SupportedUrl
 
 @containerHeader(collectionDefinition, frontProperties)
 
@@ -12,7 +13,7 @@
             @collectionDefinition.collectionEssentials.items.zipWithIndex.map { case (item, index) =>
             <li class="fc-slice__item--nav-list">
                 <div class="fc-item fc-item--list-compact">
-                    <a href="@LinkTo.hrefOrId(item)" data-link-name=" | article | @index">@item.headline</a>
+                    <a href="@LinkTo(SupportedUrl.fromFaciaContent(item))" data-link-name=" | article | @index">@item.headline</a>
                 </div>
             </li>
         }

--- a/common/app/views/fragments/containers/facia_cards/navMediaListContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/navMediaListContainer.scala.html
@@ -5,6 +5,8 @@
 @import views.html.fragments.items.elements.facia_cards.image
 @import views.html.fragments.containers.facia_cards.containerHeader
 @import implicits.FaciaContentImplicits._
+@import model.SupportedUrl
+
 
 @containerHeader(containerDefinition, frontProperties)
 
@@ -13,7 +15,7 @@
         <ul class="u-unstyled fc-slice fc-slice--nav-list--media">
         @containerDefinition.items.zipWithIndex.map { case (item, index) =>
             <li class="fc-slice__item--nav-list">
-                <a href="@LinkTo.hrefOrId(item)" data-link-name=" | article | @index" class="fc-item fc-item--list-compact--media">
+                <a href="@LinkTo(SupportedUrl.fromFaciaContent(item))" data-link-name=" | article | @index" class="fc-item fc-item--list-compact--media">
                     @InlineImage.fromFaciaContent(item).map { imageContainer =>
                         @image(imageContainer.imageContainer)
                     }

--- a/common/app/views/fragments/linkText.scala.html
+++ b/common/app/views/fragments/linkText.scala.html
@@ -1,4 +1,4 @@
-@(trail:  com.gu.facia.api.models.FaciaContent, info: RowInfo)(implicit request: RequestHeader)
+@(faciaContent: com.gu.facia.api.models.FaciaContent, info: RowInfo)(implicit request: RequestHeader)
 
 @import views.support.RowInfo
 @import common.LinkTo
@@ -6,6 +6,6 @@
 @import implicits.FaciaContentImplicits._
 @import model.SupportedUrl
 
-<a href="@LinkTo(SupportedUrl.fromFaciaContent(trail))" data-link-name="@info.rowNum | text">
-    @trail.maybeWebTitle.map(RemoveOuterParaHtml.apply)
+<a href="@LinkTo(SupportedUrl.fromFaciaContent(faciaContent))" data-link-name="@info.rowNum | text">
+    @faciaContent.maybeWebTitle.map(RemoveOuterParaHtml.apply)
 </a>

--- a/common/app/views/fragments/linkText.scala.html
+++ b/common/app/views/fragments/linkText.scala.html
@@ -4,7 +4,8 @@
 @import common.LinkTo
 @import views.support.RemoveOuterParaHtml
 @import implicits.FaciaContentImplicits._
+@import model.SupportedUrl
 
-<a href="@LinkTo.hrefOrId(trail)" data-link-name="@info.rowNum | text">
+<a href="@LinkTo(SupportedUrl.fromFaciaContent(trail))" data-link-name="@info.rowNum | text">
     @trail.maybeWebTitle.map(RemoveOuterParaHtml.apply)
 </a>


### PR DESCRIPTION
When content was in a `navListContainer`, `navMediaListContainer` or used inside `linkText`, it was not working for `Snap` content, as it was using a relative URL.

This fixes these cases by using `SupportedUrl.fromFaciaContent` which returns a `String`, and using this in `LinkTo.apply`.

`LinkTo.hrefOrId` is no longer needed.

An example of these broken links can be found [here](http://www.theguardian.com/info/about-guardian-us)

This pretty much reverts https://github.com/guardian/frontend/pull/9346

@stephanfowler 
