### PR TITLE
Optimise page header first steps

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -6,9 +6,9 @@
 @fragments.metaData(metaData)
 @head
 
-@fragments.stylesheetsLoad(projectName)
-
 @fragments.javaScriptFirstSteps(metaData)
+
+@fragments.stylesheetsLoad(projectName)
 
 @fragments.stylesheetsUse()
 

--- a/common/app/views/fragments/javaScriptFirstSteps.scala.html
+++ b/common/app/views/fragments/javaScriptFirstSteps.scala.html
@@ -135,17 +135,8 @@
             loaded: false
         },
         config: @fragments.javaScriptConfig(item)
-    }, baseFontSize,
+    },
     docClass = document.documentElement.className;
-
-    // rems are calculated in the CSS assuming a 16px baseline.
-    // if the user has changed theirs, account for it.
-    if('getComputedStyle' in window) {
-        baseFontSize = window.getComputedStyle(document.documentElement).getPropertyValue("font-size");
-        if(parseInt(baseFontSize, 10) !== 16) {
-            document.documentElement.style.fontSize = baseFontSize;
-        }
-    }
 
     @* http://modernizr.com/download/#-svg *@
     if (
@@ -231,6 +222,19 @@
         }
     })(guardian.isModernBrowser);
 
+    // *** MINIMISE DOM THRASHING…
+    // READ
+    // rems are calculated in the CSS assuming a 16px baseline.
+    // if the user has changed theirs, account for it.
+    var baseFontSize = null;
+    if('getComputedStyle' in window) {
+        baseFontSize = window.getComputedStyle(document.documentElement).getPropertyValue("font-size");
+    }
+
+    // WRITE
+    if(baseFontSize && parseInt(baseFontSize, 10) !== 16) {
+        document.documentElement.style.fontSize = baseFontSize;
+    }
     document.documentElement.className = docClass.replace(/\bjs-off\b/g, 'js-on');
 
 </script>

--- a/common/app/views/fragments/stylesheetsUse.scala.html
+++ b/common/app/views/fragments/stylesheetsUse.scala.html
@@ -52,15 +52,6 @@
 
             // GO!
             useCss();
-
-            // TEMPORARY: Tidy up localStorage - can remove after a bit
-            try {
-                Object.keys(localStorage).forEach(function(key) {
-                    if (key.match(/^gu.css./g)) {
-                        localStorage.removeItem(key);
-                    }
-                });
-            } catch (e) {};
         })(document.getElementsByTagName('link'), window.document.styleSheets)
     </script>
 }


### PR DESCRIPTION
- batches first steps DOM reads/write
- moves all feature detection scope class insertion to before the CSS, so there's no need to re-calc the render tree

These show the time between beginning parsing the HTML and first redraw triggered by the inline CSS being parsed. 

before:
![screen shot 2015-06-26 at 15 10 30](https://cloud.githubusercontent.com/assets/867233/8379276/d3375518-1c16-11e5-93ce-f7cdc0f795dd.png)

after:
![screen shot 2015-06-26 at 15 13 16](https://cloud.githubusercontent.com/assets/867233/8379279/d6edf5f4-1c16-11e5-9c5a-eabae2bc7e8b.png)
