### PR TITLE
Fix snaps in show-more

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -205,7 +205,7 @@ object FaciaCard {
     } yield kickerText contains byline) getOrElse false
 
     ContentCard(
-      faciaContent.maybeContentId,
+      faciaContent.maybeContentId.orElse(Option(faciaContent.id)),
       faciaContent.headline,
       FaciaCardHeader.fromTrailAndKicker(faciaContent, maybeKicker, Some(config)),
       getByline(faciaContent).filterNot(Function.const(suppressByline)),


### PR DESCRIPTION
#### Problem

When clicking the `show-more` button on a front, the items get deduped based off of the `data-id` on the item.
#### Why

For plain snaps (LinkSnaps), the `data-id` got naturally filtered to fix `dreamsnaps` in #9678 as these don't have any data associated with them.

But this then broke the `show-more` for `dreamsnaps`.
#### Fix

This ensures that every item has a `data-id`, but now a `content-id` takes precedence over any `snap-id`s.
