### PR TITLE
Consider Ad Tests When Opening Top-Below-Nav Ad Slot

### DIFF
--- a/common/app/dfp/AdSlotAgent.scala
+++ b/common/app/dfp/AdSlotAgent.scala
@@ -6,6 +6,8 @@ import conf.Switches.ExposeHasTopBelowNavAdSlotFlagSwitch
 
 trait AdSlotAgent {
 
+  protected val isProd: Boolean
+
   protected def lineItems: Seq[GuLineItem]
 
   def hasAdInTopBelowNavSlot(adUnitWithoutRoot: String, edition: Edition): Boolean = {
@@ -38,13 +40,16 @@ trait AdSlotAgent {
         adUnits.contains(adUnitWithRoot)
       }
 
+      def targetsAdTest(lineItem: GuLineItem) = lineItem.targeting.hasAdTestTargetting
+
       val isFront = adUnitWithoutRoot.endsWith("/front") || adUnitWithoutRoot.endsWith("/front/ng")
 
       isFront && lineItems.exists { lineItem =>
         isCurrent(lineItem) &&
           targetsTopBelowNavSlot(lineItem) &&
           targetsEdition(lineItem) &&
-          targetsAdUnit(lineItem)
+          targetsAdUnit(lineItem) &&
+          !(isProd && targetsAdTest(lineItem))
       }
 
     } else false


### PR DESCRIPTION
In non-Prod environments the top-below-nav ad slot should open when it's being tested as well as when it's active, but in the Prod environment the slot should only open when there's an active ad ready to appear in it.

/cc @Calanthe 
