### PR TITLE
Swimlane jspm versions for frontend and facia-tool

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,7 +119,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask('install', ['install:npm', 'install:jspm']);
     grunt.registerTask('install:jspm', ['shell:jspmInstallStatic', 'shell:jspmInstallFaciaTool']);
-    grunt.registerTask('install:npm', ['shell:npmInstall']);
+    grunt.registerTask('install:npm', ['shell:npmInstall', 'shell:npmInstallFaciaTool']);
 
     grunt.registerTask('prepare', function() {
         megalog.error('`grunt prepare` has been removed.\n\nUse `grunt install` instead… ');

--- a/facia-tool/public/package.json
+++ b/facia-tool/public/package.json
@@ -1,6 +1,9 @@
 {
   "name": "facia-tool",
   "version": "1.0.0",
+  "devDependencies": {
+    "jspm": "^0.15.6"
+  },
   "jspm": {
     "directories": {
       "lib": "js"

--- a/grunt-configs/shell.js
+++ b/grunt-configs/shell.js
@@ -24,17 +24,21 @@ module.exports = function(grunt, options) {
                      'static/abtests.json'
         },
 
-        npmInstall: {
-            command: 'npm prune && npm install'
+        npmInstallFaciaTool: {
+            command: 'cd facia-tool/public && npm prune && npm install'
         },
 
         jspmInstallFaciaTool: {
-            command: 'node ../../node_modules/jspm/jspm.js install',
+            command: './node_modules/.bin/jspm install',
             options: {
                 execOptions: {
                     cwd: 'facia-tool/public'
                 }
             }
+        },
+
+        npmInstall: {
+            command: 'npm prune && npm install'
         },
 
         jspmInstallStatic: {


### PR DESCRIPTION
So we don't have to update facia-tool in https://github.com/guardian/frontend/pull/9474
