### PR TITLE
add in the placeholder for first comment

### DIFF
--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -6,6 +6,7 @@
     <ul class="d-thread d-thread--comments">
         @userMessageForLargeDiscussion
 
+        <div class="js-new-comments"></div>
         @page.comments.map { comment =>
             @fragments.comment(comment, page.isClosedForRecommendation, false)
         }


### PR DESCRIPTION
Fixes https://github.com/guardian/frontend/issues/7164
The problem was the placeholder was lost late last year so the comments were just being injected somewhere random in the discussion tree.  I've added it back in so they have a defined place to drop in.
