### PR TITLE
Add exemptions for crosswords opt-out banner

### DIFF
--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -16,8 +16,10 @@
 
 <div class="l-side-margins">
 
-    @if(index.page.id.contains("crosswords")) {
-        @fragments.crosswordsOptOutBanner()
+    @if(!(index.page.id.endsWith("crosswords/series/crossword-editor-update") || index.page.id.endsWith("crosswords/crossword-blog"))) {
+        @if(index.page.id.contains("crosswords")) {
+            @fragments.crosswordsOptOutBanner()
+        }
     }
 
     <div class="@RenderClasses(Map(


### PR DESCRIPTION
We don't want to show the crosswords opt-out banner on the crosswords blog or the editor updates.

This removes the banner from these paths in `applications`.
