### PR TITLE
discussion first comment fix

### DIFF
--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -3,10 +3,10 @@
 <div class="d-discussion @if(!page.isClosedForRecommendation){d-discussion--recommendations-open} u-cf"
     @page.switches.map{ switch => data-@switch.name="@switch.state" }>
 
-    <ul class="d-thread d-thread--comments">
-        @userMessageForLargeDiscussion
+    @userMessageForLargeDiscussion
 
-        <div class="js-new-comments"></div>
+    <ul class="d-thread d-thread--comments js-new-comments">
+
         @page.comments.map { comment =>
             @fragments.comment(comment, page.isClosedForRecommendation, false)
         }

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -109,22 +109,14 @@ $avatarPadding: $gs-gutter / 2;
 }
 
 .d-discussion__size-message {
-    display: none;
-}
+    @include fs-textSans(2);
+    margin-bottom: $gs-baseline * 2 / 3;
+    border-top: 1px solid colour(neutral-4);
+    padding-top: $gs-baseline;
+    color: colour(neutral-2);
 
-.discussion--pagesize-msg-show {
-
-    .d-discussion__size-message {
-        @include fs-textSans(2);
-        margin-bottom: $gs-baseline * 2 / 3;
-        border-top: 1px solid colour(neutral-4);
-        padding-top: $gs-baseline;
-        color: colour(neutral-2);
-        display: block;
-
-        & + .d-comment {
-            border-top: 0;
-        }
+    & + .d-comment {
+        border-top: 0;
     }
 }
 
@@ -200,9 +192,7 @@ $avatarPadding: $gs-gutter / 2;
 }
 
 .discussion--empty {
-    .discussion__top-comments,
     .discussion__toolbar,
-    .discussion__main-comments,
     .discussion__show-button {
         display: none;
     }


### PR DESCRIPTION
If users posted the first comment, it wasn't displayed, and my previous fix attempt was wrong https://github.com/guardian/frontend/pull/9955

Also, there were 1 or 2 divs inside the ul for the comments, which was confusing the "only show first two comments" logic into showing zero or one comment.  So I have moved all non-comments out of the ul.

@OliverJAsh I didn't put a comment on the line but suggestions appreciated
