### PR TITLE
fully qualified url in linked data

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -1,7 +1,7 @@
 package layout
 
 import com.gu.facia.api.models.{CollectionConfig, CuratedContent, FaciaContent}
-import conf.Switches
+import conf.{Configuration, Switches}
 import dfp.{DfpAgent, SponsorshipTag}
 import implicits.FaciaContentFrontendHelpers._
 import implicits.FaciaContentImplicits._
@@ -436,7 +436,7 @@ object Front extends implicits.Collections {
               "", // don't have a uri for each container
               collection.items.zipWithIndex.map {
                 case (item, index) =>
-                  ListItem(position = index, url = Some(item.url))
+                  ListItem(position = index, url = Some(Configuration.site.host + item.url))
               }
             )
           ))

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -3,7 +3,7 @@ package services
 import com.gu.facia.api.models.{CollectionConfig, FaciaContent}
 import com.gu.facia.api.utils.{ReviewKicker, CartoonKicker, TagKicker}
 import common.Edition
-import conf.Switches
+import conf.{Configuration, Switches}
 import contentapi.Paths
 import layout.DateHeadline.cardTimestampDisplay
 import layout._
@@ -152,7 +152,7 @@ object IndexPage {
       indexPage.page.url,
       indexPage.trails.zipWithIndex.map {
         case (trail, index) =>
-          ListItem(position = index, url = Some(trail.url))
+          ListItem(position = index, url = Some(Configuration.site.host + trail.url))
       }
     )
   }


### PR DESCRIPTION
In linked data if we embed it as json-ld case we need fully qualified URLs as it may not pick up the document base.

This does add to our page weight, but GZIP should take most of that extra out again.  The alternative would be to change to microdata instead of json-ld, but the items each need an index in the page, so I would have to pass the index all the way through to the templates which would be more invasive.
