### PR TITLE
Use _.template

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable-v2.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable-v2.js
@@ -135,7 +135,7 @@ define([
                 scrollbg: (this.params.backgroundImagePType !== '' || this.params.backgroundImagePType !== 'none') ?
                     '<div class="ad-exp--expand-scrolling-bg" style="background-image: url(' + this.params.backgroundImageP + '); background-position: ' + this.params.backgroundImagePPosition + ' 50%;"></div>' : ''
             },
-            $expandablev2 = $.create(template(expandableV2Tpl, _.merge(this.params, showmoreArrow, showmorePlus, videoDesktop, scrollingbg)));
+            $expandablev2 = $.create(template(expandableV2Tpl, { data: _.merge(this.params, showmoreArrow, showmorePlus, videoDesktop, scrollingbg) }));
 
         var domPromise = new Promise(function (resolve) {
             fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable-v3.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable-v3.js
@@ -153,7 +153,7 @@ define([
                 scrollbg: (this.params.backgroundImagePType !== '' || this.params.backgroundImagePType !== 'none') ?
                     '<div class="ad-exp--expand-scrolling-bg" style="background-image: url(' + this.params.backgroundImageP + '); background-position: ' + this.params.backgroundImagePPosition + ' 50%; background-repeat: ' + this.params.backgroundImagePRepeat + ';"></div>' : ''
             },
-            $expandableV3 = $.create(template(expandableV3Tpl, _.merge(this.params, showmoreArrow, showmorePlus, videoDesktop, scrollingbg)));
+            $expandableV3 = $.create(template(expandableV3Tpl, { data: _.merge(this.params, showmoreArrow, showmorePlus, videoDesktop, scrollingbg) }));
 
         var domPromise = new Promise(function (resolve) {
             fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
@@ -43,7 +43,7 @@ define([
     };
 
     Expandable.prototype.create = function () {
-        var $expandable = $.create(template(expandableTpl, this.params));
+        var $expandable = $.create(template(expandableTpl, { data: this.params }));
 
         this.$ad     = $('.ad-exp--expand', $expandable).css('height', this.closedHeight);
         this.$button = $('.ad-exp__close-button', $expandable);

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250-v3.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250-v3.js
@@ -88,7 +88,7 @@ define([
                     '<div class="ad-scrolling-bg" style="background-image: url(' + this.params.backgroundImageP + '); background-position: 50% 0; background-repeat: ' + this.params.backgroundImagePRepeat + ';"></div>' : ''
             };
 
-        $.create(template(fluid250Tpl, _.merge(this.params, templateOptions, videoDesktop, scrollingbg))).appendTo(this.$adSlot);
+        $.create(template(fluid250Tpl, { data: _.merge(this.params, templateOptions, videoDesktop, scrollingbg) })).appendTo(this.$adSlot);
 
         if (this.params.trackingPixel) {
             this.$adSlot.before('<img src="' + this.params.trackingPixel + this.params.cacheBuster + '" class="creative__tracking-pixel" height="1px" width="1px"/>');

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250.js
@@ -39,7 +39,7 @@ define([
                     '<iframe width="409px" height="230px" src="' + this.params.videoURL + '?rel=0&amp;controls=0&amp;showinfo=0&amp;title=0&amp;byline=0&amp;portrait=0" frameborder="0" class="fluid250_video fluid250_video--desktop fluid250_video--vert-pos-' + this.params.videoPositionV + ' fluid250_video--horiz-pos-' + this.params.videoPositionH + '" style="' + leftPosition + rightPosition + '"></iframe>' : ''
             };
 
-        $.create(template(fluid250Tpl, _.merge(this.params, templateOptions, videoDesktop))).appendTo(this.$adSlot);
+        $.create(template(fluid250Tpl, { data: _.merge(this.params, templateOptions, videoDesktop) })).appendTo(this.$adSlot);
 
         if (this.params.trackingPixel) {
             this.$adSlot.before('<img src="' + this.params.trackingPixel + this.params.cacheBuster + '" class="creative__tracking-pixel" height="1px" width="1px"/>');

--- a/static/src/javascripts/projects/common/utils/template.js
+++ b/static/src/javascripts/projects/common/utils/template.js
@@ -4,10 +4,14 @@ define([
     _
 ) {
 
-    return function template(tmpl, params) {
-        return _.reduce(_.keys(params), function (tmpl, token) {
-            return tmpl.replace(new RegExp('{{' + token + '}}', 'g'), params[token]);
-        }, tmpl);
-    };
+    // Update default settings
+    _.merge(_.templateSettings, {
+        // Normally evaluate and interpolate at the other way round
+        evaluate:    /{{=([\s\S]+?)}}/g,
+        interpolate: /{{([\s\S]+?)}}/g,
+        escape:      /{{-([\s\S]+?)}}/g
+    });
+
+    return _.template.bind(_);
 
 });

--- a/static/src/javascripts/projects/common/views/commercial/creatives/expandable-v2.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/expandable-v2.html
@@ -2,45 +2,45 @@
     <div class="ad-slot__label adFullWidth__label facia-container--layout-front" data-test-id="ad-slot-label">
         <div class="facia-container__inner">Advertisement</div>
     </div>
-    <div class="ad-exp--expand l-side-margins mobile-only" style="background-color: {{backgroundColor}}">
-        <div class="facia-container__inner facia-container__inner--full-span" style="background: url('{{backgroundImageM}}') {{backgroundRepeatM}} {{backgroundPositionM}};">
-            {{showPlus}}
-            {{showArrow}}
-            <div class="ad-exp-collapse__slide slide-1" style="background: {{slide1BGColor}} url('{{slide1BGImageM}}') {{slide1BGImageRepeatM}} {{slide1BGImagePositionM}};">
-                <a href="{{clickMacro}}{{link}}" target="_new">
-                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{slide1Layer1BGImageM}}') {{slide1Layer1BGImageRepeatM}} {{slide1Layer1BGImagePositionM}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{slide1Layer2BGImageM}}') {{slide1Layer2BGImageRepeatM}} {{slide1Layer2BGImagePositionM}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{slide1Layer3BGImageM}}') {{slide1Layer3BGImageRepeatM}} {{slide1Layer3BGImagePositionM}};"></div>
+    <div class="ad-exp--expand l-side-margins mobile-only" style="background-color: {{data.backgroundColor}}">
+        <div class="facia-container__inner facia-container__inner--full-span" style="background: url('{{data.backgroundImageM}}') {{data.backgroundRepeatM}} {{data.backgroundPositionM}};">
+            {{data.showPlus}}
+            {{data.showArrow}}
+            <div class="ad-exp-collapse__slide slide-1" style="background: {{data.slide1BGColor}} url('{{data.slide1BGImageM}}') {{data.slide1BGImageRepeatM}} {{data.slide1BGImagePositionM}};">
+                <a href="{{data.clickMacro}}{{data.link}}" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{data.slide1Layer1BGImageM}}') {{data.slide1Layer1BGImageRepeatM}} {{data.slide1Layer1BGImagePositionM}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{data.slide1Layer2BGImageM}}') {{data.slide1Layer2BGImageRepeatM}} {{data.slide1Layer2BGImagePositionM}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{data.slide1Layer3BGImageM}}') {{data.slide1Layer3BGImageRepeatM}} {{data.slide1Layer3BGImagePositionM}};"></div>
                 </a>
             </div>
-            <div class="ad-exp-collapse__slide slide-2" style="background: {{slide2BGColor}} url('{{slide2BGImageM}}') {{slide2BGImagePositionM}} {{slide2BGImageRepeatM}};">
-                {{video}}
-                <a href="{{clickMacro}}{{link}}" target="_new">
-                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{slide2Layer1BGImageM}}') {{slide2Layer1BGImageRepeatM}} {{slide2Layer1BGImagePositionM}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{slide2Layer2BGImageM}}') {{slide2Layer2BGImageRepeatM}} {{slide2Layer2BGImagePositionM}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{slide2Layer3BGImageM}}') {{slide2Layer3BGImageRepeatM}} {{slide2Layer3BGImagePositionM}};"></div>
+            <div class="ad-exp-collapse__slide slide-2" style="background: {{data.slide2BGColor}} url('{{data.slide2BGImageM}}') {{data.slide2BGImagePositionM}} {{data.slide2BGImageRepeatM}};">
+                {{data.video}}
+                <a href="{{data.clickMacro}}{{data.link}}" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{data.slide2Layer1BGImageM}}') {{data.slide2Layer1BGImageRepeatM}} {{data.slide2Layer1BGImagePositionM}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{data.slide2Layer2BGImageM}}') {{data.slide2Layer2BGImageRepeatM}} {{data.slide2Layer2BGImagePositionM}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{data.slide2Layer3BGImageM}}') {{data.slide2Layer3BGImageRepeatM}} {{data.slide2Layer3BGImagePositionM}};"></div>
                 </a>
             </div>
         </div>
     </div>
-    <div class="ad-exp--expand l-side-margins hide-until-tablet" style="background-color: {{backgroundColor}}">
-        <div class="facia-container__inner facia-container__inner--full-span" style="background: url('{{backgroundImage}}') {{backgroundRepeat}} {{backgroundPosition}};">
-            {{showPlus}}
-            {{showArrow}}
-            {{scrollbg}}
-            <div class="ad-exp-collapse__slide slide-1" style="background: {{slide1BGColor}} url('{{slide1BGImage}}') {{slide1BGImageRepeat}} {{slide1BGImagePosition}};">
-                <a href="{{clickMacro}}{{link}}" target="_new">
-                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{slide1Layer1BGImage}}') {{slide1Layer1BGImageRepeat}} {{slide1Layer1BGImagePosition}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{slide1Layer2BGImage}}') {{slide1Layer2BGImageRepeat}} {{slide1Layer2BGImagePosition}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer3" style="background : url('{{slide1Layer3BGImage}}') {{slide1Layer3BGImageRepeat}} {{slide1Layer3BGImagePosition}};"></div>
+    <div class="ad-exp--expand l-side-margins hide-until-tablet" style="background-color: {{data.backgroundColor}}">
+        <div class="facia-container__inner facia-container__inner--full-span" style="background: url('{{data.backgroundImage}}') {{data.backgroundRepeat}} {{data.backgroundPosition}};">
+            {{data.showPlus}}
+            {{data.showArrow}}
+            {{data.scrollbg}}
+            <div class="ad-exp-collapse__slide slide-1" style="background: {{data.slide1BGColor}} url('{{data.slide1BGImage}}') {{data.slide1BGImageRepeat}} {{data.slide1BGImagePosition}};">
+                <a href="{{data.clickMacro}}{{data.link}}" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{data.slide1Layer1BGImage}}') {{data.slide1Layer1BGImageRepeat}} {{data.slide1Layer1BGImagePosition}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{data.slide1Layer2BGImage}}') {{data.slide1Layer2BGImageRepeat}} {{data.slide1Layer2BGImagePosition}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background : url('{{data.slide1Layer3BGImage}}') {{data.slide1Layer3BGImageRepeat}} {{data.slide1Layer3BGImagePosition}};"></div>
                 </a>
             </div>
-            <div class="ad-exp-collapse__slide slide-2" style="background: {{slide2BGColor}} url('{{slide2BGImage}}') {{slide2BGImagePosition}} {{slide2BGImageRepeat}};">
-                {{video}}
-                <a href="{{clickMacro}}{{link}}" target="_new">
-                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{slide2Layer1BGImage}}') {{slide2Layer1BGImageRepeat}} {{slide2Layer1BGImagePosition}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{slide2Layer2BGImage}}') {{slide2Layer2BGImageRepeat}} {{slide2Layer2BGImagePosition}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{slide2Layer3BGImage}}') {{slide2Layer3BGImageRepeat}} {{slide2Layer3BGImagePosition}};"></div>
+            <div class="ad-exp-collapse__slide slide-2" style="background: {{data.slide2BGColor}} url('{{data.slide2BGImage}}') {{data.slide2BGImagePosition}} {{data.slide2BGImageRepeat}};">
+                {{data.video}}
+                <a href="{{data.clickMacro}}{{data.link}}" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{data.slide2Layer1BGImage}}') {{data.slide2Layer1BGImageRepeat}} {{data.slide2Layer1BGImagePosition}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{data.slide2Layer2BGImage}}') {{data.slide2Layer2BGImageRepeat}} {{data.slide2Layer2BGImagePosition}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{data.slide2Layer3BGImage}}') {{data.slide2Layer3BGImageRepeat}} {{data.slide2Layer3BGImagePosition}};"></div>
                 </a>
             </div>
         </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/expandable-v3.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/expandable-v3.html
