### PR TITLE
display most recently saved articles first

### DIFF
--- a/identity/app/controllers/SaveContentController.scala
+++ b/identity/app/controllers/SaveContentController.scala
@@ -113,7 +113,7 @@ class SaveContentController @Inject() ( api: IdApiClient,
       def onSuccess(data: SavedArticleData): Future[Result] = {
         val response: Future[Result] = savedArticleService.getOrCreateArticlesList(request.user.auth).flatMap {
           savedArticles =>
-            val form = savedArticlesForm.fill(SavedArticleData(savedArticles.articles.map(_.shortUrl)))
+            val form = savedArticlesForm.fill(SavedArticleData(savedArticles.newestFirst.map(_.shortUrl)))
             val updatedArticlesViow: Option[Future[Result]] = data.deleteArticle.map {
               shortUrlOfDeletedArticle =>
                 val updatedArticles = savedArticles.removeArticle(shortUrlOfDeletedArticle)

--- a/identity/app/implicits/Articles.scala
+++ b/identity/app/implicits/Articles.scala
@@ -16,14 +16,14 @@ trait Articles {
 
   implicit class RichSavedArticles(savedArticles: SavedArticles) {
     val fmt = ISODateTimeFormat.dateTimeNoMillis()
-    private val itemsPerPage = 4
 
-    val pages = savedArticles.articles.grouped(itemsPerPage).toList
+    private val itemsPerPage = 4
+    val newestFirst = savedArticles.articles.reverse
+
+    val pages = newestFirst.grouped(itemsPerPage).toList
 
     val numPages = pages.length
-
     val totalSaved = savedArticles.articles.length
-    def newestFirst = savedArticles.articles.reverse
     def contains(shortUrl: String) : Boolean = savedArticles.articles.exists( sa => sa.shortUrl == shortUrl)
 
     def addArticle(id: String, shortUrl: String, platform: String): SavedArticles = {

--- a/identity/app/model/SaveForLaterPageData.scala
+++ b/identity/app/model/SaveForLaterPageData.scala
@@ -18,7 +18,7 @@ case class SaveForLaterItem (
   content: Content,
   savedArticle: SavedArticle) extends Ordered[SaveForLaterItem] {
 
-  def compare(other: SaveForLaterItem) : Int = this.savedArticle.date.compareTo(other.savedArticle.date)
+  def compare(other: SaveForLaterItem) : Int = other.savedArticle.date.compareTo(this.savedArticle.date)
 
   val contentCard = FaciaCard.fromTrail(
     FaciaContentConvert.frontentContentToFaciaContent(content),


### PR DESCRIPTION
Changes the order of the articles of the save-for-later-pages so that the most recently saved articles are first
