### PR TITLE
First Step in Using Full Tag IDs for DFP Targeting

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -567,6 +567,16 @@ object Switches {
     exposeClientSide = false
   )
 
+  val UkNewsTargeting = Switch(
+    "Commercial",
+    "uk-news-target",
+    "Uses full UK News keyword for DFP targeting.",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 9, 9),
+    exposeClientSide = true
+  )
+
+
   // Monitoring
 
   val OphanSwitch = Switch(

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -38,7 +38,11 @@ define([
             if (!id) {
                 return null;
             }
-            return format(id.split('/').pop());
+            if (config.switches.ukNewsTarget && id === 'uk/uk') {
+                return id;
+            } else {
+                return format(id.split('/').pop());
+            }
         },
         parseIds = function (ids) {
             if (!ids) {

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -33,7 +33,7 @@ System.config({
   "map": {
     "EventEmitter": "github:Wolfy87/EventEmitter@4.2.11",
     "Promise": "github:cujojs/when@3.7.3/es6-shim/Promise",
-    "babel": "npm:babel-core@5.8.21",
+    "babel": "npm:babel-core@5.8.22",
     "babel-runtime": "npm:babel-runtime@5.8.20",
     "bean": "npm:bean@1.0.15",
     "bonzo": "npm:bonzo@1.4.0",


### PR DESCRIPTION
This is a tactical step to solve an immediate problem in targeting UK news content and a strategic step to solve tag targeting problems in general.

We can't currently distinguish between 'uk/uk' and for example 'travel/uk' in targeting or excluding ads.  This change starts using full keyword ID for UK news.

/cc @Calanthe @uplne

(It's been agreed with Ad Ops.)
