### PR TITLE
Remove mention of Twitter on password reset page

### DIFF
--- a/identity/app/views/password/requestPasswordReset.scala.html
+++ b/identity/app/views/password/requestPasswordReset.scala.html
@@ -32,8 +32,8 @@
     </form>
 
     <div class="identity-section">
-        <a class="u-underline" href="#unlink-password" data-toggle="js-unlink-password" data-link-name="Unlink password">Unlinked the Guardian from Facebook, Twitter or Google and want to sign in?</a>
-        <p class="identity-section__text js-unlink-password is-off">Use the email address field to send a reset link to your registered Facebook, Twitter or Google email. You will then be able to add a password to your account.</p>
+        <a class="u-underline" href="#unlink-password" data-toggle="js-unlink-password" data-link-name="Unlink password">Unlinked the Guardian from Facebook or Google and want to sign in?</a>
+        <p class="identity-section__text js-unlink-password is-off">Use the email address field to send a reset link to your registered Facebook or Google email. You will then be able to add a password to your account.</p>
     </div>
 
     <div class="identity-section">


### PR DESCRIPTION
We haven't supported Twitter for social login for quite some time.

This change just removes the mention of Twitter from the password reset page at `profile.theguardian.com`.
