### PR TITLE
Sfl button article tones

### DIFF
--- a/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
+++ b/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
@@ -1,7 +1,7 @@
 <div class="save-for-later-delete-all" data-link-name="meta-save-for-later-delete--all" data-component="meta-save-for-later--delete-all">
     <button type="submit" class="submit-input button button--medium button--tertiary save-for-later__button--delete-all js-save-for-later__button save-for-later__button--delete-all--<%= state %>" data-link-name="meta-save-for-later--delete-all" value="all" name="deleteArticle">
         <%= icon %>
-        <span class="save-for-later__label save-for-later__label--delete">Remove all</span>
-        <span class="save-for-later__label save-for-later__label--confirm">Remove all stories?</span>
+        <span class="save-for-later__label save-for-later__label--delete-all">Remove all</span>
+        <span class="save-for-later__label save-for-later__label--delete-all--confirm">Remove all stories?</span>
     </button>
 </div>

--- a/static/src/javascripts/projects/common/views/save-for-later/save-button.html
+++ b/static/src/javascripts/projects/common/views/save-for-later/save-button.html
@@ -1,4 +1,4 @@
-<button class="button button--medium button--tertiary save-for-later__button js-save-for-later__button save-for-later--<%= isSaved ? 'saved' : 'save' %>"
+<button class="button button--medium button--tertiary save-for-later__button js-save-for-later__button save-for-later__button--<%= isSaved ? 'saved' : 'save' %>"
    data-link-name="<%= isSaved ? 'Unsave' : 'Save' %> | <%= position %>"
    data-component="save-for-later"
    <%= !isSaved ? 'data-custom-event-properties=\'{ "prop74": "' + config.page.contentType + 'Save:' + config.page.pageId + '" }\'' : '' %>>

--- a/static/src/javascripts/projects/common/views/save-for-later/save-link.html
+++ b/static/src/javascripts/projects/common/views/save-for-later/save-link.html
@@ -1,4 +1,4 @@
-<a class="button button--medium button--tertiary save-for-later__button js-save-for-later__button save-for-later--<%= isSaved ? 'saved' : 'save' %>"
+<a class="button button--medium button--tertiary save-for-later__button js-save-for-later__button save-for-later__button--<%= isSaved ? 'saved' : 'save' %>"
    data-link-name="Save | <%= position %>"
    data-component="save-for-later"
    href="<%= url %>">

