### PR TITLE
Pass byline image in cuts out through the resizer

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -71,7 +71,7 @@ case class VideoProfile(
 
 // Configuration of our different image profiles
 object Contributor extends Profile(width = Some(140), height = Some(140))
-object RichLinkContributor extends Profile(width = Some(720))
+object RichLinkContributor extends Profile(width = Some(173))
 object Item120 extends Profile(width = Some(120))
 object Item140 extends Profile(width = Some(140))
 object Item300 extends Profile(width = Some(300))

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -71,6 +71,7 @@ case class VideoProfile(
 
 // Configuration of our different image profiles
 object Contributor extends Profile(width = Some(140), height = Some(140))
+object RichLinkContributor extends Profile(width = Some(720))
 object Item120 extends Profile(width = Some(120))
 object Item140 extends Profile(width = Some(140))
 object Item300 extends Profile(width = Some(300))

--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -3,7 +3,7 @@
 
 @import com.gu.facia.api.utils.{Comment, DefaultCardstyle, Feature, Media}
 @import views.support.TrailCssClasses.toneClass
-@import views.support.{CardStyleForFrontend, Item460, RenderClasses}
+@import views.support.{ImgSrc, CardStyleForFrontend, RichLinkContributor, Item460, RenderClasses}
 
 @kicker = {
     @if(content.isAnalysis) {
@@ -52,7 +52,7 @@
                 @content.contributors.headOption.map { profile =>
                     @profile.contributorLargeImagePath.map{ image =>
                         <div class="rich-link__byline-img">
-                            <img class="rich-link__byline-img__img" src="@image" alt="@profile.name" />
+                            <img class="rich-link__byline-img__img" src="@ImgSrc(image, RichLinkContributor)" alt="@profile.name" />
                         </div>
                     }
                 }


### PR DESCRIPTION
This was an attempt to fix https://github.com/guardian/frontend/issues/8948. Testing this in Browserstack I can see the images are still pixelated in IE 11. Still think its worth the resizing though. cc @johnduffell 
