### PR TITLE
Fix a11y preferences: do not duplicate AMD modules

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -20,7 +20,7 @@ var bundlesUri = 'bundles';
 var bundleConfigs = [
     ['core + system-script + domready', 'core'],
     ['es6/bootstraps/crosswords - core', 'crosswords'],
-    ['bootstraps/accessibility - core', 'accessibility'],
+    ['bootstraps/accessibility - core - bootstraps/app - bootstraps/facia', 'accessibility'],
     ['bootstraps/app - core', 'app'],
     ['bootstraps/commercial - core', 'commercial'],
     ['bootstraps/sudoku - core - bootstraps/app', 'sudoku'],

--- a/grunt-configs/requirejs.js
+++ b/grunt-configs/requirejs.js
@@ -301,6 +301,7 @@ module.exports = function(grunt, options) {
                 exclude: [
                     'core',
                     'bootstraps/app',
+                    'bootstraps/facia',
                     'text',
                     'inlineSvg'
                 ]


### PR DESCRIPTION
We currently have this error (only in curl world, not SystemJS):

![image](https://cloud.githubusercontent.com/assets/921609/8773621/797f4976-2ecd-11e5-82e1-7ef3c3ff804c.png)

This is because the a11y bundle contained a module (`common/modules/accessibility/main`) that was already registered inside `bootstraps/facia`.

/cc @piuccio 
