### PR TITLE
FR DFP param value fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -82,7 +82,7 @@ define([
             var alreadyVisited = storage.local.get('alreadyVisited') || 0,
                 visitedValue;
 
-            if (alreadyVisited > 5) {
+            if (alreadyVisited > 4) {
                 visitedValue = '5+';
             } else {
                 visitedValue = alreadyVisited.toString();


### PR DESCRIPTION
The `fr` (frequency) param sent to DFP should be [1,2,3,4,5+] not [1,2,3,4,5,5+] as it was before.
