### PR TITLE
Robust: rethrow error

### DIFF
--- a/static/src/javascripts/projects/common/utils/robust.js
+++ b/static/src/javascripts/projects/common/utils/robust.js
@@ -19,7 +19,7 @@ define([
             block();
         } catch (e) {
             reporter(e, { tags: { module: name } });
-            throw e;
+            window.console.error(e);
         }
     }
 

--- a/static/src/javascripts/projects/common/utils/robust.js
+++ b/static/src/javascripts/projects/common/utils/robust.js
@@ -19,6 +19,7 @@ define([
             block();
         } catch (e) {
             reporter(e, { tags: { module: name } });
+            throw e;
         }
     }
 


### PR DESCRIPTION
Errors caught using robust are being captured by Raven, but they are not thrown again afterwards, as per `Raven.wrap`: https://github.com/getsentry/raven-js/blob/master/src/raven.js#L194. This led to silent errors in DEV.

/cc @gklopper 
