### PR TITLE
Omniture: reset events when populating event properties

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -112,7 +112,7 @@ define([
         this.s.linkTrackVars = 'channel,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,' +
                                'prop51,prop61,prop64,prop65,prop74,eVar7,eVar37,eVar38,eVar39,eVar50,events';
         this.s.linkTrackEvents = 'event37';
-        this.s.events = this.s.apl(this.s.events, 'event37', ',');
+        this.s.events = 'event37';
         this.s.eVar37 = (config.page.contentType) ? config.page.contentType + ':' + linkName : linkName;
 
         // this allows 'live' Omniture tracking of Navigation Interactions
@@ -326,10 +326,6 @@ define([
     Omniture.prototype.go = function () {
         this.populatePageProperties();
         this.logView();
-        // Clean up
-        this.s.events = _.filter((this.s.events || '').split(','), function (event) {
-            return event !== 'event46';
-        }).join(',');
         mediator.emit('analytics:ready');
     };
 

--- a/static/src/javascripts/vendor/omniture.js
+++ b/static/src/javascripts/vendor/omniture.js
@@ -75,7 +75,6 @@ function s_doPlugins(s) {
     newDiary=newDiary.join(",");
     dtmNow.setFullYear(dtmNow.getFullYear()+5);
     s.c_w("s_daily_habit",newDiary,dtmNow);
-    if (s.getVisitStart()==1) s.events = s.apl(s.events, 'event89='+vC, ',');
     s.eVar64=vC;
 
     /* Campaign stacking */
@@ -314,14 +313,6 @@ s.apl=new Function("l","v","d","u",""
     +"var s=this,m=0;if(!l)l='';if(u){var i,n,a=s.split(l,d);for(i=0;i<a."
     +"length;i++){n=a[i];m=m||(u==1?(n==v):(n.toLowerCase()==v.toLowerCas"
     +"e()));}}if(!m)l=l?l+d+v:v;return l");
-
-/*
- * Plugin: getVisitStart v2.1 - return 1 on start of visit, else 0
- */
-s.getVisitStart=new Function("c",""
-    +"var s=this,n,t=new Date;if(typeof s.callType=='function'&&s.callTyp"
-    +"e()=='+')return 0;if(!c)c='s_visit';t.setTime(t.getTime()+18e5);n=s"
-    +".c_r(c)?0:1;if(!s.c_w(c,1,t))s.c_w(c,1,0);if(!s.c_r(c))n=0;return n");
 
 /*
  * Utility Function: split v1.5 (JS 1.0 compatible)


### PR DESCRIPTION
Fixes #9901

In https://github.com/guardian/frontend/pull/9568, I had to remove the reset to allow `event89`—added by the vendor Omniture code—to persist. This had the unexpected consequence of incorrectly persisting certain events (https://github.com/guardian/frontend/issues/9901).

We no longer care about `event89`. By removing this I can restore the reset of `events`, thereby fixing https://github.com/guardian/frontend/issues/9901.

This reverts commit 4da4b70e958fa4cf90ff55b33b8092d6b76f50f8, reversing
changes made to 5a6fd7dfb41ff7bd7a99bbfa74f93bdc235500cc.
