### PR TITLE
Fix Firefox bug where blockquote overlaps text

### DIFF
--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -304,6 +304,8 @@ figure.element--thumbnail + h2 {
     @include mq(tablet) {
         width: gs-span(3);
         float: left;
+        // Prevent previous embeds from interfering
+        clear: left;
         padding-right: $gs-gutter;
         padding-top: $gs-baseline/4;
         margin-bottom: $gs-baseline/2;


### PR DESCRIPTION
Fixes #9877 

Before in Firefox (re. #9877):
![image](https://cloud.githubusercontent.com/assets/921609/8806663/ae4407fc-2fcf-11e5-8c93-a835d0f64975.png)

Before in Chrome (not consistent with other pull quotes):
![image](https://cloud.githubusercontent.com/assets/921609/8806697/cdce80c0-2fcf-11e5-849b-3c26ccf1c9eb.png)

After in both:
![image](https://cloud.githubusercontent.com/assets/921609/8806669/b3da9226-2fcf-11e5-8b6a-362042320999.png)
