### PR TITLE
Add some older iOs devices to 2nd tier.

### DIFF
--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -105,8 +105,10 @@
                 'older' iOs normally indicates a device with lower power (they stop being upgradeable at some point).
                 We won't run all javascript on these
                 For usage stats see http://david-smith.org/iosversionstats/
+
+                On 12 June 2015 this represents about 1/4 iPads and 1/4 iPhones
             *@
-            return /.*(iPhone|iPad; CPU) OS ([3456])_\d+.*/.test(navigator.userAgent);
+            return /.*(iPhone|iPad; CPU) OS ([34567])_\d+.*/.test(navigator.userAgent) || window.devicePixelRatio === 1;
         }
         return false;
     })();


### PR DESCRIPTION
The iPad 2s are still causing us issues.

Or more accurately, we are still causing iPad 2s issues.

@michaelwmcnamara 
