### PR TITLE
Always provide a web app manifest

### DIFF
--- a/applications/app/controllers/WebAppController.scala
+++ b/applications/app/controllers/WebAppController.scala
@@ -16,11 +16,6 @@ object WebAppController extends Controller with ExecutionContexts {
   }
 
   def manifest() = Action {
-    Cached(3600) {
-      conf.Switches.NotificationsSwitch.isSwitchedOn match {
-        case true => Ok(templates.js.webAppManifest())
-        case false => NotFound
-      }
-    }
+    Cached(3600) { Ok(templates.js.webAppManifest()) }
   }
 }


### PR DESCRIPTION
Removes the notifications switch. There is still no service worker, but the manifest allows newer chrome versions to install the web to home screen.
