### PR TITLE
Lowercase test name

### DIFF
--- a/common/test/common/MultiVariateTestingTest.scala
+++ b/common/test/common/MultiVariateTestingTest.scala
@@ -16,15 +16,15 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
   }
 
   "a request with a valid test header" should "be assigned to the appropriate test" in {
-    TestCases.Test1.switch.switchOn
+    TestCases.test1.switch.switchOn
     val testRequest = TestRequest("/uk")
       .withHeaders(
         "X-GU-mvt-variant" -> "variant-2"
       )
     MultiVariateTesting.getVariant(testRequest) should be (Some(Variant2))
     TestCases.isParticipatingInATest(testRequest) should be (true)
-    TestCases.getParticipatingTest(testRequest) should be (Some(TestCases.Test1))
-    TestCases.Test1.switch.switchOff
+    TestCases.getParticipatingTest(testRequest) should be (Some(TestCases.test1))
+    TestCases.test1.switch.switchOff
   }
 
   "a request with an invalid test header" should "be ignored" in {
@@ -38,23 +38,23 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
   }
 
   "a test definition" should "have a default switch state to off" in {
-    TestCases.Test0.switch.isSwitchedOff should be (true)
+    TestCases.test0.switch.isSwitchedOff should be (true)
   }
 
   object TestCases extends Tests {
-    object Test0 extends TestDefinition(
+    object test0 extends TestDefinition(
       List(Variant0),
-      "Test0",
+      "test0",
       "an experiment test",
       Switches.never
     )
-    object Test1 extends TestDefinition(
+    object test1 extends TestDefinition(
       List(Variant1, Variant2),
-      "Test1",
+      "test1",
       "an experiment test",
       Switches.never
     )
 
-    val tests = List(Test0, Test1)
+    val tests = List(test0, test1)
   }
 }


### PR DESCRIPTION
stops this error running tests:

```
[info] - should have names consisting only of lowercase letters, numbers and hyphens *** FAILED ***
[info]   'Test0' is not a good switch name, it may only consist of lowercase letters, numbers and hyphens (SwitchesTest.scala:14)
```

cc @rich-nguyen 
