### PR TITLE
Comment mpu fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/comment-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/comment-adverts.js
@@ -62,7 +62,6 @@ define([
             });
         });
 
-
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/commercial/comment-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/comment-adverts.js
@@ -4,6 +4,7 @@ define([
     'common/utils/_',
     'common/utils/$',
     'common/utils/config',
+    'common/utils/mediator',
     'common/modules/identity/api',
     'common/modules/experiments/ab',
     'common/modules/commercial/create-ad-slot'
@@ -13,6 +14,7 @@ define([
     _,
     $,
     config,
+    mediator,
     identityApi,
     ab,
     createAdSlot
@@ -39,24 +41,28 @@ define([
         $adSlotContainer = $(opts.adSlotContainerSelector);
         $commentMainColumn = $(opts.commentMainColumn, '.js-comments');
 
-        // is the switch off, or not in the AB test, or there is no adslot container, or comments are disabled, or not signed in
-        if (!config.switches.standardAdverts || !isMtRecTest() || !$adSlotContainer.length || !config.switches.discussion || !identityApi.isUserLoggedIn()) {
-            return false;
-        }
+        mediator.once('modules:comments:renderComments:rendered', function () {
+            // is the switch off, or not in the AB test, or there is no adslot container, or comments are disabled, or not signed in, or comments container is lower than 280px
+            if (!config.switches.standardAdverts || !isMtRecTest() || !$adSlotContainer.length || !config.switches.discussion || !identityApi.isUserLoggedIn() || $commentMainColumn.dim().height < 280) {
+                return false;
+            }
 
-        $commentMainColumn.addClass('discussion__ad-wrapper');
+            $commentMainColumn.addClass('discussion__ad-wrapper');
 
-        return new Promise(function (resolve) {
-            fastdom.read(function () {
-                adType = 'comments';
+            return new Promise(function (resolve) {
+                fastdom.read(function () {
+                    adType = 'comments';
 
-                fastdom.write(function () {
-                    $adSlotContainer.append(createAdSlot(adType, 'mpu-banner-ad'));
+                    fastdom.write(function () {
+                        $adSlotContainer.append(createAdSlot(adType, 'mpu-banner-ad'));
 
-                    resolve($adSlotContainer);
+                        resolve($adSlotContainer);
+                    });
                 });
             });
         });
+
+
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -204,6 +204,8 @@ Comments.prototype.renderComments = function(resp) {
 
     this.relativeDates();
     this.emit('rendered', resp.paginationHtml);
+
+    mediator.emit('modules:comments:renderComments:rendered');
 };
 
 Comments.prototype.showHiddenComments = function(e) {

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -239,9 +239,9 @@ $avatarPadding: $gs-gutter / 2;
     .discussion__ad-slot {
         position: absolute;
         top: 10px;
-        right: -320px;
+        right: -1 * (gs-span(4) + $gs-gutter);
         @include mq(wide) {
-            right: -400px;
+            right: -1 * (gs-span(5) + $gs-gutter);
         }
     }
 }

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -240,6 +240,9 @@ $avatarPadding: $gs-gutter / 2;
         position: absolute;
         top: 10px;
         right: -320px;
+        @include mq(wide) {
+            right: -400px;
+        }
     }
 }
 


### PR DESCRIPTION
The alignment of comment MPU is now the same as MPU in RHC (article).
I also fixed the bug then MPU was shown and cut when comments' container was too short.
![screen shot 2015-06-16 at 12 56 28](https://cloud.githubusercontent.com/assets/489567/8182408/08530c80-1427-11e5-9450-c8d6cbc03238.png)
