### PR TITLE
Tidy up team city messages

### DIFF
--- a/dist-assets-tc
+++ b/dist-assets-tc
@@ -6,10 +6,19 @@ set -o errexit
 
 echo "Asset compilation"
 
+set +x
 echo "##teamcity[progressStart 'asset validation and tests']"
+set -x
+
 ./grunt-tc validate:sass validate:js test:unit
+
+set +x
 echo "##teamcity[progressFinish 'asset validation and tests']"
 
 echo "##teamcity[progressStart 'asset dist']"
+set -x
 ./grunt-tc compile emitAbTestInfo
+
+set +x
 echo "##teamcity[progressFinish 'asset dist']"
+set -x

--- a/dist-play-tc
+++ b/dist-play-tc
@@ -6,11 +6,17 @@ set -o errexit
 
 echo "Dist play jars."
 
+set +x
 echo "##teamcity[progressStart 'sbt test and dist']"
+set -x
+
 ./sbt-tc "project root" compile test assets dist
+
+set +x
 echo "##teamcity[progressFinish 'sbt test and dist']"
 
 echo "##teamcity[progressStart 'zipping and publishing']"
+set -x
 
 rm -rf "dist"
 
@@ -43,6 +49,8 @@ do
     set -o xtrace
 done
 
+set +x
 echo "##teamcity[progressFinish 'zipping and publishing']"
+set -x
 
 echo "Done disting."


### PR DESCRIPTION
The `xtrace` option was printing each bash command, which was confusing teamcity's messaging system.
