### PR TITLE
Remove npm warnings

### DIFF
--- a/facia-tool/public/package.json
+++ b/facia-tool/public/package.json
@@ -1,6 +1,7 @@
 {
   "name": "facia-tool",
   "version": "1.0.0",
+  "private": true,
   "jspm": {
     "directories": {
       "lib": "js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "frontend",
   "version": "0.1.0",
+  "private": true,
   "devDependencies": {
     "btoa": "1.1.2",
     "esprima": "1.2.2",


### PR DESCRIPTION
```
$ npm i
npm WARN package.json frontend@0.1.0 No repository field.
npm WARN package.json frontend@0.1.0 No license field.
$ cd facia-tool/public
$ npm i
npm WARN package.json facia-tool@1.0.0 No description
npm WARN package.json facia-tool@1.0.0 No repository field.
npm WARN package.json facia-tool@1.0.0 No README data
npm WARN package.json facia-tool@1.0.0 No license field.
```
