### PR TITLE
Npm tweaks for Team City

### DIFF
--- a/dist-assets-tc
+++ b/dist-assets-tc
@@ -4,5 +4,12 @@ set -o xtrace
 set -o nounset
 set -o errexit
 
-echo "2. Asset compilation."
-./grunt-tc validate:sass validate:js test:unit compile emitAbTestInfo
+echo "Asset compilation"
+
+echo "##teamcity[progressStart 'asset validation and tests']"
+./grunt-tc validate:sass validate:js test:unit
+echo "##teamcity[progressFinish 'asset validation and tests']"
+
+echo "##teamcity[progressStart 'asset dist']"
+./grunt-tc compile emitAbTestInfo
+echo "##teamcity[progressFinish 'asset dist']"

--- a/dist-assets-tc
+++ b/dist-assets-tc
@@ -5,4 +5,4 @@ set -o nounset
 set -o errexit
 
 echo "2. Asset compilation."
-grunt --stack --no-color validate:sass validate:js test:unit compile emitAbTestInfo
+./grunt-tc validate:sass validate:js test:unit compile emitAbTestInfo

--- a/dist-assets-tc
+++ b/dist-assets-tc
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o xtrace
+set -o nounset
+set -o errexit
+
+echo "2. Asset compilation."
+grunt --stack --no-color validate:sass validate:js test:unit compile emitAbTestInfo

--- a/dist-npm-tc
+++ b/dist-npm-tc
@@ -4,7 +4,7 @@ set -o xtrace
 set -o nounset
 set -o errexit
 
-echo "1. Npm installation."
+echo "Npm installation."
 npm prune --production
 npm install --production
 

--- a/dist-npm-tc
+++ b/dist-npm-tc
@@ -8,4 +8,4 @@ echo "1. Npm installation."
 npm prune --production
 npm install --production
 
-grunt --stack --no-color clean shell:npmInstallFaciaTool shell:jspmInstallStatic
+grunt --stack --no-color clean shell:npmInstallFaciaTool install:jspm

--- a/dist-npm-tc
+++ b/dist-npm-tc
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -o xtrace
+set -o nounset
+set -o errexit
+
+echo "1. Npm installation."
+npm prune --production
+npm install --production
+
+./grunt-tc clean shell:npmInstallFaciaTool shell:jspmInstallStatic

--- a/dist-npm-tc
+++ b/dist-npm-tc
@@ -8,4 +8,4 @@ echo "1. Npm installation."
 npm prune --production
 npm install --production
 
-./grunt-tc clean shell:npmInstallFaciaTool shell:jspmInstallStatic
+grunt --stack --no-color clean shell:npmInstallFaciaTool shell:jspmInstallStatic

