### PR TITLE
Fix syntax error on profile comment activity

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message.js
@@ -37,8 +37,8 @@ define([
              */
             var alreadyVisited = storage.local.get('alreadyVisited') || 0;
             return !detect.adblockInUse &&
-                config.page.edition.toLowerCase() === 'uk' &&
-                config.page.contentType.toLowerCase() === 'article' &&
+                config.page.edition === 'UK' &&
+                config.page.contentType === 'Article' &&
                 alreadyVisited > 9;
         };
 


### PR DESCRIPTION
Fixes an error caused by https://github.com/guardian/frontend/pull/9548, kindly reported by @johnduffell 

`contentType` can be undefined so calling `toLowerCase()` caused a `TypeError` on profile pages. This PR returns to previous version which didn't call `toLowerCase`.

![screen shot 2015-06-19 at 15 10 24](https://cloud.githubusercontent.com/assets/123386/8255227/5a002740-1696-11e5-97a8-25769874831c.png)

@stephanfowler 
