### PR TITLE
DOM manipulations should be wrapped by fastdom

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/navigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/navigation.js
@@ -29,16 +29,17 @@ define([
         },
 
         jsEnableFooterNav: function () {
-            $('.navigation-container--default').removeClass('navigation-container--default').addClass('navigation-container--collapsed');
+            fastdom.write(function () {
+                $('.navigation-container--default').removeClass('navigation-container--default').addClass('navigation-container--collapsed');
+            });
         },
 
         copyMegaNavMenu: function () {
             var megaNavCopy = $.create($('.js-mega-nav').html()),
                 placeholder = $('.js-mega-nav-placeholder');
 
-            $('.global-navigation', megaNavCopy).addClass('global-navigation--top');
-
             fastdom.write(function () {
+                $('.global-navigation', megaNavCopy).addClass('global-navigation--top');
                 placeholder.append(megaNavCopy);
             });
         },


### PR DESCRIPTION
@sndrs commented on https://github.com/guardian/frontend/pull/10072 just after I'd merged it, so here's a new PR to pick up that suggestion.
