### PR TITLE
Bump facia-scala-client to 0.54

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ object Dependencies {
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
   val dispatchTest = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3" % Test
   val exactTargetClient = "com.gu" %% "exact-target-client" % "2.24"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.53"
-  val faciaScalaClient = "com.gu" %% "facia-json" % "0.53"
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.54"
+  val faciaScalaClient = "com.gu" %% "facia-json" % "0.54"
   val flexibleContentBlockToText = "com.gu" %% "flexible-content-block-to-text" % "0.4"
   val flexibleContentBodyParser = "com.gu" %% "flexible-content-body-parser" % "0.6"
   val googleSheetsApi = "com.google.gdata" % "core" % "1.47.1"


### PR DESCRIPTION
This removes editors picks from the head of the backfill results.

Please see https://github.com/guardian/facia-scala-client/pull/124 for more information.

@jennysivapalan 
