### PR TITLE
Fix Firefox bug where blockquote overlaps text

### DIFF
--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -146,12 +146,6 @@
     color: colour(neutral-2);
 }
 
-.caption--img {
-    @include mq(leftCol) {
-        padding-bottom: $gs-baseline * 2;
-    }
-}
-
 .caption--main {
     padding: ($gs-baseline/3)*2 $gs-gutter/2 $gs-baseline*2;
 


### PR DESCRIPTION
Fixes #9877

This bug was occurring because the float of the figure above was interfering, and Firefox couldn't handle it (for some unknown reason).

I'm not sure why but this padding was introduced by #7333.

Before:
![image](https://cloud.githubusercontent.com/assets/921609/8806425/95b34046-2fce-11e5-8ac9-54bbb153f4af.png)

After:
![image](https://cloud.githubusercontent.com/assets/921609/8806439/9e4da552-2fce-11e5-91bf-ae0eae0b98df.png)

According to #7333, this padding was needed for the tablet scenario, but it seems fine without:
![image](https://cloud.githubusercontent.com/assets/921609/8806460/aff5a494-2fce-11e5-8cb4-f2a61383ac02.png)
