### PR TITLE
Serve woff2 fonts to firefox >= 39

### DIFF
--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -241,7 +241,7 @@ define([
         var thisBrowserSupportsWoff2 = function (candidacy) {
             return _.some(browsersThatSupportWoff2, function (supportingVersion, supportingBrowser) {
                 return candidacy[1] === supportingBrowser && candidacy[2] >= supportingVersion;
-            })
+            });
         };
 
         var woff2Candidacy = /(chrome|firefox)\/([0-9]+)/.exec(ua);

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -240,7 +240,7 @@ define([
 
         var thisBrowserSupportsWoff2 = function (candidacy) {
             return _.some(browsersThatSupportWoff2, function (supportingVersion, supportingBrowser) {
-                return candidacy[1] === supportingBrowser && candidacy[2] >= supportingVersion;
+                return candidacy[1] === supportingBrowser && parseInt(candidacy[2], 10) >= supportingVersion;
             });
         };
 

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -234,7 +234,8 @@ define([
         ua = ua.toLowerCase();
 
         var browsersThatSupportWoff2 = {
-            'chrome': 36
+            'chrome': 36,
+            'firefox': 39
         };
 
         var thisBrowserSupportsWoff2 = function (candidacy) {
@@ -243,7 +244,7 @@ define([
             })
         };
 
-        var woff2Candidacy = /(chrome)\/([0-9]+)/.exec(ua);
+        var woff2Candidacy = /(chrome|firefox)\/([0-9]+)/.exec(ua);
 
         if (!!woff2Candidacy && thisBrowserSupportsWoff2(woff2Candidacy)) {
             return 'woff2';

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -232,21 +232,20 @@ define([
 
     function getFontFormatSupport(ua) {
         ua = ua.toLowerCase();
-        var browserSupportsWoff2 = false,
-            // for now only Chrome 36+ supports WOFF 2.0.
-            // Opera/Chromium also support it but their share on theguardian.com is around 0.5%
-            woff2browsers = /Chrome\/([0-9]+)/i,
-            chromeVersion;
 
-        if (woff2browsers.test(ua)) {
-            chromeVersion = parseInt(woff2browsers.exec(ua)[1], 10);
+        var browsersThatSupportWoff2 = {
+            'chrome': 36
+        };
 
-            if (chromeVersion >= 36) {
-                browserSupportsWoff2 = true;
-            }
-        }
+        var thisBrowserSupportsWoff2 = function (candidacy) {
+            return _.some(browsersThatSupportWoff2, function (supportingVersion, supportingBrowser) {
+                return candidacy[1] === supportingBrowser && candidacy[2] >= supportingVersion;
+            })
+        };
 
-        if (browserSupportsWoff2) {
+        var woff2Candidacy = /(chrome)\/([0-9]+)/.exec(ua);
+
+        if (!!woff2Candidacy && thisBrowserSupportsWoff2(woff2Candidacy)) {
             return 'woff2';
         }
 


### PR DESCRIPTION
Firefox 39 [supports woff2](https://developer.mozilla.org/en-US/Firefox/Releases/39#Miscelleanous), this adds support.

![screen shot 2015-08-13 at 12 32 03](https://cloud.githubusercontent.com/assets/867233/9248844/5549b2ce-41b7-11e5-89e5-aa350fd527bd.png)
