### PR TITLE
Use SystemJS CSP to download using script tags

### DIFF
--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -136,7 +136,7 @@ class Assets(base: String, assetMap: String = "assets/assets.map") extends Loggi
 
      val systemJsPolyfills: String = inlineJs("assets/system-polyfills.src.js")
 
-     val systemJs: String = inlineJs("assets/system.src.js")
+     val systemJs: String = inlineJs("assets/system-csp-production.src.js")
 
      val systemJsAppConfig: String = inlineJs("assets/systemjs-config.js")
 

--- a/grunt-configs/uglify.js
+++ b/grunt-configs/uglify.js
@@ -21,7 +21,7 @@ module.exports = function(grunt, options) {
                 expand: true,
                 cwd: 'static/src/jspm_packages',
                 src: [
-                    'system.src.js',
+                    'system-csp-production.src.js',
                     'system-polyfills.src.js'
                 ],
                 dest: 'common/conf/assets'


### PR DESCRIPTION
My hypothesis is that this will see us return to fast DOMContentLoadedEvent times.

See https://dashboard.ophan.co.uk/perf/timings?ab=jspmTest:inTest and https://dashboard.ophan.co.uk/perf/timings?ab=jspmControl:inTest
