### PR TITLE
Extend supporter message expiry [Corrected]

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1046,7 +1046,7 @@ object Switches {
     "ab-membership-message",
     "Switch for the Membership message A/B test.",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 6, 27),
+    sellByDate = new LocalDate(2015, 7, 14),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message.js
@@ -20,20 +20,20 @@ define([
 
         this.id = 'MembershipMessage';
         this.start = '2015-06-17';
-        this.expiry = '2015-06-26';
+        this.expiry = '2015-07-14';
         this.author = 'David Rapson';
         this.description = 'Test if loyal users are encouraged to join Membership as a Supporter';
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Loyal users will be interested in becoming a Supporter';
-        this.audienceCriteria = 'Users who have seen at least 10 pages, message shown only on article pages';
+        this.audienceCriteria = 'Users who have seen 10 or more pages, message shown only on article pages';
         this.dataLinkNames = 'supporter message, hide, read more';
         this.idealOutcome = 'Users will sign up as a Supporter';
 
         this.canRun = function () {
             /**
              * Exclude adblock users to avoid conflicts with similar adblock Supporter message,
-             * only show to users who have viewed at least 10 pages.
+             * only show to users who have viewed 10 or more pages.
              */
             var alreadyVisited = storage.local.get('alreadyVisited') || 0;
             return !detect.adblockInUse &&


### PR DESCRIPTION
**This is a correction to https://github.com/guardian/frontend/pull/9612 which has been reverted**

I unnecessarily changed `detect.adblockInUse` to a function call which caused a syntax error (it's a boolean property). Not sure why I didn't catch this in my original testing, this was my mistake.

This version of the PR simply extends the expiry date as that is the only essential change at this point.

---

We are looking to make this Supporter message an actual feature, rather than an A/B test, but we're not quite ready to do that. This PR extends the expiry date for a couple of weeks.

cc/ @stephanfowler @uplne  @OliverJAsh 
