### PR TITLE
Remove mobile ad behind the switch

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -333,6 +333,15 @@ object Switches {
     exposeClientSide = true
   )
 
+  val NoMobileTopAdSwitch = Switch(
+    "Commercial",
+    "no-mobile-top-ad",
+    "On mobile there is no top banner and we are showing only two MPUs",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 9, 30),
+    exposeClientSide = true
+  )
+
   val DfpCachingSwitch = Switch(
     "Commercial",
     "dfp-caching",

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -39,13 +39,6 @@ object JspmControlTest extends TestDefinition(
   new LocalDate(2015, 9, 30)
 )
 
-object MobileTopBannerRemoveTest extends TestDefinition(
-  List(Variant1),
-  "mobile-top-banner-remove",
-  "To test the effect of top banner removal on mobile",
-  new LocalDate(2015, 8, 30)
-)
-
 object ABHeadlinesTestVariant extends TestDefinition(
   List(Variant1, Variant2, Variant3, Variant4, Variant5),
   "headlines-ab-variant",
@@ -61,7 +54,7 @@ object ABHeadlinesTestControl extends TestDefinition(
 )
 
 object ActiveTests extends Tests {
-  val tests: Seq[TestDefinition] = List(JspmTest, JspmControlTest, MobileTopBannerRemoveTest, ABHeadlinesTestControl, ABHeadlinesTestVariant)
+  val tests: Seq[TestDefinition] = List(JspmTest, JspmControlTest, ABHeadlinesTestControl, ABHeadlinesTestVariant)
 
   def getJavascriptConfig(implicit request: RequestHeader): String = {
     val configEntries = List(InternationalEditionVariant(request).map{ international => s""""internationalEditionVariant" : "$international" """}) ++

--- a/common/app/views/fragments/commercial/topBannerMobile.scala.html
+++ b/common/app/views/fragments/commercial/topBannerMobile.scala.html
@@ -1,7 +1,8 @@
 @(metaData: model.MetaData, edition: common.Edition)(implicit request: RequestHeader)
 @import views.support.Commercial.topSlot
+@import conf.Switches._
 
-@if(mvt.MobileTopBannerRemoveTest.isParticipating) {
+@if(NoMobileTopAdSwitch.isSwitchedOn) {
     @if(topSlot.hasResponsiveAd(metaData, edition)) {
         <div class="top-banner-ad-container top-banner-ad-container--mobile top-banner-ad-container--ab-mobile js-top-banner-mobile">
         @fragments.commercial.standardAd(

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -65,7 +65,7 @@ define([
     }
 
     function inMobileAdsTest() {
-        return config.tests.mobileTopBannerRemove && detect.getBreakpoint() === 'mobile';
+        return config.switches.noMobileTopAd && detect.getBreakpoint() === 'mobile';
     }
 
     var ads = [],

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -94,7 +94,7 @@ define([
         }
     };
 
-    if (config.tests && !!config.tests.mobileTopBannerRemove && detect.getBreakpoint() === 'mobile') {
+    if (config.switches.noMobileTopAd && detect.getBreakpoint() === 'mobile') {
         adSlotDefinitions.inline1.sizeMappings = {
             mobile: '1,1|300,250'
         };

--- a/static/src/javascripts/projects/common/modules/onward/popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/popular.js
@@ -39,7 +39,7 @@ define([
 
     MostPopular.prototype.mobileMaximumSlotsReached = function () {
         return (detect.getBreakpoint() === 'mobile'
-            && config.tests.mobileTopBannerRemove
+            && config.switches.noMobileTopAd
             && $('.ad-slot--inline').length > 1) ? true : false;
     };
 

--- a/static/src/javascripts/test/spec/common/onward/popular.spec.js
+++ b/static/src/javascripts/test/spec/common/onward/popular.spec.js
@@ -51,7 +51,7 @@ describe('Most popular', function () {
     afterEach(function () {
         server.restore();
         fixtures.clean(fixturesConfig.id);
-        config.tests.mobileTopBannerRemove = false;
+        config.switches.noMobileTopAd = false;
         detect.getBreakpoint = function () { return 'desktop'; };
     });
 
@@ -92,7 +92,7 @@ describe('Most popular', function () {
     it('should not render MPU when on mobile and 2+ MPUs are already on the page', function () {
         var popular = new Popular();
 
-        config.tests.mobileTopBannerRemove = true;
+        config.switches.noMobileTopAd = true;
         detect.getBreakpoint = function () { return 'mobile'; };
         popular.prerender();
         expect(popular.$mpu).toBeUndefined();

--- a/static/src/systemjs-config.js
+++ b/static/src/systemjs-config.js
@@ -33,7 +33,7 @@ System.config({
   "map": {
     "EventEmitter": "github:Wolfy87/EventEmitter@4.2.11",
     "Promise": "github:cujojs/when@3.7.3/es6-shim/Promise",
-    "babel": "npm:babel-core@5.8.21",
+    "babel": "npm:babel-core@5.8.22",
     "babel-runtime": "npm:babel-runtime@5.8.20",
     "bean": "npm:bean@1.0.15",
     "bonzo": "npm:bonzo@1.4.0",


### PR DESCRIPTION
1. Removing AB test
2. Putting this behind the switch so we can test it on devices and then push it live easily

CC @kelvin-chappell 
