### PR TITLE
Add media icon to merchandising component items

### DIFF
--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -44,7 +44,10 @@
                                             @fragments.items.elements.facia_cards.image(trailPictureContainer, true)
                                         }
                                         <div class="fc-item__content">
-                                            <h2 class="fc-item__header">@item.webTitle</h2>
+                                            <h2 class="fc-item__title">
+                                                @insertItemMediaIcon(item)
+                                                @item.webTitle
+                                            </h2>
                                             <div class="fc-item__meta">
                                                 <time
                                                     class="fc-item__timestamp js-item__timestamp"
@@ -70,4 +73,13 @@
             </div>
         </div>
     </section>
+}
+
+@insertItemMediaIcon(item : model.Content) = @{
+    item match {
+        case _: Video => fragments.inlineSvg("video-icon", "icon")
+        case _: Audio => fragments.inlineSvg("volume-high ", "icon")
+        case _: Gallery => fragments.inlineSvg("camera", "icon")
+        case _ => ""
+    }
 }

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -33,8 +33,8 @@
     }
 
     &.commercial-dfp-multi {
-        .fc-item__header {
-            @include fs-bodyHeading(2, $size-only: true);
+        .fc-item__title {
+            padding-top: 0;
         }
     }
 }


### PR DESCRIPTION
This is a fix for the merchandising component. Currently, items with media don't have the appropriate media icons. For example, these tiles should have video icons:

![image](https://cloud.githubusercontent.com/assets/3148617/9175700/0b05e7e4-3f7f-11e5-8d83-792a9df21f93.png)

_(Taken from http://www.theguardian.com/travel/2015/aug/03/best-of-ghent-belgium-readers-travel-tips)_

This pull request fixes the issue, so that video, gallery and audio icons appear where necessary:

![image](https://cloud.githubusercontent.com/assets/3148617/9175757/4a71f724-3f7f-11e5-84f4-54d10d1a2144.png)
# Changes
- items.scala.html now inlines an SVG based on the media type
- the icon is displayed inside an fc-item_title rather than an fc-item__header - styles for icons in a title already exist, and the only difference for our purposes seems to be that the former has some padding to remove. This is eliminated in _capi.scss
# Queries
- we also inline an icon in title.scala.html by similar means - is this something worth extracting into a common util?
- would it be worth extracting the body of the item in the items list into its own partial (so that the wrapper and the wrapped instances are in two separate files)? What should such a file be called? Is there a convention for such things already?
