### PR TITLE
Fix dynamic container duplication

### DIFF
--- a/common/app/implicits/FaciaContentFrontendHelpers.scala
+++ b/common/app/implicits/FaciaContentFrontendHelpers.scala
@@ -69,11 +69,7 @@ object FaciaContentFrontendHelpers {
       isAdvertisementFeature && faciaContent.webPublicationDateOption.exists(_.isOlderThan(2.weeks))
     }
 
-    def url: String = fold(faciaContent)(
-      curatedContent => SupportedUrl(curatedContent.content),
-      supportingCuratedContent => SupportedUrl(supportingCuratedContent.content),
-      linkSnap => linkSnap.id,
-      latestSnap => latestSnap.latestContent.map(SupportedUrl(_)).getOrElse(latestSnap.id))
+    def url: String = faciaContent.maybeContent.map(SupportedUrl(_)).getOrElse(faciaContent.id)
 
     def slideshow: Option[List[FaciaImageElement]] = faciaContent.image match {
       case Some(ImageSlideshow(assets)) =>

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -321,7 +321,7 @@ object Front extends implicits.Collections {
           faciaContentList.map(Story.fromFaciaContent)
         ) map { containerDefinition =>
           (seen ++ faciaContentList
-            .map(faciaContent => faciaContent.maybeContentId.getOrElse(faciaContent.id))
+            .map(_.url)
             .take(itemsVisible(containerDefinition)), faciaContentList)
         } getOrElse {
           (seen, faciaContentList)

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -318,10 +318,10 @@ object Front extends implicits.Collections {
           * matter what occurred further up the page.
           */
         dynamicContainer.containerDefinitionFor(
-          faciaContentList.collect({ case content: CuratedContent => content }).map(Story.fromFaciaContent)
+          faciaContentList.map(Story.fromFaciaContent)
         ) map { containerDefinition =>
           (seen ++ faciaContentList
-            .map(_.url)
+            .map(faciaContent => faciaContent.maybeContentId.getOrElse(faciaContent.id))
             .take(itemsVisible(containerDefinition)), faciaContentList)
         } getOrElse {
           (seen, faciaContentList)


### PR DESCRIPTION
#### Problem

If a `dreamsnap` ends up at the top of a `dynamic` container, it doesn't not get counted for deduplication.

For example, if we had a `dreamsnap` at the top of a dynamic container, and the next container had the piece of content in it either explicitly or as a `dreamsnap`, then it would not disappear.

This is specific to dynamic containers. It has not caused a problem so far as `dreamsnaps` aren't generally used at the top of dynamic containers.
#### Fix

This includes all types of `FaicaContent` in the deduping in a `dynamic` container.

I have also removed an unnecessary fold.
