### PR TITLE
Opengraph images take 2

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -64,7 +64,7 @@
                                             <meta itemprop="width" content="@mv.width" />
                                         }
                                         <meta itemprop="requiresSubscription" content="false" />
-                                        <meta itemprop="image" content="@video.openGraphImage" />
+                                        <meta itemprop="image" content="@Html(video.openGraphImage)" />
                                         @video.thumbnail.map{ img => <meta itemprop="thumbnail" content="@SeoOptimisedContentImage.bestFor(img)" /> }
                                         @video.mainVideo.map { videoElement =>
                                             @fragments.media.video(VideoPlayer(

--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -84,7 +84,7 @@
                         <meta itemprop="width" content="@mv.width" />
                     }
                     <meta itemprop="requiresSubscription" content="no" />
-                    <meta itemprop="image" content="@video.openGraphImage" />
+                    <meta itemprop="image" content="@Html(video.openGraphImage)" />
                     @video.thumbnail.map{ img => <meta itemprop="thumbnail" content="@SeoOptimisedContentImage.bestFor(img)" /> }
                     @video.mainVideo.map { videoElement =>
                         @fragments.media.video(VideoPlayer(

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -17,7 +17,7 @@ import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
 import org.scala_tools.time.Imports._
 import play.api.libs.json._
-import views.support.{ImgSrc, Item700, Naked, StripHtmlTagsAndUnescapeEntities}
+import views.support._
 
 import scala.collection.JavaConversions._
 import scala.language.postfixOps
@@ -96,10 +96,12 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   // read this before modifying
   // https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
   lazy val openGraphImage: String = {
-    bestOpenGraphImage
+    val imageUrl = bestOpenGraphImage
       .orElse(mainPicture.flatMap(largestImageUrl))
       .orElse(trailPicture.flatMap(largestImageUrl))
       .getOrElse(facebook.imageFallback)
+
+    ImgSrc(imageUrl, FacebookOpenGraphImage)
   }
 
   lazy val shouldHideAdverts: Boolean = fields.get("shouldHideAdverts").exists(_.toBoolean)
@@ -701,12 +703,14 @@ class Gallery(content: ApiContentWithMeta) extends Content(content) with Lightbo
   )
 
   override lazy val openGraphImage: String = {
-    bestOpenGraphImage
+    val imageUrl = bestOpenGraphImage
       .orElse(galleryImages.headOption.flatMap(_.largestImage.flatMap(_.url)))
       .getOrElse(conf.Configuration.facebook.imageFallback)
+
+    ImgSrc(imageUrl, FacebookOpenGraphImage)
   }
 
-  override def openGraphImages: Seq[String] = largestCrops.flatMap(_.url)
+  override def openGraphImages: Seq[String] = largestCrops.flatMap(_.url).map(ImgSrc(_, FacebookOpenGraphImage))
 
   override def schemaType = Some("http://schema.org/ImageGallery")
 

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -95,7 +95,7 @@
 }
 
 @item.openGraphImages.map{ case (imageUrl) =>
-    <meta property="og:image" content="@{imageUrl}" />
+    <meta property="og:image" content="@Html(imageUrl)" />
 }
 
 @item.pagination.map{ pagination =>

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -69,6 +69,7 @@ object Item620 extends Profile(width = Some(620))
 object Item640 extends Profile(width = Some(640))
 object Item700 extends Profile(width = Some(700))
 object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
+object FacebookOpenGraphImage extends Profile(width = Some(1200))
 
 // The imager/images.js base image.
 object SeoOptimisedContentImage extends Profile(width = Some(460))


### PR DESCRIPTION
A repeat of #10042 but with added `@Html` tags. 

I think the previous implementation was fine and my testing on CODE was not accurate. I used the Edit as Html on the browser Developer tool which coverts `&` to `amp&;` in urls which when used against the image service return an Unauthorised response. To be on the save side I've added the `@Html` tag. This time tested locally with the correct switches on. :bulb: 

cc @gklopper 