@@ -2,45 +2,45 @@
     <div class="ad-slot__label adFullWidth__label facia-container--layout-front" data-test-id="ad-slot-label">
         <div class="facia-container__inner">Advertisement</div>
     </div>
-    <div class="ad-exp--expand l-side-margins mobile-only" style="background-color: {{backgroundColor}}">
-        <div class="facia-container__inner facia-container__inner--full-span" style="background: url('{{backgroundImageM}}') {{backgroundRepeatM}} {{backgroundPositionM}};">
-            {{showPlus}}
-            {{showArrow}}
-            <div class="ad-exp-collapse__slide slide-1" style="background: {{slide1BGColor}} url('{{slide1BGImageM}}') {{slide1BGImageRepeatM}} {{slide1BGImagePositionM}};">
-                <a href="{{clickMacro}}{{link}}" target="_new">
-                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{slide1Layer1BGImageM}}') {{slide1Layer1BGImageRepeatM}} {{slide1Layer1BGImagePositionM}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{slide1Layer2BGImageM}}') {{slide1Layer2BGImageRepeatM}} {{slide1Layer2BGImagePositionM}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{slide1Layer3BGImageM}}') {{slide1Layer3BGImageRepeatM}} {{slide1Layer3BGImagePositionM}};"></div>
+    <div class="ad-exp--expand l-side-margins mobile-only" style="background-color: {{data.backgroundColor}}">
+        <div class="facia-container__inner facia-container__inner--full-span" style="background: url('{{data.backgroundImageM}}') {{data.backgroundRepeatM}} {{data.backgroundPositionM}};">
+            {{data.showPlus}}
+            {{data.showArrow}}
+            <div class="ad-exp-collapse__slide slide-1" style="background: {{data.slide1BGColor}} url('{{data.slide1BGImageM}}') {{data.slide1BGImageRepeatM}} {{data.slide1BGImagePositionM}};">
+                <a href="{{data.clickMacro}}{{data.link}}" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{data.slide1Layer1BGImageM}}') {{data.slide1Layer1BGImageRepeatM}} {{data.slide1Layer1BGImagePositionM}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{data.slide1Layer2BGImageM}}') {{data.slide1Layer2BGImageRepeatM}} {{data.slide1Layer2BGImagePositionM}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{data.slide1Layer3BGImageM}}') {{data.slide1Layer3BGImageRepeatM}} {{data.slide1Layer3BGImagePositionM}};"></div>
                 </a>
             </div>
