### PR TITLE
Filter Ads to Consider in Fixing Size of Top Ad Slot

### DIFF
--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -3,6 +3,7 @@ package dfp
 import common.Edition
 import common.dfp.AdSize.{leaderboardSize, responsiveSize}
 import common.dfp.{GeoTarget, GuLineItem, InlineMerchandisingTagSet, PageSkinSponsorship}
+import org.joda.time.DateTime
 
 case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
 
@@ -32,29 +33,55 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
     }
   }
 
-  val topAboveNavSlotTakeovers: Seq[GuLineItem] = lineItems filter { lineItem =>
-    lineItem.costType == "CPD" &&
-      lineItem.targeting.adUnits.exists { adUnit =>
-        val prefix = adUnit.path.mkString("/").stripSuffix("/ng").stripSuffix("/front")
-        prefix.endsWith("/uk") || prefix.endsWith("/us") || prefix.endsWith("/au")
-      } &&
-      lineItem.targeting.geoTargetsIncluded.exists { geoTarget =>
-        geoTarget.locationType == "COUNTRY" && (
-          geoTarget.name == "United Kingdom" ||
-            geoTarget.name == "United States" ||
-            geoTarget.name == "Australia"
-          )
-      } &&
-      lineItem.creativeSizes.exists { size =>
-        size == leaderboardSize || size == responsiveSize
-      }
+  def dateSort(lineItems: => Seq[GuLineItem]): Seq[GuLineItem] = lineItems sortBy { lineItem =>
+    (lineItem.startTime.getMillis, lineItem.endTime.map(_.getMillis).getOrElse(0L))
   }
 
-  val topBelowNavSlotTakeovers: Seq[GuLineItem] = lineItems filter {
-    _.targeting.customTargetSets.exists(_.targets.exists(_.isSlot("top-below-nav")))
+  val topAboveNavSlotTakeovers: Seq[GuLineItem] = dateSort {
+    lineItems filter { lineItem =>
+      lineItem.costType == "CPD" &&
+        lineItem.targeting.adUnits.exists { adUnit =>
+          val prefix = adUnit.path.mkString("/").stripSuffix("/ng").stripSuffix("/front")
+          prefix.endsWith("/uk") || prefix.endsWith("/us") || prefix.endsWith("/au")
+        } &&
+        lineItem.targeting.geoTargetsIncluded.exists { geoTarget =>
+          geoTarget.locationType == "COUNTRY" && (
+            geoTarget.name == "United Kingdom" ||
+              geoTarget.name == "United States" ||
+              geoTarget.name == "Australia"
+            )
+        } &&
+        lineItem.creativeSizes.exists { size =>
+          size == leaderboardSize || size == responsiveSize
+        } &&
+        lineItem.startTime.isBefore(DateTime.now.plusDays(1))
+    }
   }
 
-  val topSlotTakeovers = topAboveNavSlotTakeovers
+  val topBelowNavSlotTakeovers: Seq[GuLineItem] = dateSort {
+    lineItems filter {
+      _.targeting.customTargetSets.exists(_.targets.exists(_.isSlot("top-below-nav")))
+    }
+  }
+
+  val topSlotTakeovers = dateSort {
+    lineItems filter { lineItem =>
+      lineItem.costType == "CPD" &&
+        lineItem.targeting.adUnits.exists { adUnit =>
+          val prefix = adUnit.path.mkString("/").stripSuffix("/ng").stripSuffix("/front")
+          prefix.endsWith("/uk") || prefix.endsWith("/us") || prefix.endsWith("/au")
+        } &&
+        lineItem.targeting.geoTargetsIncluded.exists { geoTarget =>
+          geoTarget.locationType == "COUNTRY" && (
+            geoTarget.name == "United Kingdom" ||
+              geoTarget.name == "United States" ||
+              geoTarget.name == "Australia"
+            )
+        } &&
+        lineItem.creativeSizes.contains(responsiveSize) &&
+        lineItem.startTime.isBefore(DateTime.now.plusDays(1))
+    }
+  }
 
   def editionsTargeted(lineItem: GuLineItem): Seq[Edition] = {
     for {

--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -103,7 +103,7 @@ class DfpDataHydrator extends Logging {
             sponsor = sponsor,
             creativeSizes = dfpLineItem.getCreativePlaceholders.map { placeholder =>
               AdSize(placeholder.getSize.getWidth.toInt, placeholder.getSize.getHeight.toInt)
-            }.toSeq,
+            }.toList.sortBy(size => (size.width, size.height)),
             targeting = GuTargeting(adUnits,
               geoTargetsIncluded,
               geoTargetsExcluded,


### PR DESCRIPTION
- No need to fetch ads that run more than a day ahead and 
- Only need to consider responsive ads in mobile top slot.
