### PR TITLE
Perform a find to pair content with saved items

### DIFF
--- a/identity/app/model/SaveForLaterPageData.scala
+++ b/identity/app/model/SaveForLaterPageData.scala
@@ -47,12 +47,19 @@ class SaveForLaterDataBuilder @Inject()(idUrlBuilder: IdentityUrlBuilder) extend
       .showFields("all")
       .showElements ("all")
     ).map(r => {
-      val contentModels = r.results.map(ApiContent(_)).zip(articles)
-      contentModels.map(SaveForLaterItem.tupled)
+
+      val items = r.results.flatMap { result =>
+        for {
+          content <- Some(ApiContent(result))
+          article <- articles.find( article => article.id == content.id)
+        } yield {
+          SaveForLaterItem(content, article)
+        }
+      }
 
       SaveForLaterPageData(
         idUrlBuilder.buildUrl("/saved-for-later", idRequest),
-        contentModels.map(SaveForLaterItem.tupled),
+        items,
         Pagination(pageNum, savedArticles.numPages, savedArticles.totalSaved),
         idUrlBuilder.buildUrl("/saved-for-later"),
         savedArticles.totalSaved,


### PR DESCRIPTION
The ordering of articles from CAPI and the ordering of saved articles from Identity do not match, so do a `find` to pair them together. This means the data link name is in added to the corresponding saved article 
