### PR TITLE
SFL: correct data link name for containers

### DIFF
--- a/common/app/views/fragments/items/facia_cards/meta.scala.html
+++ b/common/app/views/fragments/items/facia_cards/meta.scala.html
@@ -3,7 +3,7 @@
 @import views.support.Format
 
 <aside class="fc-item__meta js-item__meta">
-    <button data-link-name="save-for-later" class="js-save-for-later-link fc-save-for-later is-hidden u-faux-block-link__promote" type="button">
+    <button class="js-save-for-later-link fc-save-for-later is-hidden u-faux-block-link__promote" type="button">
         @fragments.inlineSvg("bookmark", "icon", List("inline-tone-fill"))
     </button>
     @for(publishedAt <- item.webPublicationDate; timeStampDisplay <- item.timeStampDisplay) {

--- a/static/src/javascripts/projects/common/modules/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/save-for-later.js
@@ -173,6 +173,7 @@ define([
                     $itemSaveLink.addClass(self.classes.fcItemIsSaved);
                 }
                 $item.addClass('fc-item--has-metadata'); // while in test
+                $itemSaveLink.attr('data-link-name', isSaved ? 'Unsave' : 'Save');
                 $itemSaveLink.removeClass('is-hidden'); // while in test
             });
         });
@@ -199,9 +200,7 @@ define([
         );
     };
 
-    SaveForLater.prototype.deleteArticle = function (onArticleDeleted, onArticleDeletedError, userData, pageId, shortUrl, event) {
-        event.stop();
-
+    SaveForLater.prototype.deleteArticle = function (onArticleDeleted, onArticleDeletedError, userData, pageId, shortUrl) {
         var self = this;
 
         userData.articles = _.filter(userData.articles, function (article) {
@@ -236,7 +235,9 @@ define([
         self.createDeleteArticleHandler(link, id, shortUrl);
 
         fastdom.write(function () {
-            bonzo(link).addClass(self.classes.fcItemIsSaved);
+            bonzo(link)
+                .addClass(self.classes.fcItemIsSaved)
+                .attr('data-link-name', 'Unsave');
         });
     };
 
@@ -254,7 +255,9 @@ define([
         self.createSaveArticleHandler(link, id, shortUrl);
 
         fastdom.write(function () {
-            bonzo(link).removeClass(self.classes.fcItemIsSaved);
+            bonzo(link)
+                .removeClass(self.classes.fcItemIsSaved)
+                .attr('data-link-name', 'Save');
         });
     };
 


### PR DESCRIPTION
As per https://docs.google.com/spreadsheets/d/1kRs3TllcjufTBQBIjh-5BUCtU069SuH1cIFt6srMUHI

This is a good illustration of the problem we have with frontend JS. The server renders the HTML, and then we make assumptions about the returned template in our JS in order to progressively enhance it by mutating the DOM. Very brittle. I really hope we can find a way to share templates between server and client.
