### PR TITLE
Send beacon for unique visitors in JspmTest and JspmControl

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -177,6 +177,15 @@ object Switches {
     exposeClientSide = false
   )
 
+  val JspmTestUniqueVisitorsBeacon = Switch(
+    "Performance",
+    "jspm-test-unique-visitors-beacon",
+    "Send beacon for unique visitors in JspmTest and JspmControl server-side test variants",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 8, 18),
+    exposeClientSide = true
+  )
+
   val RelatedContentSwitch = Switch(
     "Performance",
     "related-content",

--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -90,12 +90,15 @@
             var tests = guardian.config.tests;
             var inTest = tests.jspmTest || tests.jspmControl;
             var localStorageKey = 'gu.jspm-test.visited';
-            var visited = !!window.localStorage.getItem(localStorageKey)
-            if (!visited && inTest) {
-                var beaconName = tests.jspmTest ? 'jspm-test' : 'jspm-control';
-                (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + beaconName + '.gif';
-                window.localStorage.setItem(localStorageKey, true);
-            }
+            // Protect browsers with localStorage but permissions disabled
+            try {
+                var visited = !!window.localStorage.getItem(localStorageKey)
+                if (!visited && inTest) {
+                    var beaconName = tests.jspmTest ? 'jspm-test' : 'jspm-control';
+                    (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + beaconName + '.gif';
+                    window.localStorage.setItem(localStorageKey, true);
+                }
+            } catch (e) {}
         }
     })(window, navigator);
 }

--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -85,19 +85,17 @@
         }
 
         // Send beacon for unique visitors in JspmTest and JspmControl server-side test variants
-        if (guardian.config.switches.jspmTestUniqueVisitorsBeacon) {
+        // Requires localStorage, so modern browsers only
+        if (window.guardian.isModernBrowser && guardian.config.switches.jspmTestUniqueVisitorsBeacon) {
             var tests = guardian.config.tests;
             var inTest = tests.jspmTest || tests.jspmControl;
             var localStorageKey = 'gu.jspm-test.visited';
-            // Protect browsers with no localStorage
-            try {
-                var visited = !!window.localStorage.getItem(localStorageKey)
-                if (!visited && inTest) {
-                    var beaconName = tests.jspmTest ? 'jspm-test' : 'jspm-control';
-                    (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + beaconName + '.gif';
-                    window.localStorage.setItem(localStorageKey, true);
-                }
-            } catch (e) {}
+            var visited = !!window.localStorage.getItem(localStorageKey)
+            if (!visited && inTest) {
+                var beaconName = tests.jspmTest ? 'jspm-test' : 'jspm-control';
+                (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + beaconName + '.gif';
+                window.localStorage.setItem(localStorageKey, true);
+            }
         }
     })(window, navigator);
 }

--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -83,5 +83,21 @@
                 logDevice('sgs3', 'android');
             }
         }
+
+        // Send beacon for unique visitors in JspmTest and JspmControl server-side test variants
+        if (guardian.config.switches.jspmTestUniqueVisitorsBeacon) {
+            var tests = guardian.config.tests;
+            var inTest = tests.jspmTest || tests.jspmControl;
+            var localStorageKey = 'gu.jspm-test.visited';
+            // Protect browsers with no localStorage
+            try {
+                var visited = !!window.localStorage.getItem(localStorageKey)
+                if (!visited && inTest) {
+                    var beaconName = tests.jspmTest ? 'jspm-test' : 'jspm-control';
+                    (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + beaconName + '.gif';
+                    window.localStorage.setItem(localStorageKey, true);
+                }
+            } catch (e) {}
+        }
     })(window, navigator);
 }

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -73,6 +73,8 @@ object Metric extends Logging {
     ("android-sgs3-start-raf", CountMetric(s"android-sgs3-start-raf")),
     ("android-sgs3-after-5-raf", CountMetric(s"android-sgs3-after-5-raf")),
 
+    ("jspm-test", CountMetric(s"jspm-test")),
+    ("jspm-control", CountMetric(s"jspm-control")),
 
     ("tech-feedback", CountMetric("tech-feedback")),
 


### PR DESCRIPTION
We want to know if the ~1.5% drop in unique visitors and 3% drop in page views for JspmTest is because of an error in SystemJS or something beforehand (i.e. inaccurate bucketing or bounce due to bigger payload). We can use the data from these beacons and compare it with the data in Omniture.

/cc @gklopper @sndrs
