### PR TITLE
make sure the video player is displayed before enhancing it

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -129,8 +129,8 @@ define([
                         placeholder.removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
                         player.removeClass('media__container--hidden').addClass('media__container--active');
                         $el.removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
+                        enhanceVideo($('video', player).get(0), true);
                     });
-                    enhanceVideo($('video', player).get(0), true);
                 });
                 fastdom.write(function () {
                     $el.removeClass('media__placeholder--hidden').addClass('media__placeholder--active');


### PR DESCRIPTION
Fixes https://github.com/guardian/frontend/issues/9727

Fastdom deferred making the video element visible, but IMA seemed to think the area to display the advert was 0pixels in the top left corner.

@robertberry I'm not really making it use fastdom properly, but that might be unnecessary since it's an explicit action to play video.  What do you think?
