### PR TITLE
Remove weather location tracking

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -101,7 +101,6 @@ define([
                 return this.getWeatherData(config.page.weatherapiurl + '.json')
                     .then(function (response) {
                         this.fetchWeatherData(response);
-                        omniture.trackLinkImmediate(true, 'o', 'weather location set by fastly');
                     }.bind(this)).catch(function (err) {
                         raven.captureException(err, {
                             tags: {


### PR DESCRIPTION
This is what is causing `eVar37=Network Front:true` to erroneously be tracked when fronts load, because we are sending invalid arguments to `omniture.trackLinkImmediate`. Obviously no-one is using this data.

/cc @crifmulholland 
