### PR TITLE
Add extra variant to Membership message, extend test

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -997,7 +997,7 @@ object Switches {
     "ab-membership-message",
     "Switch for the Membership message A/B test.",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 7, 14),
+    sellByDate = new LocalDate(2015, 8, 20),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -992,10 +992,10 @@ object Switches {
     )
   }
 
-  val ABMembershipMessage = Switch(
+  val ABMembershipMessageVariants = Switch(
     "A/B Tests",
-    "ab-membership-message",
-    "Switch for the Membership message A/B test.",
+    "ab-membership-message-variants",
+    "Switch for the Membership message A/B variants test",
     safeState = Off,
     sellByDate = new LocalDate(2015, 8, 20),
     exposeClientSide = true

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message.js
@@ -18,8 +18,8 @@ define([
 
     return function () {
 
-        this.id = 'MembershipMessage';
-        this.start = '2015-06-17';
+        this.id = 'MembershipMessageVariants';
+        this.start = '2015-07-13';
         this.expiry = '2015-08-20';
         this.author = 'David Rapson';
         this.description = 'Test if loyal users are encouraged to join Membership as a Supporter';
@@ -45,7 +45,7 @@ define([
         this.variants = [{
             id: 'A',
             test: function () {
-                new Message('membership-message', {
+                new Message('membership-message-variants', {
                     pinOnHide: false,
                     siteMessageLinkName: 'membership message',
                     siteMessageCloseBtn: 'hide'
@@ -59,7 +59,7 @@ define([
         {
             id: 'B',
             test: function () {
-                new Message('membership-message', {
+                new Message('membership-message-variants', {
                     pinOnHide: false,
                     siteMessageLinkName: 'membership message',
                     siteMessageCloseBtn: 'hide'

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message.js
@@ -20,7 +20,7 @@ define([
 
         this.id = 'MembershipMessage';
         this.start = '2015-06-17';
-        this.expiry = '2015-07-14';
+        this.expiry = '2015-08-20';
         this.author = 'David Rapson';
         this.description = 'Test if loyal users are encouraged to join Membership as a Supporter';
         this.audience = 1;
@@ -50,9 +50,23 @@ define([
                     siteMessageLinkName: 'membership message',
                     siteMessageCloseBtn: 'hide'
                 }).show(template(messageTemplate, {
-                    supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=MEMBERSHIP_SUBSCRIBER_LOYALTY_BANNER',
+                    supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=MEMBERSHIP_SUBSCRIBER_LOYALTY_BANNER_A',
                     messageText: 'Become a Guardian Member and support fearless investigative journalism',
                     linkText: 'Become a supporter'
+                }));
+            }
+        },
+        {
+            id: 'B',
+            test: function () {
+                new Message('membership-message', {
+                    pinOnHide: false,
+                    siteMessageLinkName: 'membership message',
+                    siteMessageCloseBtn: 'hide'
+                }).show(template(messageTemplate, {
+                    supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=MEMBERSHIP_SUBSCRIBER_LOYALTY_BANNER_B',
+                    messageText: '"If you read the Guardian, join the Guardian" Polly Toynbee.',
+                    linkText: 'Find out more'
                 }));
             }
         }];

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -426,7 +426,10 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 .site-message--adblock {
     background: colour(news-support-2);
 }
-
-.site-message--membership-message {
+/**
+ * Membership message A/B test
+ */
+.site-message--membership-message,
+.site-message--membership-message-variants {
     background: colour(news-main-2);
 }


### PR DESCRIPTION
Adds and extra variant to the Membership message, testing different copy for the message. Extends test.

![screen shot 2015-07-10 at 16 02 31](https://cloud.githubusercontent.com/assets/123386/8621559/2b034402-271e-11e5-84e9-416616a0668c.png)
![screen shot 2015-07-10 at 16 00 36](https://cloud.githubusercontent.com/assets/123386/8621558/2b00aa30-271e-11e5-87b9-0a5d51c5d5a3.png)

@dominickendrick @stephanfowler 
