### PR TITLE
Drop some social stuff from Preview.

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -10,7 +10,8 @@ define([
     var outbrainUrl = 'http://widgets.outbrain.com/outbrain.js';
 
     function load() {
-        if (config.switches.outbrain) {
+        // outbrain leaks the URL of preview content so we don't show it there.
+        if (config.switches.outbrain && !config.page.isPreview) {
             var widgetIds = {
                 mobile: 'MB_2',
                 tablet: 'MB_1',

--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -69,7 +69,10 @@ define([
     }
 
     return function () {
-        if ($shareCountEls.length) {
+        // asking for social counts in preview "leaks" upcoming URLs to social sights.
+        // when they then crawl them they get 404s which affects later sharing.
+        // don't call counts in preview
+        if ($shareCountEls.length && !config.page.isPreview) {
             var url = 'http://www.theguardian.com/' + config.page.pageId;
             try {
                 ajax({

--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -69,7 +69,7 @@ define([
     }
 
     return function () {
-        // asking for social counts in preview "leaks" upcoming URLs to social sights.
+        // asking for social counts in preview "leaks" upcoming URLs to social sites.
         // when they then crawl them they get 404s which affects later sharing.
         // don't call counts in preview
         if ($shareCountEls.length && !config.page.isPreview) {


### PR DESCRIPTION
Preview exposes upcoming URLs to social sites. They then crawl them and get 404s.

Don't run these components on Preview.
