### PR TITLE
Return 404 for profile requests for 'guest users'

### DIFF
--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -19,7 +19,7 @@ class PublicProfileController @Inject()(idUrlBuilder: IdentityUrlBuilder,
   with ExecutionContexts
   with SafeLogging{
 
-  def page(url: String, username: Option[String]) = IdentityPage(url, username.get +"'s public profile", "public profile")
+  def page(url: String, username: String) = IdentityPage(url,  s"$username's public profile", "public profile")
 
   def renderProfileFromVanityUrl(vanityUrl: String, activityType: String) = renderPublicProfilePage(
     "/user/" + vanityUrl,
@@ -37,9 +37,11 @@ class PublicProfileController @Inject()(idUrlBuilder: IdentityUrlBuilder,
           NotFound(views.html.errors._404())
 
         case Right(user) =>
-          val idRequest = idRequestParser(request)
-          Cached(60)(Ok(views.html.publicProfilePage(
-            page(url, user.publicFields.displayName), idRequest, idUrlBuilder, user, activityType)))
+          user.publicFields.displayName.map { displayName =>
+            val idRequest = idRequestParser(request)
+            Cached(60)(Ok(views.html.publicProfilePage(
+              page(url, displayName), idRequest, idUrlBuilder, user, activityType)))
+          } getOrElse NotFound(views.html.errors._404())
       }
   }
 }

--- a/identity/test/controllers/PublicProfileControllerTest.scala
+++ b/identity/test/controllers/PublicProfileControllerTest.scala
@@ -98,6 +98,17 @@ class PublicProfileControllerTest extends path.FreeSpec with ShouldMatchers with
         status(result) should be(404)
       }
     }
+
+    "with no display name for the specified user" - {
+      val guestUser = user.copy(publicFields = user.publicFields.copy(displayName = None))
+      when(api.userFromVanityUrl(Matchers.anyString, Matchers.any[Auth])) thenReturn Future.successful(Left(Nil))
+      when(api.userFromVanityUrl(vanityUrl)) thenReturn Future.successful(Right(guestUser))
+      val result = controller.renderProfileFromVanityUrl(vanityUrl, "discussions")(request)
+
+      "then should return status 404" in {
+        status(result) should be(404)
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Currently a request for a profile for a "guest user" results in a 500 due to a .get on a None for the display name. In lieu of a better way to detect whether a user is a guest user, this PR returns a 404 when no display name is present.
