### PR TITLE
Only include master images when using ImgIx resizing service

### DIFF
--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -28,7 +28,8 @@ case class ImageAsset(delegate: Asset, index: Int) {
   lazy val source: Option[String] = fields.get("source")
   lazy val photographer: Option[String] = fields.get("photographer")
   lazy val credit: Option[String] = fields.get("credit")
-  lazy val displayCredit: Boolean = fields.get("displayCredit").exists(_=="true")
+  lazy val displayCredit: Boolean = fields.get("displayCredit").contains("true")
+  lazy val isMaster: Boolean = fields.get("isMaster").contains("true")
 
   def showCaption = caption.exists(_.trim.nonEmpty) || (displayCredit && credit.nonEmpty)
 

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -32,11 +32,14 @@ object Element {
 
 trait ImageContainer extends Element {
 
-  lazy val imageCrops: Seq[ImageAsset] =
-    delegate.assets.filter(_.`type` == "image").map(ImageAsset(_,index)).sortBy(-_.width)
+  private val allImages: Seq[ImageAsset] = delegate.assets.filter(_.`type` == "image").map(ImageAsset(_,index)).sortBy(-_.width)
+
+  lazy val imageCrops: Seq[ImageAsset] = allImages.filterNot(_.isMaster)
+
+  lazy val masterImage: Option[ImageAsset] = allImages.find(_.isMaster)
 
   // The image crop with the largest width.
-  lazy val largestImage: Option[ImageAsset] = imageCrops.headOption
+  lazy val largestImage: Option[ImageAsset] = masterImage.orElse(imageCrops.headOption)
 
   // all landscape images get 4:3 aspect autocrops generated at widths of 1024 and 2048. portrait images are never
   // auto-cropped.. this is a temporary solution until the new media service is in use and we can properly

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -1,9 +1,10 @@
 package views.support
 
+import org.joda.time.DateTime
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import model.{ImageContainer, ImageAsset}
-import com.gu.contentapi.client.model.Asset
+import com.gu.contentapi.client.model.{Content, Asset, Tag, Element}
 import conf.Switches.{ImageServerSwitch, PngResizingSwitch}
 import conf.Configuration
 
@@ -12,16 +13,28 @@ class ImgSrcTest extends FlatSpec with Matchers  {
 
   val imageHost = Configuration.images.path
 
-  val asset: Asset = Asset(
+  val asset = Asset(
     "image",
     Some("image/jpeg"),
     Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg"),
     Map.empty[String, String]
   )
 
+  val element = Element("elementId", "main", "image", Some(1), List(asset))
+
+  val tag = List(Tag(id = "type/article", `type` = "keyword", webTitle = "",
+      sectionId = None, sectionName = None, webUrl = "", apiUrl = "apiurl", references = Nil))
+
+  val content = Content("foo/2012/jan/07/bar", None, None, Some(new DateTime), "Some article",
+      "http://www.guardian.co.uk/foo/2012/jan/07/bar",
+      "http://content.guardianapis.com/foo/2012/jan/07/bar",
+      tags = tag,
+      elements = Some(List(element))
+    )
+
   val imageAsset = ImageAsset(asset, 1)
 
-  val image = ImageContainer(Seq(imageAsset), null, imageAsset.index) // yep null, sorry but the tests don't need it
+  val image = ImageContainer(Seq(imageAsset), element, imageAsset.index) // yep null, sorry but the tests don't need it
 
   val mediaImageAsset = ImageAsset(Asset(
     "image",
@@ -30,7 +43,7 @@ class ImgSrcTest extends FlatSpec with Matchers  {
     Map.empty[String, String]
   ), 1)
 
-  val mediaImage = ImageContainer(Seq(mediaImageAsset), null, mediaImageAsset.index)
+  val mediaImage = ImageContainer(Seq(mediaImageAsset), element, mediaImageAsset.index)
 
 
   "ImgSrc" should "convert the URL of a static image to the resizing endpoint with a /static prefix" in {
@@ -51,19 +64,19 @@ class ImgSrcTest extends FlatSpec with Matchers  {
   it should "convert the URL of the image if it is a PNG" in {
     ImageServerSwitch.switchOn()
     PngResizingSwitch.switchOn()
-    val pngImage = ImageContainer(Seq(ImageAsset(asset.copy(file = Some("http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)), null, 0)
+    val pngImage = ImageContainer(Seq(ImageAsset(asset.copy(file = Some("http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)), element, 0)
     Item700.bestFor(pngImage) should be (Some(s"$imageHost/static/w-700/h--/q-95/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png"))
   }
 
   it should "not convert the URL of the image if it is a GIF (we do not support animated GIF)" in {
     ImageServerSwitch.switchOn()
-    val gifImage = ImageContainer(Seq(ImageAsset(asset.copy(file = Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.gif")),0)), null, 0)
+    val gifImage = ImageContainer(Seq(ImageAsset(asset.copy(file = Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.gif")),0)), element, 0)
     Item700.bestFor(gifImage) should be (Some("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.gif"))
   }
 
   it should "not convert the URL of the image if it is not one of ours" in {
     ImageServerSwitch.switchOn()
-    val someoneElsesImage = ImageContainer(Seq(ImageAsset(asset.copy(file = Some("http://foo.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.gif")),0)), null, 0)
+    val someoneElsesImage = ImageContainer(Seq(ImageAsset(asset.copy(file = Some("http://foo.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.gif")),0)), element, 0)
     Item700.bestFor(someoneElsesImage) should be (Some("http://foo.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.gif"))
   }
 }


### PR DESCRIPTION
We can accomodate for the upcoming introduction of master images (in https://github.com/guardian/content-api/pull/965) by excluding master images in the standard image resizing service (to save CPU load), and by prioritising master images in the ImgIx image resizing service (to save money).

We only use `largestImage` when constructing image srcsets for ImgIx. This service has a pricing model that prefers a consistent master src throughout the whole srcset.

@kenoir
