### PR TITLE
Allow self-signed https CAPI client to be used in training preview

### DIFF
--- a/training-preview/app/controllers/TrainingHealthCheck.scala
+++ b/training-preview/app/controllers/TrainingHealthCheck.scala
@@ -15,8 +15,8 @@ class TrainingHttp extends contentapi.Http with ExecutionContexts {
   // https://groups.google.com/forum/#!topic/play-framework/2xxg_n55wD8
   val http = Http.configure { _
     .setAllowPoolingConnections(true)
-    .setMaxConnectionsPerHost(10)
-    .setMaxConnections(10)
+    .setMaxConnectionsPerHost(100)
+    .setMaxConnections(100)
     .setConnectTimeout(1000)
     .setRequestTimeout(2000)
     .setCompressionEnforced(true)

--- a/training-preview/app/controllers/TrainingHealthCheck.scala
+++ b/training-preview/app/controllers/TrainingHealthCheck.scala
@@ -1,9 +1,58 @@
 package controllers
 
-import conf.AllGoodHealthcheckController
+import common.ExecutionContexts
+import conf.{LiveContentApi, AllGoodHealthcheckController}
+import dispatch.{FunctionHandler, Http}
+import scala.concurrent.Future
+import contentapi.Response
+import conf.Configuration.contentApi.previewAuth
+import play.api.mvc.Action
+
+class TrainingHttp extends contentapi.Http with ExecutionContexts {
+
+  // Play 2.4.2 has problems passing the any certificate flag through play.ws.ssl.loose.acceptAnyCertificate
+  // This is a workaround. Forum here (called 'Play 2.4 disable certification check'):
+  // https://groups.google.com/forum/#!topic/play-framework/2xxg_n55wD8
+  val http = Http.configure { _
+    .setAllowPoolingConnections(true)
+    .setMaxConnectionsPerHost(10)
+    .setMaxConnections(10)
+    .setConnectTimeout(1000)
+    .setRequestTimeout(2000)
+    .setCompressionEnforced(true)
+    .setFollowRedirect(true)
+    .setConnectionTTL(60000)
+    .setAcceptAnyCertificate(true)
+  }
+
+  def GET(url: String, headers: Iterable[(String, String)]): Future[Response] = {
+
+    val req = headers.foldLeft(dispatch.url(url)) {
+      case (r, (name, value)) => r.setHeader(name, value)
+    }
+    val authReq = previewAuth.fold(req)(
+      auth =>
+        req.as_!(auth.user, auth.password)
+    )
+    def handler = new FunctionHandler(r => Response(r.getResponseBody("utf-8"), r.getStatusCode, r.getStatusText))
+    http(authReq.toRequest, handler)
+  }
+}
 
 object TrainingHealthCheck extends AllGoodHealthcheckController(
  9016,
  "/world/2012/sep/11/barcelona-march-catalan-independence"
-)
+) {
 
+  lazy val init = {
+    LiveContentApi._http = new TrainingHttp
+    ()=>()
+  }
+
+  override def healthcheck() = if (!isOk) {
+    init()
+    Action(InternalServerError("Training healthcheck has not passed using the current https client"))
+  } else {
+    super.healthcheck()
+  }
+}

--- a/training-preview/app/controllers/TrainingHealthCheck.scala
+++ b/training-preview/app/controllers/TrainingHealthCheck.scala
@@ -49,10 +49,10 @@ object TrainingHealthCheck extends AllGoodHealthcheckController(
     ()=>()
   }
 
-  override def healthcheck() = if (!isOk) {
-    init()
-    Action(InternalServerError("Training healthcheck has not passed using the current https client"))
-  } else {
+  override def healthcheck() = {
+    if (!isOk) {
+      init()
+    }
     super.healthcheck()
   }
 }


### PR DESCRIPTION
Fixes an issue in Play 2.4.2 which means that the WS library cannot be configured to allow any ssl certificate. arguably a good thing, but we use self-signed certs in non-prod environments, and we currently don't have a trust manager set up yet. we should.
