### PR TITLE
Fix all sections nav in the footer for non-JS browsers

### DIFF
--- a/common/app/views/fragments/nav/navigationFooter.scala.html
+++ b/common/app/views/fragments/nav/navigationFooter.scala.html
@@ -4,7 +4,7 @@
 @import views.support.RenderClasses
 
 @defining(Edition(request).navigation) { navigation =>
-    <div class="js-navigation-footer navigation-container navigation-container--collapsed">
+    <div class="js-navigation-footer navigation-container navigation-container--default">
         <div class="gs-container navigation">
             <div class="navigation__inner" aria-hidden="true">
                 <div class="navigation__scroll">

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -15,6 +15,7 @@ define([
 ) {
     var Navigation = {
         init: function () {
+            this.jsEnableFooterNav();
             this.copyMegaNavMenu();
             this.enableMegaNavToggle();
             this.replaceAllSectionsLink();
@@ -25,6 +26,10 @@ define([
                     $('.navigation__scroll').css({'-webkit-overflow-scrolling': 'touch'});
                 });
             }
+        },
+
+        jsEnableFooterNav: function() {
+            $('.navigation-container--default').removeClass('navigation-container--default').addClass('navigation-container--collapsed');
         },
 
         copyMegaNavMenu: function () {

--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -28,7 +28,7 @@ define([
             }
         },
 
-        jsEnableFooterNav: function() {
+        jsEnableFooterNav: function () {
             $('.navigation-container--default').removeClass('navigation-container--default').addClass('navigation-container--collapsed');
         },
 

--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -558,9 +558,10 @@ $c-navigation-expandable-background: colour(neutral-1);
 }
 
 
-/* State: expanded
+/* State: default (nojs) / expanded
    ========================================================================== */
 
+.navigation-container--default,
 .navigation-container--expanded {
     .navigation {
         z-index: 2;
@@ -785,9 +786,11 @@ $c-navigation-expandable-background: colour(neutral-1);
     }
 }
 .navigation-toggle-label--close,
+.navigation-container--default .navigation-toggle-label--open,
 .navigation-container--expanded .navigation-toggle-label--open {
     display: none;
 }
+
 .navigation-container--expanded .navigation-toggle-label--close {
     display: inline;
 }
@@ -836,7 +839,7 @@ $c-navigation-expandable-background: colour(neutral-1);
 
     .burger-icon {
         margin-top: $gs-baseline * 1.5;
-        
+
         @include mq($until: mobileLandscape) {
             margin: $gs-baseline * 1.5 0 0;
         }


### PR DESCRIPTION
When a non-JS browser visits us, the footer of the page should display the fully-expanded all sections navigation menu, and the menu button at the top of the page should reposition the reader on to the lower section when clicked.

If a JS-enabled browser visits, the all sections menus (at the head and foot of the page) should collapse and expand in response to user interactions.

This PR sets an initial default class for the footer nav section which is replaced with the collapsed class by javascript (which will only ever work if JS is enabled, obvs).

Without JS:
<img width="300" alt="screen shot 2015-08-07 at 17 16 11" src="https://cloud.githubusercontent.com/assets/690395/9140623/85c28f70-3d2a-11e5-8c41-2364b2ed9a2b.png">

With JS:
<img width="302" alt="screen shot 2015-08-07 at 17 16 49" src="https://cloud.githubusercontent.com/assets/690395/9140629/8fd2296c-3d2a-11e5-9eb7-42415ab4bb76.png">
