### PR TITLE
Facia data link hygiene

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -225,7 +225,8 @@ object FaciaCard {
       faciaContent.isLive,
       None,
       faciaContent.shortUrlPath,
-      useShortByline = false
+      useShortByline = false,
+      faciaContent.group
     )
   }
 }
@@ -253,7 +254,8 @@ case class ContentCard(
   isLive: Boolean,
   timeStampDisplay: Option[FaciaCardTimestamp],
   shortUrl: Option[String],
-  useShortByline: Boolean
+  useShortByline: Boolean,
+  group: String
 ) extends FaciaCard {
   def bylineText: Option[String] = if (useShortByline) byline.map(_.shortByline) else byline.map(_.get)
 
@@ -281,6 +283,8 @@ case class ContentCard(
   def mediaWidthsByBreakpoint = FaciaWidths.mediaFromItemClasses(cardTypes)
 
   def showTimestamp = timeStampDisplay.isDefined && webPublicationDate.isDefined
+
+  val analyticsPrefix = s"${cardStyle.toneString} | group-$group${if(displaySettings.isBoosted) "+" else ""}"
 }
 
 case class HtmlBlob(html: Html, customCssClasses: Seq[String], cardTypes: ItemClasses) extends FaciaCard

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -15,7 +15,7 @@
     }
     <section id="@componentName"
              class="@GetClasses.forContainerDefinition(containerDefinition)"
-             data-link-name="@{containerDefinition.index + 1} | @componentName"
+             data-link-name="container-@{containerDefinition.index + 1} | @componentName"
              data-id="@containerDefinition.dataId"
              @for(tag <- containerDefinition.commercialOptions.sponsorshipTag) {
                  @tag.tagType match {

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -26,7 +26,7 @@
         data-headline-variants="@headlines"
     }
 
-data-link-name="@item.cardStyle.toneString | @{index + 1}"
+data-link-name="@item.analyticsPrefix | card-@{index + 1}"
     @item.id.map { id =>
     data-id="@id"
     }


### PR DESCRIPTION
This adds meaningful labels to the existing data link names. An index that refers to the container order looks like `container-1`, and an index that refers to the order of a facia card within a single container looks like `card-1`.

Also added a group value, which is used to infer editorial priority for a specific card.

@philwills  
