### PR TITLE
Remove text clamping to fix text overlapping in non-{Webkit,Blink} br…

### DIFF
--- a/static/src/stylesheets/module/onward/_right-hand-most-popular.scss
+++ b/static/src/stylesheets/module/onward/_right-hand-most-popular.scss
@@ -4,7 +4,6 @@
 
 .right-most-popular-item {
     clear: left;
-    height: $gs-row-height*2 + 3px;
     padding-top: ($gs-baseline/3)*2;
     margin-bottom: $gs-baseline*2;
 
@@ -19,7 +18,7 @@
     color: colour(neutral-1);
     margin-bottom: 0;
     @include fs-headline(2);
-    @include text-clamp(4, 20);
+    @include text-clamp(4);
 }
 
 .right-most-popular-item__url {


### PR DESCRIPTION
…owsers

Fixes #10036 

There were other options for fixing this bug, but I think this one has the best accessibility: https://github.com/guardian/frontend/issues/10036#issuecomment-127990675

Before in WebKit and Blink browsers:
![image](https://cloud.githubusercontent.com/assets/921609/9086343/ca66d614-3b7b-11e5-8417-85253bef2275.png)

Before in non-{Webkit,Blink} browsers:
![image](https://cloud.githubusercontent.com/assets/921609/9086310/95ab5170-3b7b-11e5-8c6a-ea193bcc9b98.png)

After in WebKit and Blink browsers (same):
![image](https://cloud.githubusercontent.com/assets/921609/9086343/ca66d614-3b7b-11e5-8417-85253bef2275.png)

After in non-{Webkit,Blink} browsers (new):
![image](https://cloud.githubusercontent.com/assets/921609/9086300/83e77be4-3b7b-11e5-9151-bb85ea94b60c.png)
