### PR TITLE
Report abuse non cors redux

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/api.js
+++ b/static/src/javascripts/projects/common/modules/discussion/api.js
@@ -70,7 +70,7 @@ define([
      */
     Api.previewComment = function (comment) {
         var endpoint = '/comment/preview';
-        return Api.send(endpoint, 'post', comment);
+        return Api.send(endpoint, 'post', comment, true);
     };
 
     /**

--- a/static/src/javascripts/projects/common/modules/discussion/api.js
+++ b/static/src/javascripts/projects/common/modules/discussion/api.js
@@ -108,7 +108,7 @@ define([
      */
     Api.reportComment = function (id, report) {
         var endpoint = '/comment/' + id + '/reportAbuse';
-        return Api.send(endpoint, 'post', report);
+        return Api.send(endpoint, 'post', report, true);
     };
 
     /**


### PR DESCRIPTION
For reasons unknown the nginx proxy fails recommends as 400 Bad Request. So I have reverted to the old style selective proxying only `/preview` and `/reportAbuse` which we know work through the proxy and users have complained about not working.
CC @guardian/discussion @johnduffell 
