### PR TITLE
Temporary fix for URL polyfill in old browsers, i.e. Mobile Safari 7

### DIFF
--- a/common/app/templates/systemJsSetup.scala.js
+++ b/common/app/templates/systemJsSetup.scala.js
@@ -1,6 +1,17 @@
 @()
 
 @JavaScript(Static.js.systemJsPolyfills)
+// Temporary fix for URL polyfill in old browsers, i.e. Mobile Safari 7
+// As per https://github.com/systemjs/systemjs/issues/548
+// This will be removed when the fix has been released
+try {
+    if (new URL('test:///').protocol != 'test:') {
+        URL = URLPolyfill;
+    }
+}
+catch (e) {
+    URL = URLPolyfill;
+}
 @JavaScript(Static.js.systemJs)
 
 System.config({


### PR DESCRIPTION
This will fix SystemJS for Mobile Safari 7, and hopefully other older browsers. See https://github.com/systemjs/systemjs/issues/548 for more details.

See https://docs.google.com/a/guardian.co.uk/spreadsheets/d/1Vd07TQ4O43z6t35MS6Pu5KDBWELmpoIXbHhDyh0tFs8/edit?usp=sharing for browser breakdown.
