### PR TITLE
Force Twitter handle to fit inside button

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -731,6 +731,8 @@
     .button {
         padding-top: 1px;
         margin-right: 0;
+        // Force content to fit inside button
+        white-space: nowrap;
 
         .tonal--tone-media & {
             border: 0;


### PR DESCRIPTION
Fixes #9858 

When the user handle is too long, it just clips it:

![image](https://cloud.githubusercontent.com/assets/921609/8873815/7377f14e-3202-11e5-9385-5be179850be7.png)

/cc @paperboyo
