### PR TITLE
Return canonical container for a front

### DIFF
--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -61,7 +61,7 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
     val config = configAgent.get()
     val canonicalCollectionMap = config.map (_.fronts.mapValues(front => front.canonical.orElse(front.collections.headOption))).getOrElse(Map.empty)
 
-    canonicalCollectionMap(frontId)
+    canonicalCollectionMap.get(frontId).flatten
   }
 
   def getConfigForId(id: String): Option[List[CollectionConfigWithId]] = {

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -57,6 +57,13 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
     }).toSeq
   }
 
+  def getCanonicalIdForFront(frontId: String): Option[String] = {
+    val config = configAgent.get()
+    val canonicalCollectionMap = config.map (_.fronts.mapValues(front => front.canonical.orElse(front.collections.headOption))).getOrElse(Map.empty)
+
+    canonicalCollectionMap(frontId)
+  }
+
   def getConfigForId(id: String): Option[List[CollectionConfigWithId]] = {
     val config = configAgent.get()
     config.flatMap(_.fronts.get(id).map(_.collections))

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -310,6 +310,7 @@ GET         /$path<(lifeandstyle/love-and-sex|lifeandstyle/home-and-garden|world
 GET         /$path<(uk|au|us)(/(culture|sport|commentisfree|business|money|travel|rss))?>                            controllers.FaciaController.renderFrontPress(path)
 GET         /*path/lite.json                                                                                         controllers.FaciaController.renderFrontJsonLite(path)
 GET         /container/*id.json                                                                                      controllers.FaciaController.renderContainerJson(id)
+GET         /most-relevant-container/*frontId.json                                                                   controllers.FaciaController.renderMostRelevantContainerJson(frontId)
 
 
 # Editionalised pages

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -310,7 +310,7 @@ GET         /$path<(lifeandstyle/love-and-sex|lifeandstyle/home-and-garden|world
 GET         /$path<(uk|au|us)(/(culture|sport|commentisfree|business|money|travel|rss))?>                            controllers.FaciaController.renderFrontPress(path)
 GET         /*path/lite.json                                                                                         controllers.FaciaController.renderFrontJsonLite(path)
 GET         /container/*id.json                                                                                      controllers.FaciaController.renderContainerJson(id)
-GET         /most-relevant-container/*frontId.json                                                                   controllers.FaciaController.renderMostRelevantContainerJson(frontId)
+GET         /most-relevant-container/*path.json                                                                      controllers.FaciaController.renderMostRelevantContainerJson(path)
 
 
 # Editionalised pages

--- a/facia-end-to-end/conf/routes
+++ b/facia-end-to-end/conf/routes
@@ -50,6 +50,7 @@ GET         /front/lastmodified/*path                                       cont
 
 #Facia Press
 GET         /container/*id.json                                             controllers.FaciaController.renderContainerJson(id)
+GET         /most-relevant-container/*frontId.json                          controllers.FaciaController.renderMostRelevantContainerJson(frontId)
 GET         /collection/*id/rss                                             controllers.FaciaController.renderCollectionRss(id)
 
 GET         /collection/*id                                                 controllers.FaciaToolController.getCollection(id)

--- a/facia-end-to-end/conf/routes
+++ b/facia-end-to-end/conf/routes
@@ -50,7 +50,7 @@ GET         /front/lastmodified/*path                                       cont
 
 #Facia Press
 GET         /container/*id.json                                             controllers.FaciaController.renderContainerJson(id)
-GET         /most-relevant-container/*frontId.json                          controllers.FaciaController.renderMostRelevantContainerJson(frontId)
+GET         /most-relevant-container/*path.json                             controllers.FaciaController.renderMostRelevantContainerJson(path)
 GET         /collection/*id/rss                                             controllers.FaciaController.renderCollectionRss(id)
 
 GET         /collection/*id                                                 controllers.FaciaToolController.getCollection(id)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -200,16 +200,6 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
       })
     }.getOrElse(Future.successful(None))
 
-//  private def getCanonicalPressedCollection(path: String): Future[Option[PressedCollection]] = {
-//    ConfigAgent.getCanonicalIdForFront(path).map { collectionId =>
-//      getPressedCollection(collectionId)
-//
-//    }.getOrElse(Future.successful(None))
-//  }
-
-
-
-
 
   /* Google news hits this endpoint */
   def renderCollectionRss(id: String) = MemcachedAction { implicit request =>

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -69,7 +69,6 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
   // Needed as aliases for reverse routing
   def renderFrontJson(id: String) = renderFront(id)
   def renderContainerJson(id: String) = renderContainer(id)
-  def renderCanonicalContainerJson(frontId: String) = renderCanonicalContainer(frontId)
 
   def renderFrontRss(path: String) = MemcachedAction { implicit  request =>
     log.info(s"Serving RSS Path: $path")
@@ -129,8 +128,8 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
     renderContainerView(id)
   }
 
-  def renderCanonicalContainer(frontId: String) = MemcachedAction { implicit request =>
-    log.info(s"Serving canonical collection for frontID : $frontId")
+  def renderMostRelevantContainerJson(frontId: String) = MemcachedAction { implicit request =>
+    log.info(s"Serving most relevant container for front id : $frontId")
 
     ConfigAgent.getCanonicalIdForFront(frontId).map { collectionId =>
       renderContainerView(collectionId)

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -22,7 +22,7 @@ GET        /$path<(culture|sport|commentisfree|business|money|rss)>    controlle
 #Facia Press
 GET        /collection/*id/rss                                         controllers.FaciaController.renderCollectionRss(id)
 GET        /container/*id.json                                         controllers.FaciaController.renderContainerJson(id)
-GET        /most-relevant-container/*frontId.json                      controllers.FaciaController.renderMostRelevantContainerJson(frontId)
+GET        /most-relevant-container/*path.json                         controllers.FaciaController.renderMostRelevantContainerJson(path)
 
 # Editionalised pages
 GET        /*path/show-more/*id.json                                   controllers.FaciaController.renderShowMore(path, id)

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -22,6 +22,7 @@ GET        /$path<(culture|sport|commentisfree|business|money|rss)>    controlle
 #Facia Press
 GET        /collection/*id/rss                                         controllers.FaciaController.renderCollectionRss(id)
 GET        /container/*id.json                                         controllers.FaciaController.renderContainerJson(id)
+GET        /canonical-container/*frontId.json                          controllers.FaciaController.renderCanonicalContainerJson(frontId)
 
 # Editionalised pages
 GET        /*path/show-more/*id.json                                   controllers.FaciaController.renderShowMore(path, id)

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -22,7 +22,7 @@ GET        /$path<(culture|sport|commentisfree|business|money|rss)>    controlle
 #Facia Press
 GET        /collection/*id/rss                                         controllers.FaciaController.renderCollectionRss(id)
 GET        /container/*id.json                                         controllers.FaciaController.renderContainerJson(id)
-GET        /canonical-container/*frontId.json                          controllers.FaciaController.renderCanonicalContainerJson(frontId)
+GET        /most-relevant-container/*frontId.json                      controllers.FaciaController.renderMostRelevantContainerJson(frontId)
 
 # Editionalised pages
 GET        /*path/show-more/*id.json                                   controllers.FaciaController.renderShowMore(path, id)

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -153,4 +153,10 @@ import services.ConfigAgent
     val redirectToInternational = FaciaController.editionRedirect("commentisfree")(international)
     header("Location", redirectToInternational).head should endWith ("/uk/commentisfree")
   }
+
+  it should "list the alterative options for a path by section and edition" in {
+    FaciaController.alternativeEndpoints("uk/lifeandstyle") should be (List("lifeandstyle", "uk"))
+    FaciaController.alternativeEndpoints("uk") should be (List("uk"))
+    FaciaController.alternativeEndpoints("uk/business/stock-markets") should be (List("business", "uk"))
+  }
 }


### PR DESCRIPTION
Return the canonical container for a front. The endpoint will sit on `/canonical-container/[front-path].json`

If a front has a canonical collection set this is returned otherwise the top collection is used.

cc @stephanfowler @janua 
