### PR TITLE
Update gemfile for new bundler versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,3 +19,6 @@ DEPENDENCIES
   hologram (= 1.2.0)
   sass (~> 3.3.14)
   scss-lint (= 0.26.2)
+
+BUNDLED WITH
+   1.10.4


### PR DESCRIPTION
This new block happens on new versions of bundler. It's all going to be removed soon when we get rid of our ruby dependencies.
