### PR TITLE
Fix sfl button on live blogs

### DIFF
--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -146,6 +146,15 @@
     @include mq(tablet, leftCol) {
         left: ($social-width * 5);
     }
+
+    .content--liveblog & {
+        @include mq(desktop) {
+            position: relative;
+            left: 0;
+            top: 0;
+            border-top: 1px dotted colour(neutral-5);
+        }
+    }
 }
 
 .meta__number:not(.u-h) + .meta__number {


### PR DESCRIPTION
fixes sfl button position on live blog layouts above mobile

before:
![screen shot 2015-06-19 at 11 09 04](https://cloud.githubusercontent.com/assets/867233/8251380/03a63924-1674-11e5-8d4c-61c345718dd1.png)

after:
![screen shot 2015-06-19 at 11 04 28](https://cloud.githubusercontent.com/assets/867233/8251396/29717114-1674-11e5-8897-0f5105917eb3.png)

sorry about the branch name :dancers: 
