### PR TITLE
make apple devices use the native itunes banner

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -76,7 +76,7 @@ trait MetaData extends Tags {
     "fb:app_id"    -> Configuration.facebook.appId,
     "og:type"      -> "website",
     "og:url"       -> webUrl,
-    "al:ios:url" -> s"gnmguardian://${iosId("applinks")}",
+    "al:ios:url" -> s"gnmguardian://${id + iosSuffix("applinks")}",
     "al:ios:app_store_id" -> "409128287",
     "al:ios:app_name" -> "The Guardian"
   )
@@ -87,12 +87,13 @@ trait MetaData extends Tags {
     "twitter:site" -> "@guardian",
     "twitter:app:name:iphone" -> "The Guardian",
     "twitter:app:id:iphone" -> "409128287",
-    "twitter:app:url:iphone" -> s"gnmguardian://${iosId("twitter")}",
+    "twitter:app:url:iphone" -> s"gnmguardian://${id + iosSuffix("twitter")}",
     "twitter:app:name:ipad" -> "The Guardian",
     "twitter:app:id:ipad" -> "409128287",
-    "twitter:app:url:ipad" -> s"gnmguardian://${iosId("twitter")}",
+    "twitter:app:url:ipad" -> s"gnmguardian://${id + iosSuffix("twitter")}",
     "twitter:app:name:googleplay" -> "The Guardian",
-    "twitter:app:id:googleplay" -> "com.guardian"
+    "twitter:app:id:googleplay" -> "com.guardian",
+    "apple-itunes-app" -> s"app-id=409128287, app-argument=${webUrl + iosSuffix("apple")}"
   )
 
   def linkedData: List[LinkedData] = List(
@@ -100,7 +101,7 @@ trait MetaData extends Tags {
     WebPage(webUrl, PotentialAction(target = "android-app://com.guardian/" + webUrl.replace("://", "/")))
   )
 
-  def iosId(referrer: String): String = s"$id?contenttype=$iosType&source=$referrer"
+  def iosSuffix(referrer: String): String = s"?contenttype=$iosType&source=$referrer"
 
   // this could be article/front/list, it's a hint to the ios app to start the right engine
   def iosType: String = "article"

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -118,4 +118,4 @@
     </script>
 }
 
-<link rel="alternate" href="ios-app://409128287/gnmguardian/@{item.iosId("google")}" />
+<link rel="alternate" href="ios-app://409128287/gnmguardian/@{item.id + item.iosSuffix("google")}" />

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -2,17 +2,11 @@ define([
     'common/utils/$',
     'common/utils/cookies',
     'common/utils/detect',
-    'common/utils/storage',
-    'common/utils/template',
-    'common/modules/user-prefs',
     'common/modules/ui/message'
 ], function (
     $,
     cookies,
     detect,
-    storage,
-    template,
-    userPrefs,
     Message
 ) {
     /**
@@ -23,29 +17,18 @@ define([
      * Persist close state
      */
     var COOKIE_IMPRESSION_KEY = 'GU_SMARTAPPBANNER',
-        DATA = {
-            IOS: {
-                LOGO: 'http://assets.guim.co.uk/images/apps/ios-logo.png',
-                SCREENSHOTS: 'http://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
-                LINK: 'http://ad-x.co.uk/API/click/guardian789057jo/web3537df56ab1f7e',
-                STORE: 'on the App Store'
-            },
-            ANDROID: {
-                LOGO: 'http://assets.guim.co.uk/images/apps/android-logo-2x.png',
-                SCREENSHOTS: 'http://assets.guim.co.uk/images/apps/ios-screenshots.jpg',
-                LINK: 'https://app.adjust.com/642i3r?deep_link=x-gu://www.theguardian.com/?source=adjust',
-                STORE: 'in Google Play'
-            }
-        },
         cookieVal = cookies.get(COOKIE_IMPRESSION_KEY),
         impressions = cookieVal && !isNaN(cookieVal) ? parseInt(cookieVal, 10) : 0,
-        tmp = '<img src="<%=LOGO%>" class="app__logo" alt="Guardian App logo" /><div class="app__cta"><h4 class="app__heading">The Guardian app</h4>' +
+        message = '<img src="http://assets.guim.co.uk/images/apps/android-logo-2x.png" class="app__logo" alt="Guardian App logo" />' +
+            '<div class="app__cta">' +
+            '<h4 class="app__heading">The Guardian app</h4>' +
             '<p class="app__copy">Instant alerts. Offline reading.<br/>Tailored to you.</p>' +
-            '<p class="app__copy"><strong>FREE</strong> – <%=STORE%></p></div><a href="<%=LINK%>" class="app__link">View</a>',
-        tablet = '<img src="<%=SCREENSHOTS%>" class="app__screenshots" alt="screenshots" />';
+            '<p class="app__copy"><strong>FREE</strong> – in Google Play</p>' +
+            '</div>' +
+            '<a href="https://app.adjust.com/642i3r?deep_link=x-gu://www.theguardian.com/?source=adjust" class="app__link">View</a>';
 
     function isDevice() {
-        return ((detect.isIOS() || detect.isAndroid()) && !detect.isFireFoxOSApp());
+        return ((detect.isAndroid()) && !detect.isFireFoxOSApp());
     }
 
     function canShow() {
@@ -53,11 +36,9 @@ define([
     }
 
     function showMessage() {
-        var platform = (detect.isIOS()) ? 'ios' : 'android',
-            msg = new Message(platform),
-            fullTemplate = tmp + (detect.getBreakpoint() === 'mobile' ? '' : tablet);
+        var msg = new Message('android');
 
-        msg.show(template(fullTemplate, DATA[platform.toUpperCase()]));
+        msg.show(message);
         cookies.add(COOKIE_IMPRESSION_KEY, impressions + 1);
     }
 
@@ -68,11 +49,11 @@ define([
     }
 
     function isMessageShown() {
-        return ($('.site-message--android').css('display') === 'block' || $('.site-message--ios').css('display') === 'block');
+        return $('.site-message--android').css('display') === 'block';
     }
 
     function getMessageHeight() {
-        return ($('.site-message--android').dim().height || $('.site-message--ios').dim().height);
+        return $('.site-message--android').dim().height;
     }
 
     return {


### PR DESCRIPTION
originally we rolled our own app banner to cover iphones and android, however we would now get an SEO boost from using the Proper apple one, as well as better fuctionality.
the old one:
![image](https://cloud.githubusercontent.com/assets/7304387/9201844/e4f01f16-4046-11e5-90e3-00329a0d8581.png)

As the new one is native, it will detect if the app is installed and react accordingly, also it won't cause repainting and will also save memory which might help the ipads crashing issue.

Unfortunately there isn't an android equivalent, we can only use the play store button which is quite boring.

There doesn't seem to be any tracking, but any other potential issues would be appreciated.
fyi @PetrK-GNM keep an eye on when this one goes live
