### PR TITLE
Downgrade requirejs to fix source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-concurrent": "1.0.0",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-copy": "0.6.0",
-    "grunt-contrib-requirejs": "0.4.4",
+    "grunt-contrib-requirejs": "OliverJAsh/grunt-contrib-requirejs#30acf0e2a04767933c0ebade3ca814238e98957a",
     "grunt-contrib-uglify": "0.9.1",
     "grunt-contrib-watch": "0.6.1",
     "grunt-csdevmode": "0.1.2",


### PR DESCRIPTION
I've just [forked `grunt-contrib-requirejs` to use `requirjes@2.1.15`](https://github.com/OliverJAsh/grunt-contrib-requirejs/commit/30acf0e2a04767933c0ebade3ca814238e98957a), as `2.1.16` breaks source maps, as per https://github.com/jrburke/r.js/issues/802.

(I'm using http://sourcemap-validator.herokuapp.com/ to validate our source maps.)

Hopefully this will fix source maps in Sentry, however this might also be a problem: https://github.com/jrburke/r.js/issues/829
