### PR TITLE
Use Facia collection config for showing timestamp

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -223,7 +223,7 @@ object FaciaCard {
       MediaType.fromFaciaContent(faciaContent),
       DisplaySettings.fromTrail(faciaContent),
       faciaContent.isLive,
-      None,
+      if (config.showTimestamps) Option(DateTimestamp) else None,
       faciaContent.shortUrlPath,
       useShortByline = false,
       faciaContent.group


### PR DESCRIPTION
The config already exists in Facia.

In the future we might want to make this more configurable, i.e. choose the timestamp format, but this suits my requirements for now.

/cc @janua
