### PR TITLE
Expose ab-cookie-refresh switch in client-side

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -989,7 +989,7 @@ object Switches {
     "It this switch is turned on, users cookies will be refreshed. Turn off if the identity API barfs" ,
     safeState = Off,
     sellByDate = never,
-    exposeClientSide = false
+    exposeClientSide = true
   )
 
   val ABHeadlineSwitches = (1 to 10) map { n =>


### PR DESCRIPTION
This change is required to enable ab testing of the feature as currently the switch is not exposed client-side.
