### PR TITLE
No lazy loading on pageskinned pages

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -203,14 +203,6 @@ define([
             mediator.on('window:resize', windowResize);
         },
 
-        isLzAdsSwitchOn = function () {
-            return config.switches.lzAds;
-        },
-
-        isPageSkinned = function () {
-            return config.page.hasPageSkin;
-        },
-
         /**
          * Public functions
          */
@@ -237,7 +229,7 @@ define([
 
             // We want to run lazy load if user is in the main test or if there is a switch on
             // We do not want lazy loading on pageskins because it messes up the roadblock
-            if ((ab.shouldRunTest('Viewability', 'variant') || isLzAdsSwitchOn()) && !isPageSkinned()) {
+            if ((ab.shouldRunTest('Viewability', 'variant') || config.switches.lzAds) && !(config.page.hasPageSkin)) {
                 window.googletag.cmd.push(displayLazyAds);
             } else {
                 window.googletag.cmd.push(displayAds);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -207,6 +207,10 @@ define([
             return config.switches.lzAds;
         },
 
+        isPageSkinned = function () {
+            return config.page.hasPageSkin;
+        },
+
         /**
          * Public functions
          */
@@ -232,7 +236,8 @@ define([
             window.googletag.cmd.push(defineSlots);
 
             // We want to run lazy load if user is in the main test or if there is a switch on
-            if (ab.shouldRunTest('Viewability', 'variant') || isLzAdsSwitchOn()) {
+            // We do not want lazy loading on pageskins because it messes up the roadblock
+            if ((ab.shouldRunTest('Viewability', 'variant') || isLzAdsSwitchOn()) && !isPageSkinned()) {
                 window.googletag.cmd.push(displayLazyAds);
             } else {
                 window.googletag.cmd.push(displayAds);

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -38,8 +38,8 @@ System.config({
   "map": {
     "EventEmitter": "github:Wolfy87/EventEmitter@4.2.11",
     "Promise": "github:guardian/native-promise-only@0.7.6-e",
-    "babel": "npm:babel-core@5.6.5",
-    "babel-runtime": "npm:babel-runtime@5.6.5",
+    "babel": "npm:babel-core@5.6.11",
+    "babel-runtime": "npm:babel-runtime@5.6.11",
     "bean": "npm:bean@1.0.15",
     "bonzo": "npm:bonzo@1.4.0",
     "classnames": "npm:classnames@1.2.0",
@@ -132,7 +132,7 @@ System.config({
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:babel-runtime@5.6.5": {
+    "npm:babel-runtime@5.6.11": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:bean@1.0.15": {


### PR DESCRIPTION
Pageskins are implemented with Master-Companion roadblocks. These
roadblocks do not work with lazy loading.
