### PR TITLE
SystemJS svg plugin fixes: correct classes

### DIFF
--- a/static/src/javascripts/es6/projects/common/utils/svg.js
+++ b/static/src/javascripts/es6/projects/common/utils/svg.js
@@ -1,8 +1,10 @@
 import _ from 'lodash';
 
 export function translate(load) {
+    const moduleId = load.metadata.loaderArgument.split('!')[0];
+    const relativeModuleId = moduleId.match(new RegExp('^' + System.baseURL + '(.*).svg$'))[1];
     const prefix = 'inline-',
-          data = _.rest(load.metadata.loaderArgument.split('/')),
+          data = _.rest(relativeModuleId.split('/')),
           fileName = data.pop(),
           typesClasses = _.map(data, function (imageType) {
               return prefix + imageType;


### PR DESCRIPTION
Bug introduced by https://github.com/systemjs/systemjs/releases/tag/0.18.0 ("Plugin modules and arguments run through full normalization pipeline"). This meant that SVG elements had lots of unnecessary classes.
