### PR TITLE
Slim header no navigation

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -8,7 +8,7 @@
 
 
 <header id="header"
-        class="l-header u-cf @if(metaData.hasSlimHeader) { l-header--is-slim }"
+        class="l-header u-cf @if(metaData.hasSlimHeader) {l-header--is-slim l-header--no-navigation}"
         role="banner"
         data-link-name="global navigation: header">
     <div class="js-navigation-header navigation-container navigation-container--collapsed">

--- a/static/src/stylesheets/module/nav/_brand-bar.scss
+++ b/static/src/stylesheets/module/nav/_brand-bar.scss
@@ -209,15 +209,6 @@
     }
 }
 
-.brand-bar__item--masterclasses {
-    .brand-bar__item--right--au-edition & {
-        // Hide on mobile
-        @include mq($until: tablet) {
-            display: none;
-        }
-    }
-}
-
 // Popups
 
 // Mobile only

--- a/static/src/stylesheets/module/nav/_brand-bar.scss
+++ b/static/src/stylesheets/module/nav/_brand-bar.scss
@@ -202,6 +202,19 @@
         @include mq($until: tablet) {
             display: none;
         }
+
+        .l-header--is-slim & {
+            display: none;
+        }
+    }
+}
+
+.brand-bar__item--masterclasses {
+    .brand-bar__item--right--au-edition & {
+        // Hide on mobile
+        @include mq($until: tablet) {
+            display: none;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -75,10 +75,6 @@ $c-navigation-expandable-background: colour(neutral-1);
         border-bottom: 1px solid $c-global-navigation-border;
         background-clip: padding-box;
 
-        .l-header--is-slim & {
-            display: none;
-        }
-
         .l-header--is-slim-ab & {
             display: block;
         }
@@ -139,6 +135,55 @@ $c-navigation-expandable-background: colour(neutral-1);
     list-style-type: none;
     margin: 0;
     padding: 0;
+}
+
+// Slim version of global header without navigation
+.l-header--no-navigation {
+    &:before {
+        display: none;
+    }
+
+    .navigation-container--collapsed {
+        .navigation__scroll {
+            display: none;
+        }
+
+        .navigation,
+        .signposting,
+        .local-navigation {
+            height: auto;
+        }
+    }
+
+    .navigation-toggle-label {
+        @include mq($until: mobileLandscape) {
+            display: none;
+        }
+    }
+
+    @include mq(navigationBreakOnTwoLevels) {
+        .navigation--has-signposting {
+            .navigation__container--first {
+                border-top: 0;
+            }
+        }
+    }
+
+    .navigation-toggle {
+        float: left;
+        min-width: 0;
+        line-height: 48px;
+        position: static;
+        border-left: 0;
+    }
+
+    .navigation-toggle-label__extra {
+        display: none;
+    }
+
+    .burger-icon {
+        margin-top: $gs-baseline * 1.5;
+    }
 }
 
 /* Signposting
@@ -479,10 +524,6 @@ $c-navigation-expandable-background: colour(neutral-1);
             white-space: nowrap;
         }
 
-        .l-header--is-slim & {
-            display: none;
-        }
-
         &::-webkit-scrollbar {
             display: none;
         }
@@ -494,10 +535,6 @@ $c-navigation-expandable-background: colour(neutral-1);
     .signposting,
     .local-navigation {
         height: $navigation-height;
-
-        .l-header--is-slim & {
-            height: auto;
-        }
     }
     .signposting,
     .local-navigation {
@@ -647,10 +684,6 @@ $c-navigation-expandable-background: colour(neutral-1);
         .navigation__container--first {
             background: $c-local-navigation-background;
             border-top: $navigation-height solid $c-top-header-background;
-
-            .l-header--is-slim & {
-                border-top: 0;
-            }
         }
         .navigation__container--second {
             position: absolute;
@@ -698,19 +731,6 @@ $c-navigation-expandable-background: colour(neutral-1);
     outline: none;
     min-width: $navigation-toggler-width;
 
-    // Remove redundant min-width and override breakpoint
-    .l-header--is-slim & {
-        min-width: 0;
-    }
-
-    .l-header--is-slim & {
-        float: left;
-        line-height: 48px;
-        position: static;
-        border-left: 0;
-    }
-
-
     &,
     &:hover,
     &:focus,
@@ -755,10 +775,6 @@ $c-navigation-expandable-background: colour(neutral-1);
         @include mq($until: wide) {
             display: none;
         }
-    }
-
-    .l-header--is-slim & {
-        display: none;
     }
 
     .has-page-skin & {
@@ -860,9 +876,5 @@ $burger-width: 16px;
 
     @if $old-ie {
         display: none;
-    }
-
-    .l-header--is-slim & {
-        margin-top: $gs-baseline * 1.5;
     }
 }


### PR DESCRIPTION
This is a preparation for sticky navigation. Interactive slim header is now removing navigation as default. I've updated this to create slim header with navigation and there is a --no-navigation modification for interactive.

Everything should look and work as it is now. It is just a logic change.

Default header: https://www.browserstack.com/screenshots/371d068b5d5feeb41e64306bd3f6b9d3b0f198fc

Slim header:
https://www.browserstack.com/screenshots/b8404da9124d50f7387889fe15695dc9cb1e8aac
