### PR TITLE
fix #9821: fix position of sfl button in articles/interactives

### DIFF
--- a/static/src/stylesheets/module/content/_content.global.scss
+++ b/static/src/stylesheets/module/content/_content.global.scss
@@ -140,11 +140,24 @@
     @include mq(mobileLandscape, leftCol) {
         position: absolute;
         top: 1px;
-        left: ($social-width * 6);
+    }
+
+    @include mq(mobileLandscape, tablet) {
+        left: $social-width * 7;
     }
 
     @include mq(tablet, leftCol) {
-        left: ($social-width * 5);
+        left: $social-width * 6;
+    }
+
+    .content--interactive & {
+        @include mq(leftCol) {
+            $social-width: 35px;
+
+            position: absolute;
+            top: 1px;
+            left: $social-width * 6;
+        }
     }
 
     .content--liveblog & {

--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -42,8 +42,14 @@
         border-bottom: 0;
 
         .meta__number {
+            float: right;
             border-left: 1px solid colour(neutral-5);
             padding-left: $gs-gutter / 2;
+
+            @include mq($until: mobile) {
+                position: relative;
+                top: $gs-baseline;
+            }
         }
 
         .meta__social {


### PR DESCRIPTION
Accommodate extra social buttons and position the share counter to the right on interactives.