--- a/dist-play-tc
+++ b/dist-play-tc
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -o xtrace
+set -o nounset
+set -o errexit
+
+echo "3. Dist play jars."
+rm -rf "dist"
+
+configurations="admin applications archive article commercial diagnostics discussion "\
+"facia facia-tool facia-press identity image onward png-resizer preview training-preview router sport rss"
+
+for config in $configurations
+do
+    echo "Dist for $config"
+
+    # Generate folder for the application zip.
+    app_folder="dist/$config"
+
+    mkdir -p "$app_folder/packages/frontend-static"
+    mkdir -p "$app_folder/packages/$config"
+
+    mv "$config/target/universal/$config-0.1-SNAPSHOT.zip"  "$app_folder/packages/$config/$config.zip"
+    cp "$config/conf/deploy.json"                           "$app_folder"
+    cp -r static/hash/*                                     "$app_folder/packages/frontend-static"
+    cp static/abtests.json                                  "$app_folder/packages/frontend-abtests"
+
+    pushd $app_folder
+    zip -r "../$config.zip" .
+    popd
+
+    rm -rf $app_folder
+
+    set +o xtrace
+    echo "##teamcity[publishArtifacts 'dist/$config.zip']"
+    set -o xtrace
+done
+
+echo "Done disting."

--- a/dist-play-tc
+++ b/dist-play-tc
@@ -5,6 +5,8 @@ set -o nounset
 set -o errexit
 
 echo "3. Dist play jars."
+./sbt-tc "project root" compile test assets dist
+
 rm -rf "dist"
 
 configurations="admin applications archive article commercial diagnostics discussion "\

--- a/dist-play-tc
+++ b/dist-play-tc
@@ -4,8 +4,13 @@ set -o xtrace
 set -o nounset
 set -o errexit
 
-echo "3. Dist play jars."
+echo "Dist play jars."
+
+echo "##teamcity[progressStart 'sbt test and dist']"
 ./sbt-tc "project root" compile test assets dist
+echo "##teamcity[progressFinish 'sbt test and dist']"
+
+echo "##teamcity[progressStart 'zipping and publishing']"
 
 rm -rf "dist"
 
@@ -37,5 +42,7 @@ do
     echo "##teamcity[publishArtifacts 'dist/$config.zip']"
     set -o xtrace
 done
+
+echo "##teamcity[progressFinish 'zipping and publishing']"
 
 echo "Done disting."

--- a/dist-root-tc
+++ b/dist-root-tc
@@ -4,7 +4,10 @@ set -o xtrace
 set -o nounset
 set -o errexit
 
-./grunt-tc clean install validate:sass validate:js test:unit compile emitAbTestInfo
+npm prune
+npm install
+
+./grunt-tc clean shell:npmInstallFaciaTool shell:jspmInstallStatic validate:sass validate:js test:unit compile emitAbTestInfo
 ./sbt-tc "project root" compile test assets dist
 
 echo "Disting everything."

--- a/grunt-tc
+++ b/grunt-tc
@@ -20,7 +20,6 @@ export PATH=dev/gems/bin:$PATH
 # `without` is a remembered option - this can be removed once it's been deleted from all boxes
 bundle config --delete without
 bundle install --binstubs dev/gems/bin --path dev/gems
-npm install
 
 ./node_modules/.bin/jspm registry create bower jspm-bower-endpoint -y
 ./node_modules/.bin/jspm config endpoints.github.auth `echo -n $JSPM_GITHUB_AUTH_USERNAME:$JSPM_GITHUB_AUTH_TOKEN | base64`

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,213 +2,162 @@
   "name": "frontend",
   "version": "0.1.0",
   "dependencies": {
-    "autoprefixer-core": {
-      "version": "5.2.1",
-      "from": "autoprefixer-core@>=5.2.1 <6.0.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
-      "dependencies": {
-        "browserslist": {
-          "version": "0.4.0",
-          "from": "browserslist@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
-        },
-        "num2fraction": {
-          "version": "1.1.0",
-          "from": "num2fraction@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz"
-        },
-        "caniuse-db": {
-          "version": "1.0.30000255",
-          "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000255.tgz"
-        },
-        "postcss": {
-          "version": "4.1.16",
-          "from": "postcss@>=4.1.12 <4.2.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-          "dependencies": {
-            "es6-promise": {
-              "version": "2.3.0",
-              "from": "es6-promise@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "from": "source-map@>=0.4.2 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.8 <2.2.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            }
-          }
-        }
-      }
-    },
     "babel": {
       "version": "5.8.21",
-      "from": "babel@>=5.5.8 <6.0.0",
+      "from": "babel@^5.5.8",
       "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.21.tgz",
       "dependencies": {
         "babel-core": {
-          "version": "5.8.21",
-          "from": "babel-core@>=5.6.21 <6.0.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.21.tgz",
+          "version": "5.8.22",
+          "from": "babel-core@^5.6.21",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.22.tgz",
           "dependencies": {
             "babel-plugin-constant-folding": {
               "version": "1.0.1",
-              "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
+              "from": "babel-plugin-constant-folding@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
             },
             "babel-plugin-dead-code-elimination": {
               "version": "1.0.2",
-              "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
+              "from": "babel-plugin-dead-code-elimination@^1.0.2",
               "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
             },
             "babel-plugin-eval": {
               "version": "1.0.1",
-              "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
+              "from": "babel-plugin-eval@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
             },
             "babel-plugin-inline-environment-variables": {
               "version": "1.0.1",
-              "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
+              "from": "babel-plugin-inline-environment-variables@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
             },
             "babel-plugin-jscript": {
               "version": "1.0.4",
-              "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
+              "from": "babel-plugin-jscript@^1.0.4",
               "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
             },
             "babel-plugin-member-expression-literals": {
               "version": "1.0.1",
-              "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
+              "from": "babel-plugin-member-expression-literals@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
             },
             "babel-plugin-property-literals": {
               "version": "1.0.1",
-              "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
+              "from": "babel-plugin-property-literals@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
             },
             "babel-plugin-proto-to-assign": {
               "version": "1.0.4",
-              "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
+              "from": "babel-plugin-proto-to-assign@^1.0.3",
               "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
             },
             "babel-plugin-react-constant-elements": {
               "version": "1.0.3",
-              "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
+              "from": "babel-plugin-react-constant-elements@^1.0.3",
               "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
             },
             "babel-plugin-react-display-name": {
               "version": "1.0.3",
-              "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
+              "from": "babel-plugin-react-display-name@^1.0.3",
               "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
             },
             "babel-plugin-remove-console": {
               "version": "1.0.1",
-              "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
+              "from": "babel-plugin-remove-console@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
             },
             "babel-plugin-remove-debugger": {
               "version": "1.0.1",
-              "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
+              "from": "babel-plugin-remove-debugger@^1.0.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
             },
             "babel-plugin-runtime": {
               "version": "1.0.7",
-              "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
+              "from": "babel-plugin-runtime@^1.0.7",
               "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
             },
             "babel-plugin-undeclared-variables-check": {
               "version": "1.0.2",
-              "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
+              "from": "babel-plugin-undeclared-variables-check@^1.0.2",
               "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
               "dependencies": {
                 "leven": {
                   "version": "1.0.2",
-                  "from": "leven@>=1.0.2 <2.0.0",
+                  "from": "leven@^1.0.2",
                   "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
                 }
               }
             },
             "babel-plugin-undefined-to-void": {
               "version": "1.1.6",
-              "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
+              "from": "babel-plugin-undefined-to-void@^1.1.6",
               "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
             },
             "babylon": {
-              "version": "5.8.21",
-              "from": "babylon@>=5.8.21 <6.0.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.21.tgz"
+              "version": "5.8.22",
+              "from": "babylon@^5.8.22",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.22.tgz"
             },
             "bluebird": {
               "version": "2.9.34",
-              "from": "bluebird@>=2.9.33 <3.0.0",
+              "from": "bluebird@^2.9.33",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
             },
             "chalk": {
               "version": "1.1.0",
-              "from": "chalk@>=1.0.0 <2.0.0",
+              "from": "chalk@^1.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "from": "ansi-styles@^2.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "escape-string-regexp@^1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "has-ansi@^2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "strip-ansi@^3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "supports-color@^2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "core-js": {
               "version": "1.0.1",
-              "from": "core-js@>=1.0.0 <2.0.0",
+              "from": "core-js@^1.0.0",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.0.1.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.1.1 <3.0.0",
+              "from": "debug@^2.1.1",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
@@ -220,83 +169,83 @@
             },
             "detect-indent": {
               "version": "3.0.1",
-              "from": "detect-indent@>=3.0.0 <4.0.0",
+              "from": "detect-indent@^3.0.0",
               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "get-stdin@^4.0.1",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "minimist": {
-                  "version": "1.1.2",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                  "version": "1.1.3",
+                  "from": "minimist@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 }
               }
             },
             "esutils": {
               "version": "2.0.2",
-              "from": "esutils@>=2.0.0 <3.0.0",
+              "from": "esutils@^2.0.0",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "globals": {
               "version": "6.4.1",
-              "from": "globals@>=6.4.0 <7.0.0",
+              "from": "globals@^6.4.0",
               "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
             },
             "home-or-tmp": {
               "version": "1.0.0",
-              "from": "home-or-tmp@>=1.0.0 <2.0.0",
+              "from": "home-or-tmp@^1.0.0",
               "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
               "dependencies": {
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                  "from": "os-tmpdir@^1.0.1",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 },
                 "user-home": {
                   "version": "1.1.1",
-                  "from": "user-home@>=1.1.1 <2.0.0",
+                  "from": "user-home@^1.1.1",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                 }
               }
             },
             "is-integer": {
               "version": "1.0.4",
-              "from": "is-integer@>=1.0.4 <2.0.0",
+              "from": "is-integer@^1.0.4",
               "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "is-finite@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "number-is-nan@^1.0.0",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "is-nan": {
                   "version": "1.1.0",
-                  "from": "is-nan@>=1.0.1 <2.0.0",
+                  "from": "is-nan@^1.0.1",
                   "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.1.0.tgz",
                   "dependencies": {
                     "define-properties": {
                       "version": "1.1.1",
-                      "from": "define-properties@>=1.0.2 <2.0.0",
+                      "from": "define-properties@^1.0.2",
                       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.1.tgz",
                       "dependencies": {
                         "foreach": {
                           "version": "2.0.5",
-                          "from": "foreach@>=2.0.5 <3.0.0",
+                          "from": "foreach@^2.0.5",
                           "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                         },
                         "object-keys": {
                           "version": "1.0.7",
-                          "from": "object-keys@>=1.0.7 <2.0.0",
+                          "from": "object-keys@^1.0.7",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.7.tgz"
                         }
                       }
@@ -312,7 +261,7 @@
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "json5@^0.4.0",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             },
             "line-numbers": {
@@ -329,17 +278,17 @@
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.3 <3.0.0",
+              "from": "minimatch@^2.0.3",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "brace-expansion@^1.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "balanced-match@^0.2.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -353,7 +302,7 @@
             },
             "private": {
               "version": "0.1.6",
-              "from": "private@>=0.1.6 <0.2.0",
+              "from": "private@^0.1.6",
               "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
             },
             "regenerator": {
@@ -363,71 +312,71 @@
               "dependencies": {
                 "commoner": {
                   "version": "0.10.3",
-                  "from": "commoner@>=0.10.0 <0.11.0",
+                  "from": "commoner@~0.10.0",
                   "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
                   "dependencies": {
                     "q": {
                       "version": "1.1.2",
-                      "from": "q@>=1.1.2 <1.2.0",
+                      "from": "q@~1.1.2",
                       "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
                     },
                     "commander": {
                       "version": "2.5.1",
-                      "from": "commander@>=2.5.0 <2.6.0",
+                      "from": "commander@~2.5.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
                     },
                     "graceful-fs": {
                       "version": "3.0.8",
-                      "from": "graceful-fs@>=3.0.4 <3.1.0",
+                      "from": "graceful-fs@~3.0.4",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                     },
                     "glob": {
                       "version": "4.2.2",
-                      "from": "glob@>=4.2.1 <4.3.0",
+                      "from": "glob@~4.2.1",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "from": "inflight@^1.0.4",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "wrappy@1",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "from": "inherits@2",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "minimatch": {
                           "version": "1.0.0",
-                          "from": "minimatch@>=1.0.0 <2.0.0",
+                          "from": "minimatch@^1.0.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.6.5",
-                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "from": "lru-cache@2",
                               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.1",
-                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "from": "sigmund@~1.0.0",
                               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                             }
                           }
                         },
                         "once": {
                           "version": "1.3.2",
-                          "from": "once@>=1.3.0 <2.0.0",
+                          "from": "once@^1.3.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "wrappy@1",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -436,79 +385,84 @@
                     },
                     "install": {
                       "version": "0.1.8",
-                      "from": "install@>=0.1.7 <0.2.0",
+                      "from": "install@~0.1.7",
                       "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
                     },
                     "iconv-lite": {
                       "version": "0.4.11",
-                      "from": "iconv-lite@>=0.4.5 <0.5.0",
+                      "from": "iconv-lite@~0.4.5",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
                     }
                   }
                 },
                 "defs": {
                   "version": "1.1.0",
-                  "from": "defs@>=1.1.0 <1.2.0",
+                  "from": "defs@~1.1.0",
                   "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.0.tgz",
                   "dependencies": {
                     "alter": {
                       "version": "0.2.0",
-                      "from": "alter@>=0.2.0 <0.3.0",
+                      "from": "alter@~0.2.0",
                       "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                       "dependencies": {
                         "stable": {
                           "version": "0.1.5",
-                          "from": "stable@>=0.1.3 <0.2.0",
+                          "from": "stable@~0.1.3",
                           "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
                         }
                       }
                     },
                     "ast-traverse": {
                       "version": "0.1.1",
-                      "from": "ast-traverse@>=0.1.1 <0.2.0",
+                      "from": "ast-traverse@~0.1.1",
                       "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
                     },
                     "breakable": {
                       "version": "1.0.0",
-                      "from": "breakable@>=1.0.0 <1.1.0",
+                      "from": "breakable@~1.0.0",
                       "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
                     },
                     "esprima-fb": {
                       "version": "8001.1001.0-dev-harmony-fb",
-                      "from": "esprima-fb@>=8001.1001.0-dev-harmony-fb <8001.1002.0",
+                      "from": "esprima-fb@~8001.1001.0-dev-harmony-fb",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
                     },
                     "simple-fmt": {
                       "version": "0.1.0",
-                      "from": "simple-fmt@>=0.1.0 <0.2.0",
+                      "from": "simple-fmt@~0.1.0",
                       "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
                     },
                     "simple-is": {
                       "version": "0.2.0",
-                      "from": "simple-is@>=0.2.0 <0.3.0",
+                      "from": "simple-is@~0.2.0",
                       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
                     },
                     "stringmap": {
                       "version": "0.2.2",
-                      "from": "stringmap@>=0.2.2 <0.3.0",
+                      "from": "stringmap@~0.2.2",
                       "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
                     },
                     "stringset": {
                       "version": "0.2.1",
-                      "from": "stringset@>=0.2.1 <0.3.0",
+                      "from": "stringset@~0.2.1",
                       "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
                     },
                     "tryor": {
                       "version": "0.1.2",
-                      "from": "tryor@>=0.1.2 <0.2.0",
+                      "from": "tryor@~0.1.2",
                       "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
                     },
                     "yargs": {
                       "version": "1.3.3",
-                      "from": "yargs@>=1.3.2 <1.4.0",
+                      "from": "yargs@~1.3.2",
                       "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
                     }
                   }
+                },
+                "esprima-fb": {
+                  "version": "15001.1.0-dev-harmony-fb",
+                  "from": "esprima-fb@~15001.1.0-dev-harmony-fb",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
                 },
                 "recast": {
                   "version": "0.10.24",
@@ -524,46 +478,46 @@
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.6 <2.4.0",
+                  "from": "through@~2.3.6",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "regexpu": {
               "version": "1.2.0",
-              "from": "regexpu@>=1.1.2 <2.0.0",
+              "from": "regexpu@^1.1.2",
               "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
               "dependencies": {
                 "recast": {
-                  "version": "0.10.26",
-                  "from": "recast@>=0.10.6 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.26.tgz",
+                  "version": "0.10.28",
+                  "from": "recast@^0.10.6",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.28.tgz",
                   "dependencies": {
                     "ast-types": {
-                      "version": "0.8.7",
-                      "from": "ast-types@0.8.7",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.7.tgz"
+                      "version": "0.8.8",
+                      "from": "ast-types@0.8.8",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.8.tgz"
                     }
                   }
                 },
                 "regenerate": {
                   "version": "1.2.1",
-                  "from": "regenerate@>=1.2.1 <2.0.0",
+                  "from": "regenerate@^1.2.1",
                   "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
                 },
                 "regjsgen": {
                   "version": "0.2.0",
-                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "from": "regjsgen@^0.2.0",
                   "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
                 },
                 "regjsparser": {
                   "version": "0.1.4",
-                  "from": "regjsparser@>=0.1.4 <0.2.0",
+                  "from": "regjsparser@^0.1.4",
                   "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.4.tgz",
                   "dependencies": {
                     "jsesc": {
                       "version": "0.5.0",
-                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "from": "jsesc@~0.5.0",
                       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
                     }
                   }
@@ -572,17 +526,17 @@
             },
             "repeating": {
               "version": "1.1.3",
-              "from": "repeating@>=1.1.2 <2.0.0",
+              "from": "repeating@^1.1.2",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "is-finite@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "number-is-nan@^1.0.0",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -591,17 +545,17 @@
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@>=1.1.6 <2.0.0",
+              "from": "resolve@^1.1.6",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "from": "shebang-regex@>=1.0.0 <2.0.0",
+              "from": "shebang-regex@^1.0.0",
               "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "source-map-support@>=0.2.10 <0.3.0",
+              "from": "source-map-support@^0.2.10",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
@@ -620,86 +574,86 @@
             },
             "to-fast-properties": {
               "version": "1.0.1",
-              "from": "to-fast-properties@>=1.0.0 <2.0.0",
+              "from": "to-fast-properties@^1.0.0",
               "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
             },
             "trim-right": {
               "version": "1.0.1",
-              "from": "trim-right@>=1.0.0 <2.0.0",
+              "from": "trim-right@^1.0.0",
               "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
             },
             "try-resolve": {
               "version": "1.0.1",
-              "from": "try-resolve@>=1.0.0 <2.0.0",
+              "from": "try-resolve@^1.0.0",
               "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
             }
           }
         },
         "chokidar": {
           "version": "1.0.5",
-          "from": "chokidar@>=1.0.0 <2.0.0",
+          "from": "chokidar@^1.0.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@>=1.1.0 <2.0.0",
+              "from": "anymatch@^1.1.0",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
                   "version": "2.2.0",
-                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "from": "micromatch@^2.1.5",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "arr-diff@>=1.0.1 <2.0.0",
+                      "from": "arr-diff@^1.0.1",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
                           "version": "0.2.3",
-                          "from": "array-slice@>=0.2.2 <0.3.0",
+                          "from": "array-slice@^0.2.2",
                           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
-                      "from": "array-unique@>=0.2.1 <0.3.0",
+                      "from": "array-unique@^0.2.1",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "braces@>=1.8.0 <2.0.0",
+                      "from": "braces@^1.8.0",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "from": "expand-range@^1.8.1",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.2",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "from": "fill-range@^2.1.0",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "is-number@>=1.1.2 <2.0.0",
+                                  "from": "is-number@^1.1.2",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
                                   "version": "1.0.2",
-                                  "from": "isobject@>=1.0.0 <2.0.0",
+                                  "from": "isobject@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "randomatic@>=1.1.0 <2.0.0",
+                                  "from": "randomatic@^1.1.0",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "repeat-string@^1.5.2",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -708,36 +662,36 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "from": "preserve@^0.2.0",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "repeat-element@>=1.1.0 <2.0.0",
+                          "from": "repeat-element@^1.1.0",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.3",
-                      "from": "expand-brackets@>=0.1.1 <0.2.0",
+                      "from": "expand-brackets@^0.1.1",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
                       "dependencies": {
                         "is-posix-bracket": {
                           "version": "0.1.0",
-                          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                          "from": "is-posix-bracket@^0.1.0",
                           "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz"
                         }
                       }
                     },
                     "extglob": {
                       "version": "0.3.1",
-                      "from": "extglob@>=0.3.0 <0.4.0",
+                      "from": "extglob@^0.3.0",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
                       "dependencies": {
                         "ansi-green": {
                           "version": "0.1.1",
-                          "from": "ansi-green@>=0.1.1 <0.2.0",
+                          "from": "ansi-green@^0.1.1",
                           "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
                           "dependencies": {
                             "ansi-wrap": {
@@ -749,85 +703,85 @@
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "from": "is-extglob@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "success-symbol": {
                           "version": "0.1.0",
-                          "from": "success-symbol@>=0.1.0 <0.2.0",
+                          "from": "success-symbol@^0.1.0",
                           "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
                         }
                       }
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "from": "filename-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "kind-of@>=1.1.0 <2.0.0",
+                      "from": "kind-of@^1.1.0",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "1.1.0",
-                      "from": "object.omit@>=1.1.0 <2.0.0",
+                      "from": "object.omit@^1.1.0",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@>=0.1.3 <0.2.0",
+                          "from": "for-own@^0.1.3",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "from": "for-in@^0.1.4",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "1.0.2",
-                          "from": "isobject@>=1.0.0 <2.0.0",
+                          "from": "isobject@^1.0.0",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.2",
-                      "from": "parse-glob@>=3.0.1 <4.0.0",
+                      "from": "parse-glob@^3.0.1",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "glob-base@>=0.2.0 <0.3.0",
+                          "from": "glob-base@^0.2.0",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.1",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "from": "is-dotfile@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "from": "is-extglob@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "regex-cache@>=0.4.2 <0.5.0",
+                      "from": "regex-cache@^0.4.2",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                          "from": "is-equal-shallow@^0.1.1",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "from": "is-primitive@^2.0.0",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -838,71 +792,71 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0",
+              "from": "arrify@^1.0.0",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
+              "from": "async-each@^0.1.5",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "glob-parent@>=1.2.0 <2.0.0",
+              "from": "glob-parent@^1.0.0",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "from": "is-binary-path@^1.0.0",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.3.1",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "from": "binary-extensions@^1.0.0",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "is-glob@>=1.1.3 <2.0.0",
+              "from": "is-glob@^1.1.3",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
             },
             "readdirp": {
               "version": "1.4.0",
-              "from": "readdirp@>=1.3.0 <2.0.0",
+              "from": "readdirp@^1.3.0",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <4.2.0",
+                  "from": "graceful-fs@~4.1.2",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.12 <0.3.0",
+                  "from": "minimatch@~0.2.12",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.5",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "from": "readable-stream@~1.0.26-2",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -912,12 +866,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -925,14 +879,14 @@
               }
             },
             "fsevents": {
-              "version": "0.3.7",
-              "from": "fsevents@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.7.tgz",
+              "version": "0.3.8",
+              "from": "fsevents@^0.3.1",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
               "dependencies": {
                 "nan": {
-                  "version": "1.9.0",
-                  "from": "nan@>=1.8.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
+                  "version": "2.0.5",
+                  "from": "nan@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
                 }
               }
             }
@@ -940,61 +894,61 @@
         },
         "commander": {
           "version": "2.8.1",
-          "from": "commander@>=2.6.0 <3.0.0",
+          "from": "commander@^2.6.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
+              "from": "graceful-readlink@>= 1.0.0",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "convert-source-map": {
           "version": "1.1.1",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
+          "from": "convert-source-map@^1.1.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
         },
         "fs-readdir-recursive": {
           "version": "0.1.2",
-          "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
+          "from": "fs-readdir-recursive@^0.1.0",
           "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
         },
         "glob": {
           "version": "5.0.14",
-          "from": "glob@>=5.0.5 <6.0.0",
+          "from": "glob@5.x",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "inflight@1.0.4",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "inherits@2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
+              "from": "minimatch@^2.0.1",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "brace-expansion@^1.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "balanced-match@^0.2.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -1008,12 +962,12 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "once@^1.3.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -1022,17 +976,17 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.2.0 <4.0.0",
+          "from": "lodash@^3.2.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "output-file-sync": {
           "version": "1.1.1",
-          "from": "output-file-sync@>=1.1.0 <2.0.0",
+          "from": "output-file-sync@^1.1.0",
           "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "from": "mkdirp@^0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
@@ -1044,24 +998,24 @@
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "xtend@^4.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "path-exists": {
           "version": "1.0.0",
-          "from": "path-exists@>=1.0.0 <2.0.0",
+          "from": "path-exists@^1.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "path-is-absolute@^1.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.0 <0.5.0",
+          "from": "source-map@^0.4.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
@@ -1073,1755 +1027,8 @@
         },
         "slash": {
           "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
+          "from": "slash@^1.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
-        }
-      }
-    },
-    "browser-sync": {
-      "version": "2.8.2",
-      "from": "browser-sync@>=2.8.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.8.2.tgz",
-      "dependencies": {
-        "anymatch": {
-          "version": "1.3.0",
-          "from": "anymatch@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-          "dependencies": {
-            "arrify": {
-              "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
-            },
-            "micromatch": {
-              "version": "2.2.0",
-              "from": "micromatch@>=2.1.5 <3.0.0",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
-              "dependencies": {
-                "arr-diff": {
-                  "version": "1.0.1",
-                  "from": "arr-diff@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
-                  "dependencies": {
-                    "array-slice": {
-                      "version": "0.2.3",
-                      "from": "array-slice@>=0.2.2 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
-                    }
-                  }
-                },
-                "array-unique": {
-                  "version": "0.2.1",
-                  "from": "array-unique@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-                },
-                "braces": {
-                  "version": "1.8.0",
-                  "from": "braces@>=1.8.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
-                  "dependencies": {
-                    "expand-range": {
-                      "version": "1.8.1",
-                      "from": "expand-range@>=1.8.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
-                      "dependencies": {
-                        "fill-range": {
-                          "version": "2.2.2",
-                          "from": "fill-range@>=2.1.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
-                          "dependencies": {
-                            "is-number": {
-                              "version": "1.1.2",
-                              "from": "is-number@>=1.1.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
-                            },
-                            "isobject": {
-                              "version": "1.0.2",
-                              "from": "isobject@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
-                            },
-                            "randomatic": {
-                              "version": "1.1.0",
-                              "from": "randomatic@>=1.1.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "preserve": {
-                      "version": "0.2.0",
-                      "from": "preserve@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-                    },
-                    "repeat-element": {
-                      "version": "1.1.2",
-                      "from": "repeat-element@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-                    }
-                  }
-                },
-                "expand-brackets": {
-                  "version": "0.1.3",
-                  "from": "expand-brackets@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
-                  "dependencies": {
-                    "is-posix-bracket": {
-                      "version": "0.1.0",
-                      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz"
-                    }
-                  }
-                },
-                "extglob": {
-                  "version": "0.3.1",
-                  "from": "extglob@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-                  "dependencies": {
-                    "ansi-green": {
-                      "version": "0.1.1",
-                      "from": "ansi-green@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-                      "dependencies": {
-                        "ansi-wrap": {
-                          "version": "0.1.0",
-                          "from": "ansi-wrap@0.1.0",
-                          "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
-                        }
-                      }
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    },
-                    "success-symbol": {
-                      "version": "0.1.0",
-                      "from": "success-symbol@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
-                    }
-                  }
-                },
-                "filename-regex": {
-                  "version": "2.0.0",
-                  "from": "filename-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
-                },
-                "is-glob": {
-                  "version": "1.1.3",
-                  "from": "is-glob@>=1.1.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
-                },
-                "kind-of": {
-                  "version": "1.1.0",
-                  "from": "kind-of@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
-                },
-                "object.omit": {
-                  "version": "1.1.0",
-                  "from": "object.omit@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
-                  "dependencies": {
-                    "for-own": {
-                      "version": "0.1.3",
-                      "from": "for-own@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-                      "dependencies": {
-                        "for-in": {
-                          "version": "0.1.4",
-                          "from": "for-in@>=0.1.4 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
-                        }
-                      }
-                    },
-                    "isobject": {
-                      "version": "1.0.2",
-                      "from": "isobject@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
-                    }
-                  }
-                },
-                "parse-glob": {
-                  "version": "3.0.2",
-                  "from": "parse-glob@>=3.0.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
-                  "dependencies": {
-                    "glob-base": {
-                      "version": "0.2.0",
-                      "from": "glob-base@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
-                      "dependencies": {
-                        "glob-parent": {
-                          "version": "1.2.0",
-                          "from": "glob-parent@>=1.2.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
-                        }
-                      }
-                    },
-                    "is-dotfile": {
-                      "version": "1.0.1",
-                      "from": "is-dotfile@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    }
-                  }
-                },
-                "regex-cache": {
-                  "version": "0.4.2",
-                  "from": "regex-cache@>=0.4.2 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
-                  "dependencies": {
-                    "is-equal-shallow": {
-                      "version": "0.1.3",
-                      "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-                    },
-                    "is-primitive": {
-                      "version": "2.0.0",
-                      "from": "is-primitive@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "async-each-series": {
-          "version": "0.1.1",
-          "from": "async-each-series@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz"
-        },
-        "browser-sync-client": {
-          "version": "2.2.1",
-          "from": "browser-sync-client@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.2.1.tgz",
-          "dependencies": {
-            "etag": {
-              "version": "1.7.0",
-              "from": "etag@>=1.7.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
-            },
-            "fresh": {
-              "version": "0.3.0",
-              "from": "fresh@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
-            }
-          }
-        },
-        "browser-sync-ui": {
-          "version": "0.5.13",
-          "from": "browser-sync-ui@>=0.5.13 <0.6.0",
-          "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.5.13.tgz",
-          "dependencies": {
-            "angular": {
-              "version": "1.4.3",
-              "from": "angular@>=1.3.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular/-/angular-1.4.3.tgz"
-            },
-            "angular-route": {
-              "version": "1.4.3",
-              "from": "angular-route@>=1.3.8 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular-route/-/angular-route-1.4.3.tgz"
-            },
-            "angular-sanitize": {
-              "version": "1.4.3",
-              "from": "angular-sanitize@>=1.3.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.4.3.tgz"
-            },
-            "angular-touch": {
-              "version": "1.4.3",
-              "from": "angular-touch@>=1.3.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular-touch/-/angular-touch-1.4.3.tgz"
-            },
-            "connect-history-api-fallback": {
-              "version": "0.0.5",
-              "from": "connect-history-api-fallback@0.0.5",
-              "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.5.tgz"
-            },
-            "stream-throttle": {
-              "version": "0.1.3",
-              "from": "stream-throttle@>=0.1.3 <0.2.0",
-              "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.8.1",
-                  "from": "commander@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "limiter": {
-                  "version": "1.0.5",
-                  "from": "limiter@>=1.0.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.0.5.tgz"
-                }
-              }
-            },
-            "weinre": {
-              "version": "2.0.0-pre-I0Z7U9OV",
-              "from": "weinre@>=2.0.0-pre-I0Z7U9OV <3.0.0",
-              "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
-              "dependencies": {
-                "express": {
-                  "version": "2.5.11",
-                  "from": "express@>=2.5.0 <2.6.0",
-                  "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
-                  "dependencies": {
-                    "connect": {
-                      "version": "1.9.2",
-                      "from": "connect@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
-                      "dependencies": {
-                        "formidable": {
-                          "version": "1.0.17",
-                          "from": "formidable@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
-                        }
-                      }
-                    },
-                    "mime": {
-                      "version": "1.2.4",
-                      "from": "mime@1.2.4",
-                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
-                    },
-                    "qs": {
-                      "version": "0.4.2",
-                      "from": "qs@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.3.0",
-                      "from": "mkdirp@0.3.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.3",
-                  "from": "nopt@>=3.0.0 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                },
-                "underscore": {
-                  "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "chokidar": {
-          "version": "1.0.5",
-          "from": "chokidar@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
-          "dependencies": {
-            "arrify": {
-              "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
-            },
-            "async-each": {
-              "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
-            },
-            "glob-parent": {
-              "version": "1.2.0",
-              "from": "glob-parent@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
-            },
-            "is-binary-path": {
-              "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-              "dependencies": {
-                "binary-extensions": {
-                  "version": "1.3.1",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
-                }
-              }
-            },
-            "is-glob": {
-              "version": "1.1.3",
-              "from": "is-glob@>=1.1.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-            },
-            "readdirp": {
-              "version": "1.4.0",
-              "from": "readdirp@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <4.2.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@>=0.2.12 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "fsevents": {
-              "version": "0.3.7",
-              "from": "fsevents@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.7.tgz",
-              "dependencies": {
-                "nan": {
-                  "version": "1.9.0",
-                  "from": "nan@>=1.8.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "connect": {
-          "version": "3.4.0",
-          "from": "connect@>=3.4.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.0.tgz",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                }
-              }
-            },
-            "finalhandler": {
-              "version": "0.4.0",
-              "from": "finalhandler@0.4.0",
-              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
-              "dependencies": {
-                "escape-html": {
-                  "version": "1.0.2",
-                  "from": "escape-html@1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
-                },
-                "on-finished": {
-                  "version": "2.3.0",
-                  "from": "on-finished@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.1.1",
-                      "from": "ee-first@1.1.1",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                    }
-                  }
-                },
-                "unpipe": {
-                  "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-                }
-              }
-            },
-            "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
-            },
-            "utils-merge": {
-              "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
-              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-            }
-          }
-        },
-        "dev-ip": {
-          "version": "1.0.1",
-          "from": "dev-ip@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz"
-        },
-        "easy-extender": {
-          "version": "2.3.1",
-          "from": "easy-extender@>=2.3.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.1.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
-            }
-          }
-        },
-        "eazy-logger": {
-          "version": "2.1.2",
-          "from": "eazy-logger@>=2.1.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-2.1.2.tgz",
-          "dependencies": {
-            "opt-merger": {
-              "version": "1.1.0",
-              "from": "opt-merger@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/opt-merger/-/opt-merger-1.1.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "2.4.2",
-                  "from": "lodash@>=2.4.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
-                },
-                "minimist": {
-                  "version": "1.1.2",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
-                }
-              }
-            },
-            "tfunk": {
-              "version": "3.0.1",
-              "from": "tfunk@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.0.1.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "0.5.1",
-                  "from": "chalk@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "1.1.0",
-                      "from": "ansi-styles@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.3",
-                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "0.1.0",
-                      "from": "has-ansi@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "0.3.0",
-                      "from": "strip-ansi@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "0.2.0",
-                      "from": "supports-color@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
-                    }
-                  }
-                },
-                "object-path": {
-                  "version": "0.9.2",
-                  "from": "object-path@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "emitter-steward": {
-          "version": "0.0.1",
-          "from": "emitter-steward@>=0.0.1 <0.0.2",
-          "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-0.0.1.tgz"
-        },
-        "foxy": {
-          "version": "11.1.2",
-          "from": "foxy@>=11.1.1 <12.0.0",
-          "resolved": "https://registry.npmjs.org/foxy/-/foxy-11.1.2.tgz",
-          "dependencies": {
-            "cookie": {
-              "version": "0.1.3",
-              "from": "cookie@>=0.1.3 <0.2.0",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
-            },
-            "http-proxy": {
-              "version": "1.11.1",
-              "from": "http-proxy@>=1.9.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.1.tgz",
-              "dependencies": {
-                "eventemitter3": {
-                  "version": "1.1.1",
-                  "from": "eventemitter3@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz"
-                },
-                "requires-port": {
-                  "version": "0.0.1",
-                  "from": "requires-port@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.1.tgz"
-                }
-              }
-            },
-            "lodash.merge": {
-              "version": "3.3.2",
-              "from": "lodash.merge@>=3.3.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
-              "dependencies": {
-                "lodash._arraycopy": {
-                  "version": "3.0.0",
-                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
-                },
-                "lodash._arrayeach": {
-                  "version": "3.0.0",
-                  "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
-                },
-                "lodash._createassigner": {
-                  "version": "3.1.1",
-                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-                  "dependencies": {
-                    "lodash._bindcallback": {
-                      "version": "3.0.1",
-                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-                    },
-                    "lodash._isiterateecall": {
-                      "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-                    },
-                    "lodash.restparam": {
-                      "version": "3.6.1",
-                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-                    }
-                  }
-                },
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                },
-                "lodash.isplainobject": {
-                  "version": "3.2.0",
-                  "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-                  "dependencies": {
-                    "lodash._basefor": {
-                      "version": "3.0.2",
-                      "from": "lodash._basefor@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
-                    }
-                  }
-                },
-                "lodash.istypedarray": {
-                  "version": "3.0.2",
-                  "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "lodash.keys@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-                },
-                "lodash.keysin": {
-                  "version": "3.0.8",
-                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
-                },
-                "lodash.toplainobject": {
-                  "version": "3.0.0",
-                  "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "resp-modifier": {
-              "version": "5.0.0",
-              "from": "resp-modifier@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-5.0.0.tgz",
-              "dependencies": {
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "immutable": {
-          "version": "3.7.4",
-          "from": "immutable@>=3.7.4 <4.0.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.4.tgz"
-        },
-        "localtunnel": {
-          "version": "1.7.0",
-          "from": "localtunnel@>=1.7.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.7.0.tgz",
-          "dependencies": {
-            "request": {
-              "version": "2.11.4",
-              "from": "request@2.11.4",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.11.4.tgz",
-              "dependencies": {
-                "form-data": {
-                  "version": "0.0.3",
-                  "from": "form-data",
-                  "dependencies": {
-                    "combined-stream": {
-                      "version": "0.0.3",
-                      "from": "combined-stream@0.0.3",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5"
-                        }
-                      }
-                    },
-                    "async": {
-                      "version": "0.1.9",
-                      "from": "async@0.1.9"
-                    }
-                  }
-                },
-                "mime": {
-                  "version": "1.2.7",
-                  "from": "mime"
-                }
-              }
-            },
-            "yargs": {
-              "version": "3.15.0",
-              "from": "yargs@3.15.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                },
-                "cliui": {
-                  "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "dependencies": {
-                    "center-align": {
-                      "version": "0.1.1",
-                      "from": "center-align@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.3",
-                          "from": "align-text@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "2.0.0",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "right-align": {
-                      "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.3",
-                          "from": "align-text@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "2.0.0",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.0.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
-                },
-                "window-size": {
-                  "version": "0.1.2",
-                  "from": "window-size@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "debug@0.7.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            },
-            "openurl": {
-              "version": "1.1.0",
-              "from": "openurl@1.1.0",
-              "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.0.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.9.3 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
-        "longest": {
-          "version": "1.0.1",
-          "from": "longest@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-        },
-        "meow": {
-          "version": "3.3.0",
-          "from": "meow@>=3.3.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
-          "dependencies": {
-            "camelcase-keys": {
-              "version": "1.0.0",
-              "from": "camelcase-keys@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "from": "camelcase@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                },
-                "map-obj": {
-                  "version": "1.0.1",
-                  "from": "map-obj@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                }
-              }
-            },
-            "indent-string": {
-              "version": "1.2.2",
-              "from": "indent-string@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "repeating": {
-                  "version": "1.1.3",
-                  "from": "repeating@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.1",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.1.2",
-              "from": "minimist@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
-            },
-            "object-assign": {
-              "version": "3.0.0",
-              "from": "object-assign@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-            }
-          }
-        },
-        "opn": {
-          "version": "2.0.1",
-          "from": "opn@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-2.0.1.tgz"
-        },
-        "pad-left": {
-          "version": "1.0.2",
-          "from": "pad-left@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
-          "dependencies": {
-            "repeat-string": {
-              "version": "1.5.2",
-              "from": "repeat-string@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-            }
-          }
-        },
-        "portscanner": {
-          "version": "1.0.0",
-          "from": "portscanner@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.0.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.1.15",
-              "from": "async@0.1.15",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.1.15.tgz"
-            }
-          }
-        },
-        "query-string": {
-          "version": "2.4.0",
-          "from": "query-string@>=2.4.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-2.4.0.tgz",
-          "dependencies": {
-            "strict-uri-encode": {
-              "version": "1.0.2",
-              "from": "strict-uri-encode@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.0.2.tgz"
-            }
-          }
-        },
-        "resp-modifier": {
-          "version": "4.0.4",
-          "from": "resp-modifier@>=4.0.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-4.0.4.tgz",
-          "dependencies": {
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "serve-index": {
-          "version": "1.7.2",
-          "from": "serve-index@>=1.7.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.2.tgz",
-          "dependencies": {
-            "accepts": {
-              "version": "1.2.12",
-              "from": "accepts@>=1.2.12 <1.3.0",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.12.tgz",
-              "dependencies": {
-                "negotiator": {
-                  "version": "0.5.3",
-                  "from": "negotiator@0.5.3",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
-                }
-              }
-            },
-            "batch": {
-              "version": "0.5.2",
-              "from": "batch@0.5.2",
-              "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
-            },
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                }
-              }
-            },
-            "escape-html": {
-              "version": "1.0.2",
-              "from": "escape-html@1.0.2",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
-            },
-            "http-errors": {
-              "version": "1.3.1",
-              "from": "http-errors@>=1.3.1 <1.4.0",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "statuses": {
-                  "version": "1.2.1",
-                  "from": "statuses@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
-                }
-              }
-            },
-            "mime-types": {
-              "version": "2.1.4",
-              "from": "mime-types@>=2.1.4 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.16.0",
-                  "from": "mime-db@>=1.16.0 <1.17.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
-                }
-              }
-            },
-            "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
-            }
-          }
-        },
-        "serve-static": {
-          "version": "1.10.0",
-          "from": "serve-static@>=1.10.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz",
-          "dependencies": {
-            "escape-html": {
-              "version": "1.0.2",
-              "from": "escape-html@1.0.2",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
-            },
-            "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
-            },
-            "send": {
-              "version": "0.13.0",
-              "from": "send@0.13.0",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
-              "dependencies": {
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-                },
-                "depd": {
-                  "version": "1.0.1",
-                  "from": "depd@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
-                },
-                "destroy": {
-                  "version": "1.0.3",
-                  "from": "destroy@1.0.3",
-                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
-                },
-                "etag": {
-                  "version": "1.7.0",
-                  "from": "etag@>=1.7.0 <1.8.0",
-                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
-                },
-                "fresh": {
-                  "version": "0.3.0",
-                  "from": "fresh@0.3.0",
-                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
-                },
-                "http-errors": {
-                  "version": "1.3.1",
-                  "from": "http-errors@>=1.3.1 <1.4.0",
-                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "mime": {
-                  "version": "1.3.4",
-                  "from": "mime@1.3.4",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-                },
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                },
-                "on-finished": {
-                  "version": "2.3.0",
-                  "from": "on-finished@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.1.1",
-                      "from": "ee-first@1.1.1",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                    }
-                  }
-                },
-                "range-parser": {
-                  "version": "1.0.2",
-                  "from": "range-parser@>=1.0.2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
-                },
-                "statuses": {
-                  "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "socket.io": {
-          "version": "1.3.6",
-          "from": "socket.io@>=1.3.6 <2.0.0",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.3.6.tgz",
-          "dependencies": {
-            "engine.io": {
-              "version": "1.5.2",
-              "from": "engine.io@1.5.2",
-              "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.5.2.tgz",
-              "dependencies": {
-                "base64id": {
-                  "version": "0.1.0",
-                  "from": "base64id@0.1.0",
-                  "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
-                },
-                "debug": {
-                  "version": "1.0.3",
-                  "from": "debug@1.0.3",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "engine.io-parser": {
-                  "version": "1.2.1",
-                  "from": "engine.io-parser@1.2.1",
-                  "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
-                  "dependencies": {
-                    "after": {
-                      "version": "0.8.1",
-                      "from": "after@0.8.1",
-                      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
-                    },
-                    "arraybuffer.slice": {
-                      "version": "0.0.6",
-                      "from": "arraybuffer.slice@0.0.6",
-                      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
-                    },
-                    "base64-arraybuffer": {
-                      "version": "0.1.2",
-                      "from": "base64-arraybuffer@0.1.2",
-                      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
-                    },
-                    "blob": {
-                      "version": "0.0.2",
-                      "from": "blob@0.0.2",
-                      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
-                    },
-                    "has-binary": {
-                      "version": "0.1.5",
-                      "from": "has-binary@0.1.5",
-                      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
-                      "dependencies": {
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        }
-                      }
-                    },
-                    "utf8": {
-                      "version": "2.0.0",
-                      "from": "utf8@2.0.0",
-                      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
-                    }
-                  }
-                },
-                "ws": {
-                  "version": "0.7.2",
-                  "from": "ws@0.7.2",
-                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.7.2.tgz",
-                  "dependencies": {
-                    "options": {
-                      "version": "0.0.6",
-                      "from": "options@>=0.0.5",
-                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-                    },
-                    "ultron": {
-                      "version": "1.0.2",
-                      "from": "ultron@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
-                    },
-                    "bufferutil": {
-                      "version": "1.1.0",
-                      "from": "bufferutil@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.1.0.tgz",
-                      "dependencies": {
-                        "bindings": {
-                          "version": "1.2.1",
-                          "from": "bindings@>=1.2.0 <1.3.0",
-                          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                        },
-                        "nan": {
-                          "version": "1.8.4",
-                          "from": "nan@>=1.8.0 <1.9.0",
-                          "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
-                        }
-                      }
-                    },
-                    "utf-8-validate": {
-                      "version": "1.1.0",
-                      "from": "utf-8-validate@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.1.0.tgz",
-                      "dependencies": {
-                        "bindings": {
-                          "version": "1.2.1",
-                          "from": "bindings@>=1.2.0 <1.3.0",
-                          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                        },
-                        "nan": {
-                          "version": "1.8.4",
-                          "from": "nan@>=1.8.0 <1.9.0",
-                          "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "socket.io-parser": {
-              "version": "2.2.4",
-              "from": "socket.io-parser@2.2.4",
-              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
-              "dependencies": {
-                "debug": {
-                  "version": "0.7.4",
-                  "from": "debug@0.7.4",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                },
-                "json3": {
-                  "version": "3.2.6",
-                  "from": "json3@3.2.6",
-                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-                },
-                "component-emitter": {
-                  "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "benchmark": {
-                  "version": "1.0.0",
-                  "from": "benchmark@1.0.0",
-                  "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
-                }
-              }
-            },
-            "socket.io-client": {
-              "version": "1.3.6",
-              "from": "socket.io-client@1.3.6",
-              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.3.6.tgz",
-              "dependencies": {
-                "debug": {
-                  "version": "0.7.4",
-                  "from": "debug@0.7.4",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                },
-                "engine.io-client": {
-                  "version": "1.5.2",
-                  "from": "engine.io-client@1.5.2",
-                  "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.5.2.tgz",
-                  "dependencies": {
-                    "component-inherit": {
-                      "version": "0.0.3",
-                      "from": "component-inherit@0.0.3",
-                      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
-                    },
-                    "debug": {
-                      "version": "1.0.4",
-                      "from": "debug@1.0.4",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.6.2",
-                          "from": "ms@0.6.2",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                        }
-                      }
-                    },
-                    "engine.io-parser": {
-                      "version": "1.2.1",
-                      "from": "engine.io-parser@1.2.1",
-                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
-                      "dependencies": {
-                        "after": {
-                          "version": "0.8.1",
-                          "from": "after@0.8.1",
-                          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
-                        },
-                        "arraybuffer.slice": {
-                          "version": "0.0.6",
-                          "from": "arraybuffer.slice@0.0.6",
-                          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
-                        },
-                        "base64-arraybuffer": {
-                          "version": "0.1.2",
-                          "from": "base64-arraybuffer@0.1.2",
-                          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
-                        },
-                        "blob": {
-                          "version": "0.0.2",
-                          "from": "blob@0.0.2",
-                          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
-                        },
-                        "has-binary": {
-                          "version": "0.1.5",
-                          "from": "has-binary@0.1.5",
-                          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
-                          "dependencies": {
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            }
-                          }
-                        },
-                        "utf8": {
-                          "version": "2.0.0",
-                          "from": "utf8@2.0.0",
-                          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "has-cors": {
-                      "version": "1.0.3",
-                      "from": "has-cors@1.0.3",
-                      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
-                      "dependencies": {
-                        "global": {
-                          "version": "2.0.1",
-                          "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
-                          "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
-                        }
-                      }
-                    },
-                    "parsejson": {
-                      "version": "0.0.1",
-                      "from": "parsejson@0.0.1",
-                      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "from": "callsite@1.0.0",
-                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "parseqs": {
-                      "version": "0.0.2",
-                      "from": "parseqs@0.0.2",
-                      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "from": "callsite@1.0.0",
-                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "parseuri": {
-                      "version": "0.0.4",
-                      "from": "parseuri@0.0.4",
-                      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "from": "callsite@1.0.0",
-                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "ws": {
-                      "version": "0.7.2",
-                      "from": "ws@0.7.2",
-                      "resolved": "https://registry.npmjs.org/ws/-/ws-0.7.2.tgz",
-                      "dependencies": {
-                        "options": {
-                          "version": "0.0.6",
-                          "from": "options@>=0.0.5",
-                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-                        },
-                        "ultron": {
-                          "version": "1.0.2",
-                          "from": "ultron@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
-                        },
-                        "bufferutil": {
-                          "version": "1.1.0",
-                          "from": "bufferutil@>=1.1.0 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.1.0.tgz",
-                          "dependencies": {
-                            "bindings": {
-                              "version": "1.2.1",
-                              "from": "bindings@>=1.2.0 <1.3.0",
-                              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                            },
-                            "nan": {
-                              "version": "1.8.4",
-                              "from": "nan@>=1.8.0 <1.9.0",
-                              "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
-                            }
-                          }
-                        },
-                        "utf-8-validate": {
-                          "version": "1.1.0",
-                          "from": "utf-8-validate@>=1.1.0 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.1.0.tgz",
-                          "dependencies": {
-                            "bindings": {
-                              "version": "1.2.1",
-                              "from": "bindings@>=1.2.0 <1.3.0",
-                              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                            },
-                            "nan": {
-                              "version": "1.8.4",
-                              "from": "nan@>=1.8.0 <1.9.0",
-                              "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "xmlhttprequest": {
-                      "version": "1.5.0",
-                      "from": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz",
-                      "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
-                    }
-                  }
-                },
-                "component-bind": {
-                  "version": "1.0.0",
-                  "from": "component-bind@1.0.0",
-                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
-                },
-                "component-emitter": {
-                  "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                },
-                "object-component": {
-                  "version": "0.0.3",
-                  "from": "object-component@0.0.3",
-                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
-                },
-                "has-binary": {
-                  "version": "0.1.6",
-                  "from": "has-binary@0.1.6",
-                  "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-                  "dependencies": {
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    }
-                  }
-                },
-                "indexof": {
-                  "version": "0.0.1",
-                  "from": "indexof@0.0.1",
-                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-                },
-                "parseuri": {
-                  "version": "0.0.2",
-                  "from": "parseuri@0.0.2",
-                  "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
-                  "dependencies": {
-                    "better-assert": {
-                      "version": "1.0.2",
-                      "from": "better-assert@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                      "dependencies": {
-                        "callsite": {
-                          "version": "1.0.0",
-                          "from": "callsite@1.0.0",
-                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "to-array": {
-                  "version": "0.1.3",
-                  "from": "to-array@0.1.3",
-                  "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
-                },
-                "backo2": {
-                  "version": "1.0.2",
-                  "from": "backo2@1.0.2",
-                  "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
-                }
-              }
-            },
-            "socket.io-adapter": {
-              "version": "0.3.1",
-              "from": "socket.io-adapter@0.3.1",
-              "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
-              "dependencies": {
-                "debug": {
-                  "version": "1.0.2",
-                  "from": "debug@1.0.2",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
-                },
-                "socket.io-parser": {
-                  "version": "2.2.2",
-                  "from": "socket.io-parser@2.2.2",
-                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-                  "dependencies": {
-                    "debug": {
-                      "version": "0.7.4",
-                      "from": "debug@0.7.4",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                    },
-                    "json3": {
-                      "version": "3.2.6",
-                      "from": "json3@3.2.6",
-                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-                    },
-                    "component-emitter": {
-                      "version": "1.1.2",
-                      "from": "component-emitter@1.1.2",
-                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "benchmark": {
-                      "version": "1.0.0",
-                      "from": "benchmark@1.0.0",
-                      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
-                    }
-                  }
-                },
-                "object-keys": {
-                  "version": "1.0.1",
-                  "from": "object-keys@1.0.1",
-                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz"
-                }
-              }
-            },
-            "has-binary-data": {
-              "version": "0.1.3",
-              "from": "has-binary-data@0.1.3",
-              "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz",
-              "dependencies": {
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                }
-              }
-            },
-            "debug": {
-              "version": "2.1.0",
-              "from": "debug@2.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.9",
-          "from": "ua-parser-js@>=0.7.9 <0.8.0",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.9.tgz"
-        },
-        "ucfirst": {
-          "version": "0.0.1",
-          "from": "ucfirst@0.0.1",
-          "resolved": "https://registry.npmjs.org/ucfirst/-/ucfirst-0.0.1.tgz"
         }
       }
     },
@@ -2830,309 +1037,95 @@
       "from": "btoa@1.1.2",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.2.tgz"
     },
-    "del": {
-      "version": "1.2.0",
-      "from": "del@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-1.2.0.tgz",
-      "dependencies": {
-        "each-async": {
-          "version": "1.1.1",
-          "from": "each-async@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
-          "dependencies": {
-            "onetime": {
-              "version": "1.0.0",
-              "from": "onetime@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
-            },
-            "set-immediate-shim": {
-              "version": "1.0.1",
-              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
-            }
-          }
-        },
-        "globby": {
-          "version": "2.1.0",
-          "from": "globby@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
-          "dependencies": {
-            "array-union": {
-              "version": "1.0.1",
-              "from": "array-union@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "from": "array-uniq@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "async": {
-              "version": "1.4.0",
-              "from": "async@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
-            },
-            "glob": {
-              "version": "5.0.14",
-              "from": "glob@>=5.0.3 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "3.0.0",
-              "from": "object-assign@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-            }
-          }
-        },
-        "is-path-cwd": {
-          "version": "1.0.0",
-          "from": "is-path-cwd@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
-        },
-        "is-path-in-cwd": {
-          "version": "1.0.0",
-          "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-          "dependencies": {
-            "is-path-inside": {
-              "version": "1.0.0",
-              "from": "is-path-inside@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-              "dependencies": {
-                "path-is-inside": {
-                  "version": "1.0.1",
-                  "from": "path-is-inside@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-        },
-        "rimraf": {
-          "version": "2.4.2",
-          "from": "rimraf@>=2.2.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "5.0.14",
-              "from": "glob@>=5.0.14 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "eslint": {
-      "version": "1.0.0",
-      "from": "eslint@>=0.8.0||>=1.0.0-rc-0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.0.0.tgz",
+      "version": "1.1.0",
+      "from": "eslint@>=0.8.0 || ~1.0.0-rc-0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.1.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@^1.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "ansi-styles@^2.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "has-ansi@^2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "strip-ansi@^3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "supports-color@^2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "concat-stream": {
           "version": "1.5.0",
-          "from": "concat-stream@>=1.4.6 <2.0.0",
+          "from": "concat-stream@^1.4.6",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@~2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@>=0.0.5 <0.1.0",
+              "from": "typedarray@~0.0.5",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "2.0.2",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "readable-stream@^2.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.2",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                  "from": "process-nextick-args@~1.0.0",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.1",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "util-deprecate@~1.0.1",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                 }
               }
@@ -3141,7 +1134,7 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.1 <3.0.0",
+          "from": "debug@^2.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
@@ -3153,192 +1146,169 @@
         },
         "doctrine": {
           "version": "0.6.4",
-          "from": "doctrine@>=0.6.2 <0.7.0",
+          "from": "doctrine@^0.6.2",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
           "dependencies": {
             "esutils": {
               "version": "1.1.6",
-              "from": "esutils@>=1.1.6 <2.0.0",
+              "from": "esutils@^1.1.6",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "escape-string-regexp": {
           "version": "1.0.3",
-          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+          "from": "escape-string-regexp@^1.0.2",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
         "escope": {
           "version": "3.2.0",
-          "from": "escope@>=3.2.0 <4.0.0",
+          "from": "escope@^3.2.0",
           "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
           "dependencies": {
             "es6-map": {
               "version": "0.1.1",
-              "from": "es6-map@>=0.1.1 <0.2.0",
+              "from": "es6-map@^0.1.1",
               "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
               "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@~0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "from": "es5-ext@~0.10.4",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@~2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "from": "es6-iterator@~0.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@~2.0.1",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
                 "es6-set": {
                   "version": "0.1.1",
-                  "from": "es6-set@>=0.1.1 <0.2.0",
+                  "from": "es6-set@~0.1.1",
                   "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
                 },
                 "es6-symbol": {
                   "version": "0.1.1",
-                  "from": "es6-symbol@>=0.1.1 <0.2.0",
+                  "from": "es6-symbol@~0.1.1",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                 },
                 "event-emitter": {
                   "version": "0.3.3",
-                  "from": "event-emitter@>=0.3.1 <0.4.0",
+                  "from": "event-emitter@~0.3.1",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                 }
               }
             },
             "es6-weak-map": {
               "version": "0.1.4",
-              "from": "es6-weak-map@>=0.1.2 <0.2.0",
+              "from": "es6-weak-map@^0.1.2",
               "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
               "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@~0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "from": "es5-ext@~0.10.6",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
+                },
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "from": "es6-iterator@~0.1.3",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                },
                 "es6-symbol": {
                   "version": "2.0.1",
-                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                  "from": "es6-symbol@~2.0.1",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                 }
               }
             },
             "esrecurse": {
               "version": "3.1.1",
-              "from": "esrecurse@>=3.1.1 <4.0.0",
+              "from": "esrecurse@^3.1.1",
               "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
             },
             "estraverse": {
               "version": "3.1.0",
-              "from": "estraverse@>=3.1.0 <4.0.0",
+              "from": "estraverse@^3.1.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
-            },
-            "es6-iterator": {
-              "version": "0.1.3",
-              "from": "es6-iterator@0.1.3",
-              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1",
-                  "from": "d@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                },
-                "es5-ext": {
-                  "version": "0.10.7",
-                  "from": "es5-ext@>=0.10.5 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
-                },
-                "es6-symbol": {
-                  "version": "2.0.1",
-                  "from": "es6-symbol@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                }
-              }
-            },
-            "d": {
-              "version": "0.1.1",
-              "from": "d@0.1.1",
-              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-              "dependencies": {
-                "es5-ext": {
-                  "version": "0.10.7",
-                  "from": "es5-ext@>=0.10.2 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
-                  "dependencies": {
-                    "es6-iterator": {
-                      "version": "0.1.3",
-                      "from": "es6-iterator@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
-                    },
-                    "es6-symbol": {
-                      "version": "2.0.1",
-                      "from": "es6-symbol@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "es5-ext": {
-              "version": "0.10.7",
-              "from": "es5-ext@0.10.7",
-              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
-              "dependencies": {
-                "es6-iterator": {
-                  "version": "0.1.3",
-                  "from": "es6-iterator@>=0.1.3 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                    }
-                  }
-                },
-                "es6-symbol": {
-                  "version": "2.0.1",
-                  "from": "es6-symbol@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                    }
-                  }
-                }
-              }
             }
           }
         },
         "espree": {
           "version": "2.2.3",
-          "from": "espree@>=2.2.0 <3.0.0",
+          "from": "espree@^2.2.0",
           "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.3.tgz"
         },
         "estraverse": {
           "version": "4.1.0",
-          "from": "estraverse@>=4.1.0 <5.0.0",
+          "from": "estraverse@^4.1.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
         },
         "estraverse-fb": {
           "version": "1.3.1",
-          "from": "estraverse-fb@>=1.3.1 <2.0.0",
+          "from": "estraverse-fb@^1.3.1",
           "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
         },
         "globals": {
           "version": "8.3.0",
-          "from": "globals@>=8.2.0 <9.0.0",
+          "from": "globals@^8.3.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-8.3.0.tgz"
         },
         "inquirer": {
-          "version": "0.8.5",
-          "from": "inquirer@>=0.8.2 <0.9.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+          "version": "0.9.0",
+          "from": "inquirer@^0.9.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "1.1.1",
-              "from": "ansi-regex@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+              "version": "2.0.0",
+              "from": "ansi-regex@^2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             },
             "cli-width": {
               "version": "1.0.1",
-              "from": "cli-width@>=1.0.1 <2.0.0",
+              "from": "cli-width@^1.0.1",
               "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
             },
             "figures": {
               "version": "1.3.5",
-              "from": "figures@>=1.3.5 <2.0.0",
+              "from": "figures@^1.3.5",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@^3.3.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "readline2": {
               "version": "0.1.1",
-              "from": "readline2@>=0.1.1 <0.2.0",
+              "from": "readline2@^0.1.1",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
               "dependencies": {
                 "mute-stream": {
@@ -3348,196 +1318,393 @@
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
                 }
               }
             },
-            "rx": {
-              "version": "2.5.3",
-              "from": "rx@>=2.4.3 <3.0.0",
-              "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
+            "run-async": {
+              "version": "0.1.0",
+              "from": "run-async@^0.1.0",
+              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@^1.3.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "rx-lite": {
+              "version": "2.5.2",
+              "from": "rx-lite@^2.5.2",
+              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz"
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@^3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.3.6 <3.0.0",
+              "from": "through@^2.3.6",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "is-my-json-valid": {
           "version": "2.12.1",
-          "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+          "from": "is-my-json-valid@^2.10.0",
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
           "dependencies": {
             "generate-function": {
               "version": "2.0.0",
-              "from": "generate-function@>=2.0.0 <3.0.0",
+              "from": "generate-function@^2.0.0",
               "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
             },
             "generate-object-property": {
               "version": "1.2.0",
-              "from": "generate-object-property@>=1.1.0 <2.0.0",
+              "from": "generate-object-property@^1.1.0",
               "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
               "dependencies": {
                 "is-property": {
                   "version": "1.0.2",
-                  "from": "is-property@>=1.0.0 <2.0.0",
+                  "from": "is-property@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                 }
               }
             },
             "jsonpointer": {
               "version": "1.1.0",
-              "from": "jsonpointer@>=1.1.0 <2.0.0",
+              "from": "jsonpointer@^1.1.0",
               "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "xtend@^4.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "js-yaml": {
           "version": "3.3.1",
-          "from": "js-yaml@>=3.2.5 <4.0.0",
+          "from": "js-yaml@^3.2.5",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.2",
-              "from": "argparse@>=1.0.2 <1.1.0",
+              "from": "argparse@~1.0.2",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
               "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>= 3.2.0 < 4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "from": "sprintf-js@~1.0.2",
                   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.2.0",
-              "from": "esprima@>=2.2.0 <2.3.0",
+              "from": "esprima@~2.2.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
             }
           }
         },
         "lodash.clonedeep": {
           "version": "3.0.2",
-          "from": "lodash.clonedeep@>=3.0.1 <4.0.0",
+          "from": "lodash.clonedeep@^3.0.1",
           "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
           "dependencies": {
             "lodash._baseclone": {
               "version": "3.3.0",
-              "from": "lodash._baseclone@>=3.0.0 <4.0.0",
+              "from": "lodash._baseclone@^3.0.0",
               "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
               "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._arraycopy@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0",
+                  "from": "lodash._arrayeach@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                },
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
+                  "from": "lodash._baseassign@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "lodash._basecopy@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "from": "lodash._basefor@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    }
+                  }
                 }
               }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "from": "lodash._bindcallback@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             }
           }
         },
         "lodash.merge": {
           "version": "3.3.2",
-          "from": "lodash.merge@>=3.3.2 <4.0.0",
+          "from": "lodash.merge@^3.3.2",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
           "dependencies": {
+            "lodash._arraycopy": {
+              "version": "3.0.0",
+              "from": "lodash._arraycopy@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+            },
+            "lodash._arrayeach": {
+              "version": "3.0.0",
+              "from": "lodash._arrayeach@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+            },
             "lodash._createassigner": {
               "version": "3.1.1",
-              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+              "from": "lodash._createassigner@^3.0.0",
               "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "from": "lodash._bindcallback@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                },
                 "lodash._isiterateecall": {
                   "version": "3.0.9",
-                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "from": "lodash._isiterateecall@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                 }
               }
             },
+            "lodash._getnative": {
+              "version": "3.9.1",
+              "from": "lodash._getnative@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+            },
+            "lodash.isarguments": {
+              "version": "3.0.4",
+              "from": "lodash.isarguments@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+            },
+            "lodash.isarray": {
+              "version": "3.0.4",
+              "from": "lodash.isarray@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+            },
             "lodash.isplainobject": {
               "version": "3.2.0",
-              "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz"
+              "from": "lodash.isplainobject@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "from": "lodash._basefor@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                }
+              }
             },
             "lodash.istypedarray": {
               "version": "3.0.2",
-              "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
+              "from": "lodash.istypedarray@^3.0.0",
               "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "from": "lodash.keys@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "from": "lodash.keysin@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
             },
             "lodash.toplainobject": {
               "version": "3.0.0",
-              "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz"
+              "from": "lodash.toplainobject@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                }
+              }
             }
           }
         },
         "lodash.omit": {
           "version": "3.1.0",
-          "from": "lodash.omit@>=3.1.0 <4.0.0",
+          "from": "lodash.omit@^3.1.0",
           "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
           "dependencies": {
             "lodash._arraymap": {
               "version": "3.0.0",
-              "from": "lodash._arraymap@>=3.0.0 <4.0.0",
+              "from": "lodash._arraymap@^3.0.0",
               "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
             },
             "lodash._basedifference": {
               "version": "3.0.3",
-              "from": "lodash._basedifference@>=3.0.0 <4.0.0",
+              "from": "lodash._basedifference@^3.0.0",
               "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
               "dependencies": {
                 "lodash._baseindexof": {
                   "version": "3.1.0",
-                  "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
+                  "from": "lodash._baseindexof@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
                 },
                 "lodash._cacheindexof": {
                   "version": "3.0.2",
-                  "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
+                  "from": "lodash._cacheindexof@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
                 },
                 "lodash._createcache": {
                   "version": "3.1.2",
-                  "from": "lodash._createcache@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz"
+                  "from": "lodash._createcache@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    }
+                  }
                 }
               }
             },
             "lodash._baseflatten": {
               "version": "3.1.4",
-              "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz"
+              "from": "lodash._baseflatten@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarguments@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "from": "lodash._bindcallback@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             },
             "lodash._pickbyarray": {
               "version": "3.0.2",
-              "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
+              "from": "lodash._pickbyarray@^3.0.0",
               "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
             },
             "lodash._pickbycallback": {
               "version": "3.0.0",
-              "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz"
+              "from": "lodash._pickbycallback@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "from": "lodash._basefor@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                }
+              }
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "from": "lodash.keysin@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarguments@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "lodash.restparam@^3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             }
           }
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.1 <3.0.0",
+          "from": "minimatch@^2.0.1",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "brace-expansion@^1.0.0",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "from": "balanced-match@^0.2.0",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
@@ -3551,146 +1718,81 @@
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "object-assign@^2.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         },
         "optionator": {
           "version": "0.5.0",
-          "from": "optionator@>=0.5.0 <0.6.0",
+          "from": "optionator@^0.5.0",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
           "dependencies": {
             "prelude-ls": {
               "version": "1.1.2",
-              "from": "prelude-ls@>=1.1.1 <1.2.0",
+              "from": "prelude-ls@~1.1.1",
               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "deep-is@>=0.1.2 <0.2.0",
+              "from": "deep-is@~0.1.2",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             },
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "type-check": {
               "version": "0.3.1",
-              "from": "type-check@>=0.3.1 <0.4.0",
+              "from": "type-check@~0.3.1",
               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
             },
             "levn": {
               "version": "0.2.5",
-              "from": "levn@>=0.2.5 <0.3.0",
+              "from": "levn@~0.2.5",
               "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
             },
             "fast-levenshtein": {
               "version": "1.0.6",
-              "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+              "from": "fast-levenshtein@~1.0.0",
               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "path-is-absolute@^1.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "from": "path-is-inside@>=1.0.1 <2.0.0",
+          "from": "path-is-inside@^1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.4",
-          "from": "strip-json-comments@>=1.0.1 <1.1.0",
+          "from": "strip-json-comments@~1.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "text-table@~0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         },
         "user-home": {
           "version": "1.1.1",
-          "from": "user-home@>=1.0.0 <2.0.0",
+          "from": "user-home@^1.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
         },
         "xml-escape": {
           "version": "1.0.0",
-          "from": "xml-escape@>=1.0.0 <1.1.0",
+          "from": "xml-escape@~1.0.0",
           "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
-        "lodash._arraycopy": {
-          "version": "3.0.0",
-          "from": "lodash._arraycopy@3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
-        },
-        "lodash._arrayeach": {
-          "version": "3.0.0",
-          "from": "lodash._arrayeach@3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
-        },
-        "lodash._basecopy": {
-          "version": "3.0.1",
-          "from": "lodash._basecopy@3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-        },
-        "lodash._basefor": {
-          "version": "3.0.2",
-          "from": "lodash._basefor@3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "from": "lodash._bindcallback@3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "from": "lodash._getnative@3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-        },
-        "lodash.isarguments": {
-          "version": "3.0.4",
-          "from": "lodash.isarguments@3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "from": "lodash.isarray@3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "from": "lodash.keys@3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-        },
-        "lodash.keysin": {
-          "version": "3.0.8",
-          "from": "lodash.keysin@3.0.8",
-          "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "from": "lodash.restparam@3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
         }
       }
     },
     "eslint-plugin-react": {
       "version": "2.7.1",
-      "from": "eslint-plugin-react@>=2.7.0 <3.0.0",
+      "from": "eslint-plugin-react@^2.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.7.1.tgz"
     },
     "esprima": {
@@ -3699,70 +1801,9 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
     },
     "esprima-fb": {
-      "version": "15001.1.0-dev-harmony-fb",
-      "from": "esprima-fb@>=15001.1.0-dev-harmony-fb <15002.0.0",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
-    },
-    "foreman": {
-      "version": "1.4.1",
-      "from": "foreman@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/foreman/-/foreman-1.4.1.tgz",
-      "dependencies": {
-        "commander": {
-          "version": "2.1.0",
-          "from": "commander@>=2.1.0 <2.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
-        },
-        "http-proxy": {
-          "version": "1.11.1",
-          "from": "http-proxy@>=1.11.1 <1.12.0",
-          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.1.tgz",
-          "dependencies": {
-            "eventemitter3": {
-              "version": "1.1.1",
-              "from": "eventemitter3@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz"
-            },
-            "requires-port": {
-              "version": "0.0.1",
-              "from": "requires-port@>=0.0.0 <1.0.0",
-              "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.1.tgz"
-            }
-          }
-        },
-        "mu2": {
-          "version": "0.5.20",
-          "from": "mu2@>=0.5.20 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mu2/-/mu2-0.5.20.tgz"
-        },
-        "shell-quote": {
-          "version": "1.4.3",
-          "from": "shell-quote@>=1.4.2 <1.5.0",
-          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
-          "dependencies": {
-            "jsonify": {
-              "version": "0.0.0",
-              "from": "jsonify@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-            },
-            "array-filter": {
-              "version": "0.0.1",
-              "from": "array-filter@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
-            },
-            "array-reduce": {
-              "version": "0.0.0",
-              "from": "array-reduce@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
-            },
-            "array-map": {
-              "version": "0.0.0",
-              "from": "array-map@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
-            }
-          }
-        }
-      }
+      "version": "15001.1001.0-dev-harmony-fb",
+      "from": "esprima-fb@^15001.1.0-dev-harmony-fb",
+      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
     },
     "glob": {
       "version": "4.0.6",
@@ -3771,39 +1812,39 @@
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.2 <4.0.0",
+          "from": "graceful-fs@^3.0.2",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.0 <3.0.0",
+          "from": "inherits@~2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "minimatch@>=1.0.0 <2.0.0",
+          "from": "minimatch@^1.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "once": {
           "version": "1.3.2",
-          "from": "once@>=1.3.0 <2.0.0",
+          "from": "once@^1.3.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@>=1.0.0 <2.0.0",
+              "from": "wrappy@1",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
@@ -3817,17 +1858,17 @@
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@>=0.1.22 <0.2.0",
+          "from": "async@~0.1.22",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@>=1.3.3 <1.4.0",
+          "from": "coffee-script@~1.3.3",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
+          "from": "colors@~0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
@@ -3837,37 +1878,37 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "from": "eventemitter2@~0.4.13",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "from": "findup-sync@~0.1.2",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
+              "from": "glob@~3.2.9",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "minimatch@0.3",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.5",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -3876,149 +1917,149 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "glob@~3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "from": "graceful-fs@~1.2.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@>=1.0.0 <2.0.0",
+              "from": "inherits@1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@>=0.2.11 <0.3.0",
+          "from": "iconv-lite@~0.2.11",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.12 <0.3.0",
+          "from": "minimatch@~0.2.12",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
+          "from": "nopt@~1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "abbrev@>=1.0.0 <2.0.0",
+              "from": "abbrev@1",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.8 <2.3.0",
+          "from": "rimraf@~2.2.8",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@>=0.9.2 <0.10.0",
+          "from": "lodash@~0.9.2",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@>=2.2.1 <2.3.0",
+          "from": "underscore.string@~2.2.1",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "which@>=1.0.5 <1.1.0",
+          "from": "which@~1.0.5",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "from": "js-yaml@~2.0.5",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
+              "from": "argparse@~ 0.1.11",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "from": "underscore@~1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "from": "underscore.string@~2.4.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "esprima@~ 1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0",
+          "from": "exit@~0.1.1",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@>=0.1.0 <0.2.0",
+          "from": "getobject@~0.1.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+          "from": "grunt-legacy-util@~0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.2",
-          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "from": "grunt-legacy-log@~0.1.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "dependencies": {
             "grunt-legacy-log-utils": {
               "version": "0.1.1",
-              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
+              "from": "grunt-legacy-log-utils@^0.1.1",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "lodash@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "from": "underscore.string@~2.3.3",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -4037,12 +2078,12 @@
       "dependencies": {
         "prettysize": {
           "version": "0.0.3",
-          "from": "prettysize@>=0.0.2 <0.1.0",
+          "from": "prettysize@~0.0.2",
           "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz"
         },
         "aws-sdk": {
           "version": "2.0.31",
-          "from": "aws-sdk@>=2.0.0-rc4 <2.1.0",
+          "from": "aws-sdk@~2.0.0-rc4",
           "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
           "dependencies": {
             "xml2js": {
@@ -4066,17 +2107,17 @@
         },
         "css-parse": {
           "version": "2.0.0",
-          "from": "css-parse@>=2.0.0 <2.1.0",
+          "from": "css-parse@~2.0.0",
           "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
           "dependencies": {
             "css": {
               "version": "2.2.1",
-              "from": "css@>=2.0.0 <3.0.0",
+              "from": "css@^2.0.0",
               "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.38 <0.2.0",
+                  "from": "source-map@^0.1.38",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -4088,34 +2129,34 @@
                 },
                 "source-map-resolve": {
                   "version": "0.3.1",
-                  "from": "source-map-resolve@>=0.3.0 <0.4.0",
+                  "from": "source-map-resolve@^0.3.0",
                   "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
                   "dependencies": {
                     "source-map-url": {
                       "version": "0.3.0",
-                      "from": "source-map-url@>=0.3.0 <0.4.0",
+                      "from": "source-map-url@~0.3.0",
                       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
                     },
                     "atob": {
                       "version": "1.1.2",
-                      "from": "atob@>=1.1.0 <1.2.0",
+                      "from": "atob@~1.1.0",
                       "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.2.tgz"
                     },
                     "resolve-url": {
                       "version": "0.2.1",
-                      "from": "resolve-url@>=0.2.1 <0.3.0",
+                      "from": "resolve-url@~0.2.1",
                       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
                     }
                   }
                 },
                 "urix": {
                   "version": "0.1.0",
-                  "from": "urix@>=0.1.0 <0.2.0",
+                  "from": "urix@^0.1.0",
                   "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "inherits@~2.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -4124,85 +2165,107 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <3.0.0",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "grunt-autoprefixer": {
       "version": "3.0.3",
-      "from": "grunt-autoprefixer@>=3.0.0 <4.0.0",
+      "from": "grunt-autoprefixer@^3.0.0",
       "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.3.tgz",
       "dependencies": {
+        "autoprefixer-core": {
+          "version": "5.2.1",
+          "from": "autoprefixer-core@^5.1.7",
+          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
+          "dependencies": {
+            "browserslist": {
+              "version": "0.4.0",
+              "from": "browserslist@~0.4.0",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
+            },
+            "num2fraction": {
+              "version": "1.1.0",
+              "from": "num2fraction@^1.1.0",
+              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz"
+            },
+            "caniuse-db": {
+              "version": "1.0.30000265",
+              "from": "caniuse-db@^1.0.30000214",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000265.tgz"
+            }
+          }
+        },
         "chalk": {
           "version": "1.0.0",
-          "from": "chalk@>=1.0.0 <1.1.0",
+          "from": "chalk@~1.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "from": "ansi-styles@^2.0.1",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "from": "has-ansi@^1.0.3",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "from": "ansi-regex@^1.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@*",
+                  "from": "get-stdin@^4.0.1",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "from": "strip-ansi@^2.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "ansi-regex@^1.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
+              "from": "supports-color@^1.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
         },
         "diff": {
           "version": "1.3.2",
-          "from": "diff@>=1.3.0 <1.4.0",
+          "from": "diff@~1.3.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz"
         },
         "postcss": {
           "version": "4.1.16",
-          "from": "postcss@>=4.1.11 <5.0.0",
+          "from": "postcss@^4.1.11",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
           "dependencies": {
             "es6-promise": {
               "version": "2.3.0",
-              "from": "es6-promise@>=2.3.0 <2.4.0",
+              "from": "es6-promise@~2.3.0",
               "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.2 <0.5.0",
+              "from": "source-map@~0.4.2",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
@@ -4214,17 +2277,12 @@
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@>=2.1.8 <2.2.0",
+              "from": "js-base64@~2.1.8",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
         }
       }
-    },
-    "grunt-browser-sync": {
-      "version": "2.1.3",
-      "from": "grunt-browser-sync@>=2.1.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-browser-sync/-/grunt-browser-sync-2.1.3.tgz"
     },
     "grunt-bytesize": {
       "version": "0.1.1",
@@ -4233,7 +2291,7 @@
       "dependencies": {
         "bytesize": {
           "version": "0.2.0",
-          "from": "bytesize@>=0.2.0 <0.3.0",
+          "from": "bytesize@~0.2.0",
           "resolved": "https://registry.npmjs.org/bytesize/-/bytesize-0.2.0.tgz",
           "dependencies": {
             "humanize": {
@@ -4252,17 +2310,17 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "async@^0.9.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "pad-stdio": {
           "version": "1.0.0",
-          "from": "pad-stdio@>=1.0.0 <2.0.0",
+          "from": "pad-stdio@^1.0.0",
           "resolved": "https://registry.npmjs.org/pad-stdio/-/pad-stdio-1.0.0.tgz",
           "dependencies": {
             "lpad": {
               "version": "1.0.0",
-              "from": "lpad@>=1.0.0 <2.0.0",
+              "from": "lpad@^1.0.0",
               "resolved": "https://registry.npmjs.org/lpad/-/lpad-1.0.0.tgz"
             }
           }
@@ -4276,7 +2334,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.1 <2.3.0",
+          "from": "rimraf@~2.2.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
@@ -4288,46 +2346,46 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "chalk@~0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -4341,7 +2399,7 @@
       "dependencies": {
         "requirejs": {
           "version": "2.1.20",
-          "from": "requirejs@>=2.1.0 <2.2.0",
+          "from": "requirejs@~2.1",
           "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz"
         }
       }
@@ -4353,93 +2411,93 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@^1.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "ansi-styles@^2.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "has-ansi@^2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "strip-ansi@^3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "supports-color@^2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.2.0 <4.0.0",
+          "from": "lodash@^3.8.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "maxmin": {
           "version": "1.1.0",
-          "from": "maxmin@>=1.0.0 <2.0.0",
+          "from": "maxmin@^1.0.0",
           "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
           "dependencies": {
             "figures": {
               "version": "1.3.5",
-              "from": "figures@>=1.0.1 <2.0.0",
+              "from": "figures@^1.0.1",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "gzip-size": {
               "version": "1.0.0",
-              "from": "gzip-size@>=1.0.0 <2.0.0",
+              "from": "gzip-size@^1.0.0",
               "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.0",
-                  "from": "concat-stream@>=1.4.1 <2.0.0",
+                  "from": "concat-stream@^1.4.1",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "from": "typedarray@~0.0.5",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.2",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "from": "readable-stream@~2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -4449,17 +2507,17 @@
                         },
                         "process-nextick-args": {
                           "version": "1.0.2",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "from": "process-nextick-args@~1.0.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "util-deprecate@~1.0.1",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
@@ -4468,12 +2526,12 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
+                  "from": "browserify-zlib@^0.1.4",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
                       "version": "0.2.7",
-                      "from": "pako@>=0.2.0 <0.3.0",
+                      "from": "pako@~0.2.0",
                       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
                     }
                   }
@@ -4482,54 +2540,54 @@
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "pretty-bytes@>=1.0.0 <2.0.0",
+              "from": "pretty-bytes@^1.0.0",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "get-stdin@^4.0.1",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "meow@>=3.1.0 <4.0.0",
+                  "from": "meow@^3.1.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "from": "camelcase-keys@^1.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "from": "camelcase@^1.0.1",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "map-obj@^1.0.0",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.2",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "from": "indent-string@^1.1.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "from": "repeating@^1.1.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "is-finite@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "number-is-nan@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -4539,13 +2597,13 @@
                       }
                     },
                     "minimist": {
-                      "version": "1.1.2",
-                      "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                      "version": "1.1.3",
+                      "from": "minimist@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                     },
                     "object-assign": {
                       "version": "3.0.0",
-                      "from": "object-assign@>=3.0.0 <4.0.0",
+                      "from": "object-assign@^3.0.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                     }
                   }
@@ -4556,12 +2614,12 @@
         },
         "uglify-js": {
           "version": "2.4.24",
-          "from": "uglify-js@>=2.4.19 <3.0.0",
+          "from": "uglify-js@^2.4.19",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
+              "from": "async@~0.2.6",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
@@ -4578,22 +2636,22 @@
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "from": "uglify-to-browserify@~1.0.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.5.4",
-              "from": "yargs@>=3.5.4 <3.6.0",
+              "from": "yargs@~3.5.4",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "from": "camelcase@^1.0.2",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "decamelize@^1.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "window-size": {
@@ -4624,49 +2682,49 @@
       "dependencies": {
         "gaze": {
           "version": "0.5.1",
-          "from": "gaze@>=0.5.1 <0.6.0",
+          "from": "gaze@~0.5.1",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "globule@>=0.1.0 <0.2.0",
+              "from": "globule@~0.1.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.2",
-                  "from": "lodash@>=1.0.1 <1.1.0",
+                  "from": "lodash@~1.0.1",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "glob@>=3.1.21 <3.2.0",
+                  "from": "glob@~3.1.21",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "1.2.3",
-                      "from": "graceful-fs@>=1.2.0 <1.3.0",
+                      "from": "graceful-fs@~1.2.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                     },
                     "inherits": {
                       "version": "1.0.0",
-                      "from": "inherits@>=1.0.0 <2.0.0",
+                      "from": "inherits@1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "from": "minimatch@~0.2.11",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.5",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -4682,27 +2740,27 @@
           "dependencies": {
             "qs": {
               "version": "0.5.6",
-              "from": "qs@>=0.5.2 <0.6.0",
+              "from": "qs@~0.5.2",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
             },
             "faye-websocket": {
               "version": "0.4.4",
-              "from": "faye-websocket@>=0.4.3 <0.5.0",
+              "from": "faye-websocket@~0.4.3",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
             },
             "noptify": {
               "version": "0.0.3",
-              "from": "noptify@>=0.0.3 <0.1.0",
+              "from": "noptify@~0.0.3",
               "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "2.0.0",
-                  "from": "nopt@>=2.0.0 <2.1.0",
+                  "from": "nopt@~2.0.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "abbrev@1",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
@@ -4711,19 +2769,19 @@
             },
             "debug": {
               "version": "0.7.4",
-              "from": "debug@>=0.7.0 <0.8.0",
+              "from": "debug@~0.7.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.9 <0.3.0",
+          "from": "async@~0.2.9",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }
@@ -4735,7 +2793,7 @@
       "dependencies": {
         "socket.io": {
           "version": "1.0.6",
-          "from": "socket.io@>=1.0.4 <1.1.0",
+          "from": "socket.io@~1.0.4",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.0.6.tgz",
           "dependencies": {
             "engine.io": {
@@ -4755,17 +2813,17 @@
                   "dependencies": {
                     "commander": {
                       "version": "0.6.1",
-                      "from": "commander@>=0.6.1 <0.7.0",
+                      "from": "commander@~0.6.1",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                     },
                     "nan": {
                       "version": "0.3.2",
-                      "from": "nan@>=0.3.0 <0.4.0",
+                      "from": "nan@~0.3.0",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "from": "tinycolor@0.x",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
@@ -4872,17 +2930,17 @@
                       "dependencies": {
                         "commander": {
                           "version": "0.6.1",
-                          "from": "commander@>=0.6.1 <0.7.0",
+                          "from": "commander@~0.6.1",
                           "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                         },
                         "nan": {
                           "version": "0.3.2",
-                          "from": "nan@>=0.3.0 <0.4.0",
+                          "from": "nan@~0.3.0",
                           "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
                         },
                         "tinycolor": {
                           "version": "0.0.1",
-                          "from": "tinycolor@>=0.0.0 <1.0.0",
+                          "from": "tinycolor@0.x",
                           "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                         },
                         "options": {
@@ -4936,7 +2994,7 @@
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "from": "better-assert@~1.0.0",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
@@ -4955,7 +3013,7 @@
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "from": "better-assert@~1.0.0",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
@@ -5001,7 +3059,7 @@
                   "dependencies": {
                     "better-assert": {
                       "version": "1.0.2",
-                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "from": "better-assert@~1.0.0",
                       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "dependencies": {
                         "callsite": {
@@ -5077,27 +3135,27 @@
         },
         "win-spawn": {
           "version": "2.0.0",
-          "from": "win-spawn@>=2.0.0 <2.1.0",
+          "from": "win-spawn@~2.0.0",
           "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
         },
         "ua-parser-js": {
           "version": "0.7.9",
-          "from": "ua-parser-js@>=0.7.0 <0.8.0",
+          "from": "ua-parser-js@~0.7.0",
           "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.9.tgz"
         },
         "express": {
           "version": "4.4.5",
-          "from": "express@>=4.4.4 <4.5.0",
+          "from": "express@~4.4.4",
           "resolved": "https://registry.npmjs.org/express/-/express-4.4.5.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.0.7",
-              "from": "accepts@>=1.0.5 <1.1.0",
+              "from": "accepts@~1.0.5",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "mime-types@>=1.0.0 <1.1.0",
+                  "from": "mime-types@~1.0.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "negotiator": {
@@ -5241,22 +3299,22 @@
         },
         "weinre": {
           "version": "2.0.0-pre-I0Z7U9OV",
-          "from": "weinre@>=2.0.0-pre-HH0SN197 <2.1.0",
+          "from": "weinre@~2.0.0-pre-HH0SN197",
           "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
           "dependencies": {
             "express": {
               "version": "2.5.11",
-              "from": "express@>=2.5.0 <2.6.0",
+              "from": "express@2.5.x",
               "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
               "dependencies": {
                 "connect": {
                   "version": "1.9.2",
-                  "from": "connect@>=1.0.0 <2.0.0",
+                  "from": "connect@1.x",
                   "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
                   "dependencies": {
                     "formidable": {
                       "version": "1.0.17",
-                      "from": "formidable@>=1.0.0 <1.1.0",
+                      "from": "formidable@1.0.x",
                       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
                     }
                   }
@@ -5268,7 +3326,7 @@
                 },
                 "qs": {
                   "version": "0.4.2",
-                  "from": "qs@>=0.4.0 <0.5.0",
+                  "from": "qs@0.4.x",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
                 },
                 "mkdirp": {
@@ -5280,26 +3338,26 @@
             },
             "nopt": {
               "version": "3.0.3",
-              "from": "nopt@>=3.0.0 <3.1.0",
+              "from": "nopt@3.0.x",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "abbrev@1",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "underscore": {
               "version": "1.7.0",
-              "from": "underscore@>=1.7.0 <1.8.0",
+              "from": "underscore@1.7.x",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
             }
           }
         },
         "array.prototype.findindex": {
           "version": "0.1.1",
-          "from": "array.prototype.findindex@>=0.1.1 <0.2.0",
+          "from": "array.prototype.findindex@~0.1.1",
           "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-0.1.1.tgz"
         }
       }
@@ -5316,124 +3374,124 @@
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
+              "from": "minimatch@~0.2.11",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.5",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "from": "graceful-fs@~1.2.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@>=1.0.0 <2.0.0",
+              "from": "inherits@1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "css-parse": {
           "version": "1.4.0",
-          "from": "css-parse@>=1.4.0 <1.5.0",
+          "from": "css-parse@~1.4.0",
           "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.4.0.tgz"
         },
         "humanize": {
           "version": "0.0.9",
-          "from": "humanize@>=0.0.7 <0.1.0",
+          "from": "humanize@~0.0.7",
           "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz"
         }
       }
     },
     "grunt-eslint": {
       "version": "15.0.0",
-      "from": "grunt-eslint@>=15.0.0 <16.0.0",
+      "from": "grunt-eslint@^15.0.0",
       "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-15.0.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@^1.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "ansi-styles@^2.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "has-ansi@^2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "strip-ansi@^3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "supports-color@^2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "eslint": {
           "version": "0.23.0",
-          "from": "eslint@>=0.23.0 <0.24.0",
+          "from": "eslint@^0.23.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.23.0.tgz",
           "dependencies": {
             "concat-stream": {
               "version": "1.5.0",
-              "from": "concat-stream@>=1.4.6 <2.0.0",
+              "from": "concat-stream@^1.4.6",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "from": "typedarray@~0.0.5",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.2",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "from": "readable-stream@~2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -5443,17 +3501,17 @@
                     },
                     "process-nextick-args": {
                       "version": "1.0.2",
-                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "from": "process-nextick-args@~1.0.0",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.1",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "util-deprecate@~1.0.1",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
@@ -5462,7 +3520,7 @@
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.1.1 <3.0.0",
+              "from": "debug@^2.1.1",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
@@ -5474,12 +3532,12 @@
             },
             "doctrine": {
               "version": "0.6.4",
-              "from": "doctrine@>=0.6.2 <0.7.0",
+              "from": "doctrine@^0.6.2",
               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "1.1.6",
-                  "from": "esutils@>=1.1.6 <2.0.0",
+                  "from": "esutils@^1.1.6",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                 },
                 "isarray": {
@@ -5491,152 +3549,152 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "escope": {
               "version": "3.2.0",
-              "from": "escope@>=3.1.0 <4.0.0",
+              "from": "escope@^3.1.0",
               "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
               "dependencies": {
                 "es6-map": {
                   "version": "0.1.1",
-                  "from": "es6-map@>=0.1.1 <0.2.0",
+                  "from": "es6-map@^0.1.1",
                   "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
+                      "from": "d@~0.1.1",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "es5-ext@>=0.10.4 <0.11.0",
+                      "from": "es5-ext@~0.10.4",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                       "dependencies": {
                         "es6-symbol": {
                           "version": "2.0.1",
-                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "from": "es6-symbol@~2.0.1",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                         }
                       }
                     },
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "es6-iterator@>=0.1.1 <0.2.0",
+                      "from": "es6-iterator@~0.1.1",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                       "dependencies": {
                         "es6-symbol": {
                           "version": "2.0.1",
-                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "from": "es6-symbol@~2.0.1",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                         }
                       }
                     },
                     "es6-set": {
                       "version": "0.1.1",
-                      "from": "es6-set@>=0.1.1 <0.2.0",
+                      "from": "es6-set@~0.1.1",
                       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
                     },
                     "es6-symbol": {
                       "version": "0.1.1",
-                      "from": "es6-symbol@>=0.1.1 <0.2.0",
+                      "from": "es6-symbol@~0.1.1",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                     },
                     "event-emitter": {
                       "version": "0.3.3",
-                      "from": "event-emitter@>=0.3.1 <0.4.0",
+                      "from": "event-emitter@~0.3.1",
                       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                     }
                   }
                 },
                 "es6-weak-map": {
                   "version": "0.1.4",
-                  "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                  "from": "es6-weak-map@^0.1.2",
                   "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
+                      "from": "d@~0.1.1",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "es5-ext@>=0.10.6 <0.11.0",
+                      "from": "es5-ext@~0.10.6",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
                     },
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "from": "es6-iterator@~0.1.3",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                     },
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "from": "es6-symbol@~2.0.1",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "esrecurse": {
                   "version": "3.1.1",
-                  "from": "esrecurse@>=3.1.1 <4.0.0",
+                  "from": "esrecurse@^3.1.1",
                   "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
                 },
                 "estraverse": {
                   "version": "3.1.0",
-                  "from": "estraverse@>=3.1.0 <4.0.0",
+                  "from": "estraverse@^3.1.0",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
                 }
               }
             },
             "espree": {
               "version": "2.2.3",
-              "from": "espree@>=2.0.1 <3.0.0",
+              "from": "espree@^2.0.1",
               "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.3.tgz"
             },
             "estraverse": {
               "version": "2.0.0",
-              "from": "estraverse@>=2.0.0 <3.0.0",
+              "from": "estraverse@^2.0.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
             },
             "estraverse-fb": {
               "version": "1.3.1",
-              "from": "estraverse-fb@>=1.3.1 <2.0.0",
+              "from": "estraverse-fb@^1.3.1",
               "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "globals": {
               "version": "8.3.0",
-              "from": "globals@>=8.0.0 <9.0.0",
+              "from": "globals@^8.0.0",
               "resolved": "https://registry.npmjs.org/globals/-/globals-8.3.0.tgz"
             },
             "inquirer": {
               "version": "0.8.5",
-              "from": "inquirer@>=0.8.2 <0.9.0",
+              "from": "inquirer@^0.8.2",
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.1 <2.0.0",
+                  "from": "ansi-regex@^1.1.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "cli-width": {
                   "version": "1.0.1",
-                  "from": "cli-width@>=1.0.1 <2.0.0",
+                  "from": "cli-width@^1.0.1",
                   "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
                 },
                 "figures": {
                   "version": "1.3.5",
-                  "from": "figures@>=1.3.5 <2.0.0",
+                  "from": "figures@^1.3.5",
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.3.1 <4.0.0",
+                  "from": "lodash@>= 3.2.0 < 4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "readline2@>=0.1.1 <0.2.0",
+                  "from": "readline2@^0.1.1",
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "mute-stream": {
@@ -5646,99 +3704,99 @@
                     },
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "from": "strip-ansi@^2.0.1",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
                     }
                   }
                 },
                 "rx": {
                   "version": "2.5.3",
-                  "from": "rx@>=2.4.3 <3.0.0",
+                  "from": "rx@^2.4.3",
                   "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.6 <3.0.0",
+                  "from": "through@^2.3.6",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.12.1",
-              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+              "from": "is-my-json-valid@^2.10.0",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "from": "generate-function@^2.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "from": "generate-object-property@^1.1.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "from": "is-property@^1.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "1.1.0",
-                  "from": "jsonpointer@>=1.1.0 <2.0.0",
+                  "from": "jsonpointer@^1.1.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "from": "xtend@^4.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "js-yaml": {
               "version": "3.3.1",
-              "from": "js-yaml@>=3.2.5 <4.0.0",
+              "from": "js-yaml@^3.2.5",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "from": "argparse@~1.0.2",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "from": "lodash@>= 3.2.0 < 4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "from": "sprintf-js@~1.0.2",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.2.0",
-                  "from": "esprima@>=2.2.0 <2.3.0",
+                  "from": "esprima@~2.2.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
+              "from": "minimatch@^2.0.1",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "brace-expansion@^1.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "balanced-match@^0.2.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -5752,69 +3810,69 @@
             },
             "object-assign": {
               "version": "2.1.1",
-              "from": "object-assign@>=2.0.0 <3.0.0",
+              "from": "object-assign@^2.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "optionator": {
               "version": "0.5.0",
-              "from": "optionator@>=0.5.0 <0.6.0",
+              "from": "optionator@^0.5.0",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
                 "prelude-ls": {
                   "version": "1.1.2",
-                  "from": "prelude-ls@>=1.1.1 <1.2.0",
+                  "from": "prelude-ls@~1.1.1",
                   "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "deep-is@>=0.1.2 <0.2.0",
+                  "from": "deep-is@~0.1.2",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "from": "wordwrap@~0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "type-check": {
                   "version": "0.3.1",
-                  "from": "type-check@>=0.3.1 <0.4.0",
+                  "from": "type-check@~0.3.1",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                 },
                 "levn": {
                   "version": "0.2.5",
-                  "from": "levn@>=0.2.5 <0.3.0",
+                  "from": "levn@~0.2.5",
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                 },
                 "fast-levenshtein": {
                   "version": "1.0.6",
-                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                  "from": "fast-levenshtein@~1.0.0",
                   "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "path-is-absolute@^1.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "strip-json-comments@>=1.0.1 <1.1.0",
+              "from": "strip-json-comments@~1.0.1",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "text-table": {
               "version": "0.2.0",
-              "from": "text-table@>=0.2.0 <0.3.0",
+              "from": "text-table@~0.2.0",
               "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.0.0 <2.0.0",
+              "from": "user-home@^1.0.0",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             },
             "xml-escape": {
               "version": "1.0.0",
-              "from": "xml-escape@>=1.0.0 <1.1.0",
+              "from": "xml-escape@~1.0.0",
               "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
             }
           }
@@ -5823,12 +3881,12 @@
     },
     "grunt-frequency-graph": {
       "version": "0.1.6",
-      "from": "grunt-frequency-graph@>=0.1.6 <0.2.0",
+      "from": "grunt-frequency-graph@^0.1.6",
       "resolved": "https://registry.npmjs.org/grunt-frequency-graph/-/grunt-frequency-graph-0.1.6.tgz",
       "dependencies": {
         "asset-frequency-graph": {
           "version": "0.3.1",
-          "from": "asset-frequency-graph@>=0.3.0 <0.4.0",
+          "from": "asset-frequency-graph@^0.3.0",
           "resolved": "https://registry.npmjs.org/asset-frequency-graph/-/asset-frequency-graph-0.3.1.tgz",
           "dependencies": {
             "async": {
@@ -5843,7 +3901,7 @@
               "dependencies": {
                 "shelljs": {
                   "version": "0.3.0",
-                  "from": "shelljs@>=0.3.0 <0.4.0",
+                  "from": "shelljs@~0.3.0",
                   "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
                 }
               }
@@ -5855,34 +3913,34 @@
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "inflight@^1.0.4",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "minimatch@^2.0.1",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "balanced-match@^0.2.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -5896,12 +3954,12 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -5910,32 +3968,32 @@
             },
             "gzip-size": {
               "version": "1.0.0",
-              "from": "gzip-size@>=1.0.0 <2.0.0",
+              "from": "gzip-size@^1.0.0",
               "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.0",
-                  "from": "concat-stream@>=1.4.1 <2.0.0",
+                  "from": "concat-stream@^1.4.1",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "from": "typedarray@~0.0.5",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.2",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "from": "readable-stream@~2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -5945,17 +4003,17 @@
                         },
                         "process-nextick-args": {
                           "version": "1.0.2",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "from": "process-nextick-args@~1.0.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "util-deprecate@~1.0.1",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
@@ -5964,12 +4022,12 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
+                  "from": "browserify-zlib@^0.1.4",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
                       "version": "0.2.7",
-                      "from": "pako@>=0.2.0 <0.3.0",
+                      "from": "pako@~0.2.0",
                       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
                     }
                   }
@@ -6045,7 +4103,7 @@
                           "dependencies": {
                             "esprima-fb": {
                               "version": "8001.1001.0-dev-harmony-fb",
-                              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
+                              "from": "esprima-fb@~8001.1001.0-dev-harmony-fb",
                               "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
                             },
                             "source-map": {
@@ -6159,7 +4217,7 @@
                         },
                         "esprima-fb": {
                           "version": "8001.1001.0-dev-harmony-fb",
-                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
+                          "from": "esprima-fb@~8001.1001.0-dev-harmony-fb",
                           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
                         },
                         "source-map": {
@@ -6197,59 +4255,59 @@
             },
             "moment": {
               "version": "2.10.6",
-              "from": "moment@>=2.9.0 <3.0.0",
+              "from": "moment@^2.9.0",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "pretty-bytes@>=1.0.2 <2.0.0",
+              "from": "pretty-bytes@^1.0.2",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "get-stdin@^4.0.1",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "meow@>=3.1.0 <4.0.0",
+                  "from": "meow@^3.1.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "from": "camelcase-keys@^1.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "from": "camelcase@^1.0.1",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "map-obj@^1.0.0",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.2",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "from": "indent-string@^1.1.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "from": "repeating@^1.1.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "is-finite@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "number-is-nan@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -6259,13 +4317,13 @@
                       }
                     },
                     "minimist": {
-                      "version": "1.1.2",
-                      "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                      "version": "1.1.3",
+                      "from": "minimist@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                     },
                     "object-assign": {
                       "version": "3.0.0",
-                      "from": "object-assign@>=3.0.0 <4.0.0",
+                      "from": "object-assign@^3.0.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                     }
                   }
@@ -6279,12 +4337,12 @@
             },
             "uglify-js": {
               "version": "2.4.24",
-              "from": "uglify-js@>=2.4.16 <3.0.0",
+              "from": "uglify-js@^2.4.16",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "async@~0.2.6",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
@@ -6301,22 +4359,22 @@
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "from": "uglify-to-browserify@~1.0.0",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.5.4",
-                  "from": "yargs@>=3.5.4 <3.6.0",
+                  "from": "yargs@~3.5.4",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "from": "camelcase@^1.0.2",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "decamelize": {
                       "version": "1.0.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "from": "decamelize@^1.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                     },
                     "window-size": {
@@ -6336,9 +4394,9 @@
           }
         },
         "aws-sdk": {
-          "version": "2.1.43",
-          "from": "aws-sdk@>=2.1.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.43.tgz",
+          "version": "2.1.44",
+          "from": "aws-sdk@^2.1.8",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.44.tgz",
           "dependencies": {
             "sax": {
               "version": "0.5.3",
@@ -6359,7 +4417,7 @@
         },
         "es6-promise": {
           "version": "2.3.0",
-          "from": "es6-promise@>=2.0.1 <3.0.0",
+          "from": "es6-promise@^2.0.1",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
         }
       }
@@ -6371,12 +4429,12 @@
       "dependencies": {
         "which": {
           "version": "1.0.9",
-          "from": "which@>=1.0.5 <1.1.0",
+          "from": "which@~1.0.5",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "win-spawn": {
           "version": "2.0.0",
-          "from": "win-spawn@>=2.0.0 <2.1.0",
+          "from": "win-spawn@~2.0.0",
           "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
         }
       }
@@ -6388,68 +4446,68 @@
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jscs": {
           "version": "1.13.1",
-          "from": "jscs@>=1.13.0 <1.14.0",
+          "from": "jscs@~1.13.0",
           "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.0.0",
-              "from": "chalk@>=1.0.0 <1.1.0",
+              "from": "chalk@~1.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                  "from": "ansi-styles@^2.0.1",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "escape-string-regexp@^1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "1.0.3",
-                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                  "from": "has-ansi@^1.0.3",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                      "from": "ansi-regex@^1.1.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     },
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "from": "get-stdin@^4.0.1",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "from": "strip-ansi@^2.0.1",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "from": "ansi-regex@1.1.1",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "1.3.1",
-                  "from": "supports-color@>=1.3.0 <2.0.0",
+                  "from": "supports-color@^1.3.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                 }
               }
             },
             "cli-table": {
               "version": "0.3.1",
-              "from": "cli-table@>=0.3.1 <0.4.0",
+              "from": "cli-table@~0.3.1",
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
               "dependencies": {
                 "colors": {
@@ -6461,12 +4519,12 @@
             },
             "commander": {
               "version": "2.6.0",
-              "from": "commander@>=2.6.0 <2.7.0",
+              "from": "commander@~2.6.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "esprima": {
               "version": "1.2.5",
-              "from": "esprima@>=1.2.5 <2.0.0",
+              "from": "esprima@^1.2.5",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "esprima-harmony-jscs": {
@@ -6476,88 +4534,88 @@
             },
             "estraverse": {
               "version": "1.9.3",
-              "from": "estraverse@>=1.9.3 <2.0.0",
+              "from": "estraverse@^1.9.3",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@>=0.1.2 <0.2.0",
+              "from": "exit@~0.1.2",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "glob": {
               "version": "5.0.14",
-              "from": "glob@>=5.0.1 <6.0.0",
+              "from": "glob@^5.0.1",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "inflight@^1.0.4",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "path-is-absolute@^1.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "lodash.assign": {
               "version": "3.0.0",
-              "from": "lodash.assign@>=3.0.0 <3.1.0",
+              "from": "lodash.assign@~3.0.0",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                  "from": "lodash._baseassign@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "from": "lodash._basecopy@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     },
                     "lodash.keys": {
                       "version": "3.1.2",
-                      "from": "lodash.keys@>=3.0.0 <4.0.0",
+                      "from": "lodash.keys@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "dependencies": {
                         "lodash._getnative": {
                           "version": "3.9.1",
-                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                          "from": "lodash._getnative@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                         },
                         "lodash.isarguments": {
                           "version": "3.0.4",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "from": "lodash.isarguments@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.4",
-                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "from": "lodash.isarray@^3.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                         }
                       }
@@ -6566,22 +4624,22 @@
                 },
                 "lodash._createassigner": {
                   "version": "3.1.1",
-                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                  "from": "lodash._createassigner@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
                       "version": "3.0.1",
-                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                      "from": "lodash._bindcallback@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "from": "lodash._isiterateecall@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     },
                     "lodash.restparam": {
                       "version": "3.6.1",
-                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                      "from": "lodash.restparam@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                     }
                   }
@@ -6590,17 +4648,17 @@
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <2.1.0",
+              "from": "minimatch@^2.0.1",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "brace-expansion@^1.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "from": "balanced-match@^0.2.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -6614,44 +4672,44 @@
             },
             "pathval": {
               "version": "0.1.1",
-              "from": "pathval@>=0.1.1 <0.2.0",
+              "from": "pathval@~0.1.1",
               "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
             },
             "prompt": {
               "version": "0.2.14",
-              "from": "prompt@>=0.2.14 <0.3.0",
+              "from": "prompt@~0.2.14",
               "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "dependencies": {
                 "pkginfo": {
                   "version": "0.3.0",
-                  "from": "pkginfo@>=0.0.0 <1.0.0",
+                  "from": "pkginfo@0.x.x",
                   "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
                 },
                 "read": {
                   "version": "1.0.6",
-                  "from": "read@>=1.0.0 <1.1.0",
+                  "from": "read@1.0.x",
                   "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.5",
-                      "from": "mute-stream@>=0.0.4 <0.1.0",
+                      "from": "mute-stream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "revalidator": {
                   "version": "0.1.8",
-                  "from": "revalidator@>=0.1.0 <0.2.0",
+                  "from": "revalidator@0.1.x",
                   "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
                 },
                 "utile": {
                   "version": "0.2.1",
-                  "from": "utile@>=0.2.0 <0.3.0",
+                  "from": "utile@0.2.x",
                   "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.9 <0.3.0",
+                      "from": "async@~0.2.9",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "deep-equal": {
@@ -6661,54 +4719,54 @@
                     },
                     "i": {
                       "version": "0.3.3",
-                      "from": "i@>=0.3.0 <0.4.0",
+                      "from": "i@0.3.x",
                       "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                     },
                     "ncp": {
                       "version": "0.4.2",
-                      "from": "ncp@>=0.4.0 <0.5.0",
+                      "from": "ncp@0.4.x",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                     },
                     "rimraf": {
                       "version": "2.4.2",
-                      "from": "rimraf@>=2.0.0 <3.0.0",
+                      "from": "rimraf@2.x.x",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz"
                     }
                   }
                 },
                 "winston": {
                   "version": "0.8.3",
-                  "from": "winston@>=0.8.0 <0.9.0",
+                  "from": "winston@0.8.x",
                   "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.0 <0.3.0",
+                      "from": "async@0.2.x",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "colors": {
                       "version": "0.6.2",
-                      "from": "colors@>=0.6.0 <0.7.0",
+                      "from": "colors@0.6.x",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
                     },
                     "cycle": {
                       "version": "1.0.3",
-                      "from": "cycle@>=1.0.0 <1.1.0",
+                      "from": "cycle@1.0.x",
                       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                     },
                     "eyes": {
                       "version": "0.1.8",
-                      "from": "eyes@>=0.1.0 <0.2.0",
+                      "from": "eyes@0.1.x",
                       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                     },
                     "isstream": {
                       "version": "0.1.2",
-                      "from": "isstream@>=0.1.0 <0.2.0",
+                      "from": "isstream@0.1.x",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "stack-trace": {
                       "version": "0.0.9",
-                      "from": "stack-trace@>=0.0.0 <0.1.0",
+                      "from": "stack-trace@0.0.x",
                       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                     }
                   }
@@ -6717,54 +4775,54 @@
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "strip-json-comments@>=1.0.2 <1.1.0",
+              "from": "strip-json-comments@~1.0.2",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "vow-fs": {
               "version": "0.3.4",
-              "from": "vow-fs@>=0.3.4 <0.4.0",
+              "from": "vow-fs@~0.3.4",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.2 <2.0.0",
+                  "from": "node-uuid@^1.4.2",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "vow-queue": {
                   "version": "0.4.2",
-                  "from": "vow-queue@>=0.4.1 <0.5.0",
+                  "from": "vow-queue@^0.4.1",
                   "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@>=4.3.1 <5.0.0",
+                  "from": "glob@^4.3.1",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "inflight@^1.0.4",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@^1.3.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -6775,12 +4833,12 @@
             },
             "xmlbuilder": {
               "version": "2.6.4",
-              "from": "xmlbuilder@>=2.6.1 <3.0.0",
+              "from": "xmlbuilder@^2.6.1",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.5.0 <4.0.0",
+                  "from": "lodash@^3.5.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
@@ -6789,12 +4847,12 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "vow": {
           "version": "0.4.10",
-          "from": "vow@>=0.4.1 <0.5.0",
+          "from": "vow@~0.4.1",
           "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.10.tgz"
         }
       }
@@ -6806,7 +4864,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
@@ -6823,51 +4881,51 @@
       "dependencies": {
         "psi": {
           "version": "0.1.6",
-          "from": "psi@>=0.1.1 <0.2.0",
+          "from": "psi@^0.1.1",
           "resolved": "https://registry.npmjs.org/psi/-/psi-0.1.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@>=0.5.1 <0.6.0",
+              "from": "chalk@^0.5.1",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "from": "ansi-styles@^1.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "from": "escape-string-regexp@^1.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "from": "has-ansi@^0.1.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@^0.2.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "from": "strip-ansi@^0.3.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@^0.2.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "from": "supports-color@^0.2.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
@@ -6879,69 +4937,69 @@
               "dependencies": {
                 "googleapis": {
                   "version": "1.1.5",
-                  "from": "googleapis@>=1.0.2 <2.0.0",
+                  "from": "googleapis@^1.0.2",
                   "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-1.1.5.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "async@~0.9.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "gapitoken": {
                       "version": "0.1.5",
-                      "from": "gapitoken@>=0.1.2 <0.2.0",
+                      "from": "gapitoken@~0.1.2",
                       "resolved": "https://registry.npmjs.org/gapitoken/-/gapitoken-0.1.5.tgz",
                       "dependencies": {
                         "jws": {
                           "version": "3.0.0",
-                          "from": "jws@>=3.0.0 <3.1.0",
+                          "from": "jws@~3.0.0",
                           "resolved": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
                           "dependencies": {
                             "jwa": {
                               "version": "1.0.2",
-                              "from": "jwa@>=1.0.0 <1.1.0",
+                              "from": "jwa@~1.0.0",
                               "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
                               "dependencies": {
                                 "base64url": {
                                   "version": "0.0.6",
-                                  "from": "base64url@>=0.0.4 <0.1.0",
+                                  "from": "base64url@~0.0.4",
                                   "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
                                 },
                                 "buffer-equal-constant-time": {
                                   "version": "1.0.1",
-                                  "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0",
+                                  "from": "buffer-equal-constant-time@^1.0.1",
                                   "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
                                 },
                                 "ecdsa-sig-formatter": {
                                   "version": "1.0.2",
-                                  "from": "ecdsa-sig-formatter@>=1.0.0 <2.0.0",
+                                  "from": "ecdsa-sig-formatter@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
                                   "dependencies": {
                                     "asn1.js": {
-                                      "version": "2.1.3",
-                                      "from": "asn1.js@>=2.0.3 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.3.tgz",
+                                      "version": "2.2.0",
+                                      "from": "asn1.js@^2.0.3",
+                                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz",
                                       "dependencies": {
                                         "bn.js": {
                                           "version": "2.2.0",
-                                          "from": "bn.js@>=2.0.0 <3.0.0",
+                                          "from": "bn.js@^2.0.0",
                                           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                                         },
                                         "inherits": {
                                           "version": "2.0.1",
-                                          "from": "inherits@>=2.0.1 <3.0.0",
+                                          "from": "inherits@^2.0.1",
                                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                         },
                                         "minimalistic-assert": {
                                           "version": "1.0.0",
-                                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                                          "from": "minimalistic-assert@^1.0.0",
                                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                                         }
                                       }
                                     },
                                     "base64-url": {
                                       "version": "1.2.1",
-                                      "from": "base64-url@>=1.2.1 <2.0.0",
+                                      "from": "base64-url@^1.2.1",
                                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                                     }
                                   }
@@ -6950,32 +5008,32 @@
                             },
                             "base64url": {
                               "version": "1.0.4",
-                              "from": "base64url@>=1.0.4 <1.1.0",
+                              "from": "base64url@~1.0.4",
                               "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
                               "dependencies": {
                                 "concat-stream": {
                                   "version": "1.4.10",
-                                  "from": "concat-stream@>=1.4.7 <1.5.0",
+                                  "from": "concat-stream@~1.4.7",
                                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                                   "dependencies": {
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "from": "inherits@~2.0.1",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "typedarray": {
                                       "version": "0.0.6",
-                                      "from": "typedarray@>=0.0.5 <0.1.0",
+                                      "from": "typedarray@~0.0.5",
                                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                                     },
                                     "readable-stream": {
                                       "version": "1.1.13",
-                                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                                      "from": "readable-stream@~1.1.9",
                                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                                       "dependencies": {
                                         "core-util-is": {
                                           "version": "1.0.1",
-                                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                                          "from": "core-util-is@~1.0.0",
                                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                         },
                                         "isarray": {
@@ -6985,7 +5043,7 @@
                                         },
                                         "string_decoder": {
                                           "version": "0.10.31",
-                                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                                          "from": "string_decoder@~0.10.x",
                                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                         }
                                       }
@@ -6994,49 +5052,49 @@
                                 },
                                 "meow": {
                                   "version": "2.0.0",
-                                  "from": "meow@>=2.0.0 <2.1.0",
+                                  "from": "meow@~2.0.0",
                                   "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
                                   "dependencies": {
                                     "camelcase-keys": {
                                       "version": "1.0.0",
-                                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                                      "from": "camelcase-keys@^1.0.0",
                                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                                       "dependencies": {
                                         "camelcase": {
                                           "version": "1.2.1",
-                                          "from": "camelcase@>=1.0.1 <2.0.0",
+                                          "from": "camelcase@^1.0.1",
                                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                                         },
                                         "map-obj": {
                                           "version": "1.0.1",
-                                          "from": "map-obj@>=1.0.0 <2.0.0",
+                                          "from": "map-obj@^1.0.0",
                                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                                         }
                                       }
                                     },
                                     "indent-string": {
                                       "version": "1.2.2",
-                                      "from": "indent-string@>=1.1.0 <2.0.0",
+                                      "from": "indent-string@^1.1.0",
                                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                                       "dependencies": {
                                         "get-stdin": {
                                           "version": "4.0.1",
-                                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                                          "from": "get-stdin@^4.0.1",
                                           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                                         },
                                         "repeating": {
                                           "version": "1.1.3",
-                                          "from": "repeating@>=1.1.0 <2.0.0",
+                                          "from": "repeating@^1.1.0",
                                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                                           "dependencies": {
                                             "is-finite": {
                                               "version": "1.0.1",
-                                              "from": "is-finite@>=1.0.0 <2.0.0",
+                                              "from": "is-finite@^1.0.0",
                                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                               "dependencies": {
                                                 "number-is-nan": {
                                                   "version": "1.0.0",
-                                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                                  "from": "number-is-nan@^1.0.0",
                                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                                 }
                                               }
@@ -7046,13 +5104,13 @@
                                       }
                                     },
                                     "minimist": {
-                                      "version": "1.1.2",
-                                      "from": "minimist@>=1.1.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                                      "version": "1.1.3",
+                                      "from": "minimist@^1.1.0",
+                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                                     },
                                     "object-assign": {
                                       "version": "1.0.0",
-                                      "from": "object-assign@>=1.0.0 <2.0.0",
+                                      "from": "object-assign@^1.0.0",
                                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
                                     }
                                   }
@@ -7063,27 +5121,27 @@
                         },
                         "request": {
                           "version": "2.60.0",
-                          "from": "request@>=2.54.0 <3.0.0",
+                          "from": "request@^2.54.0",
                           "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
                           "dependencies": {
                             "bl": {
                               "version": "1.0.0",
-                              "from": "bl@>=1.0.0 <1.1.0",
+                              "from": "bl@~1.0.0",
                               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
                               "dependencies": {
                                 "readable-stream": {
                                   "version": "2.0.2",
-                                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                                  "from": "readable-stream@~2.0.0",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "from": "core-util-is@~1.0.0",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "from": "inherits@~2.0.1",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
@@ -7093,17 +5151,17 @@
                                     },
                                     "process-nextick-args": {
                                       "version": "1.0.2",
-                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "from": "process-nextick-args@~1.0.0",
                                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "from": "string_decoder@~0.10.x",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.1",
-                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "from": "util-deprecate@~1.0.1",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                                     }
                                   }
@@ -7112,61 +5170,61 @@
                             },
                             "caseless": {
                               "version": "0.11.0",
-                              "from": "caseless@>=0.11.0 <0.12.0",
+                              "from": "caseless@~0.11.0",
                               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                             },
                             "extend": {
                               "version": "3.0.0",
-                              "from": "extend@>=3.0.0 <3.1.0",
+                              "from": "extend@~3.0.0",
                               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                             },
                             "forever-agent": {
                               "version": "0.6.1",
-                              "from": "forever-agent@>=0.6.0 <0.7.0",
+                              "from": "forever-agent@~0.6.0",
                               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                             },
                             "form-data": {
                               "version": "1.0.0-rc3",
-                              "from": "form-data@>=1.0.0-rc1 <1.1.0",
+                              "from": "form-data@~1.0.0-rc1",
                               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
                               "dependencies": {
                                 "async": {
-                                  "version": "1.4.0",
-                                  "from": "async@>=1.4.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
+                                  "version": "1.4.2",
+                                  "from": "async@^1.4.0",
+                                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                                 }
                               }
                             },
                             "json-stringify-safe": {
                               "version": "5.0.1",
-                              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                              "from": "json-stringify-safe@~5.0.0",
                               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                             },
                             "mime-types": {
                               "version": "2.1.4",
-                              "from": "mime-types@>=2.1.2 <2.2.0",
+                              "from": "mime-types@~2.1.2",
                               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
                               "dependencies": {
                                 "mime-db": {
                                   "version": "1.16.0",
-                                  "from": "mime-db@>=1.16.0 <1.17.0",
+                                  "from": "mime-db@~1.16.0",
                                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
                                 }
                               }
                             },
                             "node-uuid": {
                               "version": "1.4.3",
-                              "from": "node-uuid@>=1.4.0 <1.5.0",
+                              "from": "node-uuid@~1.4.0",
                               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                             },
                             "qs": {
                               "version": "4.0.0",
-                              "from": "qs@>=4.0.0 <4.1.0",
+                              "from": "qs@~4.0.0",
                               "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
                             },
                             "tunnel-agent": {
                               "version": "0.4.1",
-                              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                              "from": "tunnel-agent@~0.4.0",
                               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                             },
                             "tough-cookie": {
@@ -7176,12 +5234,12 @@
                             },
                             "http-signature": {
                               "version": "0.11.0",
-                              "from": "http-signature@>=0.11.0 <0.12.0",
+                              "from": "http-signature@~0.11.0",
                               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                               "dependencies": {
                                 "assert-plus": {
                                   "version": "0.1.5",
-                                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                                  "from": "assert-plus@^0.1.5",
                                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                                 },
                                 "asn1": {
@@ -7198,161 +5256,161 @@
                             },
                             "oauth-sign": {
                               "version": "0.8.0",
-                              "from": "oauth-sign@>=0.8.0 <0.9.0",
+                              "from": "oauth-sign@~0.8.0",
                               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                             },
                             "hawk": {
                               "version": "3.1.0",
-                              "from": "hawk@>=3.1.0 <3.2.0",
+                              "from": "hawk@~3.1.0",
                               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
                               "dependencies": {
                                 "hoek": {
                                   "version": "2.14.0",
-                                  "from": "hoek@>=2.0.0 <3.0.0",
+                                  "from": "hoek@2.x.x",
                                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                                 },
                                 "boom": {
                                   "version": "2.8.0",
-                                  "from": "boom@>=2.8.0 <3.0.0",
+                                  "from": "boom@^2.8.x",
                                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                                 },
                                 "cryptiles": {
                                   "version": "2.0.4",
-                                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                                  "from": "cryptiles@2.x.x",
                                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                                 },
                                 "sntp": {
                                   "version": "1.0.9",
-                                  "from": "sntp@>=1.0.0 <2.0.0",
+                                  "from": "sntp@1.x.x",
                                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                                 }
                               }
                             },
                             "aws-sign2": {
                               "version": "0.5.0",
-                              "from": "aws-sign2@>=0.5.0 <0.6.0",
+                              "from": "aws-sign2@~0.5.0",
                               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                             },
                             "stringstream": {
                               "version": "0.0.4",
-                              "from": "stringstream@>=0.0.4 <0.1.0",
+                              "from": "stringstream@~0.0.4",
                               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                             },
                             "combined-stream": {
                               "version": "1.0.5",
-                              "from": "combined-stream@>=1.0.1 <1.1.0",
+                              "from": "combined-stream@~1.0.1",
                               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                               "dependencies": {
                                 "delayed-stream": {
                                   "version": "1.0.0",
-                                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                                  "from": "delayed-stream@~1.0.0",
                                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                                 }
                               }
                             },
                             "isstream": {
                               "version": "0.1.2",
-                              "from": "isstream@>=0.1.1 <0.2.0",
+                              "from": "isstream@~0.1.1",
                               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                             },
                             "har-validator": {
                               "version": "1.8.0",
-                              "from": "har-validator@>=1.6.1 <2.0.0",
+                              "from": "har-validator@^1.6.1",
                               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                               "dependencies": {
                                 "bluebird": {
                                   "version": "2.9.34",
-                                  "from": "bluebird@>=2.9.30 <3.0.0",
+                                  "from": "bluebird@^2.9.30",
                                   "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
                                 },
                                 "chalk": {
                                   "version": "1.1.0",
-                                  "from": "chalk@>=1.0.0 <2.0.0",
+                                  "from": "chalk@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
                                   "dependencies": {
                                     "ansi-styles": {
                                       "version": "2.1.0",
-                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                      "from": "ansi-styles@^2.1.0",
                                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                                     },
                                     "escape-string-regexp": {
                                       "version": "1.0.3",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "from": "escape-string-regexp@^1.0.2",
                                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                                     },
                                     "has-ansi": {
                                       "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                                      "from": "has-ansi@^2.0.0",
                                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                       "dependencies": {
                                         "ansi-regex": {
                                           "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                          "from": "ansi-regex@^2.0.0",
                                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                         }
                                       }
                                     },
                                     "strip-ansi": {
                                       "version": "3.0.0",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                      "from": "strip-ansi@^3.0.0",
                                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                       "dependencies": {
                                         "ansi-regex": {
                                           "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                          "from": "ansi-regex@^2.0.0",
                                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                         }
                                       }
                                     },
                                     "supports-color": {
                                       "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
+                                      "from": "supports-color@^2.0.0",
                                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "commander": {
                                   "version": "2.8.1",
-                                  "from": "commander@>=2.8.1 <3.0.0",
+                                  "from": "commander@^2.8.1",
                                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                                   "dependencies": {
                                     "graceful-readlink": {
                                       "version": "1.0.1",
-                                      "from": "graceful-readlink@>=1.0.0",
+                                      "from": "graceful-readlink@>= 1.0.0",
                                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                                     }
                                   }
                                 },
                                 "is-my-json-valid": {
                                   "version": "2.12.1",
-                                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                                  "from": "is-my-json-valid@^2.12.0",
                                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
                                   "dependencies": {
                                     "generate-function": {
                                       "version": "2.0.0",
-                                      "from": "generate-function@>=2.0.0 <3.0.0",
+                                      "from": "generate-function@^2.0.0",
                                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                                     },
                                     "generate-object-property": {
                                       "version": "1.2.0",
-                                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                                      "from": "generate-object-property@^1.1.0",
                                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                                       "dependencies": {
                                         "is-property": {
                                           "version": "1.0.2",
-                                          "from": "is-property@>=1.0.0 <2.0.0",
+                                          "from": "is-property@^1.0.0",
                                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                                         }
                                       }
                                     },
                                     "jsonpointer": {
                                       "version": "1.1.0",
-                                      "from": "jsonpointer@>=1.1.0 <2.0.0",
+                                      "from": "jsonpointer@^1.1.0",
                                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                                     },
                                     "xtend": {
                                       "version": "4.0.0",
-                                      "from": "xtend@>=4.0.0 <5.0.0",
+                                      "from": "xtend@^4.0.0",
                                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                                     }
                                   }
@@ -7365,22 +5423,22 @@
                     },
                     "request": {
                       "version": "2.51.0",
-                      "from": "request@>=2.51.0 <2.52.0",
+                      "from": "request@~2.51.0",
                       "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                       "dependencies": {
                         "bl": {
                           "version": "0.9.4",
-                          "from": "bl@>=0.9.0 <0.10.0",
+                          "from": "bl@~0.9.0",
                           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.33",
-                              "from": "readable-stream@>=1.0.26 <1.1.0",
+                              "from": "readable-stream@~1.0.26",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "from": "core-util-is@~1.0.0",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                 },
                                 "isarray": {
@@ -7390,12 +5448,12 @@
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "from": "string_decoder@~0.10.x",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "from": "inherits@~2.0.1",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
@@ -7404,27 +5462,27 @@
                         },
                         "caseless": {
                           "version": "0.8.0",
-                          "from": "caseless@>=0.8.0 <0.9.0",
+                          "from": "caseless@~0.8.0",
                           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                         },
                         "forever-agent": {
                           "version": "0.5.2",
-                          "from": "forever-agent@>=0.5.0 <0.6.0",
+                          "from": "forever-agent@~0.5.0",
                           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                         },
                         "form-data": {
                           "version": "0.2.0",
-                          "from": "form-data@>=0.2.0 <0.3.0",
+                          "from": "form-data@~0.2.0",
                           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                           "dependencies": {
                             "mime-types": {
                               "version": "2.0.14",
-                              "from": "mime-types@>=2.0.3 <2.1.0",
+                              "from": "mime-types@~2.0.3",
                               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                               "dependencies": {
                                 "mime-db": {
                                   "version": "1.12.0",
-                                  "from": "mime-db@>=1.12.0 <1.13.0",
+                                  "from": "mime-db@~1.12.0",
                                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                                 }
                               }
@@ -7433,27 +5491,27 @@
                         },
                         "json-stringify-safe": {
                           "version": "5.0.1",
-                          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                          "from": "json-stringify-safe@~5.0.0",
                           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                         },
                         "mime-types": {
                           "version": "1.0.2",
-                          "from": "mime-types@>=1.0.1 <1.1.0",
+                          "from": "mime-types@~1.0.1",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                         },
                         "node-uuid": {
                           "version": "1.4.3",
-                          "from": "node-uuid@>=1.4.0 <1.5.0",
+                          "from": "node-uuid@~1.4.0",
                           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                         },
                         "qs": {
                           "version": "2.3.3",
-                          "from": "qs@>=2.3.1 <2.4.0",
+                          "from": "qs@~2.3.1",
                           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                         },
                         "tunnel-agent": {
                           "version": "0.4.1",
-                          "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                          "from": "tunnel-agent@~0.4.0",
                           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                         },
                         "tough-cookie": {
@@ -7463,12 +5521,12 @@
                         },
                         "http-signature": {
                           "version": "0.10.1",
-                          "from": "http-signature@>=0.10.0 <0.11.0",
+                          "from": "http-signature@~0.10.0",
                           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                           "dependencies": {
                             "assert-plus": {
                               "version": "0.1.5",
-                              "from": "assert-plus@>=0.1.5 <0.2.0",
+                              "from": "assert-plus@^0.1.5",
                               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                             },
                             "asn1": {
@@ -7485,7 +5543,7 @@
                         },
                         "oauth-sign": {
                           "version": "0.5.0",
-                          "from": "oauth-sign@>=0.5.0 <0.6.0",
+                          "from": "oauth-sign@~0.5.0",
                           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                         },
                         "hawk": {
@@ -7495,39 +5553,39 @@
                           "dependencies": {
                             "hoek": {
                               "version": "0.9.1",
-                              "from": "hoek@>=0.9.0 <0.10.0",
+                              "from": "hoek@0.9.x",
                               "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                             },
                             "boom": {
                               "version": "0.4.2",
-                              "from": "boom@>=0.4.0 <0.5.0",
+                              "from": "boom@0.4.x",
                               "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                             },
                             "cryptiles": {
                               "version": "0.2.2",
-                              "from": "cryptiles@>=0.2.0 <0.3.0",
+                              "from": "cryptiles@0.2.x",
                               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                             },
                             "sntp": {
                               "version": "0.2.4",
-                              "from": "sntp@>=0.2.0 <0.3.0",
+                              "from": "sntp@0.2.x",
                               "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                             }
                           }
                         },
                         "aws-sign2": {
                           "version": "0.5.0",
-                          "from": "aws-sign2@>=0.5.0 <0.6.0",
+                          "from": "aws-sign2@~0.5.0",
                           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                         },
                         "stringstream": {
                           "version": "0.0.4",
-                          "from": "stringstream@>=0.0.4 <0.1.0",
+                          "from": "stringstream@~0.0.4",
                           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                         },
                         "combined-stream": {
                           "version": "0.0.7",
-                          "from": "combined-stream@>=0.0.5 <0.1.0",
+                          "from": "combined-stream@~0.0.5",
                           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                           "dependencies": {
                             "delayed-stream": {
@@ -7541,83 +5599,83 @@
                     },
                     "string-template": {
                       "version": "0.2.1",
-                      "from": "string-template@>=0.2.0 <0.3.0",
+                      "from": "string-template@~0.2.0",
                       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
                     }
                   }
                 },
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "minimist@>=0.2.0 <0.3.0",
+                  "from": "minimist@^0.2.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "valid-url": {
                   "version": "1.0.9",
-                  "from": "valid-url@>=1.0.9 <2.0.0",
+                  "from": "valid-url@^1.0.9",
                   "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz"
                 }
               }
             },
             "minimist": {
-              "version": "1.1.2",
-              "from": "minimist@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+              "version": "1.1.3",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
             },
             "prepend-http": {
               "version": "1.0.2",
-              "from": "prepend-http@>=1.0.0 <2.0.0",
+              "from": "prepend-http@^1.0.0",
               "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "pretty-bytes@>=1.0.1 <2.0.0",
+              "from": "pretty-bytes@^1.0.0",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "get-stdin@^4.0.1",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "meow@>=3.1.0 <4.0.0",
+                  "from": "meow@^3.1.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "from": "camelcase-keys@^1.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "from": "camelcase@^1.0.1",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "map-obj@^1.0.0",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.2",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "from": "indent-string@^1.1.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "from": "repeating@^1.1.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "is-finite@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "number-is-nan@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -7628,7 +5686,7 @@
                     },
                     "object-assign": {
                       "version": "3.0.0",
-                      "from": "object-assign@>=3.0.0 <4.0.0",
+                      "from": "object-assign@^3.0.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                     }
                   }
@@ -7646,12 +5704,12 @@
       "dependencies": {
         "postcss": {
           "version": "4.0.6",
-          "from": "postcss@>=4.0.6 <4.1.0",
+          "from": "postcss@~4.0.6",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.2.0",
-              "from": "source-map@>=0.2.0 <0.3.0",
+              "from": "source-map@~0.2.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "dependencies": {
                 "amdefine": {
@@ -7663,58 +5721,58 @@
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@>=2.1.7 <2.2.0",
+              "from": "js-base64@~2.1.7",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
         },
         "chalk": {
           "version": "1.0.0",
-          "from": "chalk@>=1.0.0 <1.1.0",
+          "from": "chalk@~1.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "from": "ansi-styles@^2.0.1",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "from": "has-ansi@^1.0.3",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "from": "ansi-regex@^1.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "get-stdin@^4.0.1",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "from": "strip-ansi@^2.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "from": "ansi-regex@1.1.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
+              "from": "supports-color@^1.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
@@ -7728,122 +5786,122 @@
       "dependencies": {
         "each-async": {
           "version": "1.1.1",
-          "from": "each-async@>=1.0.0 <2.0.0",
+          "from": "each-async@^1.0.0",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "onetime@>=1.0.0 <2.0.0",
+              "from": "onetime@^1.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
             "set-immediate-shim": {
               "version": "1.0.1",
-              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+              "from": "set-immediate-shim@^1.0.0",
               "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
             }
           }
         },
         "node-sass": {
           "version": "3.2.0",
-          "from": "node-sass@>=3.0.0 <4.0.0",
+          "from": "node-sass@^3.0.0",
           "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.2.0.tgz",
           "dependencies": {
             "async-foreach": {
               "version": "0.1.3",
-              "from": "async-foreach@>=0.1.3 <0.2.0",
+              "from": "async-foreach@^0.1.3",
               "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
             },
             "chalk": {
               "version": "1.1.0",
-              "from": "chalk@>=1.0.0 <2.0.0",
+              "from": "chalk@^1.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "from": "ansi-styles@^2.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "escape-string-regexp@^1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "has-ansi@^2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "strip-ansi@^3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "supports-color@^2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "gaze": {
               "version": "0.5.1",
-              "from": "gaze@>=0.5.1 <0.6.0",
+              "from": "gaze@^0.5.1",
               "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
               "dependencies": {
                 "globule": {
                   "version": "0.1.0",
-                  "from": "globule@>=0.1.0 <0.2.0",
+                  "from": "globule@~0.1.0",
                   "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "1.0.2",
-                      "from": "lodash@>=1.0.1 <1.1.0",
+                      "from": "lodash@~1.0.1",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                     },
                     "glob": {
                       "version": "3.1.21",
-                      "from": "glob@>=3.1.21 <3.2.0",
+                      "from": "glob@~3.1.21",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "1.2.3",
-                          "from": "graceful-fs@>=1.2.0 <1.3.0",
+                          "from": "graceful-fs@~1.2.0",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                         },
                         "inherits": {
                           "version": "1.0.0",
-                          "from": "inherits@>=1.0.0 <2.0.0",
+                          "from": "inherits@1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "from": "minimatch@~0.2.11",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.6.5",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "from": "lru-cache@2",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "from": "sigmund@~1.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
@@ -7854,44 +5912,44 @@
             },
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "from": "get-stdin@^4.0.1",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "glob": {
               "version": "5.0.14",
-              "from": "glob@>=5.0.3 <6.0.0",
+              "from": "glob@^5.0.3",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "inflight@^1.0.4",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "minimatch@^2.0.1",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "balanced-match@^0.2.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -7905,63 +5963,63 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "path-is-absolute@^1.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@>=3.1.0 <4.0.0",
+              "from": "meow@^3.1.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "from": "camelcase-keys@^1.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "from": "camelcase@^1.0.1",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "from": "map-obj@^1.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.2",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "from": "indent-string@^1.1.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "from": "repeating@^1.1.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "is-finite@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "number-is-nan@^1.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -7971,93 +6029,93 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.1.2",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                  "version": "1.1.3",
+                  "from": "minimist@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "from": "object-assign@^3.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
             },
             "nan": {
               "version": "1.9.0",
-              "from": "nan@>=1.8.4 <2.0.0",
+              "from": "nan@^1.8.4",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
             },
             "npmconf": {
               "version": "2.1.2",
-              "from": "npmconf@>=2.1.1 <3.0.0",
+              "from": "npmconf@^2.1.1",
               "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.9",
-                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "from": "config-chain@~1.1.8",
                   "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
                   "dependencies": {
                     "proto-list": {
                       "version": "1.2.4",
-                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "from": "proto-list@~1.2.1",
                       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "from": "inherits@~2.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "from": "ini@>=1.2.0 <2.0.0",
+                  "from": "ini@^1.2.0",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "nopt": {
                   "version": "3.0.3",
-                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "from": "nopt@~3.0.1",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "abbrev@1",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <1.4.0",
+                  "from": "once@~1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "from": "osenv@^0.1.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "from": "os-homedir@^1.0.0",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "from": "os-tmpdir@^1.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "semver": {
                   "version": "4.3.6",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                  "from": "semver@2 || 3 || 4",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 },
                 "uid-number": {
@@ -8068,52 +6126,52 @@
               }
             },
             "pangyp": {
-              "version": "2.2.1",
-              "from": "pangyp@>=2.2.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.1.tgz",
+              "version": "2.3.0",
+              "from": "pangyp@^2.2.0",
+              "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.0.tgz",
               "dependencies": {
                 "fstream": {
                   "version": "1.0.7",
-                  "from": "fstream@>=1.0.3 <1.1.0",
+                  "from": "fstream@~1.0.3",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <2.1.0",
+                      "from": "inherits@~2.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@>=4.3.5 <4.4.0",
+                  "from": "glob@~4.3.5",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "inflight@^1.0.4",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@^1.3.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -8122,22 +6180,22 @@
                 },
                 "graceful-fs": {
                   "version": "3.0.8",
-                  "from": "graceful-fs@>=3.0.5 <3.1.0",
+                  "from": "graceful-fs@~3.0.5",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <2.1.0",
+                  "from": "minimatch@~2.0.1",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "balanced-match@^0.2.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -8151,44 +6209,44 @@
                 },
                 "nopt": {
                   "version": "3.0.3",
-                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "from": "nopt@~3.0.1",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "abbrev@1",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "npmlog": {
                   "version": "1.0.0",
-                  "from": "npmlog@>=1.0.0 <1.1.0",
+                  "from": "npmlog@~1.0.0",
                   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
                   "dependencies": {
                     "ansi": {
                       "version": "0.3.0",
-                      "from": "ansi@>=0.3.0 <0.4.0",
+                      "from": "ansi@~0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                     },
                     "are-we-there-yet": {
                       "version": "1.0.4",
-                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                      "from": "are-we-there-yet@~1.0.0",
                       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                       "dependencies": {
                         "delegates": {
                           "version": "0.1.0",
-                          "from": "delegates@>=0.1.0 <0.2.0",
+                          "from": "delegates@^0.1.0",
                           "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
                         },
                         "readable-stream": {
                           "version": "1.1.13",
-                          "from": "readable-stream@>=1.1.13 <2.0.0",
+                          "from": "readable-stream@^1.1.13",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "core-util-is@~1.0.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
@@ -8198,12 +6256,12 @@
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "string_decoder@~0.10.x",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "inherits@~2.0.1",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -8212,12 +6270,12 @@
                     },
                     "gauge": {
                       "version": "1.0.2",
-                      "from": "gauge@>=1.0.2 <1.1.0",
+                      "from": "gauge@~1.0.2",
                       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                       "dependencies": {
                         "has-unicode": {
                           "version": "1.0.0",
-                          "from": "has-unicode@>=1.0.0 <2.0.0",
+                          "from": "has-unicode@^1.0.0",
                           "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
                         }
                       }
@@ -8226,39 +6284,39 @@
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@>=0.0.0 <1.0.0",
+                  "from": "osenv@0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "from": "os-homedir@^1.0.0",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "from": "os-tmpdir@^1.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "request": {
                   "version": "2.51.0",
-                  "from": "request@>=2.51.0 <2.52.0",
+                  "from": "request@~2.51.0",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "0.9.4",
-                      "from": "bl@>=0.9.0 <0.10.0",
+                      "from": "bl@~0.9.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.26 <1.1.0",
+                          "from": "readable-stream@~1.0.26",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "core-util-is@~1.0.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
@@ -8268,12 +6326,12 @@
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "string_decoder@~0.10.x",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "inherits@~2.0.1",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -8282,32 +6340,32 @@
                     },
                     "caseless": {
                       "version": "0.8.0",
-                      "from": "caseless@>=0.8.0 <0.9.0",
+                      "from": "caseless@~0.8.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                     },
                     "forever-agent": {
                       "version": "0.5.2",
-                      "from": "forever-agent@>=0.5.0 <0.6.0",
+                      "from": "forever-agent@~0.5.0",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                     },
                     "form-data": {
                       "version": "0.2.0",
-                      "from": "form-data@>=0.2.0 <0.3.0",
+                      "from": "form-data@~0.2.0",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.9.2",
-                          "from": "async@>=0.9.0 <0.10.0",
+                          "from": "async@~0.9.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                         },
                         "mime-types": {
                           "version": "2.0.14",
-                          "from": "mime-types@>=2.0.3 <2.1.0",
+                          "from": "mime-types@~2.0.3",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                           "dependencies": {
                             "mime-db": {
                               "version": "1.12.0",
-                              "from": "mime-db@>=1.12.0 <1.13.0",
+                              "from": "mime-db@~1.12.0",
                               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                             }
                           }
@@ -8316,27 +6374,27 @@
                     },
                     "json-stringify-safe": {
                       "version": "5.0.1",
-                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                      "from": "json-stringify-safe@~5.0.0",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "mime-types": {
                       "version": "1.0.2",
-                      "from": "mime-types@>=1.0.1 <1.1.0",
+                      "from": "mime-types@~1.0.1",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                     },
                     "node-uuid": {
                       "version": "1.4.3",
-                      "from": "node-uuid@>=1.4.0 <1.5.0",
+                      "from": "node-uuid@~1.4.0",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                     },
                     "qs": {
                       "version": "2.3.3",
-                      "from": "qs@>=2.3.1 <2.4.0",
+                      "from": "qs@~2.3.1",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.1",
-                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                      "from": "tunnel-agent@~0.4.0",
                       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                     },
                     "tough-cookie": {
@@ -8346,12 +6404,12 @@
                     },
                     "http-signature": {
                       "version": "0.10.1",
-                      "from": "http-signature@>=0.10.0 <0.11.0",
+                      "from": "http-signature@~0.10.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.5",
-                          "from": "assert-plus@>=0.1.5 <0.2.0",
+                          "from": "assert-plus@^0.1.5",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                         },
                         "asn1": {
@@ -8368,7 +6426,7 @@
                     },
                     "oauth-sign": {
                       "version": "0.5.0",
-                      "from": "oauth-sign@>=0.5.0 <0.6.0",
+                      "from": "oauth-sign@~0.5.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                     },
                     "hawk": {
@@ -8378,39 +6436,39 @@
                       "dependencies": {
                         "hoek": {
                           "version": "0.9.1",
-                          "from": "hoek@>=0.9.0 <0.10.0",
+                          "from": "hoek@0.9.x",
                           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                         },
                         "boom": {
                           "version": "0.4.2",
-                          "from": "boom@>=0.4.0 <0.5.0",
+                          "from": "boom@0.4.x",
                           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                         },
                         "cryptiles": {
                           "version": "0.2.2",
-                          "from": "cryptiles@>=0.2.0 <0.3.0",
+                          "from": "cryptiles@0.2.x",
                           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                         },
                         "sntp": {
                           "version": "0.2.4",
-                          "from": "sntp@>=0.2.0 <0.3.0",
+                          "from": "sntp@0.2.x",
                           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                         }
                       }
                     },
                     "aws-sign2": {
                       "version": "0.5.0",
-                      "from": "aws-sign2@>=0.5.0 <0.6.0",
+                      "from": "aws-sign2@~0.5.0",
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                     },
                     "stringstream": {
                       "version": "0.0.4",
-                      "from": "stringstream@>=0.0.4 <0.1.0",
+                      "from": "stringstream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.5 <0.1.0",
+                      "from": "combined-stream@~0.0.5",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
@@ -8424,17 +6482,17 @@
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@>=2.2.8 <2.3.0",
+                  "from": "rimraf@~2.2.8",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "semver": {
                   "version": "4.3.6",
-                  "from": "semver@>=4.3.6 <4.4.0",
+                  "from": "semver@~4.3.6",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 },
                 "tar": {
                   "version": "1.0.3",
-                  "from": "tar@>=1.0.3 <1.1.0",
+                  "from": "tar@~1.0.3",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
                   "dependencies": {
                     "block-stream": {
@@ -8444,41 +6502,41 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "which": {
                   "version": "1.0.9",
-                  "from": "which@>=1.0.8 <1.1.0",
+                  "from": "which@~1.0.8",
                   "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
                 }
               }
             },
             "request": {
               "version": "2.60.0",
-              "from": "request@>=2.55.0 <3.0.0",
+              "from": "request@^2.55.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "1.0.0",
-                  "from": "bl@>=1.0.0 <1.1.0",
+                  "from": "bl@~1.0.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.2",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "from": "readable-stream@~2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@~2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
@@ -8488,17 +6546,17 @@
                         },
                         "process-nextick-args": {
                           "version": "1.0.2",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "from": "process-nextick-args@~1.0.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "util-deprecate@~1.0.1",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
@@ -8507,61 +6565,61 @@
                 },
                 "caseless": {
                   "version": "0.11.0",
-                  "from": "caseless@>=0.11.0 <0.12.0",
+                  "from": "caseless@~0.11.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "from": "extend@>=3.0.0 <3.1.0",
+                  "from": "extend@~3.0.0",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "forever-agent@>=0.6.0 <0.7.0",
+                  "from": "forever-agent@~0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "1.0.0-rc3",
-                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
+                  "from": "form-data@~1.0.0-rc1",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "1.4.0",
-                      "from": "async@>=1.4.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
+                      "version": "1.4.2",
+                      "from": "async@^1.4.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "json-stringify-safe@~5.0.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.4",
-                  "from": "mime-types@>=2.1.2 <2.2.0",
+                  "from": "mime-types@~2.1.2",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.16.0",
-                      "from": "mime-db@>=1.16.0 <1.17.0",
+                      "from": "mime-db@~1.16.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "node-uuid@~1.4.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "4.0.0",
-                  "from": "qs@>=4.0.0 <4.1.0",
+                  "from": "qs@~4.0.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "tunnel-agent@~0.4.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
@@ -8571,12 +6629,12 @@
                 },
                 "http-signature": {
                   "version": "0.11.0",
-                  "from": "http-signature@>=0.11.0 <0.12.0",
+                  "from": "http-signature@~0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "assert-plus@^0.1.5",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
@@ -8593,115 +6651,115 @@
                 },
                 "oauth-sign": {
                   "version": "0.8.0",
-                  "from": "oauth-sign@>=0.8.0 <0.9.0",
+                  "from": "oauth-sign@~0.8.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                 },
                 "hawk": {
                   "version": "3.1.0",
-                  "from": "hawk@>=3.1.0 <3.2.0",
+                  "from": "hawk@~3.1.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.14.0",
-                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "from": "hoek@2.x.x",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
                       "version": "2.8.0",
-                      "from": "boom@>=2.8.0 <3.0.0",
+                      "from": "boom@^2.8.x",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "from": "sntp@1.x.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "aws-sign2@~0.5.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "combined-stream@>=1.0.1 <1.1.0",
+                  "from": "combined-stream@~1.0.1",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <1.1.0",
+                      "from": "delayed-stream@~1.0.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "from": "isstream@~0.1.1",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "1.8.0",
-                  "from": "har-validator@>=1.6.1 <2.0.0",
+                  "from": "har-validator@^1.6.1",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "dependencies": {
                     "bluebird": {
                       "version": "2.9.34",
-                      "from": "bluebird@>=2.9.30 <3.0.0",
+                      "from": "bluebird@^2.9.30",
                       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
                     },
                     "commander": {
                       "version": "2.8.1",
-                      "from": "commander@>=2.8.1 <3.0.0",
+                      "from": "commander@^2.8.1",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0",
+                          "from": "graceful-readlink@>= 1.0.0",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.12.1",
-                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                      "from": "is-my-json-valid@^2.12.0",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "from": "generate-function@^2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "from": "generate-object-property@^1.1.0",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "from": "is-property@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "1.1.0",
-                          "from": "jsonpointer@>=1.1.0 <2.0.0",
+                          "from": "jsonpointer@^1.1.0",
                           "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.0",
-                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "from": "xtend@^4.0.0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                         }
                       }
@@ -8711,53 +6769,53 @@
               }
             },
             "sass-graph": {
-              "version": "2.0.0",
-              "from": "sass-graph@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
+              "version": "2.0.1",
+              "from": "sass-graph@^2.0.0",
+              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.8.0 <4.0.0",
+                  "from": "lodash@^3.8.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "yargs": {
-                  "version": "3.17.1",
-                  "from": "yargs@>=3.8.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.17.1.tgz",
+                  "version": "3.18.0",
+                  "from": "yargs@^3.8.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.18.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "from": "camelcase@^1.0.2",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "from": "cliui@^2.1.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.1",
-                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "from": "center-align@^0.1.1",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.0 <0.2.0",
+                              "from": "align-text@^0.1.1",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.0",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "from": "kind-of@^2.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "longest@^1.0.1",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "repeat-string@^1.5.2",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -8766,27 +6824,27 @@
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "from": "right-align@^0.1.1",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.0 <0.2.0",
+                              "from": "align-text@^0.1.1",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.0",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "from": "kind-of@^2.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "longest@^1.0.1",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "repeat-string@^1.5.2",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -8802,17 +6860,17 @@
                     },
                     "decamelize": {
                       "version": "1.0.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "from": "decamelize@^1.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.2",
-                      "from": "window-size@>=0.1.1 <0.2.0",
+                      "from": "window-size@^0.1.1",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
                     },
                     "y18n": {
                       "version": "3.0.0",
-                      "from": "y18n@>=3.0.0 <4.0.0",
+                      "from": "y18n@^3.0.0",
                       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.0.0.tgz"
                     }
                   }
@@ -8823,7 +6881,7 @@
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
+          "from": "object-assign@^2.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         }
       }
@@ -8845,53 +6903,53 @@
           "dependencies": {
             "lodash-node": {
               "version": "2.4.1",
-              "from": "lodash-node@>=2.4.1 <2.5.0",
+              "from": "lodash-node@~2.4.1",
               "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
             }
           }
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@0.5.1",
+          "from": "chalk@^0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@^1.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@^0.2.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -8905,46 +6963,46 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
+          "from": "chalk@~0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "from": "ansi-styles@^1.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "from": "has-ansi@^0.1.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "from": "strip-ansi@^0.3.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@^0.2.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
+              "from": "supports-color@^0.2.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -8953,127 +7011,127 @@
     },
     "grunt-svgmin": {
       "version": "2.0.1",
-      "from": "grunt-svgmin@>=2.0.0 <3.0.0",
+      "from": "grunt-svgmin@^2.0.0",
       "resolved": "https://registry.npmjs.org/grunt-svgmin/-/grunt-svgmin-2.0.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@^1.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "ansi-styles@^2.0.1",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "has-ansi@^2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "strip-ansi@^3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "supports-color@^2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "each-async": {
           "version": "1.1.1",
-          "from": "each-async@>=1.0.0 <2.0.0",
+          "from": "each-async@^1.0.0",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "onetime@>=1.0.0 <2.0.0",
+              "from": "onetime@^1.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
             "set-immediate-shim": {
               "version": "1.0.1",
-              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+              "from": "set-immediate-shim@^1.0.0",
               "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
             }
           }
         },
         "log-symbols": {
           "version": "1.0.2",
-          "from": "log-symbols@>=1.0.0 <2.0.0",
+          "from": "log-symbols@^1.0.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
         },
         "pretty-bytes": {
           "version": "1.0.4",
-          "from": "pretty-bytes@>=1.0.1 <2.0.0",
+          "from": "pretty-bytes@^1.0.1",
           "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "from": "get-stdin@^4.0.1",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@>=3.3.0 <4.0.0",
+              "from": "meow@^3.3.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "from": "camelcase-keys@^1.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "from": "camelcase@^1.0.1",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "from": "map-obj@^1.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.2",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "from": "indent-string@^1.1.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "from": "repeating@^1.1.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "is-finite@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "number-is-nan@^1.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -9083,13 +7141,13 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.1.2",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                  "version": "1.1.3",
+                  "from": "minimist@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "from": "object-assign@^3.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
@@ -9098,68 +7156,68 @@
         },
         "svgo": {
           "version": "0.5.5",
-          "from": "svgo@>=0.5.0 <0.6.0",
+          "from": "svgo@^0.5.0",
           "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.5.5.tgz",
           "dependencies": {
             "sax": {
               "version": "1.1.1",
-              "from": "sax@>=1.1.1 <1.2.0",
+              "from": "sax@~1.1.1",
               "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.1.tgz"
             },
             "coa": {
               "version": "1.0.1",
-              "from": "coa@>=1.0.1 <1.1.0",
+              "from": "coa@~1.0.1",
               "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
               "dependencies": {
                 "q": {
                   "version": "1.4.1",
-                  "from": "q@>=1.1.2 <2.0.0",
+                  "from": "q@^1.1.2",
                   "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                 }
               }
             },
             "js-yaml": {
               "version": "3.3.1",
-              "from": "js-yaml@>=3.3.1 <3.4.0",
+              "from": "js-yaml@3.x",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "from": "argparse@~1.0.2",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "from": "lodash@>= 3.2.0 < 4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "from": "sprintf-js@~1.0.2",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.2.0",
-                  "from": "esprima@>=2.2.0 <2.3.0",
+                  "from": "esprima@~2.2.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                 }
               }
             },
             "colors": {
               "version": "1.1.2",
-              "from": "colors@>=1.1.2 <1.2.0",
+              "from": "colors@~1.1.2",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
             },
             "whet.extend": {
               "version": "0.9.9",
-              "from": "whet.extend@>=0.9.9 <0.10.0",
+              "from": "whet.extend@~0.9.9",
               "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "from": "mkdirp@~0.5.1",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
@@ -9190,2935 +7248,13 @@
           "dependencies": {
             "commander": {
               "version": "1.1.1",
-              "from": "commander@>=1.1.1 <1.2.0",
+              "from": "commander@~1.1.1",
               "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
               "dependencies": {
                 "keypress": {
                   "version": "0.1.0",
-                  "from": "keypress@>=0.1.0 <0.2.0",
+                  "from": "keypress@0.1.x",
                   "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp": {
-      "version": "3.9.0",
-      "from": "gulp@>=3.9.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.0.tgz",
-      "dependencies": {
-        "archy": {
-          "version": "1.0.0",
-          "from": "archy@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "deprecated": {
-          "version": "0.0.1",
-          "from": "deprecated@>=0.0.1 <0.0.2",
-          "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
-        },
-        "interpret": {
-          "version": "0.6.5",
-          "from": "interpret@>=0.6.2 <0.7.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.5.tgz"
-        },
-        "liftoff": {
-          "version": "2.1.0",
-          "from": "liftoff@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.1.0.tgz",
-          "dependencies": {
-            "extend": {
-              "version": "2.0.1",
-              "from": "extend@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
-            },
-            "findup-sync": {
-              "version": "0.2.1",
-              "from": "findup-sync@>=0.2.1 <0.3.0",
-              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "4.3.5",
-                  "from": "glob@>=4.3.0 <4.4.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "2.0.10",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.0",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.0",
-                              "from": "balanced-match@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "flagged-respawn": {
-              "version": "0.3.1",
-              "from": "flagged-respawn@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "from": "rechoir@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
-            },
-            "resolve": {
-              "version": "1.1.6",
-              "from": "resolve@>=1.1.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.1.2",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
-        },
-        "orchestrator": {
-          "version": "0.3.7",
-          "from": "orchestrator@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
-          "dependencies": {
-            "end-of-stream": {
-              "version": "0.1.5",
-              "from": "end-of-stream@>=0.1.5 <0.2.0",
-              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-              "dependencies": {
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "sequencify": {
-              "version": "0.0.7",
-              "from": "sequencify@>=0.0.7 <0.1.0",
-              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
-            },
-            "stream-consume": {
-              "version": "0.1.0",
-              "from": "stream-consume@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
-            }
-          }
-        },
-        "pretty-hrtime": {
-          "version": "1.0.0",
-          "from": "pretty-hrtime@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.0.tgz"
-        },
-        "semver": {
-          "version": "4.3.6",
-          "from": "semver@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-        },
-        "tildify": {
-          "version": "1.1.0",
-          "from": "tildify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.0.tgz",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1",
-              "from": "os-homedir@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-            }
-          }
-        },
-        "v8flags": {
-          "version": "2.0.10",
-          "from": "v8flags@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.10.tgz",
-          "dependencies": {
-            "user-home": {
-              "version": "1.1.1",
-              "from": "user-home@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-            }
-          }
-        },
-        "vinyl-fs": {
-          "version": "0.3.13",
-          "from": "vinyl-fs@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.13.tgz",
-          "dependencies": {
-            "defaults": {
-              "version": "1.0.2",
-              "from": "defaults@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.2.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "0.1.19",
-                  "from": "clone@>=0.1.5 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
-                }
-              }
-            },
-            "glob-stream": {
-              "version": "3.1.18",
-              "from": "glob-stream@>=3.1.5 <4.0.0",
-              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "4.5.3",
-                  "from": "glob@>=4.3.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "ordered-read-streams": {
-                  "version": "0.1.0",
-                  "from": "ordered-read-streams@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                },
-                "glob2base": {
-                  "version": "0.0.12",
-                  "from": "glob2base@>=0.0.12 <0.0.13",
-                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-                  "dependencies": {
-                    "find-index": {
-                      "version": "0.1.1",
-                      "from": "find-index@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
-                    }
-                  }
-                },
-                "unique-stream": {
-                  "version": "1.0.0",
-                  "from": "unique-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "glob-watcher": {
-              "version": "0.0.6",
-              "from": "glob-watcher@>=0.0.6 <0.0.7",
-              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-              "dependencies": {
-                "gaze": {
-                  "version": "0.5.1",
-                  "from": "gaze@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-                  "dependencies": {
-                    "globule": {
-                      "version": "0.1.0",
-                      "from": "globule@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "1.0.2",
-                          "from": "lodash@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                        },
-                        "glob": {
-                          "version": "3.1.21",
-                          "from": "glob@>=3.1.21 <3.2.0",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "1.2.3",
-                              "from": "graceful-fs@>=1.2.0 <1.3.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                            },
-                            "inherits": {
-                              "version": "1.0.0",
-                              "from": "inherits@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "minimatch": {
-                          "version": "0.2.14",
-                          "from": "minimatch@>=0.2.11 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "2.6.5",
-                              "from": "lru-cache@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                            },
-                            "sigmund": {
-                              "version": "1.0.1",
-                              "from": "sigmund@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-            },
-            "strip-bom": {
-              "version": "1.0.0",
-              "from": "strip-bom@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-              "dependencies": {
-                "first-chunk-stream": {
-                  "version": "1.0.0",
-                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-                },
-                "is-utf8": {
-                  "version": "0.2.0",
-                  "from": "is-utf8@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
-                }
-              }
-            },
-            "through2": {
-              "version": "0.6.5",
-              "from": "through2@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-                }
-              }
-            },
-            "vinyl": {
-              "version": "0.4.6",
-              "from": "vinyl@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "0.2.0",
-                  "from": "clone@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.0.2",
-                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-filter": {
-      "version": "2.0.2",
-      "from": "gulp-filter@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-2.0.2.tgz",
-      "dependencies": {
-        "merge-stream": {
-          "version": "0.1.8",
-          "from": "merge-stream@>=0.1.7 <0.2.0",
-          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz"
-        },
-        "multimatch": {
-          "version": "2.0.0",
-          "from": "multimatch@2.0.0",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "array-differ@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-union": {
-              "version": "1.0.1",
-              "from": "array-union@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "from": "array-uniq@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "plexer": {
-          "version": "0.0.3",
-          "from": "plexer@0.0.3",
-          "resolved": "https://registry.npmjs.org/plexer/-/plexer-0.0.3.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "readable-stream@>=1.0.26-2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-load-plugins": {
-      "version": "0.10.0",
-      "from": "gulp-load-plugins@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-0.10.0.tgz",
-      "dependencies": {
-        "findup-sync": {
-          "version": "0.2.1",
-          "from": "findup-sync@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "4.3.5",
-              "from": "glob@>=4.3.0 <4.4.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "multimatch": {
-          "version": "2.0.0",
-          "from": "multimatch@2.0.0",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "array-differ@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-union": {
-              "version": "1.0.1",
-              "from": "array-union@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "from": "array-uniq@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-load-tasks": {
-      "version": "0.8.3",
-      "from": "gulp-load-tasks@>=0.8.3 <0.9.0",
-      "resolved": "https://registry.npmjs.org/gulp-load-tasks/-/gulp-load-tasks-0.8.3.tgz"
-    },
-    "gulp-postcss": {
-      "version": "5.1.10",
-      "from": "gulp-postcss@>=5.1.6 <6.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-5.1.10.tgz",
-      "dependencies": {
-        "postcss": {
-          "version": "4.1.16",
-          "from": "postcss@>=4.1.11 <5.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-          "dependencies": {
-            "es6-promise": {
-              "version": "2.3.0",
-              "from": "es6-promise@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "from": "source-map@>=0.4.2 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.8 <2.2.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            }
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.43",
-              "from": "source-map@>=0.1.39 <0.2.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-sass": {
-      "version": "2.0.4",
-      "from": "gulp-sass@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-2.0.4.tgz",
-      "dependencies": {
-        "node-sass": {
-          "version": "3.2.0",
-          "from": "node-sass@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.2.0.tgz",
-          "dependencies": {
-            "async-foreach": {
-              "version": "0.1.3",
-              "from": "async-foreach@>=0.1.3 <0.2.0",
-              "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
-            },
-            "chalk": {
-              "version": "1.1.0",
-              "from": "chalk@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "gaze": {
-              "version": "0.5.1",
-              "from": "gaze@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-              "dependencies": {
-                "globule": {
-                  "version": "0.1.0",
-                  "from": "globule@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                  "dependencies": {
-                    "lodash": {
-                      "version": "1.0.2",
-                      "from": "lodash@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                    },
-                    "glob": {
-                      "version": "3.1.21",
-                      "from": "glob@>=3.1.21 <3.2.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "1.2.3",
-                          "from": "graceful-fs@>=1.2.0 <1.3.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                        },
-                        "inherits": {
-                          "version": "1.0.0",
-                          "from": "inherits@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@>=0.2.11 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.6.5",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            },
-            "glob": {
-              "version": "5.0.14",
-              "from": "glob@>=5.0.3 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            },
-            "meow": {
-              "version": "3.3.0",
-              "from": "meow@>=3.1.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                    },
-                    "map-obj": {
-                      "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                    }
-                  }
-                },
-                "indent-string": {
-                  "version": "1.2.2",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                  "dependencies": {
-                    "repeating": {
-                      "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimist": {
-                  "version": "1.1.2",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
-                },
-                "object-assign": {
-                  "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-                }
-              }
-            },
-            "nan": {
-              "version": "1.9.0",
-              "from": "nan@>=1.8.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
-            },
-            "npmconf": {
-              "version": "2.1.2",
-              "from": "npmconf@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
-              "dependencies": {
-                "config-chain": {
-                  "version": "1.1.9",
-                  "from": "config-chain@>=1.1.8 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
-                  "dependencies": {
-                    "proto-list": {
-                      "version": "1.2.4",
-                      "from": "proto-list@>=1.2.1 <1.3.0",
-                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@>=1.2.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                },
-                "nopt": {
-                  "version": "3.0.3",
-                  "from": "nopt@>=3.0.1 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    },
-                    "os-tmpdir": {
-                      "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "4.3.6",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-                },
-                "uid-number": {
-                  "version": "0.0.5",
-                  "from": "uid-number@0.0.5",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
-                }
-              }
-            },
-            "pangyp": {
-              "version": "2.2.1",
-              "from": "pangyp@>=2.2.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.1.tgz",
-              "dependencies": {
-                "fstream": {
-                  "version": "1.0.7",
-                  "from": "fstream@>=1.0.3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "glob": {
-                  "version": "4.3.5",
-                  "from": "glob@>=4.3.5 <4.4.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "3.0.8",
-                  "from": "graceful-fs@>=3.0.5 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "nopt": {
-                  "version": "3.0.3",
-                  "from": "nopt@>=3.0.1 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                },
-                "npmlog": {
-                  "version": "1.0.0",
-                  "from": "npmlog@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
-                  "dependencies": {
-                    "ansi": {
-                      "version": "0.3.0",
-                      "from": "ansi@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-                    },
-                    "are-we-there-yet": {
-                      "version": "1.0.4",
-                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
-                      "dependencies": {
-                        "delegates": {
-                          "version": "0.1.0",
-                          "from": "delegates@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-                        },
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "from": "readable-stream@>=1.1.13 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "gauge": {
-                      "version": "1.0.2",
-                      "from": "gauge@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
-                      "dependencies": {
-                        "has-unicode": {
-                          "version": "1.0.0",
-                          "from": "has-unicode@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "from": "osenv@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    },
-                    "os-tmpdir": {
-                      "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                    }
-                  }
-                },
-                "request": {
-                  "version": "2.51.0",
-                  "from": "request@>=2.51.0 <2.52.0",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
-                  "dependencies": {
-                    "bl": {
-                      "version": "0.9.4",
-                      "from": "bl@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.26 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "caseless": {
-                      "version": "0.8.0",
-                      "from": "caseless@>=0.8.0 <0.9.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-                    },
-                    "forever-agent": {
-                      "version": "0.5.2",
-                      "from": "forever-agent@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-                    },
-                    "form-data": {
-                      "version": "0.2.0",
-                      "from": "form-data@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                      "dependencies": {
-                        "async": {
-                          "version": "0.9.2",
-                          "from": "async@>=0.9.0 <0.10.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-                        },
-                        "mime-types": {
-                          "version": "2.0.14",
-                          "from": "mime-types@>=2.0.3 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                          "dependencies": {
-                            "mime-db": {
-                              "version": "1.12.0",
-                              "from": "mime-db@>=1.12.0 <1.13.0",
-                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                    },
-                    "mime-types": {
-                      "version": "1.0.2",
-                      "from": "mime-types@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                    },
-                    "node-uuid": {
-                      "version": "1.4.3",
-                      "from": "node-uuid@>=1.4.0 <1.5.0",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-                    },
-                    "qs": {
-                      "version": "2.3.3",
-                      "from": "qs@>=2.3.1 <2.4.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.1",
-                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                    },
-                    "tough-cookie": {
-                      "version": "2.0.0",
-                      "from": "tough-cookie@>=0.12.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
-                    },
-                    "http-signature": {
-                      "version": "0.10.1",
-                      "from": "http-signature@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "assert-plus@>=0.1.5 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                        },
-                        "asn1": {
-                          "version": "0.1.11",
-                          "from": "asn1@0.1.11",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                        },
-                        "ctype": {
-                          "version": "0.5.3",
-                          "from": "ctype@0.5.3",
-                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.5.0",
-                      "from": "oauth-sign@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-                    },
-                    "hawk": {
-                      "version": "1.1.1",
-                      "from": "hawk@1.1.1",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "0.9.1",
-                          "from": "hoek@>=0.9.0 <0.10.0",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                        },
-                        "boom": {
-                          "version": "0.4.2",
-                          "from": "boom@>=0.4.0 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                        },
-                        "cryptiles": {
-                          "version": "0.2.2",
-                          "from": "cryptiles@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                        },
-                        "sntp": {
-                          "version": "0.2.4",
-                          "from": "sntp@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                        }
-                      }
-                    },
-                    "aws-sign2": {
-                      "version": "0.5.0",
-                      "from": "aws-sign2@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                    },
-                    "stringstream": {
-                      "version": "0.0.4",
-                      "from": "stringstream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-                    },
-                    "combined-stream": {
-                      "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.5 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.2.8",
-                  "from": "rimraf@>=2.2.8 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                },
-                "semver": {
-                  "version": "4.3.6",
-                  "from": "semver@>=4.3.6 <4.4.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-                },
-                "tar": {
-                  "version": "1.0.3",
-                  "from": "tar@>=1.0.3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
-                  "dependencies": {
-                    "block-stream": {
-                      "version": "0.0.8",
-                      "from": "block-stream@*",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "which": {
-                  "version": "1.0.9",
-                  "from": "which@>=1.0.8 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
-                }
-              }
-            },
-            "request": {
-              "version": "2.60.0",
-              "from": "request@>=2.55.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
-              "dependencies": {
-                "bl": {
-                  "version": "1.0.0",
-                  "from": "bl@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.2",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.2",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.1",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "caseless": {
-                  "version": "0.11.0",
-                  "from": "caseless@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "from": "extend@>=3.0.0 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "from": "forever-agent@>=0.6.0 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                },
-                "form-data": {
-                  "version": "1.0.0-rc3",
-                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "1.4.0",
-                      "from": "async@>=1.4.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
-                    }
-                  }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                },
-                "mime-types": {
-                  "version": "2.1.4",
-                  "from": "mime-types@>=2.1.2 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.16.0",
-                      "from": "mime-db@>=1.16.0 <1.17.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-                },
-                "qs": {
-                  "version": "4.0.0",
-                  "from": "qs@>=4.0.0 <4.1.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                },
-                "tough-cookie": {
-                  "version": "2.0.0",
-                  "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
-                },
-                "http-signature": {
-                  "version": "0.11.0",
-                  "from": "http-signature@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.0",
-                  "from": "oauth-sign@>=0.8.0 <0.9.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-                },
-                "hawk": {
-                  "version": "3.1.0",
-                  "from": "hawk@>=3.1.0 <3.2.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.14.0",
-                      "from": "hoek@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
-                    },
-                    "boom": {
-                      "version": "2.8.0",
-                      "from": "boom@>=2.8.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.4",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "from": "combined-stream@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                    }
-                  }
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "from": "isstream@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                },
-                "har-validator": {
-                  "version": "1.8.0",
-                  "from": "har-validator@>=1.6.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-                  "dependencies": {
-                    "bluebird": {
-                      "version": "2.9.34",
-                      "from": "bluebird@>=2.9.30 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
-                    },
-                    "commander": {
-                      "version": "2.8.1",
-                      "from": "commander@>=2.8.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.12.1",
-                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
-                      "dependencies": {
-                        "generate-function": {
-                          "version": "2.0.0",
-                          "from": "generate-function@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "from": "generate-object-property@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                          "dependencies": {
-                            "is-property": {
-                              "version": "1.0.2",
-                              "from": "is-property@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "jsonpointer": {
-                          "version": "1.1.0",
-                          "from": "jsonpointer@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
-                        },
-                        "xtend": {
-                          "version": "4.0.0",
-                          "from": "xtend@>=4.0.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "sass-graph": {
-              "version": "2.0.0",
-              "from": "sass-graph@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "3.10.1",
-                  "from": "lodash@>=3.8.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                },
-                "yargs": {
-                  "version": "3.17.1",
-                  "from": "yargs@>=3.8.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.17.1.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.1",
-                          "from": "center-align@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.3",
-                              "from": "align-text@>=0.1.0 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "2.0.0",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.3",
-                              "from": "align-text@>=0.1.0 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "2.0.0",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.0.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
-                    },
-                    "window-size": {
-                      "version": "0.1.2",
-                      "from": "window-size@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
-                    },
-                    "y18n": {
-                      "version": "3.0.0",
-                      "from": "y18n@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.43",
-              "from": "source-map@>=0.1.39 <0.2.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-shell": {
-      "version": "0.4.2",
-      "from": "gulp-shell@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.4.2.tgz",
-      "dependencies": {
-        "async": {
-          "version": "1.2.1",
-          "from": "async@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
-        },
-        "lodash": {
-          "version": "3.9.3",
-          "from": "lodash@>=3.9.3 <3.10.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-sourcemaps": {
-      "version": "1.5.2",
-      "from": "gulp-sourcemaps@>=1.5.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.5.2.tgz",
-      "dependencies": {
-        "convert-source-map": {
-          "version": "1.1.1",
-          "from": "convert-source-map@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
-        },
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        },
-        "strip-bom": {
-          "version": "1.0.0",
-          "from": "strip-bom@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-          "dependencies": {
-            "first-chunk-stream": {
-              "version": "1.0.0",
-              "from": "first-chunk-stream@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-            },
-            "is-utf8": {
-              "version": "0.2.0",
-              "from": "is-utf8@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "from": "vinyl@>=0.4.6 <0.5.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "from": "clone@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-util": {
-      "version": "3.0.6",
-      "from": "gulp-util@>=3.0.6 <4.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.6.tgz",
-      "dependencies": {
-        "array-differ": {
-          "version": "1.0.0",
-          "from": "array-differ@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-        },
-        "array-uniq": {
-          "version": "1.0.2",
-          "from": "array-uniq@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-        },
-        "beeper": {
-          "version": "1.1.0",
-          "from": "beeper@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "dateformat": {
-          "version": "1.0.11",
-          "from": "dateformat@>=1.0.11 <2.0.0",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-          "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@*",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            },
-            "meow": {
-              "version": "3.3.0",
-              "from": "meow@*",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                    },
-                    "map-obj": {
-                      "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                    }
-                  }
-                },
-                "indent-string": {
-                  "version": "1.2.2",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                  "dependencies": {
-                    "repeating": {
-                      "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "lodash._reescape": {
-          "version": "3.0.0",
-          "from": "lodash._reescape@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-        },
-        "lodash._reevaluate": {
-          "version": "3.0.0",
-          "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-        },
-        "lodash._reinterpolate": {
-          "version": "3.0.0",
-          "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-        },
-        "lodash.template": {
-          "version": "3.6.2",
-          "from": "lodash.template@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-          "dependencies": {
-            "lodash._basecopy": {
-              "version": "3.0.1",
-              "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-            },
-            "lodash._basetostring": {
-              "version": "3.0.1",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-            },
-            "lodash._basevalues": {
-              "version": "3.0.0",
-              "from": "lodash._basevalues@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-            },
-            "lodash._isiterateecall": {
-              "version": "3.0.9",
-              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-            },
-            "lodash.escape": {
-              "version": "3.0.0",
-              "from": "lodash.escape@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
-            },
-            "lodash.keys": {
-              "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-            },
-            "lodash.templatesettings": {
-              "version": "3.1.0",
-              "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.1.2",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
-        },
-        "multipipe": {
-          "version": "0.1.2",
-          "from": "multipipe@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-          "dependencies": {
-            "duplexer2": {
-              "version": "0.0.2",
-              "from": "duplexer2@0.0.2",
-              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "from": "replace-ext@0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.2",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.2",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.1",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        },
-        "vinyl": {
-          "version": "0.5.1",
-          "from": "vinyl@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
-          "dependencies": {
-            "clone": {
-              "version": "1.0.2",
-              "from": "clone@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-watch": {
-      "version": "4.3.4",
-      "from": "gulp-watch@>=4.3.4 <5.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-watch/-/gulp-watch-4.3.4.tgz",
-      "dependencies": {
-        "anymatch": {
-          "version": "1.3.0",
-          "from": "anymatch@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-          "dependencies": {
-            "arrify": {
-              "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
-            },
-            "micromatch": {
-              "version": "2.2.0",
-              "from": "micromatch@>=2.1.5 <3.0.0",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
-              "dependencies": {
-                "arr-diff": {
-                  "version": "1.0.1",
-                  "from": "arr-diff@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
-                  "dependencies": {
-                    "array-slice": {
-                      "version": "0.2.3",
-                      "from": "array-slice@>=0.2.2 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
-                    }
-                  }
-                },
-                "array-unique": {
-                  "version": "0.2.1",
-                  "from": "array-unique@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-                },
-                "braces": {
-                  "version": "1.8.0",
-                  "from": "braces@>=1.8.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
-                  "dependencies": {
-                    "expand-range": {
-                      "version": "1.8.1",
-                      "from": "expand-range@>=1.8.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
-                      "dependencies": {
-                        "fill-range": {
-                          "version": "2.2.2",
-                          "from": "fill-range@>=2.1.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
-                          "dependencies": {
-                            "is-number": {
-                              "version": "1.1.2",
-                              "from": "is-number@>=1.1.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
-                            },
-                            "isobject": {
-                              "version": "1.0.2",
-                              "from": "isobject@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
-                            },
-                            "randomatic": {
-                              "version": "1.1.0",
-                              "from": "randomatic@>=1.1.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "preserve": {
-                      "version": "0.2.0",
-                      "from": "preserve@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-                    },
-                    "repeat-element": {
-                      "version": "1.1.2",
-                      "from": "repeat-element@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-                    }
-                  }
-                },
-                "expand-brackets": {
-                  "version": "0.1.3",
-                  "from": "expand-brackets@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
-                  "dependencies": {
-                    "is-posix-bracket": {
-                      "version": "0.1.0",
-                      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz"
-                    }
-                  }
-                },
-                "extglob": {
-                  "version": "0.3.1",
-                  "from": "extglob@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-                  "dependencies": {
-                    "ansi-green": {
-                      "version": "0.1.1",
-                      "from": "ansi-green@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-                      "dependencies": {
-                        "ansi-wrap": {
-                          "version": "0.1.0",
-                          "from": "ansi-wrap@0.1.0",
-                          "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
-                        }
-                      }
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    },
-                    "success-symbol": {
-                      "version": "0.1.0",
-                      "from": "success-symbol@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
-                    }
-                  }
-                },
-                "filename-regex": {
-                  "version": "2.0.0",
-                  "from": "filename-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
-                },
-                "is-glob": {
-                  "version": "1.1.3",
-                  "from": "is-glob@>=1.1.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
-                },
-                "kind-of": {
-                  "version": "1.1.0",
-                  "from": "kind-of@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
-                },
-                "object.omit": {
-                  "version": "1.1.0",
-                  "from": "object.omit@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
-                  "dependencies": {
-                    "for-own": {
-                      "version": "0.1.3",
-                      "from": "for-own@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-                      "dependencies": {
-                        "for-in": {
-                          "version": "0.1.4",
-                          "from": "for-in@>=0.1.4 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
-                        }
-                      }
-                    },
-                    "isobject": {
-                      "version": "1.0.2",
-                      "from": "isobject@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
-                    }
-                  }
-                },
-                "parse-glob": {
-                  "version": "3.0.2",
-                  "from": "parse-glob@>=3.0.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
-                  "dependencies": {
-                    "glob-base": {
-                      "version": "0.2.0",
-                      "from": "glob-base@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
-                      "dependencies": {
-                        "glob-parent": {
-                          "version": "1.2.0",
-                          "from": "glob-parent@>=1.2.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
-                        }
-                      }
-                    },
-                    "is-dotfile": {
-                      "version": "1.0.1",
-                      "from": "is-dotfile@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    }
-                  }
-                },
-                "regex-cache": {
-                  "version": "0.4.2",
-                  "from": "regex-cache@>=0.4.2 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
-                  "dependencies": {
-                    "is-equal-shallow": {
-                      "version": "0.1.3",
-                      "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-                    },
-                    "is-primitive": {
-                      "version": "2.0.0",
-                      "from": "is-primitive@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "chokidar": {
-          "version": "1.0.5",
-          "from": "chokidar@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
-          "dependencies": {
-            "arrify": {
-              "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
-            },
-            "async-each": {
-              "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
-            },
-            "glob-parent": {
-              "version": "1.2.0",
-              "from": "glob-parent@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
-            },
-            "is-binary-path": {
-              "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-              "dependencies": {
-                "binary-extensions": {
-                  "version": "1.3.1",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
-                }
-              }
-            },
-            "is-glob": {
-              "version": "1.1.3",
-              "from": "is-glob@>=1.1.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
-            },
-            "readdirp": {
-              "version": "1.4.0",
-              "from": "readdirp@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <4.2.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "from": "minimatch@>=0.2.12 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "fsevents": {
-              "version": "0.3.7",
-              "from": "fsevents@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.7.tgz",
-              "dependencies": {
-                "nan": {
-                  "version": "1.9.0",
-                  "from": "nan@>=1.8.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "5.0.14",
-          "from": "glob@>=5.0.13 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "glob2base": {
-          "version": "0.0.12",
-          "from": "glob2base@0.0.12",
-          "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-          "dependencies": {
-            "find-index": {
-              "version": "0.1.1",
-              "from": "find-index@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.2",
-          "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.1",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-            },
-            "process-nextick-args": {
-              "version": "1.0.2",
-              "from": "process-nextick-args@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "util-deprecate": {
-              "version": "1.0.1",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
-            }
-          }
-        },
-        "vinyl": {
-          "version": "0.5.1",
-          "from": "vinyl@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.1.tgz",
-          "dependencies": {
-            "clone": {
-              "version": "1.0.2",
-              "from": "clone@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            }
-          }
-        },
-        "vinyl-file": {
-          "version": "1.2.1",
-          "from": "vinyl-file@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.2.1.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "from": "strip-bom@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "dependencies": {
-                "is-utf8": {
-                  "version": "0.2.0",
-                  "from": "is-utf8@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
-                }
-              }
-            },
-            "strip-bom-stream": {
-              "version": "1.0.0",
-              "from": "strip-bom-stream@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-              "dependencies": {
-                "first-chunk-stream": {
-                  "version": "1.0.0",
-                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
                 }
               }
             }
@@ -12133,29 +7269,29 @@
       "dependencies": {
         "optimist": {
           "version": "0.3.7",
-          "from": "optimist@>=0.3.0 <0.4.0",
+          "from": "optimist@~0.3",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.3.6",
-          "from": "uglify-js@>=2.3.0 <2.4.0",
+          "from": "uglify-js@~2.3",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
+              "from": "async@~0.2.6",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@>=0.1.7 <0.2.0",
+              "from": "source-map@~0.1.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
@@ -12171,7 +7307,7 @@
     },
     "jasmine-core": {
       "version": "2.3.4",
-      "from": "jasmine-core@>=2.3.2 <3.0.0",
+      "from": "jasmine-core@^2.3.2",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
     },
     "jit-grunt": {
@@ -12191,165 +7327,165 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@^1.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "ansi-styles@^2.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "has-ansi@^2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "strip-ansi@^3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "supports-color@^2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "core-js": {
           "version": "0.9.18",
-          "from": "core-js@>=0.9.17 <0.10.0",
+          "from": "core-js@^0.9.17",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.9.18.tgz"
         },
         "glob": {
           "version": "5.0.14",
-          "from": "glob@>=5.0.10 <6.0.0",
+          "from": "glob@^5.0.10",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "inflight@^1.0.4",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "inherits@2",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "once@^1.3.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "path-is-absolute@^1.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.8 <4.0.0",
+          "from": "graceful-fs@^3.0.8",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "jspm-github": {
           "version": "0.12.2",
-          "from": "jspm-github@>=0.12.2 <0.13.0",
+          "from": "jspm-github@^0.12.2",
           "resolved": "https://registry.npmjs.org/jspm-github/-/jspm-github-0.12.2.tgz",
           "dependencies": {
             "decompress-zip": {
               "version": "0.1.0",
-              "from": "decompress-zip@>=0.1.0 <0.2.0",
+              "from": "decompress-zip@^0.1.0",
               "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
               "dependencies": {
                 "binary": {
                   "version": "0.3.0",
-                  "from": "binary@>=0.3.0 <0.4.0",
+                  "from": "binary@^0.3.0",
                   "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                   "dependencies": {
                     "chainsaw": {
                       "version": "0.1.0",
-                      "from": "chainsaw@>=0.1.0 <0.2.0",
+                      "from": "chainsaw@~0.1.0",
                       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.3.9",
-                          "from": "traverse@>=0.3.0 <0.4.0",
+                          "from": "traverse@>=0.3.0 <0.4",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                         }
                       }
                     },
                     "buffers": {
                       "version": "0.1.1",
-                      "from": "buffers@>=0.1.1 <0.2.0",
+                      "from": "buffers@~0.1.1",
                       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                     }
                   }
                 },
                 "mkpath": {
                   "version": "0.1.0",
-                  "from": "mkpath@>=0.1.0 <0.2.0",
+                  "from": "mkpath@^0.1.0",
                   "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
                 },
                 "nopt": {
                   "version": "3.0.3",
-                  "from": "nopt@>=3.0.1 <4.0.0",
+                  "from": "nopt@^3.0.1",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "abbrev@1",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "q": {
                   "version": "1.4.1",
-                  "from": "q@>=1.1.2 <2.0.0",
+                  "from": "q@^1.1.2",
                   "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.8 <2.0.0",
+                  "from": "readable-stream@^1.1.8",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -12359,12 +7495,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -12376,12 +7512,12 @@
                   "dependencies": {
                     "nopt": {
                       "version": "1.0.10",
-                      "from": "nopt@>=1.0.10 <1.1.0",
+                      "from": "nopt@~1.0.10",
                       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                       "dependencies": {
                         "abbrev": {
                           "version": "1.0.7",
-                          "from": "abbrev@>=1.0.0 <2.0.0",
+                          "from": "abbrev@1",
                           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                         }
                       }
@@ -12392,27 +7528,27 @@
             },
             "netrc": {
               "version": "0.1.3",
-              "from": "netrc@>=0.1.3 <0.2.0",
+              "from": "netrc@^0.1.3",
               "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.3.tgz"
             },
             "request": {
               "version": "2.53.0",
-              "from": "request@>=2.53.0 <2.54.0",
+              "from": "request@~2.53.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "bl@~0.9.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "readable-stream@~1.0.26",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -12422,12 +7558,12 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@~2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -12436,56 +7572,56 @@
                 },
                 "caseless": {
                   "version": "0.9.0",
-                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "from": "caseless@~0.9.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "from": "forever-agent@~0.5.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "from": "form-data@~0.2.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "async@~0.9.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "json-stringify-safe@~5.0.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "from": "mime-types@~2.0.1",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "mime-db@>=1.12.0 <1.13.0",
+                      "from": "mime-db@~1.12.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "node-uuid@~1.4.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@>=2.3.1 <2.4.0",
+                  "from": "qs@~2.3.1",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "tunnel-agent@~0.4.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
@@ -12495,12 +7631,12 @@
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "http-signature@~0.10.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "assert-plus@^0.1.5",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
@@ -12517,49 +7653,49 @@
                 },
                 "oauth-sign": {
                   "version": "0.6.0",
-                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "from": "oauth-sign@~0.6.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "from": "hawk@~2.3.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.14.0",
-                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "from": "hoek@2.x.x",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
                       "version": "2.8.0",
-                      "from": "boom@>=2.0.0 <3.0.0",
+                      "from": "boom@2.x.x",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "from": "sntp@1.x.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "aws-sign2@~0.5.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "from": "combined-stream@~0.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -12571,46 +7707,46 @@
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "from": "isstream@~0.1.1",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 }
               }
             },
             "rimraf": {
               "version": "2.3.4",
-              "from": "rimraf@>=2.3.2 <2.4.0",
+              "from": "rimraf@~2.3.2",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@>=4.4.2 <5.0.0",
+                  "from": "glob@^4.4.2",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "inflight@^1.0.4",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@^1.3.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -12621,7 +7757,7 @@
             },
             "tar": {
               "version": "1.0.3",
-              "from": "tar@>=1.0.3 <1.1.0",
+              "from": "tar@~1.0.3",
               "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
@@ -12631,29 +7767,29 @@
                 },
                 "fstream": {
                   "version": "1.0.7",
-                  "from": "fstream@>=1.0.2 <2.0.0",
+                  "from": "fstream@^1.0.2",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "which": {
               "version": "1.1.1",
-              "from": "which@>=1.0.9 <2.0.0",
+              "from": "which@^1.0.9",
               "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "is-absolute@>=0.1.7 <0.2.0",
+                  "from": "is-absolute@^0.1.7",
                   "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
-                      "from": "is-relative@>=0.1.0 <0.2.0",
+                      "from": "is-relative@^0.1.0",
                       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
@@ -12664,27 +7800,27 @@
         },
         "jspm-npm": {
           "version": "0.23.4",
-          "from": "jspm-npm@>=0.23.2 <0.24.0",
+          "from": "jspm-npm@^0.23.2",
           "resolved": "https://registry.npmjs.org/jspm-npm/-/jspm-npm-0.23.4.tgz",
           "dependencies": {
             "request": {
               "version": "2.58.0",
-              "from": "request@>=2.58.0 <2.59.0",
+              "from": "request@~2.58.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "bl@~0.9.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "readable-stream@~1.0.26",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -12694,12 +7830,12 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@~2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -12708,37 +7844,37 @@
                 },
                 "caseless": {
                   "version": "0.10.0",
-                  "from": "caseless@>=0.10.0 <0.11.0",
+                  "from": "caseless@~0.10.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
                 },
                 "extend": {
                   "version": "2.0.1",
-                  "from": "extend@>=2.0.1 <2.1.0",
+                  "from": "extend@~2.0.1",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "forever-agent@>=0.6.0 <0.7.0",
+                  "from": "forever-agent@~0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "1.0.0-rc3",
-                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
+                  "from": "form-data@~1.0.0-rc1",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "1.4.0",
-                      "from": "async@>=1.4.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
+                      "version": "1.4.2",
+                      "from": "async@^1.4.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.4",
-                      "from": "mime-types@>=2.1.3 <3.0.0",
+                      "from": "mime-types@^2.1.3",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.16.0",
-                          "from": "mime-db@>=1.16.0 <1.17.0",
+                          "from": "mime-db@~1.16.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
                         }
                       }
@@ -12747,34 +7883,34 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "json-stringify-safe@~5.0.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "from": "mime-types@~2.0.1",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "mime-db@>=1.12.0 <1.13.0",
+                      "from": "mime-db@~1.12.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "node-uuid@~1.4.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "3.1.0",
-                  "from": "qs@>=3.1.0 <3.2.0",
+                  "from": "qs@~3.1.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "tunnel-agent@~0.4.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
@@ -12784,12 +7920,12 @@
                 },
                 "http-signature": {
                   "version": "0.11.0",
-                  "from": "http-signature@>=0.11.0 <0.12.0",
+                  "from": "http-signature@~0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "assert-plus@^0.1.5",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
@@ -12806,115 +7942,115 @@
                 },
                 "oauth-sign": {
                   "version": "0.8.0",
-                  "from": "oauth-sign@>=0.8.0 <0.9.0",
+                  "from": "oauth-sign@~0.8.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "from": "hawk@~2.3.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.14.0",
-                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "from": "hoek@2.x.x",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
                       "version": "2.8.0",
-                      "from": "boom@>=2.0.0 <3.0.0",
+                      "from": "boom@2.x.x",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "from": "sntp@1.x.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "aws-sign2@~0.5.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "combined-stream@>=1.0.1 <1.1.0",
+                  "from": "combined-stream@~1.0.1",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <1.1.0",
+                      "from": "delayed-stream@~1.0.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "from": "isstream@~0.1.1",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "1.8.0",
-                  "from": "har-validator@>=1.6.1 <2.0.0",
+                  "from": "har-validator@^1.6.1",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "dependencies": {
                     "bluebird": {
                       "version": "2.9.34",
-                      "from": "bluebird@>=2.9.30 <3.0.0",
+                      "from": "bluebird@^2.9.30",
                       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
                     },
                     "commander": {
                       "version": "2.8.1",
-                      "from": "commander@>=2.8.1 <3.0.0",
+                      "from": "commander@^2.8.1",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0",
+                          "from": "graceful-readlink@>= 1.0.0",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.12.1",
-                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                      "from": "is-my-json-valid@^2.12.0",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "from": "generate-function@^2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "from": "generate-object-property@^1.1.0",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "from": "is-property@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "1.1.0",
-                          "from": "jsonpointer@>=1.1.0 <2.0.0",
+                          "from": "jsonpointer@^1.1.0",
                           "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.0",
-                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "from": "xtend@^4.0.0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                         }
                       }
@@ -12925,12 +8061,12 @@
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@>=1.1.6 <2.0.0",
+              "from": "resolve@^1.1.6",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "rmdir": {
               "version": "1.1.0",
-              "from": "rmdir@>=1.1.0 <1.2.0",
+              "from": "rmdir@~1.1.0",
               "resolved": "https://registry.npmjs.org/rmdir/-/rmdir-1.1.0.tgz",
               "dependencies": {
                 "node.flow": {
@@ -12945,12 +8081,12 @@
                       "dependencies": {
                         "is": {
                           "version": "0.2.7",
-                          "from": "is@>=0.2.6 <0.3.0",
+                          "from": "is@~0.2.6",
                           "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz"
                         },
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "object-keys@>=0.4.0 <0.5.0",
+                          "from": "object-keys@~0.4.0",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -12961,7 +8097,7 @@
             },
             "tar": {
               "version": "1.0.3",
-              "from": "tar@>=1.0.3 <1.1.0",
+              "from": "tar@~1.0.3",
               "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
@@ -12971,29 +8107,29 @@
                 },
                 "fstream": {
                   "version": "1.0.7",
-                  "from": "fstream@>=1.0.2 <2.0.0",
+                  "from": "fstream@^1.0.2",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "which": {
               "version": "1.1.1",
-              "from": "which@>=1.1.1 <2.0.0",
+              "from": "which@^1.1.1",
               "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "is-absolute@>=0.1.7 <0.2.0",
+                  "from": "is-absolute@^0.1.7",
                   "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
-                      "from": "is-relative@>=0.1.0 <0.2.0",
+                      "from": "is-relative@^0.1.0",
                       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
@@ -13004,54 +8140,54 @@
         },
         "jspm-registry": {
           "version": "0.4.0",
-          "from": "jspm-registry@>=0.4.0 <0.5.0",
+          "from": "jspm-registry@^0.4.0",
           "resolved": "https://registry.npmjs.org/jspm-registry/-/jspm-registry-0.4.0.tgz"
         },
         "liftoff": {
           "version": "2.1.0",
-          "from": "liftoff@>=2.1.0 <3.0.0",
+          "from": "liftoff@^2.1.0",
           "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.1.0.tgz",
           "dependencies": {
             "extend": {
               "version": "2.0.1",
-              "from": "extend@>=2.0.1 <3.0.0",
+              "from": "extend@^2.0.1",
               "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
             },
             "findup-sync": {
               "version": "0.2.1",
-              "from": "findup-sync@>=0.2.1 <0.3.0",
+              "from": "findup-sync@^0.2.1",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@>=4.3.0 <4.4.0",
+                  "from": "glob@~4.3.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "inflight@^1.0.4",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@^1.3.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -13062,34 +8198,34 @@
             },
             "flagged-respawn": {
               "version": "0.3.1",
-              "from": "flagged-respawn@>=0.3.1 <0.4.0",
+              "from": "flagged-respawn@^0.3.1",
               "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
             },
             "rechoir": {
               "version": "0.6.2",
-              "from": "rechoir@>=0.6.0 <0.7.0",
+              "from": "rechoir@^0.6.0",
               "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@>=1.1.6 <2.0.0",
+              "from": "resolve@^1.1.6",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             }
           }
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.8 <3.0.0",
+          "from": "minimatch@^2.0.8",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "brace-expansion@^1.0.0",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "from": "balanced-match@^0.2.0",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
@@ -13103,7 +8239,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "from": "mkdirp@~0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
@@ -13115,32 +8251,32 @@
         },
         "ncp": {
           "version": "2.0.0",
-          "from": "ncp@>=2.0.0 <3.0.0",
+          "from": "ncp@^2.0.0",
           "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
         },
         "request": {
           "version": "2.60.0",
-          "from": "request@>=2.58.0 <3.0.0",
+          "from": "request@^2.58.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
           "dependencies": {
             "bl": {
               "version": "1.0.0",
-              "from": "bl@>=1.0.0 <1.1.0",
+              "from": "bl@~1.0.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.2",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "from": "readable-stream@~2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
@@ -13150,17 +8286,17 @@
                     },
                     "process-nextick-args": {
                       "version": "1.0.2",
-                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "from": "process-nextick-args@~1.0.0",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.1",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "util-deprecate@~1.0.1",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
@@ -13169,61 +8305,61 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
+              "from": "caseless@~0.11.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
+              "from": "extend@~3.0.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.0 <0.7.0",
+              "from": "forever-agent@~0.6.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "from": "form-data@>=1.0.0-rc1 <1.1.0",
+              "from": "form-data@~1.0.0-rc1",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
-                  "version": "1.4.0",
-                  "from": "async@>=1.4.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
+                  "version": "1.4.2",
+                  "from": "async@^1.4.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "json-stringify-safe@~5.0.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.4",
-              "from": "mime-types@>=2.1.2 <2.2.0",
+              "from": "mime-types@~2.1.2",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.16.0",
-                  "from": "mime-db@>=1.16.0 <1.17.0",
+                  "from": "mime-db@~1.16.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "node-uuid@~1.4.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
               "version": "4.0.0",
-              "from": "qs@>=4.0.0 <4.1.0",
+              "from": "qs@~4.0.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.1",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "tunnel-agent@~0.4.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "tough-cookie": {
@@ -13233,12 +8369,12 @@
             },
             "http-signature": {
               "version": "0.11.0",
-              "from": "http-signature@>=0.11.0 <0.12.0",
+              "from": "http-signature@~0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "assert-plus@^0.1.5",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -13255,115 +8391,115 @@
             },
             "oauth-sign": {
               "version": "0.8.0",
-              "from": "oauth-sign@>=0.8.0 <0.9.0",
+              "from": "oauth-sign@~0.8.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "hawk": {
               "version": "3.1.0",
-              "from": "hawk@>=3.1.0 <3.2.0",
+              "from": "hawk@~3.1.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.14.0",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "hoek@2.x.x",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                 },
                 "boom": {
                   "version": "2.8.0",
-                  "from": "boom@>=2.8.0 <3.0.0",
+                  "from": "boom@^2.8.x",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "cryptiles@2.x.x",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "sntp@1.x.x",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "aws-sign2@~0.5.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "stringstream@~0.0.4",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.1 <1.1.0",
+              "from": "combined-stream@~1.0.1",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "from": "delayed-stream@~1.0.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.1 <0.2.0",
+              "from": "isstream@~0.1.1",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "1.8.0",
-              "from": "har-validator@>=1.6.1 <2.0.0",
+              "from": "har-validator@^1.6.1",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "dependencies": {
                 "bluebird": {
                   "version": "2.9.34",
-                  "from": "bluebird@>=2.9.30 <3.0.0",
+                  "from": "bluebird@^2.9.30",
                   "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
                 },
                 "commander": {
                   "version": "2.8.1",
-                  "from": "commander@>=2.8.1 <3.0.0",
+                  "from": "commander@^2.8.1",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "graceful-readlink@>= 1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.1",
-                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                  "from": "is-my-json-valid@^2.12.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "from": "generate-function@^2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "generate-object-property@^1.1.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "from": "is-property@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "1.1.0",
-                      "from": "jsonpointer@>=1.1.0 <2.0.0",
+                      "from": "jsonpointer@^1.1.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "from": "xtend@^4.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -13374,44 +8510,44 @@
         },
         "rimraf": {
           "version": "2.4.2",
-          "from": "rimraf@>=2.4.0 <3.0.0",
+          "from": "rimraf@^2.4.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz"
         },
         "rsvp": {
-          "version": "3.0.20",
-          "from": "rsvp@>=3.0.18 <4.0.0",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.20.tgz"
+          "version": "3.0.21",
+          "from": "rsvp@^3.0.18",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.21.tgz"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.3.6 <5.0.0",
+          "from": "semver@^4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         },
         "systemjs": {
-          "version": "0.18.6",
-          "from": "systemjs@>=0.18.2 <0.19.0",
-          "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.18.6.tgz",
+          "version": "0.18.9",
+          "from": "systemjs@^0.18.2",
+          "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.18.9.tgz",
           "dependencies": {
             "es6-module-loader": {
-              "version": "0.17.4",
-              "from": "es6-module-loader@>=0.17.4 <0.18.0",
-              "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.4.tgz"
+              "version": "0.17.5",
+              "from": "es6-module-loader@^0.17.4",
+              "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.5.tgz"
             },
             "when": {
               "version": "3.7.3",
-              "from": "when@>=3.7.2 <4.0.0",
+              "from": "when@^3.7.2",
               "resolved": "https://registry.npmjs.org/when/-/when-3.7.3.tgz"
             }
           }
         },
         "systemjs-builder": {
           "version": "0.12.2",
-          "from": "systemjs-builder@>=0.12.1 <0.13.0",
+          "from": "systemjs-builder@^0.12.1",
           "resolved": "https://registry.npmjs.org/systemjs-builder/-/systemjs-builder-0.12.2.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.2 <0.5.0",
+              "from": "source-map@^0.4.2",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
@@ -13430,39 +8566,39 @@
           "dependencies": {
             "commander": {
               "version": "2.6.0",
-              "from": "commander@>=2.6.0 <2.7.0",
+              "from": "commander@2.6",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "glob": {
               "version": "4.3.5",
-              "from": "glob@>=4.3.0 <4.4.0",
+              "from": "glob@4.3",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "inflight@^1.0.4",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -13471,12 +8607,12 @@
             },
             "semver": {
               "version": "2.3.2",
-              "from": "semver@>=2.0.0 <3.0.0",
+              "from": "semver@2.x",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "source-map-support@>=0.2.8 <0.3.0",
+              "from": "source-map-support@~0.2.8",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
@@ -13497,12 +8633,12 @@
         },
         "uglify-js": {
           "version": "2.4.24",
-          "from": "uglify-js@>=2.4.23 <2.5.0",
+          "from": "uglify-js@~2.4.23",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
+              "from": "async@~0.2.6",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
@@ -13519,22 +8655,22 @@
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "from": "uglify-to-browserify@~1.0.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.5.4",
-              "from": "yargs@>=3.5.4 <3.6.0",
+              "from": "yargs@~3.5.4",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "from": "camelcase@^1.0.2",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "decamelize@^1.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "window-size": {
@@ -13555,7 +8691,7 @@
     },
     "jspm-bower-endpoint": {
       "version": "0.3.2",
-      "from": "jspm-bower-endpoint@>=0.3.2 <0.4.0",
+      "from": "jspm-bower-endpoint@^0.3.2",
       "resolved": "https://registry.npmjs.org/jspm-bower-endpoint/-/jspm-bower-endpoint-0.3.2.tgz",
       "dependencies": {
         "bower": {
@@ -13565,7 +8701,7 @@
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "abbrev@>=1.0.5 <2.0.0",
+              "from": "abbrev@^1.0.5",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             },
             "archy": {
@@ -13575,32 +8711,32 @@
             },
             "bower-config": {
               "version": "0.6.1",
-              "from": "bower-config@>=0.6.0 <0.7.0",
+              "from": "bower-config@^0.6.0",
               "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "from": "graceful-fs@~2.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "mout": {
                   "version": "0.9.1",
-                  "from": "mout@>=0.9.0 <0.10.0",
+                  "from": "mout@~0.9.0",
                   "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
                 },
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "optimist@>=0.6.0 <0.7.0",
+                  "from": "optimist@~0.6.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.3",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "from": "wordwrap@~0.0.2",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     },
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "from": "minimist@~0.0.1",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
@@ -13614,59 +8750,59 @@
             },
             "bower-json": {
               "version": "0.4.0",
-              "from": "bower-json@>=0.4.0 <0.5.0",
+              "from": "bower-json@^0.4.0",
               "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
               "dependencies": {
                 "deep-extend": {
                   "version": "0.2.11",
-                  "from": "deep-extend@>=0.2.5 <0.3.0",
+                  "from": "deep-extend@~0.2.5",
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "from": "graceful-fs@~2.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "intersect": {
                   "version": "0.0.3",
-                  "from": "intersect@>=0.0.3 <0.1.0",
+                  "from": "intersect@~0.0.3",
                   "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
                 }
               }
             },
             "bower-registry-client": {
               "version": "0.2.4",
-              "from": "bower-registry-client@>=0.2.1 <0.3.0",
+              "from": "bower-registry-client@^0.2.1",
               "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.4.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.8 <0.3.0",
+                  "from": "async@~0.2.8",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "bower-config": {
                   "version": "0.5.2",
-                  "from": "bower-config@>=0.5.0 <0.6.0",
+                  "from": "bower-config@~0.5.0",
                   "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
                   "dependencies": {
                     "mout": {
                       "version": "0.9.1",
-                      "from": "mout@>=0.9.0 <0.10.0",
+                      "from": "mout@~0.9.0",
                       "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
                     },
                     "optimist": {
                       "version": "0.6.1",
-                      "from": "optimist@>=0.6.0 <0.7.0",
+                      "from": "optimist@~0.6.0",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.3",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
+                          "from": "wordwrap@~0.0.2",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         },
                         "minimist": {
                           "version": "0.0.10",
-                          "from": "minimist@>=0.0.1 <0.1.0",
+                          "from": "minimist@~0.0.1",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                         }
                       }
@@ -13680,32 +8816,32 @@
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "from": "graceful-fs@~2.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "lru-cache": {
                   "version": "2.3.1",
-                  "from": "lru-cache@>=2.3.0 <2.4.0",
+                  "from": "lru-cache@~2.3.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
                 },
                 "request": {
                   "version": "2.51.0",
-                  "from": "request@>=2.51.0 <2.52.0",
+                  "from": "request@~2.51.0",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "0.9.4",
-                      "from": "bl@>=0.9.0 <0.10.0",
+                      "from": "bl@~0.9.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.26 <1.1.0",
+                          "from": "readable-stream@~1.0.26",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "core-util-is@~1.0.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
@@ -13715,12 +8851,12 @@
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "string_decoder@~0.10.x",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "inherits@~2.0.1",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -13729,32 +8865,32 @@
                     },
                     "caseless": {
                       "version": "0.8.0",
-                      "from": "caseless@>=0.8.0 <0.9.0",
+                      "from": "caseless@~0.8.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                     },
                     "forever-agent": {
                       "version": "0.5.2",
-                      "from": "forever-agent@>=0.5.0 <0.6.0",
+                      "from": "forever-agent@~0.5.0",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                     },
                     "form-data": {
                       "version": "0.2.0",
-                      "from": "form-data@>=0.2.0 <0.3.0",
+                      "from": "form-data@~0.2.0",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.9.2",
-                          "from": "async@>=0.9.0 <0.10.0",
+                          "from": "async@~0.9.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                         },
                         "mime-types": {
                           "version": "2.0.14",
-                          "from": "mime-types@>=2.0.3 <2.1.0",
+                          "from": "mime-types@~2.0.3",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                           "dependencies": {
                             "mime-db": {
                               "version": "1.12.0",
-                              "from": "mime-db@>=1.12.0 <1.13.0",
+                              "from": "mime-db@~1.12.0",
                               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                             }
                           }
@@ -13763,27 +8899,27 @@
                     },
                     "json-stringify-safe": {
                       "version": "5.0.1",
-                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                      "from": "json-stringify-safe@~5.0.0",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "mime-types": {
                       "version": "1.0.2",
-                      "from": "mime-types@>=1.0.1 <1.1.0",
+                      "from": "mime-types@~1.0.1",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                     },
                     "node-uuid": {
                       "version": "1.4.3",
-                      "from": "node-uuid@>=1.4.0 <1.5.0",
+                      "from": "node-uuid@~1.4.0",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                     },
                     "qs": {
                       "version": "2.3.3",
-                      "from": "qs@>=2.3.1 <2.4.0",
+                      "from": "qs@~2.3.1",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.1",
-                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                      "from": "tunnel-agent@~0.4.0",
                       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                     },
                     "tough-cookie": {
@@ -13793,12 +8929,12 @@
                     },
                     "http-signature": {
                       "version": "0.10.1",
-                      "from": "http-signature@>=0.10.0 <0.11.0",
+                      "from": "http-signature@~0.10.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.5",
-                          "from": "assert-plus@>=0.1.5 <0.2.0",
+                          "from": "assert-plus@^0.1.5",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                         },
                         "asn1": {
@@ -13815,7 +8951,7 @@
                     },
                     "oauth-sign": {
                       "version": "0.5.0",
-                      "from": "oauth-sign@>=0.5.0 <0.6.0",
+                      "from": "oauth-sign@~0.5.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                     },
                     "hawk": {
@@ -13825,39 +8961,39 @@
                       "dependencies": {
                         "hoek": {
                           "version": "0.9.1",
-                          "from": "hoek@>=0.9.0 <0.10.0",
+                          "from": "hoek@0.9.x",
                           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                         },
                         "boom": {
                           "version": "0.4.2",
-                          "from": "boom@>=0.4.0 <0.5.0",
+                          "from": "boom@0.4.x",
                           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                         },
                         "cryptiles": {
                           "version": "0.2.2",
-                          "from": "cryptiles@>=0.2.0 <0.3.0",
+                          "from": "cryptiles@0.2.x",
                           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                         },
                         "sntp": {
                           "version": "0.2.4",
-                          "from": "sntp@>=0.2.0 <0.3.0",
+                          "from": "sntp@0.2.x",
                           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                         }
                       }
                     },
                     "aws-sign2": {
                       "version": "0.5.0",
-                      "from": "aws-sign2@>=0.5.0 <0.6.0",
+                      "from": "aws-sign2@~0.5.0",
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                     },
                     "stringstream": {
                       "version": "0.0.4",
-                      "from": "stringstream@>=0.0.4 <0.1.0",
+                      "from": "stringstream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.5 <0.1.0",
+                      "from": "combined-stream@~0.0.5",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
@@ -13871,17 +9007,17 @@
                 },
                 "request-replay": {
                   "version": "0.2.0",
-                  "from": "request-replay@>=0.2.0 <0.3.0",
+                  "from": "request-replay@~0.2.0",
                   "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@>=2.2.0 <2.3.0",
+                  "from": "rimraf@~2.2.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "from": "mkdirp@~0.3.5",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 }
               }
@@ -13893,65 +9029,65 @@
               "dependencies": {
                 "redeyed": {
                   "version": "0.4.4",
-                  "from": "redeyed@>=0.4.0 <0.5.0",
+                  "from": "redeyed@~0.4.0",
                   "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
                   "dependencies": {
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "esprima@>=1.0.4 <1.1.0",
+                      "from": "esprima@~1.0.4",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     }
                   }
                 },
                 "ansicolors": {
                   "version": "0.2.1",
-                  "from": "ansicolors@>=0.2.1 <0.3.0",
+                  "from": "ansicolors@~0.2.1",
                   "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
                 }
               }
             },
             "chalk": {
               "version": "1.1.0",
-              "from": "chalk@>=1.0.0 <2.0.0",
+              "from": "chalk@^1.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "from": "ansi-styles@^2.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "escape-string-regexp@^1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "has-ansi@^2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "strip-ansi@^3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "supports-color@^2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
@@ -13963,114 +9099,114 @@
             },
             "configstore": {
               "version": "0.3.2",
-              "from": "configstore@>=0.3.2 <0.4.0",
+              "from": "configstore@^0.3.2",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
               "dependencies": {
                 "js-yaml": {
                   "version": "3.3.1",
-                  "from": "js-yaml@>=3.1.0 <4.0.0",
+                  "from": "js-yaml@^3.1.0",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "1.0.2",
-                      "from": "argparse@>=1.0.2 <1.1.0",
+                      "from": "argparse@~1.0.2",
                       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                       "dependencies": {
                         "lodash": {
                           "version": "3.10.1",
-                          "from": "lodash@>=3.2.0 <4.0.0",
+                          "from": "lodash@>= 3.2.0 < 4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                         },
                         "sprintf-js": {
                           "version": "1.0.3",
-                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "from": "sprintf-js@~1.0.2",
                           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "2.2.0",
-                      "from": "esprima@>=2.2.0 <2.3.0",
+                      "from": "esprima@~2.2.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "2.1.1",
-                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "from": "object-assign@^2.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "from": "osenv@^0.1.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "from": "os-homedir@^1.0.0",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "from": "os-tmpdir@^1.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "uuid": {
                   "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "from": "uuid@^2.0.1",
                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                 },
                 "xdg-basedir": {
                   "version": "1.0.1",
-                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
+                  "from": "xdg-basedir@^1.0.0",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
                 }
               }
             },
             "decompress-zip": {
               "version": "0.1.0",
-              "from": "decompress-zip@>=0.1.0 <0.2.0",
+              "from": "decompress-zip@^0.1.0",
               "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
               "dependencies": {
                 "binary": {
                   "version": "0.3.0",
-                  "from": "binary@>=0.3.0 <0.4.0",
+                  "from": "binary@^0.3.0",
                   "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                   "dependencies": {
                     "chainsaw": {
                       "version": "0.1.0",
-                      "from": "chainsaw@>=0.1.0 <0.2.0",
+                      "from": "chainsaw@~0.1.0",
                       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.3.9",
-                          "from": "traverse@>=0.3.0 <0.4.0",
+                          "from": "traverse@>=0.3.0 <0.4",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                         }
                       }
                     },
                     "buffers": {
                       "version": "0.1.1",
-                      "from": "buffers@>=0.1.1 <0.2.0",
+                      "from": "buffers@~0.1.1",
                       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                     }
                   }
                 },
                 "mkpath": {
                   "version": "0.1.0",
-                  "from": "mkpath@>=0.1.0 <0.2.0",
+                  "from": "mkpath@^0.1.0",
                   "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.8 <2.0.0",
+                  "from": "readable-stream@^1.1.8",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -14080,12 +9216,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -14097,7 +9233,7 @@
                   "dependencies": {
                     "nopt": {
                       "version": "1.0.10",
-                      "from": "nopt@>=1.0.10 <1.1.0",
+                      "from": "nopt@~1.0.10",
                       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
                     }
                   }
@@ -14106,39 +9242,39 @@
             },
             "fstream": {
               "version": "1.0.7",
-              "from": "fstream@>=1.0.3 <2.0.0",
+              "from": "fstream@^1.0.3",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "from": "inherits@~2.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "fstream-ignore": {
               "version": "1.0.2",
-              "from": "fstream-ignore@>=1.0.2 <2.0.0",
+              "from": "fstream-ignore@^1.0.2",
               "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "minimatch@^2.0.1",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "balanced-match@^0.2.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -14154,51 +9290,51 @@
             },
             "github": {
               "version": "0.2.4",
-              "from": "github@>=0.2.3 <0.3.0",
+              "from": "github@^0.2.3",
               "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
               "dependencies": {
                 "mime": {
                   "version": "1.3.4",
-                  "from": "mime@>=1.2.11 <2.0.0",
+                  "from": "mime@^1.2.11",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 }
               }
             },
             "glob": {
               "version": "4.5.3",
-              "from": "glob@>=4.3.2 <5.0.0",
+              "from": "glob@^4.3.2",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "inflight@^1.0.4",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@2",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "minimatch@^2.0.1",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "balanced-match@^0.2.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -14212,12 +9348,12 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@^1.3.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -14226,7 +9362,7 @@
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.5 <4.0.0",
+              "from": "graceful-fs@^3.0.5",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "inquirer": {
@@ -14236,129 +9372,129 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "from": "ansi-regex@^1.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "chalk": {
                   "version": "0.5.1",
-                  "from": "chalk@>=0.5.0 <0.6.0",
+                  "from": "chalk@^0.5.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "1.1.0",
-                      "from": "ansi-styles@>=1.1.0 <2.0.0",
+                      "from": "ansi-styles@^1.1.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                      "from": "escape-string-regexp@^1.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "0.1.0",
-                      "from": "has-ansi@>=0.1.0 <0.2.0",
+                      "from": "has-ansi@^0.1.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "from": "ansi-regex@^0.2.1",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "0.3.0",
-                      "from": "strip-ansi@>=0.3.0 <0.4.0",
+                      "from": "strip-ansi@^0.3.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "from": "ansi-regex@^0.2.1",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "0.2.0",
-                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "from": "supports-color@^0.2.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                     }
                   }
                 },
                 "cli-color": {
                   "version": "0.3.3",
-                  "from": "cli-color@>=0.3.2 <0.4.0",
+                  "from": "cli-color@~0.3.2",
                   "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
+                      "from": "d@~0.1.1",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "es5-ext@>=0.10.6 <0.11.0",
+                      "from": "es5-ext@~0.10.6",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                       "dependencies": {
                         "es6-iterator": {
                           "version": "0.1.3",
-                          "from": "es6-iterator@>=0.1.3 <0.2.0",
+                          "from": "es6-iterator@~0.1.3",
                           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                         },
                         "es6-symbol": {
                           "version": "2.0.1",
-                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "from": "es6-symbol@~2.0.1",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                         }
                       }
                     },
                     "memoizee": {
                       "version": "0.3.9",
-                      "from": "memoizee@>=0.3.8 <0.4.0",
+                      "from": "memoizee@~0.3.8",
                       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
                       "dependencies": {
                         "es6-weak-map": {
                           "version": "0.1.4",
-                          "from": "es6-weak-map@>=0.1.4 <0.2.0",
+                          "from": "es6-weak-map@~0.1.4",
                           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                           "dependencies": {
                             "es6-iterator": {
                               "version": "0.1.3",
-                              "from": "es6-iterator@>=0.1.3 <0.2.0",
+                              "from": "es6-iterator@~0.1.3",
                               "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                             },
                             "es6-symbol": {
                               "version": "2.0.1",
-                              "from": "es6-symbol@>=2.0.1 <2.1.0",
+                              "from": "es6-symbol@~2.0.1",
                               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                             }
                           }
                         },
                         "event-emitter": {
                           "version": "0.3.3",
-                          "from": "event-emitter@>=0.3.3 <0.4.0",
+                          "from": "event-emitter@~0.3.3",
                           "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                         },
                         "lru-queue": {
                           "version": "0.1.0",
-                          "from": "lru-queue@>=0.1.0 <0.2.0",
+                          "from": "lru-queue@0.1",
                           "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                         },
                         "next-tick": {
                           "version": "0.2.2",
-                          "from": "next-tick@>=0.2.2 <0.3.0",
+                          "from": "next-tick@~0.2.2",
                           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                         }
                       }
                     },
                     "timers-ext": {
                       "version": "0.1.0",
-                      "from": "timers-ext@>=0.1.0 <0.2.0",
+                      "from": "timers-ext@0.1",
                       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                       "dependencies": {
                         "next-tick": {
                           "version": "0.2.2",
-                          "from": "next-tick@>=0.2.2 <0.3.0",
+                          "from": "next-tick@~0.2.2",
                           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                         }
                       }
@@ -14367,12 +9503,12 @@
                 },
                 "figures": {
                   "version": "1.3.5",
-                  "from": "figures@>=1.3.2 <2.0.0",
+                  "from": "figures@^1.3.2",
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "from": "lodash@~2.4.1",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "mute-stream": {
@@ -14382,82 +9518,82 @@
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "readline2@>=0.1.0 <0.2.0",
+                  "from": "readline2@~0.1.0",
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "from": "strip-ansi@^2.0.1",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
                     }
                   }
                 },
                 "rx": {
                   "version": "2.5.3",
-                  "from": "rx@>=2.2.27 <3.0.0",
+                  "from": "rx@^2.2.27",
                   "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.4 <2.4.0",
+                  "from": "through@~2.3.4",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "insight": {
               "version": "0.5.3",
-              "from": "insight@>=0.5.0 <0.6.0",
+              "from": "insight@^0.5.0",
               "resolved": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "async@^0.9.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "lodash.debounce": {
                   "version": "3.1.1",
-                  "from": "lodash.debounce@>=3.0.1 <4.0.0",
+                  "from": "lodash.debounce@^3.0.1",
                   "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "from": "lodash._getnative@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "2.1.1",
-                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "from": "object-assign@^2.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                 },
                 "os-name": {
                   "version": "1.0.3",
-                  "from": "os-name@>=1.0.0 <2.0.0",
+                  "from": "os-name@^1.0.0",
                   "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
                   "dependencies": {
                     "osx-release": {
                       "version": "1.1.0",
-                      "from": "osx-release@>=1.0.0 <2.0.0",
+                      "from": "osx-release@^1.0.0",
                       "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
                       "dependencies": {
                         "minimist": {
-                          "version": "1.1.2",
-                          "from": "minimist@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                          "version": "1.1.3",
+                          "from": "minimist@^1.1.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                         }
                       }
                     },
                     "win-release": {
                       "version": "1.0.0",
-                      "from": "win-release@>=1.0.0 <2.0.0",
+                      "from": "win-release@^1.0.0",
                       "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
                     }
                   }
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.1 <0.13.0",
+                  "from": "tough-cookie@^0.12.1",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
@@ -14471,32 +9607,32 @@
             },
             "is-root": {
               "version": "1.0.0",
-              "from": "is-root@>=1.0.0 <2.0.0",
+              "from": "is-root@^1.0.0",
               "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
             },
             "junk": {
               "version": "1.0.2",
-              "from": "junk@>=1.0.0 <2.0.0",
+              "from": "junk@^1.0.0",
               "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz"
             },
             "lockfile": {
               "version": "1.0.1",
-              "from": "lockfile@>=1.0.0 <2.0.0",
+              "from": "lockfile@^1.0.0",
               "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
             },
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "from": "lru-cache@^2.5.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "nopt": {
               "version": "3.0.3",
-              "from": "nopt@>=3.0.1 <4.0.0",
+              "from": "nopt@^3.0.1",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz"
             },
             "opn": {
               "version": "1.0.2",
-              "from": "opn@>=1.0.1 <2.0.0",
+              "from": "opn@^1.0.1",
               "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
             },
             "p-throttler": {
@@ -14506,7 +9642,7 @@
               "dependencies": {
                 "q": {
                   "version": "0.9.7",
-                  "from": "q@>=0.9.2 <0.10.0",
+                  "from": "q@~0.9.2",
                   "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
                 }
               }
@@ -14518,12 +9654,12 @@
               "dependencies": {
                 "read": {
                   "version": "1.0.6",
-                  "from": "read@>=1.0.4 <1.1.0",
+                  "from": "read@~1.0.4",
                   "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.5",
-                      "from": "mute-stream@>=0.0.4 <0.1.0",
+                      "from": "mute-stream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                     }
                   }
@@ -14537,17 +9673,17 @@
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "bl@~0.9.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "from": "readable-stream@~1.0.26",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -14557,12 +9693,12 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@~2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -14571,56 +9707,56 @@
                 },
                 "caseless": {
                   "version": "0.9.0",
-                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "from": "caseless@~0.9.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "from": "forever-agent@~0.5.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "from": "form-data@~0.2.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
+                      "from": "async@~0.9.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "from": "json-stringify-safe@~5.0.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "from": "mime-types@~2.0.1",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "mime-db@>=1.12.0 <1.13.0",
+                      "from": "mime-db@~1.12.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "from": "node-uuid@~1.4.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@>=2.3.1 <2.4.0",
+                  "from": "qs@~2.3.1",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "from": "tunnel-agent@~0.4.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
@@ -14630,12 +9766,12 @@
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "from": "http-signature@~0.10.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "from": "assert-plus@^0.1.5",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
@@ -14652,49 +9788,49 @@
                 },
                 "oauth-sign": {
                   "version": "0.6.0",
-                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "from": "oauth-sign@~0.6.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "from": "hawk@~2.3.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.14.0",
-                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "from": "hoek@2.x.x",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
                       "version": "2.8.0",
-                      "from": "boom@>=2.0.0 <3.0.0",
+                      "from": "boom@2.x.x",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "from": "cryptiles@2.x.x",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "from": "sntp@1.x.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "from": "aws-sign2@~0.5.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "from": "combined-stream@~0.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -14706,7 +9842,7 @@
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "from": "isstream@~0.1.1",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 }
               }
@@ -14718,7 +9854,7 @@
               "dependencies": {
                 "throttleit": {
                   "version": "0.0.2",
-                  "from": "throttleit@>=0.0.2 <0.1.0",
+                  "from": "throttleit@~0.0.2",
                   "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
                 }
               }
@@ -14730,44 +9866,44 @@
             },
             "rimraf": {
               "version": "2.4.2",
-              "from": "rimraf@>=2.2.8 <3.0.0",
+              "from": "rimraf@^2.2.8",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
               "dependencies": {
                 "glob": {
                   "version": "5.0.14",
-                  "from": "glob@>=5.0.14 <6.0.0",
+                  "from": "glob@^5.0.14",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "inflight@^1.0.4",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "from": "minimatch@^2.0.1",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.0",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "brace-expansion@^1.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.2.0",
-                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "from": "balanced-match@^0.2.0",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                             },
                             "concat-map": {
@@ -14781,19 +9917,19 @@
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@^1.3.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "path-is-absolute@^1.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
@@ -14802,64 +9938,64 @@
             },
             "semver": {
               "version": "2.3.2",
-              "from": "semver@>=2.3.0 <3.0.0",
+              "from": "semver@^2.3.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "shell-quote": {
               "version": "1.4.3",
-              "from": "shell-quote@>=1.4.2 <2.0.0",
+              "from": "shell-quote@^1.4.2",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "jsonify@~0.0.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 },
                 "array-filter": {
                   "version": "0.0.1",
-                  "from": "array-filter@>=0.0.0 <0.1.0",
+                  "from": "array-filter@~0.0.0",
                   "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
                 },
                 "array-reduce": {
                   "version": "0.0.0",
-                  "from": "array-reduce@>=0.0.0 <0.1.0",
+                  "from": "array-reduce@~0.0.0",
                   "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
                 },
                 "array-map": {
                   "version": "0.0.0",
-                  "from": "array-map@>=0.0.0 <0.1.0",
+                  "from": "array-map@~0.0.0",
                   "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
                 }
               }
             },
             "stringify-object": {
               "version": "1.0.1",
-              "from": "stringify-object@>=1.0.0 <2.0.0",
+              "from": "stringify-object@^1.0.0",
               "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
             },
             "tar-fs": {
               "version": "1.8.1",
-              "from": "tar-fs@>=1.4.1 <2.0.0",
+              "from": "tar-fs@^1.4.1",
               "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.8.1.tgz",
               "dependencies": {
                 "pump": {
                   "version": "1.0.0",
-                  "from": "pump@>=1.0.0 <2.0.0",
+                  "from": "pump@^1.0.0",
                   "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "end-of-stream@>=1.1.0 <2.0.0",
+                      "from": "end-of-stream@^1.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.1 <2.0.0",
+                      "from": "once@^1.3.1",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -14868,27 +10004,27 @@
                 },
                 "tar-stream": {
                   "version": "1.2.1",
-                  "from": "tar-stream@>=1.1.2 <2.0.0",
+                  "from": "tar-stream@^1.1.2",
                   "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "1.0.0",
-                      "from": "bl@>=1.0.0 <2.0.0",
+                      "from": "bl@^1.0.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
                     },
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                      "from": "end-of-stream@^1.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "dependencies": {
                         "once": {
                           "version": "1.3.2",
-                          "from": "once@>=1.3.0 <1.4.0",
+                          "from": "once@~1.3.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "wrappy@1",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -14897,17 +10033,17 @@
                     },
                     "readable-stream": {
                       "version": "2.0.2",
-                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                      "from": "readable-stream@^2.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@~2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
@@ -14917,24 +10053,24 @@
                         },
                         "process-nextick-args": {
                           "version": "1.0.2",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "from": "process-nextick-args@~1.0.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "util-deprecate@~1.0.1",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "from": "xtend@^4.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -14948,32 +10084,32 @@
             },
             "update-notifier": {
               "version": "0.3.2",
-              "from": "update-notifier@>=0.3.0 <0.4.0",
+              "from": "update-notifier@^0.3.0",
               "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
               "dependencies": {
                 "is-npm": {
                   "version": "1.0.0",
-                  "from": "is-npm@>=1.0.0 <2.0.0",
+                  "from": "is-npm@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
                 },
                 "latest-version": {
                   "version": "1.0.1",
-                  "from": "latest-version@>=1.0.0 <2.0.0",
+                  "from": "latest-version@^1.0.0",
                   "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
                   "dependencies": {
                     "package-json": {
                       "version": "1.2.0",
-                      "from": "package-json@>=1.0.0 <2.0.0",
+                      "from": "package-json@^1.0.0",
                       "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
                       "dependencies": {
                         "got": {
                           "version": "3.3.1",
-                          "from": "got@>=3.2.0 <4.0.0",
+                          "from": "got@^3.2.0",
                           "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
                           "dependencies": {
                             "duplexify": {
                               "version": "3.4.2",
-                              "from": "duplexify@>=3.2.0 <4.0.0",
+                              "from": "duplexify@^3.2.0",
                               "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                               "dependencies": {
                                 "end-of-stream": {
@@ -14983,12 +10119,12 @@
                                   "dependencies": {
                                     "once": {
                                       "version": "1.3.2",
-                                      "from": "once@>=1.3.0 <1.4.0",
+                                      "from": "once@^1.3.0",
                                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                                       "dependencies": {
                                         "wrappy": {
                                           "version": "1.0.1",
-                                          "from": "wrappy@>=1.0.0 <2.0.0",
+                                          "from": "wrappy@1",
                                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                         }
                                       }
@@ -14997,17 +10133,17 @@
                                 },
                                 "readable-stream": {
                                   "version": "2.0.2",
-                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "from": "readable-stream@^2.0.0",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "from": "core-util-is@~1.0.0",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "from": "inherits@2",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
@@ -15017,17 +10153,17 @@
                                     },
                                     "process-nextick-args": {
                                       "version": "1.0.2",
-                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "from": "process-nextick-args@~1.0.0",
                                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "from": "string_decoder@~0.10.x",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.1",
-                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "from": "util-deprecate@~1.0.1",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                                     }
                                   }
@@ -15036,76 +10172,76 @@
                             },
                             "infinity-agent": {
                               "version": "2.0.3",
-                              "from": "infinity-agent@>=2.0.0 <3.0.0",
+                              "from": "infinity-agent@^2.0.0",
                               "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
                             },
                             "is-redirect": {
                               "version": "1.0.0",
-                              "from": "is-redirect@>=1.0.0 <2.0.0",
+                              "from": "is-redirect@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
                             },
                             "is-stream": {
                               "version": "1.0.1",
-                              "from": "is-stream@>=1.0.0 <2.0.0",
+                              "from": "is-stream@^1.0.0",
                               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
-                              "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                              "from": "lowercase-keys@^1.0.0",
                               "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                             },
                             "nested-error-stacks": {
                               "version": "1.0.1",
-                              "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                              "from": "nested-error-stacks@^1.0.0",
                               "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
                               "dependencies": {
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "from": "inherits@~2.0.1",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "object-assign": {
                               "version": "3.0.0",
-                              "from": "object-assign@>=3.0.0 <4.0.0",
+                              "from": "object-assign@^3.0.0",
                               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                             },
                             "prepend-http": {
                               "version": "1.0.2",
-                              "from": "prepend-http@>=1.0.0 <2.0.0",
+                              "from": "prepend-http@^1.0.0",
                               "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
                             },
                             "read-all-stream": {
                               "version": "3.0.1",
-                              "from": "read-all-stream@>=3.0.0 <4.0.0",
+                              "from": "read-all-stream@^3.0.0",
                               "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
                               "dependencies": {
                                 "pinkie-promise": {
                                   "version": "1.0.0",
-                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "from": "pinkie-promise@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "1.0.0",
-                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "from": "pinkie@^1.0.0",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                     }
                                   }
                                 },
                                 "readable-stream": {
                                   "version": "2.0.2",
-                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "from": "readable-stream@^2.0.0",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                                      "from": "core-util-is@~1.0.0",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "from": "inherits@~2.0.1",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
@@ -15115,17 +10251,17 @@
                                     },
                                     "process-nextick-args": {
                                       "version": "1.0.2",
-                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "from": "process-nextick-args@~1.0.0",
                                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                                      "from": "string_decoder@~0.10.x",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.1",
-                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                      "from": "util-deprecate@~1.0.1",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                                     }
                                   }
@@ -15134,39 +10270,39 @@
                             },
                             "timed-out": {
                               "version": "2.0.0",
-                              "from": "timed-out@>=2.0.0 <3.0.0",
+                              "from": "timed-out@^2.0.0",
                               "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                             }
                           }
                         },
                         "registry-url": {
                           "version": "3.0.3",
-                          "from": "registry-url@>=3.0.0 <4.0.0",
+                          "from": "registry-url@^3.0.0",
                           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
                           "dependencies": {
                             "rc": {
                               "version": "1.1.0",
-                              "from": "rc@>=1.0.1 <2.0.0",
+                              "from": "rc@^1.0.1",
                               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.0.tgz",
                               "dependencies": {
                                 "minimist": {
-                                  "version": "1.1.2",
-                                  "from": "minimist@>=1.1.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                                  "version": "1.1.3",
+                                  "from": "minimist@^1.1.0",
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                                 },
                                 "deep-extend": {
                                   "version": "0.2.11",
-                                  "from": "deep-extend@>=0.2.5 <0.3.0",
+                                  "from": "deep-extend@~0.2.5",
                                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                                 },
                                 "strip-json-comments": {
                                   "version": "0.1.3",
-                                  "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                                  "from": "strip-json-comments@0.1.x",
                                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                                 },
                                 "ini": {
                                   "version": "1.3.4",
-                                  "from": "ini@>=1.3.0 <1.4.0",
+                                  "from": "ini@~1.3.0",
                                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                                 }
                               }
@@ -15179,29 +10315,29 @@
                 },
                 "semver-diff": {
                   "version": "2.0.0",
-                  "from": "semver-diff@>=2.0.0 <3.0.0",
+                  "from": "semver-diff@^2.0.0",
                   "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
                   "dependencies": {
                     "semver": {
                       "version": "4.3.6",
-                      "from": "semver@>=4.0.0 <5.0.0",
+                      "from": "semver@^4.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                     }
                   }
                 },
                 "string-length": {
                   "version": "1.0.1",
-                  "from": "string-length@>=1.0.0 <2.0.0",
+                  "from": "string-length@^1.0.0",
                   "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
                   "dependencies": {
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "strip-ansi@^3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "ansi-regex@^2.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
@@ -15212,22 +10348,22 @@
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.1.0 <2.0.0",
+              "from": "user-home@^1.1.0",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             },
             "which": {
               "version": "1.1.1",
-              "from": "which@>=1.0.8 <2.0.0",
+              "from": "which@^1.0.8",
               "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "is-absolute@>=0.1.7 <0.2.0",
+                  "from": "is-absolute@^0.1.7",
                   "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
-                      "from": "is-relative@>=0.1.0 <0.2.0",
+                      "from": "is-relative@^0.1.0",
                       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
@@ -15248,17 +10384,17 @@
         },
         "mout": {
           "version": "0.11.0",
-          "from": "mout@>=0.11.0 <0.12.0",
+          "from": "mout@^0.11.0",
           "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.0.tgz"
         },
         "q": {
           "version": "1.4.1",
-          "from": "q@>=1.2.0 <2.0.0",
+          "from": "q@^1.2.0",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.3.0 <5.0.0",
+          "from": "semver@^4.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
@@ -15270,7 +10406,7 @@
       "dependencies": {
         "di": {
           "version": "0.0.1",
-          "from": "di@>=0.0.1 <0.1.0",
+          "from": "di@~0.0.1",
           "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
         },
         "socket.io": {
@@ -15290,22 +10426,22 @@
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "ws@>=0.4.0 <0.5.0",
+                  "from": "ws@0.4.x",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "commander@>=2.1.0 <2.2.0",
+                      "from": "commander@~2.1.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "nan@>=1.0.0 <1.1.0",
+                      "from": "nan@~1.0.0",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "from": "tinycolor@0.x",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
@@ -15358,64 +10494,64 @@
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@>=1.1.0 <2.0.0",
+              "from": "anymatch@^1.1.0",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
                   "version": "2.2.0",
-                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "from": "micromatch@^2.1.5",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "arr-diff@>=1.0.1 <2.0.0",
+                      "from": "arr-diff@^1.0.1",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
                           "version": "0.2.3",
-                          "from": "array-slice@>=0.2.2 <0.3.0",
+                          "from": "array-slice@^0.2.2",
                           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
-                      "from": "array-unique@>=0.2.1 <0.3.0",
+                      "from": "array-unique@^0.2.1",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "braces@>=1.8.0 <2.0.0",
+                      "from": "braces@^1.8.0",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "from": "expand-range@^1.8.1",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.2",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "from": "fill-range@^2.1.0",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "is-number@>=1.1.2 <2.0.0",
+                                  "from": "is-number@^1.1.2",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
                                   "version": "1.0.2",
-                                  "from": "isobject@>=1.0.0 <2.0.0",
+                                  "from": "isobject@^1.0.0",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "randomatic@>=1.1.0 <2.0.0",
+                                  "from": "randomatic@^1.1.0",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "repeat-string@^1.5.2",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -15424,36 +10560,36 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "from": "preserve@^0.2.0",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "repeat-element@>=1.1.0 <2.0.0",
+                          "from": "repeat-element@^1.1.0",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.3",
-                      "from": "expand-brackets@>=0.1.1 <0.2.0",
+                      "from": "expand-brackets@^0.1.1",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
                       "dependencies": {
                         "is-posix-bracket": {
                           "version": "0.1.0",
-                          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                          "from": "is-posix-bracket@^0.1.0",
                           "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz"
                         }
                       }
                     },
                     "extglob": {
                       "version": "0.3.1",
-                      "from": "extglob@>=0.3.0 <0.4.0",
+                      "from": "extglob@^0.3.0",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
                       "dependencies": {
                         "ansi-green": {
                           "version": "0.1.1",
-                          "from": "ansi-green@>=0.1.1 <0.2.0",
+                          "from": "ansi-green@^0.1.1",
                           "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
                           "dependencies": {
                             "ansi-wrap": {
@@ -15465,85 +10601,85 @@
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "from": "is-extglob@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "success-symbol": {
                           "version": "0.1.0",
-                          "from": "success-symbol@>=0.1.0 <0.2.0",
+                          "from": "success-symbol@^0.1.0",
                           "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
                         }
                       }
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "from": "filename-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "kind-of@>=1.1.0 <2.0.0",
+                      "from": "kind-of@^1.1.0",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "1.1.0",
-                      "from": "object.omit@>=1.1.0 <2.0.0",
+                      "from": "object.omit@^1.1.0",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@>=0.1.3 <0.2.0",
+                          "from": "for-own@^0.1.3",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "from": "for-in@^0.1.4",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "1.0.2",
-                          "from": "isobject@>=1.0.0 <2.0.0",
+                          "from": "isobject@^1.0.0",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.2",
-                      "from": "parse-glob@>=3.0.1 <4.0.0",
+                      "from": "parse-glob@^3.0.1",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "glob-base@>=0.2.0 <0.3.0",
+                          "from": "glob-base@^0.2.0",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.1",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "from": "is-dotfile@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "from": "is-extglob@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "regex-cache@>=0.4.2 <0.5.0",
+                      "from": "regex-cache@^0.4.2",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                          "from": "is-equal-shallow@^0.1.1",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "from": "is-primitive@^2.0.0",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -15554,59 +10690,59 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0",
+              "from": "arrify@^1.0.0",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
+              "from": "async-each@^0.1.5",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "glob-parent@>=1.0.0 <2.0.0",
+              "from": "glob-parent@^1.0.0",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "from": "is-binary-path@^1.0.0",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.3.1",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "from": "binary-extensions@^1.0.0",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "is-glob@>=1.1.3 <2.0.0",
+              "from": "is-glob@^1.1.3",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "path-is-absolute@^1.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
               "version": "1.4.0",
-              "from": "readdirp@>=1.3.0 <2.0.0",
+              "from": "readdirp@^1.3.0",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <4.2.0",
+                  "from": "graceful-fs@~4.1.2",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "from": "readable-stream@~1.0.26-2",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -15616,12 +10752,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -15629,14 +10765,14 @@
               }
             },
             "fsevents": {
-              "version": "0.3.7",
-              "from": "fsevents@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.7.tgz",
+              "version": "0.3.8",
+              "from": "fsevents@^0.3.1",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
               "dependencies": {
                 "nan": {
-                  "version": "1.9.0",
-                  "from": "nan@>=1.8.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
+                  "version": "2.0.5",
+                  "from": "nan@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
                 }
               }
             }
@@ -15644,27 +10780,27 @@
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.7 <3.3.0",
+          "from": "glob@~3.2.7",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "inherits@2",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
+              "from": "minimatch@0.3",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.5",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -15673,39 +10809,39 @@
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.0 <0.3.0",
+          "from": "minimatch@~0.2",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "http-proxy": {
           "version": "0.10.4",
-          "from": "http-proxy@>=0.10.0 <0.11.0",
+          "from": "http-proxy@~0.10",
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
           "dependencies": {
             "pkginfo": {
               "version": "0.3.0",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "from": "pkginfo@0.3.x",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "utile": {
               "version": "0.2.1",
-              "from": "utile@>=0.2.1 <0.3.0",
+              "from": "utile@~0.2.1",
               "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.9 <0.3.0",
+                  "from": "async@~0.2.9",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "deep-equal": {
@@ -15715,12 +10851,12 @@
                 },
                 "i": {
                   "version": "0.3.3",
-                  "from": "i@>=0.3.0 <0.4.0",
+                  "from": "i@0.3.x",
                   "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                 },
                 "ncp": {
                   "version": "0.4.2",
-                  "from": "ncp@>=0.4.0 <0.5.0",
+                  "from": "ncp@0.4.x",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                 }
               }
@@ -15729,64 +10865,64 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
+          "from": "optimist@~0.6.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "wordwrap@~0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "minimist@~0.0.1",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.5 <2.3.0",
+          "from": "rimraf@~2.2.5",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "q": {
           "version": "0.9.7",
-          "from": "q@>=0.9.7 <0.10.0",
+          "from": "q@~0.9.7",
           "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
+          "from": "colors@~0.6.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@>=1.2.11 <1.3.0",
+          "from": "mime@~1.2.11",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "log4js": {
           "version": "0.6.26",
-          "from": "log4js@>=0.6.3 <0.7.0",
+          "from": "log4js@~0.6.3",
           "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.26.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.0 <0.3.0",
+              "from": "async@~0.2.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "from": "readable-stream@~1.0.2",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -15796,19 +10932,19 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.3.3 <4.4.0",
+              "from": "semver@~4.3.3",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "underscore": {
@@ -15820,24 +10956,24 @@
         },
         "useragent": {
           "version": "2.0.10",
-          "from": "useragent@>=2.0.4 <2.1.0",
+          "from": "useragent@~2.0.4",
           "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.10.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
-              "from": "lru-cache@>=2.2.0 <2.3.0",
+              "from": "lru-cache@2.2.x",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
             }
           }
         },
         "graceful-fs": {
           "version": "2.0.3",
-          "from": "graceful-fs@>=2.0.1 <2.1.0",
+          "from": "graceful-fs@~2.0.1",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
         },
         "connect": {
           "version": "2.26.6",
-          "from": "connect@>=2.26.0 <2.27.0",
+          "from": "connect@~2.26.0",
           "resolved": "https://registry.npmjs.org/connect/-/connect-2.26.6.tgz",
           "dependencies": {
             "basic-auth-connect": {
@@ -15847,7 +10983,7 @@
             },
             "body-parser": {
               "version": "1.8.4",
-              "from": "body-parser@>=1.8.4 <1.9.0",
+              "from": "body-parser@~1.8.4",
               "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
               "dependencies": {
                 "iconv-lite": {
@@ -15886,7 +11022,7 @@
             },
             "cookie-parser": {
               "version": "1.3.5",
-              "from": "cookie-parser@>=1.3.3 <1.4.0",
+              "from": "cookie-parser@~1.3.3",
               "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
               "dependencies": {
                 "cookie": {
@@ -15908,22 +11044,22 @@
             },
             "compression": {
               "version": "1.1.2",
-              "from": "compression@>=1.1.2 <1.2.0",
+              "from": "compression@~1.1.2",
               "resolved": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@>=1.1.2 <1.2.0",
+                  "from": "accepts@~1.1.2",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "from": "mime-types@~2.0.4",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
+                          "from": "mime-db@~1.12.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
@@ -15937,26 +11073,26 @@
                 },
                 "compressible": {
                   "version": "2.0.5",
-                  "from": "compressible@>=2.0.1 <2.1.0",
+                  "from": "compressible@~2.0.1",
                   "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.5.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.16.0",
-                      "from": "mime-db@>=1.16.0 <2.0.0",
+                      "from": "mime-db@>= 1.16.0 < 2",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
                     }
                   }
                 },
                 "vary": {
                   "version": "1.0.1",
-                  "from": "vary@>=1.0.0 <1.1.0",
+                  "from": "vary@~1.0.0",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
                 }
               }
             },
             "connect-timeout": {
               "version": "1.3.0",
-              "from": "connect-timeout@>=1.3.0 <1.4.0",
+              "from": "connect-timeout@~1.3.0",
               "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
               "dependencies": {
                 "ms": {
@@ -15968,12 +11104,12 @@
             },
             "csurf": {
               "version": "1.6.6",
-              "from": "csurf@>=1.6.2 <1.7.0",
+              "from": "csurf@~1.6.2",
               "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
               "dependencies": {
                 "csrf": {
                   "version": "2.0.7",
-                  "from": "csrf@>=2.0.5 <2.1.0",
+                  "from": "csrf@~2.0.5",
                   "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.7.tgz",
                   "dependencies": {
                     "base64-url": {
@@ -15983,7 +11119,7 @@
                     },
                     "rndm": {
                       "version": "1.1.0",
-                      "from": "rndm@>=1.1.0 <1.2.0",
+                      "from": "rndm@~1.1.0",
                       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz"
                     },
                     "scmp": {
@@ -15993,12 +11129,12 @@
                     },
                     "uid-safe": {
                       "version": "1.1.0",
-                      "from": "uid-safe@>=1.1.0 <1.2.0",
+                      "from": "uid-safe@~1.1.0",
                       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
                           "version": "1.1.2",
-                          "from": "native-or-bluebird@>=1.1.2 <1.2.0",
+                          "from": "native-or-bluebird@~1.1.2",
                           "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
                         }
                       }
@@ -16007,17 +11143,17 @@
                 },
                 "http-errors": {
                   "version": "1.2.8",
-                  "from": "http-errors@>=1.2.8 <1.3.0",
+                  "from": "http-errors@~1.2.8",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "statuses": {
                       "version": "1.2.1",
-                      "from": "statuses@>=1.0.0 <2.0.0",
+                      "from": "statuses@1",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                     }
                   }
@@ -16026,7 +11162,7 @@
             },
             "debug": {
               "version": "2.0.0",
-              "from": "debug@>=2.0.0 <2.1.0",
+              "from": "debug@~2.0.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
                 "ms": {
@@ -16043,22 +11179,22 @@
             },
             "errorhandler": {
               "version": "1.2.4",
-              "from": "errorhandler@>=1.2.2 <1.3.0",
+              "from": "errorhandler@~1.2.2",
               "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.4.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@>=1.1.2 <1.2.0",
+                  "from": "accepts@~1.1.2",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "from": "mime-types@~2.0.1",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
+                          "from": "mime-db@~1.12.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
@@ -16079,7 +11215,7 @@
             },
             "express-session": {
               "version": "1.8.2",
-              "from": "express-session@>=1.8.2 <1.9.0",
+              "from": "express-session@~1.8.2",
               "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
               "dependencies": {
                 "crc": {
@@ -16094,29 +11230,29 @@
                   "dependencies": {
                     "mz": {
                       "version": "1.3.0",
-                      "from": "mz@>=1.0.0 <2.0.0",
+                      "from": "mz@1",
                       "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
                           "version": "1.2.0",
-                          "from": "native-or-bluebird@>=1.0.0 <2.0.0",
+                          "from": "native-or-bluebird@1",
                           "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
                         },
                         "thenify": {
                           "version": "3.1.0",
-                          "from": "thenify@>=3.0.0 <4.0.0",
+                          "from": "thenify@3",
                           "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz"
                         },
                         "thenify-all": {
                           "version": "1.6.0",
-                          "from": "thenify-all@>=1.0.0 <2.0.0",
+                          "from": "thenify-all@1",
                           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
                         }
                       }
                     },
                     "base64-url": {
                       "version": "1.2.1",
-                      "from": "base64-url@>=1.0.0 <2.0.0",
+                      "from": "base64-url@1",
                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     }
                   }
@@ -16152,7 +11288,7 @@
             },
             "method-override": {
               "version": "2.2.0",
-              "from": "method-override@>=2.2.0 <2.3.0",
+              "from": "method-override@~2.2.0",
               "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
               "dependencies": {
                 "methods": {
@@ -16162,14 +11298,14 @@
                 },
                 "vary": {
                   "version": "1.0.1",
-                  "from": "vary@>=1.0.0 <1.1.0",
+                  "from": "vary@~1.0.0",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
                 }
               }
             },
             "morgan": {
               "version": "1.3.2",
-              "from": "morgan@>=1.3.2 <1.4.0",
+              "from": "morgan@~1.3.2",
               "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
               "dependencies": {
                 "basic-auth": {
@@ -16198,12 +11334,12 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -16213,31 +11349,31 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "stream-counter": {
                   "version": "0.2.0",
-                  "from": "stream-counter@>=0.2.0 <0.3.0",
+                  "from": "stream-counter@~0.2.0",
                   "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
                 }
               }
             },
             "on-headers": {
               "version": "1.0.0",
-              "from": "on-headers@>=1.0.0 <1.1.0",
+              "from": "on-headers@~1.0.0",
               "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
             },
             "parseurl": {
               "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
+              "from": "parseurl@~1.3.0",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
             },
             "qs": {
@@ -16247,17 +11383,17 @@
             },
             "response-time": {
               "version": "2.0.1",
-              "from": "response-time@>=2.0.1 <2.1.0",
+              "from": "response-time@~2.0.1",
               "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz"
             },
             "serve-favicon": {
               "version": "2.1.7",
-              "from": "serve-favicon@>=2.1.5 <2.2.0",
+              "from": "serve-favicon@~2.1.5",
               "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
               "dependencies": {
                 "etag": {
                   "version": "1.5.1",
-                  "from": "etag@>=1.5.0 <1.6.0",
+                  "from": "etag@~1.5.0",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
                   "dependencies": {
                     "crc": {
@@ -16276,22 +11412,22 @@
             },
             "serve-index": {
               "version": "1.2.1",
-              "from": "serve-index@>=1.2.1 <1.3.0",
+              "from": "serve-index@~1.2.1",
               "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@>=1.1.0 <1.2.0",
+                  "from": "accepts@~1.1.0",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "from": "mime-types@~2.0.4",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
+                          "from": "mime-db@~1.12.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
@@ -16312,7 +11448,7 @@
             },
             "serve-static": {
               "version": "1.6.5",
-              "from": "serve-static@>=1.6.4 <1.7.0",
+              "from": "serve-static@~1.6.4",
               "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
               "dependencies": {
                 "escape-html": {
@@ -16332,7 +11468,7 @@
                     },
                     "etag": {
                       "version": "1.4.0",
-                      "from": "etag@>=1.4.0 <1.5.0",
+                      "from": "etag@~1.4.0",
                       "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
                       "dependencies": {
                         "crc": {
@@ -16361,7 +11497,7 @@
                     },
                     "range-parser": {
                       "version": "1.0.2",
-                      "from": "range-parser@>=1.0.2 <1.1.0",
+                      "from": "range-parser@~1.0.2",
                       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
                     }
                   }
@@ -16375,17 +11511,17 @@
             },
             "type-is": {
               "version": "1.5.7",
-              "from": "type-is@>=1.5.2 <1.6.0",
+              "from": "type-is@~1.5.2",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@>=2.0.9 <2.1.0",
+                  "from": "mime-types@~2.0.1",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "mime-db@>=1.12.0 <1.13.0",
+                      "from": "mime-db@~1.12.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
@@ -16394,7 +11530,7 @@
             },
             "vhost": {
               "version": "3.0.1",
-              "from": "vhost@>=3.0.0 <3.1.0",
+              "from": "vhost@~3.0.0",
               "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.1.tgz"
             },
             "pause": {
@@ -16406,7 +11542,7 @@
         },
         "source-map": {
           "version": "0.1.43",
-          "from": "source-map@>=0.1.31 <0.2.0",
+          "from": "source-map@~0.1.31",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
@@ -16425,17 +11561,17 @@
       "dependencies": {
         "which": {
           "version": "1.1.1",
-          "from": "which@>=1.0.9 <2.0.0",
+          "from": "which@^1.0.9",
           "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "from": "is-absolute@>=0.1.7 <0.2.0",
+              "from": "is-absolute@^0.1.7",
               "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
-                  "from": "is-relative@>=0.1.0 <0.2.0",
+                  "from": "is-relative@^0.1.0",
                   "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                 }
               }
@@ -16451,12 +11587,12 @@
       "dependencies": {
         "coffee-script": {
           "version": "1.7.1",
-          "from": "coffee-script@>=1.7.0 <1.8.0",
+          "from": "coffee-script@~1.7",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "from": "mkdirp@~0.3.5",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             }
           }
@@ -16470,69 +11606,69 @@
       "dependencies": {
         "istanbul": {
           "version": "0.3.17",
-          "from": "istanbul@>=0.3.0 <0.4.0",
+          "from": "istanbul@~0.3.0",
           "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.17.tgz",
           "dependencies": {
             "esprima": {
               "version": "2.4.1",
-              "from": "esprima@>=2.4.0 <2.5.0",
+              "from": "esprima@2.4.x",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.4.1.tgz"
             },
             "escodegen": {
               "version": "1.6.1",
-              "from": "escodegen@>=1.6.0 <1.7.0",
+              "from": "escodegen@1.6.x",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
               "dependencies": {
                 "estraverse": {
                   "version": "1.9.3",
-                  "from": "estraverse@>=1.9.1 <2.0.0",
+                  "from": "estraverse@^1.9.1",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                 },
                 "esutils": {
                   "version": "1.1.6",
-                  "from": "esutils@>=1.1.6 <2.0.0",
+                  "from": "esutils@^1.1.6",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                 },
                 "esprima": {
                   "version": "1.2.5",
-                  "from": "esprima@>=1.2.2 <2.0.0",
+                  "from": "esprima@^1.2.2",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                 },
                 "optionator": {
                   "version": "0.5.0",
-                  "from": "optionator@>=0.5.0 <0.6.0",
+                  "from": "optionator@^0.5.0",
                   "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                   "dependencies": {
                     "prelude-ls": {
                       "version": "1.1.2",
-                      "from": "prelude-ls@>=1.1.1 <1.2.0",
+                      "from": "prelude-ls@~1.1.1",
                       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                     },
                     "deep-is": {
                       "version": "0.1.3",
-                      "from": "deep-is@>=0.1.2 <0.2.0",
+                      "from": "deep-is@~0.1.2",
                       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                     },
                     "type-check": {
                       "version": "0.3.1",
-                      "from": "type-check@>=0.3.1 <0.4.0",
+                      "from": "type-check@~0.3.1",
                       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                     },
                     "levn": {
                       "version": "0.2.5",
-                      "from": "levn@>=0.2.5 <0.3.0",
+                      "from": "levn@~0.2.5",
                       "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                     },
                     "fast-levenshtein": {
                       "version": "1.0.6",
-                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                      "from": "fast-levenshtein@~1.0.0",
                       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "from": "source-map@~0.1.40",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -16551,19 +11687,19 @@
               "dependencies": {
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "optimist@>=0.6.1 <0.7.0",
+                  "from": "optimist@^0.6.1",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "from": "minimist@~0.0.1",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "from": "source-map@^0.1.40",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -16575,17 +11711,17 @@
                 },
                 "uglify-js": {
                   "version": "2.3.6",
-                  "from": "uglify-js@>=2.3.0 <2.4.0",
+                  "from": "uglify-js@~2.3",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@>=0.2.6 <0.3.0",
+                      "from": "async@~0.2.6",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "optimist@>=0.3.5 <0.4.0",
+                      "from": "optimist@~0.3.5",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
                     }
                   }
@@ -16594,27 +11730,27 @@
             },
             "nopt": {
               "version": "3.0.3",
-              "from": "nopt@>=3.0.0 <4.0.0",
+              "from": "nopt@3.x",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz"
             },
             "fileset": {
               "version": "0.2.1",
-              "from": "fileset@>=0.2.0 <0.3.0",
+              "from": "fileset@0.2.x",
               "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.0 <3.0.0",
+                  "from": "minimatch@2.x",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "brace-expansion@^1.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "balanced-match@^0.2.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -16628,29 +11764,29 @@
                 },
                 "glob": {
                   "version": "5.0.14",
-                  "from": "glob@>=5.0.0 <6.0.0",
+                  "from": "glob@5.x",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "inflight@^1.0.4",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "wrappy@1",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@2",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "path-is-absolute@^1.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
@@ -16659,71 +11795,71 @@
             },
             "which": {
               "version": "1.0.9",
-              "from": "which@>=1.0.0 <1.1.0",
+              "from": "which@1.0.x",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             },
             "async": {
-              "version": "1.4.0",
-              "from": "async@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
+              "version": "1.4.2",
+              "from": "async@1.x",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <1.4.0",
+              "from": "supports-color@1.3.x",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             },
             "abbrev": {
               "version": "1.0.7",
-              "from": "abbrev@>=1.0.0 <1.1.0",
+              "from": "abbrev@1.0.x",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             },
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.0 <0.1.0",
+              "from": "wordwrap@0.0.x",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@>=1.1.0 <1.2.0",
+              "from": "resolve@1.1.x",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "js-yaml": {
               "version": "3.3.1",
-              "from": "js-yaml@>=3.0.0 <4.0.0",
+              "from": "js-yaml@3.x",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "argparse@>=1.0.2 <1.1.0",
+                  "from": "argparse@~1.0.2",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "from": "lodash@>= 3.2.0 < 4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "from": "sprintf-js@~1.0.2",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.2.0",
-                  "from": "esprima@>=2.2.0 <2.3.0",
+                  "from": "esprima@~2.2.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.0.0 <2.0.0",
+              "from": "once@1.x",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -16732,7 +11868,7 @@
         },
         "dateformat": {
           "version": "1.0.11",
-          "from": "dateformat@>=1.0.6 <1.1.0",
+          "from": "dateformat@~1.0.6",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
           "dependencies": {
             "get-stdin": {
@@ -16747,39 +11883,39 @@
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "from": "camelcase-keys@^1.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "from": "camelcase@^1.0.1",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "from": "map-obj@^1.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.2",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "from": "indent-string@^1.1.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "from": "repeating@^1.1.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "from": "is-finite@^1.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "from": "number-is-nan@^1.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -16789,13 +11925,13 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.1.2",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                  "version": "1.1.3",
+                  "from": "minimist@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "from": "object-assign@^3.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
@@ -16804,17 +11940,17 @@
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
+          "from": "minimatch@~0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "lru-cache@2",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
+              "from": "sigmund@~1.0.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
@@ -16838,32 +11974,32 @@
     },
     "karma-jspm": {
       "version": "1.1.6",
-      "from": "rich-nguyen/karma-jspm#1.1.6",
+      "from": "git://github.com/rich-nguyen/karma-jspm.git#1.1.6",
       "resolved": "git://github.com/rich-nguyen/karma-jspm.git#491f43be0891f1a0a598f3e5e7bdb27a6f5bf050",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.0 <3.3.0",
+          "from": "glob@~3.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "inherits@~2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
+              "from": "minimatch@0.3",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.5",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -16879,7 +12015,7 @@
     },
     "karma-phantomjs-shim": {
       "version": "1.0.0",
-      "from": "karma-phantomjs-shim@>=1.0.0 <2.0.0",
+      "from": "karma-phantomjs-shim@^1.0.0",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-shim/-/karma-phantomjs-shim-1.0.0.tgz"
     },
     "karma-requirejs": {
@@ -16899,7 +12035,7 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.0 <0.7.0",
+          "from": "colors@~0.6.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         }
       }
@@ -16911,121 +12047,121 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.10 <0.3.0",
+          "from": "async@~0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cson": {
           "version": "1.6.2",
-          "from": "cson@>=1.6.2 <1.7.0",
+          "from": "cson@~1.6.2",
           "resolved": "https://registry.npmjs.org/cson/-/cson-1.6.2.tgz",
           "dependencies": {
             "ambi": {
               "version": "2.2.0",
-              "from": "ambi@>=2.2.0 <3.0.0",
+              "from": "ambi@^2.2.0",
               "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.2.0.tgz",
               "dependencies": {
                 "typechecker": {
                   "version": "2.0.8",
-                  "from": "typechecker@>=2.0.1 <2.1.0",
+                  "from": "typechecker@~2.0.7",
                   "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz"
                 }
               }
             },
             "coffee-script": {
               "version": "1.8.0",
-              "from": "coffee-script@>=1.8.0 <1.9.0",
+              "from": "coffee-script@~1.8.0",
               "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "from": "mkdirp@~0.3.5",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 }
               }
             },
             "extract-opts": {
               "version": "2.2.0",
-              "from": "extract-opts@>=2.2.0 <2.3.0",
+              "from": "extract-opts@~2.2.0",
               "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-2.2.0.tgz",
               "dependencies": {
                 "typechecker": {
                   "version": "2.0.8",
-                  "from": "typechecker@>=2.0.1 <2.1.0",
+                  "from": "typechecker@~2.0.7",
                   "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz"
                 }
               }
             },
             "js2coffee": {
               "version": "0.3.5",
-              "from": "js2coffee@>=0.3.5 <0.4.0",
+              "from": "js2coffee@~0.3.5",
               "resolved": "https://registry.npmjs.org/js2coffee/-/js2coffee-0.3.5.tgz",
               "dependencies": {
                 "coffee-script": {
                   "version": "1.7.1",
-                  "from": "coffee-script@>=1.7.1 <1.8.0",
+                  "from": "coffee-script@~1.7.1",
                   "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.3.5",
-                      "from": "mkdirp@>=0.3.5 <0.4.0",
+                      "from": "mkdirp@~0.3.5",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                     }
                   }
                 },
                 "file": {
                   "version": "0.2.2",
-                  "from": "file@>=0.2.1 <0.3.0",
+                  "from": "file@~0.2.1",
                   "resolved": "https://registry.npmjs.org/file/-/file-0.2.2.tgz"
                 },
                 "nopt": {
                   "version": "3.0.3",
-                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "from": "nopt@~3.0.1",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "from": "abbrev@1",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "underscore@>=1.6.0 <1.7.0",
+                  "from": "underscore@~1.6.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 }
               }
             },
             "requirefresh": {
               "version": "1.1.2",
-              "from": "requirefresh@>=1.1.2 <1.2.0",
+              "from": "requirefresh@~1.1.2",
               "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-1.1.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.6 <3.3.0",
+          "from": "glob@~3.2.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "inherits@2",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
+              "from": "minimatch@0.3",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.5",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "lru-cache@2",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "sigmund@~1.0.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -17034,61 +12170,61 @@
         },
         "jit-grunt": {
           "version": "0.8.0",
-          "from": "jit-grunt@>=0.8.0 <0.9.0",
+          "from": "jit-grunt@~0.8.0",
           "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz"
         },
         "js-yaml": {
           "version": "3.0.2",
-          "from": "js-yaml@>=3.0.1 <3.1.0",
+          "from": "js-yaml@~3.0.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
+              "from": "argparse@~ 0.1.11",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "from": "underscore@~1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "from": "underscore.string@~2.4.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
+              "from": "esprima@~ 1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "load-grunt-tasks": {
           "version": "0.3.0",
-          "from": "load-grunt-tasks@>=0.3.0 <0.4.0",
+          "from": "load-grunt-tasks@~0.3.0",
           "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
           "dependencies": {
             "globule": {
               "version": "0.2.0",
-              "from": "globule@>=0.2.0 <0.3.0",
+              "from": "globule@~0.2.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "from": "minimatch@~0.2.11",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.5",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "lru-cache@2",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "sigmund@~1.0.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -17097,77 +12233,77 @@
             },
             "findup-sync": {
               "version": "0.1.3",
-              "from": "findup-sync@>=0.1.2 <0.2.0",
+              "from": "findup-sync@~0.1.2",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "lodash@~2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "megalog": {
-      "version": "0.0.2",
-      "from": "megalog@>=0.0.2 <0.0.3",
-      "resolved": "https://registry.npmjs.org/megalog/-/megalog-0.0.2.tgz",
+      "version": "0.1.0",
+      "from": "megalog@",
+      "resolved": "https://registry.npmjs.org/megalog/-/megalog-0.1.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@^1.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "ansi-styles@^2.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "has-ansi@^2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "strip-ansi@^3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "supports-color@^2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.8.0 <4.0.0",
+          "from": "lodash@^3.8.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "window-size": {
           "version": "0.1.2",
-          "from": "window-size@>=0.1.0 <0.2.0",
+          "from": "window-size@^0.1.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
         }
       }
@@ -17196,22 +12332,22 @@
       "dependencies": {
         "dnode": {
           "version": "1.2.1",
-          "from": "dnode@>=1.2.0 <1.3.0",
+          "from": "dnode@~1.2.0",
           "resolved": "https://registry.npmjs.org/dnode/-/dnode-1.2.1.tgz",
           "dependencies": {
             "dnode-protocol": {
               "version": "0.2.2",
-              "from": "dnode-protocol@>=0.2.2 <0.3.0",
+              "from": "dnode-protocol@~0.2.2",
               "resolved": "https://registry.npmjs.org/dnode-protocol/-/dnode-protocol-0.2.2.tgz"
             },
             "jsonify": {
               "version": "0.0.0",
-              "from": "jsonify@>=0.0.0 <0.1.0",
+              "from": "jsonify@~0.0.0",
               "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             },
             "weak": {
               "version": "0.4.1",
-              "from": "weak@>=0.4.1 <0.5.0",
+              "from": "weak@~0.4.1",
               "resolved": "https://registry.npmjs.org/weak/-/weak-0.4.1.tgz",
               "dependencies": {
                 "bindings": {
@@ -17221,7 +12357,7 @@
                 },
                 "nan": {
                   "version": "1.8.4",
-                  "from": "nan@>=1.8.4 <1.9.0",
+                  "from": "nan@~1.8.4",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                 }
               }
@@ -17230,12 +12366,12 @@
         },
         "win-spawn": {
           "version": "2.0.0",
-          "from": "win-spawn@>=2.0.0 <2.1.0",
+          "from": "win-spawn@~2.0.0",
           "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
         },
         "traverse": {
           "version": "0.6.6",
-          "from": "traverse@>=0.6.3 <0.7.0",
+          "from": "traverse@~0.6.3",
           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
         }
       }
@@ -17267,70 +12403,70 @@
           "dependencies": {
             "config-chain": {
               "version": "1.1.9",
-              "from": "config-chain@>=1.1.8 <1.2.0",
+              "from": "config-chain@~1.1.8",
               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "from": "proto-list@~1.2.1",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@~2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
               "version": "1.3.4",
-              "from": "ini@>=1.2.0 <2.0.0",
+              "from": "ini@^1.2.0",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "nopt": {
               "version": "3.0.3",
-              "from": "nopt@>=3.0.1 <3.1.0",
+              "from": "nopt@~3.0.1",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "abbrev@1",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.3.0 <1.4.0",
+              "from": "once@~1.3.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "wrappy@1",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "osenv@>=0.1.0 <0.2.0",
+              "from": "osenv@^0.1.0",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "from": "os-homedir@^1.0.0",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "from": "os-tmpdir@^1.0.0",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+              "from": "semver@2 || 3 || 4",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "uid-number": {
@@ -17352,17 +12488,17 @@
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@>=0.9.0 <0.10.0",
+              "from": "bl@~0.9.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "readable-stream@~1.0.26",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -17372,12 +12508,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "string_decoder@~0.10.x",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -17386,37 +12522,37 @@
             },
             "caseless": {
               "version": "0.6.0",
-              "from": "caseless@>=0.6.0 <0.7.0",
+              "from": "caseless@~0.6.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "from": "forever-agent@~0.5.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "qs": {
               "version": "1.2.2",
-              "from": "qs@>=1.2.0 <1.3.0",
+              "from": "qs@~1.2.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "json-stringify-safe@~5.0.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "1.0.2",
-              "from": "mime-types@>=1.0.1 <1.1.0",
+              "from": "mime-types@~1.0.1",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
+              "from": "node-uuid@~1.4.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.1",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+              "from": "tunnel-agent@~0.4.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "tough-cookie": {
@@ -17426,12 +12562,12 @@
             },
             "form-data": {
               "version": "0.1.4",
-              "from": "form-data@>=0.1.0 <0.2.0",
+              "from": "form-data@~0.1.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "from": "combined-stream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -17443,24 +12579,24 @@
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@>=1.2.11 <1.3.0",
+                  "from": "mime@~1.2.11",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
+                  "from": "async@~0.9.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
+              "from": "http-signature@~0.10.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "assert-plus@^0.1.5",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -17477,7 +12613,7 @@
             },
             "oauth-sign": {
               "version": "0.4.0",
-              "from": "oauth-sign@>=0.4.0 <0.5.0",
+              "from": "oauth-sign@~0.4.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
             },
             "hawk": {
@@ -17487,34 +12623,34 @@
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "hoek@>=0.9.0 <0.10.0",
+                  "from": "hoek@0.9.x",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "boom@>=0.4.0 <0.5.0",
+                  "from": "boom@0.4.x",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "cryptiles@>=0.2.0 <0.3.0",
+                  "from": "cryptiles@0.2.x",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "sntp@>=0.2.0 <0.3.0",
+                  "from": "sntp@0.2.x",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
+              "from": "aws-sign2@~0.5.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "stringstream@~0.0.4",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             }
           }
@@ -17526,56 +12662,20 @@
           "dependencies": {
             "throttleit": {
               "version": "0.0.2",
-              "from": "throttleit@>=0.0.2 <0.1.0",
+              "from": "throttleit@~0.0.2",
               "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@>=2.2.2 <2.3.0",
+          "from": "rimraf@~2.2.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "which@>=1.0.5 <1.1.0",
+          "from": "which@~1.0.5",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
-        }
-      }
-    },
-    "postcss-pxtorem": {
-      "version": "2.3.2",
-      "from": "postcss-pxtorem@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-pxtorem/-/postcss-pxtorem-2.3.2.tgz",
-      "dependencies": {
-        "postcss": {
-          "version": "4.1.16",
-          "from": "postcss@>=4.1.11 <5.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-          "dependencies": {
-            "es6-promise": {
-              "version": "2.3.0",
-              "from": "es6-promise@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "from": "source-map@>=0.4.2 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.8 <2.2.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            }
-          }
         }
       }
     },
@@ -17584,68 +12684,10 @@
       "from": "q@1.0.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
     },
-    "require-dir": {
-      "version": "0.3.0",
-      "from": "require-dir@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.0.tgz"
-    },
     "requirejs": {
       "version": "2.1.20",
-      "from": "requirejs@>=2.1.0 <2.2.0",
+      "from": "requirejs@~2.1",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz"
-    },
-    "run-sequence": {
-      "version": "1.1.2",
-      "from": "run-sequence@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.1.2.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.0",
-          "from": "chalk@*",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        }
-      }
     },
     "shoe": {
       "version": "0.0.11",
@@ -17654,7 +12696,7 @@
       "dependencies": {
         "sockjs": {
           "version": "0.3.1",
-          "from": "git://github.com/substack/sockjs-node.git#npm",
+          "from": "sockjs@git://github.com/substack/sockjs-node.git#npm",
           "resolved": "git://github.com/substack/sockjs-node.git#49090a1212ba2e7216c1cf36415de3c5c74e1901",
           "dependencies": {
             "node-uuid": {
@@ -17671,70 +12713,70 @@
         },
         "sockjs-client": {
           "version": "0.0.0-unreleasable",
-          "from": "git://github.com/substack/sockjs-client.git#browserify-npm",
+          "from": "sockjs-client@git://github.com/substack/sockjs-client.git#browserify-npm",
           "resolved": "git://github.com/substack/sockjs-client.git#40d48d06b4dba884416bf88a051f76ca3c8ffcae"
         }
       }
     },
     "svgo": {
       "version": "0.4.5",
-      "from": "https://registry.npmjs.org/svgo/-/svgo-0.4.5.tgz",
+      "from": "svgo@0.4.5",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.4.5.tgz",
       "dependencies": {
         "sax": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
+          "from": "sax@~0.6.0",
           "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
         },
         "coa": {
           "version": "0.4.1",
-          "from": "https://registry.npmjs.org/coa/-/coa-0.4.1.tgz",
+          "from": "coa@~0.4.0",
           "resolved": "https://registry.npmjs.org/coa/-/coa-0.4.1.tgz",
           "dependencies": {
             "q": {
               "version": "0.9.7",
-              "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+              "from": "q@~0.9.6",
               "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
             }
           }
         },
         "js-yaml": {
           "version": "2.1.3",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
+          "from": "js-yaml@~2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@~ 0.1.11",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@~1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@~2.4.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@~ 1.0.2",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@~0.6.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "whet.extend": {
           "version": "0.9.9",
-          "from": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+          "from": "whet.extend@~0.9.9",
           "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
         }
       }
@@ -17746,148 +12788,148 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@^1.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "ansi-styles@^2.1.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "escape-string-regexp@^1.0.2",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "has-ansi@^2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "strip-ansi@^3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "supports-color@^2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "date-time": {
           "version": "1.0.0",
-          "from": "date-time@>=1.0.0 <2.0.0",
+          "from": "date-time@^1.0.0",
           "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
         },
         "figures": {
           "version": "1.3.5",
-          "from": "figures@>=1.0.0 <2.0.0",
+          "from": "figures@^1.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "pretty-ms": {
           "version": "1.4.0",
-          "from": "pretty-ms@>=1.0.0 <2.0.0",
+          "from": "pretty-ms@^1.0.0",
           "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "from": "get-stdin@^4.0.1",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@>=1.0.1 <2.0.0",
+              "from": "is-finite@^1.0.1",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "dependencies": {
                 "number-is-nan": {
                   "version": "1.0.0",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "from": "number-is-nan@^1.0.0",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                 }
               }
             },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@>=3.3.0 <4.0.0",
+              "from": "meow@^3.3.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "from": "camelcase-keys@^1.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "from": "camelcase@^1.0.1",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "from": "map-obj@^1.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.2",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "from": "indent-string@^1.1.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "from": "repeating@^1.1.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
                     }
                   }
                 },
                 "minimist": {
-                  "version": "1.1.2",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                  "version": "1.1.3",
+                  "from": "minimist@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "from": "object-assign@^3.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
             },
             "parse-ms": {
               "version": "1.0.0",
-              "from": "parse-ms@>=1.0.0 <2.0.0",
+              "from": "parse-ms@^1.0.0",
               "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz"
             },
             "plur": {
               "version": "1.0.0",
-              "from": "plur@>=1.0.0 <2.0.0",
+              "from": "plur@^1.0.0",
               "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
+          "from": "text-table@^0.2.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
-  "devDependencies": {
+  "dependencies": {
     "babel": "^5.5.8",
     "btoa": "1.1.2",
     "eslint-plugin-react": "^2.7.0",
@@ -56,7 +56,7 @@
     "karma-script-launcher": "0.1.0",
     "karma-spec-reporter": "0.0.19",
     "load-grunt-config": "0.17.1",
-    "megalog": "^0.0.2",
+    "megalog": "^0.1.0",
     "mkdirp": "0.5.0",
     "moment": "2.8.3",
     "shoe": "0.0.11",

--- a/tools/clean-project
+++ b/tools/clean-project
@@ -8,7 +8,7 @@ set -o errexit
 cd `dirname $0`/..
 
 rm -rf node_modules
-npm prune
+npm prune --production
 npm cache clean
 
 echo "Done cleaning."


### PR DESCRIPTION
This is a mix of analysis work so that we can better audit where the time is spent in Team City, and an npm shrinkwrap fix.

I've split the bash script we use to package our assets and code into three smaller files, one for npm, another grunt's asset compilation, and another for sbt play packaging. We can then use Team Cit's perf tools to see how long each step is taking.

also, @sndrs has modified our npm package.json, but the packages are still being downloaded by everyone because of shrinkwrap. I am still not sure what's best regarding shrinkwrapping. I would hope a semver solves most issues, and i am looking for a way to solve a transitive dependency issue.