-            <div class="ad-exp-collapse__slide slide-2" style="background: {{slide2BGColor}} url('{{slide2BGImageM}}') {{slide2BGImagePositionM}} {{slide2BGImageRepeatM}};">
-                {{video}}
-                <a href="{{clickMacro}}{{link}}" target="_new">
-                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{slide2Layer1BGImageM}}') {{slide2Layer1BGImageRepeatM}} {{slide2Layer1BGImagePositionM}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{slide2Layer2BGImageM}}') {{slide2Layer2BGImageRepeatM}} {{slide2Layer2BGImagePositionM}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{slide2Layer3BGImageM}}') {{slide2Layer3BGImageRepeatM}} {{slide2Layer3BGImagePositionM}};"></div>
+            <div class="ad-exp-collapse__slide slide-2" style="background: {{data.slide2BGColor}} url('{{data.slide2BGImageM}}') {{data.slide2BGImagePositionM}} {{data.slide2BGImageRepeatM}};">
+                {{data.video}}
+                <a href="{{data.clickMacro}}{{data.link}}" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{data.slide2Layer1BGImageM}}') {{data.slide2Layer1BGImageRepeatM}} {{data.slide2Layer1BGImagePositionM}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{data.slide2Layer2BGImageM}}') {{data.slide2Layer2BGImageRepeatM}} {{data.slide2Layer2BGImagePositionM}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{data.slide2Layer3BGImageM}}') {{data.slide2Layer3BGImageRepeatM}} {{data.slide2Layer3BGImagePositionM}};"></div>
                 </a>
             </div>
         </div>
     </div>
