### PR TITLE
Infinite autocomplete

### DIFF
--- a/facia-tool/public/.eslintrc
+++ b/facia-tool/public/.eslintrc
@@ -26,7 +26,8 @@
         "templateStrings": true,
         "unicodeCodePointEscapes": true,
         "globalReturn": true,
-        "jsx": true
+        "jsx": true,
+        "restParams": true
     },
     "rules": {
         "no-shadow": 0,

--- a/facia-tool/public/css/style.css
+++ b/facia-tool/public/css/style.css
@@ -1372,6 +1372,11 @@ button {
     padding: 0 10px;
 }
 
+.suggestions--more {
+    text-align: center;
+    line-height: 200%;
+}
+
 .search-submit {
     position: absolute;
     right: 0;

--- a/facia-tool/public/js/constants/defaults.js
+++ b/facia-tool/public/js/constants/defaults.js
@@ -53,8 +53,9 @@ export default {
     latestArticlesPollMs:  30000,
     configSettingsPollMs:  30000,
     cacheExpiryMs:         60000,
-    sparksRefreshMs:       300000,
+    sparksRefreshMs:      300000,
     pubTimeRefreshMs:      30000,
+    searchDebounceMs:        300,
 
     highFrequencyPaths:    ['uk', 'us', 'au', 'uk/sport', 'us/sport', 'au/sport'],
 

--- a/facia-tool/public/js/models/collections/latest-articles.js
+++ b/facia-tool/public/js/models/collections/latest-articles.js
@@ -1,64 +1,46 @@
-define([
-    'jquery',
-    'underscore',
-    'modules/vars',
-    'utils/array',
-    'utils/internal-page-code',
-    'utils/parse-query-params',
-    'utils/url-abs-path',
-    'models/collections/article',
-    'modules/auto-complete',
-    'modules/cache',
-    'modules/content-api',
-    'knockout'
-], function (
-    $,
-    _,
-    vars,
-    array,
-    internalPageCode,
-    parseQueryParams,
-    urlAbsPath,
-    Article,
-    autoComplete,
-    cache,
-    contentApi,
-    ko
-) {
-    parseQueryParams = parseQueryParams.default;
-    internalPageCode = internalPageCode.default;
-    urlAbsPath = urlAbsPath.default;
+import ko from 'knockout';
+import _ from 'underscore';
+import * as vars from 'modules/vars';
+import {combine} from 'utils/array';
+import internalPageCode from 'utils/internal-page-code';
+import parseQueryParams from 'utils/parse-query-params';
+import urlAbsPath from 'utils/url-abs-path';
+import Article from 'models/collections/article';
+import * as cache from 'modules/cache';
+import * as capi from 'modules/content-api';
+import debounce from 'utils/debounce';
+import AutoComplete from 'widgets/autocomplete';
+import BaseClass from 'modules/class';
 
-    return function(options) {
+var pollerSym = Symbol();
+var debounceSym = Symbol();
+var fetchSym = Symbol();
 
-        var self = this,
-            loadCallback = options.callback || function () {},
-            deBounced,
-            poller,
-            opts = options || {},
-            counter = 0,
-            scrollable = options.container.querySelector('.scrollable'),
-            pageSize = vars.CONST.searchPageSize || 25,
+class Latest extends BaseClass {
+    constructor(options) {
+        super();
+        var opts = this.opts = options || {};
+
+        var pageSize = vars.CONST.searchPageSize || 25,
             showingDrafts = opts.showingDrafts;
 
         this.articles = ko.observableArray();
         this.message = ko.observable();
 
         this.term = ko.observable(parseQueryParams().q || '');
-        this.term.subscribe(function() { self.search(); });
-        this.isTermAnItem = function() { return (self.term() || '').match(/\//); };
+        this.term.subscribe(() => this.search());
+        this.autocompleteValue = ko.observable({
+            query: '',
+            param: 'section'
+        });
+        this.autocompleteValue.subscribe(() => this.search());
 
-        this.filter     = ko.observable();
-        this.filterType = ko.observable();
-        this.filterTypes = ko.observableArray(_.values(opts.filterTypes) || []);
-
-        this.suggestions = ko.observableArray();
-        this.lastSearch = ko.observable();
+        this.lastSearch = ko.observable({});
 
         this.page = ko.observable(1);
         this.totalPages = ko.observable(1);
 
-        this.title = ko.computed(function () {
+        this.title = ko.computed(() => {
             var lastSearch = this.lastSearch(),
                 title = 'latest';
             if (lastSearch && lastSearch.filter) {
@@ -67,157 +49,32 @@ define([
             return title;
         }, this);
 
-        this.setFilter = function(item) {
-            self.filter(item && item.id ? item.id : item);
-            self.suggestions.removeAll();
-            self.filterChange();
-            self.search();
-        };
-
-        this.clearFilter = function() {
-            self.filter('');
-            self.suggestions.removeAll();
-        };
-
-        this.clearTerm = function() {
-            self.term('');
-        };
-
-        this.autoComplete = function() {
-            autoComplete({
-                query:    self.filter(),
-                path:    (self.filterType() || {}).path
-            })
-            .progress(self.suggestions)
-            .then(self.suggestions);
-        };
-
-        this.filterChange = function () {
-            if (!this.filter()) {
-                var lastSearch = this.lastSearch();
-                if (lastSearch && lastSearch.filter) {
-                    // The filter has been cleared
-                    this.search();
-                }
+        this[debounceSym] = debounce((opts = {}) => {
+            if (!opts.noFlushFirst) {
+                this.flush('searching...');
             }
-        };
 
-        function fetch (opts) {
-            var count = counter += 1;
+            var request = {
+                isDraft: showingDrafts(),
+                page: this.page(),
+                pageSize: pageSize,
+                filter: this.autocompleteValue().query,
+                filterType: this.autocompleteValue().param,
+                isPoll: opts.isPoll
+            };
 
-            opts = opts || {};
+            var term = this.term();
+            // If term contains slashes, assume it's an article id (and first convert it to a path)
+            if (this.isTermAnItem()) {
+                term = urlAbsPath(term);
+                this.term(term);
+                request.article = term;
+            } else {
+                request.term = term;
+            }
 
-            clearTimeout(deBounced);
-            deBounced = setTimeout(function() {
-                if (self.suggestions().length) {
-                    // The auto complete is open, if we ask the API most likely we won't get any result
-                    // which will lead to displaying the alert
-                    return;
-                }
-                if (!opts.noFlushFirst) {
-                    self.flush('searching...');
-                }
-
-                var request = {
-                    isDraft: showingDrafts(),
-                    page: self.page(),
-                    pageSize: pageSize,
-                    filter: self.filter(),
-                    filterType: self.filterType().param,
-                    isPoll: opts.isPoll
-                };
-
-                var term = self.term();
-                // If term contains slashes, assume it's an article id (and first convert it to a path)
-                if (self.isTermAnItem()) {
-                    term = urlAbsPath(term);
-                    self.term(term);
-                    request.article = term;
-                } else {
-                    request.term = term;
-                }
-
-                contentApi.fetchLatest(request)
-                .then(
-                    function (response) {
-                        if (count !== counter) { return; }
-                        var rawArticles = response.results,
-                            newArticles,
-                            initialScroll = scrollable.scrollTop;
-
-                        self.lastSearch(request);
-                        self.totalPages(response.pages);
-                        self.page(response.currentPage);
-
-                        if (rawArticles.length) {
-                            newArticles = array.combine(rawArticles, self.articles(), function (one, two) {
-                                var oneId = one instanceof Article ? one.id() : internalPageCode(one);
-                                var twoId = two instanceof Article ? two.id() : internalPageCode(two);
-                                return oneId === twoId;
-                            }, function (opts) {
-                                var icc = internalPageCode(opts);
-
-                                opts.id = icc;
-                                cache.put('contentApi', icc, opts);
-
-                                opts.uneditable = true;
-                                return new Article(opts, true);
-                            }, function (oldArticle, newArticle) {
-                                oldArticle.props.webPublicationDate(newArticle.webPublicationDate);
-                                return oldArticle;
-                            });
-                            self.articles(newArticles);
-                            self.message(null);
-                        } else {
-                            self.flush('...sorry, no articles were found.');
-                        }
-
-                        scrollable.scrollTop = initialScroll;
-                        loadCallback();
-                    },
-                    function (error) {
-                        var errMsg = error.message;
-                        vars.model.alert(errMsg);
-                        self.flush(errMsg);
-                        loadCallback();
-                    }
-                );
-            }, 300);
-        }
-
-        // Grab articles from Content Api
-        this.search = function(opts) {
-            self.page(1);
-            fetch(opts);
-
-            return true; // ensure default click happens on all the bindings
-        };
-
-        this.flush = function(message) {
-            self.articles.removeAll();
-            self.message(message);
-        };
-
-        this.refresh = function() {
-            self.page(1);
-            fetch();
-        };
-
-        this.reset = function() {
-            self.page(1);
-            this.clearTerm();
-            this.clearFilter();
-        };
-
-        this.pageNext = function() {
-            self.page(self.page() + 1);
-            fetch();
-        };
-
-        this.pagePrev = function() {
-            self.page(_.max([1, self.page() - 1]));
-            fetch();
-        };
+            return capi.fetchLatest(request);
+        }, vars.CONST.searchDebounceMs);
 
         this.showNext = ko.pureComputed(function () {
             return this.totalPages() > this.page();
@@ -230,24 +87,135 @@ define([
         this.showTop = ko.pureComputed(function () {
             return this.page() > 2;
         }, this);
+    }
 
-        this.startPoller = function() {
-            poller = setInterval(function(){
-                if (self.page() === 1) {
-                    self.search({
-                        noFlushFirst: true,
-                        isPoll: true
-                    });
-                }
-            }, vars.CONST.latestArticlesPollMs || 60000);
+    [fetchSym](request) {
+        var loadCallback = this.opts.callback || function () {};
 
-            this.startPoller = function() {}; // make idempotent
-        };
+        this[debounceSym](request)
+        .then(({
+            results,
+            pages,
+            currentPage
+        }) => {
+            var scrollable = this.opts.container.querySelector('.scrollable'),
+                initialScroll = scrollable.scrollTop;
 
-        this.dispose = function () {
-            clearTimeout(deBounced);
-            clearInterval(poller);
-        };
+            this.lastSearch(request);
+            this.totalPages(pages);
+            this.page(currentPage);
 
-    };
-});
+            if (results.length) {
+                let newArticles = combine(results, this.articles(), compareArticles, createNewArticle, reuseOldArticle);
+                this.articles(newArticles);
+                this.message(null);
+            } else {
+                this.flush('...sorry, no articles were found.');
+            }
+
+            scrollable.scrollTop = initialScroll;
+            loadCallback();
+            this.emit('search:update');
+        })
+        .catch((error = {
+            message: 'Invalid CAPI result. Please try again'
+        }) => {
+            var errMsg = error.message;
+            vars.model.alert(errMsg);
+            this.flush(errMsg);
+            loadCallback();
+            this.emit('search:update');
+        });
+    }
+
+    isTermAnItem() {
+        return (this.term() || '').match(/\//);
+    }
+
+    registerChild(child) {
+        if (child instanceof AutoComplete) {
+            this.listenOn(child, 'change', value => {
+                this.autocompleteValue(value);
+            });
+        }
+    }
+
+    clearTerm() {
+        this.term('');
+    }
+
+    startPoller() {
+        this[pollerSym] = setInterval(() => {
+            if (this.page() === 1) {
+                this.search({
+                    noFlushFirst: true,
+                    isPoll: true
+                });
+            }
+        }, vars.CONST.latestArticlesPollMs || 60000);
+
+        this.startPoller = function() {}; // make idempotent
+    }
+
+    search(opts) {
+        this.page(1);
+        this[fetchSym](opts);
+
+        return true; // ensure default click happens on all the bindings
+    }
+
+    flush(message) {
+        this.articles.removeAll();
+        this.message(message);
+    }
+
+    refresh() {
+        this.page(1);
+        this[fetchSym]();
+    }
+
+    reset() {
+        this.page(1);
+        this.clearTerm();
+        this.emit('clear');
+    }
+
+    pageNext() {
+        this.page(this.page() + 1);
+        this[fetchSym]();
+    }
+
+    pagePrev() {
+        this.page(_.max([1, this.page() - 1]));
+        this[fetchSym]();
+    }
+
+    dispose() {
+        super.dispose();
+        this[debounceSym].dispose();
+        clearInterval(this[pollerSym]);
+    }
+}
+
+function compareArticles (one, two) {
+    var oneId = one instanceof Article ? one.id() : internalPageCode(one);
+    var twoId = two instanceof Article ? two.id() : internalPageCode(two);
+    return oneId === twoId;
+}
+
+function createNewArticle (opts) {
+    var icc = internalPageCode(opts);
+
+    opts.id = icc;
+    cache.put('contentApi', icc, opts);
+
+    opts.uneditable = true;
+    return new Article(opts, true);
+}
+
+function reuseOldArticle (oldArticle, newArticle) {
+    oldArticle.props.webPublicationDate(newArticle.webPublicationDate);
+    return oldArticle;
+}
+
+export default Latest;

--- a/facia-tool/public/js/models/common-handlers.js
+++ b/facia-tool/public/js/models/common-handlers.js
@@ -1,39 +1,34 @@
-define([
-    'knockout',
-    'jquery'
-], function (
-    ko,
-    $
-) {
-    ko.bindingHandlers.toggleClick = {
-        init: function (element, valueAccessor) {
-            var value = valueAccessor();
+import ko from 'knockout';
+import $ from 'jquery';
 
-            ko.utils.registerEventHandler(element, 'click', function () {
-                value(!value());
-            });
-        }
-    };
+ko.bindingHandlers.toggleClick = {
+    init: function (element, valueAccessor) {
+        var value = valueAccessor();
 
-    ko.bindingHandlers.slideVisible = {
-        init: function (element, valueAccessor) {
-            var value = valueAccessor();
-            $(element).toggle(ko.unwrap(value));
-        },
-        update: function (element, valueAccessor) {
-            var value = ko.unwrap(valueAccessor());
-            if (value) { $(element).slideDown(200); } else { $(element).slideUp(200); }
-        }
-    };
+        ko.utils.registerEventHandler(element, 'click', function () {
+            value(!value());
+        });
+    }
+};
 
-    ko.bindingHandlers.fadeVisible = {
-        init: function(element, valueAccessor) {
-            var value = valueAccessor();
-            $(element).toggle(ko.unwrap(value)); // Use "unwrapObservable" so we can handle values that may or may not be observable
-        },
-        update: function(element, valueAccessor) {
-            var value = valueAccessor();
-            if (ko.unwrap(value)) { $(element).fadeIn(); } else { $(element).fadeOut(); }
-        }
-    };
-});
+ko.bindingHandlers.slideVisible = {
+    init: function (element, valueAccessor) {
+        var value = valueAccessor();
+        $(element).toggle(ko.unwrap(value));
+    },
+    update: function (element, valueAccessor) {
+        var value = ko.unwrap(valueAccessor());
+        if (value) { $(element).slideDown(200); } else { $(element).slideUp(200); }
+    }
+};
+
+ko.bindingHandlers.fadeVisible = {
+    init: function(element, valueAccessor) {
+        var value = valueAccessor();
+        $(element).toggle(ko.unwrap(value)); // Use "unwrapObservable" so we can handle values that may or may not be observable
+    },
+    update: function(element, valueAccessor) {
+        var value = valueAccessor();
+        if (ko.unwrap(value)) { $(element).fadeIn(); } else { $(element).fadeOut(); }
+    }
+};

--- a/facia-tool/public/js/models/widgets.js
+++ b/facia-tool/public/js/models/widgets.js
@@ -78,6 +78,10 @@ var register = _.once(() => {
         },
         template: { text: 'widgets/select_snap_type.html' }
     });
+    ko.components.register('autocomplete', {
+        viewModel: { jspm: 'widgets/autocomplete' },
+        template: { text: 'widgets/autocomplete.html' }
+    });
     ko.bindingHandlers.ownerClass = {
         init: function (element, valueAccessor) {
             var owner = valueAccessor();

--- a/facia-tool/public/js/modules/auto-complete.js
+++ b/facia-tool/public/js/modules/auto-complete.js
@@ -1,65 +1,45 @@
-define([
-    'jquery',
-    'modules/vars',
-    'modules/authed-ajax',
-    'modules/cache'
-],
-function (
-    $,
-    vars,
-    authedAjax,
-    cache
-){
-    var maxItems = 50,
-        counter = 0;
+import Promise from 'Promise';
+import {request} from 'modules/authed-ajax';
+import * as cache from 'modules/cache';
+import {CONST} from 'modules/vars';
 
-    return function (opts) {
-        var defer = $.Deferred(),
-            q = opts.query || '',
-            path = opts.path || 'tags',
-            url  = '/' + path + '?q=' + q,
-            count = counter += 1,
-            results;
+var maxItems = 50;
 
-        if(!q.match(/[a-z0-9]+/i)) {
-            defer.resolve([]);
+export default function ({
+    query = '',
+    path = 'tags',
+    page = 1
+} = {}) {
+    return new Promise((resolve, reject) => {
+        if (!query) {
+            return resolve();
+        } else if (!query.match(/[a-z0-9]+/i)) {
+            return reject(new Error('Invalid search term'));
         }
 
-        results = cache.get('contentApi', url);
+        var url  = '/' + path + '?' + [
+            'q=' + query,
+            'page-size=' + maxItems,
+            'page=' + page
+        ].join('&'),
+            cached = cache.get('contentApi', url);
 
-        if(results) {
-            defer.resolve(results);
+        if (cached) {
+            resolve(cached);
         } else {
-            defer.notify([{_alert : 'searching for ' + path + '...'}]);
-
-            authedAjax.request({
-                url: vars.CONST.apiSearchBase + url + '&page-size=' + maxItems
-            }).then(
-                function(resp) {
-                    var results = resp.response && resp.response.results ? resp.response.results : false;
-
-                    if (!results) {
-                        defer.resolve();
-                        return;
-                    }
-
-                    cache.put('contentApi', url, results);
-
-                    if (count !== counter) {
-                        defer.resolve();
-                        return;
-                    }
-
-                    if (results.length === 0) {
-                        defer.resolve([{_alert : '...sorry, no ' + path + ' found.'}]);
-                        return;
-                    }
-
-                    defer.resolve(results);
+            request({
+                url: CONST.apiSearchBase + url
+            })
+            .then(({ response } = {}) => {
+                if (!response || !response.results) {
+                    reject(new Error('No results from CAPI'));
+                } else {
+                    cache.put('contentApi', url, response);
+                    resolve(response);
                 }
-            );
+            }, () => {
+                reject(new Error('Error getting results from CAPI'));
+            });
         }
-
-        return defer;
-    };
-});
+    });
+}

--- a/facia-tool/public/js/modules/class.js
+++ b/facia-tool/public/js/modules/class.js
@@ -1,0 +1,36 @@
+import EventEmitter from 'EventEmitter';
+
+var listeners = Symbol();
+var subscriptions = Symbol();
+
+export default class BaseClass extends EventEmitter {
+    constructor() {
+        super();
+        this[listeners] = [];
+        this[subscriptions] = [];
+    }
+
+    subscribeOn(observable, callback) {
+        this[subscriptions].push(observable.subscribe(callback.bind(this)));
+    }
+
+    listenOn(emitter, event, callback) {
+        this[listeners].push({ emitter, event, callback });
+        emitter.on(event, callback);
+    }
+
+    dispose() {
+        if (this[subscriptions]) {
+            this[subscriptions].forEach(subscriber => {
+                subscriber.dispose();
+            });
+            delete this[subscriptions];
+        }
+        if (this[listeners]) {
+            this[listeners].forEach(({ emitter, event, callback }) => {
+                emitter.off(event, callback);
+            });
+            delete this[listeners];
+        }
+    }
+}

--- a/facia-tool/public/js/modules/vars.js
+++ b/facia-tool/public/js/modules/vars.js
@@ -1,5 +1,6 @@
 import CONST from 'constants/defaults';
 import _ from 'underscore';
+import mediator from 'utils/mediator';
 
 export const priority = (function (pathname) {
     let priority = pathname.match(/^\/?([^\/]+)/);
@@ -26,8 +27,9 @@ export let state = {
 export function update (res) {
     currentRes = res;
     state.config = res.config;
-    if (model) {
+    if (model && !_.isEqual(res.switches, model.switches())) {
         model.switches(res.switches);
+        mediator.emit('switches:change', res.switches);
     }
 }
 

--- a/facia-tool/public/js/utils/debounce.js
+++ b/facia-tool/public/js/utils/debounce.js
@@ -1,0 +1,33 @@
+import Promise from 'Promise';
+
+export default function (fn, time) {
+    var bouncedTimeoutID,
+        fnID = 0,
+        bounced;
+
+    bounced = function (...args) {
+        return new Promise((resolve, reject) => {
+            clearTimeout(bouncedTimeoutID);
+            let id = ++fnID;
+            bouncedTimeoutID = setTimeout(() => {
+                Promise.resolve(fn(...args))
+                    .then(result => {
+                        if (id === fnID) {
+                            resolve(result);
+                        }
+                    })
+                    .catch(err => {
+                        if (id === fnID) {
+                            reject(err);
+                        }
+                    });
+            }, time);
+        });
+    };
+
+    bounced.dispose = function () {
+        clearTimeout(bouncedTimeoutID);
+    };
+
+    return bounced;
+}

--- a/facia-tool/public/js/utils/fetch-visible-stories.js
+++ b/facia-tool/public/js/utils/fetch-visible-stories.js
@@ -1,6 +1,7 @@
 import Promise from 'Promise';
 import _ from 'underscore';
 import {request} from 'modules/authed-ajax';
+import mediator from 'utils/mediator';
 
 export default function(type, groups) {
     var stories = [];
@@ -23,6 +24,10 @@ export default function(type, groups) {
                 stories: stories
             }),
             dataType: 'json'
+        })
+        .then(result => {
+            setTimeout(() => mediator.emit('visible:stories:fetch', result), 10);
+            return result;
         })
         .catch(function (error) {
             throw new Error(error.statusText);

--- a/facia-tool/public/js/widgets/autocomplete.html
+++ b/facia-tool/public/js/widgets/autocomplete.html
@@ -1,0 +1,31 @@
+<div class="autocompleter dropdown" data-bind="css: {
+    'dropdown-open': open
+}">
+    <select class="search--filterType" data-bind="
+        event: { change: clear },
+        options: filterTypes,
+        optionsText: 'display',
+        value: filterType"></select>
+
+    <input type="text" class="search--filter" placeholder="filter" data-bind='
+        attr: { placeholder: placeholder},
+        textInput: filter'/>
+
+    <ul class="suggestions">
+        <!-- ko if: alertMessage -->
+        <li>
+            <span data-bind="text: alertMessage"></span>
+        </li>
+        <!-- /ko -->
+        <!-- ko foreach: suggestions -->
+            <li data-bind="click: $parent.select.bind($parent)">
+                <a data-bind="text: id"></a>
+            </li>
+        <!-- /ko -->
+        <!-- ko if: hasMoreSuggestions -->
+            <li class="suggestions--more" data-bind="click: nextPage">
+                <a>&hellip;more</a>
+            </li>
+        <!-- /ko -->
+    </ul>
+</div>

--- a/facia-tool/public/js/widgets/autocomplete.js
+++ b/facia-tool/public/js/widgets/autocomplete.js
@@ -1,0 +1,124 @@
+import ko from 'knockout';
+import _ from 'underscore';
+import BaseWidget from 'widgets/base-widget';
+import autocomplete from 'modules/auto-complete';
+import debounce from 'utils/debounce';
+import {CONST} from 'modules/vars';
+
+var typeBounceSym = Symbol();
+var setFilter = Symbol();
+var preventUpdate = Symbol();
+
+class AutoComplete extends BaseWidget {
+    constructor(opts) {
+        super();
+
+        this.suggestions = ko.observableArray();
+        this.filterType = ko.observable();
+        this.filterTypes = ko.observableArray(_.values(CONST.filterTypes) || []);
+        this.alertMessage = ko.observable(false);
+        this.filter = ko.observable('');
+        this.subscribeOn(this.filter, () => {
+            if (!this[preventUpdate]) {
+                this.type();
+            }
+        });
+        this[setFilter] = (suggestion) => {
+            // Prevent types update
+            this[preventUpdate] = true;
+            this.filter(suggestion && suggestion.id ? suggestion.id : suggestion);
+            this[preventUpdate] = false;
+        };
+        this.placeholder = ko.pureComputed(() => {
+            return (this.filterType() || {}).placeholder;
+        });
+        this.open = ko.pureComputed(() => {
+            return this.alertMessage() || this.suggestions().length;
+        });
+        this.paginationInProgress = ko.observable(false);
+        this.currentPage = ko.observable(1);
+        this.totalPages = ko.observable(1);
+        this.hasMoreSuggestions = ko.pureComputed(() => {
+            return this.suggestions().length > 0 && (this.currentPage() < this.totalPages());
+        });
+
+        this[typeBounceSym] = debounce(() => {
+            return autocomplete(this.state());
+        }, CONST.searchDebounceMs);
+
+        if (opts.parent && opts.parent.registerChild) {
+            opts.parent.registerChild(this);
+            this.listenOn(opts.parent, 'clear', () => {
+                this.clear();
+                this.emit('change', this.state());
+            });
+        }
+    }
+
+    select(suggestion) {
+        this[setFilter](suggestion);
+        this.suggestions.removeAll();
+        this.emit('change', this.state());
+    }
+
+    state() {
+        return {
+            query: this.filter(),
+            path: this.getPath(),
+            param: (this.filterType() || {}).param
+        };
+    }
+
+    getPath() {
+        return (this.filterType() || {}).path;
+    }
+
+    clear() {
+        this.suggestions.removeAll();
+        this.alertMessage(false);
+        this[setFilter]('');
+    }
+
+    type() {
+        this.alertMessage('searching for ' + this.filter() + '...');
+        this[typeBounceSym]().then(res => {
+            this.alertMessage(false);
+            if (res && res.results && res.results.length) {
+                this.currentPage(res.currentPage || 1);
+                this.totalPages(res.pages || 1);
+                this.suggestions(res.results);
+            } else {
+                this.alertMessage('...sorry, no ' + this.getPath() + ' found.');
+            }
+        })
+        .catch(ex => {
+            this.alertMessage(ex.message);
+        })
+        .then(() => this.emit('update'));
+    }
+
+    nextPage() {
+        var state = this.state();
+        state.page = this.currentPage() + 1;
+        this.paginationInProgress(true);
+
+        autocomplete(state).then(res => {
+            if (res && res.results && res.results.length) {
+                this.currentPage(res.currentPage || 1);
+                this.totalPages(res.pages || 1);
+                this.suggestions(this.suggestions().concat(res.results));
+            } else {
+                this.alertMessage('...sorry, no ' + this.getPath() + ' found.');
+            }
+        })
+        .catch(ex => {
+            this.alertMessage(ex.message);
+        })
+        .then(() => {
+            this.paginationInProgress(false);
+            this.emit('update');
+        });
+    }
+}
+
+export default AutoComplete;

--- a/facia-tool/public/js/widgets/base-widget.js
+++ b/facia-tool/public/js/widgets/base-widget.js
@@ -1,22 +1,13 @@
-var allListenersMap = new Map();
+import Promise from 'Promise';
+import mediator from 'utils/mediator';
+import BaseClass from 'modules/class';
 
-class BaseWidget {
-    subscribeOn(observable, callback) {
-        var listeners = allListenersMap.get(this);
-        if (!listeners) {
-            listeners = [];
-        }
-        listeners.push(observable.subscribe(callback.bind(this)));
-        allListenersMap.set(this, listeners);
-    }
-
-    dispose() {
-        var listeners = allListenersMap.get(this);
-        if (listeners && listeners.length) {
-            listeners.forEach(function (subscriber) {
-                subscriber.dispose();
-            });
-        }
+class BaseWidget extends BaseClass {
+    constructor() {
+        super();
+        Promise.resolve().then(() => {
+            mediator.emit('widget:load', this);
+        });
     }
 }
 

--- a/facia-tool/public/js/widgets/latest.html
+++ b/facia-tool/public/js/widgets/latest.html
@@ -27,38 +27,13 @@
 
         <div class="search-form">
             <div class="search-term">
-                <input type="text" placeholder="Search for..." data-bind='
+                <input type="text" class="search--term" placeholder="Search for..." data-bind='
                     event: {keyup: search, afterpaste: search},
                     value: term,
                     valueUpdate: ["afterkeydown", "afterpaste"]'/>
             </div>
 
-            <div class="autocompleter dropdown" data-bind="css: {
-                'dropdown-open': !!suggestions().length
-            }">
-                <select data-bind="
-                    event: { change: clearFilter },
-                    options: filterTypes,
-                    optionsText: 'display',
-                    value: filterType"></select>
-
-                <input type="text" placeholder="filter" data-bind='
-                    attr: {placeholder: filterType().placeholder},
-                    event: {keyup: autoComplete, afterpaste: autoComplete, change: filterChange},
-                    value: filter,
-                    valueUpdate: ["afterkeydown", "afterpaste"]'/>
-
-                <ul class="suggestions" data-bind="foreach: suggestions">
-                    <li>
-                        <!-- ko if: $data._alert -->
-                        <span data-bind="text: _alert"></span>
-                        <!-- /ko -->
-                        <!-- ko if: $data.id -->
-                        <a data-bind="text: id, click: $parent.setFilter"></a>
-                        <!-- /ko -->
-                    </li>
-                </ul>
-            </div>
+            <autocomplete params="parent: $data"></autocomplete>
         </div>
 
         <search-controls params="context: $context"></search-controls>

--- a/facia-tool/public/js/widgets/latest.js
+++ b/facia-tool/public/js/widgets/latest.js
@@ -1,36 +1,18 @@
-define([
-    'knockout',
-    'underscore',
-    'models/collections/latest-articles',
-    'modules/vars',
-    'utils/mediator',
-    'utils/update-scrollables'
-], function (
-    ko,
-    _,
-    LatestArticles,
-    vars,
-    mediator,
-    updateScrollables
-) {
-    mediator = mediator.default;
+import ko from 'knockout';
+import _ from 'underscore';
+import BaseWidget from 'widgets/base-widget';
+import LatestArticles from 'models/collections/latest-articles';
+import mediator from 'utils/mediator';
+import updateScrollables from 'utils/update-scrollables';
 
-    function Latest (params, element) {
-        var self = this;
+class Latest extends BaseWidget {
+    constructor(params, element) {
+        super();
         this.column = params.column;
 
         this.showingDrafts = ko.observable(false);
-        this.showDrafts = function() {
-            self.showingDrafts(true);
-            self.latestArticles.search();
-        };
-        this.showLive = function() {
-            self.showingDrafts(false);
-            self.latestArticles.search();
-        };
 
         this.latestArticles = new LatestArticles({
-            filterTypes: vars.CONST.filterTypes,
             container: element,
             showingDrafts: this.showingDrafts,
             callback: _.once(function () {
@@ -41,18 +23,28 @@ define([
         this.latestArticles.search();
         this.latestArticles.startPoller();
 
-        this.subscriptionOnVars = vars.model.switches.subscribe(function (switches) {
-            if (!switches['facia-tool-draft-content']) {
-                self.showingDrafts(false);
+        this.listenOn(mediator, 'switches:change', switches => {
+            if (this.showingDrafts() && !switches['facia-tool-draft-content']) {
+                this.showLive();
             }
         });
-        this.subscriptionOnArticles = this.latestArticles.articles.subscribe(updateScrollables);
+        this.subscribeOn(this.latestArticles.articles, updateScrollables);
     }
 
-    Latest.prototype.dispose = function () {
-        this.subscriptionOnArticles.dispose();
-        this.subscriptionOnVars.dispose();
-    };
+    showDrafts() {
+        this.showingDrafts(true);
+        this.latestArticles.search();
+    }
 
-    return Latest;
-});
+    showLive() {
+        this.showingDrafts(false);
+        this.latestArticles.search();
+    }
+
+    dispose() {
+        super.dispose();
+        this.latestArticles.dispose();
+    }
+}
+
+export default Latest;

--- a/facia-tool/public/js/widgets/search_controls.html
+++ b/facia-tool/public/js/widgets/search_controls.html
@@ -1,11 +1,15 @@
 <div class="finder__controls">
     Page <span data-bind="text: page"></span>
     <!-- ko if: showNext() -->
-        <a data-bind="click: pageNext">next</a>
+        <a class="pagination--next" data-bind="click: pageNext">next</a>
     <!-- /ko -->
     <!-- ko ifnot: showNext() -->
         <span>last</span>
     <!-- /ko -->
-    <a data-bind="click: pagePrev, visible: showPrev()">prev</a>
-    <a data-bind="click: refresh,  visible: showTop()">top</a>
+    <!-- ko if: showPrev() -->
+        <a class="pagination--prev" data-bind="click: pagePrev">prev</a>
+    <!-- /ko -->
+    <!-- ko if: showTop() -->
+        <a class="pagination--top" data-bind="click: refresh">top</a>
+    <!-- /ko -->
 </div>

--- a/facia-tool/test/.eslintrc
+++ b/facia-tool/test/.eslintrc
@@ -25,7 +25,8 @@
         "templateStrings": true,
         "unicodeCodePointEscapes": true,
         "globalReturn": true,
-        "jsx": true
+        "jsx": true,
+        "restParams": true
     },
     "rules": {
         // Overrides old

--- a/facia-tool/test/public/spec/autocomplete.spec.js
+++ b/facia-tool/test/public/spec/autocomplete.spec.js
@@ -1,0 +1,277 @@
+import $ from 'jquery';
+import autocomplete from 'modules/auto-complete';
+import * as mockjax from 'test/utils/mockjax';
+import * as cache from 'modules/cache';
+import {CONST} from 'modules/vars';
+import inject from 'test/utils/inject';
+import * as wait from 'test/utils/wait';
+
+describe('Autocomplete', function () {
+    beforeEach(function () {
+        this.originalsearchDebounceMs = CONST.searchDebounceMs;
+        CONST.searchDebounceMs = 50;
+        this.scope = mockjax.scope();
+    });
+    afterEach(function () {
+        CONST.searchDebounceMs = this.originalsearchDebounceMs;
+        this.scope.clear();
+    });
+
+    describe('API', function () {
+        it('ignores empty strings', function (done) {
+            autocomplete({}).then(res => {
+                expect(res).toBeUndefined();
+                done();
+            }, done.fail);
+        });
+
+        it('rejects invalid characters', function (done) {
+            autocomplete({
+                query: '!@£$%^&*('
+            }).then(done.fail, done);
+        });
+
+        it('rejects malformed response', function (done) {
+            this.scope({
+                url: CONST.apiSearchBase + '/fruit?q=banana*',
+                responseText: {
+                    nothing: 'here'
+                }
+            });
+
+            autocomplete({
+                query: 'banana',
+                path: 'fruit'
+            }).then(done.fail, done);
+        });
+
+        it('handles missing results', function (done) {
+            this.scope({
+                url: CONST.apiSearchBase + '/fruit?q=apple*',
+                responseText: {
+                    response: { results: [] }
+                }
+            });
+
+            autocomplete({
+                query: 'apple',
+                path: 'fruit'
+            }).then(res => {
+                expect(cache.get('contentApi', '/fruit?q=apple&page-size=50&page=1')).toEqual({
+                    results: []
+                });
+                expect(res).toEqual({
+                    results: []
+                });
+                done();
+            })
+            .catch(done.fail);
+        });
+
+        it('returns expected results', function (done) {
+            this.scope({
+                url: CONST.apiSearchBase + '/fruit?q=kiwi*',
+                responseText: {
+                    response: { results: ['one', 'two', 'three'] }
+                }
+            });
+
+            autocomplete({
+                query: 'kiwi',
+                path: 'fruit'
+            }).then(res => {
+                expect(cache.get('contentApi', '/fruit?q=kiwi&page-size=50&page=1')).toEqual({
+                    results: ['one', 'two', 'three']
+                });
+                expect(res).toEqual({
+                    results: ['one', 'two', 'three']
+                });
+                done();
+            })
+            .catch(done.fail);
+        });
+
+        it('uses the cache', function (done) {
+            var counter = 0;
+            this.scope({
+                url: CONST.apiSearchBase + '/fruit?q=mango*',
+                responseText: {
+                    response: { results: ['a'] }
+                },
+                onAfterComplete: function () {
+                    counter += 1;
+                }
+            });
+
+            autocomplete({
+                query: 'mango',
+                path: 'fruit'
+            }).then(res => {
+                expect(cache.get('contentApi', '/fruit?q=mango&page-size=50&page=1')).toEqual({
+                    results: ['a']
+                });
+                expect(res).toEqual({
+                    results: ['a']
+                });
+                expect(counter).toBe(1);
+
+                autocomplete({
+                    query: 'mango',
+                    path: 'fruit'
+                }).then(fromCache => {
+                    expect(cache.get('contentApi', '/fruit?q=mango&page-size=50&page=1')).toEqual({
+                        results: ['a']
+                    });
+                    expect(fromCache).toEqual({
+                        results: ['a']
+                    });
+                    expect(counter).toBe(1);
+                    done();
+                });
+            })
+            .catch(done.fail);
+        });
+    });
+
+    describe('Widget', function () {
+        beforeEach(function () {
+            this.ko = inject(`
+                <autocomplete></autocomplete>
+            `);
+        });
+        afterEach(function () {
+            this.ko.dispose();
+        });
+
+        it('searches debouncing', function (done) {
+            var counter = 0, widget;
+            this.scope({
+                url: CONST.apiSearchBase + '/sections?q=*',
+                response: function () {
+                    counter += 1;
+                    this.responseText = {
+                        response: {
+                            results: [{ id: 'one' }, {id: 'two' }]
+                        }
+                    };
+                }
+            });
+            this.ko.apply({}, true)
+            .then((autocompleteWidget) => {
+                widget = autocompleteWidget;
+                $('.search--filter').val('n').change();
+            })
+            .then(() => {
+                $('.search--filter').val('ne').change();
+            })
+            .then(() => {
+                $('.search--filter').val('new').change();
+            })
+            .then(() => {
+                $('.search--filter').val('news').change();
+            })
+            .then(() => wait.event('update', widget))
+            .then(() => {
+                expect(counter).toBe(1);
+
+                setTimeout(() => $('ul.suggestions li:nth(0)').click(), 10);
+            })
+            .then(() => wait.event('change', widget))
+            .then(evtArgument => {
+                expect(evtArgument).toEqual({
+                    query: 'one',
+                    path: 'sections',
+                    param: 'section'
+                });
+                expect(counter).toBe(1);
+                expect($('.search--filter').val()).toBe('one');
+            })
+            .then(() => {
+                // can't change type, just check the clear works
+                $('.search--filterType').val('missing').change();
+            })
+            .then(() => {
+                expect($('.search--filter').val()).toBe('');
+            })
+            .then(done)
+            .catch(done.fail);
+        });
+
+        it('scrolls indefinitely', function (done) {
+            var widget, counter = 0;
+            this.scope({
+                url: CONST.apiSearchBase + '/sections?q=*',
+                response: function (req) {
+                    counter += 1;
+                    if (req.url.indexOf('page=1') !== -1) {
+                        this.responseText = {
+                            response: {
+                                results: [{ id: 'one' }, {id: 'two' }],
+                                total: 5,
+                                pages: 3,
+                                currentPage: 1
+                            }
+                        };
+                    } else if (req.url.indexOf('page=2') !== -1) {
+                        this.responseText = {
+                            response: {
+                                results: [{ id: 'three' }, {id: 'four' }],
+                                total: 5,
+                                pages: 3,
+                                currentPage: 2
+                            }
+                        };
+                    } else if (req.url.indexOf('page=3') !== -1) {
+                        this.responseText = {
+                            response: {
+                                results: [{ id: 'five' }],
+                                total: 5,
+                                pages: 3,
+                                currentPage: 3
+                            }
+                        };
+                    } else {
+                        this.responseText = {};
+                    }
+                }
+            });
+            this.ko.apply({}, true)
+            .then((autocompleteWidget) => {
+                widget = autocompleteWidget;
+                $('.search--filter').val('any').change();
+            })
+            .then(() => wait.event('update', widget))
+            .then(() => {
+                // Two suggestions and the more button
+                expect($('.suggestions li').length).toBe(3);
+
+                setTimeout(() => $('.suggestions li:nth(2)').click(), 10);
+            })
+            .then(() => wait.event('update', widget))
+            .then(() => {
+                expect($('.suggestions li').length).toBe(5);
+
+                setTimeout(() => $('.suggestions li:nth(4)').click(), 10);
+            })
+            .then(() => wait.event('update', widget))
+            .then(() => {
+                // More button is replaced by last result
+                expect($('.suggestions li').length).toBe(5);
+
+                setTimeout(() => $('.suggestions li:nth(4)').click(), 10);
+            })
+            .then(() => wait.event('change', widget))
+            .then(evtArgument => {
+                expect(evtArgument).toEqual({
+                    query: 'five',
+                    path: 'sections',
+                    param: 'section'
+                });
+                expect(counter).toBe(3);
+                expect($('.search--filter').val()).toBe('five');
+            })
+            .then(done)
+            .catch(done.fail);
+        });
+    });
+});

--- a/facia-tool/test/public/spec/base.widget.spec.js
+++ b/facia-tool/test/public/spec/base.widget.spec.js
@@ -3,6 +3,7 @@ import ko from 'knockout';
 
 class Widget extends BaseWidget {
     constructor() {
+        super();
         this.one = ko.observable('one');
         this.two = ko.observable('two');
     }

--- a/facia-tool/test/public/spec/config.spec.js
+++ b/facia-tool/test/public/spec/config.spec.js
@@ -1,16 +1,28 @@
 import $ from 'jquery';
-import sandbox from 'test/utils/async-test';
 import drag from 'test/utils/drag';
 import configAction from 'test/utils/config-actions';
 import * as dom from 'test/utils/dom-nodes';
+import ConfigLoader from 'test/utils/config-loader';
+import ko from 'knockout';
+import listManager from 'modules/list-manager';
+import mediator from 'utils/mediator';
 
 describe('Config', function () {
-    var test = sandbox('config');
+    beforeEach(function () {
+        this.testInstance = new ConfigLoader();
+    });
+    afterEach(function () {
+        this.testInstance.dispose();
+        ko.cleanNode(window.document.body);
+        mediator.removeAllListeners();
+        listManager.reset();
+    });
 
-    test('/config/fronts', function (done) {
-        var mockConfig = test.context().mockConfig;
+    it('/config/fronts', function (done) {
+        var mockConfig = this.testInstance.mockConfig;
 
-        createFrontWithCollection()
+        this.testInstance.load()
+        .then(createFrontWithCollection)
         .then(function (request) {
             var data = request.data;
             expect(data.id).toEqual('test/front');

--- a/facia-tool/test/public/spec/debounce.spec.js
+++ b/facia-tool/test/public/spec/debounce.spec.js
@@ -1,0 +1,196 @@
+import debounce from 'utils/debounce';
+import tick from 'test/utils/tick';
+
+describe('Debounce', function () {
+    beforeEach(function () {
+        jasmine.clock().install();
+    });
+    afterEach(function () {
+        jasmine.clock().uninstall();
+    });
+
+    it('waits and calls the last bounced method', function (done) {
+        var countPromises = 0,
+            countCalls = 0,
+            inProgress = false,
+            bounced = debounce(() => {
+                return new Promise(resolve => {
+                    countCalls += 1;
+                    setTimeout(function () {
+                        inProgress = true;
+                        resolve('value');
+                    }, 1000);
+                });
+            }, 200),
+            fn = () => {
+                bounced().then(res => {
+                    inProgress = false;
+                    countPromises += 1;
+                    expect(res).toBe('value');
+                });
+            };
+
+        fn();
+        expect(countPromises).toBe(0);
+        expect(countCalls).toBe(0);
+        expect(inProgress).toBe(false);
+        fn();
+        expect(countPromises).toBe(0);
+        expect(countCalls).toBe(0);
+        expect(inProgress).toBe(false);
+
+        tick(100).then(() => {
+            expect(countPromises).toBe(0);
+            expect(countCalls).toBe(0);
+            expect(inProgress).toBe(false);
+            fn();
+
+            return tick(120);
+        }).then(() => {
+            // the other callbacks are debounced
+            expect(countPromises).toBe(0);
+            expect(countCalls).toBe(0);
+            expect(inProgress).toBe(false);
+
+            // enough time for the callback to be called
+            return tick(200);
+        }).then(() => {
+            expect(countPromises).toBe(0);
+            expect(countCalls).toBe(1);
+            expect(inProgress).toBe(false);
+
+            // the subsequent calls should abort the previous
+            fn();
+            fn();
+            return tick(1000);
+        }).then(() => {
+            expect(countPromises).toBe(0);
+            expect(countCalls).toBe(2);
+            expect(inProgress).toBe(true);
+
+            // give time to the last bounced request to complete
+            return tick(200);
+        }).then(() => {
+            expect(countPromises).toBe(1);
+            expect(countCalls).toBe(2);
+            expect(inProgress).toBe(false);
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+
+    it('debounces on rejected failures', function (done) {
+        var counter = 0, inProgress = false,
+            bounced = debounce(() => {
+                return new Promise((resolve, reject) => {
+                    setTimeout(function () {
+                        inProgress = true;
+                        reject('value');
+                    }, 1000);
+                });
+            }, 200),
+            fn = () => {
+                bounced().then(done.fail, res => {
+                    inProgress = false;
+                    counter += 1;
+                    expect(res).toBe('value');
+                });
+            };
+
+        fn();
+        expect(counter).toBe(0);
+        expect(inProgress).toBe(false);
+        fn();
+        expect(counter).toBe(0);
+        expect(inProgress).toBe(false);
+
+        tick(100).then(() => {
+            expect(counter).toBe(0);
+            expect(inProgress).toBe(false);
+            fn();
+
+            return tick(120);
+        }).then(() => {
+            // the other callbacks are debounced
+            expect(counter).toBe(0);
+            expect(inProgress).toBe(false);
+
+            // enough time for the callback to be called
+            return tick(200);
+        }).then(() => {
+            expect(counter).toBe(0);
+            expect(inProgress).toBe(false);
+
+            // the subsequent calls should abort the previous
+            fn();
+            fn();
+            return tick(1000);
+        }).then(() => {
+            expect(counter).toBe(0);
+            expect(inProgress).toBe(true);
+
+            // give time to the last bounced request to complete
+            return tick(200);
+        }).then(() => {
+            expect(counter).toBe(1);
+            expect(inProgress).toBe(false);
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+
+    it('handles parameters', function (done) {
+        var called = false,
+            bounced = debounce((input, string) => {
+                return new Promise(resolve => {
+                    setTimeout(function () {
+                        resolve({
+                            num: input + 1,
+                            string
+                        });
+                    }, 1000);
+                });
+            }, 200);
+
+        bounced(1).then(done.fail);
+        bounced(2).then(done.fail);
+        bounced(3, 'long').then((res) => {
+            expect(res).toEqual({
+                num: 4,
+                string: 'long'
+            });
+            called = true;
+        });
+
+        tick(200).then(() => tick(1000))
+        .then(() => {
+            expect(called).toBe(true);
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+
+    it('dispose debounce', function (done) {
+        var called = false,
+            bounced = debounce(() => {
+                called = true;
+                return new Promise(resolve => {
+                    setTimeout(function () {
+                        resolve();
+                    }, 1000);
+                });
+            }, 200);
+
+        bounced().then(done.fail);
+        bounced().then(done.fail);
+        bounced().then(done.fail);
+        jasmine.clock().tick(100);
+        bounced.dispose();
+
+        tick(200).then(() => {
+            expect(called).toBe(false);
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+});

--- a/facia-tool/test/public/spec/latest.articles.spec.js
+++ b/facia-tool/test/public/spec/latest.articles.spec.js
@@ -1,0 +1,290 @@
+import inject from 'test/utils/inject';
+import ko from 'knockout';
+import $ from 'jquery';
+import * as capi from 'modules/content-api';
+import * as wait from 'test/utils/wait';
+import {CONST} from 'modules/vars';
+import * as mockjax from 'test/utils/mockjax';
+import mediator from 'utils/mediator';
+
+describe('Latest widget', function () {
+    beforeEach(function () {
+        this.originalsearchDebounceMs = CONST.searchDebounceMs;
+        this.originallatestArticlesDebounce = CONST.latestArticlesDebounce;
+        this.originallatestArticlesPollMs = CONST.latestArticlesPollMs;
+        this.ko = inject(`
+            <latest-widget params="position: 0, column: $data"></latest-widget>
+            <script type="text/html" id="template_article">
+            </script>
+        `);
+        this.scope = mockjax.scope();
+        CONST.latestArticlesDebounce = 30;
+        CONST.latestArticlesPollMs = 1000 * 60 * 60;
+    });
+    afterEach(function () {
+        CONST.searchDebounceMs = this.originalsearchDebounceMs;
+        CONST.latestArticlesDebounce = this.originallatestArticlesDebounce;
+        CONST.latestArticlesPollMs = this.originallatestArticlesPollMs;
+        this.scope.clear();
+        this.ko.dispose();
+    });
+    function getLatest (host) {
+        return ko.contextFor(host.container.querySelector('latest-widget').firstChild)
+            .$component.latestArticles;
+    }
+    function getAutocomplete (host) {
+        return ko.contextFor(host.container.querySelector('autocomplete').firstChild)
+            .$component;
+    }
+
+    it('toggles draft and live content', function (done) {
+        var latest;
+        spyOn(capi, 'fetchLatest').and.callFake(function () {
+            return Promise.resolve({
+                results: [],
+                currentPage: 1
+            });
+        });
+        // short time for polling
+        CONST.latestArticlesPollMs = 6 * CONST.searchDebounceMs;
+
+        this.ko.apply({
+            switches: ko.observable({
+                'facia-tool-draft-content': true
+            })
+        })
+        .then(() => wait.event('latest:loaded'))
+        .then(() => {
+            latest = getLatest(this.ko);
+        })
+        .then(() => {
+            expect(capi.fetchLatest.calls.count()).toBe(1);
+            expect(capi.fetchLatest.calls.argsFor(0)[0].isDraft).toBe(false);
+            expect($('a.live-mode').hasClass('active')).toBe(true);
+            expect($('a.draft-mode').hasClass('active')).toBe(false);
+
+            return $('.draft-mode').click();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.count()).toBe(2);
+            expect(capi.fetchLatest.calls.argsFor(1)[0].isDraft).toBe(true);
+            expect($('a.live-mode').hasClass('active')).toBe(false);
+            expect($('a.draft-mode').hasClass('active')).toBe(true);
+
+            // Polling
+            return wait.ms(CONST.latestArticlesPollMs + CONST.searchDebounceMs);
+        })
+        .then(() => {
+            expect(capi.fetchLatest.calls.count()).toBe(3);
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+
+    it('searches articles', function (done) {
+        var latest, autocomplete;
+        spyOn(capi, 'fetchLatest').and.callFake(function () {
+            return Promise.resolve({
+                results: [],
+                currentPage: 1
+            });
+        });
+
+        this.scope({
+            url: /api\/proxy\/section/,
+            responseText: {
+                response: {
+                    results: [{ id: 'section-one' }, { id: 'section-two' }]
+                }
+            },
+            onAfterComplete: () => {
+                mediator.emit('mock:search:complete');
+            }
+        });
+
+        this.ko.apply({
+            switches: ko.observable({
+                'facia-tool-draft-content': false
+            })
+        }, true)
+        .then(() => wait.event('latest:loaded'))
+        .then(() => {
+            latest = getLatest(this.ko);
+            autocomplete = getAutocomplete(this.ko);
+        })
+        .then(() => {
+            expect(capi.fetchLatest).toHaveBeenCalled();
+            expect(capi.fetchLatest.calls.argsFor(0)[0].term).toBe('');
+            expect(capi.fetchLatest.calls.argsFor(0)[0].filter).toBe('');
+            expect(capi.fetchLatest.calls.argsFor(0)[0].filterType).toBe('section');
+
+            $('.search--term').val('banana').change();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.count()).toBe(2);
+            expect(capi.fetchLatest.calls.argsFor(1)[0].term).toBe('banana');
+            expect(capi.fetchLatest.calls.argsFor(1)[0].filter).toBe('');
+            expect(capi.fetchLatest.calls.argsFor(1)[0].filterType).toBe('section');
+
+            return $('.search--filter').val('fruit').change().trigger('keyup');
+        })
+        .then(() => wait.event('update', autocomplete))
+        .then(() => {
+            expect($('.suggestions li').length).toBe(2);
+            $('.suggestions a:nth(0)').click();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.count()).toBe(3);
+            expect(capi.fetchLatest.calls.argsFor(2)[0].term).toBe('banana');
+            expect(capi.fetchLatest.calls.argsFor(2)[0].filter).toBe('section-one');
+            expect(capi.fetchLatest.calls.argsFor(2)[0].filterType).toBe('section');
+
+            // Repeat the same search
+            $('.search-tools .fa-refresh').click();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.count()).toBe(4);
+            expect(capi.fetchLatest.calls.argsFor(3)[0].term).toBe('banana');
+            expect(capi.fetchLatest.calls.argsFor(3)[0].filter).toBe('section-one');
+            expect(capi.fetchLatest.calls.argsFor(3)[0].filterType).toBe('section');
+
+            // Reset
+            $('.search-tools .fa-remove').click();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.count()).toBe(5);
+            expect(capi.fetchLatest.calls.argsFor(4)[0].term).toBe('');
+            expect(capi.fetchLatest.calls.argsFor(4)[0].filter).toBe('');
+            expect(capi.fetchLatest.calls.argsFor(4)[0].filterType).toBe('section');
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+
+    it('pagination', function (done) {
+        var latest;
+        spyOn(capi, 'fetchLatest').and.callFake(function (opts) {
+            return Promise.resolve({
+                results: [{
+                    webUrl: '/banana/' + opts.page,
+                    fields: { headline: 'Banana on page ' + opts.page }
+                }],
+                currentPage: opts.page,
+                pages: 3
+            });
+        });
+        function paginationText () {
+            return $('.finder__controls:nth(0)').text().trim().replace(/\s+/g, ' ').toLowerCase();
+        }
+
+        this.ko.apply({
+            switches: ko.observable({
+                'facia-tool-draft-content': false
+            })
+        })
+        .then(() => wait.event('latest:loaded'))
+        .then(() => {
+            latest = getLatest(this.ko);
+        })
+        .then(() => {
+            expect(paginationText()).toBe('page 1 next');
+
+            $('.pagination--next:nth(0)').click();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.argsFor(1)[0].page).toBe(2);
+            expect(paginationText()).toBe('page 2 next prev');
+
+            $('.pagination--next:nth(0)').click();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.argsFor(2)[0].page).toBe(3);
+            expect(paginationText()).toBe('page 3 last prev top');
+
+            $('.pagination--prev:nth(0)').click();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.argsFor(3)[0].page).toBe(2);
+            expect(paginationText()).toBe('page 2 next prev');
+
+            $('.pagination--next:nth(0)').click();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.argsFor(4)[0].page).toBe(3);
+            expect(paginationText()).toBe('page 3 last prev top');
+
+            $('.pagination--top:nth(0)').click();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.argsFor(5)[0].page).toBe(1);
+            expect(paginationText()).toBe('page 1 next');
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+
+    it('reacts to switches changes', function (done) {
+        var latest, switches = ko.observable({
+            'facia-tool-draft-content': true
+        });
+        spyOn(capi, 'fetchLatest').and.callFake(function () {
+            return Promise.resolve({
+                results: [],
+                currentPage: 1
+            });
+        });
+
+        this.ko.apply({ switches })
+        .then(() => wait.event('latest:loaded'))
+        .then(() => {
+            latest = getLatest(this.ko);
+        })
+        .then(() => {
+            expect($('a.live-mode').hasClass('active')).toBe(true);
+            expect($('a.draft-mode').hasClass('active')).toBe(false);
+
+            return $('.draft-mode').click();
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.count()).toBe(2);
+            expect(capi.fetchLatest.calls.argsFor(1)[0].isDraft).toBe(true);
+            expect($('a.live-mode').hasClass('active')).toBe(false);
+            expect($('a.draft-mode').hasClass('active')).toBe(true);
+
+            switches({
+                'facia-tool-draft-content': false
+            });
+            mediator.emit('switches:change', switches());
+        })
+        .then(() => wait.event('search:update', latest))
+        .then(() => {
+            expect(capi.fetchLatest.calls.count()).toBe(3);
+            expect(capi.fetchLatest.calls.argsFor(2)[0].isDraft).toBe(false);
+            expect($('a.live-mode').hasClass('active')).toBe(true);
+            expect($('a.draft-mode').length).toBe(0);
+
+            switches({
+                'facia-tool-draft-content': true
+            });
+            mediator.emit('switches:change', switches());
+        })
+        .then(() => {
+            expect(capi.fetchLatest.calls.count()).toBe(3);
+            expect($('a.live-mode').hasClass('active')).toBe(true);
+            expect($('a.draft-mode').hasClass('active')).toBe(false);
+        })
+        .then(done)
+        .catch(done.fail);
+    });
+});

--- a/facia-tool/test/public/utils/config-actions.js
+++ b/facia-tool/test/public/utils/config-actions.js
@@ -1,6 +1,6 @@
 import mockjax from 'test/utils/mockjax';
 import Promise from 'Promise';
-import tick from 'test/utils/tick';
+import persistence from 'models/config/persistence';
 
 export default function(mockConfig, action) {
 
@@ -17,8 +17,10 @@ export default function(mockConfig, action) {
             onAfterComplete: function () {
                 clearRequest();
                 // Every such action is also triggering an update of the config
-                tick(100).then(() => tick(100)).then(() => {
-                    resolve(lastRequest);
+                persistence.once('after update', () => {
+                    setTimeout(() => {
+                        resolve(lastRequest);
+                    }, 100);
                 });
             }
         });
@@ -35,8 +37,10 @@ export default function(mockConfig, action) {
             onAfterComplete: function () {
                 clearRequest();
                 // Every such action is also triggering an update of the config
-                tick(100).then(() => tick(100)).then(() => {
-                    resolve(lastRequest);
+                persistence.once('after update', () => {
+                    setTimeout(() => {
+                        resolve(lastRequest);
+                    }, 100);
                 });
             }
         });
@@ -48,8 +52,5 @@ export default function(mockConfig, action) {
 
         desiredAnswer = action();
         mockConfig.update(desiredAnswer);
-
-        // This action triggers a network request, advance time
-        tick(100).then(() => tick(100));
     });
 }

--- a/facia-tool/test/public/utils/edit-actions.js
+++ b/facia-tool/test/public/utils/edit-actions.js
@@ -1,6 +1,5 @@
 import Promise from 'Promise';
 import mockjax from 'test/utils/mockjax';
-import tick from 'test/utils/tick';
 
 export default function(mockCollection, action) {
     return new Promise(function (resolve) {
@@ -14,9 +13,9 @@ export default function(mockCollection, action) {
             },
             onAfterComplete: function () {
                 mockjax.clear(interceptor);
-                tick(100).then(() => tick(100)).then(() => {
+                setTimeout(() => {
                     resolve(lastRequest);
-                });
+                }, 20);
             }
         });
         desiredAnswer = action();
@@ -26,8 +25,5 @@ export default function(mockCollection, action) {
             desiredAnswer[name].lastUpdated = (new Date()).toISOString();
         }
         mockCollection.set(desiredAnswer);
-
-        // This action triggers a network request, advance time
-        tick(100).then(() => tick(100));
     });
 }

--- a/facia-tool/test/public/utils/inject.js
+++ b/facia-tool/test/public/utils/inject.js
@@ -1,0 +1,34 @@
+import ko from 'knockout';
+import Promise from 'Promise';
+import {register} from 'models/widgets';
+import * as wait from 'test/utils/wait';
+
+export default function (html) {
+    register();
+    const DOM_ID = 'test_dom_' + Math.round(Math.random() * 10000);
+
+    document.body.innerHTML += `
+        <div id="${DOM_ID}">
+            ${html}
+        </div>
+    `;
+
+    let container = document.getElementById(DOM_ID);
+    return {
+        container,
+        apply: (model, waitWidget) => {
+            return new Promise(resolve => {
+                if (waitWidget) {
+                    wait.event('widget:load').then(resolve);
+                } else {
+                    setTimeout(resolve, 10);
+                }
+                ko.applyBindings(model, container);
+            });
+        },
+        dispose: () => {
+            ko.cleanNode(container);
+            container.parentNode.removeChild(container);
+        }
+    };
+}

--- a/facia-tool/test/public/utils/mockjax.js
+++ b/facia-tool/test/public/utils/mockjax.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import _ from 'underscore';
 import 'jquery-mockjax';
 
 export default $.mockjax;
@@ -7,15 +6,14 @@ export default $.mockjax;
 export function scope () {
     var ids = [];
 
-    var addMocks = function () {
-        var mocks = [].slice.call(arguments, 0);
-        _.each(mocks, function (mock) {
+    var addMocks = function (...mocks) {
+        mocks.forEach(function (mock) {
             ids.push($.mockjax(mock));
         });
     };
 
     addMocks.clear = function () {
-        _.each(ids, function (id) {
+        ids.forEach(function (id) {
             $.mockjax.clear(id);
         });
     };

--- a/facia-tool/test/public/utils/publish-actions.js
+++ b/facia-tool/test/public/utils/publish-actions.js
@@ -1,6 +1,5 @@
 import Promise from 'Promise';
 import mockjax from 'test/utils/mockjax';
-import tick from 'test/utils/tick';
 
 export default function(action) {
     return new Promise(function (resolve) {
@@ -15,10 +14,11 @@ export default function(action) {
             },
             onAfterComplete: function () {
                 mockjax.clear(publishInterceptor);
-                resolve(publishedCollection);
+                setTimeout(() => {
+                    resolve(publishedCollection);
+                }, 20);
             }
         });
         action();
-        tick(100).then(() => tick(100));
     });
 }

--- a/facia-tool/test/public/utils/wait.js
+++ b/facia-tool/test/public/utils/wait.js
@@ -1,0 +1,14 @@
+import Promise from 'Promise';
+import mediator from 'utils/mediator';
+
+export function event (name, emitter) {
+    return new Promise(resolve => {
+        (emitter || mediator).once(name, resolve);
+    });
+}
+
+export function ms (time) {
+    return new Promise(resolve => {
+        setTimeout(resolve, time);
+    });
+}


### PR DESCRIPTION
When CAPI has more than 50 tags or sections, show a `more` button that allows to paginate and get get the remaining results.

Also converts more files to ES6

![out](https://cloud.githubusercontent.com/assets/680284/8774705/e9e1f5fa-2ed8-11e5-877f-30c488a4046a.gif)

@OliverJAsh this should also fix intermittent timeout tests because I'm not using `jasmine.clock()` anymore.
@stephanfowler you might like this :)
