### PR TITLE
Enable Omniture confidence tracking for no-JS devices

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -602,6 +602,15 @@ object Switches {
     exposeClientSide = true
   )
 
+  val OmnitureConfidenceNoJsSwitch = Switch(
+    "Monitoring",
+    "enable-omniture-confidence-no-js",
+    "Enables Omniture confidence tracking for no-JS devices",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 8, 1),
+    exposeClientSide = true
+  )
+
   val DiagnosticsLogging = Switch(
     "Monitoring",
     "enable-diagnostics-logging",

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -2,7 +2,7 @@
 @import conf.Configuration
 @import common.AnalyticsHost
 @import views.support.OmnitureAnalyticsData
-@import conf.Static
+@import conf.{Static,Switches}
 
 @defining(s"${request.host}${request.path}") { path =>
 
@@ -13,6 +13,10 @@
                 <div>
                     <img id="omnitureNoScriptImage" alt=""
                          src="@Html(omnitureCall)" width="1" height="1" class="u-h" />
+                    @if(Switches.OmnitureConfidenceNoJsSwitch.isSwitchedOn) {
+                        <img id="omnitureConfidenceNoScriptImage" alt=""
+                             src="@{Configuration.debug.beaconUrl}/count/pva.gif" width="1" height="1" class="u-h" />
+                    }
                 </div>
             </noscript>
     }


### PR DESCRIPTION
I'm investigating why our confidence rating is so low (83%-92%). I know some of this will be due to:
1. no JS enabled (inc. bots?)
2. the user navigated away before `pva.gif` beacon JS executed
3. there was a leaky JS error (in theory our JS is swimlaned, however)
4. crashes

This PR should eliminate 1.

I haven't tested this yet, but will do tomorrow :smile:
