### PR TITLE
Colourised save article icons on fronts

### DIFF
--- a/common/app/views/fragments/items/facia_cards/meta.scala.html
+++ b/common/app/views/fragments/items/facia_cards/meta.scala.html
@@ -4,7 +4,7 @@
 
 <aside class="fc-item__meta js-item__meta">
     <button data-link-name="save-for-later" class="js-save-for-later-link fc-save-for-later is-hidden u-faux-block-link__promote" type="button">
-        @fragments.inlineSvg("bookmark", "icon")
+        @fragments.inlineSvg("bookmark", "icon", List("inline-tone-fill"))
     </button>
     @for(publishedAt <- item.webPublicationDate; timeStampDisplay <- item.timeStampDisplay) {
         <time class="fc-item__timestamp@if(timeStampDisplay.javaScriptUpdate){ js-item__timestamp}"

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -521,6 +521,7 @@ $fc-item-gutter: $gs-gutter / 4;
     background-color: transparent;
     padding: 0;
 
+    color: transparent;
     float: right;
 
     &:hover {

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -524,8 +524,11 @@ $fc-item-gutter: $gs-gutter / 4;
     color: transparent;
     float: right;
 
-    &:hover {
+    &:hover,
+    &:focus,
+    &:active {
         text-decoration: underline;
+        color: inherit;
     }
 
     &:before {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
@@ -25,7 +25,8 @@
     .fc-item__kicker,
     .rich-link__kicker,
     .fc-item__byline,
-    .rich-link__standfirst {
+    .rich-link__standfirst,
+    .fc-save-for-later--is-saved {
         color: colour(news-support-6);
     }
 
@@ -35,6 +36,10 @@
 
     .fc-item__meta {
         color: colour(neutral-2);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(news-support-6);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
@@ -18,7 +18,8 @@
     .rich-link__kicker,
     .fc-item__byline,
     .rich-link__byline,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(comment-default);
     }
 
@@ -35,6 +36,10 @@
         ul > li:before {
             background: colour(neutral-3);
         }
+    }
+
+    .fc-save-for-later--is-saved  .inline-tone-fill {
+        fill: colour(comment-default);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
@@ -14,7 +14,8 @@
     }
 
     .fc-item__kicker,
-    .fc-item__byline {
+    .fc-item__byline,
+    .fc-save-for-later--is-saved {
         color: colour(live-accent);
     }
 
@@ -28,6 +29,10 @@
 
     .rich-link__arrow-icon {
         fill: colour(neutral-2);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(live-accent);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
@@ -34,7 +34,8 @@
     .fc-item__kicker,
     .fc-item__byline,
     .fc-item__standfirst,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(editorial-accent);
     }
 
@@ -48,6 +49,10 @@
 
     .fc-item__meta {
         color: colour(editorial-accent);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(editorial-accent);
     }
 
     .fc-sublink__title:before {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
@@ -2,7 +2,8 @@
     background-color: colour(neutral-6);
 
     .fc-item__kicker,
-    .fc-item__byline {
+    .fc-item__byline,
+    .fc-save-for-later--is-saved {
         color: colour(external-main-1);
     }
 
@@ -17,6 +18,10 @@
     .fc-item__container:before,
     .rich-link__container:before {
         background-color: colour(external-support-1);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(external-main-1);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
@@ -34,7 +34,8 @@
     .fc-item__kicker,
     .fc-item__byline,
     .fc-item__meta,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(feature-mute);
     }
 
@@ -68,6 +69,10 @@
 
     .fc-sublink__title:before {
         border-color: mix($c-headline, colour(feature-default), 40%);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(features-mute);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -31,7 +31,8 @@
     .fc-item__kicker,
     .fc-item__byline,
     .fc-item__meta,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(live-mute);
     }
 
@@ -67,6 +68,10 @@
         .inline-icon {
             fill: colour(live-mute);
         }
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(live-mute);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
@@ -36,7 +36,8 @@
     .fc-item__kicker,
     .rich-link__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(media-default);
     }
 
@@ -54,6 +55,10 @@
     .rich-link__standfirst,
     .fc-item__meta {
         color: colour(neutral-3);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(media-default);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-news.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-news.scss
@@ -11,7 +11,8 @@
 
     .fc-item__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(news-default);
     }
 
@@ -24,6 +25,10 @@
     }
 
     .rich-link__arrow-icon {
+        fill: colour(news-default);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
         fill: colour(news-default);
     }
 }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
@@ -30,7 +30,8 @@
 
     .fc-item__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(review-accent);
     }
 
@@ -53,6 +54,10 @@
 
     .fc-item__meta {
         color: colour(neutral-4);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(review-accent);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
@@ -31,7 +31,8 @@
 
     .fc-item__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(news-support-1);
     }
 
@@ -63,6 +64,10 @@
 
     .fc-item__meta {
         color: colour(neutral-4);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(news-support-1);
     }
 }
 


### PR DESCRIPTION
- hide the labels of unsaved articles
- show the label on hover (no labels un-saved on touch)

![screen shot 2015-06-12 at 15 26 42](https://cloud.githubusercontent.com/assets/867233/8132229/1b1293e8-1118-11e5-81aa-bf28377c4049.png)
