### PR TITLE
Only use colours when not in dev

### DIFF
--- a/grunt-configs/karma.js
+++ b/grunt-configs/karma.js
@@ -6,7 +6,8 @@ module.exports = function(grunt, options) {
             browserDisconnectTimeout: 10000,
             browserDisconnectTolerance: 3,
             browserNoActivityTimeout: 60000,
-            reportSlowerThan: 1000
+            reportSlowerThan: 1000,
+            colors: !!options.isDev
         },
         'facia-tool': {
             configFile: 'facia-tool/test/public/conf/karma.conf.js'


### PR DESCRIPTION
Prevent colour codes from appearing in our builds, e.g. https://teamcity.gutools.co.uk/viewLog.html?buildId=691648&buildTypeId=bt1304&tab=buildLog#_focus=657
