### PR TITLE
Crosswords: grouped entries (navigation and highlighting)

### DIFF
--- a/applications/app/crosswords/CrosswordData.scala
+++ b/applications/app/crosswords/CrosswordData.scala
@@ -12,20 +12,24 @@ object Entry {
   implicit val jsonWrites = Json.writes[Entry]
 
   def fromCrosswordEntry(entry: CrosswordEntry): Entry = Entry(
+    entry.id,
     entry.number.getOrElse(0),
     entry.clue.getOrElse(""),
     entry.direction.getOrElse(""),
     entry.length.getOrElse(0),
+    entry.group,
     entry.position.getOrElse(CrosswordPosition(0,0)),
     entry.solution
   )
 }
 
 case class Entry(
+  id: String,
   number: Int,
   clue: String,
   direction: String,
   length: Int,
+  group: Option[Seq[String]],
   position: CrosswordPosition,
   solution: Option[String]
 )

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/helpers.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/helpers.js
@@ -2,6 +2,36 @@ import _ from 'common/utils/_';
 
 import constants from 'es6/projects/common/modules/crosswords/constants';
 
+const getLastCellInClue = (clue) => {
+    const ax = { true: 'x', false: 'y' };
+    const axis = ax[isAcross(clue)];
+    const otherAxis = ax[!isAcross(clue)];
+    return {
+        [axis]: clue.position[axis] + (clue.length - 1),
+        [otherAxis]: clue.position[otherAxis]
+    };
+};
+
+const isFirstCellInClue = (cell, clue) => {
+    const axis = isAcross(clue) ? 'x' : 'y';
+    return cell[axis] === clue.position[axis];
+};
+
+const isLastCellInClue = (cell, clue) => {
+    const axis = isAcross(clue) ? 'x' : 'y';
+    return cell[axis] === clue.position[axis] + (clue.length - 1);
+};
+
+const getNextClueInGroup = (entries, clue) => {
+    const newClueId = clue.group[_.findIndex(clue.group, id => id === clue.id) + 1];
+    return _.find(entries, { id: newClueId });
+};
+
+const getPreviousClueInGroup = (entries, clue) => {
+    const newClueId = clue.group[_.findIndex(clue.group, id => id === clue.id) - 1];
+    return _.find(entries, { id: newClueId });
+};
+
 const isAcross = (clue) => clue.direction === 'across';
 
 const otherDirection = (direction) => direction === 'across' ? 'down' : 'across';
@@ -88,5 +118,10 @@ export default {
     cellsForEntry: cellsForEntry,
     entryHasCell: entryHasCell,
     gridSize: gridSize,
-    mapGrid: mapGrid
+    mapGrid: mapGrid,
+    getLastCellInClue,
+    isFirstCellInClue,
+    isLastCellInClue,
+    getNextClueInGroup,
+    getPreviousClueInGroup
 };

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -450,7 +450,12 @@ class Crossword extends React.Component {
 
     render () {
         const focussed = this.clueInFocus();
-        const isHighlighted = (x, y) => focussed ? helpers.entryHasCell(focussed, x, y) : false;
+        const isHighlighted = (x, y) => focussed
+            ? focussed.group.some(id => {
+                const entry = _.find(this.props.data.entries, { id });
+                return helpers.entryHasCell(entry, x, y);
+            })
+            : false;
 
         const anagramHelper = this.state.showAnagramHelper && (
             <AnagramHelper clue={focussed} grid={this.state.grid} close={this.onToggleAnagramHelper}/>

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -200,18 +200,39 @@ class Crossword extends React.Component {
     }
 
     focusPrevious () {
-        if (this.isAcross()) {
-            this.moveFocus(-1, 0);
+        const cell = this.state.cellInFocus;
+        const clue = this.clueInFocus();
+
+        if (helpers.isFirstCellInClue(cell, clue)) {
+            const newClue = helpers.getPreviousClueInGroup(this.props.data.entries, clue);
+            if (newClue) {
+                const newCell = helpers.getLastCellInClue(newClue);
+                this.focusClue(newCell.x, newCell.y, newClue.direction);
+            }
         } else {
-            this.moveFocus(0, -1);
+            if (this.isAcross()) {
+                this.moveFocus(-1, 0);
+            } else {
+                this.moveFocus(0, -1);
+            }
         }
     }
 
     focusNext () {
-        if (this.isAcross()) {
-            this.moveFocus(1, 0);
+        const cell = this.state.cellInFocus;
+        const clue = this.clueInFocus();
+
+        if (helpers.isLastCellInClue(cell, clue)) {
+            const newClue = helpers.getNextClueInGroup(this.props.data.entries, clue);
+            if (newClue) {
+                this.focusClue(newClue.position.x, newClue.position.y, newClue.direction);
+            }
         } else {
-            this.moveFocus(0, 1);
+            if (this.isAcross()) {
+                this.moveFocus(1, 0);
+            } else {
+                this.moveFocus(0, 1);
+            }
         }
     }
 


### PR DESCRIPTION
Still to do with groups:
- [ ] 'Clear/reveal' should clear/reveal all entries in group? This is the R2 behaviour

I suspect I could improve this by calculating the data format I need upfront. /cc @desbo @janua 

![image](https://cloud.githubusercontent.com/assets/921609/9226811/46694eb8-4108-11e5-9f9e-a5b12391afe5.png)
