### PR TITLE
Fix archive diffs in facia-tool

### DIFF
--- a/facia-tool/app/model/frontsapi.scala
+++ b/facia-tool/app/model/frontsapi.scala
@@ -140,12 +140,12 @@ trait UpdateActions extends Logging with ExecutionContexts {
 
   def archiveUpdateBlock(collectionId: String, collectionJson: CollectionJson, updateJson: JsValue, identity: User): CollectionJson = {
     FaciaToolArchive.archive(ArchiveRequest(collectionId, identity.email, Json.toJson(collectionJson), Json.obj("action" -> "update", "update" -> updateJson)))
-    archiveBlock(collectionId, collectionJson, Json.obj("action" -> "delete", "update" -> updateJson), identity)
+    archiveBlock(collectionId, collectionJson, Json.obj("action" -> "update", "update" -> updateJson), identity)
   }
 
   def archiveDeleteBlock(collectionId: String, collectionJson: CollectionJson, updateJson: JsValue, identity: User): CollectionJson = {
     FaciaToolArchive.archive(ArchiveRequest(collectionId, identity.email, Json.toJson(collectionJson), Json.obj("action" -> "delete", "update" -> updateJson)))
-    archiveBlock(collectionId, collectionJson, Json.obj("action" -> "update", "update" -> updateJson), identity)
+    archiveBlock(collectionId, collectionJson, Json.obj("action" -> "delete", "update" -> updateJson), identity)
   }
 
   private def archiveBlock(id: String, collectionJson: CollectionJson, action: String, identity: User): CollectionJson =
@@ -294,7 +294,7 @@ trait UpdateActions extends Logging with ExecutionContexts {
     FaciaApiIO.getCollectionJson(collectionId).map{ maybeCollectionJson =>
       maybeCollectionJson
         .map(removeFromTreatsList(update, _))
-        .map(archiveUpdateBlock(collectionId, _, updateJson, identity))
+        .map(archiveDeleteBlock(collectionId, _, updateJson, identity))
         .map(FaciaApi.updateIdentity(_, identity))
         .map(putCollectionJson(collectionId, _))}}
 


### PR DESCRIPTION
This changes:
- `archiveUpdateBlock` to use the `action` -> `update`
- `archiveDeleteBlock` to use the `action` -> `delete`
- `removeTreats` to call `archiveDeleteBlock` instead of `archiveUpdateBlock` so that is gets the correct `action` in the history diff.

@piuccio 
