### PR TITLE
Prevent overlapping form submissions

### DIFF
--- a/static/src/javascripts/projects/common/modules/identity/account-profile.js
+++ b/static/src/javascripts/projects/common/modules/identity/account-profile.js
@@ -130,6 +130,9 @@ define([
         var formData = new FormData(document.querySelector('form' + self.classes.avatarUploadForm));
         var xhr = self.createCORSRequest('POST', self.urls.avatarApiUrl);
 
+        // disable form while submitting to prevent overlapping submissions
+        document.querySelector(self.classes.avatarUploadButton).disabled = true;
+
         if (!xhr) {
             self.prependErrorMessage(self.messages.noCorsError, avatarForm);
         }
@@ -138,7 +141,6 @@ define([
             var status = xhr.status;
             if (status >= 200 && status < 300) {
                 self.prependSuccessMessage(self.messages.avatarUploadSuccess, avatarForm);
-                document.querySelector(self.classes.avatarUploadButton).disabled = true;
             } else if (status >= 400 && status < 500) {
                 self.prependErrorMessage(
                     JSON.parse(xhr.responseText).message || self.messages.avatarUploadFailure,
@@ -150,6 +152,7 @@ define([
 
         xhr.onerror = function () {
             self.prependErrorMessage(self.messages.noServerError, avatarForm);
+            document.querySelector(self.classes.avatarUploadButton).disabled = false;
         };
 
         xhr.setRequestHeader('Authorization', 'Bearer cookie=' + cookies.get('GU_U'));


### PR DESCRIPTION
We are currently seeing quite often users upload multiple avatars within a short time period (< 1 second), probably because they are clicking the upload button multiple times. The previous behaviour only disabled the form once the upload had completed, which was too slow.

This commit disabled the form immediately after the user clicks the button to prevent overlapping submissions. We re-enable the form if the upload returns as an error.
