### PR TITLE
Change default page-size in facia-press

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -91,6 +91,7 @@ trait FapiFrontPress extends QueryDefaults with Logging with ExecutionContexts {
       .showElements("all")
       .showTags("all")
       .showReferences(references)
+      .pageSize(20)
 
   val itemApiQuery: AdjustItemQuery = (itemQuery: ItemQuery) =>
     itemQuery


### PR DESCRIPTION
This changes the default `page-size` to `20` in `facia-press`.

This used to be the old default, but got lost in the conversion over to `facia-scala-client`.

Some containers look weird when you only get back 10 items.

The configuration for `apiQuery` still supports `page-size`, and will override this if set.
