### PR TITLE
Extending ophanID and commercial components server tests switches

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -260,7 +260,7 @@ object Switches {
     "ophan-view-id",
     "Depeneding on ophan to pass view ID to the gdf targeting",
     safeState = On,
-    sellByDate = new LocalDate(2015, 6, 30),
+    sellByDate = new LocalDate(2015, 7, 14),
     exposeClientSide = true
   )
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -35,14 +35,14 @@ object CMHRTest extends TestDefinition(
   List(Variant1, Variant2, Variant3),
   "cm-hr-test",
   "Test moving commercial high relevance component above most popular",
-  new LocalDate(2015, 6, 30)
+  new LocalDate(2015, 7, 14)
 )
 
 object CMOutbrainTest extends TestDefinition(
   List(Variant4, Variant5, Variant6),
   "cm-outbrain-test",
   "Test moving outbrain component to the second position below the article",
-  new LocalDate(2015, 6, 30)
+  new LocalDate(2015, 7, 14)
 )
 
 object ActiveTests extends Tests {


### PR DESCRIPTION
Extending these switches. We have to look at ophanID one more time after sticky header with com components, especially outbrain, we are waiting for changes approval. That should be all sorted out in two weeks.
