### PR TITLE
initialise crosswords thumbnails in js bootstrap

### DIFF
--- a/common/app/templates/headerInlineJS/bootSystemJS.scala.js
+++ b/common/app/templates/headerInlineJS/bootSystemJS.scala.js
@@ -95,9 +95,6 @@ System['import']('core').then(function () {
                         System['import']('es6/bootstraps/crosswords').then(function (crosswords) {
                             crosswords.default.init();
                         });
-                        System['import']('es6/projects/common/modules/crosswords/thumbnails').then(function (crosswordThumbnails) {
-                            crosswordThumbnails.default.init();
-                        });
                     }
                 });
             });

--- a/static/src/javascripts/es6/bootstraps/crosswords.js
+++ b/static/src/javascripts/es6/bootstraps/crosswords.js
@@ -1,5 +1,9 @@
 import init from 'es6/projects/common/modules/crosswords/main';
+import thumbnails from 'es6/projects/common/modules/crosswords/thumbnails';
 
 export default {
-    init: init
+    init: function () {
+        init();
+        thumbnails.init();
+    }
 };


### PR DESCRIPTION
The crossword thumbnail init function was only being loaded as part of `bootSystemJS.scala.js` rather than imported into the JS bootstrap. This meant it wasn't bundled and wouldn't work for people not using jspm. 

I've moved it into `bootstraps/crosswords.js` so it gets included in the bundle.
