### PR TITLE
Increase Jasmine timeout to fix tests

### DIFF
--- a/static/src/javascripts/test/setup.js
+++ b/static/src/javascripts/test/setup.js
@@ -1,3 +1,6 @@
+// http://jasmine.github.io/2.0/introduction.html#section-43
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+
 window.guardian = {
     config: {
         switches: { },


### PR DESCRIPTION
A SystemJS update has, somehow, made `System.import` slower, which means our tests now timeout (especially so on the TeamCity boxes because they are slower). It has got slower because of something in https://github.com/systemjs/systemjs/releases/tag/0.18.5, https://github.com/systemjs/systemjs/releases/tag/0.18.6 or https://github.com/ModuleLoader/es6-module-loader/releases/tag/v0.17.4, but I can't tell what. @guybedford, can you shed some light?

This broke our build overnight because SystemJS automatically updates patch versions, which are ideally backwards compatible, but in practice they are often not. I've filed an issue at https://github.com/jspm/jspm-cli/issues/743 to ask if we can get the ability to shrinkwrap/lock.
