### PR TITLE
Save for later: fix button icon alignment when signed out

### DIFF
--- a/static/src/stylesheets/module/_save-for-later.scss
+++ b/static/src/stylesheets/module/_save-for-later.scss
@@ -41,6 +41,7 @@ $sfl-button-height: 30px;
     padding: 0;
 
     .inline-icon {
+        text-align: center;
         margin: 0;
         margin-right: .5em;
         width: $sfl-button-height;


### PR DESCRIPTION
When signed out:

![image](https://cloud.githubusercontent.com/assets/921609/8849425/74709734-3137-11e5-9cad-1eca526d5a29.png)

This is because, when signed in, we are relying on the user agent stylesheet to provide `button { text-align: center }`, but when signed out, we use an anchor instead of a button.
