### PR TITLE
Change press-on-demand switch to never expire

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1201,7 +1201,7 @@ object Switches {
     "facia-press-on-demand",
     "If this is switched on, you can force facia to press on demand (Leave off)",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 6, 30),
+    sellByDate = never,
     exposeClientSide = false
   )
 


### PR DESCRIPTION
This is a useful feature, but we want it to mainly stay switched off until we need it.
