### PR TITLE
Add USA Membership/Supporter message test

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -935,6 +935,15 @@ object Switches {
     exposeClientSide = true
   )
 
+  val ABMembershipMessageUsa = Switch(
+    "A/B Tests",
+    "ab-membership-message-usa",
+    "Switch for the USA Supporter message test",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 9, 21),
+    exposeClientSide = true
+  )
+
   val ABSignedOutSaveForLaterAug = Switch(
     "A/B Tests",
     "ab-signed-out-save-for-later-aug",

--- a/common/app/templates/headerInlineJS/bootCurl.scala.js
+++ b/common/app/templates/headerInlineJS/bootCurl.scala.js
@@ -101,13 +101,16 @@ require([
         'common/utils/config',
         'common/modules/experiments/ab',
         'common/modules/ui/images',
-        'common/modules/ui/lazy-load-images'
+        'common/modules/ui/lazy-load-images',
+        'common/utils/storage'
     ], function (
         config,
         ab,
         images,
-        lazyLoadImages
+        lazyLoadImages,
+        storage
     ) {
+        var alreadyVisted;
 
         if (guardian.isModernBrowser) {
             ab.segmentUser();
@@ -121,6 +124,11 @@ require([
         lazyLoadImages.init();
         images.upgradePictures();
         images.listen();
+
+        if (guardian.isModernBrowser) {
+            alreadyVisted = storage.local.get('alreadyVisited') || 0;
+            storage.local.set('alreadyVisited', alreadyVisted + 1);
+        }
 
         // Preference pages are served via HTTPS for service worker support.
         // These pages must not have mixed (HTTP/HTTPS) content, so

--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -36,8 +36,6 @@ define([
                     }
                 ));
         }
-
-        storage.local.set('alreadyVisited', alreadyVisted + 1);
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -12,7 +12,8 @@ define([
     'common/modules/experiments/tests/high-commercial-component',
     'common/modules/experiments/tests/signed-out-save-for-later',
     'common/modules/experiments/tests/cookie-refresh',
-    'common/modules/experiments/tests/membership-message'
+    'common/modules/experiments/tests/membership-message',
+    'common/modules/experiments/tests/membership-message-usa'
 ], function (
     raven,
     _,
@@ -27,7 +28,8 @@ define([
     HighCommercialComponent,
     SignedOutSaveForLater,
     CookieRefresh,
-    MembershipMessage
+    MembershipMessage,
+    MembershipMessageUSA
 ) {
 
     var TESTS = _.flatten([
@@ -37,7 +39,8 @@ define([
         new HighCommercialComponent(),
         new SignedOutSaveForLater(),
         new CookieRefresh(),
-        new MembershipMessage()
+        new MembershipMessage(),
+        new MembershipMessageUSA()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-usa.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-usa.js
@@ -1,0 +1,69 @@
+define([
+    'common/utils/config',
+    'common/utils/detect',
+    'common/utils/storage',
+    'common/utils/template',
+    'common/modules/identity/api',
+    'common/modules/ui/message',
+    'text!common/views/membership-message.html',
+    'common/views/svgs'
+], function (
+    config,
+    detect,
+    storage,
+    template,
+    idApi,
+    Message,
+    messageTemplate,
+    svgs
+) {
+
+    return function () {
+
+        this.id = 'MembershipMessageUsa';
+        this.start = '2015-08-05';
+        this.expiry = '2015-09-21';
+        this.author = 'David Rapson';
+        this.description = 'Test if loyal visitors in the US edition are encouraged to join Membership as a Supporter';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Loyal visitors will be interested in becoming a Supporter';
+        this.audienceCriteria = 'US edition visitors who have seen at least 10 pages, message shown only on article pages';
+        this.dataLinkNames = 'membership message, hide, read more';
+        this.idealOutcome = 'Users will sign up as a Supporter';
+
+        this.canRun = function () {
+            /**
+             * - Exclude adblock users to avoid conflicts with similar adblock Supporter message
+             * - Exclude mobile/small-screen devices
+             * - Only show for US edition
+             * - Only show on Article pages
+             * - Only show to visitors who have viewed at least 10 pages.
+             */
+            var alreadyVisited = storage.local.get('alreadyVisited') || 0;
+            return !detect.adblockInUse &&
+                detect.getBreakpoint() !== 'mobile' &&
+                config.page.edition === 'US' &&
+                config.page.contentType === 'Article' &&
+                alreadyVisited > 10;
+        };
+
+        this.variants = [{
+            id: 'A',
+            test: function () {
+                new Message('membership-message-usa', {
+                    pinOnHide: false,
+                    siteMessageLinkName: 'membership message',
+                    siteMessageCloseBtn: 'hide'
+                }).show(template(messageTemplate, {
+                    supporterLink: 'https://membership.theguardian.com/us/supporter?INTCMP=MEMBERSHIP_SUBSCRIBER_LOYALTY_BANNER_USA',
+                    messageText: 'Support open, independent journalism. Become a Supporter from just £5/$8 per month',
+                    linkText: 'Find out more',
+                    arrowWhiteRight: svgs('arrowWhiteRight')
+                }));
+            }
+        }];
+
+    };
+
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-usa.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-usa.js
@@ -18,6 +18,8 @@ define([
     svgs
 ) {
 
+    var messageId = 'membership-message-usa';
+
     return function () {
 
         this.id = 'MembershipMessageUsa';
@@ -51,13 +53,27 @@ define([
         this.variants = [{
             id: 'A',
             test: function () {
-                new Message('membership-message-usa', {
+                new Message(messageId, {
                     pinOnHide: false,
                     siteMessageLinkName: 'membership message',
                     siteMessageCloseBtn: 'hide'
                 }).show(template(messageTemplate, {
-                    supporterLink: 'https://membership.theguardian.com/us/supporter?INTCMP=MEMBERSHIP_SUBSCRIBER_LOYALTY_BANNER_USA',
+                    supporterLink: 'https://membership.theguardian.com/us/supporter?INTCMP=MEMBERSHIP_SUPPORTER_BANNER_USA_A',
                     messageText: 'Support open, independent journalism. Become a Supporter from just £5/$8 per month',
+                    linkText: 'Find out more',
+                    arrowWhiteRight: svgs('arrowWhiteRight')
+                }));
+            }
+        }, {
+            id: 'B',
+            test: function () {
+                new Message(messageId, {
+                    pinOnHide: false,
+                    siteMessageLinkName: 'membership message',
+                    siteMessageCloseBtn: 'hide'
+                }).show(template(messageTemplate, {
+                    supporterLink: 'https://membership.theguardian.com/us/supporter?INTCMP=MEMBERSHIP_SUPPORTER_BANNER_USA_B',
+                    messageText: '“The Guardian enjoys rare freedom and independence. Support our journalism” – Ewen MacAskill',
                     linkText: 'Find out more',
                     arrowWhiteRight: svgs('arrowWhiteRight')
                 }));

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -416,6 +416,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
  * Membership message A/B test
  */
 .site-message--membership-message,
-.site-message--membership-message-variants {
+.site-message--membership-message-variants,
+.site-message--membership-message-usa {
     background: colour(news-main-2);
 }


### PR DESCRIPTION
This PR adds a new A/B test for a US edition version of the Supporter banner.
- Excludes adblock users to avoid conflicts with similar adblock Supporter message
- Excludes mobile/small-screen devices
- Only shown for US edition
- Only shown on Article pages
- Only shown to visitors who have viewed at least 10 pages.

The banner links to https://membership.theguardian.com/us/supporter

**A**

![screen shot 2015-08-06 at 17 03 58](https://cloud.githubusercontent.com/assets/123386/9116631/3fd31480-3c5d-11e5-9617-4ac1ea2b79a6.png)

**B**

![screen shot 2015-08-06 at 17 04 20](https://cloud.githubusercontent.com/assets/123386/9116636/47b6112a-3c5d-11e5-8a83-175d4d54b2b1.png)

@OliverJAsh @dominickendrick 
