### PR TITLE
Change the RefreshFrontsJob to give training fronts a lower frequency

### DIFF
--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -31,9 +31,10 @@ object RefreshFrontsJob extends Logging {
 
   def getFrontType(json: JsValue, path: String): FrontType = {
     lazy val isCommercial: Boolean = (json \ "fronts" \ path \ "priority") == JsString("commercial")
+    lazy val isTraining: Boolean = (json \ "fronts" \ path \ "priority") == JsString("training")
     if (HighFrequency.highFrequencyPaths.contains(path))
       HighFrequency
-    else if (isCommercial)
+    else if (isCommercial || isTraining)
       LowFrequency
     else
       StandardFrequency


### PR DESCRIPTION
We are pressing `training` fronts every 5 minutes. They probably should be given the same frequency as `commercial` fronts.

@piuccio 
