### PR TITLE
Comments tone image desktop size change

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -275,7 +275,7 @@
         }
 
         @include mq(phablet) {
-            height: gs-span(2.5) + ($gs-gutter*2);
+            height: gs-span(2.5);
         }
 
         @include mq(desktop) {


### PR DESCRIPTION
This is fixing https://github.com/guardian/frontend/issues/9702

After:
![nafurpdp42](https://cloud.githubusercontent.com/assets/2579465/8747762/931bd274-2c8d-11e5-85ff-0b840b18550b.gif)
