### PR TITLE
Fix crosswords links print pdf

### DIFF
--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -75,6 +75,10 @@
 }
 
 .crossword__links {
+    @include mq(leftCol) {
+        top: $gs-baseline * -3;
+    }
+
     position: relative;
     top: $gs-baseline * -2;
     font-family: $f-sans-serif-text;

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -76,7 +76,7 @@
 
 .crossword__links {
     position: relative;
-    top: $gs-baseline * -3;
+    top: $gs-baseline * -2;
     font-family: $f-sans-serif-text;
     font-size: 15px;
 }


### PR DESCRIPTION
On smaller breakpoints, it seems too close to the text above.

![before](https://cloud.githubusercontent.com/assets/445472/9169999/fcf636a4-3f56-11e5-8321-806c078b3fe5.png)
![after](https://cloud.githubusercontent.com/assets/445472/9170000/fcf91b6c-3f56-11e5-9e9e-1cc92430e4ab.png)

@desbo  
