### PR TITLE
Anchor links with sticky situation fixed

### DIFF
--- a/static/src/stylesheets/base/_links.scss
+++ b/static/src/stylesheets/base/_links.scss
@@ -13,6 +13,8 @@ a,
         text-decoration: none;
     }
 }
+/* to prevent bugs while anchor jumping with sticky nav
+ based on http://stackoverflow.com/questions/11386807/adding-an-automatic-offset-to-the-scroll-position-for-all-hash-links-calls */
 a[name] {
     padding-top: gs-height(2);
     margin-top: gs-height(-2);

--- a/static/src/stylesheets/base/_links.scss
+++ b/static/src/stylesheets/base/_links.scss
@@ -13,3 +13,9 @@ a,
         text-decoration: none;
     }
 }
+a[name] {
+    padding-top: gs-height(2);
+    margin-top: gs-height(-2);
+    display: inline-block;
+    width: 0px;
+}


### PR DESCRIPTION
Before:
![screen shot 2015-07-20 at 17 26 16](https://cloud.githubusercontent.com/assets/489567/8780957/48240d76-2f04-11e5-98d3-bc7e887a8be1.png)

After:
![screen shot 2015-07-20 at 17 26 26](https://cloud.githubusercontent.com/assets/489567/8780962/4da6d2e2-2f04-11e5-94cb-0823937e80ac.png)

This is the fix for https://github.com/guardian/frontend/issues/9776
