### PR TITLE
Update the link for the banner to the android app

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -33,7 +33,7 @@ define([
             ANDROID: {
                 LOGO: 'http://assets.guim.co.uk/images/apps/android-logo-2x.png',
                 SCREENSHOTS: 'http://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
-                LINK: 'http://ad-x.co.uk/API/click/guardian789057jo/web3537df5992e76b',
+                LINK: 'https://app.adjust.com/642i3r?deep_link=x-gu://www.theguardian.com/?source=adjust',
                 STORE: 'in Google Play'
             }
         },


### PR DESCRIPTION
The acquisition tracking in the Android app from Ad-X to Adjust so the link requires updating. I'm not sure how best to test this is doing the right thing, I tried BroswerStack but as the link goes to the Play Store and a valid email is required it doesn't quite work. The new link does go the Guardian app on the Play Store.
