### PR TITLE
Aria hide old blocks. Fix zoom glitch.

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -23,8 +23,8 @@ define([
     detect,
     blockTemplate
 ) {
-    var numDisplayedBlocks = 4,
-        blockHeightPx = 74,
+    var numDisplayedBlocks = 1,
+        blockHeightPx = 71,
 
         animateDelayMs = 2000,
         refreshSecs = 30,
@@ -33,8 +33,6 @@ define([
 
         selector = '.js-snappable .js-liveblog-blocks',
         blocksClassName = 'fc-item__liveblog-blocks',
-        newBlockClassName = 'fc-item__liveblog-block--new',
-        oldBlockClassName = 'fc-item__liveblog-block--old',
         articleIdAttribute = 'data-article-id',
         sessionStorageKey = 'gu.liveblog.block-dates',
         prefixedTransforms = ['-webkit-transform', '-ms-transform', 'transform'],
@@ -61,7 +59,7 @@ define([
         }
 
         return template(blockTemplate, {
-            classes: block.isNew ? newBlockClassName : oldBlockClassName,
+            ariaHidden: !block.isNew,
             href: '/' + articleId + '#' + block.id,
             relativeTime: relTime,
             text: _.compact([block.title, block.body.slice(0, 500)]).join('. '),

--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -23,9 +23,7 @@ define([
     detect,
     blockTemplate
 ) {
-    var numDisplayedBlocks = 1,
-        blockHeightPx = 71,
-
+    var pxBeforeAnimate = 100,
         animateDelayMs = 2000,
         refreshSecs = 30,
         refreshDecay = 1,
@@ -67,53 +65,37 @@ define([
         });
     }
 
-    function translateVertical(offset) {
-        return 'translate3d(0, -' + offset + 'px, 0)';
-    }
-
-    function translateNone() {
-        return 'translate3d(0)';
-    }
-
-    function translateCss(valueFn, offset) {
-        return prefixedTransforms.map(function (rule) {
-            return rule + ':' + valueFn(offset);
-        }).join(';');
-    }
-
     function showBlocks(articleId, targets, blocks, oldBlockDate) {
         var fakeUpdate = _.isUndefined(oldBlockDate);
 
         fastdom.write(function () {
             _.forEach(targets, function (element) {
-                var numNewBlocks = 0,
+                var hasNewBlock = false,
+                    wrapperClasses = [
+                        'fc-item__liveblog-blocks__inner',
+                        'u-faux-block-link__promote'
+                    ];
 
                     blocksHtml = _.chain(blocks)
+                        .slice(0, 2)
                         .map(function (block, index) {
-                            if (numNewBlocks < numDisplayedBlocks
-                                && (block.publishedDateTime > oldBlockDate || (fakeUpdate && index === 0))) {
+                            if (!hasNewBlock && (block.publishedDateTime > oldBlockDate || fakeUpdate)) {
                                 block.isNew = true;
-                                numNewBlocks += 1;
+                                hasNewBlock = true;
+                                wrapperClasses.push('fc-item__liveblog-blocks__inner--offset');
                             }
-                            return block;
-                        })
-                        .slice(0, numDisplayedBlocks + numNewBlocks)
-                        .map(function (block, index) {
                             return renderBlock(articleId, block, index);
                         })
-                        .value()
-                        .join(''),
+                        .slice(0, hasNewBlock ? 2 : 1)
+                        .value(),
 
                     el = bonzo.create(
-                        '<div class="fc-item__liveblog-blocks__inner u-faux-block-link__promote"' +
-                            ' style="' + translateCss(translateVertical, numNewBlocks * blockHeightPx) + '">' +
-                            blocksHtml +
-                        '</div>'
+                        '<div class="' + wrapperClasses.join(' ') + '">' + blocksHtml.join('') + '</div>'
                     );
 
                 bonzo(element).addClass(blocksClassName).append(el);
 
-                if (numNewBlocks) {
+                if (hasNewBlock) {
                     animateBlocks(el[0]);
                 }
             });
@@ -131,9 +113,9 @@ define([
     function maybeAnimateBlocks(el, immediate) {
         var vPosition = el.getBoundingClientRect().top;
 
-        if (vPosition > blockHeightPx * -1 && vPosition < veiwportHeightPx - blockHeightPx) {
+        if (vPosition > pxBeforeAnimate * -1 && vPosition < veiwportHeightPx - pxBeforeAnimate) {
             setTimeout(function () {
-                bonzo(el).attr('style', translateCss(translateNone));
+                bonzo(el).removeClass('fc-item__liveblog-blocks__inner--offset');
             }, immediate ? 0 : animateDelayMs);
             return true; // remove listener
         }

--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -74,8 +74,7 @@ define([
                     wrapperClasses = [
                         'fc-item__liveblog-blocks__inner',
                         'u-faux-block-link__promote'
-                    ];
-
+                    ],
                     blocksHtml = _.chain(blocks)
                         .slice(0, 2)
                         .map(function (block, index) {

--- a/static/src/javascripts/projects/facia/views/liveblog-block.html
+++ b/static/src/javascripts/projects/facia/views/liveblog-block.html
@@ -1,4 +1,4 @@
-<a href="<%=href%>" class="fc-item__liveblog-block <%=classes%>" data-link-name="block | <%=index%>">
+<a href="<%=href%>" class="fc-item__liveblog-block" data-link-name="block | <%=index%>" aria-hidden="<%=ariaHidden%>">
     <div class="fc-item__liveblog-block__text">
         <div class="fc-item__liveblog-block__time"><%=relativeTime%></div>
         <%=text%>

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -401,7 +401,7 @@ $fc-item-gutter: $gs-gutter / 4;
 }
 
 // Liveblog blocks
-$block-height: 74px;
+$block-height: 71px;
 
 .fc-item__liveblog-blocks {
     box-sizing: content-box !important;
@@ -445,7 +445,7 @@ $block-height: 74px;
     right: 0;
     @include fs-headline(1);
     font-size: 30px;
-    line-height: $gs-baseline/2;
+    line-height: $gs-baseline;
     color: mix(#ffffff, colour(live-default), 92%);
     height: 18px;
     padding-right: 8px;

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -411,7 +411,11 @@ $block-height: 71px;
 }
 
 .fc-item__liveblog-blocks__inner {
-    transition: transform .75s ease-out;
+    transition: transform .5s ease-in;
+}
+
+.fc-item__liveblog-blocks__inner--offset {
+    transform: translate3d(0, $block-height * -1, 0);
 }
 
 .fc-item__liveblog-block {


### PR DESCRIPTION
- Hides previous update (hidden by animation) from screen readers.
- Reduces risk of visible overflow text at certain zoom levels:

![liveblog](https://cloud.githubusercontent.com/assets/1147913/8413329/ab61fdfe-1e87-11e5-9f7d-5f0d0f70ad33.jpg)
