### PR TITLE
Adding an AWS beacon to track Windows7 visits

### DIFF
--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -67,8 +67,10 @@
         }
 
         // Send AWS beacons for Windows7 Chrome & Opera users (user agent is almost identical). This is so we have a indicator of loss on something which we are confident is stable
-        if (/.*Windows NT 6.1; WOW64*/.test(navigator.userAgent)) {
-            logDevice('chrome', 'windows7');
+        if (navigator.platform === 'Win32') {
+            if ((/Windows NT 6.1; WOW64/.test(navigator.userAgent)) && (/Chrome/.test(navigator.userAgent))) {
+                logDevice('chrome', 'windows7');
+            }
         }
 
 

--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -60,29 +60,18 @@
         // This is a subset of the navigator.platform values used by Android. We may need to add more to capture more devices
         if ((navigator.platform === 'Linux armv7l') || (navigator.platform === 'Linux aarch64') || (navigator.platform === 'Android')) {
             var isNexus5 = /.*Nexus 5 */.test(navigator.userAgent);
-            var isNexus7 = /.*Nexus 7 */.test(navigator.userAgent);
-
-            // There is a very large variety in model id's for Samsung devices, different id's for different carriers.
-            // so we will only really be able to beacon on a subset of the Samsung GS4's that visit us
-            var isSGS4 = ((/.*GT-I9500 */.test(navigator.userAgent)) || (/.*GT-I9505 */.test(navigator.userAgent)));
-            var isSGS3 = /.*GT-I9300 */.test(navigator.userAgent);
 
             if (isNexus5) {
                 logDevice('nexus5', 'android');
             }
-
-            if (isNexus7) {
-                logDevice('nexus7', 'android');
-            }
-
-            if (isSGS4) {
-                logDevice('sgs4', 'android');
-            }
-
-            if (isSGS3) {
-                logDevice('sgs3', 'android');
-            }
         }
+
+        // Send AWS beacons for Windows7 Chrome users. This is so we have a indicator of loss on something which we are confident is stable
+        if (navigator.platform === 'Win32') {
+            if ((/.*Windows NT 6.1; WOW64*/.test(navigator.userAgent)) && (/.*Chrome*/.test(navigator.userAgent)))
+                logDevice('chrome', 'windows7');
+        }
+
 
         // Send beacon for unique visitors in JspmTest and JspmControl server-side test variants
         // Requires localStorage, so modern browsers only

--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -66,10 +66,9 @@
             }
         }
 
-        // Send AWS beacons for Windows7 Chrome users. This is so we have a indicator of loss on something which we are confident is stable
-        if (navigator.platform === 'Win32') {
-            if ((/.*Windows NT 6.1; WOW64*/.test(navigator.userAgent)) && (/.*Chrome*/.test(navigator.userAgent)))
-                logDevice('chrome', 'windows7');
+        // Send AWS beacons for Windows7 Chrome & Opera users (user agent is almost identical). This is so we have a indicator of loss on something which we are confident is stable
+        if (/.*Windows NT 6.1; WOW64*/.test(navigator.userAgent)) {
+            logDevice('chrome', 'windows7');
         }
 
 

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -50,12 +50,8 @@ object Metric extends Logging {
     ("ipad-3orLater-after-5", CountMetric(s"ipad-3orLater-after-5")),
     ("android-nexus5-start", CountMetric(s"android-nexus5-start")),
     ("android-nexus5-after-5", CountMetric(s"android-nexus5-after-5")),
-    ("android-nexus7-start", CountMetric(s"android-nexus7-start")),
-    ("android-nexus7-after-5", CountMetric(s"android-nexus7-after-5")),
-    ("android-sgs4-start", CountMetric(s"android-sgs4-start")),
-    ("android-sgs4-after-5", CountMetric(s"android-sgs4-after-5")),
-    ("android-sgs3-start", CountMetric(s"android-sgs3-start")),
-    ("android-sgs3-after-5", CountMetric(s"android-sgs3-after-5")),
+    ("windows7-chrome-start", CountMetric(s"windows7-chrome-start")),
+    ("windows7-chrome-after-5", CountMetric(s"windows7-chrome-after-5")),
 
     // temporarily count use of RAF for LoadCSSRafTest
     ("ipad-old-start-raf", CountMetric(s"ipad-old-start-raf")),

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -33,7 +33,7 @@ System.config({
   "map": {
     "EventEmitter": "github:Wolfy87/EventEmitter@4.2.11",
     "Promise": "github:cujojs/when@3.7.3/es6-shim/Promise",
-    "babel": "npm:babel-core@5.8.20",
+    "babel": "npm:babel-core@5.8.21",
     "babel-runtime": "npm:babel-runtime@5.8.20",
     "bean": "npm:bean@1.0.15",
     "bonzo": "npm:bonzo@1.4.0",


### PR DESCRIPTION
Adding an AWS beacon to track Windows7 visits - this will be in for a period of time to give us a measure of bounce rate in first 5 seconds against a platform we are confident is very stable. The data from this can then be applied to the other beacons as a fudge factor to seperate crash rate from users navigating away.

Also have removed the beacons for all android devices except the nexus5 as they are broken. Keeping the nexus 5 one so that we can investigate why data is not correct but no point keeping more thna one.
