### PR TITLE
Make sure errors are rethrown

### DIFF
--- a/common/app/templates/headerInlineJS/bootCurl.scala.js
+++ b/common/app/templates/headerInlineJS/bootCurl.scala.js
@@ -91,10 +91,21 @@ require([
     // Report uncaught exceptions
     raven.install();
 
+    var oldOnError = window.onerror;
+    window.onerror = function (message, filename, lineno, colno, error) {
+        // Not all browsers pass the error object
+        if (!error || !error.reported) {
+            oldOnError.apply(window, arguments);
+        }
+    };
+
     // Report unhandled promise rejections
     // https://github.com/cujojs/when/blob/master/docs/debug-api.md#browser-window-events
     window.addEventListener('unhandledRejection', function (event) {
-        raven.captureException(event.detail.reason);
+        var error = event.detail.reason;
+        if (error && !error.reported) {
+            raven.captureException(error);
+        }
     });
 
     require([

--- a/common/app/templates/headerInlineJS/bootSystemJS.scala.js
+++ b/common/app/templates/headerInlineJS/bootSystemJS.scala.js
@@ -49,10 +49,21 @@ System['import']('core').then(function () {
             // Report uncaught exceptions
             raven.install();
 
+            var oldOnError = window.onerror;
+            window.onerror = function (message, filename, lineno, colno, error) {
+                // Not all browsers pass the error object
+                if (!error || !error.reported) {
+                    oldOnError.apply(window, arguments);
+                }
+            };
+
             // Report unhandled promise rejections
             // https://github.com/cujojs/when/blob/master/docs/debug-api.md#browser-window-events
             window.addEventListener('unhandledRejection', function (event) {
-                raven.captureException(event.detail.reason);
+                var error = event.detail.reason;
+                if (error && !error.reported) {
+                    raven.captureException(error);
+                }
             });
 
             // Safe to depend on Lodash because it's part of core

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -1,5 +1,5 @@
 define([
-    'raven',
+    'common/utils/report-error',
     'common/utils/_',
     'common/utils/config',
     'common/utils/cookies',
@@ -14,7 +14,7 @@ define([
     'common/modules/experiments/tests/membership-message',
     'common/modules/experiments/tests/membership-message-usa'
 ], function (
-    raven,
+    reportError,
     _,
     config,
     cookies,
@@ -332,7 +332,7 @@ define([
             } catch (error) {
                 // Encountering an error should invalidate the logging process.
                 abLogObject = {};
-                raven.captureException(error);
+                reportError(error);
             }
 
             return abLogObject;

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -332,7 +332,7 @@ define([
             } catch (error) {
                 // Encountering an error should invalidate the logging process.
                 abLogObject = {};
-                reportError(error);
+                reportError(error, false);
             }
 
             return abLogObject;

--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -100,7 +100,7 @@ define([
             } catch (e) {
                 reportError(new Error('Error retrieving share counts (' + e.message + ')'), {
                     feature: 'share-count'
-                });
+                }, false);
             }
         }
     };

--- a/static/src/javascripts/projects/common/modules/social/share-count.js
+++ b/static/src/javascripts/projects/common/modules/social/share-count.js
@@ -1,5 +1,5 @@
 define([
-    'raven',
+    'common/utils/report-error',
     'common/utils/$',
     'common/utils/ajax',
     'common/utils/detect',
@@ -8,7 +8,7 @@ define([
     'common/utils/template',
     'text!common/views/content/share-count.html'
 ], function (
-    raven,
+    reportError,
     $,
     ajax,
     detect,
@@ -98,10 +98,8 @@ define([
                     updateTooltip();
                 });
             } catch (e) {
-                raven.captureException(new Error('Error retrieving share counts (' + e.message + ')'), {
-                    tags: {
-                        feature: 'share-count'
-                    }
+                reportError(new Error('Error retrieving share counts (' + e.message + ')'), {
+                    feature: 'share-count'
                 });
             }
         }

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -2,7 +2,7 @@
 define([
     'bean',
     'qwery',
-    'raven',
+    'common/utils/report-error',
     'common/utils/$',
     'common/utils/_',
     'common/utils/config',
@@ -14,7 +14,7 @@ define([
 ], function (
     bean,
     qwery,
-    raven,
+    reportError,
     $,
     _,
     config,
@@ -222,11 +222,9 @@ define([
 
     function beaconError(err) {
         if (err && 'message' in err && 'code' in err) {
-            raven.captureException(new Error(err.message), {
-                tags: {
-                    feature: 'player',
-                    vjsCode: err.code
-                }
+            reportError(new Error(err.message), {
+                feature: 'player',
+                vjsCode: err.code
             });
         }
     }

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -225,7 +225,7 @@ define([
             reportError(new Error(err.message), {
                 feature: 'player',
                 vjsCode: err.code
-            });
+            }, false);
         }
     }
 

--- a/static/src/javascripts/projects/common/utils/fastdom-errors.js
+++ b/static/src/javascripts/projects/common/utils/fastdom-errors.js
@@ -3,20 +3,14 @@
 
 define([
     'fastdom',
-    'raven'
+    'common/utils/report-error'
 ], function (
     fastdom,
-    raven
+    reportError
 ) {
     fastdom.onError = function (error) {
-        raven.captureException(error, {
-            tags: {
-                feature: 'fastdom'
-            }
+        reportError(error, {
+            feature: 'fastdom'
         });
-        // Some environments don't support or don't always expose the console object
-        if (window.console && window.console.warn) {
-            window.console.warn('Caught FastDom error.', error.stack);
-        }
     };
 });

--- a/static/src/javascripts/projects/common/utils/fastdom-errors.js
+++ b/static/src/javascripts/projects/common/utils/fastdom-errors.js
@@ -9,12 +9,12 @@ define([
     reportError
 ) {
     fastdom.onError = function (error) {
-        reportError(error, {
-            feature: 'fastdom'
-        }, false);
         // Some environments don't support or don't always expose the console object
         if (window.console && window.console.warn) {
             window.console.warn('Caught FastDom error.', error.stack);
         }
+        reportError(error, {
+            feature: 'fastdom'
+        }, false);
     };
 });

--- a/static/src/javascripts/projects/common/utils/fastdom-errors.js
+++ b/static/src/javascripts/projects/common/utils/fastdom-errors.js
@@ -11,6 +11,10 @@ define([
     fastdom.onError = function (error) {
         reportError(error, {
             feature: 'fastdom'
-        });
+        }, false);
+        // Some environments don't support or don't always expose the console object
+        if (window.console && window.console.warn) {
+            window.console.warn('Caught FastDom error.', error.stack);
+        }
     };
 });

--- a/static/src/javascripts/projects/common/utils/report-error.js
+++ b/static/src/javascripts/projects/common/utils/report-error.js
@@ -1,14 +1,21 @@
 // Report errors to Sentry with optional tags metadata
-// We re-throw the error to ensure the error is still logged to the console via
-// browsers built-in logging for uncaught exceptions
+// We optionally re-throw the error to halt execution and to ensure the error is
+// still logged to the console via browsers built-in logging for uncaught
+// exceptions. This is optional because sometimes we log errors for tracking
+// user data.
 define(['raven'], function (raven) {
-    return function reportError(err, meta) {
+    return function reportError(err, meta, shouldThrow) {
+        if (shouldThrow === undefined) {
+            shouldThrow = true;
+        }
         raven.captureException(err, {
             tags: meta
         });
-        // Flag to ensure it is not reported to Sentry again via global handlers
-        err.reported = true;
-        throw err;
+        if (shouldThrow) {
+            // Flag to ensure it is not reported to Sentry again via global handlers
+            err.reported = true;
+            throw err;
+        }
     };
 
 });

--- a/static/src/javascripts/projects/common/utils/report-error.js
+++ b/static/src/javascripts/projects/common/utils/report-error.js
@@ -1,0 +1,14 @@
+// Report errors to Sentry with optional tags metadata
+// We re-throw the error to ensure the error is still logged to the console via
+// browsers built-in logging for uncaught exceptions
+define(['raven'], function (raven) {
+    return function reportError(err, meta) {
+        raven.captureException(err, {
+            tags: meta
+        });
+        // Flag to ensure it is not reported to Sentry again via global handlers
+        err.reported = true;
+        throw err;
+    };
+
+});

--- a/static/src/javascripts/projects/common/utils/robust.js
+++ b/static/src/javascripts/projects/common/utils/robust.js
@@ -20,10 +20,13 @@ define([
     };
 
     var log = function (name, error, reporter) {
+        if (window.console && window.console.warn) {
+            window.console.warn('Caught error.', error.stack);
+        }
         if (!reporter) {
             reporter = reportError;
         }
-        reporter(error, { module: name });
+        reporter(error, { module: name }, false);
     };
 
     var catchErrorsAndLog = function (name, fn, reporter) {

--- a/static/src/javascripts/projects/common/utils/robust.js
+++ b/static/src/javascripts/projects/common/utils/robust.js
@@ -3,10 +3,10 @@
     For example "comments throwing an exception should not stop auto refresh"
  */
 define([
-    'raven',
+    'common/utils/report-error',
     'common/utils/_'
 ], function (
-    raven,
+    reportError,
     _
 ) {
     var catchErrors = function (fn) {
@@ -20,13 +20,10 @@ define([
     };
 
     var log = function (name, error, reporter) {
-        if (window.console && window.console.warn) {
-            window.console.warn('Caught error.', error.stack);
-        }
         if (!reporter) {
-            reporter = raven.captureException;
+            reporter = reportError;
         }
-        reporter(error, { tags: { module: name } });
+        reporter(error, { module: name });
     };
 
     var catchErrorsAndLog = function (name, fn, reporter) {

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -107,6 +107,8 @@ define([
                                 feature: 'weather'
                             }
                         });
+                        err.reported = true;
+                        throw err;
                     });
             }
         },
@@ -122,6 +124,8 @@ define([
                             feature: 'weather'
                         }
                     });
+                    err.reported = true;
+                    throw err;
                 });
         },
 
@@ -140,6 +144,8 @@ define([
                             feature: 'weather'
                         }
                     });
+                    err.reported = true;
+                    throw err;
                 });
         },
 

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -15,7 +15,7 @@
 define([
     'bean',
     'qwery',
-    'raven',
+    'common/utils/report-error',
     'common/utils/_',
     'common/utils/$',
     'common/utils/ajax-promise',
@@ -29,7 +29,7 @@ define([
 ], function (
     bean,
     qwery,
-    raven,
+    reportError,
     _,
     $,
     ajaxPromise,
@@ -102,13 +102,7 @@ define([
                     .then(function (response) {
                         this.fetchWeatherData(response);
                     }.bind(this)).catch(function (err) {
-                        raven.captureException(err, {
-                            tags: {
-                                feature: 'weather'
-                            }
-                        });
-                        err.reported = true;
-                        throw err;
+                        reportError(err, { feature: 'weather' });
                     });
             }
         },
@@ -119,13 +113,7 @@ define([
                     this.render(response, location.city);
                     this.fetchForecastData(location);
                 }.bind(this)).catch(function (err) {
-                    raven.captureException(err, {
-                        tags: {
-                            feature: 'weather'
-                        }
-                    });
-                    err.reported = true;
-                    throw err;
+                    reportError(err, { feature: 'weather' });
                 });
         },
 
@@ -139,13 +127,7 @@ define([
                 .then(function (response) {
                     this.renderForecast(response);
                 }.bind(this)).catch(function (err) {
-                    raven.captureException(err, {
-                        tags: {
-                            feature: 'weather'
-                        }
-                    });
-                    err.reported = true;
-                    throw err;
+                    reportError(err, { feature: 'weather' });
                 });
         },
 

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -2,7 +2,7 @@ define([
     'bonzo',
     'fastdom',
     'qwery',
-    'raven',
+    'common/utils/report-error',
     'common/utils/_',
     'common/utils/$',
     'common/utils/ajax-promise',
@@ -13,7 +13,7 @@ define([
     bonzo,
     fastdom,
     qwery,
-    raven,
+    reportError,
     _,
     $,
     ajax,
@@ -137,7 +137,7 @@ define([
             });
 
             showErrorMessage(button);
-            raven.captureException(new Error('Error retrieving show more (' + err + ')'));
+            reportError(new Error('Error retrieving show more (' + err + ')'));
         });
     }
 

--- a/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
+++ b/static/src/javascripts/projects/facia/modules/ui/container-show-more.js
@@ -137,7 +137,7 @@ define([
             });
 
             showErrorMessage(button);
-            reportError(new Error('Error retrieving show more (' + err + ')'));
+            reportError(new Error('Error retrieving show more (' + err + ')'), false);
         });
     }
 

--- a/static/src/javascripts/test/spec/common/utils/robust.spec.js
+++ b/static/src/javascripts/test/spec/common/utils/robust.spec.js
@@ -7,9 +7,9 @@ describe('Robust', function () {
 
     it('should log and swallow exceptions', function (success) {
 
-        var reporter = function (ex, options) {
+        var reporter = function (ex, meta) {
             expect(ex.message).toBe('fail');
-            expect(options.tags.module).toBe('test');
+            expect(meta.module).toBe('test');
             success();
         };
 


### PR DESCRIPTION
We are catching certain errors in order to report them to Sentry with additional metadata, e.g. tags such as  for weather related errors. However, because these errors are being caught, they are no longer printed to the console (as uncaught exceptions usually are), which makes debugging extremely difficult—you don't know when errors are happpening, let alone where they are happening.

When catching errors for these purposes, we still want them to be handled the same as uncaught exceptions (i.e. logged to the console). This commit makes sure we re-throw the errors after they have been reported. We also make sure the error isn't reported twice (as uncaught exceptions are automatically reported by `window.onerror`/`unhandledRejection`.

Esssentially this is a much better version of #9981. (Sorry about that, @piuccio and @rich-nguyen.)
