### PR TITLE
Use the image service for the open graph image urls. 

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -17,7 +17,7 @@ import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
 import org.scala_tools.time.Imports._
 import play.api.libs.json._
-import views.support.{ImgSrc, Item700, Naked, StripHtmlTagsAndUnescapeEntities}
+import views.support._
 
 import scala.collection.JavaConversions._
 import scala.language.postfixOps
@@ -96,10 +96,12 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   // read this before modifying
   // https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
   lazy val openGraphImage: String = {
-    bestOpenGraphImage
+    val imageUrl = bestOpenGraphImage
       .orElse(mainPicture.flatMap(largestImageUrl))
       .orElse(trailPicture.flatMap(largestImageUrl))
       .getOrElse(facebook.imageFallback)
+
+    ImgSrc(imageUrl, FacebookOpenGraphImage)
   }
 
   lazy val shouldHideAdverts: Boolean = fields.get("shouldHideAdverts").exists(_.toBoolean)
@@ -701,12 +703,14 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) with Lightbo
   )
 
   override lazy val openGraphImage: String = {
-    bestOpenGraphImage
+    val imageUrl = bestOpenGraphImage
       .orElse(galleryImages.headOption.flatMap(_.largestImage.flatMap(_.url)))
       .getOrElse(conf.Configuration.facebook.imageFallback)
+
+    ImgSrc(imageUrl, FacebookOpenGraphImage)
   }
 
-  override def openGraphImages: Seq[String] = largestCrops.flatMap(_.url)
+  override def openGraphImages: Seq[String] = largestCrops.flatMap(_.url).map(ImgSrc(_, FacebookOpenGraphImage))
 
   override def schemaType = Some("http://schema.org/ImageGallery")
 

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -69,7 +69,7 @@ object Item620 extends Profile(width = Some(620))
 object Item640 extends Profile(width = Some(640))
 object Item700 extends Profile(width = Some(700))
 object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
-object FacebookOpenGraphImage extends Profile(width = Some(1200), height = Some(630))
+object FacebookOpenGraphImage extends Profile(width = Some(1200))
 
 // The imager/images.js base image.
 object SeoOptimisedContentImage extends Profile(width = Some(460))

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -69,6 +69,7 @@ object Item620 extends Profile(width = Some(620))
 object Item640 extends Profile(width = Some(640))
 object Item700 extends Profile(width = Some(700))
 object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
+object FacebookOpenGraphImage extends Profile(width = Some(1200), height = Some(630))
 
 // The imager/images.js base image.
 object SeoOptimisedContentImage extends Profile(width = Some(460))


### PR DESCRIPTION
This allows us to select the most appropriate image based on: https://developers.facebook.com/docs/sharing/best-practices#images

I've gone with 1200 x 630 pixels as the best practises link states this is the minimum for the best display on high resolution devices.

@gklopper is this the right implementation for using with image resizing?
