### PR TITLE
repel cutout from articles with long localnav

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -37,7 +37,7 @@ case class NavItem(name: SectionLink, links: Seq[SectionLink] = Nil) {
     ).flatten.contains(name.href.stripPrefix("/")) || page.url == name.href
   }
 
-  def repelCutout: Boolean = links.size > 5
+  val repelCutout: Boolean = links.size > 5
 
 }
 

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -36,6 +36,9 @@ case class NavItem(name: SectionLink, links: Seq[SectionLink] = Nil) {
       Some(page.section)
     ).flatten.contains(name.href.stripPrefix("/")) || page.url == name.href
   }
+
+  def repelCutout: Boolean = links.size > 5
+
 }
 
 trait Navigation {

--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -37,6 +37,7 @@ case class NavItem(name: SectionLink, links: Seq[SectionLink] = Nil) {
     ).flatten.contains(name.href.stripPrefix("/")) || page.url == name.href
   }
 
+  // arbitrary cutoff, feel free to tweak - https://github.com/guardian/frontend/pull/9487
   val repelCutout: Boolean = links.size > 5
 
 }

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -43,11 +43,13 @@ http://developers.theguardian.com/join-the-team.html
                 (AppleAdTravelFrontSwitch.isSwitchedOn && edition.id == "UK" && metaData.id == "travel") ||
                 (AppleAdUsNetworkFrontSwitch.isSwitchedOn && edition.id == "US" && metaData.id == "us"))
     ) { adBelowNav =>
+        @defining(Navigation.topLevelItem(edition.navigation, metaData)) { navigation =>
     <body
         id="top"
         class="@RenderClasses(Map(
             ("has-page-skin", metaData.hasPageSkin(edition)),
-            ("has-localnav", Navigation.topLevelItem(edition.navigation, metaData).filter(_.links.nonEmpty).nonEmpty),
+            ("has-localnav", navigation.filter(_.links.nonEmpty).nonEmpty),
+            ("wide-localnav", navigation.map(_.repelCutout).getOrElse(false)),
             ("has-membership-access-requirement", metaData.requiresMembershipAccess),
             ("childrens-books-site", metaData.section == "childrens-books-site"),
             ("ad-below-nav", adBelowNav),
@@ -94,5 +96,6 @@ http://developers.theguardian.com/join-the-team.html
 
     </body>
     </html>
+}
 }
 }

--- a/static/src/stylesheets/_head.common.scss
+++ b/static/src/stylesheets/_head.common.scss
@@ -64,6 +64,7 @@
 @import 'module/_media';
 @import 'module/_headers';
 @import 'module/nav/_has-localnav-overrides';
+@import 'module/nav/_wide-localnav-overrides';
 @import 'module/nav/_navigation';
 @import 'module/_rounded-icon';
 

--- a/static/src/stylesheets/module/nav/_wide-localnav-overrides.scss
+++ b/static/src/stylesheets/module/nav/_wide-localnav-overrides.scss
@@ -1,0 +1,14 @@
+.wide-localnav {
+
+    .content__head--byline-pic {
+        .byline-img {
+
+            @include mq(phablet) {
+                height: gs-span(2.5) + $gs-gutter;
+            }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
The cutouts are designed to overlap slightly into the localnav area, however some sections have very long lists of links.
This change just checks if there are more than 5 links, and if so makes the cutouts slightly smaller.

Before....
![image](https://cloud.githubusercontent.com/assets/7304387/8165358/b963f67e-1387-11e5-83a6-687cf441c246.png)
After...
![image](https://cloud.githubusercontent.com/assets/7304387/8165364/c633eb34-1387-11e5-9118-154839388b3b.png)

However... if the list is 5 or less, it still uses the original size:
![image](https://cloud.githubusercontent.com/assets/7304387/8165372/e4ba6c2c-1387-11e5-8a4c-74977c0381d2.png)
