### PR TITLE
Use a non constrained form for rendering to prevent the bind from flash revalidating the form

### DIFF
--- a/identity/app/controllers/ChangePasswordController.scala
+++ b/identity/app/controllers/ChangePasswordController.scala
@@ -5,7 +5,7 @@ import com.google.inject.Inject
 import javax.inject.Singleton
 import model.{NoCache, IdentityPage}
 import play.api.mvc._
-import play.api.data.Form
+import play.api.data.{Forms, Form}
 import play.api.data.Forms._
 import services._
 import utils.SafeLogging
@@ -31,6 +31,14 @@ class ChangePasswordController @Inject()( api: IdApiClient,
   val page = IdentityPage("/password/change", "Change Password", "change-password")
 
   val passwordForm = Form(
+    mapping(
+      ("oldPassword", optional(Forms.text)),
+      ("newPassword1", Forms.text),
+      ("newPassword2", Forms.text)
+    )(PasswordFormData.apply)(PasswordFormData.unapply)
+  )
+
+  val passwordFormWithConstraints = Form(
     mapping(
       ("oldPassword", optional(idPassword)),
       ("newPassword1", idPassword),
@@ -69,7 +77,7 @@ class ChangePasswordController @Inject()( api: IdApiClient,
     authAction.async {
       implicit request =>
         val idRequest = idRequestParser(request)
-        val boundForm = passwordForm.bindFromRequest()
+        val boundForm = passwordFormWithConstraints.bindFromRequest()
         val futureFormOpt = boundForm.value map {
           data =>
             val update = PasswordUpdate(data.oldPassword, data.newPassword1)

--- a/identity/app/controllers/ReauthenticationController.scala
+++ b/identity/app/controllers/ReauthenticationController.scala
@@ -32,6 +32,12 @@ class ReauthenticationController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
   val form = Form(
     Forms.single(
       "password" -> Forms.text
+    )
+  )
+
+  val formWithConstraints = Form(
+    Forms.single(
+      "password" -> Forms.text
         .verifying(Constraints.nonEmpty)
     )
   )
@@ -46,7 +52,7 @@ class ReauthenticationController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
 
   def processForm = authenticatedActions.authActionWithUser.async { implicit request =>
     val idRequest = idRequestParser(request)
-    val boundForm = form.bindFromRequest
+    val boundForm = formWithConstraints.bindFromRequest
     val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
 
     def onError(formWithErrors: Form[String]): Future[Result] = {

--- a/identity/app/controllers/RegistrationController.scala
+++ b/identity/app/controllers/RegistrationController.scala
@@ -33,6 +33,18 @@ class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
 
   val registrationForm = Form(
     Forms.tuple(
+      "user.firstName" -> Forms.text,
+      "user.secondName" -> Forms.text,
+      emailKey -> Forms.text,
+      "user.publicFields.username" -> Forms.text,
+      passwordKey -> Forms.text,
+      "receive_gnm_marketing" -> Forms.boolean,
+      "receive_third_party_marketing" -> Forms.boolean
+    )
+  )
+
+  val registrationFormWithConstraints = Form(
+    Forms.tuple(
       "user.firstName" -> idFirstName,
       "user.secondName" -> idSecondName,
       emailKey -> idRegEmail,
@@ -60,7 +72,7 @@ class RegistrationController @Inject()( returnUrlVerifier : ReturnUrlVerifier,
   }
 
   def processForm = Action.async { implicit request =>
-    val boundForm = registrationForm.bindFromRequest
+    val boundForm = registrationFormWithConstraints.bindFromRequest
     val idRequest = idRequestParser(request, boundForm.data.getOrElse(emailKey,"unable to extract email from form data" ))
     val trackingData = idRequest.trackingData
     val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)

--- a/identity/app/controllers/ResetPasswordController.scala
+++ b/identity/app/controllers/ResetPasswordController.scala
@@ -28,11 +28,25 @@ class ResetPasswordController @Inject()(  api : IdApiClient,
 
   val requestPasswordResetForm = Form(
     Forms.single(
+      "email-address" -> Forms.text
+    )
+  )
+
+  val requestPasswordResetFormWithConstraints = Form(
+    Forms.single(
       "email-address" -> of[String].verifying(Constraints.nonEmpty)
     )
   )
 
   val passwordResetForm = Form(
+    Forms.tuple (
+      "password" -> Forms.text,
+      "password-confirm" ->  Forms.text,
+      "email-address" -> Forms.text
+    )
+  )
+
+  val passwordResetFormWithConstraints = Form(
     Forms.tuple (
       "password" ->  idPassword
         .verifying(Constraints.nonEmpty),
@@ -64,7 +78,7 @@ class ResetPasswordController @Inject()(  api : IdApiClient,
 
   def processPasswordResetRequestForm = Action.async { implicit request =>
     val idRequest = idRequestParser(request)
-    val boundForm = requestPasswordResetForm.bindFromRequest
+    val boundForm = requestPasswordResetFormWithConstraints.bindFromRequest
 
     def onError(formWithErrors: Form[(String)]): Future[Result] = {
       logger.info("bad password reset request form submission")
@@ -100,7 +114,7 @@ class ResetPasswordController @Inject()(  api : IdApiClient,
   }
 
   def resetPassword(token : String) = Action.async { implicit request =>
-    val boundForm = passwordResetForm.bindFromFlash.getOrElse(passwordResetForm.bindFromRequest)
+    val boundForm = passwordResetFormWithConstraints.bindFromRequest
 
     def onError(formWithErrors: Form[(String, String, String)]): Future[Result] = {
       logger.info("form errors in reset password attempt")

--- a/identity/app/controllers/SigninController.scala
+++ b/identity/app/controllers/SigninController.scala
@@ -29,6 +29,14 @@ class SigninController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
 
   val form = Form(
     Forms.tuple(
+      "email" -> Forms.text,
+      "password" -> Forms.text,
+      "keepMeSignedIn" -> Forms.boolean
+    )
+  )
+
+  val formWithConstraints = Form(
+    Forms.tuple(
       "email" -> idEmail
         .verifying(Constraints.nonEmpty),
       "password" -> Forms.text
@@ -48,7 +56,7 @@ class SigninController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
 
   def processForm = Action.async { implicit request =>
     val idRequest = idRequestParser(request)
-    val boundForm = form.bindFromRequest
+    val boundForm = formWithConstraints.bindFromRequest
     val verifiedReturnUrlAsOpt = returnUrlVerifier.getVerifiedReturnUrl(request)
 
     def onError(formWithErrors: Form[(String, String, Boolean)]): Future[Result] = {

--- a/identity/app/form/Mappings.scala
+++ b/identity/app/form/Mappings.scala
@@ -42,7 +42,7 @@ trait Mappings extends I18nSupport {
 
   val idSecondName: Mapping[String] = nonEmptyText(maxLength = 50)
 
-  val idPassword: Mapping[String] = of[String] verifying(
+  val idPassword: Mapping[String] = text verifying(
     Messages("error.passwordLength"), {value => 6 <= value.length && value.length <= 20}
   )
 


### PR DESCRIPTION
On all forms on profile.gu.com validation messages are displayed twice. The validation messages are first added to the form when it is bound from the request when submitted. Following this, the form with errors is added as a flash to a redirect which re-renders the form. When the action for rendering the form is invoked, the form is bound from the flash. This adds the errors from the form in the flash scope to the form, but it also revalidates it, thus adding all the error messages for a second time. 

This PR removes the constraints from the form object used for rendering, preventing any secondary validation from taking place and preserving the error messages added to the form during submission.

![image](https://cloud.githubusercontent.com/assets/1684649/9218991/66d680aa-40cf-11e5-9208-53d9d99e5f29.png)
