### PR TITLE
Update Facia client and FAPI client versions

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ object Dependencies {
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
   val dispatchTest = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3" % Test
   val exactTargetClient = "com.gu" %% "exact-target-client" % "2.24"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.51"
-  val faciaScalaClient = "com.gu" %% "facia-json" % "0.51"
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.52"
+  val faciaScalaClient = "com.gu" %% "facia-json" % "0.52"
   val flexibleContentBlockToText = "com.gu" %% "flexible-content-block-to-text" % "0.4"
   val flexibleContentBodyParser = "com.gu" %% "flexible-content-body-parser" % "0.6"
   val googleSheetsApi = "com.google.gdata" % "core" % "1.47.1"


### PR DESCRIPTION
This includes https://github.com/guardian/facia-scala-client/pull/123.
