### PR TITLE
Updated z-index for content specific

### DIFF
--- a/static/src/stylesheets/base/_zindex.scss
+++ b/static/src/stylesheets/base/_zindex.scss
@@ -3,6 +3,7 @@
  */
 
 $zindex-ads: 1010;     // Ads
+$zindex-content: 1015; // Modals and overlays inside content
 $zindex-sticky: 1020;  // Sticky header
 $zindex-modal: 1030;   // Search modal
 $zindex-popover: 1040; // Breaking news

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -900,7 +900,7 @@ $comment-recommend-button-size: 19px;
     position: absolute;
     top: 0;
     right: 0;
-    z-index: 3;
+    z-index: $zindex-content;
     width: gs-span(4);
     color: colour(neutral-1);
     padding: $gs-baseline / 2 $gs-gutter / 2;


### PR DESCRIPTION
I had to create new layer for content specific modals/popovers.

Before:
![screen shot 2015-07-29 at 12 30 54](https://cloud.githubusercontent.com/assets/2579465/8956814/5f7aa630-35f1-11e5-9b03-6f4fadb24854.png)

After:
![screen shot 2015-07-29 at 12 34 46](https://cloud.githubusercontent.com/assets/2579465/8956817/670c0894-35f1-11e5-9f93-17ac71d542d0.png)
