### PR TITLE
use fully qualified urls in list page linked data

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -426,14 +426,14 @@ object Front extends implicits.Collections {
 
   }
 
-  def makeLinkedData(collections: Seq[FaciaContainer]): ItemList = {
+  def makeLinkedData(url: String, collections: Seq[FaciaContainer]): ItemList = {
     ItemList(
-      "", // relative iri so just resolves to the base
+      Configuration.site.host + url,
       collections.zipWithIndex.map {
         case (collection, index) =>
           ListItem(position = index, item = Some(
             ItemList(
-              "", // don't have a uri for each container
+              Configuration.site.host + url, // don't have a uri for each container
               collection.items.zipWithIndex.map {
                 case (item, index) =>
                   ListItem(position = index, url = Some(Configuration.site.host + item.url))

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -149,7 +149,7 @@ object IndexPage {
 
   def makeLinkedData(indexPage: IndexPage): ItemList = {
     ItemList(
-      indexPage.page.url,
+      Configuration.site.host + indexPage.page.url,
       indexPage.trails.zipWithIndex.map {
         case (trail, index) =>
           ListItem(position = index, url = Some(Configuration.site.host + trail.url))

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -27,7 +27,7 @@
                         @fragments.containers.facia_cards.container(containerDefinition, faciaPage.frontProperties)
                     }
 
-                    @defining(layout.Front.makeLinkedData(collections)) { linkedData =>
+                    @defining(layout.Front.makeLinkedData(faciaPage.url, collections)) { linkedData =>
                         <script data-schema="@{linkedData.`@type`}" type="application/ld+json">
                             @Html(model.meta.LinkedData.toJson(linkedData))
                         </script>


### PR DESCRIPTION
WE shouldn't use relative urls in the linked data as apparently it can cause google to choke.  So I have updated it to pass in full urls everywhere.
