### PR TITLE
If a contributor does not have a profile picture still show their name in the live blog block.

### DIFF
--- a/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
+++ b/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
@@ -1,8 +1,9 @@
 @(profileTag: Tag)(implicit request: RequestHeader)
-
-@profileTag.contributorImagePath.map{ src =>
     <div class="liveblog-block-byline">
+    @profileTag.contributorImagePath.map{ src =>
         <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
-        <p class="liveblog-block-byline__name">@profileTag.name</p>
-    </div>
-}
+    }
+    <p class="liveblog-block-byline__name">@profileTag.name</p>
+</div>
+
+


### PR DESCRIPTION
For live blogs that have multiple contributors only contributor tags include a profile picture are displaying at the top of their live blog block. e.g:
<img width="782" alt="screen shot 2015-08-07 at 17 54 02" src="https://cloud.githubusercontent.com/assets/944375/9141029/6cd97796-3d2d-11e5-8037-c7f9efbb00ec.png">

A request has come in that contributors that do not have profile picture also show:
<img width="797" alt="screen shot 2015-08-07 at 17 53 50" src="https://cloud.githubusercontent.com/assets/944375/9141053/9ee94270-3d2d-11e5-8246-cf28331e5f0d.png">
