### PR TITLE
update message for older browsers in discussion

### DIFF
--- a/discussion/app/views/discussionComments/discussionPage.scala.html
+++ b/discussion/app/views/discussionComments/discussionPage.scala.html
@@ -14,7 +14,12 @@
     <div class="gs-container">
         <div class="content__main-column">
             <h2 class="page-sub-header tone-colour">Comments</h2>
-            <div class="discussion__warning modern-hidden">Please note: posting and replying to comments requires a more recent browser.</div>
+            <div class="discussion__warning modern-hidden">
+                This is our basic discussion experience, designed to perform well in most browsers.  You can read and report comments, and view
+                them in date order.
+                The full range of features are available if you use one of our <a href='@LinkTo{"/help/recommended-browsers"}'>recommended browsers</a>.
+                We review our list of recommended browsers from time to time, to make sure you get the best overall experience.
+            </div>
             @commentsList(page, true)
         </div>
     </div>

--- a/discussion/app/views/discussionComments/discussionPage.scala.html
+++ b/discussion/app/views/discussionComments/discussionPage.scala.html
@@ -15,10 +15,8 @@
         <div class="content__main-column">
             <h2 class="page-sub-header tone-colour">Comments</h2>
             <div class="discussion__warning modern-hidden">
-                This is our basic discussion experience, designed to perform well in most browsers.  You can read and report comments, and view
-                them in date order.
-                The full range of features are available if you use one of our <a href='@LinkTo{"/help/recommended-browsers"}'>recommended browsers</a>.
-                We review our list of recommended browsers from time to time, to make sure you get the best overall experience.
+                This is our basic commenting system.  For the full range of features, use one of our
+                    <a href="@LinkTo{/help/recommended-browsers}">recommended browsers</a>.
             </div>
             @commentsList(page, true)
         </div>


### PR DESCRIPTION
Everyone (who has contacted tech-feedback) is shocked because ipad non retina don't cut the mustard any more hence no discussion.

This is a big size problem in terms of amount of time to fix it properly.

However at least we can be clear about what's the situation, at the moment we're just telling them their browser is too old which seems strange to them as they didn't downgrade anything.

I'm going to update the linked article to reflect the current situation too.

Edit: updated to wording suggested by Theresa:
![image](https://cloud.githubusercontent.com/assets/7304387/8163074/d92b1064-1378-11e5-85e9-9c9074dcf63d.png)
