### PR TITLE
fix crossword preview images

### DIFF
--- a/common/app/model/FaciaDisplayElement.scala
+++ b/common/app/model/FaciaDisplayElement.scala
@@ -18,7 +18,7 @@ object FaciaDisplayElement {
           InlineImage.fromFaciaContent(faciaContent)
         ))
       case _ if faciaContent.isCrossword && Switches.CrosswordSvgThumbnailsSwitch.isSwitchedOn =>
-        Some(CrosswordSvg(faciaContent.id))
+        faciaContent.maybeContentId map CrosswordSvg
       case _ if faciaContent.imageSlideshowReplace && itemClasses.canShowSlideshow =>
         InlineSlideshow.fromFaciaContent(faciaContent)
       case _ => InlineImage.fromFaciaContent(faciaContent)

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -33,8 +33,8 @@ System.config({
   "map": {
     "EventEmitter": "github:Wolfy87/EventEmitter@4.2.11",
     "Promise": "github:guardian/native-promise-only@0.7.6-e",
-    "babel": "npm:babel-core@5.7.4",
-    "babel-runtime": "npm:babel-runtime@5.7.0",
+    "babel": "npm:babel-core@5.8.3",
+    "babel-runtime": "npm:babel-runtime@5.8.3",
     "bean": "npm:bean@1.0.15",
     "bonzo": "npm:bonzo@1.4.0",
     "classnames": "npm:classnames@1.2.0",
@@ -127,7 +127,7 @@ System.config({
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:babel-runtime@5.7.0": {
+    "npm:babel-runtime@5.8.3": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:bean@1.0.15": {


### PR DESCRIPTION
Previously dreamsnaps were using the snap id rather than the crossword id for the image url. 
