### PR TITLE
Re-auth expired sessions

### DIFF
--- a/facia-tool/README.md
+++ b/facia-tool/README.md
@@ -6,5 +6,7 @@ Setup
    [dev-nginx](https://github.com/guardian/dev-nginx).
 3. Use the mapping in the ```nginx``` folder to generate a host for
    nginx.
-4. Run the app in sbt.
-5. It should now be available at [https://fronts.local.dev-gutools.co.uk](https://fronts.local.dev-gutools.co.uk).
+4. Include the following line in the `nginx` config, i.e. `/usr/local/etc/nginx/sites-enabled/fronts.conf`
+   merge_slashes off;
+5. Run the app in sbt.
+6. It should now be available at [https://fronts.local.dev-gutools.co.uk](https://fronts.local.dev-gutools.co.uk).

--- a/facia-tool/app/controllers/CollectionController.scala
+++ b/facia-tool/app/controllers/CollectionController.scala
@@ -24,7 +24,7 @@ object CreateCollectionResponse {
 case class CreateCollectionResponse(id: String)
 
 object CollectionController extends Controller with PanDomainAuthActions {
-  def create = AuthAction { request =>
+  def create = APIAuthAction { request =>
     request.body.read[CollectionRequest] match {
       case Some(CollectionRequest(frontIds, collection)) =>
         val identity = request.user
@@ -36,7 +36,7 @@ object CollectionController extends Controller with PanDomainAuthActions {
     }
   }
 
-  def update(collectionId: String) = AuthAction { request =>
+  def update(collectionId: String) = APIAuthAction { request =>
     request.body.read[CollectionRequest] match {
       case Some(CollectionRequest(frontIds, collection)) =>
         val identity = request.user

--- a/facia-tool/app/controllers/FaciaContentApiProxy.scala
+++ b/facia-tool/app/controllers/FaciaContentApiProxy.scala
@@ -16,7 +16,7 @@ object FaciaContentApiProxy extends Controller with Logging with ExecutionContex
   override lazy val actorSystem = ActorSystem()
   import play.api.Play.current
 
-  def capi(path: String) = AuthAction.async { request =>
+  def capi(path: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
     val queryString = request.queryString.filter(_._2.exists(_.nonEmpty)).map { p =>
        "%s=%s".format(p._1, p._2.head.urlEncoded)
@@ -35,7 +35,7 @@ object FaciaContentApiProxy extends Controller with Logging with ExecutionContex
     }
   }
 
-  def http(url: String) = AuthAction.async { request =>
+  def http(url: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
 
     WS.url(url).withPreviewAuth.get().map { response =>
@@ -45,7 +45,7 @@ object FaciaContentApiProxy extends Controller with Logging with ExecutionContex
     }
   }
 
-  def json(url: String) = AuthAction.async { request =>
+  def json(url: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
     Logger.info("Proxying json request to: %s".format(url, request))
 
@@ -56,7 +56,7 @@ object FaciaContentApiProxy extends Controller with Logging with ExecutionContex
     }
   }
 
-  def ophan(path: String) = AuthAction.async { request =>
+  def ophan(path: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
     val paths = request.queryString.get("path").map(_.mkString("path=", "&path=", "")).getOrElse("")
     val queryString = request.queryString.filterNot(_._1 == "path").filter(_._2.exists(_.nonEmpty)).map { p =>

--- a/facia-tool/app/controllers/FrontController.scala
+++ b/facia-tool/app/controllers/FrontController.scala
@@ -30,7 +30,7 @@ case class CreateFront(
 )
 
 object FrontController extends Controller with PanDomainAuthActions {
-  def create = AuthAction { request =>
+  def create = APIAuthAction { request =>
     request.body.read[CreateFront] match {
       case Some(createFrontRequest) =>
         val identity = request.user
@@ -42,7 +42,7 @@ object FrontController extends Controller with PanDomainAuthActions {
     }
   }
 
-  def update(frontId: String) = AuthAction { request =>
+  def update(frontId: String) = APIAuthAction { request =>
     request.body.read[FrontJson] match {
       case Some(front) =>
         val identity = request.user

--- a/facia-tool/app/controllers/FrontendDependentController.scala
+++ b/facia-tool/app/controllers/FrontendDependentController.scala
@@ -43,7 +43,7 @@ object FrontendDependentController extends Controller with PanDomainAuthActions 
     "snap"
   )
 
-  def configuration = AuthAction { request =>
+  def configuration = APIAuthAction { request =>
     Cached(60) {
       Ok(Json.toJson(Defaults(
         Play.isDev,

--- a/facia-tool/app/controllers/SwitchesProxy.scala
+++ b/facia-tool/app/controllers/SwitchesProxy.scala
@@ -10,7 +10,7 @@ import auth.PanDomainAuthActions
 
 object SwitchesProxy extends Controller with PanDomainAuthActions {
 
-  def getSwitches() = AuthAction { request =>
+  def getSwitches() = APIAuthAction { request =>
     FaciaToolMetrics.ProxyCount.increment()
     val r = Switches.all.map {switch =>
       switch.name -> switch.isSwitchedOn

--- a/facia-tool/public/js/main.js
+++ b/facia-tool/public/js/main.js
@@ -5,7 +5,6 @@ import 'font-awesome/css/font-awesome.min.css!';
 import {init, update, differs} from 'modules/vars';
 import logger from 'utils/logger';
 import oauthSession from 'utils/oauth-session';
-import {onVisibilityChange} from 'utils/oauth-session';
 
 function terminate (error) {
     if (error) {
@@ -55,7 +54,6 @@ export default function load (ModuleClass) {
         update(res);
         bootstrap.every(updateModuleConfig);
         oauthSession();
-        onVisibilityChange();
     }
 
     bootstrap = new Bootstrap()

--- a/facia-tool/public/js/main.js
+++ b/facia-tool/public/js/main.js
@@ -5,6 +5,7 @@ import 'font-awesome/css/font-awesome.min.css!';
 import {init, update, differs} from 'modules/vars';
 import logger from 'utils/logger';
 import oauthSession from 'utils/oauth-session';
+import {onVisibilityChange} from 'utils/oauth-session';
 
 function terminate (error) {
     if (error) {
@@ -54,6 +55,7 @@ export default function load (ModuleClass) {
         update(res);
         bootstrap.every(updateModuleConfig);
         oauthSession();
+        onVisibilityChange();
     }
 
     bootstrap = new Bootstrap()

--- a/facia-tool/public/js/models/collections/article.js
+++ b/facia-tool/public/js/models/collections/article.js
@@ -819,7 +819,7 @@ define([
                 url: '/http/proxy/' + url + (isOnSite ? '?view=mobile' : ''),
                 type: 'GET'
             })
-            .done(function(response) {
+            .then(function(response) {
                 var doc = document.createElement('div'),
                     title,
                     og = {};
@@ -843,7 +843,7 @@ define([
 
                 self.updateEditorsDisplay();
             })
-            .fail(function() {
+            .catch(function() {
                 self.meta.headline(undefined);
             });
         };

--- a/facia-tool/public/js/models/collections/collection.js
+++ b/facia-tool/public/js/models/collections/collection.js
@@ -267,7 +267,7 @@ define([
         authedAjax.request({
             url: vars.CONST.apiBase + '/collection/' + this.id
         })
-        .done(function(raw) {
+        .then(function(raw) {
             if (opts.isRefresh && self.isPending()) { return; }
 
             if (!raw) {
@@ -285,10 +285,10 @@ define([
 
             self.state.timeAgo(self.getTimeAgo(raw.lastUpdated));
         })
-        .fail(function () {
+        .catch(function () {
             self.loaded.resolve();
         })
-        .always(function() {
+        .then(function() {
             self.setPending(false);
         });
 

--- a/facia-tool/public/js/models/collections/new-items.js
+++ b/facia-tool/public/js/models/collections/new-items.js
@@ -50,13 +50,8 @@ define([
     }
 
     function newItemsValidator(newItems, context) {
-        var defer = $.Deferred();
-
-        contentApi.validateItem(newItems[0])
-        .fail(function(err) {
-            defer.reject(err);
-        })
-        .done(function(item) {
+        return contentApi.validateItem(newItems[0])
+        .then(function(item) {
             var front = context ? context.front() : '',
                 err;
 
@@ -73,13 +68,11 @@ define([
             }
 
             if (err) {
-                defer.reject(err);
+                throw new Error(err);
             } else {
-                defer.resolve(item);
+                return item;
             }
         });
-
-        return defer.promise();
     }
 
     function newItemsPersister(newItems, sourceContext, sourceGroup, targetContext, targetGroup, position, isAfter) {

--- a/facia-tool/public/js/models/config/collection.js
+++ b/facia-tool/public/js/models/config/collection.js
@@ -190,8 +190,9 @@ define([
         apiQuery += 'show-fields=headline';
 
         contentApi.fetchContent(apiQuery)
-        .done(function(results) {
+        .then(function(res) {
             if (cc === checkCount) {
+                var results = res && res.content;
                 self.capiResults(results || []);
                 self.state.apiQueryStatus(results && results.length ? 'valid' : 'invalid');
             }

--- a/facia-tool/public/js/models/config/front.js
+++ b/facia-tool/public/js/models/config/front.js
@@ -199,7 +199,7 @@ define([
         this.collections.items().map(function(collection) { collection.close(); });
 
         contentApi.fetchMetaForPath(this.id())
-        .done(function(meta) {
+        .then(function(meta) {
             meta = meta || {};
             _.each(self.capiProps, function(val, key) {
                 val(meta[key]);

--- a/facia-tool/public/js/models/config/main.js
+++ b/facia-tool/public/js/models/config/main.js
@@ -9,7 +9,7 @@ import findFirstById from 'utils/find-first-by-id';
 import Group from 'models/group';
 import Front from 'models/config/front';
 import Collection from 'models/config/collection';
-import newItems from 'models/config/new-items';
+import * as newItems from 'models/config/new-items';
 import persistence from 'models/config/persistence';
 import frontCount from 'utils/front-count';
 

--- a/facia-tool/public/js/models/config/new-items.js
+++ b/facia-tool/public/js/models/config/new-items.js
@@ -1,36 +1,26 @@
-define([
-    'jquery',
-    'modules/vars',
-    'utils/url-abs-path',
-    'utils/find-first-by-id'
-], function(
-    $,
-    vars,
-    urlAbsPath,
-    findFirstById
-) {
-    urlAbsPath = urlAbsPath.default;
-    findFirstById = findFirstById.default;
+import Promise from 'Promise';
+import * as vars from 'modules/vars';
+import urlAbsPath from 'utils/url-abs-path';
+import findFirstById from 'utils/find-first-by-id';
 
-    return {
-        newItemsConstructor: function(id) {
-            return [findFirstById(vars.model.collections, urlAbsPath(id))];
-        },
+function newItemsConstructor (id) {
+    return [findFirstById(vars.model.collections, urlAbsPath(id))];
+}
 
-        newItemsValidator: function(newItems) {
-            var defer = $.Deferred();
+function newItemsValidator (newItems) {
+    return Promise[newItems[0] ? 'resolve' : 'reject']();
+}
 
-            defer[newItems[0] ? 'resolve' : 'reject']();
+function newItemsPersister (newItems, sourceContext, sourceGroup, targetContext, targetGroup) {
+    if (newItems[0].parents.indexOf(targetGroup.parent) < 0) {
+        newItems[0].parents.push(targetGroup.parent);
+    }
 
-            return defer.promise();
-        },
+    targetGroup.parent.saveProps();
+}
 
-        newItemsPersister: function(newItems, sourceContext, sourceGroup, targetContext, targetGroup) {
-            if (newItems[0].parents.indexOf(targetGroup.parent) < 0) {
-                newItems[0].parents.push(targetGroup.parent);
-            }
-
-            targetGroup.parent.saveProps();
-        }
-    };
-});
+export {
+    newItemsConstructor,
+    newItemsValidator,
+    newItemsPersister
+};

--- a/facia-tool/public/js/models/config/persistence.js
+++ b/facia-tool/public/js/models/config/persistence.js
@@ -14,13 +14,15 @@ define([
     var postUpdate = function (opts) {
         vars.model.pending(true);
 
-        authedAjax.request(_.extend({
-            type: 'POST'
-        }, opts)).always(function () {
+        function callCallbacks () {
             _.each(onUpdateCallbacks, function (callback) {
                 callback();
             });
-        });
+        }
+
+        authedAjax.request(_.extend({
+            type: 'POST'
+        }, opts)).then(callCallbacks, callCallbacks);
     };
 
     /**

--- a/facia-tool/public/js/modules/bootstrap.js
+++ b/facia-tool/public/js/modules/bootstrap.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import authedAjax from 'modules/authed-ajax';
+import {request} from 'modules/authed-ajax';
 import CONST from 'constants/defaults';
 import Promise from 'Promise';
 
@@ -20,20 +20,18 @@ var endpoints = [{
 }];
 
 function sendRequest (endpoint) {
-    return new Promise(function (resolve, reject) {
-        authedAjax.request({
-            url: endpoint.url
-        })
-        .then(function (response) {
-            var error = endpoint.validate && endpoint.validate(response);
-            if (error) {
-                reject(error);
-            } else {
-                resolve(response);
-            }
-        }, function () {
-            reject(new Error('The ' + endpoint.key + ' is invalid or unavailable'));
-        });
+    return request({
+        url: endpoint.url
+    })
+    .then(function (response) {
+        var error = endpoint.validate && endpoint.validate(response);
+        if (error) {
+            throw error;
+        } else {
+            return response;
+        }
+    }, function () {
+        throw new Error('The ' + endpoint.key + ' is invalid or unavailable');
     });
 }
 

--- a/facia-tool/public/js/modules/cache.js
+++ b/facia-tool/public/js/modules/cache.js
@@ -1,49 +1,50 @@
 /*eslint-disable consistent-return*/
-define(['modules/vars'], function(vars) {
-    var cache = {},
-        expiry = vars.CONST.cacheExpiryMs || 300000; // 300000 == 5 mins
+import {CONST} from 'modules/vars';
 
-    function put(pot, key, data) {
-        var p;
+export let overrides = {
+    Date: Date
+};
 
-        if (!pot || !key) { return; }
+var cache = {},
+    expiry = CONST.cacheExpiryMs || 300000; // 300000 == 5 mins
 
-        p = cache[pot];
+function put(pot, key, data) {
+    var p;
 
-        if (!p) {
-            p = cache[pot] = {};
-        }
+    if (!pot || !key) { return; }
 
-        p[key] = {
-            data: JSON.stringify(data),
+    p = cache[pot];
 
-            // Spread actual timeouts into the range of "two-times expiry"
-            time: +new Date() + expiry * Math.random()
-        };
-
-        return data;
+    if (!p) {
+        p = cache[pot] = {};
     }
 
-    function get(pot, key) {
-        var p,
-            obj;
+    p[key] = {
+        data: JSON.stringify(data),
 
-        if (!pot || !key) { return; }
-
-        p = cache[pot];
-        obj = p ? p[key] : undefined;
-
-        if (!obj) { return; }
-
-        if (+new Date() - obj.time > expiry) {
-            return;
-        }
-
-        return obj.data ? JSON.parse(obj.data) : undefined;
-    }
-
-    return {
-        put: put,
-        get: get
+        // Spread actual timeouts into the range of "two-times expiry"
+        time: +new overrides.Date() + expiry * Math.random()
     };
-});
+
+    return data;
+}
+
+function get(pot, key) {
+    var p,
+        obj;
+
+    if (!pot || !key) { return; }
+
+    p = cache[pot];
+    obj = p ? p[key] : undefined;
+
+    if (!obj) { return; }
+
+    if (+new overrides.Date() - obj.time > expiry) {
+        return;
+    }
+
+    return obj.data ? JSON.parse(obj.data) : undefined;
+}
+
+export {put, get};

--- a/facia-tool/public/js/modules/content-api.js
+++ b/facia-tool/public/js/modules/content-api.js
@@ -1,48 +1,71 @@
-define([
-    'underscore',
-    'jquery',
-    'modules/vars',
-    'modules/authed-ajax',
-    'modules/cache',
-    'modules/modal-dialog',
-    'utils/internal-content-code',
-    'utils/url-abs-path',
-    'utils/identity',
-    'utils/is-guardian-url',
-    'utils/snap'
-],
-function (
-    _,
-    $,
-    vars,
-    authedAjax,
-    cache,
-    modalDialog,
-    internalContentCode,
-    urlAbsPath,
-    identity,
-    isGuardianUrl,
-    snap
-){
-    modalDialog = modalDialog.default;
-    internalContentCode = internalContentCode.default;
-    isGuardianUrl = isGuardianUrl.default;
-    urlAbsPath = urlAbsPath.default;
+/*eslint-disable consistent-return*/
+import _ from 'underscore';
+import $ from 'jquery';
+import Promise from 'Promise';
+import {CONST} from 'modules/vars';
+import {request} from 'modules/authed-ajax';
+import * as cache from 'modules/cache';
+import modalDialog from 'modules/modal-dialog';
+import internalContentCode from 'utils/internal-content-code';
+import urlAbsPath from 'utils/url-abs-path';
+import identity from 'utils/identity';
+import isGuardianUrl from 'utils/is-guardian-url';
+import * as snap from 'utils/snap';
 
-    function validateItem (item) {
-        var defer = $.Deferred(),
-            snapId = snap.validateId(item.id()),
+function populate(article, capiData) {
+    article.addCapiData(capiData);
+}
+
+function getTagOrSectionTitle(response) {
+    return _.chain([response.tag, response.section])
+        .pluck('webTitle')
+        .filter(identity)
+        .first()
+        .value();
+}
+
+function fetchContent(apiUrl) {
+    return request({
+        url: CONST.apiSearchBase + '/' + apiUrl
+    }).then(function(resp) {
+        if (!resp.response
+            || _.intersection(['content', 'editorsPicks', 'results', 'mostViewed'], _.keys(resp.response)).length === 0
+            || resp.response.status === 'error') {
+            return;
+        } else if (resp.response.content) {
+            return {
+                content: [resp.response.content],
+                title: getTagOrSectionTitle(resp.response)
+            };
+        } else {
+            return {
+                content: _.chain(['editorsPicks', 'results', 'mostViewed'])
+                    .filter(function(key) { return _.isArray(resp.response[key]); })
+                    .map(function(key) { return resp.response[key]; })
+                    .flatten()
+                    .value(),
+                title: getTagOrSectionTitle(resp.response)
+            };
+        }
+    })
+    // swallow error
+    .catch(function () {});
+}
+
+function validateItem (item) {
+    return new Promise(function (resolve, reject) {
+        var snapId = snap.validateId(item.id()),
             capiId = urlAbsPath(item.id()),
             data = cache.get('contentApi', capiId);
 
         if (snapId) {
             item.id(snapId);
-            defer.resolve(item);
+            resolve(item);
 
         } else if (data) {
             item.id(capiId);
             populate(item, data);
-            defer.resolve(item);
+            resolve(item);
 
         } else {
             // Tag combiners need conversion from tag1+tag2 to search?tag=tag1,tag2
@@ -52,11 +75,14 @@ function (
                 capiId += '?';
             }
 
-            capiId += vars.CONST.apiSearchParams;
+            capiId += CONST.apiSearchParams;
 
             fetchContent(capiId)
-            .done(function(results, resultsTitle) {
-                var capiItem,
+            .then(function(res) {
+                res = res || {};
+                var results = res.content,
+                    resultsTitle = res.title,
+                    capiItem,
                     icc,
                     err;
 
@@ -97,15 +123,15 @@ function (
                     modalDialog.confirm({
                         name: 'select_snap_type',
                         data: {
-                            prefix: vars.CONST.latestSnapPrefix,
+                            prefix: CONST.latestSnapPrefix,
                             resultsTitle: resultsTitle
                         }
                     }).then(function () {
                         item.convertToLatestSnap(resultsTitle);
-                        defer.resolve(item);
+                        resolve(item);
                     }, function () {
                         item.convertToLinkSnap();
-                        defer.resolve(item);
+                        resolve(item);
                     });
 
                     // Waiting for the modal to be closed
@@ -117,211 +143,165 @@ function (
                 }
 
                 if (err) {
-                    defer.reject(err);
+                    reject(new Error(err));
                 } else {
-                    defer.resolve(item);
+                    resolve(item);
                 }
             });
         }
+    });
+}
 
-        return defer.promise();
+function fetchContentByIds(ids) {
+    var capiIds = _.chain(ids)
+        .filter(function(id) { return !snap.validateId(id); })
+        .map(function(id) { return encodeURIComponent(id); })
+        .value();
+
+    if (capiIds.length) {
+        return fetchContent('search?ids=' + capiIds.join(',') + '&' + CONST.apiSearchParams);
+    } else {
+        return Promise.resolve([]);
     }
+}
 
-    function decorateItems (articles) {
-        var num = vars.CONST.capiBatchSize || 10,
-            pending = [];
+function decorateBatch (articles) {
+    var ids = [];
 
-        _.each(_.range(0, articles.length, num), function(index) {
-            pending.push(decorateBatch(articles.slice(index, index + num)));
-        });
-
-        return $.when.apply($, pending);
-    }
-
-    function decorateBatch (articles) {
-        var ids = [];
-
-        articles.forEach(function(article){
-            var data = cache.get('contentApi', article.id());
-            if(data) {
-                populate(article, data);
-            } else {
-                ids.push(article.id());
-            }
-        });
-
-        return fetchContentByIds(ids)
-        .done(function(results){
-            if (!_.isArray(results)) {
-                return;
-            }
-
-            results.forEach(function(result) {
-                var icc = internalContentCode(result);
-
-                if(icc) {
-                    cache.put('contentApi', icc, result);
-
-                    _.filter(articles, function(article) {
-                        return article.id() === icc;
-                    }).forEach(function(article) {
-                        populate(article, result);
-                    });
-                }
-            });
-
-           _.chain(articles)
-            // legacy-snaps
-            .filter(function(article) { return !article.meta.href(); })
-
-            .filter(function(article) { return !article.meta.snapType(); })
-            .each(function(article) {
-                article.state.isEmpty(!article.state.isLoaded());
-            });
-        });
-    }
-
-    function populate(article, capiData) {
-        article.addCapiData(capiData);
-    }
-
-    function fetchContentByIds(ids) {
-        var capiIds = _.chain(ids)
-            .filter(function(id) { return !snap.validateId(id); })
-            .map(function(id) { return encodeURIComponent(id); })
-            .value();
-
-        if (capiIds.length) {
-            return fetchContent('search?ids=' + capiIds.join(',') + '&' + vars.CONST.apiSearchParams);
+    articles.forEach(function(article){
+        var data = cache.get('contentApi', article.id());
+        if(data) {
+            populate(article, data);
         } else {
-            return $.Deferred().resolve([]);
+            ids.push(article.id());
         }
-    }
+    });
 
-    function fetchContent(apiUrl) {
-        var defer = $.Deferred();
-
-        authedAjax.request({
-            url: vars.CONST.apiSearchBase + '/' + apiUrl
-        }).always(function(resp) {
-            if (!resp.response
-                || _.intersection(['content', 'editorsPicks', 'results', 'mostViewed'], _.keys(resp.response)).length === 0
-                || resp.response.status === 'error') {
-                defer.resolve();
-            } else if (resp.response.content) {
-                defer.resolve([resp.response.content], getTagOrSectionTitle(resp.response));
-            } else {
-                defer.resolve(
-                   _.chain(['editorsPicks', 'results', 'mostViewed'])
-                    .filter(function(key) { return _.isArray(resp.response[key]); })
-                    .map(function(key) { return resp.response[key]; })
-                    .flatten()
-                    .value(),
-                    getTagOrSectionTitle(resp.response)
-                );
-            }
-        });
-
-        return defer.promise();
-    }
-
-    function getTagOrSectionTitle(response) {
-        return _.chain([response.tag, response.section])
-            .filter(identity)
-            .pluck('webTitle')
-            .first()
-            .value();
-    }
-
-    function fetchMetaForPath(path) {
-        var defer = $.Deferred();
-
-        authedAjax.request({
-            url: vars.CONST.apiSearchBase + '/' + path + '?page-size=0'
-        }).always(function(resp) {
-            defer.resolve(!resp.response ? {} :
-               _.chain(['tag', 'section'])
-                .map(function(key) { return resp.response[key]; })
-                .filter(function(obj) { return _.isObject(obj); })
-                .reduce(function(m, obj) {
-                    m.section = m.section || _.last((obj.id || obj.sectionId).split('/'));
-                    m.webTitle = m.webTitle || obj.webTitle;
-                    m.description = m.description || obj.description; // upcoming in Capi, at time of writing
-                    m.title = m.title || obj.title;                   // this may never be added to Capi, or may under another name
-                    return m;
-                 }, {})
-                .value());
-        });
-
-        return defer.promise();
-    }
-
-    function dateYyyymmdd() {
-        var d = new Date();
-        return [d.getFullYear(), d.getMonth() + 1, d.getDate()].map(function(p) { return p < 10 ? '0' + p : p; }).join('-');
-    }
-
-    function fetchLatest (options) {
-        var url = vars.CONST.apiSearchBase + '/',
-            propName, term, filter;
-
-        options = _.extend({
-            article: '',
-            term: '',
-            filter: '',
-            filterType: '',
-            page: 1,
-            pageSize: vars.CONST.searchPageSize || 25,
-            isDraft: true
-        }, options);
-        term = options.term;
-        filter = options.filter;
-
-        if (options.article) {
-            term = options.article;
-            propName = 'content';
-            url += term + '?' + vars.CONST.apiSearchParams;
-        } else {
-            term = encodeURIComponent(term.trim());
-            propName = 'results';
-            url += 'search?' + vars.CONST.apiSearchParams;
-            url += options.isDraft ?
-                '&content-set=-web-live&order-by=oldest&use-date=scheduled-publication&from-date=' + dateYyyymmdd() :
-                '&content-set=web-live&order-by=newest';
-            url += '&page-size=' + options.pageSize;
-            url += '&page=' + options.page;
-            url += term ? '&q=' + term : '';
-            url += filter ? '&' + options.filterType + '=' + encodeURIComponent(filter) : '';
+    return fetchContentByIds(ids)
+    .then(function(res){
+        var results = res.content;
+        if (!_.isArray(results)) {
+            return;
         }
 
-        var deferred = new $.Deferred();
-        authedAjax.request({
-            url: url
-        }).then(function(data) {
-            var rawArticles = data.response && data.response[propName] ? [].concat(data.response[propName]) : [];
+        results.forEach(function(result) {
+            var icc = internalContentCode(result);
 
-            if (!term && !filter && !rawArticles.length) {
-                deferred.reject(new Error('Sorry, the Content API is not currently returning content'));
-            } else {
-                deferred.resolve(_.extend({}, data.response, {
-                    results: _.filter(rawArticles, function(opts) {
-                        return opts.fields && opts.fields.headline;
-                    })
-                }));
+            if(icc) {
+                cache.put('contentApi', icc, result);
+
+                _.filter(articles, function(article) {
+                    return article.id() === icc;
+                }).forEach(function(article) {
+                    populate(article, result);
+                });
             }
-        }, function (xhr) {
-            deferred.reject(new Error('Content API error (' + xhr.status + '). Content is currently unavailable'));
         });
 
-        return deferred.promise();
+       _.chain(articles)
+        // legacy-snaps
+        .filter(function(article) { return !article.meta.href(); })
+
+        .filter(function(article) { return !article.meta.snapType(); })
+        .each(function(article) {
+            article.state.isEmpty(!article.state.isLoaded());
+        });
+    });
+}
+
+function decorateItems (articles) {
+    var num = CONST.capiBatchSize || 10,
+        pending = [];
+
+    _.each(_.range(0, articles.length, num), function(index) {
+        pending.push(decorateBatch(articles.slice(index, index + num)));
+    });
+
+    return Promise.all(pending);
+}
+
+function fetchMetaForPath(path) {
+    return request({
+        url: CONST.apiSearchBase + '/' + path + '?page-size=0'
+    }).then(function(resp) {
+        return !resp.response ? {} :
+           _.chain(['tag', 'section'])
+            .map(function(key) { return resp.response[key]; })
+            .filter(function(obj) { return _.isObject(obj); })
+            .reduce(function(m, obj) {
+                m.section = m.section || _.last((obj.id || obj.sectionId || '').split('/'));
+                m.webTitle = m.webTitle || obj.webTitle;
+                m.description = m.description || obj.description; // upcoming in Capi, at time of writing
+                m.title = m.title || obj.title;                   // this may never be added to Capi, or may under another name
+                return m;
+             }, {})
+            .value();
+    })
+    // swallow error
+    .catch(function () {});
+}
+
+function dateYyyymmdd() {
+    var d = new Date();
+    return [d.getFullYear(), d.getMonth() + 1, d.getDate()].map(function(p) { return p < 10 ? '0' + p : p; }).join('-');
+}
+
+function fetchLatest (options) {
+    var url = CONST.apiSearchBase + '/',
+        propName, term, filter;
+
+    options = _.extend({
+        article: '',
+        term: '',
+        filter: '',
+        filterType: '',
+        page: 1,
+        pageSize: CONST.searchPageSize || 25,
+        isDraft: true
+    }, options);
+    term = options.term;
+    filter = options.filter;
+
+    if (options.article) {
+        term = options.article;
+        propName = 'content';
+        url += term + '?' + CONST.apiSearchParams;
+    } else {
+        term = encodeURIComponent(term.trim());
+        propName = 'results';
+        url += 'search?' + CONST.apiSearchParams;
+        url += options.isDraft ?
+            '&content-set=-web-live&order-by=oldest&use-date=scheduled-publication&from-date=' + dateYyyymmdd() :
+            '&content-set=web-live&order-by=newest';
+        url += '&page-size=' + options.pageSize;
+        url += '&page=' + options.page;
+        url += term ? '&q=' + term : '';
+        url += filter ? '&' + options.filterType + '=' + encodeURIComponent(filter) : '';
     }
 
-    return {
-        fetchContent: fetchContent,
-        fetchMetaForPath: fetchMetaForPath,
-        decorateItems: decorateItems,
-        validateItem:  validateItem,
-        fetchLatest: fetchLatest
-    };
+    return request({
+        url: url
+    }).then(function (data) {
+        var rawArticles = data.response && data.response[propName] ? [].concat(data.response[propName]) : [];
 
-});
+        if (!term && !filter && !rawArticles.length) {
+            throw new Error('Sorry, the Content API is not currently returning content');
+        } else {
+            return _.extend({}, data.response, {
+                results: _.filter(rawArticles, function(opts) {
+                    return opts.fields && opts.fields.headline;
+                })
+            });
+        }
+    }, function (xhr) {
+        throw new Error('Content API error (' + xhr.status + '). Content is currently unavailable');
+    });
+}
+
+export {
+    fetchContent,
+    fetchMetaForPath,
+    decorateItems,
+    validateItem,
+    fetchLatest
+};

--- a/facia-tool/public/js/modules/list-manager.js
+++ b/facia-tool/public/js/modules/list-manager.js
@@ -71,14 +71,14 @@ define([
         opts.targetGroup.items.splice(insertAt, 0, newItems[0]);
 
         opts.newItemsValidator(newItems, opts.targetContext)
-        .fail(function(err) {
-            _.each(newItems, function(item) { opts.targetGroup.items.remove(item); });
-            alertBadContent(err);
-        })
-        .done(function() {
+        .then(function() {
             if (opts.targetGroup.parent) {
                 opts.newItemsPersister(newItems, opts.sourceContext, opts.sourceGroup, opts.targetContext, opts.targetGroup, position, opts.isAfter);
             }
+        })
+        .catch(function(err) {
+            _.each(newItems, function(item) { opts.targetGroup.items.remove(item); });
+            alertBadContent(err.message);
         });
     }
 

--- a/facia-tool/public/js/utils/fetch-lastmodified.js
+++ b/facia-tool/public/js/utils/fetch-lastmodified.js
@@ -1,5 +1,4 @@
-import Promise from 'Promise';
-import authedAjax from 'modules/authed-ajax';
+import {request} from 'modules/authed-ajax';
 import {priority, CONST} from 'modules/vars';
 import humanTime from 'utils/human-time';
 
@@ -10,22 +9,23 @@ function getFrontAgeAlertMs(front) {
 }
 
 export default function(front) {
-    return new Promise(function (resolve) {
-        authedAjax.request({
-            url: '/front/lastmodified/' + front
-        })
-        .always(function(resp) {
-            if (resp.status === 200 && resp.responseText) {
-                var date = new Date(resp.responseText);
+    // The server does not respond with JSON
+    function parseResponse (resp) {
+        if (resp.status === 200 && resp.responseText) {
+            var date = new Date(resp.responseText);
 
-                resolve({
-                    date: date,
-                    human: humanTime(date),
-                    stale: new Date() - date > getFrontAgeAlertMs(front)
-                });
-            } else {
-                resolve({});
-            }
-        });
-    });
+            return {
+                date: date,
+                human: humanTime(date),
+                stale: new Date() - date > getFrontAgeAlertMs(front)
+            };
+        } else {
+            return {};
+        }
+    }
+
+    return request({
+        url: '/front/lastmodified/' + front
+    })
+    .then(parseResponse, parseResponse);
 }

--- a/facia-tool/public/js/utils/fetch-visible-stories.js
+++ b/facia-tool/public/js/utils/fetch-visible-stories.js
@@ -1,36 +1,31 @@
 import Promise from 'Promise';
 import _ from 'underscore';
-import authedAjax from 'modules/authed-ajax';
+import {request} from 'modules/authed-ajax';
 
 export default function(type, groups) {
-    return new Promise(function (resolve, reject) {
-        var stories = [];
-        _.each(groups, function (group) {
-            _.each(group.items(), function (story) {
-                stories.push({
-                    group: story.group.index,
-                    isBoosted: !!story.meta.isBoosted()
-                });
+    var stories = [];
+    _.each(groups, function (group) {
+        _.each(group.items(), function (story) {
+            stories.push({
+                group: story.group.index,
+                isBoosted: !!story.meta.isBoosted()
             });
         });
-
-        if (!stories.length) {
-            reject(new Error('Empty collection'));
-        } else {
-            authedAjax.request({
-                url: '/stories-visible/' + type,
-                method: 'POST',
-                data: JSON.stringify({
-                    stories: stories
-                }),
-                dataType: 'json'
-            })
-            .done(function (result) {
-                resolve(result);
-            })
-            .fail(function (error) {
-                reject(new Error(error.statusText));
-            });
-        }
     });
+
+    if (!stories.length) {
+        return Promise.reject(new Error('Empty collection'));
+    } else {
+        return request({
+            url: '/stories-visible/' + type,
+            method: 'POST',
+            data: JSON.stringify({
+                stories: stories
+            }),
+            dataType: 'json'
+        })
+        .catch(function (error) {
+            throw new Error(error.statusText);
+        });
+    }
 }

--- a/facia-tool/public/js/utils/oauth-session.js
+++ b/facia-tool/public/js/utils/oauth-session.js
@@ -32,11 +32,3 @@ export function reauth (overridePanda) {
     }
     return currentAction;
 }
-
-export function onVisibilityChange () {
-    document.addEventListener('visibilitychange', function () {
-        if (!document.hidden) {
-            reauth().catch(locationRedirect);
-        }
-    }, false);
-}

--- a/facia-tool/public/js/utils/presser.js
+++ b/facia-tool/public/js/utils/presser.js
@@ -1,26 +1,28 @@
 import _ from 'underscore';
-import authedAjax from 'modules/authed-ajax';
+import {request} from 'modules/authed-ajax';
 import {CONST} from 'modules/vars';
 import mediator from 'utils/mediator';
 
 var detectPressFailureCount = 0;
 var detectFailures = _.debounce(function (front) {
-    var count = ++detectPressFailureCount;
+    var count = ++detectPressFailureCount,
+        parseResponse = function(resp) {
+            var lastPressed;
 
-    authedAjax.request({
+            if (detectPressFailureCount === count && resp.status === 200) {
+                lastPressed = new Date(resp.responseText);
+
+                if (_.isDate(lastPressed)) {
+                    mediator.emit('presser:lastupdate', front, lastPressed);
+                }
+            }
+        };
+
+    request({
         url: '/front/lastmodified/' + front
     })
-    .always(function(resp) {
-        var lastPressed;
+    .then(parseResponse, parseResponse);
 
-        if (detectPressFailureCount === count && resp.status === 200) {
-            lastPressed = new Date(resp.responseText);
-
-            if (_.isDate(lastPressed)) {
-                mediator.emit('presser:lastupdate', front, lastPressed);
-            }
-        }
-    });
 }, CONST.detectPressFailureMs || 10000);
 
 mediator.on('presser:detectfailures', function (front) {
@@ -28,12 +30,14 @@ mediator.on('presser:detectfailures', function (front) {
 });
 
 export default function(env, front) {
-    authedAjax.request({
+    return request({
         url: '/press/' + env + '/' + front,
         method: 'post'
-    }).always(function () {
+    })
+    .then(function () {
         if (env === 'live') {
             detectFailures(front);
         }
-    });
+    })
+    .catch(function () {});
 }

--- a/facia-tool/public/js/utils/sparklines.js
+++ b/facia-tool/public/js/utils/sparklines.js
@@ -3,8 +3,9 @@ import * as vars from 'modules/vars';
 import ko from 'knockout';
 import _ from 'underscore';
 import $ from 'jquery';
+import Promise from 'Promise';
 import numeral from 'numeral';
-import authedAjax from 'modules/authed-ajax';
+import {request} from 'modules/authed-ajax';
 import Highcharts from 'utils/highcharts';
 import mediator from 'utils/mediator';
 import parseQueryParams from 'utils/parse-query-params';
@@ -130,30 +131,25 @@ function serializeParams (front, articles, options) {
 }
 
 function reduceRequest (memo, front, articles, options) {
-    var deferred = new $.Deferred();
-
-    authedAjax.request({
+    return request({
         url: '/ophan/histogram?' + serializeParams(front, articles, options)
-    }).then(function (data) {
+    })
+    .then(function (data) {
         _.each(data, function (content) {
             memo[content.path] = content;
         });
 
-        deferred.resolve(memo);
-    }).fail(function (error) {
-        deferred.reject(error);
+        return memo;
     });
-
-    return deferred.promise();
 }
 
 function getHistogram (front, articles, options) {
-    var deferred = new $.Deferred().resolve({});
+    var chain = Promise.resolve({});
 
     // Allow max articles in one request or the GET request is too big
     var maxArticles = vars.CONST.sparksBatchQueue;
     _.each(_.range(0, articles.length, maxArticles), function (limit) {
-        deferred = deferred.then(function (memo) {
+        chain = chain.then(function (memo) {
             return reduceRequest(
                 memo,
                 front,
@@ -163,7 +159,7 @@ function getHistogram (front, articles, options) {
         });
     });
 
-    return deferred;
+    return chain;
 }
 
 function differential (collection) {

--- a/facia-tool/public/js/widgets/clipboard.js
+++ b/facia-tool/public/js/widgets/clipboard.js
@@ -4,7 +4,7 @@ import _ from 'underscore';
 import BaseWidget from 'widgets/base-widget';
 import Article from 'models/collections/article';
 import Group from 'models/group';
-import contentApi from 'modules/content-api';
+import * as contentApi from 'modules/content-api';
 import copiedArticle from 'modules/copied-article';
 import * as globalListeners from 'utils/global-listeners';
 import * as storage from 'utils/local-storage';

--- a/facia-tool/test/public/spec/authed.ajax.spec.js
+++ b/facia-tool/test/public/spec/authed.ajax.spec.js
@@ -1,0 +1,345 @@
+import Promise from 'Promise';
+import * as ajax from 'modules/authed-ajax';
+import * as mockjax from 'test/utils/mockjax';
+import $ from 'jquery';
+import * as panda from 'panda-session';
+import * as vars from 'modules/vars';
+
+describe('Authed Ajax', function () {
+    beforeEach(function () {
+        this.scope = mockjax.scope();
+        this.scope({
+            url: '/success',
+            status: 200,
+            responseText: {}
+        }, {
+            url: '/fail',
+            status: 500,
+            responseText: {}
+        }, {
+            url: '/auth',
+            status: 419,
+            responseText: {}
+        }, {
+            url: '/redirect',
+            status: 403,
+            responseText: {}
+        });
+        spyOn($, 'ajax').and.callThrough();
+        var win = {
+            location: {
+                reload: function () {}
+            }
+        };
+        spyOn(win.location, 'reload');
+        this.win = win;
+    });
+    afterEach(function () {
+        this.scope.clear();
+    });
+
+    it('sends a successful request', function (done) {
+        ajax.request({
+            url: '/success'
+        }).then(function () {
+            expect($.ajax).toHaveBeenCalledWith({
+                url: '/success',
+                dataType: 'json',
+                contentType: undefined
+            });
+            done();
+        });
+    });
+
+    it('sends a successful request override type', function (done) {
+        ajax.request({
+            url: '/success',
+            type: 'banana'
+        }).then(function () {
+            expect($.ajax).toHaveBeenCalledWith({
+                url: '/success',
+                dataType: undefined,
+                type: 'banana',
+                contentType: undefined
+            });
+            done();
+        });
+    });
+
+    it('sends a successful request override content type', function (done) {
+        ajax.request({
+            url: '/success',
+            data: {}
+        }).then(function () {
+            expect($.ajax).toHaveBeenCalledWith({
+                url: '/success',
+                dataType: 'json',
+                contentType: 'application/json',
+                data: {}
+            });
+            done();
+        });
+    });
+
+    it('fails with an un-handled error', function (done) {
+        ajax.request({
+            url: '/fail'
+        }).then(done.fail, function () {
+            expect($.ajax).toHaveBeenCalled();
+            done();
+        });
+    });
+
+    it('fails with a reload redirect', function (done) {
+        ajax.request({
+            url: '/redirect'
+        }, this.win).then(done.fail, () => {
+            expect(this.win.location.reload).toHaveBeenCalled();
+            done();
+        });
+    });
+
+    describe('tries again for auth', function () {
+        it('works on second try', function (done) {
+            spyOn(panda, 'reEstablishSession').and.callFake(() => {
+                return new Promise(resolve => {
+                    this.scope.clear();
+                    // second requests works
+                    this.scope({
+                        url: '/auth',
+                        status: 200,
+                        responseText: {
+                            works: true
+                        }
+                    });
+                    resolve();
+                });
+            });
+
+            ajax.request({
+                url: '/auth'
+            }, this.win).then(function (result) {
+                expect(panda.reEstablishSession).toHaveBeenCalled();
+                expect(result).toEqual({
+                    works: true
+                });
+                done();
+            });
+        });
+
+        it('fails on second try', function (done) {
+            spyOn(panda, 'reEstablishSession').and.returnValue(Promise.resolve());
+
+            // the second request keeps redirecting, don't loop
+            ajax.request({
+                url: '/auth'
+            }, this.win).then(done.fail, () => {
+                expect(panda.reEstablishSession).toHaveBeenCalled();
+                expect(this.win.location.reload).toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it('fails while reauth', function (done) {
+            spyOn(panda, 'reEstablishSession').and.callFake(function () {
+                return Promise.reject(new Error('bad'));
+            });
+
+            // auth failed for some reason, redirect
+            ajax.request({
+                url: '/auth'
+            }, this.win).then(done.fail, () => {
+                expect(panda.reEstablishSession).toHaveBeenCalled();
+                expect(this.win.location.reload).toHaveBeenCalled();
+                done();
+            });
+        });
+    });
+});
+
+describe('Collections update', function () {
+    describe('works', function () {
+        beforeEach(function () {
+            this.scope = mockjax.scope();
+            this.scope({
+                url: vars.CONST.apiBase + '/edits',
+                status: 200,
+                responseText: {
+                    'banana': {
+                        works: true
+                    },
+                    'apple': {
+                        removed: true
+                    }
+                }
+            }, {
+                url: vars.CONST.apiBase + '/treats/banana',
+                status: 200,
+                responseText: {
+                    'banana': {
+                        works: true
+                    },
+                    'apple': {
+                        removed: true
+                    }
+                }
+            });
+            spyOn($, 'ajax').and.callThrough();
+        });
+        afterEach(function () {
+            this.scope.clear();
+        });
+
+        it('updates a collection', function (done) {
+            var populateArg;
+            ajax.updateCollections({
+                update: {
+                    collection: {
+                        id: 'banana',
+                        setPending: function () {},
+                        populate: function (arg) {
+                            populateArg = arg;
+                        }
+                    },
+                    mode: 'live'
+                }
+            })
+            .then(() => {
+                var call = $.ajax.calls.argsFor(0)[0], data = JSON.parse(call.data);
+                expect(call.url).toBe(vars.CONST.apiBase + '/edits');
+                expect(call.type).toBe('POST');
+                expect(data).toEqual({
+                    type: 'Update',
+                    update: {
+                        id: 'banana',
+                        live: true,
+                        draft: false
+                    }
+                });
+                expect(populateArg).toEqual({
+                    works: true
+                });
+                done();
+            });
+        });
+
+        it('removes a treat', function (done) {
+            var populateArg;
+            ajax.updateCollections({
+                remove: {
+                    collection: {
+                        id: 'banana',
+                        setPending: function () {},
+                        populate: function (arg) {
+                            populateArg = arg;
+                        }
+                    },
+                    mode: 'treats'
+                }
+            })
+            .then(() => {
+                var call = $.ajax.calls.argsFor(0)[0], data = JSON.parse(call.data);
+                expect(call.url).toBe(vars.CONST.apiBase + '/treats/banana');
+                expect(call.type).toBe('POST');
+                expect(data).toEqual({
+                    type: 'Remove',
+                    remove: {
+                        id: 'banana',
+                        live: false,
+                        draft: false
+                    }
+                });
+                expect(populateArg).toEqual({
+                    works: true
+                });
+                done();
+            });
+        });
+
+        it('updates and remove', function (done) {
+            var populateArgUpdate, populateArgRemove;
+            ajax.updateCollections({
+                update: {
+                    collection: {
+                        id: 'banana',
+                        setPending: function () {},
+                        populate: function (arg) {
+                            populateArgUpdate = arg;
+                        }
+                    },
+                    mode: 'draft'
+                },
+                remove: {
+                    collection: {
+                        id: 'apple',
+                        setPending: function () {},
+                        populate: function (arg) {
+                            populateArgRemove = arg;
+                        }
+                    },
+                    mode: 'draft'
+                }
+            })
+            .then(() => {
+                var call = $.ajax.calls.argsFor(0)[0], data = JSON.parse(call.data);
+                expect(call.url).toBe(vars.CONST.apiBase + '/edits');
+                expect(call.type).toBe('POST');
+                expect(data).toEqual({
+                    type: 'UpdateAndRemove',
+                    update: {
+                        id: 'banana',
+                        live: false,
+                        draft: true
+                    },
+                    remove: {
+                        id: 'apple',
+                        live: false,
+                        draft: true
+                    }
+                });
+                expect(populateArgUpdate).toEqual({
+                    works: true
+                });
+                expect(populateArgRemove).toEqual({
+                    removed: true
+                });
+                done();
+            });
+        });
+    });
+
+    describe('fails', function () {
+        beforeEach(function () {
+            this.scope = mockjax.scope();
+            this.scope({
+                url: vars.CONST.apiBase + '/edits',
+                status: 500,
+                responseText: {}
+            });
+            spyOn($, 'ajax').and.callThrough();
+        });
+        afterEach(function () {
+            this.scope.clear();
+        });
+
+        it('updates a collection', function (done) {
+            var collection = {
+                id: 'banana',
+                setPending: function () {},
+                load: function () {}
+            };
+            spyOn(collection, 'load');
+            ajax.updateCollections({
+                update: {
+                    collection: collection,
+                    mode: 'live'
+                }
+            })
+            .then(done.fail)
+            .catch(() => {
+                expect(collection.load).toHaveBeenCalled();
+                done();
+            });
+        });
+    });
+});

--- a/facia-tool/test/public/spec/cache.spec.js
+++ b/facia-tool/test/public/spec/cache.spec.js
@@ -1,0 +1,57 @@
+import * as cache from 'modules/cache';
+
+describe('Cache', function () {
+    it('stores until expiry', function () {
+        var currentTime = 12;
+        cache.overrides.Date = function () {};
+        cache.overrides.Date.prototype.valueOf = function () {
+            return currentTime;
+        };
+
+        var put = cache.put('fruit', 'banana', {
+            color: 'yellow',
+            sweet: true
+        });
+        expect(put).toEqual({
+            color: 'yellow',
+            sweet: true
+        });
+
+        // Advance the time but keep it below the limit
+        currentTime = 14;
+        expect(cache.get('fruit', 'banana')).toEqual({
+            color: 'yellow',
+            sweet: true
+        });
+
+        // store in a different pot / key
+        cache.put('fruit', 'apple', {
+            color: 'red'
+        });
+        cache.put('food', 'banana', {
+            color: 'green'
+        });
+        expect(cache.get('fruit', 'banana')).toEqual({
+            color: 'yellow',
+            sweet: true
+        });
+        expect(cache.get('fruit', 'apple')).toEqual({
+            color: 'red'
+        });
+        expect(cache.get('food', 'banana')).toEqual({
+            color: 'green'
+        });
+
+        // check the expiry
+        currentTime = 1212121212;
+        expect(cache.get('food', 'banana')).toBeUndefined();
+    });
+
+    it('returns undefined on error', function () {
+        expect(cache.get()).toBeUndefined();
+        expect(cache.get('one')).toBeUndefined();
+        expect(cache.get('one', 'two')).toBeUndefined();
+        expect(cache.put()).toBeUndefined();
+        expect(cache.put('one')).toBeUndefined();
+    });
+});

--- a/facia-tool/test/public/spec/capi.spec.js
+++ b/facia-tool/test/public/spec/capi.spec.js
@@ -1,8 +1,11 @@
 import _ from 'underscore';
 import sinon from 'sinon';
 import {CONST} from 'modules/vars';
-import capi from 'modules/content-api';
+import * as capi from 'modules/content-api';
 import Mock from 'mock/search';
+import {scope} from 'test/utils/mockjax';
+import * as cache from 'modules/cache';
+import modalDialog from 'modules/modal-dialog';
 
 describe('Content API', function () {
     var default_capiBatchSize,
@@ -114,6 +117,496 @@ describe('Content API', function () {
                 expect(article.addCapiData.called).toBe(true);
             });
             done();
+        });
+    });
+
+    describe('fetchContent', function () {
+        beforeEach(function () {
+            this.scope = scope();
+        });
+        afterEach(function () {
+            this.scope.clear();
+        });
+
+        it('fails if no response', function (done) {
+            this.scope({
+                url: CONST.apiSearchBase + '/capi-url',
+                status: 500
+            });
+            capi.fetchContent('capi-url')
+            .then((resp) => {
+                expect(resp).toBeUndefined();
+                done();
+            });
+        });
+
+        it('fails with empty intersection', function (done) {
+            this.scope({
+                url: CONST.apiSearchBase + '/capi-url',
+                status: 200,
+                responseText: {
+                    respose: {
+                        fruit: 'banana'
+                    }
+                }
+            });
+            capi.fetchContent('capi-url')
+            .then((resp) => {
+                expect(resp).toBeUndefined();
+                done();
+            });
+        });
+
+        it('fails with status error', function (done) {
+            this.scope({
+                url: CONST.apiSearchBase + '/capi-url',
+                status: 200,
+                responseText: {
+                    response: {
+                        status: 'error'
+                    }
+                }
+            });
+            capi.fetchContent('capi-url')
+            .then((resp) => {
+                expect(resp).toBeUndefined();
+                done();
+            });
+        });
+
+        it('returns from content', function (done) {
+            this.scope({
+                url: CONST.apiSearchBase + '/capi-url',
+                status: 200,
+                responseText: {
+                    response: {
+                        content: 'something here',
+                        tag: {
+                            webTitle: 'one'
+                        },
+                        section: {
+                            webTitle: 'two'
+                        }
+                    }
+                }
+            });
+            capi.fetchContent('capi-url')
+            .then((resp) => {
+                expect(resp).toEqual({
+                    content: ['something here'],
+                    title: 'one'
+                });
+                done();
+            });
+        });
+
+        it('returns from other fields', function (done) {
+            this.scope({
+                url: CONST.apiSearchBase + '/capi-url',
+                status: 200,
+                responseText: {
+                    response: {
+                        editorsPicks: [
+                            'one',
+                            'two'
+                        ],
+                        mostViewed: {
+                            ignoreBecauseNotAnArray: true
+                        },
+                        results: [
+                            'three'
+                        ],
+                        tag: {
+                            ignoredBecauseMissingTitle: 'one'
+                        },
+                        section: {
+                            webTitle: 'two'
+                        }
+                    }
+                }
+            });
+            capi.fetchContent('capi-url')
+            .then((resp) => {
+                expect(resp).toEqual({
+                    content: ['one', 'two', 'three'],
+                    title: 'two'
+                });
+                done();
+            });
+        });
+    });
+
+    describe('fetchMetaForPath', function () {
+        beforeEach(function () {
+            this.scope = scope();
+        });
+        afterEach(function () {
+            this.scope.clear();
+        });
+
+        it('fails if no response', function (done) {
+            this.scope({
+                url: CONST.apiSearchBase + '/meta-capi-url*',
+                status: 500,
+                responseText: {
+                    response: {
+                        section: {
+                            webTitle: 'one'
+                        }
+                    }
+                }
+            });
+            capi.fetchMetaForPath('meta-capi-url')
+            .then((resp) => {
+                expect(resp).toBeUndefined();
+                done();
+            });
+        });
+
+        it('extract meta from the response', function (done) {
+            this.scope({
+                url: CONST.apiSearchBase + '/meta-capi-url*',
+                status: 200,
+                responseText: {
+                    response: {
+                        section: {
+                            webTitle: 'one',
+                            id: 'a/b/c',
+                            description: 'apple'
+                        },
+                        tag: {
+                            description: 'banana',
+                            title: 'fruit'
+                        }
+                    }
+                }
+            });
+            capi.fetchMetaForPath('meta-capi-url')
+            .then((resp) => {
+                expect(resp).toEqual({
+                    section: 'c',
+                    webTitle: 'one',
+                    description: 'banana',
+                    title: 'fruit'
+                });
+                done();
+            });
+        });
+    });
+
+    describe('validateItem', function () {
+        beforeEach(function () {
+            this.scope = scope();
+            this.createItem = function (opts) {
+                var item = {
+                    id: function () {
+                        return opts.id;
+                    },
+                    addCapiData: function () {},
+                    group: {
+                        parentType: opts.parentType || 'Clipboard'
+                    },
+                    meta: {
+                        snapType: function () {
+                            return opts.snapType;
+                        }
+                    },
+                    convertToSnap: function () {},
+                    convertToLatestSnap: function () {},
+                    convertToLinkSnap: function () {}
+                };
+                spyOn(item, 'addCapiData');
+                spyOn(item, 'convertToSnap');
+                spyOn(item, 'convertToLatestSnap');
+                spyOn(item, 'convertToLinkSnap');
+                return item;
+            };
+        });
+        afterEach(function () {
+            this.scope.clear();
+        });
+
+        it('resolves a snapID', function (done) {
+            var item = this.createItem({
+                id: 'snap/23414'
+            });
+
+            capi.validateItem(item)
+            .then((valid) => {
+                expect(valid).toBe(item);
+                expect(item.addCapiData).not.toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it('resolves from cache', function (done) {
+            var item = this.createItem({
+                id: '/internal'
+            });
+            cache.put('contentApi', 'internal', {
+                title: 'cache'
+            });
+
+            capi.validateItem(item)
+            .then((valid) => {
+                expect(valid).toBe(item);
+                expect(item.addCapiData).toHaveBeenCalledWith({
+                    title: 'cache'
+                });
+                done();
+            });
+        });
+
+        it('resolves a single malformed capi item', function (done) {
+            var item = this.createItem({
+                id: '/item'
+            });
+            cache.put('contentApi', 'item', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/item?*',
+                status: 200,
+                responseText: {
+                    response: {
+                        content: [{
+                            fields: {
+                                // content code is missing
+                                // internalContentCode: 'banana'
+                            }
+                        }],
+                        section: {
+                            webTitle: 'one'
+                        }
+                    }
+                }
+            });
+
+            capi.validateItem(item)
+            .then(done.fail, (error) => {
+                expect(error.message).toMatch(/internalContentCode/i);
+                done();
+            });
+        });
+
+        it('resolves a single valid capi item', function (done) {
+            var item = this.createItem({
+                id: '/item'
+            });
+            cache.put('contentApi', 'item', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/item?*',
+                status: 200,
+                responseText: {
+                    response: {
+                        content: {
+                            fields: {
+                                internalContentCode: 'banana',
+                                another: true
+                            }
+                        },
+                        section: {
+                            webTitle: 'one'
+                        }
+                    }
+                }
+            });
+
+            capi.validateItem(item)
+            .then((valid) => {
+                var data = {
+                    fields: {
+                        internalContentCode: 'banana',
+                        another: true
+                    }
+                };
+                expect(valid).toBe(item);
+                expect(item.addCapiData).toHaveBeenCalledWith(data);
+                expect(cache.get('contentApi', 'internal-code/content/banana')).toEqual(data);
+                done();
+            });
+        });
+
+        it('fails on a relative snap', function (done) {
+            var item = this.createItem({
+                id: '/whatever'
+            });
+            cache.put('contentApi', 'whatever', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/whatever?*',
+                status: 200,
+                responseText: {
+                    response: {}
+                }
+            });
+
+            capi.validateItem(item)
+            .then(done.fail, (error) => {
+                expect(error.message).toMatch(/URLs must begin with http/i);
+                done();
+            });
+        });
+
+        it('fails on snaps not in the clipboard', function (done) {
+            var item = this.createItem({
+                id: 'http://whatever.com/something',
+                parentType: 'Not the clipboard'
+            });
+            cache.put('contentApi', 'something', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/something?*',
+                status: 200,
+                responseText: {
+                    response: {}
+                }
+            });
+
+            capi.validateItem(item)
+            .then(done.fail, (error) => {
+                expect(error.message).toMatch(/dragged to the Clipboard/i);
+                done();
+            });
+        });
+
+        it('fails on links coming from self', function (done) {
+            var item = this.createItem({
+                id: 'http://' + window.location.hostname + '/something'
+            });
+            cache.put('contentApi', 'something', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/something?*',
+                status: 200,
+                responseText: {
+                    response: {}
+                }
+            });
+
+            capi.validateItem(item)
+            .then(done.fail, (error) => {
+                expect(error.message).toMatch(/cannot be added/i);
+                done();
+            });
+        });
+
+        it('fails on guardian content not available', function (done) {
+            var item = this.createItem({
+                id: 'http://' + CONST.mainDomain + '/something'
+            });
+            cache.put('contentApi', 'something', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/something?*',
+                status: 200,
+                responseText: {
+                    response: {
+                        results: []
+                    }
+                }
+            });
+
+            capi.validateItem(item)
+            .then(done.fail, (error) => {
+                expect(error.message).toMatch(/Guardian content is unavailable/i);
+                done();
+            });
+        });
+
+        it('validates a snap that contains a type', function (done) {
+            var item = this.createItem({
+                id: 'http://anything.com/something',
+                snapType: 'link'
+            });
+            cache.put('contentApi', 'something', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/something?*',
+                status: 200,
+                responseText: {
+                    response: {}
+                }
+            });
+
+            capi.validateItem(item)
+            .then((valid) => {
+                expect(valid).toBe(item);
+                expect(item.convertToSnap).toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it('validates multiple snap results - latest', function (done) {
+            var item = this.createItem({
+                id: 'http://anything.com/something'
+            });
+            cache.put('contentApi', 'something', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/something?*',
+                status: 200,
+                responseText: {
+                    response: {
+                        results: ['one', 'two'],
+                        section: {
+                            webTitle: 'one'
+                        }
+                    }
+                }
+            });
+            spyOn(modalDialog, 'confirm').and.callFake(() => {
+                return Promise.resolve();
+            });
+
+            capi.validateItem(item)
+            .then((valid) => {
+                expect(valid).toBe(item);
+                expect(item.convertToLatestSnap).toHaveBeenCalledWith('one');
+                done();
+            });
+        });
+
+        it('validates multiple snap results - link', function (done) {
+            var item = this.createItem({
+                id: 'http://anything.com/something'
+            });
+            cache.put('contentApi', 'something', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/something?*',
+                status: 200,
+                responseText: {
+                    response: {
+                        results: ['one', 'two'],
+                        section: {
+                            webTitle: 'one'
+                        }
+                    }
+                }
+            });
+            spyOn(modalDialog, 'confirm').and.callFake(() => {
+                return Promise.reject();
+            });
+
+            capi.validateItem(item)
+            .then((valid) => {
+                expect(valid).toBe(item);
+                expect(item.convertToLinkSnap).toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it('validates multiple snap link', function (done) {
+            var item = this.createItem({
+                id: 'http://anything.com/something'
+            });
+            cache.put('contentApi', 'something', null);
+            this.scope({
+                url: CONST.apiSearchBase + '/something?*',
+                status: 200,
+                responseText: {
+                    response: {}
+                }
+            });
+
+            capi.validateItem(item)
+            .then((valid) => {
+                expect(valid).toBe(item);
+                expect(item.convertToLinkSnap).toHaveBeenCalled();
+                done();
+            });
         });
     });
 });

--- a/facia-tool/test/public/spec/clipboard.spec.js
+++ b/facia-tool/test/public/spec/clipboard.spec.js
@@ -2,7 +2,7 @@ import ko from 'knockout';
 import _ from 'underscore';
 import $ from 'jquery';
 import mockjax from 'test/utils/mockjax';
-import cache from 'modules/cache';
+import * as cache from 'modules/cache';
 import * as vars from 'modules/vars';
 import newItems from 'models/collections/new-items';
 import * as widgets from 'models/widgets';

--- a/facia-tool/test/public/spec/collections.spec.js
+++ b/facia-tool/test/public/spec/collections.spec.js
@@ -384,9 +384,6 @@ describe('Collections', function () {
             expect($('.desktop-indicator .indicator')[0].clientHeight > 100).toBe(true);
             done();
         })
-        .catch(function () {
-            expect(true).toBe(false);
-            done();
-        });
+        .catch(done.fail);
     });
 });

--- a/facia-tool/test/public/spec/fetch.visible.stories.spec.js
+++ b/facia-tool/test/public/spec/fetch.visible.stories.spec.js
@@ -33,10 +33,7 @@ describe('Fetch visible stories', function () {
 
     it('fails when there are no stories', function (done) {
         fetch('anything', createGroups())
-        .then(function () {
-            expect(true).toBe(false);
-            done();
-        }, function (err) {
+        .then(done.fail, function (err) {
             expect(err.message).toMatch(/Empty collection/i);
             done();
         });
@@ -44,10 +41,7 @@ describe('Fetch visible stories', function () {
 
     it('fails if the network fails', function (done) {
         return fetch('fail', createGroups([false]))
-        .then(function () {
-            expect(false).toBe(true);
-            done();
-        }, function (err) {
+        .then(done.fail, function (err) {
             expect(err).toMatch(/fail/i);
             done();
         });

--- a/facia-tool/test/public/spec/latest.articles.model.spec.js
+++ b/facia-tool/test/public/spec/latest.articles.model.spec.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import contentApi from 'modules/content-api';
+import * as contentApi from 'modules/content-api';
 import MockSearch from 'mock/search';
 import mockjax from 'test/utils/mockjax';
 
@@ -73,10 +73,7 @@ describe('Latest articles', function() {
         this.mock.latest([]);
 
         contentApi.fetchLatest()
-        .then(function () {
-            expect(true).toBe(false);
-            done();
-        }, assert(this.mock, function (request, list) {
+        .then(done.fail, assert(this.mock, function (request, list) {
             expect(list instanceof Error).toBe(true);
             expect(list.message).toMatch(/not currently returning content/i);
 
@@ -125,10 +122,7 @@ describe('Latest articles', function() {
             article: 'uk-news/less/important',
             term: 'ignored'
         })
-        .then(function () {
-            // We shouldn't get here
-            expect(true).toBe(false);
-        }, function (error) {
+        .then(done.fail, function (error) {
             expect(error instanceof Error).toBe(true);
             expect(error.message).toMatch(/Content API error/i);
 

--- a/facia-tool/test/public/spec/oauth.session.spec.js
+++ b/facia-tool/test/public/spec/oauth.session.spec.js
@@ -1,6 +1,7 @@
 import Promise from 'Promise';
 import tick from 'test/utils/tick';
 import session from 'utils/oauth-session';
+import {reauth} from 'utils/oauth-session';
 import {CONST} from 'modules/vars';
 
 describe('OAuth Session', function () {
@@ -23,10 +24,11 @@ describe('OAuth Session', function () {
         session(panda, this.redirect);
         tick(CONST.reauthInterval + 200).then(() => {
             expect(this.redirect).not.toHaveBeenCalled();
-            expect(panda).toHaveBeenCalledWith(CONST.reauthPath, CONST.reauthInterval);
+            expect(panda).toHaveBeenCalledWith(CONST.reauthPath, CONST.reauthTimeout);
 
             done();
-        });
+        })
+        .catch(done.fail);
     });
 
     it('redirects on timeout', function (done) {
@@ -39,9 +41,36 @@ describe('OAuth Session', function () {
         session(panda, this.redirect);
         tick(CONST.reauthInterval + CONST.reauthTimeout).then(() => {
             expect(this.redirect).toHaveBeenCalled();
-            expect(panda).toHaveBeenCalledWith(CONST.reauthPath, CONST.reauthInterval);
+            expect(panda).toHaveBeenCalledWith(CONST.reauthPath, CONST.reauthTimeout);
 
             done();
+        })
+        .catch(done.fail);
+    });
+
+    it('authenticates multiple requests', function (done) {
+        var panda = jasmine.createSpy('panda').and.callFake(function () {
+            return new Promise(function (resolve) {
+                setTimeout(resolve, 100);
+            });
         });
+        var spies = {
+            one: function () {},
+            two: function () {}
+        };
+        spyOn(spies, 'one');
+        spyOn(spies, 'two');
+        reauth(panda).then(spies.one);
+        reauth(panda).then(spies.two);
+
+        tick(110).then(() => {
+            expect(this.redirect).not.toHaveBeenCalled();
+            expect(panda.calls.count()).toBe(1);
+            expect(spies.one).toHaveBeenCalled();
+            expect(spies.two).toHaveBeenCalled();
+
+            done();
+        })
+        .catch(done.fail);
     });
 });

--- a/facia-tool/test/public/spec/sparklines.spec.js
+++ b/facia-tool/test/public/spec/sparklines.spec.js
@@ -6,6 +6,7 @@ import * as vars from 'modules/vars';
 import MockHistogram from 'mock/histogram';
 import mockFrontWidget from 'mock/front-widget';
 import * as sparklines from 'utils/sparklines';
+import tick from 'test/utils/tick';
 
 describe('Sparklines', function () {
     var originalsparksBatchQueue = vars.CONST.sparksBatchQueue;
@@ -30,6 +31,12 @@ describe('Sparklines', function () {
         switches['facia-tool-sparklines'] = false;
         vars.model.switches(switches);
     });
+    var originalSetTimeout = setTimeout;
+    function whenComplete (mock, cb) {
+        mock.once('complete', () => {
+            originalSetTimeout(cb, 10);
+        });
+    }
 
     it('loads sparklines for a front', function (done) {
         // Load an empty front
@@ -75,7 +82,7 @@ describe('Sparklines', function () {
         expect(onReject.called).toBe(false);
         front._resolveCollection('empty');
 
-        this.mockHistogram.once('complete', function () {
+        whenComplete(this.mockHistogram, () => {
             expect(onResolve.called).toBe(true);
             expect(onReject.called).toBe(false);
             var resolvedObject = onResolve.args[0][0];
@@ -102,7 +109,7 @@ describe('Sparklines', function () {
 
             front._resolveCollection('onlyCollection');
 
-            this.mockHistogram.once('complete', function () {
+            whenComplete(this.mockHistogram, () => {
                 expect(onResolve.called).toBe(true);
                 expect(onReject.called).toBe(false);
                 var resolvedObject = onResolve.args[0][0];
@@ -112,7 +119,7 @@ describe('Sparklines', function () {
 
                 finishTest();
             });
-        }.bind(this));
+        });
     });
 
     it('handles changing fronts while loading collections', function (done) {
@@ -160,7 +167,7 @@ describe('Sparklines', function () {
 
             finishTest();
         });
-        this.mockHistogram.once('complete', function () {
+        whenComplete(this.mockHistogram, () => {
             // After the first request, update the mock for the second
             this.mockHistogram.update({
                 '/long/front': [{
@@ -169,9 +176,9 @@ describe('Sparklines', function () {
                     totalHits: 10
                 }]
             });
-            this.mockHistogram.once('complete', continueTest);
+            whenComplete(this.mockHistogram, continueTest);
             continueTest();
-        }.bind(this));
+        });
     });
 
     it('handles changing fronts while loading sparklines', function (done) {
@@ -201,7 +208,7 @@ describe('Sparklines', function () {
         front.sparklines.promise.then(onResolveFirst, onRejectFirst);
         front._resolveCollection('two');
 
-        this.mockHistogram.once('complete', function () {
+        whenComplete(this.mockHistogram, () => {
             // After the first request, update the mock for the second, but change front
             this.mockHistogram.update({
                 '/long/front': [{
@@ -214,10 +221,10 @@ describe('Sparklines', function () {
                 one: [{ article: '/fancy-url' }]
             });
             front.sparklines.promise.then(onResolveSecond, onRejectSecond);
-            this.mockHistogram.once('complete', function () {
+            whenComplete(this.mockHistogram, () => {
                 front._resolveCollection('one');
 
-                this.mockHistogram.once('complete', function () {
+                whenComplete(this.mockHistogram, () => {
                     expect(onResolveFirst.called).toBe(false);
                     expect(onRejectFirst.called).toBe(true);
                     expect(onResolveSecond.called).toBe(true);
@@ -226,8 +233,8 @@ describe('Sparklines', function () {
 
                     finishTest();
                 });
-            }.bind(this));
-        }.bind(this));
+            });
+        });
     });
 
     it('loads sparklines on multiple fronts and polls', function (done) {
@@ -259,7 +266,7 @@ describe('Sparklines', function () {
         frontTwo.sparklines.promise.then(onResolveTwo);
         frontTwo._resolveCollection('two');
 
-        var continueTest = _.after(2, function () {
+        var continueTest = _.after(2, () => { originalSetTimeout(() => {
             this.mockHistogram.off('complete', continueTest);
             expect(onResolveOne.called).toBe(true);
             expect(onResolveTwo.called).toBe(true);
@@ -279,21 +286,22 @@ describe('Sparklines', function () {
                     totalHits: 12345
                 }]
             });
-            var afterInterval = _.after(2, function () {
+            var afterInterval = _.after(2, () => { originalSetTimeout(() => {
                 this.mockHistogram.off('complete', afterInterval);
                 expect(sparklinesTitle('_a')).toBe('500');
                 expect(sparklinesTitle('_b')).toBe('12,345');
 
                 finishTest();
-            }.bind(this));
+            }, 10); });
             this.mockHistogram.on('complete', afterInterval);
 
-            jasmine.clock().tick(3000);
-        }.bind(this));
+            tick(3000);
+            tick(100);
+        }, 10); });
         this.mockHistogram.on('complete', continueTest);
 
         // Advance time to get the mocked response
-        jasmine.clock().tick(100);
+        tick(100).then(() => tick(100)).then(() => tick(100));
     });
 
     it('refreshes when the collection changes', function (done) {
@@ -313,7 +321,7 @@ describe('Sparklines', function () {
         sparklines.subscribe(front);
         front._resolveCollection('one');
 
-        this.mockHistogram.once('complete', function () {
+        whenComplete(this.mockHistogram, () => {
             expectSparklinesOn(['_a']);
             expect(sparklinesTitle('_a')).toBe('100');
 
@@ -333,24 +341,27 @@ describe('Sparklines', function () {
             // Inject a new article in the front (either dragging or collection update)
             front._addArticle('one', { article: '/b' });
             // Adding an article makes a new request for the added articles
-            jasmine.clock().tick(100);
+            tick(100)
+            .then(() => {
+                expectSparklinesOn(['_a', '_b']);
+                // Note that the old article doesn't change
+                expect(sparklinesTitle('_a')).toBe('100');
+                expect(sparklinesTitle('_b')).toBe('200');
 
-            expectSparklinesOn(['_a', '_b']);
-            // Note that the old article doesn't change
-            expect(sparklinesTitle('_a')).toBe('100');
-            expect(sparklinesTitle('_b')).toBe('200');
+                // wait a set interval and check that A is refreshed correctly
+                return tick(2000).then(() => tick(100));
+            })
+            .then(() => {
+                expectSparklinesOn(['_a', '_b']);
+                expect(sparklinesTitle('_a')).toBe('77');
+                expect(sparklinesTitle('_b')).toBe('200');
 
-            // wait a set interval and check that A is refreshed correctly
-            jasmine.clock().tick(2000);
-            expectSparklinesOn(['_a', '_b']);
-            expect(sparklinesTitle('_a')).toBe('77');
-            expect(sparklinesTitle('_b')).toBe('200');
-
-            finishTest();
-        }.bind(this));
+                finishTest();
+            });
+        });
 
         // Advance time to get the mocked response
-        jasmine.clock().tick(100);
+        tick(100).then(() => tick(100)).then(() => tick(100));
     });
 });
 

--- a/facia-tool/test/public/spec/validate.image.spec.js
+++ b/facia-tool/test/public/spec/validate.image.spec.js
@@ -11,10 +11,7 @@ describe('Validate images', function () {
 
     it('fails on missing images', function (done) {
         validate()
-        .then(function () {
-            expect(true).toBe(false);
-            done();
-        }, function (err) {
+        .then(done.fail, function (err) {
             expect(err.message).toMatch(/missing/i);
             done();
         });
@@ -24,10 +21,7 @@ describe('Validate images', function () {
         CONST.imageCdnDomain = 'funny-host';
 
         validate('http://another-host/image.png')
-        .then(function () {
-            expect(true).toBe(false);
-            done();
-        }, function (err) {
+        .then(done.fail, function (err) {
             expect(err.message).toMatch(/images must come/i);
             done();
         });
@@ -37,10 +31,7 @@ describe('Validate images', function () {
         CONST.imageCdnDomain = window.location.host;
 
         validate('http://' + CONST.imageCdnDomain + '/this_image_doesnt_exists__promised.png')
-        .then(function () {
-            expect(true).toBe(false);
-            done();
-        }, function (err) {
+        .then(done.fail, function (err) {
             expect(err.message).toMatch(/could not be found/i);
             done();
         });
@@ -53,10 +44,7 @@ describe('Validate images', function () {
         };
 
         validate('http://' + CONST.imageCdnDomain + '/base/test/public/fixtures/square.png', criteria)
-        .then(function () {
-            expect(true).toBe(false);
-            done();
-        }, function (err) {
+        .then(done.fail, function (err) {
             expect(err.message).toMatch(/cannot be more/i);
             done();
         });
@@ -69,10 +57,7 @@ describe('Validate images', function () {
         };
 
         validate('http://' + CONST.imageCdnDomain + '/base/test/public/fixtures/square.png', criteria)
-        .then(function () {
-            expect(true).toBe(false);
-            done();
-        }, function (err) {
+        .then(done.fail, function (err) {
             expect(err.message).toMatch(/cannot be less/i);
             done();
         });
@@ -86,10 +71,7 @@ describe('Validate images', function () {
         };
 
         validate('http://' + CONST.imageCdnDomain + '/base/test/public/fixtures/square.png', criteria)
-        .then(function () {
-            expect(true).toBe(false);
-            done();
-        }, function (err) {
+        .then(done.fail, function (err) {
             expect(err.message).toMatch(/aspect ratio/i);
             done();
         });

--- a/facia-tool/test/public/utils/collections-loader.js
+++ b/facia-tool/test/public/utils/collections-loader.js
@@ -13,9 +13,18 @@ import templateCollections from 'views/collections.scala.html!text';
 import verticalLayout from 'views/templates/vertical_layout.scala.html!text';
 import mediator from 'utils/mediator';
 import 'widgets/collection.html!text';
+var originalSetTimeout = window.setTimeout;
 
 export default function() {
     var mockConfig, mockSwitches, mockCollections, mockSearch;
+    function tick (ms) {
+        jasmine.clock().tick(ms);
+        return new Promise(function (resolve) {
+            originalSetTimeout(function () {
+                resolve();
+            }, 20);
+        });
+    }
 
     var loader = new Promise(function (resolve) {
         document.body.innerHTML += '<div id="_test_container_collections">' +
@@ -43,13 +52,12 @@ export default function() {
         mockSearch.latest(fixArticles.allArticles);
 
         // Mock the time
-        var originalSetTimeout = window.setTimeout;
         jasmine.clock().install();
 
         mediator.on('latest:loaded', function () {
             // wait for the debounce (give some time to knockout to handle bindings)
             originalSetTimeout(function () {
-                jasmine.clock().tick(350);
+                tick(350);
             }, 50);
         });
 
@@ -63,9 +71,9 @@ export default function() {
         })));
 
         // The first tick is for the configuration to be loaded
-        jasmine.clock().tick(100);
         // The second tick is for the collections to be leaded
-        jasmine.clock().tick(300);
+        tick(100).then(() => tick(300))
+        .then(() => tick(100)).then(() => tick(100));
 
     });
 

--- a/facia-tool/test/public/utils/config-actions.js
+++ b/facia-tool/test/public/utils/config-actions.js
@@ -1,8 +1,9 @@
 import mockjax from 'test/utils/mockjax';
 import Promise from 'Promise';
-var originalSetTimeout = window.setTimeout;
+import tick from 'test/utils/tick';
 
 export default function(mockConfig, action) {
+
     return new Promise(function (resolve) {
         var lastRequest, desiredAnswer;
         var interceptFront = mockjax({
@@ -16,10 +17,9 @@ export default function(mockConfig, action) {
             onAfterComplete: function () {
                 clearRequest();
                 // Every such action is also triggering an update of the config
-                jasmine.clock().tick(100);
-                originalSetTimeout(function () {
+                tick(100).then(() => tick(100)).then(() => {
                     resolve(lastRequest);
-                }, 10);
+                });
             }
         });
         var interceptEdit = mockjax({
@@ -35,8 +35,7 @@ export default function(mockConfig, action) {
             onAfterComplete: function () {
                 clearRequest();
                 // Every such action is also triggering an update of the config
-                jasmine.clock().tick(100);
-                originalSetTimeout(function () {
+                tick(100).then(() => tick(100)).then(() => {
                     resolve(lastRequest);
                 });
             }
@@ -51,6 +50,6 @@ export default function(mockConfig, action) {
         mockConfig.update(desiredAnswer);
 
         // This action triggers a network request, advance time
-        jasmine.clock().tick(100);
+        tick(100).then(() => tick(100));
     });
 }

--- a/facia-tool/test/public/utils/edit-actions.js
+++ b/facia-tool/test/public/utils/edit-actions.js
@@ -1,5 +1,6 @@
 import Promise from 'Promise';
 import mockjax from 'test/utils/mockjax';
+import tick from 'test/utils/tick';
 
 export default function(mockCollection, action) {
     return new Promise(function (resolve) {
@@ -13,7 +14,9 @@ export default function(mockCollection, action) {
             },
             onAfterComplete: function () {
                 mockjax.clear(interceptor);
-                resolve(lastRequest);
+                tick(100).then(() => tick(100)).then(() => {
+                    resolve(lastRequest);
+                });
             }
         });
         desiredAnswer = action();
@@ -25,7 +28,6 @@ export default function(mockCollection, action) {
         mockCollection.set(desiredAnswer);
 
         // This action triggers a network request, advance time
-        jasmine.clock().tick(100);
-
+        tick(100).then(() => tick(100));
     });
 }

--- a/facia-tool/test/public/utils/publish-actions.js
+++ b/facia-tool/test/public/utils/publish-actions.js
@@ -1,5 +1,6 @@
 import Promise from 'Promise';
 import mockjax from 'test/utils/mockjax';
+import tick from 'test/utils/tick';
 
 export default function(action) {
     return new Promise(function (resolve) {
@@ -18,6 +19,6 @@ export default function(action) {
             }
         });
         action();
-        jasmine.clock().tick(100);
+        tick(100).then(() => tick(100));
     });
 }

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -43,7 +43,7 @@ System.config({
     "bean": "npm:bean@1.0.15",
     "bonzo": "npm:bonzo@1.4.0",
     "classnames": "npm:classnames@1.2.0",
-    "core-js": "npm:core-js@0.9.17",
+    "core-js": "npm:core-js@0.9.18",
     "domready": "npm:domready@1.0.8",
     "enhancer": "github:guardian/enhancer@0.1.3",
     "fastclick": "npm:fastclick@1.0.6",
@@ -168,7 +168,7 @@ System.config({
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
-    "npm:core-js@0.9.17": {
+    "npm:core-js@0.9.18": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "process": "github:jspm/nodelibs-process@0.1.1",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"


### PR DESCRIPTION
When sending an API request, if the token is expired, panda sends back a 419 error.
In that case, try to silently re-auth using panda-session and retry the previous request.

If the second attempt doesn't work, redirect to login page.

Lots of file changed because `authed-ajax` is now using promises instead of `$.Deferred`. I wrote a unit test for everything that changed, I hope I haven't missed anything.

@janua @stephanfowler @hmgibson23
