### PR TITLE
Log FastDom errors

### DIFF
--- a/static/src/javascripts/projects/common/utils/fastdom-errors.js
+++ b/static/src/javascripts/projects/common/utils/fastdom-errors.js
@@ -14,5 +14,6 @@ define([
                 feature: 'fastdom'
             }
         });
+        console.error(error);
     };
 });

--- a/static/src/javascripts/projects/common/utils/fastdom-errors.js
+++ b/static/src/javascripts/projects/common/utils/fastdom-errors.js
@@ -14,6 +14,6 @@ define([
                 feature: 'fastdom'
             }
         });
-        console.error(error);
+        window.console.error(error);
     };
 });


### PR DESCRIPTION
I'm noticing a theme… https://github.com/guardian/frontend/pull/9485

Silent errors :-1:
