### PR TITLE
Fix tracking for browsers without Array.prototype.forEach

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -151,7 +151,7 @@ define([
             }
         }
 
-        getServerSideTests().forEach(function (testName) {
+        _.forEach(getServerSideTests(), function (testName) {
             tag.push('AB | ' + testName + ' | inTest');
         });
 
@@ -334,7 +334,7 @@ define([
                         }
                     }
                 });
-                getServerSideTests().forEach(function (testName) {
+                _.forEach(getServerSideTests(), function (testName) {
                     abLogObject['ab' + testName] = 'inTest';
                 });
             } catch (error) {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -272,7 +272,7 @@ define([
                 forceUserIntoTest = /^#ab/.test(window.location.hash);
             if (forceUserIntoTest) {
                 tokens = window.location.hash.replace('#ab-', '').split(',');
-                tokens.forEach(function (token) {
+                _.forEach(tokens, function (token) {
                     var abParam, test, variant;
                     abParam = token.split('=');
                     test = abParam[0];


### PR DESCRIPTION
Compare https://dashboard.ophan.co.uk/ab?uafamily=IE+8 to https://dashboard.ophan.co.uk/ab?uafamily=IE+9
