### PR TITLE
sort savedforlateritems

### DIFF
--- a/identity/app/controllers/SaveContentController.scala
+++ b/identity/app/controllers/SaveContentController.scala
@@ -37,8 +37,6 @@ class SaveContentController @Inject() ( api: IdApiClient,
 
   import SavedArticleData._
 
-  implicit val dateOrdering: Ordering[DateTime] = Ordering[Long] on { _.getMillis }
-
 
   val page = IdentityPage("/saved-for-later", "Saved for later", "saved-for-later")
 

--- a/identity/app/implicits/Articles.scala
+++ b/identity/app/implicits/Articles.scala
@@ -11,6 +11,7 @@ trait Articles {
 
     lazy val href = "%s/%s".format(conf.Configuration.site.host, savedArticle.id)
     lazy val savedAt = fmt.print(savedArticle.date)
+    implicit val dateOrdering: Ordering[DateTime] = Ordering[Long] on { _.getMillis }
   }
 
   implicit class RichSavedArticles(savedArticles: SavedArticles) {

--- a/identity/app/model/SaveForLaterPageData.scala
+++ b/identity/app/model/SaveForLaterPageData.scala
@@ -14,9 +14,11 @@ import cards._
 
 import scala.concurrent.Future
 
-case class SaveForLaterItem(
+case class SaveForLaterItem (
   content: Content,
-  savedArticle: SavedArticle) {
+  savedArticle: SavedArticle) extends Ordered[SaveForLaterItem] {
+
+  def compare(other: SaveForLaterItem) : Int = this.savedArticle.date.compareTo(other.savedArticle.date)
 
   val contentCard = FaciaCard.fromTrail(
     FaciaContentConvert.frontentContentToFaciaContent(content),
@@ -59,7 +61,7 @@ class SaveForLaterDataBuilder @Inject()(idUrlBuilder: IdentityUrlBuilder) extend
 
       SaveForLaterPageData(
         idUrlBuilder.buildUrl("/saved-for-later", idRequest),
-        items,
+        items.sorted,
         Pagination(pageNum, savedArticles.numPages, savedArticles.totalSaved),
         idUrlBuilder.buildUrl("/saved-for-later"),
         savedArticles.totalSaved,

--- a/identity/app/services/IdentityUrlBuilder.scala
+++ b/identity/app/services/IdentityUrlBuilder.scala
@@ -10,7 +10,8 @@ class IdentityUrlBuilder @Inject()(conf: IdentityConfiguration) {
     val params = List(
       "returnUrl" -> idRequest.returnUrl,
       "type" -> idRequest.trackingData.registrationType,
-      "skipConfirmation" -> idRequest.skipConfirmation.map(_.toString)
+      "skipConfirmation" -> idRequest.skipConfirmation.map(_.toString),
+      "page" -> idRequest.page.map(_.toString)
     )
     params.flatMap(param => if (param._2.isDefined) Some(param._1 -> param._2.get) else None)
   }

--- a/identity/test/services/IdentityUrlBuilderTest.scala
+++ b/identity/test/services/IdentityUrlBuilderTest.scala
@@ -14,6 +14,7 @@ class IdentityUrlBuilderTest extends path.FreeSpec with Matchers with MockitoSug
   when(idRequest.trackingData) thenReturn omnitureTracking
   when(idRequest.returnUrl) thenReturn None
   when(idRequest.skipConfirmation) thenReturn None
+  when(idRequest.page) thenReturn None
   when(omnitureTracking.registrationType) thenReturn None
 
   val idUrlBuilder = new IdentityUrlBuilder(conf)

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -38,8 +38,8 @@ System.config({
   "map": {
     "EventEmitter": "github:Wolfy87/EventEmitter@4.2.11",
     "Promise": "github:guardian/native-promise-only@0.7.6-e",
-    "babel": "npm:babel-core@5.6.5",
-    "babel-runtime": "npm:babel-runtime@5.6.5",
+    "babel": "npm:babel-core@5.6.11",
+    "babel-runtime": "npm:babel-runtime@5.6.11",
     "bean": "npm:bean@1.0.15",
     "bonzo": "npm:bonzo@1.4.0",
     "classnames": "npm:classnames@1.2.0",
@@ -132,7 +132,7 @@ System.config({
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:babel-runtime@5.6.5": {
+    "npm:babel-runtime@5.6.11": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:bean@1.0.15": {


### PR DESCRIPTION
This sorts out two problems with deleting items from the save for later page. 
(1) It changes the form url to have a page parameter, so that the user is always returned to the currect page
(2) It makes sure that the items on each page are correctly ordered by the time they were saved by the user ( previously this was lost when we mapped over the list of Content returned by CAPI ). This ensures that the when a user deletes an item on a page, the first item on the following page ( previously ) now correctly appears as the last item on the refreshed page after deletion