-    <div class="ad-exp--expand l-side-margins hide-until-tablet" style="background-color: {{backgroundColor}}">
-        {{scrollbg}}
-        <div class="facia-container__inner facia-container__inner--full-span" style="background: url('{{backgroundImage}}') {{backgroundRepeat}} {{backgroundPosition}};">
-            {{showPlus}}
-            {{showArrow}}
-            <div class="ad-exp-collapse__slide slide-1" style="background: {{slide1BGColor}} url('{{slide1BGImage}}') {{slide1BGImageRepeat}} {{slide1BGImagePosition}};">
-                <a href="{{clickMacro}}{{link}}" target="_new">
-                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{slide1Layer1BGImage}}') {{slide1Layer1BGImageRepeat}} {{slide1Layer1BGImagePosition}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{slide1Layer2BGImage}}') {{slide1Layer2BGImageRepeat}} {{slide1Layer2BGImagePosition}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer3" style="background : url('{{slide1Layer3BGImage}}') {{slide1Layer3BGImageRepeat}} {{slide1Layer3BGImagePosition}};"></div>
+    <div class="ad-exp--expand l-side-margins hide-until-tablet" style="background-color: {{data.backgroundColor}}">
+        {{data.scrollbg}}
+        <div class="facia-container__inner facia-container__inner--full-span" style="background: url('{{data.backgroundImage}}') {{data.backgroundRepeat}} {{data.backgroundPosition}};">
+            {{data.showPlus}}
+            {{data.showArrow}}
+            <div class="ad-exp-collapse__slide slide-1" style="background: {{data.slide1BGColor}} url('{{data.slide1BGImage}}') {{data.slide1BGImageRepeat}} {{data.slide1BGImagePosition}};">
+                <a href="{{data.clickMacro}}{{data.link}}" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{data.slide1Layer1BGImage}}') {{data.slide1Layer1BGImageRepeat}} {{data.slide1Layer1BGImagePosition}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{data.slide1Layer2BGImage}}') {{data.slide1Layer2BGImageRepeat}} {{data.slide1Layer2BGImagePosition}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background : url('{{data.slide1Layer3BGImage}}') {{data.slide1Layer3BGImageRepeat}} {{data.slide1Layer3BGImagePosition}};"></div>
                 </a>
             </div>
-            <div class="ad-exp-collapse__slide slide-2" style="background: {{slide2BGColor}} url('{{slide2BGImage}}') {{slide2BGImagePosition}} {{slide2BGImageRepeat}};">
-                {{video}}
-                <a href="{{clickMacro}}{{link}}" target="_new">
-                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{slide2Layer1BGImage}}') {{slide2Layer1BGImageRepeat}} {{slide2Layer1BGImagePosition}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{slide2Layer2BGImage}}') {{slide2Layer2BGImageRepeat}} {{slide2Layer2BGImagePosition}};"></div>
-                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{slide2Layer3BGImage}}') {{slide2Layer3BGImageRepeat}} {{slide2Layer3BGImagePosition}};"></div>
+            <div class="ad-exp-collapse__slide slide-2" style="background: {{data.slide2BGColor}} url('{{data.slide2BGImage}}') {{data.slide2BGImagePosition}} {{data.slide2BGImageRepeat}};">
+                {{data.video}}
+                <a href="{{data.clickMacro}}{{data.link}}" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('{{data.slide2Layer1BGImage}}') {{data.slide2Layer1BGImageRepeat}} {{data.slide2Layer1BGImagePosition}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('{{data.slide2Layer2BGImage}}') {{data.slide2Layer2BGImageRepeat}} {{data.slide2Layer2BGImagePosition}};"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('{{data.slide2Layer3BGImage}}') {{data.slide2Layer3BGImageRepeat}} {{data.slide2Layer3BGImagePosition}};"></div>
                 </a>
             </div>
         </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/expandable.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/expandable.html
@@ -7,14 +7,14 @@
             <button class="ad-exp__close-button">
                 <i class="i i-close-icon-white-small"></i>
             </button>
-            <a href="{{clickMacro}}{{link}}" target="_new">
-                <div class="ad-exp-collapse__slide slide-1" style="background-image: url('{{slide1}}');">
-                    <div class="ad-exp__cta" style="background-image: url('{{cta}}');"></div>
-                    <div class="ad-exp__logo" style="background-image: url('{{logo}}');"></div>
+            <a href="{{data.clickMacro}}{{data.link}}" target="_new">
+                <div class="ad-exp-collapse__slide slide-1" style="background-image: url('{{data.slide1}}');">
+                    <div class="ad-exp__cta" style="background-image: url('{{data.cta}}');"></div>
+                    <div class="ad-exp__logo" style="background-image: url('{{data.logo}}');"></div>
                 </div>
-                <div class="ad-exp-collapse__slide slide-2" style="background-image: url('{{slide2}}');">
-                    <div class="ad-exp__text-1 mobile-only" style="background-image: url('{{textMobile}}');"></div>
-                    <div class="ad-exp__text-1 hide-until-tablet" style="background-image: url('{{text}}');"></div>
+                <div class="ad-exp-collapse__slide slide-2" style="background-image: url('{{data.slide2}}');">
+                    <div class="ad-exp__text-1 mobile-only" style="background-image: url('{{data.textMobile}}');"></div>
+                    <div class="ad-exp__text-1 hide-until-tablet" style="background-image: url('{{data.text}}');"></div>
                 </div>
             </a>
         </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/fluid250-v3.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/fluid250-v3.html
@@ -1,53 +1,53 @@
 <div class="creative--fluid250-bg-container">
 
-    <div class="ad-slot__label creative--fluid250__label fc-container--layout-front {{showLabel}}" data-test-id="ad-slot-label">
+    <div class="ad-slot__label creative--fluid250__label fc-container--layout-front {{data.showLabel}}" data-test-id="ad-slot-label">
         <div class="fc-container__inner">Advertisement</div>
     </div>
 
-    <div class="creative--fluid250 l-side-margins hide-until-tablet creative--fluid250__height--{{creativeHeight}}" style="
-            background-color: {{backgroundColor}};
-            background-image: url({{backgroundImage}});
-            background-position: {{backgroundPosition}};
-            background-repeat: {{backgroundRepeat}};
+    <div class="creative--fluid250 l-side-margins hide-until-tablet creative--fluid250__height--{{data.creativeHeight}}" style="
+            background-color: {{data.backgroundColor}};
+            background-image: url({{data.backgroundImage}});
+            background-position: {{data.backgroundPosition}};
+            background-repeat: {{data.backgroundRepeat}};
         ">
-        {{scrollbg}}
-        <a href="{{clickMacro}}{{link}}" target="_blank">
+        {{data.scrollbg}}
+        <a href="{{data.clickMacro}}{{data.link}}" target="_blank">
             <div class="gs-container">
-                {{video}}
+                {{data.video}}
                 <div class="fluid250_layer fluid250_layer1" style="
-                    background-image: url({{layerOneBGImage}});
-                    background-position: {{layerOneBGPosition}};
+                    background-image: url({{data.layerOneBGImage}});
+                    background-position: {{data.layerOneBGPosition}};
                 "></div>
                 <div class="fluid250_layer fluid250_layer2" style="
-                    background-image: url({{layerTwoBGImage}});
-                    {{layerTwoBGProperties}}
+                    background-image: url({{data.layerTwoBGImage}});
+                    {{data.layerTwoBGProperties}}
                 "></div>
                 <div class="fluid250_layer fluid250_layer3" style="
-                    background-image: url({{layerThreeBGImage}});
-                    background-position: {{layerThreeBGPosition}};
+                    background-image: url({{data.layerThreeBGImage}});
+                    background-position: {{data.layerThreeBGPosition}};
                 "></div>
             </div>
         </a>
     </div>
     <div class="creative--fluid250 l-side-margins mobile-only" style="
-            background-color: {{backgroundColor}};
-            background-image: url({{backgroundImageM}});
-            background-position: {{backgroundPositionM}};
-            background-repeat: {{backgroundRepeatM}};
+            background-color: {{data.backgroundColor}};
+            background-image: url({{data.backgroundImageM}});
+            background-position: {{data.backgroundPositionM}};
+            background-repeat: {{data.backgroundRepeatM}};
         ">
-        <a href="{{link}}" target="_blank">
+        <a href="{{data.link}}" target="_blank">
             <div class="gs-container">
                 <div class="fluid250_layer fluid250_layer1" style="
-                    background-image: url({{layerOneBGImageM}});
-                    background-position: {{layerOneBGPositionM}};
+                    background-image: url({{data.layerOneBGImageM}});
+                    background-position: {{data.layerOneBGPositionM}};
                 "></div>
                 <div class="fluid250_layer fluid250_layer2" style="
-                    background-image: url({{layerTwoBGImageM}});
-                    background-position: {{layerTwoBGPositionM}};
+                    background-image: url({{data.layerTwoBGImageM}});
+                    background-position: {{data.layerTwoBGPositionM}};
                 "></div>
                 <div class="fluid250_layer fluid250_layer3" style="
-                    background-image: url({{layerThreeBGImageM}});
-                    background-position: {{layerThreeBGPositionM}};
+                    background-image: url({{data.layerThreeBGImageM}});
+                    background-position: {{data.layerThreeBGPositionM}};
                 "></div>
             </div>
         </a>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/fluid250.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/fluid250.html
@@ -1,49 +1,49 @@
-<div class="ad-slot__label creative--fluid250__label fc-container--layout-front {{showLabel}}" data-test-id="ad-slot-label">
+<div class="ad-slot__label creative--fluid250__label fc-container--layout-front {{data.showLabel}}" data-test-id="ad-slot-label">
     <div class="fc-container__inner">Advertisement</div>
 </div>
-<div class="creative--fluid250 l-side-margins hide-until-tablet creative--fluid250__height--{{creativeHeight}}" style="
-        background-color: {{backgroundColor}};
-        background-image: url({{backgroundImage}});
-        background-position: {{backgroundPosition}};
-        background-repeat: {{backgroundRepeat}};
+<div class="creative--fluid250 l-side-margins hide-until-tablet creative--fluid250__height--{{data.creativeHeight}}" style="
+        background-color: {{data.backgroundColor}};
+        background-image: url({{data.backgroundImage}});
+        background-position: {{data.backgroundPosition}};
+        background-repeat: {{data.backgroundRepeat}};
     ">
-    <a href="{{clickMacro}}{{link}}" target="_blank">
+    <a href="{{data.clickMacro}}{{data.link}}" target="_blank">
         <div class="gs-container">
-            {{video}}
+            {{data.video}}
             <div class="fluid250_layer fluid250_layer1" style="
-                background-image: url({{layerOneBGImage}});
-                background-position: {{layerOneBGPosition}};
+                background-image: url({{data.layerOneBGImage}});
+                background-position: {{data.layerOneBGPosition}};
             "></div>
             <div class="fluid250_layer fluid250_layer2" style="
-                background-image: url({{layerTwoBGImage}});
-                background-position: {{layerTwoBGPosition}};
+                background-image: url({{data.layerTwoBGImage}});
+                background-position: {{data.layerTwoBGPosition}};
             "></div>
             <div class="fluid250_layer fluid250_layer3" style="
-                background-image: url({{layerThreeBGImage}});
-                background-position: {{layerThreeBGPosition}};
+                background-image: url({{data.layerThreeBGImage}});
+                background-position: {{data.layerThreeBGPosition}};
             "></div>
         </div>
     </a>
 </div>
 <div class="creative--fluid250 l-side-margins mobile-only" style="
-        background-color: {{backgroundColor}};
-        background-image: url({{backgroundImageM}});
-        background-position: {{backgroundPositionM}};
-        background-repeat: {{backgroundRepeatM}};
+        background-color: {{data.backgroundColor}};
+        background-image: url({{data.backgroundImageM}});
+        background-position: {{data.backgroundPositionM}};
+        background-repeat: {{data.backgroundRepeatM}};
     ">
-    <a href="{{link}}" target="_blank">
+    <a href="{{data.link}}" target="_blank">
         <div class="gs-container">
             <div class="fluid250_layer fluid250_layer1" style="
-                background-image: url({{layerOneBGImageM}});
-                background-position: {{layerOneBGPositionM}};
+                background-image: url({{data.layerOneBGImageM}});
+                background-position: {{data.layerOneBGPositionM}};
             "></div>
             <div class="fluid250_layer fluid250_layer2" style="
-                background-image: url({{layerTwoBGImageM}});
-                background-position: {{layerTwoBGPositionM}};
+                background-image: url({{data.layerTwoBGImageM}});
+                background-position: {{data.layerTwoBGPositionM}};
             "></div>
             <div class="fluid250_layer fluid250_layer3" style="
-                background-image: url({{layerThreeBGImageM}});
-                background-position: {{layerThreeBGPositionM}};
+                background-image: url({{data.layerThreeBGImageM}});
+                background-position: {{data.layerThreeBGPositionM}};
             "></div>
         </div>
     </a>


### PR DESCRIPTION
Essentially just https://github.com/guardian/frontend/pull/9464/files#diff-d54a7e1c349959665ffefe5d60707905R1.

The benefit of this over our old template system (a simple `reduce`) is we can evaluate JavaScript inside of templates, which is good for simple logic such as ternary operators.
