### PR TITLE
Mpu comment liveblog fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/comment-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/comment-adverts.js
@@ -4,6 +4,7 @@ define([
     'common/utils/_',
     'common/utils/$',
     'common/utils/config',
+    'common/utils/detect',
     'common/utils/mediator',
     'common/modules/identity/api',
     'common/modules/experiments/ab',
@@ -14,6 +15,7 @@ define([
     _,
     $,
     config,
+    detect,
     mediator,
     identityApi,
     ab,
@@ -41,15 +43,21 @@ define([
         $adSlotContainer = $(opts.adSlotContainerSelector);
         $commentMainColumn = $(opts.commentMainColumn, '.js-comments');
 
-        mediator.once('modules:comments:renderComments:rendered', function () {
-            // is the switch off, or not in the AB test, or there is no adslot container, or comments are disabled, or not signed in, or comments container is lower than 280px
-            if (!config.switches.standardAdverts || !isMtRecTest() || !$adSlotContainer.length || !config.switches.discussion || !identityApi.isUserLoggedIn() || $commentMainColumn.dim().height < 280) {
-                return false;
-            }
+        console.log(detect.getBreakpoint());
+        return new Promise(function (resolve) {
+            mediator.once('modules:comments:renderComments:rendered', function () {
+                // is the switch off, or not in the AB test, or there is no adslot container, or comments are disabled, or not signed in, or comments container is lower than 280px, or breakpoint in live-blog is lower than desktop
+                if (!config.switches.standardAdverts || !isMtRecTest() || !$adSlotContainer.length || !config.switches.discussion || !identityApi.isUserLoggedIn() || $commentMainColumn.dim().height < 280
+                    || (config.page.contentType === 'LiveBlog' && detect.getBreakpoint() !== 'wide')) {
+                    return false;
+                }
 
-            $commentMainColumn.addClass('discussion__ad-wrapper');
+                $commentMainColumn.addClass('discussion__ad-wrapper');
 
-            return new Promise(function (resolve) {
+                if (config.page.contentType !== 'LiveBlog') {
+                    $commentMainColumn.addClass('discussion__ad-wrapper-wider');
+                }
+
                 fastdom.read(function () {
                     adType = 'comments';
 
@@ -61,7 +69,6 @@ define([
                 });
             });
         });
-
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/commercial/comment-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/comment-adverts.js
@@ -43,7 +43,6 @@ define([
         $adSlotContainer = $(opts.adSlotContainerSelector);
         $commentMainColumn = $(opts.commentMainColumn, '.js-comments');
 
-        console.log(detect.getBreakpoint());
         return new Promise(function (resolve) {
             mediator.once('modules:comments:renderComments:rendered', function () {
                 // is the switch off, or not in the AB test, or there is no adslot container, or comments are disabled, or not signed in, or comments container is lower than 280px, or breakpoint in live-blog is lower than desktop

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -240,8 +240,12 @@ $avatarPadding: $gs-gutter / 2;
         position: absolute;
         top: 10px;
         right: -1 * (gs-span(4) + $gs-gutter);
-        @include mq(wide) {
-            right: -1 * (gs-span(5) + $gs-gutter);
+    }
+    &.discussion__ad-wrapper-wider {
+        .discussion__ad-slot {
+            @include mq(wide) {
+                right: -1 * (gs-span(5) + $gs-gutter);
+            }
         }
     }
 }


### PR DESCRIPTION
Fix for a comment MPU on liveblogs. Align the adslot little differently under liveblog and don't show it at all when breakpoint is smaller than 'wide'. 
Also bug with Promise is fixed.
