### PR TITLE
SystemJS baseURL: force relative protocol for old IE

### DIFF
--- a/common/app/templates/systemJsSetup.scala.js
+++ b/common/app/templates/systemJsSetup.scala.js
@@ -3,8 +3,17 @@
 @JavaScript(Static.js.systemJsPolyfills)
 @JavaScript(Static.js.systemJs)
 
+var baseURL = '@{JavaScript(Configuration.assets.path)}';
+
+// Force relative protocol for old IE (ajax requests must be targeted to the
+// same scheme as the hosting page, point 7 at
+// http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx)
+if (navigator.userAgent.match(/MSIE (8|9)\.0/)) {
+    baseURL = baseURL.replace(/^https:/, '');
+}
+
 System.config({
-    baseURL: '@{JavaScript(Configuration.assets.path)}',
+    baseURL: baseURL,
     paths: {
         'ophan/ng': '@{JavaScript(Configuration.javascript.config("ophanJsUrl"))}.js',
         // .js must be added: https://github.com/systemjs/systemjs/issues/528


### PR DESCRIPTION
Ajax requests must be targeted to the same scheme as the hosting page, point 7 at
http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx.
