### PR TITLE
Only run tests for modern browsers

### DIFF
--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -291,8 +291,10 @@
                     lazyLoadImages
                 ) {
 
-                    ab.segmentUser();
-                    ab.run();
+                    if (guardian.isModernBrowser) {
+                        ab.segmentUser();
+                        ab.run();
+                    }
                     if(guardian.config.page.isFront) {
                         if(!document.addEventListener) { // IE8 and below
                             window.onload = images.upgradePictures;

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -396,8 +396,11 @@
                     var images = values[2];
                     var lazyLoadImages = values[3];
 
-                    ab.segmentUser();
-                    ab.run();
+                    if (guardian.isModernBrowser) {
+                        ab.segmentUser();
+                        ab.run();
+                    }
+
                     if(guardian.config.page.isFront) {
                         if(!document.addEventListener) { // IE8 and below
                             window.onload = images.upgradePictures;


### PR DESCRIPTION
Is there any good reason to run tests for non-modern browsers?
