### PR TITLE
Fix collection deduplication

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -129,7 +129,7 @@ object TrailsToRss extends implicits.Collections {
     val faciaContentList: List[FaciaContent] =
       pressedPage.collections
         .filterNot(_.config.excludeFromRss)
-        .flatMap(_.all)
+        .flatMap(_.curatedPlusBackfillDeduplicated)
         .filter{
           case _: LinkSnap => false
           case _ => true}

--- a/common/app/implicits/Collections.scala
+++ b/common/app/implicits/Collections.scala
@@ -35,3 +35,5 @@ trait Collections {
     }
   }
 }
+
+object CollectionsOps extends Collections

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -78,7 +78,7 @@ object CollectionEssentials {
   )
 
   def fromPressedCollection(collection: PressedCollection) = CollectionEssentials(
-    collection.all,
+    collection.curatedPlusBackfillDeduplicated,
     collection.treats,
     Option(collection.displayName),
     collection.href,
@@ -396,11 +396,11 @@ object Front extends implicits.Collections {
     import scalaz.syntax.traverse._
 
     Front(
-      pressedPage.collections.filterNot(_.all.isEmpty).zipWithIndex.mapAccumL(
+      pressedPage.collections.filterNot(_.curatedPlusBackfillDeduplicated.isEmpty).zipWithIndex.mapAccumL(
         (Set.empty[TrailUrl], initialContext)
       ) { case ((seenTrails, context), (pressedCollection, index)) =>
         val container = Container.fromPressedCollection(pressedCollection)
-        val (newSeen, newItems) = deduplicate(seenTrails, container, pressedCollection.all)
+        val (newSeen, newItems) = deduplicate(seenTrails, container, pressedCollection.curatedPlusBackfillDeduplicated)
         val collectionEssentials = CollectionEssentials.fromPressedCollection(pressedCollection)
         val containerDisplayConfig = ContainerDisplayConfig.withDefaults(pressedCollection.collectionConfigWithId)
 

--- a/common/app/model/PressedFront.scala
+++ b/common/app/model/PressedFront.scala
@@ -3,10 +3,12 @@ package model.facia
 
 import com.gu.facia.api.models.{CuratedContent, _}
 import com.gu.facia.api.utils._
+import implicits.CollectionsOps._
 import org.joda.time.DateTime
 import play.api.libs.json._
 import services.CollectionConfigWithId
 import com.gu.contentapi.client.model._
+import implicits.FaciaContentImplicits._
 
 object FapiJsonFormats {
   /* Content API Formats */
@@ -220,7 +222,7 @@ case class PressedCollection(
 
   lazy val collectionConfigWithId = CollectionConfigWithId(id, config)
 
-  lazy val all = curated ++ backfill
+  lazy val all = (curated ++ backfill).distinctBy(c => c.maybeContentId.getOrElse(c.id))
 }
 
 object PressedCollection {

--- a/common/app/model/PressedFront.scala
+++ b/common/app/model/PressedFront.scala
@@ -222,7 +222,7 @@ case class PressedCollection(
 
   lazy val collectionConfigWithId = CollectionConfigWithId(id, config)
 
-  lazy val all = (curated ++ backfill).distinctBy(c => c.maybeContentId.getOrElse(c.id))
+  lazy val curatedPlusBackfillDeduplicated = (curated ++ backfill).distinctBy(c => c.maybeContentId.getOrElse(c.id))
 }
 
 object PressedCollection {

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -27,7 +27,7 @@ case class PressedPage(id: String,
   def allPath: Option[String] = {
     val tagAndSectionIds = for {
       pressedCollection <- collections
-      item <- pressedCollection.all
+      item <- pressedCollection.curatedPlusBackfillDeduplicated
       id <- {item match {
               case curatedContent: CuratedContent =>
                 curatedContent.content.sectionId ++ curatedContent.content.tags.map(_.id)
@@ -98,7 +98,7 @@ case class PressedPage(id: String,
     DfpAgent.omitMPUsFromContainers(id, edition)
   }
 
-  def allItems = collections.flatMap(_.all).distinct
+  def allItems = collections.flatMap(_.curatedPlusBackfillDeduplicated).distinct
 
   override def openGraph: Map[String, String] = super.openGraph ++ Map(
     "og:image" -> Configuration.facebook.imageFallback) ++

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -195,7 +195,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
           Cached(60) {
             val config: CollectionConfig = ConfigAgent.getConfig(id).getOrElse(CollectionConfig.empty)
             val webTitle = config.displayName.getOrElse("The Guardian")
-            Ok(TrailsToRss.fromFaciaContent(webTitle, collection.all, "", None)).as("text/xml; charset=utf8")}}
+            Ok(TrailsToRss.fromFaciaContent(webTitle, collection.curatedPlusBackfillDeduplicated, "", None)).as("text/xml; charset=utf8")}}
 
       case None => Future.successful(Cached(60)(NotFound))}
   }

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -68,7 +68,7 @@ trait FapiFrontJsonLite extends ExecutionContexts{
       "displayName" -> pressedCollection.displayName,
       "href" -> pressedCollection.href,
       "id" -> pressedCollection.id,
-      "content" -> pressedCollection.all.filterNot(isLinkSnap).map(getContent))
+      "content" -> pressedCollection.curatedPlusBackfillDeduplicated.filterNot(isLinkSnap).map(getContent))
 
   private def isLinkSnap(faciaContent: FaciaContent) = faciaContent match {
     case _: LinkSnap => true


### PR DESCRIPTION
#### Problem

When deduplicating fronts, within a collection/container; if an item `A` ended up in `curated` (being curated by an editor) AND also showed up in the backfill, then it would avoid deduplication.

This did not affect cross collection/container deduplication, which is currently working fine.

What was happening was that collections themselves were not being deduplicated between `curated` and `backfill`. They used to deduplicated on the old code before `facia-scala-client` started getting used, so this has been broken since around the start of June.
#### Fix

Start deduplicating items in collections between `curated` and `backfill`.

The change is ONLY the line

```
 lazy val all = (curated ++ backfill).distinctBy(c => c.maybeContentId.getOrElse(c.id))
```

I have taken the opportunity to rename it better, so the diff looks bigger.

@OliverJAsh @stephanfowler 
