### PR TITLE
extending expiry date to end of next quarter so we have time to imple…

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -960,7 +960,7 @@ object Switches {
     "ipad-no-thrashers",
     "This switch will disable Thrashers on ipads",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 6, 20),
+    sellByDate = new LocalDate(2015, 9, 30),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
Extending deadline of switch to end of next quarter - plan is to implement this in a different way as part of performance improvement work, but as this has made a difference to number of crashes in ipad 3' and later version we want to keep the change in the meantime. 
