### PR TITLE
Extending switches for viewability recommendations

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -989,7 +989,7 @@ object Switches {
     "ab-mt-rec1",
     "Viewability results - Recommendation option 1",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 6, 16),
+    sellByDate = new LocalDate(2015, 6, 30),
     exposeClientSide = true
   )
 
@@ -998,7 +998,7 @@ object Switches {
     "ab-mt-rec2",
     "Viewability results - Recommendation option 2",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 6, 16),
+    sellByDate = new LocalDate(2015, 6, 30),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/mt-rec1.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/mt-rec1.js
@@ -18,7 +18,7 @@ define([
     return function () {
         this.id = 'MtRec1';
         this.start = '2015-05-12';
-        this.expiry = '2015-06-16';
+        this.expiry = '2015-06-30';
         this.author = 'Zofia Korcz';
         this.description = 'Viewability results - Recommendation option 1';
         this.audience = 0.02;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/mt-rec2.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/mt-rec2.js
@@ -18,7 +18,7 @@ define([
     return function () {
         this.id = 'MtRec2';
         this.start = '2015-05-12';
-        this.expiry = '2015-06-16';
+        this.expiry = '2015-06-30';
         this.author = 'Steve Vadocz';
         this.description = 'Viewability results - Recommendation option 2';
         this.audience = 0.02;


### PR DESCRIPTION
Extending switches for Rec1 and Rec2 till the end of this month. We are realising viewability candidate soon and we need to keep these to for comparison and gathering more data. 