--- a/static/src/stylesheets/module/_save-for-later.scss
+++ b/static/src/stylesheets/module/_save-for-later.scss
@@ -1,51 +1,41 @@
-@mixin save-for-later-state($state, $c-accent) {
-    &.save-for-later--#{$state} {
-        .save-for-later__label--#{$state} {
-            display: inline;
-        }
+@mixin sfl-button-style($foreground: colour(neutral-2), $background: #ffffff) {
+    .save-for-later__button--save,
+    .save-for-later__button--saved:hover {
+        color: $foreground;
+        border-color: $foreground;
+        background-color: $background;
 
-        &.button .inline-icon {
-            fill: $c-accent;
+        .inline-icon {
+            fill: $foreground;
+        }
+    }
+
+    .save-for-later__button--saved,
+    .save-for-later__button--save:hover {
+        color: $background;
+        border-color: $foreground;
+        background-color: $foreground;
+
+        .inline-icon {
+            fill: $background;
         }
     }
 }
 
-.button.save-for-later__button {
+@mixin sfl-button-toned($tone, $foreground: colour(news-main-1), $background: #ffffff) {
+    .tonal--tone-#{$tone} {
+        @include sfl-button-style($foreground, $background);
+    }
+}
+
+// size etc
+.save-for-later__button {
     font-size: get-font-size(textSans, 1);
-    width: gs-span(2) - $gs-gutter;
     @include button-height(32px);
-    @include button-colour(
-        $fill-colour: colour(neutral-6),
-        $border-color: colour(neutral-6),
-        $text-colour: colour(neutral-1),
-        $hover-colour: colour(neutral-5),
-        $hover-border: colour(neutral-5)
-    );
-
-    @include save-for-later-state(save, colour(neutral-2));
-    @include save-for-later-state(saved, colour(news-accent));
-    @include save-for-later-state(remove, colour(live-accent));
-    @include save-for-later-state(confirm-delete-all, colour(live-accent));
-    @include save-for-later-state(delete-all, colour(neutral-1));
-
-    &.save-for-later--save {
-        @include button-colour(
-            $fill-colour: transparent,
-            $border-color: colour(neutral-6),
-            $text-colour: colour(neutral-1),
-            $hover-colour: colour(neutral-8),
-            $hover-border: colour(neutral-8)
-        );
-    }
-
-    &:hover {
-        background-color: colour(neutral-5);
-    }
 
     .inline-icon {
-        fill: colour(neutral-1);
-        margin-left: 0;
-        margin: 0 4px 0 0;
+        margin: 0;
+        margin-right: .5em;
 
         svg {
             width: 8px;
@@ -53,6 +43,29 @@
     }
 }
 
+// colours per state
+@include sfl-button-style();
+@include sfl-button-toned(analysis, colour(analysis-accent));
+@include sfl-button-toned(comment, colour(comment-default));
+@include sfl-button-toned(dead, colour(live-default), colour(neutral-7));
+@include sfl-button-toned(editorial, colour(editorial-default));
+@include sfl-button-toned(feature, colour(feature-default));
+@include sfl-button-toned(letters, colour(comment-default));
+@include sfl-button-toned(live, colour(live-default), colour(neutral-8));
+@include sfl-button-toned(media, colour(media-default), colour(media-background));
+@include sfl-button-toned(news);
+@include sfl-button-toned(review, colour(review-background));
+@include sfl-button-toned(special-reports);
+
+// button labels per state
 .save-for-later__label {
     display: none;
+}
+
+@each $state in (save, saved, remove) {
+    .save-for-later__button--#{$state} {
+        .save-for-later__label--#{$state} {
+            display: inline;
+        }
+    }
 }

--- a/static/src/stylesheets/module/_save-for-later.scss
+++ b/static/src/stylesheets/module/_save-for-later.scss
@@ -1,8 +1,11 @@
 @mixin sfl-button-style($foreground: colour(neutral-2), $background: #ffffff) {
+    .save-for-later__button {
+        border-color: $foreground;
+    }
+
     .save-for-later__button--save,
     .save-for-later__button--saved:hover {
         color: $foreground;
-        border-color: $foreground;
         background-color: $background;
 
         .inline-icon {
@@ -13,7 +16,6 @@
     .save-for-later__button--saved,
     .save-for-later__button--save:hover {
         color: $background;
-        border-color: $foreground;
         background-color: $foreground;
 
         .inline-icon {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
@@ -72,7 +72,7 @@
     }
 
     .fc-save-for-later--is-saved .inline-tone-fill {
-        fill: colour(features-mute);
+        fill: colour(feature-mute);
     }
 }
 

--- a/static/src/stylesheets/module/identity/_identity.scss
+++ b/static/src/stylesheets/module/identity/_identity.scss
@@ -479,8 +479,8 @@
     }
 }
 
-.save-for-later__button--delete-all--delete .save-for-later__label--delete,
-.save-for-later__button--delete-all--confirm .save-for-later__label--confirm {
+.save-for-later__button--delete-all--delete .save-for-later__label--delete-all,
+.save-for-later__button--delete-all--confirm .save-for-later__label--delete-all--confirm {
     display: inline;
 }
 


### PR DESCRIPTION
adds tonal treatment to sfl button on articles across all tones, e.g.

![screen shot 2015-06-18 at 13 50 26](https://cloud.githubusercontent.com/assets/867233/8231505/1327704c-15c1-11e5-829a-0f26befd1206.png)
![screen shot 2015-06-18 at 13 50 34](https://cloud.githubusercontent.com/assets/867233/8231508/1572b1cc-15c1-11e5-884a-df9d1bb5f2b6.png)

cc @Pearson82 
