### PR TITLE
Intermittent test failures

### DIFF
--- a/facia-tool/public/js/models/collections/latest-articles.js
+++ b/facia-tool/public/js/models/collections/latest-articles.js
@@ -32,6 +32,7 @@ define([
     return function(options) {
 
         var self = this,
+            loadCallback = options.callback || function () {},
             deBounced,
             poller,
             opts = options || {},
@@ -172,11 +173,13 @@ define([
                         }
 
                         scrollable.scrollTop = initialScroll;
+                        loadCallback();
                     },
                     function (error) {
                         var errMsg = error.message;
                         vars.model.alert(errMsg);
                         self.flush(errMsg);
+                        loadCallback();
                     }
                 );
             }, 300);

--- a/facia-tool/public/js/widgets/latest.js
+++ b/facia-tool/public/js/widgets/latest.js
@@ -1,11 +1,13 @@
 define([
     'knockout',
+    'underscore',
     'models/collections/latest-articles',
     'modules/vars',
     'utils/mediator',
     'utils/update-scrollables'
 ], function (
     ko,
+    _,
     LatestArticles,
     vars,
     mediator,
@@ -30,7 +32,10 @@ define([
         this.latestArticles = new LatestArticles({
             filterTypes: vars.CONST.filterTypes,
             container: element,
-            showingDrafts: this.showingDrafts
+            showingDrafts: this.showingDrafts,
+            callback: _.once(function () {
+                mediator.emit('latest:loaded');
+            })
         });
 
         this.latestArticles.search();
@@ -42,8 +47,6 @@ define([
             }
         });
         this.subscriptionOnArticles = this.latestArticles.articles.subscribe(updateScrollables);
-
-        mediator.emit('latest:loaded');
     }
 
     Latest.prototype.dispose = function () {

--- a/facia-tool/test/public/utils/collections-loader.js
+++ b/facia-tool/test/public/utils/collections-loader.js
@@ -46,25 +46,20 @@ export default function() {
         // Mock the time
         jasmine.clock().install();
 
-        mediator.on('latest:loaded', function () {
-            // wait for the debounce (give some time to knockout to handle bindings)
-            tick(50).then(() => tick(350));
-        });
+        // After 2 because we are waiting for latest feed and front widget
+        var pageLoaded = _.after(2, _.once(resolve));
 
+        mediator.on('latest:loaded', pageLoaded);
+        mockSearch.on('complete', pageLoaded);
 
         new CollectionsEditor().init({}, testConfig);
 
-        // Number 2 is because we wait for two search, latest and the only
-        // article in the collection.
-        mockSearch.on('complete', _.after(2, _.once(function () {
-            resolve();
-        })));
-
-        // The first tick is for the configuration to be loaded
-        // The second tick is for the collections to be leaded
-        tick(100).then(() => tick(300)).then(() => tick(300))
-        .then(() => tick(100)).then(() => tick(100));
-
+        // The first 3 ticks are for the 3 initial configuration requests
+        tick(50).then(() => tick(50)).then(() => tick(50))
+        // These 2 other ticks are for the article search and lastmodified
+        .then(() => tick(50)).then(() => tick(50))
+        // The remaining ticks are for the latest feed to load
+        .then(() => tick(350)).then(() => tick(50));
     });
 
     function unload () {


### PR DESCRIPTION
Latest feed widget now uses a more deterministic load callback. Tests are more stable because they don't have to rely on correct timing of ticks but on that callback.

@OliverJAsh 

@johnduffell You'll be pleased to know that I've updated the comment on tick. There's now an explanation for each one of them.
