### PR TITLE
add confirm button component to crosswords

### DIFF
--- a/static/src/javascripts/es6/projects/common/modules/crosswords/confirm-button.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/confirm-button.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export default class ConfirmButton extends React.Component {
+    constructor (props) {
+        super(props);
+        this.timeout = this.props.timeout || 2000;
+        this.state = { confirming: false };
+    }
+
+    confirm () {
+        if (this.state.confirming) {
+            this.setState({ confirming: false });
+            this.props.onClick();
+        } else {
+            this.setState({ confirming: true });
+            React.findDOMNode(this).blur();
+            setTimeout(() => this.setState({ confirming: false }), this.timeout);
+        }
+    }
+
+    render () {
+        const inner = this.state.confirming ?
+            'Confirm ' + this.props.text.toLowerCase() : this.props.text;
+
+        return (
+            <button {...this.props} onClick={this.confirm.bind(this)}>
+                {inner}
+            </button>
+        );
+    }
+}

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/confirm-button.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/confirm-button.js
@@ -13,7 +13,6 @@ export default class ConfirmButton extends React.Component {
             this.props.onClick();
         } else {
             this.setState({ confirming: true });
-            React.findDOMNode(this).blur();
             setTimeout(() => this.setState({ confirming: false }), this.timeout);
         }
     }

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/controls.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/controls.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import ConfirmButton from './confirm-button';
+
 const buttonClassName = 'button button--small';
 const buttonCurrentClassName = 'button--crossword--current';
 const buttonGenericClassName = 'button--secondary';
@@ -15,27 +17,27 @@ export default class Controls extends React.Component {
 
         // GRID CONTROLS
         controls.grid.unshift(
-            <button className={`${buttonClassName} ${buttonGenericClassName}`}
+            <ConfirmButton className={`${buttonClassName} ${buttonGenericClassName}`}
                 onClick={this.props.onClearAll}
-                key='clear'>
-                Clear all
-            </button>
+                key='clear'
+                text='Clear all'>
+            </ConfirmButton>
         );
 
         if (hasSolutions) {
             controls.grid.unshift(
-                <button className={`${buttonClassName} ${buttonGenericClassName}`}
+                <ConfirmButton className={`${buttonClassName} ${buttonGenericClassName}`}
                     onClick={this.props.onSolution}
-                    key='solution'>
-                    Reveal all
-                </button>
+                    key='solution'
+                    text='Reveal all'>
+                </ConfirmButton>
             );
             controls.grid.unshift(
-                <button className={`${buttonClassName} ${buttonGenericClassName}`}
+                <ConfirmButton className={`${buttonClassName} ${buttonGenericClassName}`}
                     onClick={this.props.onCheckAll}
-                    key='checkAll'>
-                    Check all
-                </button>
+                    key='checkAll'
+                    text='Check all'>
+                </ConfirmButton>
             );
         }
 


### PR DESCRIPTION
We had a few complaints from people accidentally clicking the clear and reveal all buttons. This adds a simple `ConfirmButton` component that requires you to click a button twice to carry out its `onClick` function. 

Fixes #10088. 

![170e1d04ecdf7bea3c054feb876c6cf4](https://cloud.githubusercontent.com/assets/1064734/9199587/2e323e9a-403b-11e5-8088-298f3a4ca304.gif)
