### PR TITLE
Remove Switch to Control Including User ID in Ad Calls

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -575,15 +575,6 @@ object Switches {
     exposeClientSide = false
   )
 
-  val DfpUserIdSwitch = Switch(
-    "Commercial",
-    "dfp-user-id",
-    "Include user ID in ad call.",
-    safeState = Off,
-    sellByDate = new LocalDate(2015, 8, 5),
-    exposeClientSide = true
-  )
-
 
   // Monitoring
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -211,12 +211,10 @@ define([
                 .valueOf();
         },
         setPublisherProvidedId = function () {
-            if (config.switches.dfpUserId) {
-                var user = id.getUserFromCookie();
-                if (user) {
-                    var hashedId = sha1.hash(user.id);
-                    googletag.pubads().setPublisherProvidedId(hashedId);
-                }
+            var user = id.getUserFromCookie();
+            if (user) {
+                var hashedId = sha1.hash(user.id);
+                googletag.pubads().setPublisherProvidedId(hashedId);
             }
         },
         displayAds = function () {

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -33,8 +33,8 @@ System.config({
   "map": {
     "EventEmitter": "github:Wolfy87/EventEmitter@4.2.11",
     "Promise": "github:cujojs/when@3.7.3/es6-shim/Promise",
-    "babel": "npm:babel-core@5.8.19",
-    "babel-runtime": "npm:babel-runtime@5.8.19",
+    "babel": "npm:babel-core@5.8.20",
+    "babel-runtime": "npm:babel-runtime@5.8.20",
     "bean": "npm:bean@1.0.15",
     "bonzo": "npm:bonzo@1.4.0",
     "classnames": "npm:classnames@1.2.0",
@@ -128,7 +128,7 @@ System.config({
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:babel-runtime@5.8.19": {
+    "npm:babel-runtime@5.8.20": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:bean@1.0.15": {


### PR DESCRIPTION
We're always including a PPID value in ad calls for signed-in users now.

See https://support.google.com/dfp_premium/answer/2880055
