### PR TITLE
Remove fork of requirejs, use update

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-concurrent": "1.0.0",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-copy": "0.6.0",
-    "grunt-contrib-requirejs": "OliverJAsh/grunt-contrib-requirejs#30acf0e2a04767933c0ebade3ca814238e98957a",
+    "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-uglify": "0.9.1",
     "grunt-contrib-watch": "0.6.1",
     "grunt-csdevmode": "0.1.2",


### PR DESCRIPTION
Reverts #9688, now that requirejs has been updated to 2.1.19 which includes fixes https://github.com/jrburke/r.js/issues/829 and https://github.com/jrburke/r.js/issues/802
