### PR TITLE
Remove page jump when Save for Later loads

### DIFF
--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -2,6 +2,7 @@ package views.support
 
 import com.gu.facia.api.utils.{Audio, Video, Gallery}
 import layout._
+import conf.Switches.SaveForLaterSwitch
 
 object GetClasses {
   def forHtmlBlob(item: HtmlBlob) = {
@@ -24,7 +25,8 @@ object GetClasses {
       (s"fc-item--has-sublinks-${item.sublinks.length}", item.sublinks.nonEmpty),
       ("fc-item--has-boosted-title", item.displaySettings.showBoostedHeadline),
       ("fc-item--live", item.isLive),
-      ("fc-item--has-metadata", item.timeStampDisplay.isDefined || item.discussionSettings.isCommentable),
+      ("fc-item--has-metadata",
+        item.timeStampDisplay.isDefined || item.discussionSettings.isCommentable || SaveForLaterSwitch.isSwitchedOn),
       ("fc-item--has-timestamp", item.timeStampDisplay.isDefined),
       ("fc-item--is-commentable", item.discussionSettings.isCommentable)
     ) ++ item.snapStuff.map(_.cssClasses.map(_ -> true).toMap).getOrElse(Map.empty)


### PR DESCRIPTION
We can't be sure whether the user will be running the test because this is done in browser land, but I think it's better to have some extra empty padding for users not using the feature, than to have a page jump for users who are.

![untitled](https://cloud.githubusercontent.com/assets/921609/9040685/9b47f4d4-39fb-11e5-97af-8356e561dbdb.gif)
