### PR TITLE
Move font loading above pre-flight JS

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -17,11 +17,11 @@
 @* get the stylesheets downloading ASAP *@
 @fragments.stylesheetLinks(projectName)
 
-@* polyfill, feature detect etc before we try and use the stylesheets *@
-@fragments.javaScriptPreFlight(metaData)
-
 @* try and load fonts before we use the stylesheets *@
 @fragments.fonts()
+
+@* polyfill, feature detect etc before we try and use the stylesheets *@
+@fragments.javaScriptPreFlight(metaData)
 
 @* start trying to use the stylesheets *@
 @fragments.stylesheetLinksEnable(projectName)


### PR DESCRIPTION
gets the fonts into the browser before we start parsing the css and html, reducing the need for another layout.

because they're being unencoded from base-64, it's a bit of a race.
