### PR TITLE
Fix Creative Templates Admin Page

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -52,20 +52,9 @@ object CommercialController extends Controller with Logging with AuthLogging wit
     NoCache(Ok(views.html.commercial.inlineMerchandisingTargetedTags(environment.stage, report)))
   }
 
-  def renderCreativeTemplates = AuthActions.AuthActionTest.async { implicit request =>
-    val templates = DfpDataHydrator().loadActiveUserDefinedCreativeTemplates()
-    // get some example trails
-    lazy val trailsFuture = getResponse(
-      LiveContentApi.search(Edition(request))
-        .pageSize(2)
-    ).map { response  =>
-        response.results.map {
-          Content(_)
-        }
-    }
-    trailsFuture map { trails =>
-      NoCache(Ok(views.html.commercial.templates(environment.stage, templates, trails)))
-    }
+  def renderCreativeTemplates = AuthActions.AuthActionTest { implicit request =>
+    val templates = Store.getDfpCreativeTemplates
+    NoCache(Ok(views.html.commercial.templates(environment.stage, templates)))
   }
 
   def sponsoredContainers = AuthActions.AuthActionTest.async { implicit request =>

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -1,5 +1,6 @@
 package dfp
 
+import common.dfp.GuCreativeTemplate.{lastModified, merge}
 import common.dfp._
 import common.{ExecutionContexts, Logging}
 import conf.Switches.DfpCachingSwitch
@@ -74,11 +75,11 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
       Store.putTopSlotTakeovers(stringify(toJson(LineItemReport(now, data.topSlotTakeovers))))
 
       val cachedCreativeTemplates = Store.getDfpCreativeTemplates
-      val creativeTemplateThreshold = GuCreativeTemplate.lastModified(cachedCreativeTemplates)
+      val creativeTemplateThreshold = lastModified(cachedCreativeTemplates)
       val recentCreativeTemplates =
         DfpDataHydrator().loadActiveUserDefinedCreativeTemplates(creativeTemplateThreshold)
-      if (recentCreativeTemplates.nonEmpty) {
-        val creativeTemplatesToCache = cachedCreativeTemplates ++ recentCreativeTemplates
+      val creativeTemplatesToCache = merge(cachedCreativeTemplates, recentCreativeTemplates)
+      if (creativeTemplatesToCache != cachedCreativeTemplates) {
         Store.putCreativeTemplates(stringify(toJson(creativeTemplatesToCache)))
       }
     }

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -3,6 +3,7 @@ package dfp
 import common.dfp.GuCreativeTemplate.{lastModified, merge}
 import common.dfp._
 import common.{ExecutionContexts, Logging}
+import conf.Switches
 import conf.Switches.DfpCachingSwitch
 import org.joda.time.DateTime
 import play.api.libs.json.Json.{toJson, _}
@@ -74,13 +75,19 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
         data.topBelowNavSlotTakeovers))))
       Store.putTopSlotTakeovers(stringify(toJson(LineItemReport(now, data.topSlotTakeovers))))
 
-      val cachedCreativeTemplates = Store.getDfpCreativeTemplates
-      val creativeTemplateThreshold = lastModified(cachedCreativeTemplates)
-      val recentCreativeTemplates =
-        DfpDataHydrator().loadActiveUserDefinedCreativeTemplates(creativeTemplateThreshold)
-      val creativeTemplatesToCache = merge(cachedCreativeTemplates, recentCreativeTemplates)
-      if (creativeTemplatesToCache != cachedCreativeTemplates) {
-        Store.putCreativeTemplates(stringify(toJson(creativeTemplatesToCache)))
+      if (Switches.CreativeTemplatesInS3.isSwitchedOn) {
+        log.info("Storing creative template data...")
+        val cachedCreativeTemplates = Store.getDfpCreativeTemplates
+        val creativeTemplateThreshold = lastModified(cachedCreativeTemplates)
+        val recentCreativeTemplates =
+          DfpDataHydrator().loadActiveUserDefinedCreativeTemplates(creativeTemplateThreshold)
+        val creativeTemplatesToCache = merge(cachedCreativeTemplates, recentCreativeTemplates)
+        if (creativeTemplatesToCache != cachedCreativeTemplates) {
+          Store.putCreativeTemplates(stringify(toJson(creativeTemplatesToCache)))
+          log.info("Stored creative template data")
+        } else {
+          log.info("No change in creative template data")
+        }
       }
     }
   }

--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -72,6 +72,15 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
       Store.putTopBelowNavSlotTakeovers(stringify(toJson(LineItemReport(now,
         data.topBelowNavSlotTakeovers))))
       Store.putTopSlotTakeovers(stringify(toJson(LineItemReport(now, data.topSlotTakeovers))))
