### PR TITLE
Wrap storage/session checks in try catch

### DIFF
--- a/common/app/templates/headerInlineJS/shouldEnhance.scala.js
+++ b/common/app/templates/headerInlineJS/shouldEnhance.scala.js
@@ -4,11 +4,12 @@
 (function (navigator, window) {
     // Enable manual optin to core functionality/optout of enhancement
     var personPrefersCore = function () {
-        if (window.localStorage) {
+        try {
             var preference = window.localStorage.getItem('gu.prefs.force-core') || 'off';
             return /"value":"on"/.test(preference);
+        } catch (e) {
+            return false;
         }
-        return false;
     };
 
     // Guess whether the device is too old, regardless of whether it cuts the mustard

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -69,20 +69,21 @@
 
         @* Limit to "modern browsers" *@
         if (guardian.isModernBrowser) {
+            try {
+                @* sessionStorage is part of the isModernBrowser test *@
+                var session = window.sessionStorage;
 
-            @* sessionStorage is part of the isModernBrowser test *@
-            var session = window.sessionStorage;
+                @*
+                    If this key is still present then the user went to a new page before Omniture ran
+                    and we did not count the page view
+                *@
+                if (session.getItem('gu-bounce-test') === 'true') {
+                    var img = new Image();
+                    img.src = '@{Configuration.debug.beaconUrl}/count/user-navigated-early.gif';
+                }
 
-            @*
-                If this key is still present then the user went to a new page before Omniture ran
-                and we did not count the page view
-            *@
-            if (session.getItem('gu-bounce-test') === 'true') {
-                var img = new Image();
-                img.src = '@{Configuration.debug.beaconUrl}/count/user-navigated-early.gif';
-            }
-
-            session.setItem('gu-bounce-test', 'true');
+                session.setItem('gu-bounce-test', 'true');
+            } catch (e) {};
         }
     </script>
 }


### PR DESCRIPTION
If you disallow your browser to save data locally, `window.localStorage`/`sessionStorage` don't return a falsey value, you just get a permission error. 

this was causing the rest of the JS not to run in the `personPrefersCore` instance.
