### PR TITLE
Revert "Fix IE: do not use reserved keywords"

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
@@ -50,11 +50,7 @@ define([
             if (config.switches.audienceScienceGateway && storedSegments) {
                 segments = _(_.pairs(storedSegments[section]))
                     .filter(function (placement) {
-                        /*eslint-disable dot-notation*/
-                        // jscs:disable requireDotNotation
-                        return placement[1]['default'];
-                        // jscs:enable requireDotNotation
-                        /*eslint-enable dot-notation*/
+                        return placement[1].default;
                     })
                     .map(function (placement) {
                         return ['pq_' + placement[0], 'T'];

--- a/static/src/javascripts/projects/common/modules/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/save-for-later.js
@@ -235,11 +235,7 @@ define([
         );
     };
 
-    /*eslint-disable dot-notation*/
-    // jscs:disable requireDotNotation
-    SaveForLater.prototype['delete'] = function (pageId, shortUrl, onDelete) {
-        /*eslint-enable dot-notation*/
-        // jscs:enable requireDotNotation
+    SaveForLater.prototype.delete = function (pageId, shortUrl, onDelete) {
         this.userData.articles = _.filter(this.userData.articles, function (article) {
             return article.shortUrl !== shortUrl;
         });
@@ -265,11 +261,7 @@ define([
     };
 
     SaveForLater.prototype.deleteArticle = function (pageId, shortUrl) {
-        /*eslint-disable dot-notation*/
-        // jscs:disable requireDotNotation
-        this['delete'](pageId, shortUrl, this.onDeleteArticle);
-        /*eslint-enable dot-notation*/
-        // jscs:enable requireDotNotation
+        this.delete(pageId, shortUrl, this.onDeleteArticle);
     };
 
     SaveForLater.prototype.onDeleteArticle = function (success) {
@@ -345,11 +337,7 @@ define([
 
     SaveForLater.prototype.createDeleteFaciaItemHandler = function (link, id, shortUrl) {
         bean.one(link, 'click',
-            /*eslint-disable dot-notation*/
-            // jscs:disable requireDotNotation
-            this['delete'].bind(this,
-                /*eslint-enable dot-notation*/
-                // jscs:enable requireDotNotation
+            this.delete.bind(this,
                 id,
                 shortUrl,
                 this.onDeleteFaciaItem.bind(this, link, id, shortUrl)


### PR DESCRIPTION
This reverts commit af304c5a1323df9b672dcf17fc5462b849d4089a, PR #9587.

It turns out that Uglify transforms these for us for IE compat. I was testing without minification. Oops.
