### PR TITLE
Extend Avatar API switch by a month

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -811,7 +811,7 @@ object Switches {
     "id-use-avatar-api",
     "If switched on, avatars will be uploaded using the new Avatar API",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 8, 1),
+    sellByDate = new LocalDate(2015, 9, 1),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
Forgot this was expiring :(

I'll raise a proper PR to remove the switch, make the change permanent, and remove old code separately, but would like to get this out to fix the current service.
