### PR TITLE
Omit breaking news from profile pages

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -461,7 +461,7 @@ define([
             },
 
             loadBreakingNews: function () {
-                if (config.switches.breakingNews) {
+                if (config.switches.breakingNews && config.page.section !== 'identity') {
                     breakingNews();
                 }
             },


### PR DESCRIPTION
They shouldn't really be there - and were broken anyway because they resolved again the `profile.` subdomain.
