### PR TITLE
Update jspm to 0.16.0-beta.2

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -3,17 +3,15 @@
 var path = require('path');
 
 var System = require('jspm/node_modules/systemjs');
-// Execute the IIFE
-global.systemJsRuntime = false;
-require(path.join(__dirname, 'static/src/systemjs-normalize'));
-// Modify System before creating the builder because it clones System
-System._extensions.push(function(loader) {
-    // System.normalize is exposed by the IIFE above
-    loader.normalize = System.normalize;
-});
 
 var jspm = require('jspm');
 var builder = new jspm.Builder();
+// Temporary hack, as per https://github.com/systemjs/systemjs/issues/533#issuecomment-113525639
+global.System = builder.loader;
+// Execute the IIFE
+global.systemJsRuntime = false;
+require(path.join(__dirname, 'static/src/systemjs-normalize'));
+
 var crypto = require('crypto');
 var fs = require('fs');
 var mkdirp = require('mkdirp');

--- a/bundle.js
+++ b/bundle.js
@@ -84,7 +84,7 @@ var writeBundlesConfig = function (bundles) {
         return accumulator;
     }, {});
     var configFilePath = path.join(jspmBaseUrl, 'systemjs-bundle-config.js');
-    var configFileData = 'System.bundles = ' + JSON.stringify(bundlesConfig, null, '\t');
+    var configFileData = 'System.config({ bundles: ' + JSON.stringify(bundlesConfig, null, '\t') + ' })';
     console.log('writing to %s', configFilePath);
     fs.writeFileSync(configFilePath, configFileData);
 };

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -134,7 +134,7 @@ class Assets(base: String, assetMap: String = "assets/assets.map") extends Loggi
 
      val curl: String = RelativePathEscaper.escapeLeadingDotPaths(inlineJs("assets/curl-domReady.js"))
 
-     val es6ModuleLoader: String = inlineJs("assets/system-polyfills.src.js")
+     val systemJsPolyfills: String = inlineJs("assets/system-polyfills.src.js")
 
      val systemJs: String = inlineJs("assets/system.src.js")
 

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -134,7 +134,7 @@ class Assets(base: String, assetMap: String = "assets/assets.map") extends Loggi
 
      val curl: String = RelativePathEscaper.escapeLeadingDotPaths(inlineJs("assets/curl-domReady.js"))
 
-     val es6ModuleLoader: String = inlineJs("assets/es6-module-loader.src.js")
+     val es6ModuleLoader: String = inlineJs("assets/system-polyfills.src.js")
 
      val systemJs: String = inlineJs("assets/system.src.js")
 

--- a/common/app/templates/systemJsSetup.scala.js
+++ b/common/app/templates/systemJsSetup.scala.js
@@ -2,15 +2,20 @@
 
 @JavaScript(Static.js.es6ModuleLoader)
 @JavaScript(Static.js.systemJs)
+
+System.config({
+    baseURL: '@{JavaScript(Configuration.assets.path)}',
+    paths: {
+        'ophan/ng': '@{JavaScript(Configuration.javascript.config("ophanJsUrl"))}.js',
+        'googletag': '@{JavaScript(Configuration.javascript.config("googletagJsUrl"))}'
+    }
+});
+
 @JavaScript(Static.js.systemJsAppConfig)
 
 @if(!play.Play.isDev()) {
     @JavaScript(Static.js.systemJsBundleConfig)
 }
-
-System.baseURL = '@{JavaScript(Configuration.assets.path)}';
-System.paths['ophan/ng']  = '@{JavaScript(Configuration.javascript.config("ophanJsUrl"))}.js';
-System.paths['googletag'] = '@{JavaScript(Configuration.javascript.config("googletagJsUrl"))}';
 
 @JavaScript(Static.js.systemJsNormalize)
 

--- a/common/app/templates/systemJsSetup.scala.js
+++ b/common/app/templates/systemJsSetup.scala.js
@@ -1,6 +1,6 @@
 @()
 
