### PR TITLE
Append source map URL

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -77,8 +77,9 @@ var writeBundlesToDisk = function (bundles) {
         var bundleMapFileName = bundleFileName + '.map';
 
         mkdirp.sync(path.dirname(bundleFileName));
+
         console.log('writing to %s', bundleFileName);
-        fs.writeFileSync(bundleFileName, bundle.source);
+        fs.writeFileSync(bundleFileName, bundle.source + '\n//# sourceMappingURL=' + path.basename(bundleFileName) + '.map');
         console.log('writing to %s', bundleMapFileName);
         fs.writeFileSync(bundleMapFileName, bundle.sourceMap);
     });


### PR DESCRIPTION
This is [usually handled by jspm](https://github.com/jspm/jspm-cli/blob/179735469ecce124873a7d99bdda94538e9ec347/lib/build.js#L617), but we're bypassing that to use the builder directly, so we have to do it ourselves.
