### PR TITLE
Don't show toggle for headlines container to avoid colliding with weather widget

### DIFF
--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -58,6 +58,7 @@ object GetClasses {
       containerDefinition.showLatestUpdate,
       containerDefinition.index == 0 && containerDefinition.customHeader.isEmpty,
       containerDefinition.displayName.isDefined,
+      containerDefinition.displayName == Some("headlines"),
       containerDefinition.commercialOptions,
       containerDefinition.hasDesktopShowMore,
       Some(containerDefinition.container),
@@ -72,6 +73,7 @@ object GetClasses {
     showLatestUpdate = false,
     isFirst = true,
     hasTitle,
+    false,
     ContainerCommercialOptions.empty,
     false,
     None,
@@ -84,6 +86,7 @@ object GetClasses {
     showLatestUpdate: Boolean,
     isFirst: Boolean,
     hasTitle: Boolean,
+    isHeadlines: Boolean,
     commercialOptions: ContainerCommercialOptions,
     hasDesktopShowMore: Boolean,
     container: Option[slices.Container] = None,
@@ -103,7 +106,8 @@ object GetClasses {
       ("js-container--lazy-load", lazyLoad),
       ("js-sponsored-container", commercialOptions.isPaidFor),
       ("js-container--toggle",
-        !disableHide && !container.exists(!slices.Container.showToggle(_)) && !isFirst && hasTitle && !commercialOptions.isPaidFor)
+        // no toggle for Headlines container as it will be hosting the weather widget instead
+        !disableHide && !container.exists(!slices.Container.showToggle(_)) && !isFirst && hasTitle && !isHeadlines && !commercialOptions.isPaidFor)
     ) collect {
       case (kls, true) => kls
     }) ++ extraClasses: _*)


### PR DESCRIPTION
Fixes #9121.

IANA dotCom QA so worth someone else reviewing and testing this. I don't know how to remove the top non-headlines container to prove that everything still works when headline is first.
# Before

![recorded](https://cloud.githubusercontent.com/assets/36964/8593704/f4a726d6-2631-11e5-81c3-60111489d2ba.gif)
# After

![recorded](https://cloud.githubusercontent.com/assets/36964/8593651/861015fc-2631-11e5-9b18-b791440456d5.gif)

Notes: this theoretically introduces a minor coupling of the Scala code that makes containers togglable and the JS weather injection code which adds the weather to the headlines container. However tbh that JS weather injection code is already magically coupled to a special container whose id is "headlines", which most of the times is first (and hence doesn't get a toggle), so I don't think it's that much worse, and I've added a comment below.