-@JavaScript(Static.js.es6ModuleLoader)
+@JavaScript(Static.js.systemJsPolyfills)
 @JavaScript(Static.js.systemJs)
 
 System.config({

--- a/common/app/templates/systemJsSetup.scala.js
+++ b/common/app/templates/systemJsSetup.scala.js
@@ -7,7 +7,8 @@ System.config({
     baseURL: '@{JavaScript(Configuration.assets.path)}',
     paths: {
         'ophan/ng': '@{JavaScript(Configuration.javascript.config("ophanJsUrl"))}.js',
-        'googletag': '@{JavaScript(Configuration.javascript.config("googletagJsUrl"))}'
+        // .js must be added: https://github.com/systemjs/systemjs/issues/528
+        'googletag.js': '@{JavaScript(Configuration.javascript.config("googletagJsUrl"))}'
     }
 });
 

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -213,7 +213,7 @@
                 core:                       '@Static("javascripts/core.js")',
                 facebook:                   '//connect.facebook.net/en_US/all.js',
                 foresee:                    'vendor/foresee/20141107/foresee-trigger.js',
-                googletag:                  '@{Configuration.javascript.config("googletagJsUrl")}',
+                'googletag.js':             '@{Configuration.javascript.config("googletagJsUrl")}',
                 'ophan/ng':                 '@{Configuration.javascript.config("ophanJsUrl")}',
                 stripe:                     '@Static("javascripts/vendor/stripe/stripe.min.js")',
                 text:                       'text', // noop

--- a/grunt-configs/uglify.js
+++ b/grunt-configs/uglify.js
@@ -22,7 +22,7 @@ module.exports = function(grunt, options) {
                 cwd: 'static/src/jspm_packages',
                 src: [
                     'system.src.js',
-                    'es6-module-loader.src.js'
+                    'system-polyfills.src.js'
                 ],
                 dest: 'common/conf/assets'
             },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
       "reqwest": "github:ded/reqwest@1.1.5",
       "sinonjs": "bower:sinonjs@1.10.2",
       "socketio": "github:Automattic/socket.io-client@1.1.0",
-      "system-script": "github:rich-nguyen/systemjs-script-plugin@0.1.9",
+      "system-script": "github:rich-nguyen/systemjs-script-plugin@0.1.10",
       "text": "github:systemjs/plugin-text@^0.0.2",
       "videojs": "github:guardian/video.js@4.11.1.1",
       "videojsads": "github:guardian/videojs-contrib-ads@0.4.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jasmine-core": "^2.3.2",
     "jit-grunt": "0.9.1",
     "jsonfile": "2.0.0",
-    "jspm": "0.16.0-beta",
+    "jspm": "0.16.0-beta.2",
     "jspm-bower-endpoint": "^0.3.2",
     "karma": "0.12.31",
     "karma-chrome-launcher": "0.1.10",
@@ -100,9 +100,9 @@
       "videojsplaylist": "github:tim-peterson/videojs-playlist@master"
     },
     "devDependencies": {
-      "babel": "npm:babel-core@^5.4.3",
-      "babel-runtime": "npm:babel-runtime@^5.4.3",
-      "core-js": "npm:core-js@^0.9.10"
+      "babel": "npm:babel-core@^5.5.8",
+      "babel-runtime": "npm:babel-runtime@^5.5.8",
+      "core-js": "npm:core-js@^0.9.17"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "karma-firefox-launcher": "0.1.6",
     "karma-html2js-preprocessor": "0.1.0",
     "karma-jasmine": "0.3.5",
-    "karma-jspm": "rich-nguyen/karma-jspm.git#1.1.5",
+    "karma-jspm": "rich-nguyen/karma-jspm.git#1.1.6",
     "karma-phantomjs-launcher": "0.1.4",
     "karma-phantomjs-shim": "^1.0.0",
     "karma-requirejs": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jasmine-core": "^2.3.2",
     "jit-grunt": "0.9.1",
     "jsonfile": "2.0.0",
-    "jspm": "0.15.6",
+    "jspm": "0.16.0-beta",
     "jspm-bower-endpoint": "^0.3.2",
     "karma": "0.12.31",
     "karma-chrome-launcher": "0.1.10",
@@ -100,9 +100,9 @@
       "videojsplaylist": "github:tim-peterson/videojs-playlist@master"
     },
     "devDependencies": {
-      "babel": "npm:babel-core@^5.1.13",
-      "babel-runtime": "npm:babel-runtime@^5.1.13",
-      "core-js": "npm:core-js@^0.9.4"
+      "babel": "npm:babel-core@^5.4.3",
+      "babel-runtime": "npm:babel-runtime@^5.4.3",
+      "core-js": "npm:core-js@^0.9.10"
     }
   }
 }

