### PR TITLE
Remove svgo

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "q": "1.0.1",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.1.0",
-    "svgo": "0.4.5",
     "time-grunt": "1.2.0"
   },
   "scripts": {


### PR DESCRIPTION
grunt-svgmin fetches this for us, so there's no need to depend on it ourselves.
