### PR TITLE
Modify Ad Sizes on UK Network Front

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -578,7 +578,7 @@ object Switches {
     "Expect a 728 x 90 ad in top-above-nav slot on UK network front.",
     safeState = Off,
     sellByDate = new LocalDate(2015, 7, 22),
-    exposeClientSide = true
+    exposeClientSide = false
   )
 
   val TopAboveNavAdSlot88x70Switch = Switch(
@@ -587,7 +587,7 @@ object Switches {
     "Expect an 88 x 70 ad in top-above-nav slot on UK network front.",
     safeState = Off,
     sellByDate = new LocalDate(2015, 7, 22),
-    exposeClientSide = true
+    exposeClientSide = false
   )
 
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -572,6 +572,24 @@ object Switches {
     exposeClientSide = true
   )
 
+  val TopAboveNavAdSlot728x90Switch = Switch(
+    "Commercial",
+    "top-above-nav-728-90",
+    "Expect a 728 x 90 ad in top-above-nav slot on UK network front.",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 7, 22),
+    exposeClientSide = true
+  )
+
+  val TopAboveNavAdSlot88x70Switch = Switch(
+    "Commercial",
+    "top-above-nav-88-70",
+    "Expect an 88 x 70 ad in top-above-nav slot on UK network front.",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 7, 22),
+    exposeClientSide = true
+  )
+
 
   // Monitoring
 

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -1,12 +1,10 @@
-@import conf.Switches._
+@(metaData: model.MetaData)
+@import views.support.Commercial
 
 <div class="top-banner-ad-container top-banner-ad-container--desktop top-banner-ad-container--above-nav">
     @fragments.commercial.standardAd(
         "top-above-nav",
         Seq("top-banner-ad"),
-        Map(
-            "mobile" -> Seq("1,1", "88,70", "728,90"),
-            "desktop" -> Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250")
-        )
+        Commercial.topAboveNavAdSizes(metaData)
     )
 </div>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -61,7 +61,7 @@ http://developers.theguardian.com/join-the-team.html
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
         @if(showAdverts) {
-            @fragments.commercial.topBanner()
+            @fragments.commercial.topBanner(metaData)
         }
 
         @fragments.header(metaData)

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -1,0 +1,27 @@
+package views.support
+
+import conf.Switches.{TopAboveNavAdSlot728x90Switch, TopAboveNavAdSlot88x70Switch}
+import model.MetaData
+
+object Commercial {
+
+  def topAboveNavAdSizes(metaData: MetaData): Map[String, Seq[String]] = {
+    val isUKNetworkFront = metaData.id == "uk"
+    Map(
+      "mobile" -> Seq("1,1", "88,70", "728,90"),
+      "desktop" -> {
+        if (isUKNetworkFront) {
+          if (TopAboveNavAdSlot728x90Switch.isSwitchedOn) {
+            Seq("1,1", "728,90")
+          } else if (TopAboveNavAdSlot88x70Switch.isSwitchedOn) {
+            Seq("1,1", "88,70")
+          } else {
+            Seq("1,1", "900,250", "970,250")
+          }
+        } else {
+          Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250")
+        }
+      }
+    )
+  }
+}


### PR DESCRIPTION
This is the first iteration of an attempt to stop the UK network front jumping when ads of different sizes are loaded into the top-above-nav slot.

This gives the slot a single standard size and custom sizes for takeovers.
In this iteration the change has to be made manually using switches but in the next iteration this will be detected automatically.

@uplne 
