### PR TITLE
Fix syntax in weather

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -74,7 +74,7 @@ define([
         },
 
         getWeatherData: function (url) {
-            return ajax({
+            return ajaxPromise({
                 url: url,
                 type: 'json',
                 method: 'get',
@@ -102,13 +102,13 @@ define([
                     .then(function (response) {
                         this.fetchWeatherData(response);
                         omniture.trackLinkImmediate(true, 'o', 'weather location set by fastly');
-                    }).catch(function (err) {
+                    }.bind(this)).fail(function (err) {
                         raven.captureException(err, {
                             tags: {
                                 feature: 'weather'
                             }
                         });
-                    }).bind(this);
+                    });
             }
         },
 
@@ -117,13 +117,13 @@ define([
                 .then(function (response) {
                     this.render(response, location.city);
                     this.fetchForecastData(location);
-                }).catch(function (err) {
+                }.bind(this)).fail(function (err) {
                     raven.captureException(err, {
                         tags: {
                             feature: 'weather'
                         }
                     });
-                }).bind(this);
+                });
         },
 
         clearLocation: function () {
@@ -135,13 +135,13 @@ define([
             return this.getWeatherData(config.page.forecastsapiurl + '/' + location.id + '.json?_edition=' + config.page.edition.toLowerCase())
                 .then(function (response) {
                     this.renderForecast(response);
-                }).catch(function (err) {
+                }.bind(this)).fail(function (err) {
                     raven.captureException(err, {
                         tags: {
                             feature: 'weather'
                         }
                     });
-                }).bind(this);
+                });
         },
 
         saveDeleteLocalStorage: function (response) {

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -102,7 +102,7 @@ define([
                     .then(function (response) {
                         this.fetchWeatherData(response);
                         omniture.trackLinkImmediate(true, 'o', 'weather location set by fastly');
-                    }).fail(function (err) {
+                    }).catch(function (err) {
                         raven.captureException(err, {
                             tags: {
                                 feature: 'weather'
@@ -117,7 +117,7 @@ define([
                 .then(function (response) {
                     this.render(response, location.city);
                     this.fetchForecastData(location);
-                }).fail(function (err) {
+                }).catch(function (err) {
                     raven.captureException(err, {
                         tags: {
                             feature: 'weather'
@@ -135,7 +135,7 @@ define([
             return this.getWeatherData(config.page.forecastsapiurl + '/' + location.id + '.json?_edition=' + config.page.edition.toLowerCase())
                 .then(function (response) {
                     this.renderForecast(response);
-                }).fail(function (err) {
+                }).catch(function (err) {
                     raven.captureException(err, {
                         tags: {
                             feature: 'weather'

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -102,13 +102,13 @@ define([
                     .then(function (response) {
                         this.fetchWeatherData(response);
                         omniture.trackLinkImmediate(true, 'o', 'weather location set by fastly');
-                    }.fail(function (err) {
+                    }).fail(function (err) {
                         raven.captureException(err, {
                             tags: {
                                 feature: 'weather'
                             }
                         });
-                    }).bind(this));
+                    }).bind(this);
             }
         },
 
@@ -117,13 +117,13 @@ define([
                 .then(function (response) {
                     this.render(response, location.city);
                     this.fetchForecastData(location);
-                }.fail(function (err) {
+                }).fail(function (err) {
                     raven.captureException(err, {
                         tags: {
                             feature: 'weather'
                         }
                     });
-                }).bind(this));
+                }).bind(this);
         },
 
         clearLocation: function () {
@@ -135,13 +135,13 @@ define([
             return this.getWeatherData(config.page.forecastsapiurl + '/' + location.id + '.json?_edition=' + config.page.edition.toLowerCase())
                 .then(function (response) {
                     this.renderForecast(response);
-                }.fail(function (err) {
+                }).fail(function (err) {
                     raven.captureException(err, {
                         tags: {
                             feature: 'weather'
                         }
                     });
-                }).bind(this));
+                }).bind(this);
         },
 
         saveDeleteLocalStorage: function (response) {

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -18,7 +18,7 @@ define([
     'raven',
     'common/utils/_',
     'common/utils/$',
-    'common/utils/ajax-promise',
+    'common/utils/ajax',
     'common/utils/config',
     'common/utils/detect',
     'common/utils/mediator',
@@ -32,7 +32,7 @@ define([
     raven,
     _,
     $,
-    ajaxPromise,
+    ajax,
     config,
     detect,
     mediator,
@@ -74,7 +74,7 @@ define([
         },
 
         getWeatherData: function (url) {
-            return ajaxPromise({
+            return ajax({
                 url: url,
                 type: 'json',
                 method: 'get',


### PR DESCRIPTION
After fixing some linting, I have realised that switching to `ajax-promise` wasn't going to be a drop in replacement.

I have reverted back to normal `ajax` object in `weather` for the time being.

This means though, that the `raven.captureException(err, ...)` line is actually putting a failed request object to `captureException`.
