### PR TITLE
Fix SFL delete all button

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/saved-for-later.js
+++ b/static/src/javascripts/projects/common/modules/identity/saved-for-later.js
@@ -10,7 +10,6 @@ define([
     'common/utils/template',
     'common/modules/identity/api',
     'common/views/svgs',
-
     'text!common/views/save-for-later/delete-all-button.html'
 ], function (
     $,
@@ -52,6 +51,9 @@ define([
                     }));
                 });
             });
+            if (state === 'confirm') {
+                setTimeout(this.init.bind(this), 2000);
+            }
         };
     }
 

--- a/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
+++ b/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
@@ -2,6 +2,6 @@
     <button type="submit" class="submit-input button button--medium button--tertiary save-for-later__button--delete-all js-save-for-later__button save-for-later__button--delete-all--<%= state %>" data-link-name="meta-save-for-later--delete-all" value="all" name="deleteArticle">
         <%= icon %>
         <span class="save-for-later__label save-for-later__label--delete-all">Remove all</span>
-        <span class="save-for-later__label save-for-later__label--delete-all--confirm">Sure?</span>
+        <span class="save-for-later__label save-for-later__label--delete-all--confirm">Are you sure?</span>
     </button>
 </div>

--- a/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
+++ b/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
@@ -2,6 +2,6 @@
     <button type="submit" class="submit-input button button--medium button--tertiary save-for-later__button--delete-all js-save-for-later__button save-for-later__button--delete-all--<%= state %>" data-link-name="meta-save-for-later--delete-all" value="all" name="deleteArticle">
         <%= icon %>
         <span class="save-for-later__label save-for-later__label--delete-all">Remove all</span>
-        <span class="save-for-later__label save-for-later__label--delete-all--confirm">Remove all stories?</span>
+        <span class="save-for-later__label save-for-later__label--delete-all--confirm">Sure?</span>
     </button>
 </div>


### PR DESCRIPTION
- automatically reverts from the confirmation state to the standard state after 2 seconds
- updates the confirmation message to be a simple 'sure?' so it fits at all breakpoints

![screen shot 2015-06-22 at 15 35 10](https://cloud.githubusercontent.com/assets/867233/8284366/731706da-18f4-11e5-9318-7119f2d5046e.png)

(if this works well, it seems like it would a useful behaviour to add to pasteup, so that, for example, by the addition of a simple `confirm` attribute to a button, you could co-opt this behaviour. but that doesn't need doing for this…
