### PR TITLE
Adding basic Ophan ad tracking to commercial

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -136,7 +136,7 @@ define([
                             campaignId: lineItemIdOrEmpty(event),
                             creativeId: event.creativeId,
                             timeToRenderEnded: new Date().getTime() - start,
-                            adServer: "DFP"
+                            adServer: 'DFP'
                         }]
                     });
                 });

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -124,7 +124,7 @@ define([
                 require(['ophan/ng'], function (ophan) {
                     var lineItemIdOrEmpty = function (event) {
                         if (event.isEmpty) {
-                            return "__empty__";
+                            return '__empty__';
                         } else {
                             return event.lineItemId;
                         }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -117,7 +117,31 @@ define([
          * Initial commands
          */
         setListeners = function () {
+            var start = detect.getTimeOfDomComplete();
+
+
             googletag.pubads().addEventListener('slotRenderEnded', raven.wrap(function (event) {
+                require(['ophan/ng'], function (ophan) {
+                    var lineItemIdOrEmpty = function (event) {
+                        if (event.isEmpty) {
+                            return "__empty__";
+                        } else {
+                            return event.lineItemId;
+                        }
+                    };
+
+                    ophan.record({
+                        ads: [{
+                            slot: event.slot.getSlotId().getDomId(),
+                            campaignId: lineItemIdOrEmpty(event),
+                            creativeId: event.creativeId,
+                            timeToRenderEnded: new Date().getTime() - start,
+                            adServer: "DFP"
+                        }]
+                    });
+                });
+
+
                 rendered = true;
                 recordFirstAdRendered();
                 mediator.emit('modules:commercial:dfp:rendered', event);

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -109,6 +109,15 @@ define([
         return totalTime;
     }
 
+    function getTimeOfDomComplete(performance) {
+        var perf = performance || window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
+        if (perf && perf.timing) {
+            return perf.timing.domComplete;
+        } else {
+            return new Date().getTime();
+        }
+    }
+
     function isReload() {
         var perf = window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
         if (!!perf && !!perf.navigation) {
@@ -481,6 +490,7 @@ define([
         pageVisible: pageVisible,
         hasWebSocket: hasWebSocket,
         getPageSpeed: getPageSpeed,
+        getTimeOfDomComplete: getTimeOfDomComplete,
         breakpoints: breakpoints,
         fontHinting: fontHinting(),
         isModernBrowser: isModernBrowser,


### PR DESCRIPTION
This used to be done in Ophan’s Tracker JS, but the switch to the new Curl/JSPM dependency loading has broken it. So now I'm moving it in here.
