### PR TITLE
discussion can go via a proxy now depending on a user pref

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1103,6 +1103,15 @@ object Switches {
     exposeClientSide = false
   )
 
+  val DiscussionProxySwitch = Switch(
+    "Feature",
+    "discussion-proxy",
+    "in discussion/api.js we have a feature to let you go through a proxy.  This will be permanently switched over if it works out.",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 7, 16),
+    exposeClientSide = false
+  )
+
   // Facia
 
   val ToolDisable = Switch(

--- a/static/src/javascripts/projects/common/modules/discussion/api.js
+++ b/static/src/javascripts/projects/common/modules/discussion/api.js
@@ -1,8 +1,10 @@
 define([
+    'common/modules/user-prefs',
     'common/utils/ajax',
     'common/utils/config',
     'common/utils/cookies'
 ], function (
+    prefs,
     ajax,
     config,
     cookies
@@ -15,7 +17,7 @@ define([
     var Api = {
         root: (document.location.protocol === 'https:')
                 ? config.page.secureDiscussionApiRoot
-                : config.page.discussionApiRoot,
+                : (prefs.isOn('discussion.useProxy') ? 'http://www.theguardian.com/guardianapis/discussion/discussion-api' : config.page.discussionApiRoot),
         clientHeader: config.page.discussionApiClientHeader
     };
 


### PR DESCRIPTION
the other part of https://github.com/guardian/platform/pull/778 (please +1 that too)

This is associated with a switch so I don't forget to do the other half which is switching it over for everyone once it's tested.

Putting it behind a user pref so I don't break discussion for everyone, as it's a feature our most loyal users really rely on.
