### PR TITLE
Send sticky nav items to their own layer

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/sticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/sticky.js
@@ -215,7 +215,8 @@ define([
                         'margin-top': 0,
                         '-webkit-transform': 'translateY(-100%)',
                         '-ms-transform': 'translateY(-100%)',
-                        'transform': 'translateY(-100%)'
+                        'transform': 'translateY(-100%)',
+                        'backface-visibility': 'hidden'
                     });
 
                     // Make sure banner is outside of the view
@@ -284,7 +285,8 @@ define([
                         position:  'fixed',
                         top:       0,
                         width:     '100%',
-                        'z-index': '999'
+                        'z-index': '999',
+                        'backface-visibility': 'hidden'
                     });
                     // Header is not slim yet
                     this.$els.header.removeClass('l-header--is-slim');
@@ -329,7 +331,8 @@ define([
                         'margin-top': 0,
                         '-webkit-transform': 'translateY(-100%)',
                         '-ms-transform': 'translateY(-100%)',
-                        'transform': 'translateY(-100%)'
+                        'transform': 'translateY(-100%)',
+                        'backface-visibility': 'hidden'
                     });
 
                     // Make sure banner is outside of the view
@@ -375,13 +378,15 @@ define([
                 top: headerTop,
                 width: '100%',
                 'z-index': '1001',
-                'margin-top': 0
+                'margin-top': 0,
+                'backface-visibility': 'hidden'
             });
             this.$els.bannerMobile.css({
                 position: 'fixed',
                 top: this.headerBigHeight + headerTop,
                 width: '100%',
-                'z-index': '999' // Sticky z-index -1 as it should be sticky but should go below the sticky header
+                'z-index': '999', // Sticky z-index -1 as it should be sticky but should go below the sticky header,
+                'backface-visibility': 'hidden'
             });
             this.$els.main.css('margin-top', this.headerBigHeight + bannerHeight);
         }.bind(this));


### PR DESCRIPTION
So they don't have to re-paint on scroll

before:
![orig mov](https://cloud.githubusercontent.com/assets/867233/8481421/f751034a-20da-11e5-913d-96a8518d1b5f.gif)

after:
![layer mov](https://cloud.githubusercontent.com/assets/867233/8481543/8f8dddf4-20db-11e5-9e49-d161e25c85d5.gif)

cc @uplne @Calanthe – btw, any reason these aren't implemented as classes? there's also a few instances of non-`js-` prefixed classes being used here to target elements...
