### PR TITLE
SystemJS: wait for dom ready

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -19,7 +19,7 @@ var jspmBaseUrl = 'static/src';
 var prefixPath = 'static/hash';
 var bundlesUri = 'bundles';
 var bundleConfigs = [
-    ['core + system-script', 'core'],
+    ['core + system-script + domready', 'core'],
     ['es6/bootstraps/crosswords - core', 'crosswords'],
     ['bootstraps/accessibility - core', 'accessibility'],
     ['bootstraps/app - core', 'app'],

--- a/common/app/views/fragments/javaScriptLaterSteps.scala.html
+++ b/common/app/views/fragments/javaScriptLaterSteps.scala.html
@@ -346,106 +346,111 @@
 
         // Bracket notation for IE8 (import is reserved)
         System['import']('core')
-        .then(function(){
-            return System['import']('raven');
+        .then(function() {
+            return System['import']('domready');
         })
-        .then(function(raven) {
-            raven.config(
-                'http://' + guardian.config.page.sentryPublicApiKey + '@@' + guardian.config.page.sentryHost,
-                {
-                    whitelistUrls: [
-                        /localhost/, @* will not actually log errors, but `shouldSendCallback` will be called *@
-                        /assets\.guim\.co\.uk/,
-                        /ophan\.co\.uk/
-                    ],
-                    tags: {
-                        edition:        guardian.config.page.edition,
-                        contentType:    guardian.config.page.contentType,
-                        revisionNumber: guardian.config.page.revisionNumber,
-                        loaderType:     'SystemJs'
-                    },
-                    dataCallback: function(data) {
-                        if (data.culprit) {
-                            data.culprit = data.culprit.replace(/\/[a-z\d]{32}(\/[^\/]+)$/, '$1');
-                        }
-                        data.tags.origin = (/j.ophan.co.uk/.test(data.culprit)) ? 'ophan' : 'app';
-                        return data;
-                    },
-                    shouldSendCallback: function(data) {
-                        @if(play.Play.isDev()) {
-                            console.error(data);
-                        }
+        .then(function(domready){
+            domready(function () {
+                System['import']('raven')
+                    .then(function(raven) {
+                        raven.config(
+                            'http://' + guardian.config.page.sentryPublicApiKey + '@@' + guardian.config.page.sentryHost,
+                            {
+                                whitelistUrls: [
+                                    /localhost/, @* will not actually log errors, but `shouldSendCallback` will be called *@
+                                    /assets\.guim\.co\.uk/,
+                                    /ophan\.co\.uk/
+                                ],
+                                tags: {
+                                    edition:        guardian.config.page.edition,
+                                    contentType:    guardian.config.page.contentType,
+                                    revisionNumber: guardian.config.page.revisionNumber,
+                                    loaderType:     'SystemJs'
+                                },
+                                dataCallback: function(data) {
+                                    if (data.culprit) {
+                                        data.culprit = data.culprit.replace(/\/[a-z\d]{32}(\/[^\/]+)$/, '$1');
+                                    }
+                                    data.tags.origin = (/j.ophan.co.uk/.test(data.culprit)) ? 'ophan' : 'app';
+                                    return data;
+                                },
+                                shouldSendCallback: function(data) {
+                                    @if(play.Play.isDev()) {
+                                        console.error(data);
+                                    }
 
-                        return @conf.Switches.DiagnosticsLogging.isSwitchedOn &&
-                            Math.random() < 0.2 &&
-                            @{!play.Play.isDev()}; @* don't actually notify sentry in dev mode*@
-                    }
-                }
-            ).install();
-
-            // Safe to depend on Lodash because it's part of core
-            System['import']('common/utils/_').then(function (_) {
-                var importAll = function (moduleIds) {
-                    return Promise.all(_(moduleIds)
-                        .map(function(module){ return System['import'](module); })
-                        .value());
-                };
-
-                importAll([
-                    'common/utils/config',
-                    'common/modules/experiments/ab',
-                    'common/modules/ui/images',
-                    'common/modules/ui/lazy-load-images']).then(function(values) {
-                    var config = values[0];
-                    var ab = values[1];
-                    var images = values[2];
-                    var lazyLoadImages = values[3];
-
-                    ab.segmentUser();
-                    ab.run();
-                    if(guardian.config.page.isFront) {
-                        if(!document.addEventListener) { // IE8 and below
-                            window.onload = images.upgradePictures;
-                        }
-                    }
-                    lazyLoadImages.init();
-                    images.upgradePictures();
-                    images.listen();
-
-                    if (config.switches.commercial && !config.page.isPreferencesPage) {
-                        System['import']('bootstraps/commercial').then(raven.wrap(
-                            { tags: { feature: 'commercial' } },
-                            function (commercial) {
-                                commercial.init();
+                                    return @conf.Switches.DiagnosticsLogging.isSwitchedOn &&
+                                        Math.random() < 0.2 &&
+                                        @{!play.Play.isDev()}; @* don't actually notify sentry in dev mode*@
+                                }
                             }
-                        ));
-                    }
+                        ).install();
 
-                    if (guardian.isModernBrowser) {
-                        @if(play.Play.isDev()) {
-                            System['import']('bootstraps/dev').then(function (devmode) { devmode.init(); });
-                        }
+                        // Safe to depend on Lodash because it's part of core
+                        System['import']('common/utils/_').then(function (_) {
+                            var importAll = function (moduleIds) {
+                                return Promise.all(_(moduleIds)
+                                    .map(function(module){ return System['import'](module); })
+                                    .value());
+                            };
 
-                        System['import']('bootstraps/app').then(function(app) {
-                            app.go();
+                            importAll([
+                                'common/utils/config',
+                                'common/modules/experiments/ab',
+                                'common/modules/ui/images',
+                                'common/modules/ui/lazy-load-images']).then(function(values) {
+                                var config = values[0];
+                                var ab = values[1];
+                                var images = values[2];
+                                var lazyLoadImages = values[3];
+
+                                ab.segmentUser();
+                                ab.run();
+                                if(guardian.config.page.isFront) {
+                                    if(!document.addEventListener) { // IE8 and below
+                                        window.onload = images.upgradePictures;
+                                    }
+                                }
+                                lazyLoadImages.init();
+                                images.upgradePictures();
+                                images.listen();
+
+                                if (config.switches.commercial && !config.page.isPreferencesPage) {
+                                    System['import']('bootstraps/commercial').then(raven.wrap(
+                                        { tags: { feature: 'commercial' } },
+                                        function (commercial) {
+                                            commercial.init();
+                                        }
+                                    ));
+                                }
+
+                                if (guardian.isModernBrowser) {
+                                    @if(play.Play.isDev()) {
+                                        System['import']('bootstraps/dev').then(function (devmode) { devmode.init(); });
+                                    }
+
+                                    System['import']('bootstraps/app').then(function(app) {
+                                        app.go();
+                                    });
+                                }
+
+                                @if(item.section == "crosswords") {
+                                    System['import']('es6/bootstraps/crosswords').then(function (crosswords) {
+                                        crosswords.default.init();
+                                    });
+
+                                    System['import']('es6/projects/common/modules/crosswords/thumbnails').then(function (crosswordThumbnails) {
+                                        crosswordThumbnails.default.init();
+                                    });
+                                }
+                            });
                         });
-                    }
 
-                    @if(item.section == "crosswords") {
-                        System['import']('es6/bootstraps/crosswords').then(function (crosswords) {
-                            crosswords.default.init();
-                        });
 
-                        System['import']('es6/projects/common/modules/crosswords/thumbnails').then(function (crosswordThumbnails) {
-                            crosswordThumbnails.default.init();
-                        });
-                    }
-                });
+                        @membershipAccess()
+
+                    });
             });
-
-
-            @membershipAccess()
-
         });
     </script>
 }


### PR DESCRIPTION
Mimic the RequireJS behaviour, i.e. https://github.com/guardian/frontend/blob/f675da5ce0c87655f15b054d45725ddda0dce542/common/app/views/fragments/javaScriptLaterSteps.scala.html#L246

Non-whitespace diff: https://github.com/guardian/frontend/compare/oja-systemjs-dom-ready?w=1

I'm not sure if this has a performance impact, but we should be doing the same as in RequireJS world, in any case.
