### PR TITLE
Add better error message in fetchForecastData in weather.js

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -138,7 +138,9 @@ define([
                     this.renderForecast(response);
                 }.bind(this))
                 .fail(function (err, msg) {
-                    raven.captureException(new Error('Error retrieving forecast data (' + msg + ')'), {
+                    var statusText = (err && err.statusText) || '';
+                    var statusCode = (err && err.status) || '';
+                    raven.captureException(new Error('Error retrieving forecast data (' + msg + ') (Status: ' + statusCode + ') (StatusText: ' + statusText + ')'), {
                         tags: {
                             feature: 'weather'
                         }


### PR DESCRIPTION
In `sentry`, we get error messages coming from `weather.js` that looks like

```
Error retrieving forecast data (undefined)
```

This changes that error message to use the passed in `err` to maybe get some understanding as to what is happening.

I have figured out that `err` is an `XMLHttpRequest`.
