### PR TITLE
SFL: hide containers until test is ran

### DIFF
--- a/static/src/javascripts/projects/common/modules/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/save-for-later.js
@@ -120,6 +120,7 @@ define([
 
         $savers.each(function (saver) {
             var $saver = bonzo(saver);
+            $saver.css('display', 'block');
             var templateData = {
                 icon: bookmarkSvg,
                 isSaved: options.isSaved,

--- a/static/src/stylesheets/module/_submeta.scss
+++ b/static/src/stylesheets/module/_submeta.scss
@@ -41,6 +41,8 @@
 }
 
 .submeta__save-for-later {
+    // Shown with test
+    display: none;
     margin-top: $gs-baseline / 2;
 
     @include mq(tablet) {

--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -123,6 +123,8 @@
 }
 
 .meta__save-for-later {
+    // Shown with test
+    display: none;
     padding-top: $gs-baseline / 2;
     padding-bottom: $gs-baseline / 2;
     margin-bottom: 0;


### PR DESCRIPTION
When you're not in the test, the container is still shown:

![image](https://cloud.githubusercontent.com/assets/921609/8229827/49c26382-15b2-11e5-90d9-fa9ba197052d.png)

This fixes that.
