### PR TITLE
fix breakpoint for crossword social meta

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -680,7 +680,7 @@
     box-sizing: border-box;
 
     .meta__extras--crossword & {
-        @include mq($from: desktop) {
+        @include mq(leftCol) {
             float: left;
         }
     }


### PR DESCRIPTION
previously `float: left` was applied too early, causing the comment count to overlap the clues.
@NathanielBennett 
