### PR TITLE
Zindex fixes of thrashers

### DIFF
--- a/static/src/stylesheets/facia.scss
+++ b/static/src/stylesheets/facia.scss
@@ -27,3 +27,4 @@
 @import 'module/commercial/_commercial';
 @import 'module/business/_stocks';
 @import 'module/live-pulse';
+@import 'module/facia/snaps/_facia';

--- a/static/src/stylesheets/module/facia/_containers.scss
+++ b/static/src/stylesheets/module/facia/_containers.scss
@@ -92,7 +92,6 @@
 
     .fc-item {
         margin: 0;
-        overflow: auto;
         width: 100%;
     }
 

--- a/static/src/stylesheets/module/facia/snaps/_facia.scss
+++ b/static/src/stylesheets/module/facia/snaps/_facia.scss
@@ -1,0 +1,5 @@
+.facia-snap {
+    position: relative;
+    z-index: 800;
+    overflow-y: hidden;
+}


### PR DESCRIPTION
Before:
![screen shot 2015-07-01 at 09 37 31](https://cloud.githubusercontent.com/assets/489567/8450655/b8edccca-1fd4-11e5-83a1-3e3047c6b894.png)

After:
![screen shot 2015-07-01 at 09 37 46](https://cloud.githubusercontent.com/assets/489567/8450667/e5ed2090-1fd4-11e5-8ce0-ac0bcfa7f7b7.png)

Our approach is to change z-index of every element on the page to be lower than sticky-nav (1000). 
