### PR TITLE
Stop Page Jump on UK Network Front (Part 2)

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -581,7 +581,7 @@ object Switches {
 
   val TopAboveNavAdSlot728x90Switch = Switch(
     "Commercial",
-    "top-above-nav-728-90",
+    "fixed-top-above-nav-728-90",
     "Expect a 728 x 90 ad in top-above-nav slot on UK network front.",
     safeState = Off,
     sellByDate = new LocalDate(2015, 7, 22),
@@ -590,17 +590,17 @@ object Switches {
 
   val TopAboveNavAdSlot88x70Switch = Switch(
     "Commercial",
-    "top-above-nav-88-70",
+    "fixed-top-above-nav-88-70",
     "Expect an 88 x 70 ad in top-above-nav slot on UK network front.",
     safeState = Off,
     sellByDate = new LocalDate(2015, 7, 22),
     exposeClientSide = false
   )
 
-  val TopAboveNavAdSlot1x1Switch = Switch(
+  val TopAboveNavAdSlotOmitSwitch = Switch(
     "Commercial",
-    "top-above-nav-1-1",
-    "Expect a 1x1 ad in top-above-nav slot on UK network front.",
+    "fixed-top-above-nav-omit",
+    "Leave top-above-nav ad slot out of page on UK network front.",
     safeState = Off,
     sellByDate = new LocalDate(2015, 7, 22),
     exposeClientSide = false

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -597,6 +597,15 @@ object Switches {
     exposeClientSide = false
   )
 
+  val TopAboveNavAdSlot1x1Switch = Switch(
+    "Commercial",
+    "top-above-nav-1-1",
+    "Expect a 1x1 ad in top-above-nav slot on UK network front.",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 7, 22),
+    exposeClientSide = false
+  )
+
 
   // Monitoring
 

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -1,6 +1,7 @@
 @(metaData: model.MetaData)
 @import views.support.Commercial.topAboveNavSlot
 
+@if(topAboveNavSlot.show(metaData)) {
 <div class="@topAboveNavSlot.cssClasses(metaData)">
     @fragments.commercial.standardAd(
         "top-above-nav",
@@ -8,3 +9,4 @@
         topAboveNavSlot.adSizes(metaData)
     )
 </div>
+}

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -15,9 +15,9 @@ object Commercial {
         "desktop" -> {
           if (FixedTopAboveNavAdSlotSwitch.isSwitchedOn && isUKNetworkFront(metaData)) {
             if (TopAboveNavAdSlot728x90Switch.isSwitchedOn) {
-              Seq("1,1", "728,90")
+              Seq("728,90")
             } else if (TopAboveNavAdSlot88x70Switch.isSwitchedOn) {
-              Seq("1,1", "88,70")
+              Seq("88,70")
             } else {
               Seq("1,1", "900,250", "970,250")
             }
@@ -35,11 +35,12 @@ object Commercial {
         "top-banner-ad-container--above-nav")
 
       val sizeSpecificClass = {
-        if (FixedTopAboveNavAdSlotSwitch.isSwitchedOn &&
-          isUKNetworkFront(metaData) &&
-          TopAboveNavAdSlot728x90Switch.isSwitchedOff &&
-          TopAboveNavAdSlot88x70Switch.isSwitchedOff) {
-          "top-banner-ad-container--large"
+        if (FixedTopAboveNavAdSlotSwitch.isSwitchedOn && isUKNetworkFront(metaData)) {
+          if (TopAboveNavAdSlot728x90Switch.isSwitchedOn) {
+            "top-banner-ad-container--medium"
+          } else {
+            "top-banner-ad-container--large"
+          }
         } else {
           "top-banner-ad-container--reveal"
         }

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -9,6 +9,12 @@ object Commercial {
 
     private def isUKNetworkFront(metaData: MetaData) = metaData.id == "uk"
 
+    def show(metaData: MetaData): Boolean = {
+      FixedTopAboveNavAdSlotSwitch.isSwitchedOff ||
+        TopAboveNavAdSlotOmitSwitch.isSwitchedOff ||
+        !isUKNetworkFront(metaData)
+    }
+
     def adSizes(metaData: MetaData): Map[String, Seq[String]] = {
       Map(
         "mobile" -> Seq("1,1", "88,70", "728,90"),
@@ -38,8 +44,6 @@ object Commercial {
         if (FixedTopAboveNavAdSlotSwitch.isSwitchedOn && isUKNetworkFront(metaData)) {
           if (TopAboveNavAdSlot728x90Switch.isSwitchedOn) {
             "top-banner-ad-container--medium"
-          } else if (TopAboveNavAdSlot1x1Switch.isSwitchedOn) {
-            "top-banner-ad-container--reveal"
           } else {
             "top-banner-ad-container--large"
           }

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -1,6 +1,6 @@
 package views.support
 
-import conf.Switches.{FixedTopAboveNavAdSlotSwitch, TopAboveNavAdSlot728x90Switch, TopAboveNavAdSlot88x70Switch}
+import conf.Switches._
 import model.MetaData
 
 object Commercial {
@@ -38,6 +38,8 @@ object Commercial {
         if (FixedTopAboveNavAdSlotSwitch.isSwitchedOn && isUKNetworkFront(metaData)) {
           if (TopAboveNavAdSlot728x90Switch.isSwitchedOn) {
             "top-banner-ad-container--medium"
+          } else if (TopAboveNavAdSlot1x1Switch.isSwitchedOn) {
+            "top-banner-ad-container--reveal"
           } else {
             "top-banner-ad-container--large"
           }

--- a/common/test/views/support/CommercialTest.scala
+++ b/common/test/views/support/CommercialTest.scala
@@ -24,7 +24,7 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
     FixedTopAboveNavAdSlotSwitch.switchOff()
     TopAboveNavAdSlot728x90Switch.switchOff()
     TopAboveNavAdSlot88x70Switch.switchOff()
-    TopAboveNavAdSlot1x1Switch.switchOff()
+    TopAboveNavAdSlotOmitSwitch.switchOff()
   }
 
   "topAboveNavSlot ad sizes" should "be fixed for UK network front" in {
@@ -61,13 +61,6 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
       endWith("top-banner-ad-container--large")
   }
 
-  they should "be default for 1x1 ad on UK network front" in {
-    FixedTopAboveNavAdSlotSwitch.switchOn()
-    TopAboveNavAdSlot1x1Switch.switchOn()
-    topAboveNavSlot.cssClasses(metaDataFromId("uk")) should
-      endWith("top-banner-ad-container--reveal")
-  }
-
   they should "be default for any other page" in {
     FixedTopAboveNavAdSlotSwitch.switchOn()
     topAboveNavSlot.cssClasses(metaDataFromId("us")) should
@@ -77,5 +70,27 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
     topAboveNavSlot.cssClasses(metaDataFromId(
       "business/2015/jul/07/eurozone-calls-on-athens-to-get-serious-over-greece-debt-crisis"))
       .should(endWith("top-banner-ad-container--reveal"))
+  }
+
+  "topAboveNavSlot show" should "be false for 1x1 ad on UK network front" in {
+    FixedTopAboveNavAdSlotSwitch.switchOn()
+    TopAboveNavAdSlotOmitSwitch.switchOn()
+    topAboveNavSlot.show(metaDataFromId("uk")) shouldBe false
+  }
+
+  it should "be true for non-1x1 ad on UK network front" in {
+    FixedTopAboveNavAdSlotSwitch.switchOn()
+    topAboveNavSlot.show(metaDataFromId("uk")) shouldBe true
+  }
+
+  it should "be true for any other page" in {
+    FixedTopAboveNavAdSlotSwitch.switchOn()
+    TopAboveNavAdSlotOmitSwitch.switchOn()
+    topAboveNavSlot.show(metaDataFromId("us")) shouldBe true
+  }
+
+  it should "be true when master switch is off" in {
+    FixedTopAboveNavAdSlotSwitch.switchOff()
+    topAboveNavSlot.show(metaDataFromId("uk")) shouldBe true
   }
 }

--- a/common/test/views/support/CommercialTest.scala
+++ b/common/test/views/support/CommercialTest.scala
@@ -1,0 +1,73 @@
+package views.support
+
+import conf.Switches.{FixedTopAboveNavAdSlotSwitch, TopAboveNavAdSlot728x90Switch, TopAboveNavAdSlot88x70Switch}
+import model.MetaData
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers, OptionValues}
+import views.support.Commercial.topAboveNavSlot
+
+class CommercialTest extends FlatSpec with Matchers with OptionValues with BeforeAndAfterEach {
+
+  private def metaDataFromId(pageId: String): MetaData = new model.MetaData {
+    override def id: String = pageId
+    override def section: String = "section"
+    override def analyticsName: String = "analyticsName"
+    override def webTitle: String = "webTitle"
+  }
+
+  def pageShouldHaveAdSizes(pageId: String, sizes: Seq[String]): Unit = {
+    FixedTopAboveNavAdSlotSwitch.switchOn()
+    val metaData = metaDataFromId(pageId)
+    topAboveNavSlot.adSizes(metaData).get("desktop").value shouldBe sizes
+  }
+
+  override protected def beforeEach(): Unit = {
+    FixedTopAboveNavAdSlotSwitch.switchOff()
+    TopAboveNavAdSlot728x90Switch.switchOff()
+    TopAboveNavAdSlot88x70Switch.switchOff()
+  }
+
+  "topAboveNavSlot ad sizes" should "be fixed for UK network front" in {
+    pageShouldHaveAdSizes("uk", Seq("1,1", "900,250", "970,250"))
+  }
+
+  they should "be variable for any other page" in {
+    pageShouldHaveAdSizes("us", Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250"))
+    pageShouldHaveAdSizes("uk/culture",
+      Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250"))
+    pageShouldHaveAdSizes(
+      "business/2015/jul/07/eurozone-calls-on-athens-to-get-serious-over-greece-debt-crisis",
+      Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250"))
+  }
+
+  "topAboveNavSlot css classes" should
+    "be large for 900x250, 970x250 or 1x1 ad on UK network front" in {
+    FixedTopAboveNavAdSlotSwitch.switchOn()
+    topAboveNavSlot.cssClasses(metaDataFromId("uk")) should
+      endWith("top-banner-ad-container--large")
+  }
+
+  they should "be medium for 728x90 ad on UK network front" in {
+    FixedTopAboveNavAdSlotSwitch.switchOn()
+    TopAboveNavAdSlot728x90Switch.switchOn()
+    topAboveNavSlot.cssClasses(metaDataFromId("uk")) should
+      endWith("top-banner-ad-container--medium")
+  }
+
+  they should "be large for 88x70 ad on UK network front" in {
+    FixedTopAboveNavAdSlotSwitch.switchOn()
+    TopAboveNavAdSlot88x70Switch.switchOn()
+    topAboveNavSlot.cssClasses(metaDataFromId("uk")) should
+      endWith("top-banner-ad-container--large")
+  }
+
+  they should "be default for any other page" in {
+    FixedTopAboveNavAdSlotSwitch.switchOn()
+    topAboveNavSlot.cssClasses(metaDataFromId("us")) should
+      endWith("top-banner-ad-container--reveal")
+    topAboveNavSlot.cssClasses(metaDataFromId("uk/culture")) should
+      endWith("top-banner-ad-container--reveal")
+    topAboveNavSlot.cssClasses(metaDataFromId(
+      "business/2015/jul/07/eurozone-calls-on-athens-to-get-serious-over-greece-debt-crisis"))
+      .should(endWith("top-banner-ad-container--reveal"))
+  }
+}

--- a/common/test/views/support/CommercialTest.scala
+++ b/common/test/views/support/CommercialTest.scala
@@ -1,6 +1,6 @@
 package views.support
 
-import conf.Switches.{FixedTopAboveNavAdSlotSwitch, TopAboveNavAdSlot728x90Switch, TopAboveNavAdSlot88x70Switch}
+import conf.Switches._
 import model.MetaData
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers, OptionValues}
 import views.support.Commercial.topAboveNavSlot
@@ -24,6 +24,7 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
     FixedTopAboveNavAdSlotSwitch.switchOff()
     TopAboveNavAdSlot728x90Switch.switchOff()
     TopAboveNavAdSlot88x70Switch.switchOff()
+    TopAboveNavAdSlot1x1Switch.switchOff()
   }
 
   "topAboveNavSlot ad sizes" should "be fixed for UK network front" in {
@@ -40,7 +41,7 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
   }
 
   "topAboveNavSlot css classes" should
-    "be large for 900x250, 970x250 or 1x1 ad on UK network front" in {
+    "be large for 900x250 or 970x250 ad on UK network front" in {
     FixedTopAboveNavAdSlotSwitch.switchOn()
     topAboveNavSlot.cssClasses(metaDataFromId("uk")) should
       endWith("top-banner-ad-container--large")
@@ -58,6 +59,13 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
     TopAboveNavAdSlot88x70Switch.switchOn()
     topAboveNavSlot.cssClasses(metaDataFromId("uk")) should
       endWith("top-banner-ad-container--large")
+  }
+
+  they should "be default for 1x1 ad on UK network front" in {
+    FixedTopAboveNavAdSlotSwitch.switchOn()
+    TopAboveNavAdSlot1x1Switch.switchOn()
+    topAboveNavSlot.cssClasses(metaDataFromId("uk")) should
+      endWith("top-banner-ad-container--reveal")
   }
 
   they should "be default for any other page" in {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -79,10 +79,13 @@
         @include mq(wide) {
             margin: 0;
         }
-    } 
+    }
 }
 .top-banner-ad-container--large {
     min-height: ($gs-row-height * 7) + 34;
+}
+.top-banner-ad-container--medium {
+    min-height: ($gs-row-height * 3) + 18;
 }
 .top-banner-ad-container--reveal iframe {
     transform: translateZ(0);
@@ -206,7 +209,7 @@
 }
 .ad-slot__content {
     > div {
-        margin: 0 auto;            
+        margin: 0 auto;
     }
 }
 .ad-slot--container-inline {


### PR DESCRIPTION
This fixes the size of the top-above-nav slot for the three expected ad heights.

It continues from #9707.

This first iteration uses manual switches to set the size of the slot but it will be set automatically in the next iteration.

/cc @kenlim @tijanamiletic @Calanthe 
