### PR TITLE
allow save for later ab test to run for all users

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/signed-out-save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/signed-out-save-for-later.js
@@ -21,8 +21,8 @@ define([
 ) {
 
     return function () {
-        this.id = 'SignedOutSaveForLater';
-        this.start = '2015-07-21';
+        this.id = 'SignedOutSaveForLaterAug';
+        this.start = '2015-08-03';
         this.expiry = '2015-08-31';
         this.author = 'Nathaniel Bennett';
         this.description = 'Allow signed out users to save articles via signin';
@@ -35,7 +35,7 @@ define([
         this.showForSensitive = false;
 
         this.canRun = function () {
-            return !Id.isUserLoggedIn();
+            return true;
         };
 
         this.variants = [
@@ -46,7 +46,7 @@ define([
             {
                 id: 'variant',
                 test: function () {
-                    if (config.switches.saveForLater) {
+                    if (config.switches.saveForLater && !Id.isUserLoggedIn()) {
                         var saveForLater = new SaveForLater();
                         saveForLater.init(true);
                     }


### PR DESCRIPTION
Previously `test.canRun()` was false if you were signed in, which prevented the `makeOmnitureTag` function from running for the test - a possible explanation low sign-in levels being reports.

We now allow the test to be run for everyone, but the test function only does something if you're signed out. 

@NathanielBennett 
