### PR TITLE
Press all endpoint

### DIFF
--- a/admin/app/controllers/FrontPressController.scala
+++ b/admin/app/controllers/FrontPressController.scala
@@ -1,0 +1,16 @@
+package controllers
+
+import common.{ExecutionContexts, Logging}
+import controllers.admin.AuthActions
+import jobs.RefreshFrontsJob
+import play.api.mvc.Controller
+
+object FrontPressController extends Controller with Logging with AuthLogging with ExecutionContexts {
+  def queueAllFrontsForPress() = AuthActions.AuthActionTest { request =>
+    RefreshFrontsJob.runAll() match {
+      case Some(l) => Ok(s"Pushed ${l.length} fronts to the SQS queue")
+      case None => InternalServerError("Could not push to the SQS queue, is there an SNS topic set? (frontPressSns)")
+    }
+  }
+}
+

--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -18,7 +18,7 @@ object HighFrequency extends FrontType {
 case class CronUpdate(path: String, frontType: FrontType)
 
 object RefreshFrontsJob extends Logging {
-  def getCronUpdates: Option[Seq[CronUpdate]] = {
+  def getAllCronUpdates: Option[Seq[CronUpdate]] = {
     val masterConfigJson: Option[JsValue] = S3FrontsApi.getMasterConfig.map(Json.parse)
     for (json <- masterConfigJson)
       yield
@@ -44,7 +44,7 @@ object RefreshFrontsJob extends Logging {
       log.info("Putting press jobs on Facia Cron (High Frequency)")
 
       for {
-        updates <- getCronUpdates
+        updates <- getAllCronUpdates
         update <- updates.filter(_.frontType == HighFrequency)
       } {
         log.info(s"Pressing $update")
@@ -60,7 +60,7 @@ object RefreshFrontsJob extends Logging {
       log.info("Putting press jobs on Facia Cron (Standard Frequency)")
 
       for {
-        updates <- getCronUpdates
+        updates <- getAllCronUpdates
         update <- updates.filter(_.frontType == StandardFrequency)
       } {
         log.info(s"Pressing $update")
@@ -76,7 +76,7 @@ object RefreshFrontsJob extends Logging {
       log.info("Putting press jobs on Facia Cron (Commercial Frequency)")
 
       for {
-        updates <- getCronUpdates
+        updates <- getAllCronUpdates
         update <- updates.filter(_.frontType == LowFrequency)
       } {
         log.info(s"Pressing $update")

--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -89,12 +89,11 @@ object RefreshFrontsJob extends Logging {
 
   //This is used by a route in admin to push ALL paths to the facia-press SQS queue.
   //The facia-press boxes will start to pick these off one by one, so there is no direct overloading of these boxes
-  def runAll(): Option[List[_]] = {
+  def runAll(): Option[Seq[Unit]] = {
     Configuration.aws.frontPressSns.map(Function.const {
       log.info("Putting press jobs on Facia Cron (MANUAL REQUEST)")
 
-      for {updates <- getAllCronUpdates
-           update <- updates}
+      for {update <- getAllCronUpdates.getOrElse(Nil)}
         yield {
         log.info(s"Pressing $update")
         FrontPressNotification.sendWithoutSubject(update.path)}})

--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -89,19 +89,14 @@ object RefreshFrontsJob extends Logging {
 
   //This is used by a route in admin to push ALL paths to the facia-press SQS queue.
   //The facia-press boxes will start to pick these off one by one, so there is no direct overloading of these boxes
-  def runAll(): Unit = {
-    if (Configuration.aws.frontPressSns.exists(_.nonEmpty)) {
+  def runAll(): Option[List[_]] = {
+    Configuration.aws.frontPressSns.map(Function.const {
       log.info("Putting press jobs on Facia Cron (MANUAL REQUEST)")
 
-      for {
-        updates <- getAllCronUpdates
-        update <- updates
-      } {
+      for {updates <- getAllCronUpdates
+           update <- updates}
+        yield {
         log.info(s"Pressing $update")
-        FrontPressNotification.sendWithoutSubject(update.path)
-      }
-    } else {
-      log.info("Not pressing jobs to Facia cron - is either turned off or no queue is set")
-    }
+        FrontPressNotification.sendWithoutSubject(update.path)}})
   }
 }

--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -86,4 +86,22 @@ object RefreshFrontsJob extends Logging {
       log.info("Not pressing jobs to Facia cron - is either turned off or no queue is set")
     }
   }
+
+  //This is used by a route in admin to push ALL paths to the facia-press SQS queue.
+  //The facia-press boxes will start to pick these off one by one, so there is no direct overloading of these boxes
+  def runAll(): Unit = {
+    if (Configuration.aws.frontPressSns.exists(_.nonEmpty)) {
+      log.info("Putting press jobs on Facia Cron (MANUAL REQUEST)")
+
+      for {
+        updates <- getAllCronUpdates
+        update <- updates
+      } {
+        log.info(s"Pressing $update")
+        FrontPressNotification.sendWithoutSubject(update.path)
+      }
+    } else {
+      log.info("Not pressing jobs to Facia cron - is either turned off or no queue is set")
+    }
+  }
 }

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -23,6 +23,9 @@ GET         /assets/*path                                                       
 GET         /                                                                                       controllers.admin.AdminIndexController.index()
 GET         /admin                                                                                  controllers.admin.AdminIndexController.admin()
 
+#Facia Press
+GET         /press/all                                                                              controllers.FrontPressController.queueAllFrontsForPress()
+
 # API endpoint proxying for https
 GET         /api/proxy/*path                                                                        controllers.admin.Api.proxy(path, callback)
 GET         /api/tag                                                                                controllers.admin.Api.tag(q, callback)


### PR DESCRIPTION
This adds an endpoint to `admin` under `/press/all`.

All this actually does is push all paths onto the `SQS` queue from `admin` for the `facia-press` boxes to pick up to work on.

This already happens every hour for all fronts. (And every 1 minute for network fronts and every 5 minutes for all editorial fronts).

This is a `cherry-pick` from #9762, and we have already used this code.

@rich-nguyen 
