### PR TITLE
Reduce number of layers in the nav

### DIFF
--- a/common/app/views/fragments/nav/navigation.scala.html
+++ b/common/app/views/fragments/nav/navigation.scala.html
@@ -9,7 +9,8 @@
                     ("navigation--has-signposting", !Edition.isEditionFront),
                     ("navigation--has-local-navigation", Navigation.localLinks(navigation, metaData).nonEmpty)
                 ))">
-            <div class="navigation__inner gs-container">
+        <div class="gs-container">
+            <div class="navigation__inner">
                 <div class="navigation__scroll">
                     <nav class="navigation__container navigation__container--first" data-component="nav" role="navigation" aria-label="Current section">
                         @if(!Edition.isEditionFront){
@@ -37,5 +38,6 @@
                 }
             </div>
             <div id="all-sections-popup" class="navigation__expandable js-mega-nav-placeholder" data-component="all-nav"></div>
+        </div>
     </div>
 }

--- a/common/app/views/fragments/nav/navigation.scala.html
+++ b/common/app/views/fragments/nav/navigation.scala.html
@@ -9,8 +9,7 @@
                     ("navigation--has-signposting", !Edition.isEditionFront),
                     ("navigation--has-local-navigation", Navigation.localLinks(navigation, metaData).nonEmpty)
                 ))">
-        <div class="gs-container">
-            <div class="navigation__inner">
+            <div class="navigation__inner gs-container">
                 <div class="navigation__scroll">
                     <nav class="navigation__container navigation__container--first" data-component="nav" role="navigation" aria-label="Current section">
                         @if(!Edition.isEditionFront){
@@ -38,6 +37,5 @@
                 }
             </div>
             <div id="all-sections-popup" class="navigation__expandable js-mega-nav-placeholder" data-component="all-nav"></div>
-        </div>
     </div>
 }

--- a/common/app/views/fragments/nav/topNavigation.scala.html
+++ b/common/app/views/fragments/nav/topNavigation.scala.html
@@ -8,9 +8,7 @@
            class="top-navigation__action top-navigation__action--has-icon"
            data-link-name="nav : primary : home"
            title="Back to homepage">
