### PR TITLE
Improve tracking context on SFL 'delete all'

### DIFF
--- a/identity/app/views/profile/savedForLater.scala.html
+++ b/identity/app/views/profile/savedForLater.scala.html
@@ -17,7 +17,7 @@
 
                         <div class="saved-content__header__description">you have @(pageData.totalArticlesSaved) saved articles</div>
 
-                        <div class="js-save-for-later__delete-all save-for-later__delete-all-container" data-link-name="meta-save-for-later--delete-all"></div>
+                        <div class="js-save-for-later__delete-all save-for-later__delete-all-container"></div>
                     </div>
                     <div class="fc-container__body">
                         @if(savedArticleForm.globalError.isDefined) {

--- a/static/src/javascripts/projects/common/modules/identity/saved-for-later.js
+++ b/static/src/javascripts/projects/common/modules/identity/saved-for-later.js
@@ -47,7 +47,8 @@ define([
                 fastdom.write(function () {
                     $button.html(template(deleteButtonAllTmp, {
                         icon: svgs('crossIcon'),
-                        state: state
+                        state: state,
+                        dataLinkName: 'saved | remove all' + (state === 'confirm' ? ' | confirm' : '')
                     }));
                 });
             });

--- a/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
+++ b/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
@@ -1,5 +1,5 @@
 <div class="save-for-later-delete-all" data-component="meta-save-for-later--delete-all">
-    <button type="submit" class="submit-input button button--medium button--tertiary save-for-later__button--delete-all js-save-for-later__button save-for-later__button--delete-all--<%= state %>" data-link-name="saved | remove all" value="all" name="deleteArticle">
+    <button type="submit" class="submit-input button button--medium button--tertiary save-for-later__button--delete-all js-save-for-later__button save-for-later__button--delete-all--<%= state %>" data-link-name="saved | remove all<%= state ? ' | ' + state : ''  %>" value="all" name="deleteArticle">
         <%= icon %>
         <span class="save-for-later__label save-for-later__label--delete-all">Remove all</span>
         <span class="save-for-later__label save-for-later__label--delete-all--confirm">Are you sure?</span>

--- a/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
+++ b/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
@@ -1,5 +1,5 @@
-<div class="save-for-later-delete-all" data-link-name="meta-save-for-later-delete--all" data-component="meta-save-for-later--delete-all">
-    <button type="submit" class="submit-input button button--medium button--tertiary save-for-later__button--delete-all js-save-for-later__button save-for-later__button--delete-all--<%= state %>" data-link-name="meta-save-for-later--delete-all" value="all" name="deleteArticle">
+<div class="save-for-later-delete-all" data-component="meta-save-for-later--delete-all">
+    <button type="submit" class="submit-input button button--medium button--tertiary save-for-later__button--delete-all js-save-for-later__button save-for-later__button--delete-all--<%= state %>" data-link-name="saved | remove all" value="all" name="deleteArticle">
         <%= icon %>
         <span class="save-for-later__label save-for-later__label--delete-all">Remove all</span>
         <span class="save-for-later__label save-for-later__label--delete-all--confirm">Are you sure?</span>

--- a/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
+++ b/static/src/javascripts/projects/common/views/save-for-later/delete-all-button.html
@@ -1,5 +1,5 @@
 <div class="save-for-later-delete-all" data-component="meta-save-for-later--delete-all">
-    <button type="submit" class="submit-input button button--medium button--tertiary save-for-later__button--delete-all js-save-for-later__button save-for-later__button--delete-all--<%= state %>" data-link-name="saved | remove all<%= state ? ' | ' + state : ''  %>" value="all" name="deleteArticle">
+    <button type="submit" class="submit-input button button--medium button--tertiary save-for-later__button--delete-all js-save-for-later__button save-for-later__button--delete-all--<%= state %>" data-link-name="<%= dataLinkName  %>" value="all" name="deleteArticle">
         <%= icon %>
         <span class="save-for-later__label save-for-later__label--delete-all">Remove all</span>
         <span class="save-for-later__label save-for-later__label--delete-all--confirm">Are you sure?</span>


### PR DESCRIPTION
- was: `meta-save-for-later--delete-all | meta-save-for-later-delete--all | meta-save-for-later--delete-all`
- will now be either: 
  - `saved | remove all` or
  - `saved | remove all | confirm`
