### PR TITLE
Bump sbt-teamcity-logger to 0.2.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,5 +14,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.8")
 
-addSbtPlugin("org.jetbrains" % "sbt-teamcity-logger" % "0.1.0-SNAPSHOT")
+addSbtPlugin("org.jetbrains.teamcity.plugins" % "sbt-teamcity-logger" % "0.2.0")
 


### PR DESCRIPTION
Got the following issue when starting SBT:

`unresolved dependency: org.jetbrains#sbt-teamcity-logger;0.1.0-SNAPSHOT: not found`

@johnduffell advised bumping to 0.2.0 solved the issue for him locally, but I also had to change from `org.jetbrains` to `org.jetbrains.teamcity.plugins`, which seems to be the new namespace (https://bintray.com/jetbrains/sbt-plugins/sbt-teamcity-logger/view#files)
