### PR TITLE
Fix zxcvbn in curl

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/password-strength.js
+++ b/static/src/javascripts/projects/common/modules/identity/password-strength.js
@@ -44,7 +44,7 @@ define([
         this.init = function () {
             if (!bonzo(dom.element).hasClass(config.classes.ready)) {
                 var self = this;
-                require(['zxcvbn'], function () {
+                require(['js!zxcvbn'], function () {
                     zxcvbn = this.zxcvbn;
                     dom.indicator = bonzo(bonzo.create(template)).insertAfter(dom.element)[0];
                     dom.label = dom.indicator.querySelector('.' + config.classes.label);

--- a/static/src/systemjs-normalize.js
+++ b/static/src/systemjs-normalize.js
@@ -33,6 +33,9 @@ var reduce = function (array, fn, accumulator) {
                 // the package.json’s main property.
                 if (name === 'socketio') {
                     return 'socketio/socket.io';
+                // Unlike SystemJS, curl does not support globals out of the box
+                } else if (name === 'js!zxcvbn') {
+                    return 'zxcvbn';
                 } else {
                     return name;
                 }


### PR DESCRIPTION
Fixed for jspm in https://github.com/guardian/frontend/commit/f4a1f47f7fbf06d3928078c4aad70467606b7a3d#diff-fd6526d378334a01327fcede446cb12dL47, but this broke it for curl.
