### PR TITLE
Revert previous identity change

### DIFF
--- a/identity/app/controllers/PublicProfileController.scala
+++ b/identity/app/controllers/PublicProfileController.scala
@@ -37,13 +37,11 @@ class PublicProfileController @Inject()(idUrlBuilder: IdentityUrlBuilder,
           NotFound(views.html.errors._404())
 
         case Right(user) =>
-          (user.isGuest, user.publicFields.displayName) match {
-            case (false, Some(displayName)) =>
-              val idRequest = idRequestParser(request)
-              Cached(60)(Ok(views.html.publicProfilePage(
-                page(url, displayName), idRequest, idUrlBuilder, user, activityType)))
-            case _ => NotFound(views.html.errors._404())
-          }
+          user.publicFields.displayName.map { displayName =>
+            val idRequest = idRequestParser(request)
+            Cached(60)(Ok(views.html.publicProfilePage(
+              page(url, displayName), idRequest, idUrlBuilder, user, activityType)))
+          } getOrElse NotFound(views.html.errors._404())
       }
   }
 }

--- a/identity/test/controllers/PublicProfileControllerTest.scala
+++ b/identity/test/controllers/PublicProfileControllerTest.scala
@@ -25,7 +25,6 @@ class PublicProfileControllerTest extends path.FreeSpec with ShouldMatchers with
   val userId: String = "123"
   val vanityUrl: String = "bobski"
   val user = User("test@example.com", userId,
-    password = Some("password"),
     publicFields = PublicFields(
       displayName = Some("John Smith"),
       aboutMe = Some("I read the Guardian"),
@@ -102,17 +101,6 @@ class PublicProfileControllerTest extends path.FreeSpec with ShouldMatchers with
 
     "with no display name for the specified user" - {
       val guestUser = user.copy(publicFields = user.publicFields.copy(displayName = None))
-      when(api.userFromVanityUrl(Matchers.anyString, Matchers.any[Auth])) thenReturn Future.successful(Left(Nil))
-      when(api.userFromVanityUrl(vanityUrl)) thenReturn Future.successful(Right(guestUser))
-      val result = controller.renderProfileFromVanityUrl(vanityUrl, "discussions")(request)
-
-      "then should return status 404" in {
-        status(result) should be(404)
-      }
-    }
-
-    "with guest user" - {
-      val guestUser = user.copy(password = None)
       when(api.userFromVanityUrl(Matchers.anyString, Matchers.any[Auth])) thenReturn Future.successful(Left(Nil))
       when(api.userFromVanityUrl(vanityUrl)) thenReturn Future.successful(Right(guestUser))
       val result = controller.renderProfileFromVanityUrl(vanityUrl, "discussions")(request)


### PR DESCRIPTION
Revert previous change as users will always be considered guest users when returned from identity API due to absence of password