--- a/static/src/javascripts/es6/projects/common/utils/svg.js
+++ b/static/src/javascripts/es6/projects/common/utils/svg.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 export function translate(load) {
     const prefix = 'inline-',
-          data = _.rest(load.metadata.pluginArgument.split('/')),
+          data = _.rest(load.metadata.loaderArgument.split('/')),
           fileName = data.pop(),
           typesClasses = _.map(data, function (imageType) {
               return prefix + imageType;

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -221,7 +221,8 @@ define([
             if (!window.googletag) {
                 window.googletag = { cmd: [] };
                 // load the library asynchronously
-                require(['js!googletag']);
+                // .js must be added: https://github.com/systemjs/systemjs/issues/528
+                require(['js!googletag.js']);
             }
 
             window.googletag.cmd.push = raven.wrap({ deep: true }, window.googletag.cmd.push);

--- a/static/src/javascripts/test/helpers/injector.js
+++ b/static/src/javascripts/test/helpers/injector.js
@@ -1,11 +1,16 @@
 export default class Injector {
    constructor() {
-        this.loader = System.clone();
-
-        this.loader.paths = System.paths;
-        this.loader.map = System.map;
+        this.loader = new System.constructor();
+        this.loader.config({
+            baseURL: System.baseURL,
+            defaultJSExtensions: true,
+            transpiler: System.transpiler,
+            paths: System.paths,
+            map: System.map,
+            // Map is transformed to packages
+            packages: System.packages
+        });
         this.loader.normalize = System.normalize;
-        this.loader.transpiler = System.transpiler;
     }
 
     mock(mocks) {

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -1,4 +1,5 @@
 System.config({
+  "defaultJSExtensions": true,
   "transpiler": "babel",
   "babelOptions": {
     "optional": [
@@ -7,25 +8,23 @@ System.config({
     "blacklist": []
   },
   "paths": {
-    "*": "javascripts/*.js",
-    "admin/*": "javascripts/projects/admin/*.js",
-    "common/*": "javascripts/projects/common/*.js",
-    "facia/*": "javascripts/projects/facia/*.js",
-    "membership/*": "javascripts/projects/membership/*.js",
-    "bundles/*": "bundles/*.js",
-    "test/*": "javascripts/test/*.js",
-    "helpers/*": "javascripts/test/helpers/*.js",
-    "fixtures/*": "javascripts/test/fixtures/*.js",
-    "es6/*": "javascripts/es6/*.js",
-    "bootstraps/*": "javascripts/bootstraps/*.js",
-    "vendor/*": "javascripts/vendor/*.js",
+    "*": "javascripts/*",
+    "admin/*": "javascripts/projects/admin/*",
+    "common/*": "javascripts/projects/common/*",
+    "facia/*": "javascripts/projects/facia/*",
+    "membership/*": "javascripts/projects/membership/*",
+    "bundles/*": "bundles/*",
+    "test/*": "javascripts/test/*",
+    "helpers/*": "javascripts/test/helpers/*",
+    "fixtures/*": "javascripts/test/fixtures/*",
+    "es6/*": "javascripts/es6/*",
+    "bootstraps/*": "javascripts/bootstraps/*",
+    "vendor/*": "javascripts/vendor/*",
     "svgs/*": "inline-svgs/*.svg",
-    "github:*": "jspm_packages/github/*.js",
-    "npm:*": "jspm_packages/npm/*.js",
-    "bower:*": "jspm_packages/bower/*.js",
-    "facebook": "//connect.facebook.net/en_US/all.js",
-    "http/*": "http://*",
-    "https/*": "https://*"
+    "github:*": "jspm_packages/github/*",
+    "npm:*": "jspm_packages/npm/*",
+    "bower:*": "jspm_packages/bower/*",
+    "facebook": "//connect.facebook.net/en_US/all"
   },
   "shim": {
     "omniture": {
@@ -73,11 +72,11 @@ System.config({
       "jasmine": "bower:jasmine@2.0.4",
       "sinonjs": "bower:sinonjs@1.10.2"
     },
-    "bower:video.js@4.12.5": {
+    "bower:video.js@4.12.8": {
       "css": "github:systemjs/plugin-css@0.1.9"
     },
     "bower:videojs-persistvolume@0.1.2": {
-      "video.js": "bower:video.js@4.12.5"
+      "video.js": "bower:video.js@4.12.8"
     },
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -228,10 +228,8 @@ System.config({
       "inherits": "npm:inherits@2.0.1",
       "isarray": "npm:isarray@0.0.1",
       "process": "github:jspm/nodelibs-process@0.1.1",
-      "stream": "github:jspm/nodelibs-stream@0.1.0",
       "stream-browserify": "npm:stream-browserify@1.0.0",
-      "string_decoder": "npm:string_decoder@0.10.31",
-      "util": "github:jspm/nodelibs-util@0.1.0"
+      "string_decoder": "npm:string_decoder@0.10.31"
     },
     "npm:source-map@0.1.31": {
       "amdefine": "npm:amdefine@0.1.0",

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -60,7 +60,7 @@ System.config({
     "socketio": "github:Automattic/socket.io-client@1.1.0",
     "stripe": "vendor/stripe/stripe.min",
     "svg": "es6/projects/common/utils/svg",
-    "system-script": "github:rich-nguyen/systemjs-script-plugin@0.1.9",
+    "system-script": "github:rich-nguyen/systemjs-script-plugin@0.1.10",
     "text": "github:systemjs/plugin-text@0.0.2",
     "videojs": "github:guardian/video.js@4.11.1.1",
     "videojsads": "github:guardian/videojs-contrib-ads@0.4.1",

--- a/static/src/systemjs-normalize.js
+++ b/static/src/systemjs-normalize.js
@@ -48,16 +48,6 @@ var reduce = function (array, fn, accumulator) {
                 } else {
                     return name;
                 }
-            },
-            function interactives(name) {
-                // Transforms something like:     http://interactive.guim.co.uk/2015/04/climate-letters/assets-1430142775693/js/main.js
-                // into a legal module name: http/interactive.guim.co.uk/2015/04/climate-letters/assets-1430142775693/js/main.js
-                var regExp = /(^http[s]?):\/\/(.*)/.exec(name);
-                if (regExp) {
-                    return regExp[1] + '/' + regExp[2];
-                } else {
-                    return name;
-                }
             }
         ];
 


### PR DESCRIPTION
This, in turn, uses SystemJS 0.17.x, which will eventually contain https://github.com/systemjs/systemjs/issues/504.

@mattosborn, we will need to co-ordinate this with you, as you will need to update your interactives as the SystemJS API has changed a little bit, and the new version contains bug fixes. I have started this in https://github.com/guardian/interactive-es6/compare/election-results-system...election-results-system-clone. Let's work together on this.

/cc @Rich-Harris