+
+      val cachedCreativeTemplates = Store.getDfpCreativeTemplates
+      val creativeTemplateThreshold = GuCreativeTemplate.lastModified(cachedCreativeTemplates)
+      val recentCreativeTemplates =
+        DfpDataHydrator().loadActiveUserDefinedCreativeTemplates(creativeTemplateThreshold)
+      if (recentCreativeTemplates.nonEmpty) {
+        val creativeTemplatesToCache = cachedCreativeTemplates ++ recentCreativeTemplates
+        Store.putCreativeTemplates(stringify(toJson(creativeTemplatesToCache)))
+      }
     }
   }
 }

--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -4,7 +4,6 @@ import com.google.api.ads.dfp.axis.utils.v201411.StatementBuilder
 import com.google.api.ads.dfp.axis.v201411._
 import common.Logging
 import common.dfp._
-import conf.Configuration.commercial.guMerchandisingAdvertiserId
 import dfp.DfpApiWrapper.DfpSessionException
 import org.apache.commons.lang.exception.ExceptionUtils
 import org.joda.time.{DateTime => JodaDateTime, DateTimeZone}
@@ -215,57 +214,69 @@ class DfpDataHydrator extends Logging {
   }.getOrElse(Failure(new DfpSessionException()))
 
 
-  def loadActiveUserDefinedCreativeTemplates(): Seq[GuCreativeTemplate] =
+  def loadActiveUserDefinedCreativeTemplates(threshold: Option[JodaDateTime]):
+  Seq[GuCreativeTemplate] = {
+
     dfpServiceRegistry.fold(Seq.empty[GuCreativeTemplate]) { serviceRegistry =>
-    val templatesQuery = new StatementBuilder()
-      .where("status = :active and type = :type")
-      .withBindVariableValue("active", CreativeTemplateStatus.ACTIVE.getValue)
-      .withBindVariableValue("type", CreativeTemplateType.USER_DEFINED.getValue)
-      .orderBy("name ASC")
 
-      val dfpCreativeTemplates = DfpApiWrapper.fetchCreativeTemplates(serviceRegistry,
-        templatesQuery) filterNot { template =>
-      val name = template.getName.toUpperCase
-      name.startsWith("APPS - ") || name.startsWith("AS ") || name.startsWith("QC ")
-    }
+      val templatesQuery = new StatementBuilder()
+        .where("status = :status and type = :type")
+        .withBindVariableValue("status", CreativeTemplateStatus.ACTIVE.getValue)
+        .withBindVariableValue("type", CreativeTemplateType.USER_DEFINED.getValue)
 
-    // fetch merchandising creatives by advertiser and logo creatives by size
-    val creativesQuery = new StatementBuilder()
-      .where("advertiserId = :advertiserId or (width = :width and height = :height)")
-      .withBindVariableValue("advertiserId", guMerchandisingAdvertiserId)
-      .withBindVariableValue("width", "140")
-      .withBindVariableValue("height", "90")
+      val dfpCreativeTemplates =
+        DfpApiWrapper.fetchCreativeTemplates(
+          serviceRegistry, templatesQuery
+        ) filterNot { template =>
+          val name = template.getName.toUpperCase
+          name.startsWith("APPS - ") || name.startsWith("AS ") || name.startsWith("QC ")
+        }
+
+      val creativesQuery = threshold.foldLeft(new StatementBuilder()) { (stmtBuilder,
+                                                                         lastModified) =>
+        stmtBuilder.where("lastModifiedDateTime > :lastModified")
+          .withBindVariableValue("lastModified", lastModified.getMillis)
+      }
 
       val creatives = DfpApiWrapper.fetchTemplateCreatives(serviceRegistry, creativesQuery)
 
-    dfpCreativeTemplates map { template =>
-      val templateCreatives = creatives getOrElse(template.getId, Nil)
-      GuCreativeTemplate(
-        id = template.getId,
-        name = template.getName,
-        description = template.getDescription,
-        parameters = template.getVariables map { param =>
-          GuCreativeTemplateParameter(
-            param.getCreativeTemplateVariableType.stripSuffix("CreativeTemplateVariable"),
-            param.getLabel,
-            param.getIsRequired,
-            param.getDescription
-          )
-        },
-        snippet = template.getSnippet,
-        creatives = templateCreatives map { creative =>
-          val args = creative.getCreativeTemplateVariableValues.foldLeft(Map.empty[String, String]) { case (soFar, arg) =>
-            val argValue = arg.getBaseCreativeTemplateVariableValueType match {
-              case "StringCreativeTemplateVariableValue" => Option(arg.asInstanceOf[StringCreativeTemplateVariableValue].getValue) getOrElse ""
-              case "AssetCreativeTemplateVariableValue" => "https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCT8L-fJRABGAEyCCXl5VJTW9F8"
-              case "UrlCreativeTemplateVariableValue" => Option(arg.asInstanceOf[UrlCreativeTemplateVariableValue].getValue) getOrElse ""
-              case other => "???"
-            }
-            soFar + (arg.getUniqueName -> argValue)
-          }
-          GuCreative(creative.getId.longValue(), creative.getName, args)
-        }
-      )
+      dfpCreativeTemplates.map { template =>
+        val templateCreatives = creatives getOrElse(template.getId, Nil)
+        GuCreativeTemplate(
+          id = template.getId,
+          name = template.getName,
+          description = template.getDescription,
+          parameters = template.getVariables map { param =>
+            GuCreativeTemplateParameter(
+              param.getCreativeTemplateVariableType.stripSuffix("CreativeTemplateVariable"),
+              param.getLabel,
+              param.getIsRequired,
+              Option(param.getDescription)
+            )
+          },
+          snippet = template.getSnippet,
+          creatives = templateCreatives.map { creative =>
+            val args =
+              creative.getCreativeTemplateVariableValues.foldLeft(Map.empty[String, String]) {
+                case (soFar, arg) =>
+                  val argValue = arg.getBaseCreativeTemplateVariableValueType match {
+                    case "StringCreativeTemplateVariableValue" => Option(arg
+                      .asInstanceOf[StringCreativeTemplateVariableValue].getValue) getOrElse ""
+                    case "AssetCreativeTemplateVariableValue" => "https://tpc.googlesyndication" +
+                      ".com/pagead/imgad?id=CICAgKCT8L-fJRABGAEyCCXl5VJTW9F8"
+                    case "UrlCreativeTemplateVariableValue" => Option(arg
+                      .asInstanceOf[UrlCreativeTemplateVariableValue].getValue) getOrElse ""
+                    case other => "???"
+                  }
+                  soFar + (arg.getUniqueName -> argValue)
+              }
+            GuCreative(creative.getId.longValue(),
+              creative.getName,
+              toJodaTime(creative.getLastModifiedDateTime),
+              args)
+          }.sortBy(_.name)
+        )
+      }.sortBy(_.name)
     }
   }
 

--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -235,7 +235,7 @@ class DfpDataHydrator extends Logging {
       val creativesQuery = threshold.foldLeft(new StatementBuilder()) { (stmtBuilder,
                                                                          lastModified) =>
         stmtBuilder.where("lastModifiedDateTime > :lastModified")
-          .withBindVariableValue("lastModified", lastModified.getMillis)
+          .withBindVariableValue("lastModified", lastModified.toString)
       }
 
       val creatives = DfpApiWrapper.fetchTemplateCreatives(serviceRegistry, creativesQuery)

--- a/admin/app/tools/Store.scala
+++ b/admin/app/tools/Store.scala
@@ -54,6 +54,9 @@ trait Store extends Logging with Dates {
   def putCachedTravelOffersFeed(everything: String) {
     S3.putPublic(travelOffersS3Key, everything, "text/plain")
   }
+  def putCreativeTemplates(templates: String) {
+    S3.putPublic(dfpCreativeTemplatesKey, templates, defaultJsonEncoding)
+  }
 
   val now: String = DateTime.now().toHttpDateTimeString
 
@@ -76,6 +79,13 @@ trait Store extends Logging with Dates {
     case "top-below-nav" => S3.get(topBelowNavSlotTakeoversKey)
     case "top" => S3.get(topSlotTakeoversKey)
     case _ => None
+  }
+
+  def getDfpCreativeTemplates: Seq[GuCreativeTemplate] = {
+    val templates = for (doc <- S3.get(dfpCreativeTemplatesKey)) yield {
+      Json.parse(doc).as[Seq[GuCreativeTemplate]]
+    }
+    templates getOrElse Nil
   }
 
   object commercial {

--- a/admin/app/views/commercial/templates.scala.html
+++ b/admin/app/views/commercial/templates.scala.html
@@ -1,5 +1,4 @@
-@(env: String, templates: Seq[dfp.GuCreativeTemplate], trails: Seq[model.Content])(implicit request: RequestHeader)
-
+@(env: String, templates: Seq[dfp.GuCreativeTemplate])(implicit request: RequestHeader)
 @import tools.DfpLink
 
 @main(
@@ -14,8 +13,6 @@
                 <h1>Creative Templates</h1>
                 <p>This dashboard is to help debug DFP creative templates.<br />
                     All unarchived custom creative templates are shown.</p>
-                <p>The creatives listed under each template are only either creatives owned by the Guardian Merchandising account, or sponsors' logos of size 140x90.<br />
-                    So a template might appear to be unused when in fact other creatives have been built from it.</p>
             </div>
 
             <ul class="u-unstyled">
@@ -30,19 +27,17 @@
                                 <p><b>This template is not in use.</b></p>
                             }
                             @if(template.creatives.nonEmpty){
-                                <p>Creatives built from this template:
-                                    <ul>
-                                        @for(creative <- template.creatives){
-                                            <li>@{creative.name} (<a href="@DfpLink.creative(creative.id)">@{creative.id}</a>)</li>
-                                        }
-                                    </ul>
-                                </p>
+                                <p>Creatives built from this template:</p>
+                                <ul>
+                                    @for(creative <- template.creatives){
+                                        <li>@{creative.name} (<a href="@DfpLink.creative(creative.id)">@{creative.id}</a>)</li>
+                                    }
+                                </ul>
                             }
                         </div>
-                        <h3 class="facia-container__inner">Template</h3>
-                        @Html(template.snippet)
                         @for(example <- template.example) {
                             <h3 class="facia-container__inner">Example</h3>
+                            TODO
                             @Html(example)
                         }
                     </li>

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -258,6 +258,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val dfpLineItemsKey = s"$dfpRoot/lineitems-v3.json"
     lazy val dfpAdFeatureReportKey = s"$dfpRoot/all-ad-features-v3.json"
     lazy val dfpActiveAdUnitListKey = s"$dfpRoot/active-ad-units.csv"
+    lazy val dfpCreativeTemplatesKey = s"$dfpRoot/creative-templates.json"
     lazy val topAboveNavSlotTakeoversKey = s"$dfpRoot/top-above-nav-slot-takeovers.json"
     lazy val topBelowNavSlotTakeoversKey = s"$dfpRoot/top-below-nav-slot-takeovers.json"
     lazy val topSlotTakeoversKey = s"$dfpRoot/top-slot-takeovers.json"

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -558,6 +558,15 @@ object Switches {
     exposeClientSide = false
   )
 
+  val CreativeTemplatesInS3 = Switch(
+    "Commercial",
+    "creative-templates-in-S3",
+    "Stores DFP creative template data in S3.",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 9, 9),
+    exposeClientSide = false
+  )
+
 
   // Monitoring
 

--- a/common/test/common/dfp/GuCreativeTemplateTest.scala
+++ b/common/test/common/dfp/GuCreativeTemplateTest.scala
@@ -1,0 +1,33 @@
+package common.dfp
+
+import org.joda.time.DateTime.now
+import org.scalatest.{FlatSpec, Matchers}
+
+class GuCreativeTemplateTest extends FlatSpec with Matchers {
+
+  def creative(id: Long, name: String) = GuCreative(id, name, now.withTimeAtStartOfDay(), Map.empty)
+
+  def template(id: Long, creatives: Seq[GuCreative]) =
+    GuCreativeTemplate(id, "name", "description", Nil, "snippet", creatives)
+
+  "merge" should "remove an old template that's not in new list" in {
+    val oldTemplates = Seq(template(1, Nil))
+    val newTemplates = Nil
+    val merged = GuCreativeTemplate.merge(oldTemplates, newTemplates)
+    merged shouldBe Nil
+  }
+
+  it should "for any template, add old creatives to new creatives in correct order" in {
+    val oldTemplates = Seq(template(1, Seq(creative(1, "b"))))
+    val newTemplates = Seq(template(1, Seq(creative(2, "a"), creative(3, "c"))))
+    val merged = GuCreativeTemplate.merge(oldTemplates, newTemplates)
+    merged shouldBe Seq(template(1, Seq(creative(2, "a"), creative(1, "b"), creative(3, "c"))))
+  }
+
+  it should "for any template, dedup creatives" in {
+    val oldTemplates = Seq(template(1, Seq(creative(1, "a"))))
+    val newTemplates = Seq(template(1, Seq(creative(1, "b"))))
+    val merged = GuCreativeTemplate.merge(oldTemplates, newTemplates)
+    merged shouldBe Seq(template(1, Seq(creative(1, "b"))))
+  }
+}


### PR DESCRIPTION
/analytics/commercial/templates has been broken for a long time because it takes so long to fetch data from DFP.  

This change fixes that by caching creative templates in S3 and then reading them from there.

There's still a bit more to do in a separate PR to make the examples of each template work.
