### PR TITLE
Sticky nav fix on sensitive pages

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/sticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/sticky.js
@@ -109,7 +109,7 @@ define([
                     this.$els.navigation.removeClass('animate-down-mobile').addClass('animate-up-mobile');
                 } else {
                     if (config.page.section === 'childrens-books-site' || config.page.shouldHideAdverts) {
-                        this.$els.navigation.css('height', '72px');
+                        this.$els.navigation.css('display', 'block');
                     } else {
                         this.$els.navigation.removeClass('animate-down-desktop').addClass('animate-up-desktop');
                     }
@@ -131,7 +131,7 @@ define([
                     this.$els.navigation.removeClass('animate-up-mobile').addClass('animate-down-mobile');
                 } else {
                     if (config.page.section === 'childrens-books-site' || config.page.shouldHideAdverts) {
-                        this.$els.navigation.css('height', 0);
+                        this.$els.navigation.css('display', 'none');
                     } else {
                         this.$els.navigation.removeClass('animate-up-desktop').addClass('animate-down-desktop');
                     }

--- a/static/src/javascripts/projects/common/modules/navigation/sticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/sticky.js
@@ -105,12 +105,14 @@ define([
         // If user is scrolling up and navigation threshold was met show navigation
         if (this.config.direction === 'up' && this.config.showNavigation) {
             fastdom.write(function () {
-                if (config.page.section === 'childrens-books-site' || config.page.shouldHideAdverts) {
-                    this.$els.navigation.css('height', '72px');
-                } else if (this.isTablet || this.isMobile) {
+                if (this.isTablet || this.isMobile) {
                     this.$els.navigation.removeClass('animate-down-mobile').addClass('animate-up-mobile');
                 } else {
-                    this.$els.navigation.removeClass('animate-down-desktop').addClass('animate-up-desktop');
+                    if (config.page.section === 'childrens-books-site' || config.page.shouldHideAdverts) {
+                        this.$els.navigation.css('height', '72px');
+                    } else {
+                        this.$els.navigation.removeClass('animate-down-desktop').addClass('animate-up-desktop');
+                    }
                 }
             }.bind(this));
         } else {
@@ -125,12 +127,14 @@ define([
                 }
             }
             fastdom.write(function () {
-                if (config.page.section === 'childrens-books-site' || config.page.shouldHideAdverts) {
-                    this.$els.navigation.css('height', 0);
-                } else if (this.isTablet || this.isMobile) {
+                if (this.isTablet || this.isMobile) {
                     this.$els.navigation.removeClass('animate-up-mobile').addClass('animate-down-mobile');
                 } else {
-                    this.$els.navigation.removeClass('animate-up-desktop').addClass('animate-down-desktop');
+                    if (config.page.section === 'childrens-books-site' || config.page.shouldHideAdverts) {
+                        this.$els.navigation.css('height', 0);
+                    } else {
+                        this.$els.navigation.removeClass('animate-up-desktop').addClass('animate-down-desktop');
+                    }
                 }
             }.bind(this));
         }

--- a/static/src/javascripts/projects/common/modules/navigation/sticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/sticky.js
@@ -105,7 +105,9 @@ define([
         // If user is scrolling up and navigation threshold was met show navigation
         if (this.config.direction === 'up' && this.config.showNavigation) {
             fastdom.write(function () {
-                if (this.isTablet || this.isMobile) {
+                if (config.page.section === 'childrens-books-site' || config.page.shouldHideAdverts) {
+                    this.$els.navigation.css('height', '72px');
+                } else if (this.isTablet || this.isMobile) {
                     this.$els.navigation.removeClass('animate-down-mobile').addClass('animate-up-mobile');
                 } else {
                     this.$els.navigation.removeClass('animate-down-desktop').addClass('animate-up-desktop');
@@ -123,7 +125,9 @@ define([
                 }
             }
             fastdom.write(function () {
-                if (this.isTablet || this.isMobile) {
+                if (config.page.section === 'childrens-books-site' || config.page.shouldHideAdverts) {
+                    this.$els.navigation.css('height', 0);
+                } else if (this.isTablet || this.isMobile) {
                     this.$els.navigation.removeClass('animate-up-mobile').addClass('animate-down-mobile');
                 } else {
                     this.$els.navigation.removeClass('animate-up-desktop').addClass('animate-down-desktop');
@@ -200,9 +204,6 @@ define([
                     }.bind(this));
                 } else {
                     fastdom.write(function () {
-                        // Make sure navigation is hidden
-                        this.$els.navigation.removeClass('animate-up').addClass('animate-down');
-
                         this.$els.header.css({
                             position:  'absolute',
                             'margin-top': bannerHeight,

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -170,7 +170,7 @@ $c-navigation-expandable-background: colour(neutral-1);
 }
 .navigation__expandable--sticky {
     overflow-x: hidden;
-    overflow-y: scroll; 
+    overflow-y: scroll;
 }
 .signposting,
 .local-navigation,


### PR DESCRIPTION
This pr fixes bug on sensitive pages (pages with no ads like children's books) when animation on slim nav looks like a bug.
The only (and easiest) solution I can think of is to remove animation and only show/hide slim nav instead.
