### PR TITLE
Janky ad scroll fixed

### DIFF
--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -26,6 +26,7 @@
 
         &.creative--scrollable-mpu-image-fixed {
             background-attachment: fixed;
+            /*TODO consider using solution from https://www.youtube.com/watch?v=QU1JAW5LRKU*/
             background-repeat: repeat;
             background-position: 50% 0;
         }
@@ -373,6 +374,7 @@
 
         &.ad-exp--expand-scrolling-bg-fixed {
             background-attachment: fixed;
+            /*TODO consider using solution from https://www.youtube.com/watch?v=QU1JAW5LRKU*/
         }
 
         &.ad-exp--expand-scrolling-bg-parallax {
@@ -493,7 +495,8 @@
         height: 500px;
         width: 100%;
         background-repeat: no-repeat;
-        background-attachment: fixed;
+        /*background-attachment: fixed;*/
+        /*If you need the above style, please use the solution from https://www.youtube.com/watch?v=QU1JAW5LRKU*/
     }
 
     .ad-scrolling-bg-parallax {
@@ -687,15 +690,15 @@
 
 @keyframes textanimation {
     0% {
-        background-position: 0 -250px; 
+        background-position: 0 -250px;
     }
 
     75% {
-        background-position: 0 0; 
+        background-position: 0 0;
     }
 
     100% {
-        background-position: 0 0; 
+        background-position: 0 0;
     }
 }
 


### PR DESCRIPTION
Fixed made based on @OliverJAsh email 'Ad causing very slow scrolling'

Before:
![retire_max_before](https://cloud.githubusercontent.com/assets/489567/8981414/095e8f0e-36b0-11e5-906a-10b50572d4c9.png)

![retire_max_graph_before](https://cloud.githubusercontent.com/assets/489567/8981444/43963f64-36b0-11e5-9676-bdd0503ede45.png)

After:
![retire_max_after](https://cloud.githubusercontent.com/assets/489567/8981452/55a48684-36b0-11e5-9006-e310f5b6f9d8.png)

![retire_max_graph_after](https://cloud.githubusercontent.com/assets/489567/8981454/5b100dbe-36b0-11e5-9f82-a5dd92eb717a.png)

Those changes apply only on fluid250 parallax ads. I couldn't find any working ad (except 'Retire to the max' behind 'fh5' adtest cookie) which uses any of the commented styles. If it will break anything, please try solution from the attached video link.