-            <span class="top-navigation__icon-wrapper">
-                <span class="top-navigation__icon top-navigation__icon--home"></span>
-            </span>
+            <span class="top-navigation__icon top-navigation__icon--home"></span>
             <span class="u-h">home</span>
         </a>
     </li>

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -246,8 +246,8 @@ $c-navigation-expandable-background: colour(neutral-1);
 /* Actions and items
    ========================================================================== */
 @mixin navigation-items-shrink-spacing {
-    padding-right: $gs-gutter/4;
-    padding-left: $gs-gutter/4;
+    padding-right: $navigation-h-space-between-items/2;
+    padding-left: $navigation-h-space-between-items/2;
     &:first-child {
         padding-left: $navigation-h-space-between-items;
     }

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -158,7 +158,6 @@ $c-navigation-expandable-background: colour(neutral-1);
     }
 }
 .top-navigation {
-    position: relative;
     background: $c-top-header-background;
 }
 .navigation__container--first {
@@ -187,7 +186,6 @@ $c-navigation-expandable-background: colour(neutral-1);
    ========================================================================== */
 
 .signposting {
-    position: relative;
     background: $c-signposting-background;
     border-right: 1px solid $c-global-navigation-border;
     box-sizing: border-box;
@@ -226,8 +224,6 @@ $c-navigation-expandable-background: colour(neutral-1);
 .signposting__item {
     white-space: nowrap;
     display: table-cell;
-    position: relative;
-    padding-left: $navigation-h-space-between-items/2;
 }
 .signposting__action {
     color: $c-signposting-action;
@@ -244,12 +240,18 @@ $c-navigation-expandable-background: colour(neutral-1);
     color: $c-signposting-action;
     font-size: 27px;
     line-height: $navigation-height;
-    padding-right: $navigation-h-space-between-items/2;
 }
 
 
 /* Actions and items
    ========================================================================== */
+@mixin navigation-items-shrink-spacing {
+    padding-right: $gs-gutter/4;
+    padding-left: $gs-gutter/4;
+    &:first-child {
+        padding-left: $navigation-h-space-between-items/2;
+    }
+}
 
 .local-navigation {
     background: $c-local-navigation-background;
@@ -259,15 +261,17 @@ $c-navigation-expandable-background: colour(neutral-1);
 .local-navigation__action,
 .top-navigation__action,
 .global-navigation__action {
-    position: relative;
+    padding-left: $gs-gutter/2;
+    padding-right: $gs-gutter/2;
+    height: 100%;
 
-    &:after {
-        content: '';
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        right: -$gs-gutter/4;
-        left: -$gs-gutter/4;
+    @include mq(navigationBreakOnTwoLevels, navigationBreakOnTwoLevelsWithWideToggle) {
+        @include navigation-items-shrink-spacing;
+    }
+    @include mq(wide) {
+        .has-page-skin & {
+            @include navigation-items-shrink-spacing;
+        }
     }
 }
 .local-navigation__action,
@@ -292,29 +296,9 @@ $c-navigation-expandable-background: colour(neutral-1);
 .top-navigation__item--current {
     margin-right: $gs-gutter/2;
 }
-
-@mixin navigation-items-shrink-spacing {
-    padding-right: $navigation-h-space-between-items/2 - 3;
-    padding-left: $navigation-h-space-between-items/2 - 3;
-    &:first-child {
-        padding-left: $navigation-h-space-between-items/2;
-    }
-}
 .local-navigation__item,
 .top-navigation__item {
     display: table-cell;
-    position: relative;
-    padding-right: $navigation-h-space-between-items/2;
-    padding-left: $navigation-h-space-between-items/2;
-
-    @include mq(navigationBreakOnTwoLevels, navigationBreakOnTwoLevelsWithWideToggle) {
-        @include navigation-items-shrink-spacing;
-    }
-    @include mq(wide) {
-        .has-page-skin & {
-            @include navigation-items-shrink-spacing;
-        }
-    }
 }
 .navigation-container--collapsed .navigation--has-signposting {
     .local-navigation,
@@ -345,11 +329,6 @@ $c-navigation-expandable-background: colour(neutral-1);
         display: table-cell;
     }
 }
-.top-navigation__icon-wrapper {
-    position: relative;
-    display: inline-block;
-    top: 3px;
-}
 .top-navigation__icon {
     display: inline-block;
     background-repeat: no-repeat;
@@ -359,6 +338,7 @@ $c-navigation-expandable-background: colour(neutral-1);
     width: 15px;
     height: 18px;
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAASCAQAAAAul0yEAAAAO0lEQVQoz9XPsQ0AIAwDwYzuzZ8iQjIQUiLh9r5xhA0BinqInDqsggX34EAPSpzBFTOg3Su2o3+wGtYAGI94niPCbrMAAAAASUVORK5CYII=');
+    margin-bottom: -3px;
 
     @media (-webkit-min-device-pixel-ratio: 1.3),
            (min-resolution: 124.8dpi),
@@ -519,6 +499,7 @@ $c-navigation-expandable-background: colour(neutral-1);
         @include mq($until: navigationBreakOnTwoLevels) {
             overflow-x: scroll;
             white-space: nowrap;
+            backface-visibility: hidden;
         }
 
         &::-webkit-scrollbar {
@@ -836,7 +817,7 @@ $c-navigation-expandable-background: colour(neutral-1);
 
     .burger-icon {
         margin-top: $gs-baseline * 1.5;
-        
+
         @include mq($until: mobileLandscape) {
             margin: $gs-baseline * 1.5 0 0;
         }

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -37,7 +37,7 @@ $c-navigation-toggle-background: colour(neutral-1);
 $c-navigation-toggle-icon: #ffffff;
 $c-navigation-toggle-shadow: rgba(#000000, .333333);
 
-$navigation-h-space-between-items: $gs-gutter;
+$navigation-h-space-between-items: $gs-gutter/2;
 
 $c-navigation-expandable-background: colour(neutral-1);
 
@@ -192,7 +192,7 @@ $c-navigation-expandable-background: colour(neutral-1);
     padding-right: $navigation-h-space-between-items;
 
     @include mq(mobileLandscape) {
-        padding-left: $navigation-h-space-between-items/2;
+        padding-left: $navigation-h-space-between-items;
     }
 
     .navigation-container--expanded .navigation--has-local-navigation & {
@@ -249,7 +249,7 @@ $c-navigation-expandable-background: colour(neutral-1);
     padding-right: $gs-gutter/4;
     padding-left: $gs-gutter/4;
     &:first-child {
-        padding-left: $navigation-h-space-between-items/2;
+        padding-left: $navigation-h-space-between-items;
     }
 }
 
@@ -261,8 +261,8 @@ $c-navigation-expandable-background: colour(neutral-1);
 .local-navigation__action,
 .top-navigation__action,
 .global-navigation__action {
-    padding-left: $gs-gutter/2;
-    padding-right: $gs-gutter/2;
+    padding-left: $navigation-h-space-between-items;
+    padding-right: $navigation-h-space-between-items;
     height: 100%;
 
     @include mq(navigationBreakOnTwoLevels, navigationBreakOnTwoLevelsWithWideToggle) {
@@ -294,7 +294,7 @@ $c-navigation-expandable-background: colour(neutral-1);
     white-space: nowrap;
 }
 .top-navigation__item--current {
-    margin-right: $gs-gutter/2;
+    margin-right: $navigation-h-space-between-items;
 }
 .local-navigation__item,
 .top-navigation__item {
@@ -303,14 +303,14 @@ $c-navigation-expandable-background: colour(neutral-1);
 .navigation-container--collapsed .navigation--has-signposting {
     .local-navigation,
     .top-navigation {
-        padding-left: $navigation-h-space-between-items/2;
+        padding-left: $navigation-h-space-between-items;
     }
 }
 @include mq(mobileLandscape) {
     .navigation-container--collapsed {
         .local-navigation,
         .top-navigation {
-            padding-left: $navigation-h-space-between-items/2;
+            padding-left: $navigation-h-space-between-items;
         }
     }
 }
@@ -394,8 +394,8 @@ $c-navigation-expandable-background: colour(neutral-1);
     @include mq($until: tablet) {
         line-height: $gs-baseline*2;
         padding-bottom: $gs-baseline;
-        padding-left: $gs-gutter/2;
-        padding-right: $gs-gutter/2;
+        padding-left: $navigation-h-space-between-items;
+        padding-right: $navigation-h-space-between-items;
     }
     @include mq(mobileLandscape, tablet) {
         padding-left: $gs-gutter;
@@ -429,10 +429,10 @@ $c-navigation-expandable-background: colour(neutral-1);
     overflow: hidden;
 
     @include mq($until: tablet) {
-        margin-left: -$gs-gutter/2;
-        margin-right: -$gs-gutter/2;
-        padding-left: $gs-gutter/2;
-        padding-right: $gs-gutter/2;
+        margin-left: -$navigation-h-space-between-items;
+        margin-right: -$navigation-h-space-between-items;
+        padding-left: $navigation-h-space-between-items;
+        padding-right: $navigation-h-space-between-items;
         padding-bottom: $gs-baseline*.75;
         font-size: 14px;
         line-height: 2;
@@ -443,7 +443,7 @@ $c-navigation-expandable-background: colour(neutral-1);
     }
     @include mq(tablet) {
         padding-bottom: $gs-baseline/4;
-        padding-left: $gs-gutter/2;
+        padding-left: $navigation-h-space-between-items;
     }
 
     &.global-navigation__children--history {
@@ -477,8 +477,6 @@ $c-navigation-expandable-background: colour(neutral-1);
     .global-navigation__action {
         float: left;
         line-height: $navigation-height - $gs-baseline/2;
-        margin-left: $navigation-h-space-between-items/2;
-        margin-right: $navigation-h-space-between-items/2;
         white-space: nowrap;
     }
 }
@@ -556,8 +554,8 @@ $c-navigation-expandable-background: colour(neutral-1);
         background: $c-local-navigation-background;
 
         @include mq(mobileLandscape) {
-            padding-left: $gs-gutter/2;
-            padding-right: $gs-gutter/2;
+            padding-left: $navigation-h-space-between-items;
+            padding-right: $navigation-h-space-between-items;
         }
     }
     .local-navigation__item {
@@ -586,8 +584,6 @@ $c-navigation-expandable-background: colour(neutral-1);
         width: 50%;
         padding-right: 0;
         box-sizing: border-box;
-        padding-left: $gs-gutter/2;
-        padding-right: $gs-gutter/2;
 
         &:nth-child(2n+1) {
             clear: both;

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -497,7 +497,6 @@ $c-navigation-expandable-background: colour(neutral-1);
         @include mq($until: navigationBreakOnTwoLevels) {
             overflow-x: scroll;
             white-space: nowrap;
-            backface-visibility: hidden;
         }
 
         &::-webkit-scrollbar {


### PR DESCRIPTION
At tablet and below, a combination of `overflow: scroll` and `position` (for the weird `:after` elements on links – anyone know why they were done like that?) forced almost all elements in the nav into their own layer. This undoes that.
## before

<img width="546" alt="screen shot 2015-08-07 at 15 09 07" src="https://cloud.githubusercontent.com/assets/867233/9137734/acbc3242-3d17-11e5-8556-a8dee521a51f.png">
<img width="782" alt="screen shot 2015-08-07 at 15 07 57" src="https://cloud.githubusercontent.com/assets/867233/9137735/acdacfea-3d17-11e5-85bb-532e37720a06.png">
<img width="842" alt="screen shot 2015-08-07 at 15 07 25" src="https://cloud.githubusercontent.com/assets/867233/9137736/acdd57f6-3d17-11e5-94cc-002ef0da5373.png">

<img width="485" alt="screen shot 2015-08-07 at 15 28 34" src="https://cloud.githubusercontent.com/assets/867233/9137957/0be4c378-3d19-11e5-8ecd-503e02e72f33.png">
## now

<img width="554" alt="screen shot 2015-08-07 at 15 09 13" src="https://cloud.githubusercontent.com/assets/867233/9137747/b73ac8f0-3d17-11e5-8be3-b6b0709e883a.png">
<img width="781" alt="screen shot 2015-08-07 at 15 08 14" src="https://cloud.githubusercontent.com/assets/867233/9137748/b75c06fa-3d17-11e5-87df-0e0cd511ccd8.png">
<img width="805" alt="screen shot 2015-08-07 at 15 07 31" src="https://cloud.githubusercontent.com/assets/867233/9137749/b75cf0ba-3d17-11e5-934f-d152950951fd.png">
<img width="475" alt="screen shot 2015-08-07 at 15 28 03" src="https://cloud.githubusercontent.com/assets/867233/9137970/22c84cc2-3d19-11e5-9636-d48611bf3ee5.png">
## testing

confirm across all browsers:
- [x] no visible changes to nav, compared to prod
- [x] 'click/touchability' of items in the nav is no different to prod

/cc @johnduffell 
/fyi @robertberry 
