### PR TITLE
proxy comment POSTs so http 1 users can use discussion

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1109,7 +1109,7 @@ object Switches {
     "in discussion/api.js we have a feature to let you go through a proxy.  This will be permanently switched over if it works out.",
     safeState = Off,
     sellByDate = new LocalDate(2015, 7, 16),
-    exposeClientSide = false
+    exposeClientSide = true
   )
 
   // Facia

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1106,9 +1106,9 @@ object Switches {
   val DiscussionProxySwitch = Switch(
     "Feature",
     "discussion-proxy",
-    "in discussion/api.js we have a feature to let you go through a proxy.  This will be permanently switched over if it works out.",
+    "in discussion/api.js it will use a proxy to post comments so http 1.0 users can still comment",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 7, 16),
+    sellByDate = never,
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/discussion/api.js
+++ b/static/src/javascripts/projects/common/modules/discussion/api.js
@@ -14,13 +14,14 @@ define([
      * Singleton to deal with Discussion API requests
      * @type {Object}
      */
-    var Api = {
-        root: (document.location.protocol === 'https:')
-                ? config.page.secureDiscussionApiRoot
-                : config.page.discussionApiRoot,
-        proxyRoot: (prefs.isOn('discussion.useProxy') ? 'http://www.theguardian.com/guardianapis/discussion/discussion-api' : config.page.discussionApiRoot),
-        clientHeader: config.page.discussionApiClientHeader
-    };
+    var root = (document.location.protocol === 'https:')
+            ? config.page.secureDiscussionApiRoot
+            : config.page.discussionApiRoot,
+        Api = {
+            root: root,
+            proxyRoot: (config.switches.discussionProxy ? (config.page.host + '/guardianapis/discussion/discussion-api') : root),
+            clientHeader: config.page.discussionApiClientHeader
+        };
 
     /**
      * @param {string} endpoint


### PR DESCRIPTION
following on from https://github.com/guardian/frontend/pull/9503 I have made it use the switch and stopped it expiring.  If we get a flood of complaints, we can turn it off easily, but apart from that it should be good to go.
