### PR TITLE
New adslots names

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -59,7 +59,7 @@ define([
             }
 
             // if yes add another ad and try another run
-            adNames.push(['inline-extra' + ads.length, 'inline']);
+            adNames.push(['inline' + (ads.length + 1), 'inline']);
             return insertAdAtP(nextSpace).then(function () {
                 return getAdSpace();
             });

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -44,14 +44,14 @@ define([
                 tablet:             '1,1|300,250'
             }
         },
-        inline2: {
+        inline: {
             sizeMappings: {
                 mobile:             '1,1|300,50',
                 'mobile-landscape': '1,1|300,50|320,50',
                 tablet:             '1,1|300,250'
             }
         },
-        inline3: {
+        mostpop: {
             sizeMappings: {
                 mobile:             '1,1|300,50',
                 'mobile-landscape': '1,1|300,50|320,50',
@@ -100,7 +100,7 @@ define([
             dataAttrs,
             $adSlot;
 
-        definition = (slotName.match(/^inline-extra/)) ? adSlotDefinitions.inline1 : adSlotDefinitions[slotName];
+        definition = (slotName.match(/^inline/) && slotName !== 'inline1') ? adSlotDefinitions.inline : adSlotDefinitions[slotName];
         if (config.page.hasPageSkin && slotName === 'merchandising-high') {
             definition.sizeMappings.wide = '1,1';
         }

--- a/static/src/javascripts/projects/common/modules/onward/popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/popular.js
@@ -38,7 +38,7 @@ define([
     MostPopular.prototype.prerender = function () {
         if (!config.page.shouldHideAdverts) {
             this.$mpu = $('.js-fc-slice-mpu-candidate', this.elem)
-                .append(createAdSlot('inline3', 'container-inline'));
+                .append(createAdSlot('mostpop', 'container-inline'));
         } else {
             this.$mpu = undefined;
         }


### PR DESCRIPTION
All inline ads are now named: 'inline1, inline2, inline3 etc', NOT 'inline1, inline2, inline-extra2, inline-extra3' as it was before.

All of the inline slots (except inline1) have the same 'inline' ad slot sizes.

An ad in the most popular container is now called 'mostpop', NOT 'inline3' as it was before. It has slot size the same as 'inline'.
