### PR TITLE
Strip imgIX parameters when validating images

### DIFF
--- a/facia-tool/public/js/constants/defaults.js
+++ b/facia-tool/public/js/constants/defaults.js
@@ -89,6 +89,7 @@ export default {
     reauthTimeout:         60000,
 
     imageCdnDomain:        '.guim.co.uk',
+    imgIXBasePath:         '/img/static/',
     previewBase:           'http://preview.gutools.co.uk',
 
     latestSnapPrefix:      'Latest from ',

--- a/facia-tool/public/js/utils/validate-image-src.js
+++ b/facia-tool/public/js/utils/validate-image-src.js
@@ -1,6 +1,8 @@
 import _ from 'underscore';
 import Promise from 'Promise';
 import {CONST} from 'modules/vars';
+import absPath from 'utils/url-abs-path';
+import params from 'utils/parse-query-params';
 
 /**
  * Asserts if the given image URL is on The Guardian domain, is proper size and aspect ratio.
@@ -26,6 +28,8 @@ function validateImageSrc(src, criteria) {
             reject(new Error('Images must come from *' + CONST.imageCdnDomain));
 
         } else {
+            src = stripImgIXDetails(src);
+
             img = new Image();
             img.onerror = function() {
                 reject(new Error('That image could not be found'));
@@ -56,6 +60,18 @@ function validateImageSrc(src, criteria) {
             img.src = src;
         }
     });
+}
+
+function stripImgIXDetails (src) {
+    var pathname = '/' + absPath(src),
+        base = src.substring(0, src.indexOf(pathname)),
+        hash = params(src).s || '';
+
+    if (pathname.indexOf(CONST.imgIXBasePath) === 0 && hash.match(/[0-9a-f]{32}/)) {
+        return base + '/' + pathname.substring(CONST.imgIXBasePath.length);
+    } else {
+        return src;
+    }
 }
 
 export default validateImageSrc;

--- a/facia-tool/public/js/utils/validate-image-src.js
+++ b/facia-tool/public/js/utils/validate-image-src.js
@@ -2,7 +2,6 @@ import _ from 'underscore';
 import Promise from 'Promise';
 import {CONST} from 'modules/vars';
 import absPath from 'utils/url-abs-path';
-import params from 'utils/parse-query-params';
 
 /**
  * Asserts if the given image URL is on The Guardian domain, is proper size and aspect ratio.
@@ -64,10 +63,9 @@ function validateImageSrc(src, criteria) {
 
 function stripImgIXDetails (src) {
     var pathname = '/' + absPath(src),
-        base = src.substring(0, src.indexOf(pathname)),
-        hash = params(src).s || '';
+        base = src.substring(0, src.indexOf(pathname));
 
-    if (pathname.indexOf(CONST.imgIXBasePath) === 0 && hash.match(/[0-9a-f]{32}/)) {
+    if (pathname.indexOf(CONST.imgIXBasePath) === 0) {
         return base + '/' + pathname.substring(CONST.imgIXBasePath.length);
     } else {
         return src;

--- a/facia-tool/test/public/spec/validate.image.spec.js
+++ b/facia-tool/test/public/spec/validate.image.spec.js
@@ -86,10 +86,7 @@ describe('Validate images', function () {
             expect(image.height).toBe(140);
             expect(image.src).toMatch(/square\.png/);
             done();
-        }, function (err) {
-            expect(NaN).toBe(err);
-            done();
-        });
+        }, done.fail);
     });
 
     it('works with if all criteria are met', function (done) {
@@ -107,9 +104,19 @@ describe('Validate images', function () {
             expect(image.height).toBe(140);
             expect(image.src).toMatch(/square\.png/);
             done();
-        }, function (err) {
-            expect(NaN).toBe(err);
+        }, done.fail);
+    });
+
+    it('strips unnecessary parameters', function (done) {
+        CONST.imageCdnDomain = window.location.host;
+
+        validate('http://' + CONST.imageCdnDomain + CONST.imgIXBasePath +
+            'base/test/public/fixtures/square.png?s=82a57a91afadd159bb4639d6b798f6c5&other=params')
+        .then(function (image) {
+            expect(image.width).toBe(140);
+            expect(image.height).toBe(140);
+            expect(image.src).toMatch(/square\.png$/);
             done();
-        });
+        }, done.fail);
     });
 });


### PR DESCRIPTION
Images that look like 

`http://i.guim.co.uk/img/static/sys-images/....png?w=300&q=85&auto=format&sharp=10&s=82a57a91afadd159bb4639d6b798f6c5`

are converted to 

`http://i.guim.co.uk/sys-images/....png`

@stephanfowler @paperboyo
