### PR TITLE
remove html from bylines

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -167,7 +167,8 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   override lazy val headline: String = apiContent.metaData.flatMap(_.headline).getOrElse(fields.getOrDefault("headline", ""))
 
   override lazy val trailText: Option[String] = apiContent.metaData.flatMap(_.trailText).orElse(fields.get("trailText"))
-  override lazy val byline: Option[String] = apiContent.metaData.flatMap(_.byline).orElse(fields.get("byline"))
+  // old bylines can have html http://internal.content.guardianapis.com/commentisfree/2012/nov/10/cocoa-chocolate-fix-under-threat?show-fields=byline
+  override lazy val byline: Option[String] = apiContent.metaData.flatMap(_.byline).orElse(fields.get("byline").map(stripHtml))
   override val showByline = resolvedMetaData.showByline
 
   override def isSurging: Seq[Int] = SurgingContentAgent.getSurgingLevelsFor(id)

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -2,6 +2,8 @@ package model
 
 import common.Edition
 import com.gu.contentapi.client.model.{Content => ApiContent}
+import org.jsoup.Jsoup
+import org.jsoup.safety.Whitelist
 import scala.math.abs
 
 object `package` {
@@ -48,6 +50,10 @@ object `package` {
       val normalizedPath = parts.mkString("-")
       Seq(path, s"$normalizedPath/$normalizedPath")
     }
+  }
+
+  def stripHtml(text: String) = {
+    Jsoup.clean(text, Whitelist.none())
   }
 
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7304387/8255770/55498760-169a-11e5-88b6-f9c0d143bc8f.png)
should be
![image](https://cloud.githubusercontent.com/assets/7304387/8255802/769f6a06-169a-11e5-919c-7586c09c2b93.png)
I talked to CAPI and it seems like that field "should" be text but on many old pieces of content there's some html added in, so I've just taken the precaution of stripping anything that looks like html before it gets into the model.
