### PR TITLE
Some environments don't support or don't always expose the console object

### DIFF
--- a/common/app/templates/headerInlineJS/bootCurl.scala.js
+++ b/common/app/templates/headerInlineJS/bootCurl.scala.js
@@ -73,7 +73,10 @@ require([
             },
             shouldSendCallback: function(data) {
                 @if(play.Play.isDev()) {
-                    console.warn('Raven captured error.', data);
+                    // Some environments don't support or don't always expose the console object
+                    if (window.console && window.console.warn) {
+                        console.warn('Raven captured error.', data);
+                    }
                 }
 
                 return @conf.Switches.DiagnosticsLogging.isSwitchedOn &&

--- a/common/app/templates/headerInlineJS/bootSystemJS.scala.js
+++ b/common/app/templates/headerInlineJS/bootSystemJS.scala.js
@@ -34,7 +34,10 @@ System['import']('core').then(function () {
                     },
                     shouldSendCallback: function(data) {
                         @if(play.Play.isDev()) {
-                            console.warn('Raven captured error.', data);
+                            // Some environments don't support or don't always expose the console object
+                            if (window.console && window.console.warn) {
+                                console.warn('Raven captured error.', data);
+                            }
                         }
                         return @conf.Switches.DiagnosticsLogging.isSwitchedOn &&
                             Math.random() < 0.2 &&

--- a/static/src/javascripts/projects/common/utils/fastdom-errors.js
+++ b/static/src/javascripts/projects/common/utils/fastdom-errors.js
@@ -14,6 +14,9 @@ define([
                 feature: 'fastdom'
             }
         });
-        window.console.warn('Caught FastDom error.', error.stack);
+        // Some environments don't support or don't always expose the console object
+        if (window.console && window.console.warn) {
+            window.console.warn('Caught FastDom error.', error.stack);
+        }
     };
 });

--- a/static/src/javascripts/projects/common/utils/fsm.js
+++ b/static/src/javascripts/projects/common/utils/fsm.js
@@ -42,7 +42,7 @@ define([], function () {
     }
 
     FiniteStateMachine.prototype.log = function () {
-        if (this.debug && window.console) {
+        if (this.debug && window.console && window.console.log) {
             window.console.log.apply(window.console, arguments);
         }
     };

--- a/static/src/javascripts/projects/common/utils/robust.js
+++ b/static/src/javascripts/projects/common/utils/robust.js
@@ -20,7 +20,9 @@ define([
     };
 
     var log = function (name, error, reporter) {
-        window.console.warn('Caught error.', error.stack);
+        if (window.console && window.console.warn) {
+            window.console.warn('Caught error.', error.stack);
+        }
         if (!reporter) {
             reporter = raven.captureException;
         }

--- a/static/src/javascripts/projects/common/views/svgs.js
+++ b/static/src/javascripts/projects/common/views/svgs.js
@@ -69,7 +69,10 @@ define([
             if (_.isArray(classes)) {
                 svg = svg.replace(/class="/, '$&' + classes.join(' ') + ' ');
             } else {
-                window.console.error('Classes for inlineSvg must be an array: ', classes);
+                // Some environments don't support or don't always expose the console object
+                if (window.console && window.console.error) {
+                    window.console.error('Classes for inlineSvg must be an array: ', classes);
+                }
             }
         }
 


### PR DESCRIPTION
I believe this will fix error https://app.getsentry.com/the-guardian/client-side-prod/group/69062228/

I found the issue whilst trying to understand how we broke tracking in IE9. I was able to find the issue in Sentry by setting "browser" to "IE 9.0" and "feature" to "common": https://app.getsentry.com/the-guardian/client-side-prod/?status=&feature=common&browser=IE+9.0. It's the third most frequent error for that filter search. (Although, beware that Sentry defines frequency as an aggregate, not per filter search.)

There is no stack trace so I can't be sure this is the cause of our IE9 tracking problems, but there's a good chance because it is an error happening inside of `bootstraps/common.js`.

The bug was introduced by 4d0e1395f40990b3e946813efef4f675966645e9, in PR #9485.

The reason for this error is because, [whilst `window.console` is supported in IE8 and 9, it is not defined unless you open the developer tools](http://stackoverflow.com/a/5473193/1082754). FML.

/cc @gklopper @janua
