### PR TITLE
Images must come from static or media

### DIFF
--- a/facia-tool/public/js/constants/defaults.js
+++ b/facia-tool/public/js/constants/defaults.js
@@ -89,8 +89,9 @@ export default {
     reauthInterval:        60000 * 10, // 10 minutes
     reauthTimeout:         60000,
 
-    imageCdnDomain:        '.guim.co.uk',
-    imgIXBasePath:         '/img/static/',
+    imageCdnDomain:        /^https?:\/\/(static|media)\.guim\.co\.uk\//,
+    imgIXBaseDomain:       /^https?:\/\/i\.guim\.co\.uk\/img\/static\//,
+    staticImageCdnDomain:  'https://static.guim.co.uk/',
     previewBase:           'http://preview.gutools.co.uk',
 
     latestSnapPrefix:      'Latest from ',

--- a/facia-tool/public/js/utils/validate-image-src.js
+++ b/facia-tool/public/js/utils/validate-image-src.js
@@ -1,7 +1,6 @@
 import _ from 'underscore';
 import Promise from 'Promise';
 import {CONST} from 'modules/vars';
-import absPath from 'utils/url-abs-path';
 
 /**
  * Asserts if the given image URL is on The Guardian domain, is proper size and aspect ratio.
@@ -19,15 +18,15 @@ function validateImageSrc(src, criteria) {
                 heightAspectRatio: undefined
             };
         criteria = _.extend(defaultCriteria, criteria);
+        src = stripImgIXDetails(src);
 
         if (!src) {
             reject(new Error('Missing image'));
 
-        } else if (!src.match(new RegExp('^http://.*' + CONST.imageCdnDomain.replace('.', '\\.') + '/'))) {
-            reject(new Error('Images must come from *' + CONST.imageCdnDomain));
+        } else if (!src.match(CONST.imageCdnDomain)) {
+            reject(new Error('Images must come from ' + CONST.imageCdnDomain.toString().replace(/\\/g, '').substring(11)));
 
         } else {
-            src = stripImgIXDetails(src);
 
             img = new Image();
             img.onerror = function() {
@@ -62,14 +61,11 @@ function validateImageSrc(src, criteria) {
 }
 
 function stripImgIXDetails (src) {
-    var pathname = '/' + absPath(src),
-        base = src.substring(0, src.indexOf(pathname));
-
-    if (pathname.indexOf(CONST.imgIXBasePath) === 0) {
-        return base + '/' + pathname.substring(CONST.imgIXBasePath.length);
-    } else {
-        return src;
+    if (src && CONST.imgIXBaseDomain.test(src)) {
+        src = src.substring(0, src.indexOf('?')).replace(CONST.imgIXBaseDomain, CONST.staticImageCdnDomain);
     }
+
+    return src;
 }
 
 export default validateImageSrc;

--- a/facia-tool/test/public/spec/validate.image.spec.js
+++ b/facia-tool/test/public/spec/validate.image.spec.js
@@ -4,9 +4,13 @@ import validate from 'utils/validate-image-src';
 describe('Validate images', function () {
     beforeEach(function () {
         this.originalCDNDomain = CONST.imageCdnDomain;
+        this.originalimgIXBaseDomain = CONST.imgIXBaseDomain;
+        this.originalstaticImageCdnDomain = CONST.staticImageCdnDomain;
     });
     afterEach(function () {
         CONST.imageCdnDomain = this.originalCDNDomain;
+        CONST.imgIXBaseDomain = this.originalimgIXBaseDomain;
+        CONST.staticImageCdnDomain = this.originalstaticImageCdnDomain;
     });
 
     it('fails on missing images', function (done) {
@@ -108,9 +112,11 @@ describe('Validate images', function () {
     });
 
     it('strips unnecessary parameters', function (done) {
+        CONST.imgIXBaseDomain = /https?:\/\/i.guim.co.uk\/img\/ix\//;
+        CONST.staticImageCdnDomain = 'http://' + window.location.host + '/';
         CONST.imageCdnDomain = window.location.host;
 
-        validate('http://' + CONST.imageCdnDomain + CONST.imgIXBasePath +
+        validate('http://i.guim.co.uk/img/ix/' +
             'base/test/public/fixtures/square.png?s=82a57a91afadd159bb4639d6b798f6c5&other=params')
         .then(function (image) {
             expect(image.width).toBe(140);


### PR DESCRIPTION
The only exception is cutout images currently coming from `i.guim/img/static`. There's some logic to convert those URLs to the static image anyway.

All other images can only come from `static.` or `media.` because we can't rely on `i.guim`

Unfortunately we have already ~150 images coming from places like

```
i.guim.co.uk/static/
i.guim.co.uk/sys-images/
i.guim.co.uk/img/media/
i.guim.co.uk/media/
```

Those should probably be fixed somehow

cc @gklopper @na7hangood @paperboyo
