### PR TITLE
Make sure npm is installed for pull request builds

### DIFF
--- a/test-root-tc
+++ b/test-root-tc
@@ -3,8 +3,9 @@
 set -o nounset
 set -o errexit
 
+./dist-npm-tc
 
-./grunt-tc install clean validate test:unit compile
+./grunt-tc validate test:unit compile
 ./sbt-tc "project root" test
 
 echo "Tested everything."


### PR DESCRIPTION
@sndrs fixes an issue where npm modules may not be installed at all. I prefer `dist-npm-tc` because using grunt to perform an npm install is a bit silly.
