### PR TITLE
add mainEntityOfPage linked data to articles

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -1,3 +1,4 @@
+@import conf.Configuration
 @(model: ArticlePage)(implicit request: RequestHeader)
 
 @import conf.Switches._
@@ -11,6 +12,8 @@
         @if(article.isAdvertisementFeature){content--advertisement-feature}
         @if(article.isFeature && article.hasShowcaseMainPicture){has-feature-showcase-picture}"
         itemscope itemtype="@article.schemaType" role="main">
+
+        <a itemprop="mainEntityOfPage" href="@{Configuration.site.host + article.url}"/>
 
         @fragments.headTonal(article)
 

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -13,7 +13,7 @@
         @if(article.isFeature && article.hasShowcaseMainPicture){has-feature-showcase-picture}"
         itemscope itemtype="@article.schemaType" role="main">
 
-        <a itemprop="mainEntityOfPage" href="@LinkTo(article.url)"/>
+        <meta itemprop="mainEntityOfPage" content="@LinkTo(article.url)">
 
         @fragments.headTonal(article)
 

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -1,7 +1,7 @@
-@import conf.Configuration
+
 @(model: ArticlePage)(implicit request: RequestHeader)
 
-@import conf.Switches._
+@import common.LinkTo
 @import views.BodyCleaner
 @import views.support.TrailCssClasses.articleToneClass
 
@@ -13,7 +13,7 @@
         @if(article.isFeature && article.hasShowcaseMainPicture){has-feature-showcase-picture}"
         itemscope itemtype="@article.schemaType" role="main">
 
-        <a itemprop="mainEntityOfPage" href="@{Configuration.site.host + article.url}"/>
+        <a itemprop="mainEntityOfPage" href="@LinkTo(article.url)"/>
 
         @fragments.headTonal(article)
 

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -15,7 +15,7 @@
         class="content content--liveblog tonal tonal--@articleToneClass(article) blog @if(article.isLive){is-live} section-@article.sectionName.toLowerCase"
         itemscope itemtype="@article.schemaType" role="main">
 
-        <a itemprop="url" href=""/>
+        <meta itemprop="url" content="@LinkTo(article.url)">
 
         <header class="content__head tonal__head tonal__head--@articleToneClass(article)">
             @* UPPER HEADER *@

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -1,14 +1,16 @@
 package layout
 
-import com.gu.facia.api.models.{CollectionConfig, CuratedContent, FaciaContent}
-import conf.{Configuration, Switches}
+import com.gu.facia.api.models.{CollectionConfig, FaciaContent}
+import common.LinkTo
+import conf.Switches
 import dfp.{DfpAgent, SponsorshipTag}
 import implicits.FaciaContentFrontendHelpers._
 import implicits.FaciaContentImplicits._
 import model.PressedPage
 import model.facia.PressedCollection
-import model.meta.{ListItem, ItemList}
+import model.meta.{ItemList, ListItem}
 import org.joda.time.DateTime
+import play.api.mvc.RequestHeader
 import services.{CollectionConfigWithId, FaciaContentConvert}
 import slices.{MostPopular, _}
 import views.support.CutOut
@@ -426,17 +428,17 @@ object Front extends implicits.Collections {
 
   }
 
-  def makeLinkedData(url: String, collections: Seq[FaciaContainer]): ItemList = {
+  def makeLinkedData(url: String, collections: Seq[FaciaContainer])(implicit request: RequestHeader): ItemList = {
     ItemList(
-      Configuration.site.host + url,
+      LinkTo(url),
       collections.zipWithIndex.map {
         case (collection, index) =>
           ListItem(position = index, item = Some(
             ItemList(
-              Configuration.site.host + url, // don't have a uri for each container
+              LinkTo(url), // don't have a uri for each container
               collection.items.zipWithIndex.map {
                 case (item, index) =>
-                  ListItem(position = index, url = Some(Configuration.site.host + item.url))
+                  ListItem(position = index, url = Some(LinkTo(item.url)))
               }
             )
           ))

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -1,21 +1,22 @@
 package services
 
-import com.gu.facia.api.models.{CollectionConfig, FaciaContent}
-import com.gu.facia.api.utils.{ReviewKicker, CartoonKicker, TagKicker}
-import common.Edition
-import conf.{Configuration, Switches}
+import com.gu.facia.api.models.CollectionConfig
+import com.gu.facia.api.utils.{CartoonKicker, ReviewKicker, TagKicker}
+import common.{Edition, LinkTo}
+import conf.Switches
 import contentapi.Paths
 import layout.DateHeadline.cardTimestampDisplay
 import layout._
 import model._
-import model.meta.{ListItem, ItemList}
+import model.meta.{ItemList, ListItem}
 import org.joda.time.DateTime
+import play.api.mvc.RequestHeader
 import slices.{ContainerDefinition, Fixed, FixedContainers}
 
 import scala.Function.const
-import scalaz.syntax.traverse._
 import scalaz.std.list._
 import scalaz.syntax.std.boolean._
+import scalaz.syntax.traverse._
 
 object IndexPagePagination {
   def pageSize: Int = if (Switches.TagPageSizeSwitch.isSwitchedOn) {
@@ -147,12 +148,12 @@ object IndexPage {
     }))
   }
 
-  def makeLinkedData(indexPage: IndexPage): ItemList = {
+  def makeLinkedData(indexPage: IndexPage)(implicit request: RequestHeader): ItemList = {
     ItemList(
-      Configuration.site.host + indexPage.page.url,
+      LinkTo(indexPage.page.url),
       indexPage.trails.zipWithIndex.map {
         case (trail, index) =>
-          ListItem(position = index, url = Some(Configuration.site.host + trail.url))
+          ListItem(position = index, url = Some(LinkTo(trail.url)))
       }
     )
   }


### PR DESCRIPTION
We would like to specify in the page in the article metadata what the url of the page that holds it is.  The word on the street is that this will be great for our SEO.
