### PR TITLE
Fix AMD API

### DIFF
--- a/common/app/templates/systemJsSetup.scala.js
+++ b/common/app/templates/systemJsSetup.scala.js
@@ -20,5 +20,5 @@ System.config({
 
 @JavaScript(Static.js.systemJsNormalize)
 
-window.require = System.amdRequire.bind(System);
-window.define = System.amdDefine.bind(System);
+window.require = System.amdRequire;
+window.define = System.amdDefine;


### PR DESCRIPTION
We don't need to bind.

Binding loses properties on the function, such as `System.amdDefine.amd`.
