### PR TITLE
Add show-more route on preview/standalone

### DIFF
--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -132,10 +132,12 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>.json                   
 
 # Facia
 GET        /                                                                                   controllers.FaciaDraftController.editionRedirect(path = "")
+GET        /$path<.+>/show-more/*id.json                                                       controllers.FaciaDraftController.renderShowMore(path, id)
 GET        /$path<(culture|sport|commentisfree|business|money|rss)>                            controllers.FaciaDraftController.editionRedirect(path)
 GET        /$path<(\w\w)(/[\w\d-]+)?>/rss                                                      controllers.FaciaDraftController.renderFrontRss(path)
 GET        /$path<.+>/lite.json                                                                controllers.FaciaDraftController.renderFrontJsonLite(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                                       controllers.FaciaDraftController.renderFrontJson(path)
+
 
 GET        /container/*id.json                                                                 controllers.FaciaDraftController.renderContainerJson(id)
 


### PR DESCRIPTION
The `show-more` buttons for fronts on `preview` are broken because of a missing route.

This adds the missing route.
