### PR TITLE
Fix DreamSnaps in Save For Later

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -205,7 +205,7 @@ object FaciaCard {
     } yield kickerText contains byline) getOrElse false
 
     ContentCard(
-      Option(faciaContent.id),
+      faciaContent.maybeContentId,
       faciaContent.headline,
       FaciaCardHeader.fromTrailAndKicker(faciaContent, maybeKicker, Some(config)),
       getByline(faciaContent).filterNot(Function.const(suppressByline)),


### PR DESCRIPTION
#### Problem

`Dreamsnaps` currently don't work with Save for later.

When you try to save a dreamsnap currently, it saves and unsaves fine, but does not show on the save for later page itself.

The reason for this is because when saving a save for later item, it saves it by `shortUrl` and by the `data-id` of the `Card` on the page. When then requesting each save for later item, it zips together the results of requesting from `CAPI` by `shortUrl` to the `data-id` of each `shortUrl` requested.

This `id` is **usually** a normal content ID, but in the case of `dreamsnaps`, it is coming out as a `snap` `id`, meaning that they never get zipped together.

If that doesn't make much sense but you can read code, then look [here](https://github.com/guardian/frontend/blob/master/identity/app/model/SaveForLaterPageData.scala#L56).
#### Fix

Output the content `id` in `data-id` for dreamsnaps on a content card.

@NathanielBennett 
