### PR TITLE
Fix custom error messages on profile pages

### DIFF
--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -40,6 +40,10 @@ play {
     secret: ${APP_SECRET}
   }
 
+  il8n {
+    langs: "en"
+  }
+
   ws {
     compressionEnabled: true
   }

--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -30,16 +30,14 @@ akka {
   }
 }
 
+application.langs = "en"
+
 play {
 
   crypto {
     # The secret key is used to secure cryptographics functions.
     # If you deploy your application to several instances be sure to use the same key!
     secret: ${APP_SECRET}
-  }
-
-  il8n {
-    langs: "en"
   }
 
   ws {


### PR DESCRIPTION
The Play upgrade causes our custom error messages to no longer display. The Play docs have all the details for the migration https://www.playframework.com/documentation/2.4.x/Migration24 and it looks to me that @rich-nguyen did all the necessary changes. 

To get the custom messages back I've put us back to using the old configuration for `langs`. 

Before 
![screen shot 2015-08-07 at 12 57 38](https://cloud.githubusercontent.com/assets/944375/9135373/754a36be-3d04-11e5-87db-4df5f61f6ce6.png)
![screen shot 2015-08-07 at 13 01 08](https://cloud.githubusercontent.com/assets/944375/9135374/7fde12a8-3d04-11e5-9490-5ac8bd907a1a.png)

After
![screen shot 2015-08-07 at 13 00 42](https://cloud.githubusercontent.com/assets/944375/9135375/86f46cb8-3d04-11e5-8c80-ed81d192b69a.png)
![screen shot 2015-08-07 at 13 01 23](https://cloud.githubusercontent.com/assets/944375/9135379/97f9a10e-3d04-11e5-8429-0d6fdb99b165.png)

I've looked into why messages are rendering twice in some conditions (such as above) but am struggling to unpick this. So this requires more investigation which can be done separately to this PR.
