### PR TITLE
Add a jspm disabled switch to check buckets

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -788,7 +788,7 @@ object Switches {
     sellByDate = never,
     exposeClientSide = false
   )
-  
+
   val EnhanceTweetsSwitch = Switch(
     "Feature",
     "enhance-tweets",
@@ -1150,6 +1150,16 @@ object Switches {
       exposeClientSide = false
     )
   }
+
+  // Server-side variant validation test
+  val JspmValidation = Switch(
+    "Feature",
+    "disable-jspm",
+    "A test switch that can be turned on to disable the JspmTest for bucketing validation",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 8, 15),
+    exposeClientSide = false
+  )
 
   def all: Seq[SwitchTrait] = Switch.allSwitches
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -22,7 +22,15 @@ object JspmTest extends TestDefinition(
   "jspm-test",
   "Tests our new JSPM jsavscript configuration",
   new LocalDate(2015, 9, 30)
-)
+) {
+  override def isParticipating(implicit request: RequestHeader): Boolean = {
+    if (conf.Switches.JspmValidation.isSwitchedOff) {
+      super.isParticipating(request)
+    } else {
+      false
+    }
+  }
+}
 
 object JspmControlTest extends TestDefinition(
   List(Variant7),


### PR DESCRIPTION
A sanity-test switch for jspm. Are the buckets the correct size?
