### PR TITLE
remove entities from bylines

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -55,6 +55,7 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>                        
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json    controllers.InteractiveController.renderInteractiveJson(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>         controllers.InteractiveController.renderInteractive(path)
 
+# Index pages for tags
 GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/trails.json                 controllers.IndexController.renderTrailsJson(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/trails                      controllers.IndexController.renderTrails(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                        controllers.IndexController.renderJson(path)

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -1,9 +1,8 @@
 package model
 
-import common.Edition
 import com.gu.contentapi.client.model.{Content => ApiContent}
-import org.jsoup.Jsoup
-import org.jsoup.safety.Whitelist
+import common.Edition
+
 import scala.math.abs
 
 object `package` {

--- a/common/app/model/package.scala
+++ b/common/app/model/package.scala
@@ -53,7 +53,7 @@ object `package` {
   }
 
   def stripHtml(text: String) = {
-    Jsoup.clean(text, Whitelist.none())
+    text.replaceAll("""(<a[^>]*>)|(</a>)""", "")
   }
 
 }


### PR DESCRIPTION
Using jsoup in https://github.com/guardian/frontend/pull/9558 actually turned special characters into html entites.  Rather than going for an elaborate solution I have decided to just regex out the offending <a> elements instead of the jsoup solution in the previous PR.
The result:
![image](https://cloud.githubusercontent.com/assets/7304387/8354464/3a8a3b5e-1b40-11e5-92e9-cf08e1611018.png)
@sndrs 
