### PR TITLE
Stop using https://discussion-secure.guardianapis.com

### DIFF
--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -28,7 +28,7 @@ id.membership.stripePublicToken=pk_test_Qm3CGRdrV4WfGYCpm0sftR0f
 
 # Discussion
 discussion.apiRoot=http://discussion.guardianapis.com/discussion-api
-discussion.secureApiRoot=https://discussion-secure.guardianapis.com/discussion-api
+discussion.secureApiRoot=https://discussion.guardianapis.com/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.url=http://discussion.code.dev-theguardian.com

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -31,7 +31,7 @@ id.membership.stripePublicToken=pk_live_2O6zPMHXNs2AGea4bAmq5R7Z
 
 # Discussion
 discussion.apiRoot=http://discussion.guardianapis.com/discussion-api
-discussion.secureApiRoot=https://discussion-secure.guardianapis.com/discussion-api
+discussion.secureApiRoot=https://discussion.guardianapis.com/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen
 discussion.url=http://discussion.theguardian.com


### PR DESCRIPTION
It is deprecated, as discussion.guardianapis.com now supports HTTPS.

We haven't yet done the same for non-prod environments.
