### PR TITLE
Update grunt-svgmin -> svgo to 0.5.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,160 +4,160 @@
   "dependencies": {
     "babel": {
       "version": "5.8.21",
-      "from": "babel@^5.5.8",
+      "from": "babel@>=5.5.8 <6.0.0",
       "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.21.tgz",
       "dependencies": {
         "babel-core": {
           "version": "5.8.22",
-          "from": "babel-core@^5.6.21",
+          "from": "babel-core@>=5.6.21 <6.0.0",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.22.tgz",
           "dependencies": {
             "babel-plugin-constant-folding": {
               "version": "1.0.1",
-              "from": "babel-plugin-constant-folding@^1.0.1",
+              "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
             },
             "babel-plugin-dead-code-elimination": {
               "version": "1.0.2",
-              "from": "babel-plugin-dead-code-elimination@^1.0.2",
+              "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
             },
             "babel-plugin-eval": {
               "version": "1.0.1",
-              "from": "babel-plugin-eval@^1.0.1",
+              "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
             },
             "babel-plugin-inline-environment-variables": {
               "version": "1.0.1",
-              "from": "babel-plugin-inline-environment-variables@^1.0.1",
+              "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
             },
             "babel-plugin-jscript": {
               "version": "1.0.4",
-              "from": "babel-plugin-jscript@^1.0.4",
+              "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
             },
             "babel-plugin-member-expression-literals": {
               "version": "1.0.1",
-              "from": "babel-plugin-member-expression-literals@^1.0.1",
+              "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
             },
             "babel-plugin-property-literals": {
               "version": "1.0.1",
-              "from": "babel-plugin-property-literals@^1.0.1",
+              "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
             },
             "babel-plugin-proto-to-assign": {
               "version": "1.0.4",
-              "from": "babel-plugin-proto-to-assign@^1.0.3",
+              "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
             },
             "babel-plugin-react-constant-elements": {
               "version": "1.0.3",
-              "from": "babel-plugin-react-constant-elements@^1.0.3",
+              "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
             },
             "babel-plugin-react-display-name": {
               "version": "1.0.3",
-              "from": "babel-plugin-react-display-name@^1.0.3",
+              "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
             },
             "babel-plugin-remove-console": {
               "version": "1.0.1",
-              "from": "babel-plugin-remove-console@^1.0.1",
+              "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
             },
             "babel-plugin-remove-debugger": {
               "version": "1.0.1",
-              "from": "babel-plugin-remove-debugger@^1.0.1",
+              "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
             },
             "babel-plugin-runtime": {
               "version": "1.0.7",
-              "from": "babel-plugin-runtime@^1.0.7",
+              "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
             },
             "babel-plugin-undeclared-variables-check": {
               "version": "1.0.2",
-              "from": "babel-plugin-undeclared-variables-check@^1.0.2",
+              "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
               "dependencies": {
                 "leven": {
                   "version": "1.0.2",
-                  "from": "leven@^1.0.2",
+                  "from": "leven@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
                 }
               }
             },
             "babel-plugin-undefined-to-void": {
               "version": "1.1.6",
-              "from": "babel-plugin-undefined-to-void@^1.1.6",
+              "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
             },
             "babylon": {
               "version": "5.8.22",
-              "from": "babylon@^5.8.22",
+              "from": "babylon@>=5.8.22 <6.0.0",
               "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.22.tgz"
             },
             "bluebird": {
               "version": "2.9.34",
-              "from": "bluebird@^2.9.33",
+              "from": "bluebird@>=2.9.33 <3.0.0",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
             },
             "chalk": {
               "version": "1.1.0",
-              "from": "chalk@^1.0.0",
+              "from": "chalk@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "core-js": {
               "version": "1.0.1",
-              "from": "core-js@^1.0.0",
+              "from": "core-js@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.0.1.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@^2.1.1",
+              "from": "debug@>=2.1.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
@@ -169,83 +169,83 @@
             },
             "detect-indent": {
               "version": "3.0.1",
-              "from": "detect-indent@^3.0.0",
+              "from": "detect-indent@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "minimist": {
                   "version": "1.1.3",
-                  "from": "minimist@^1.1.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 }
               }
             },
             "esutils": {
               "version": "2.0.2",
-              "from": "esutils@^2.0.0",
+              "from": "esutils@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "globals": {
               "version": "6.4.1",
-              "from": "globals@^6.4.0",
+              "from": "globals@>=6.4.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
             },
             "home-or-tmp": {
               "version": "1.0.0",
-              "from": "home-or-tmp@^1.0.0",
+              "from": "home-or-tmp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
               "dependencies": {
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@^1.0.1",
+                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 },
                 "user-home": {
                   "version": "1.1.1",
-                  "from": "user-home@^1.1.1",
+                  "from": "user-home@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                 }
               }
             },
             "is-integer": {
               "version": "1.0.4",
-              "from": "is-integer@^1.0.4",
+              "from": "is-integer@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@^1.0.0",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@^1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "is-nan": {
                   "version": "1.1.0",
-                  "from": "is-nan@^1.0.1",
+                  "from": "is-nan@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.1.0.tgz",
                   "dependencies": {
                     "define-properties": {
                       "version": "1.1.1",
-                      "from": "define-properties@^1.0.2",
+                      "from": "define-properties@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.1.tgz",
                       "dependencies": {
                         "foreach": {
                           "version": "2.0.5",
-                          "from": "foreach@^2.0.5",
+                          "from": "foreach@>=2.0.5 <3.0.0",
                           "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
                         },
                         "object-keys": {
                           "version": "1.0.7",
-                          "from": "object-keys@^1.0.7",
+                          "from": "object-keys@>=1.0.7 <2.0.0",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.7.tgz"
                         }
                       }
@@ -261,7 +261,7 @@
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@^0.4.0",
+              "from": "json5@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             },
             "line-numbers": {
@@ -278,17 +278,17 @@
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@^2.0.3",
+              "from": "minimatch@>=2.0.3 <3.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -302,7 +302,7 @@
             },
             "private": {
               "version": "0.1.6",
-              "from": "private@^0.1.6",
+              "from": "private@>=0.1.6 <0.2.0",
               "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
             },
             "regenerator": {
@@ -312,71 +312,71 @@
               "dependencies": {
                 "commoner": {
                   "version": "0.10.3",
-                  "from": "commoner@~0.10.0",
+                  "from": "commoner@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
                   "dependencies": {
                     "q": {
                       "version": "1.1.2",
-                      "from": "q@~1.1.2",
+                      "from": "q@>=1.1.2 <1.2.0",
                       "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
                     },
                     "commander": {
                       "version": "2.5.1",
-                      "from": "commander@~2.5.0",
+                      "from": "commander@>=2.5.0 <2.6.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
                     },
                     "graceful-fs": {
                       "version": "3.0.8",
-                      "from": "graceful-fs@~3.0.4",
+                      "from": "graceful-fs@>=3.0.4 <3.1.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                     },
                     "glob": {
                       "version": "4.2.2",
-                      "from": "glob@~4.2.1",
+                      "from": "glob@>=4.2.1 <4.3.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "inflight@^1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@2",
+                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "minimatch": {
                           "version": "1.0.0",
-                          "from": "minimatch@^1.0.0",
+                          "from": "minimatch@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.6.5",
-                              "from": "lru-cache@2",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.1",
-                              "from": "sigmund@~1.0.0",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                             }
                           }
                         },
                         "once": {
                           "version": "1.3.2",
-                          "from": "once@^1.3.0",
+                          "from": "once@>=1.3.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -385,84 +385,79 @@
                     },
                     "install": {
                       "version": "0.1.8",
-                      "from": "install@~0.1.7",
+                      "from": "install@>=0.1.7 <0.2.0",
                       "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
                     },
                     "iconv-lite": {
                       "version": "0.4.11",
-                      "from": "iconv-lite@~0.4.5",
+                      "from": "iconv-lite@>=0.4.5 <0.5.0",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
                     }
                   }
                 },
                 "defs": {
                   "version": "1.1.0",
-                  "from": "defs@~1.1.0",
+                  "from": "defs@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.0.tgz",
                   "dependencies": {
                     "alter": {
                       "version": "0.2.0",
-                      "from": "alter@~0.2.0",
+                      "from": "alter@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                       "dependencies": {
                         "stable": {
                           "version": "0.1.5",
-                          "from": "stable@~0.1.3",
+                          "from": "stable@>=0.1.3 <0.2.0",
                           "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
                         }
                       }
                     },
                     "ast-traverse": {
                       "version": "0.1.1",
-                      "from": "ast-traverse@~0.1.1",
+                      "from": "ast-traverse@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
                     },
                     "breakable": {
                       "version": "1.0.0",
-                      "from": "breakable@~1.0.0",
+                      "from": "breakable@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
                     },
                     "esprima-fb": {
                       "version": "8001.1001.0-dev-harmony-fb",
-                      "from": "esprima-fb@~8001.1001.0-dev-harmony-fb",
+                      "from": "esprima-fb@>=8001.1001.0-dev-harmony-fb <8001.1002.0",
                       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
                     },
                     "simple-fmt": {
                       "version": "0.1.0",
-                      "from": "simple-fmt@~0.1.0",
+                      "from": "simple-fmt@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
                     },
                     "simple-is": {
                       "version": "0.2.0",
-                      "from": "simple-is@~0.2.0",
+                      "from": "simple-is@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
                     },
                     "stringmap": {
                       "version": "0.2.2",
-                      "from": "stringmap@~0.2.2",
+                      "from": "stringmap@>=0.2.2 <0.3.0",
                       "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
                     },
                     "stringset": {
                       "version": "0.2.1",
-                      "from": "stringset@~0.2.1",
+                      "from": "stringset@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
                     },
                     "tryor": {
                       "version": "0.1.2",
-                      "from": "tryor@~0.1.2",
+                      "from": "tryor@>=0.1.2 <0.2.0",
                       "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
                     },
                     "yargs": {
                       "version": "1.3.3",
-                      "from": "yargs@~1.3.2",
+                      "from": "yargs@>=1.3.2 <1.4.0",
                       "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
                     }
                   }
-                },
-                "esprima-fb": {
-                  "version": "15001.1.0-dev-harmony-fb",
-                  "from": "esprima-fb@~15001.1.0-dev-harmony-fb",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
                 },
                 "recast": {
                   "version": "0.10.24",
@@ -478,21 +473,26 @@
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@~2.3.6",
+                  "from": "through@>=2.3.6 <2.4.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "regexpu": {
               "version": "1.2.0",
-              "from": "regexpu@^1.1.2",
+              "from": "regexpu@>=1.1.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
               "dependencies": {
                 "recast": {
                   "version": "0.10.28",
-                  "from": "recast@^0.10.6",
+                  "from": "recast@>=0.10.6 <0.11.0",
                   "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.28.tgz",
                   "dependencies": {
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                    },
                     "ast-types": {
                       "version": "0.8.8",
                       "from": "ast-types@0.8.8",
@@ -502,22 +502,22 @@
                 },
                 "regenerate": {
                   "version": "1.2.1",
-                  "from": "regenerate@^1.2.1",
+                  "from": "regenerate@>=1.2.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
                 },
                 "regjsgen": {
                   "version": "0.2.0",
-                  "from": "regjsgen@^0.2.0",
+                  "from": "regjsgen@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
                 },
                 "regjsparser": {
                   "version": "0.1.4",
-                  "from": "regjsparser@^0.1.4",
+                  "from": "regjsparser@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.4.tgz",
                   "dependencies": {
                     "jsesc": {
                       "version": "0.5.0",
-                      "from": "jsesc@~0.5.0",
+                      "from": "jsesc@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
                     }
                   }
@@ -526,17 +526,17 @@
             },
             "repeating": {
               "version": "1.1.3",
-              "from": "repeating@^1.1.2",
+              "from": "repeating@>=1.1.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@^1.0.0",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@^1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -545,17 +545,17 @@
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@^1.1.6",
+              "from": "resolve@>=1.1.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "shebang-regex": {
               "version": "1.0.0",
-              "from": "shebang-regex@^1.0.0",
+              "from": "shebang-regex@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "source-map-support@^0.2.10",
+              "from": "source-map-support@>=0.2.10 <0.3.0",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
@@ -574,86 +574,86 @@
             },
             "to-fast-properties": {
               "version": "1.0.1",
-              "from": "to-fast-properties@^1.0.0",
+              "from": "to-fast-properties@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
             },
             "trim-right": {
               "version": "1.0.1",
-              "from": "trim-right@^1.0.0",
+              "from": "trim-right@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
             },
             "try-resolve": {
               "version": "1.0.1",
-              "from": "try-resolve@^1.0.0",
+              "from": "try-resolve@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
             }
           }
         },
         "chokidar": {
           "version": "1.0.5",
-          "from": "chokidar@^1.0.0",
+          "from": "chokidar@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@^1.1.0",
+              "from": "anymatch@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
                   "version": "2.2.0",
-                  "from": "micromatch@^2.1.5",
+                  "from": "micromatch@>=2.1.5 <3.0.0",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "arr-diff@^1.0.1",
+                      "from": "arr-diff@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
                           "version": "0.2.3",
-                          "from": "array-slice@^0.2.2",
+                          "from": "array-slice@>=0.2.2 <0.3.0",
                           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
-                      "from": "array-unique@^0.2.1",
+                      "from": "array-unique@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "braces@^1.8.0",
+                      "from": "braces@>=1.8.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@^1.8.1",
+                          "from": "expand-range@>=1.8.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.2",
-                              "from": "fill-range@^2.1.0",
+                              "from": "fill-range@>=2.1.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "is-number@^1.1.2",
+                                  "from": "is-number@>=1.1.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
                                   "version": "1.0.2",
-                                  "from": "isobject@^1.0.0",
+                                  "from": "isobject@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "randomatic@^1.1.0",
+                                  "from": "randomatic@>=1.1.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@^1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -662,36 +662,36 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@^0.2.0",
+                          "from": "preserve@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "repeat-element@^1.1.0",
+                          "from": "repeat-element@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.3",
-                      "from": "expand-brackets@^0.1.1",
+                      "from": "expand-brackets@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
                       "dependencies": {
                         "is-posix-bracket": {
                           "version": "0.1.0",
-                          "from": "is-posix-bracket@^0.1.0",
+                          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz"
                         }
                       }
                     },
                     "extglob": {
                       "version": "0.3.1",
-                      "from": "extglob@^0.3.0",
+                      "from": "extglob@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
                       "dependencies": {
                         "ansi-green": {
                           "version": "0.1.1",
-                          "from": "ansi-green@^0.1.1",
+                          "from": "ansi-green@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
                           "dependencies": {
                             "ansi-wrap": {
@@ -703,85 +703,85 @@
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@^1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "success-symbol": {
                           "version": "0.1.0",
-                          "from": "success-symbol@^0.1.0",
+                          "from": "success-symbol@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
                         }
                       }
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@^2.0.0",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "kind-of@^1.1.0",
+                      "from": "kind-of@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "1.1.0",
-                      "from": "object.omit@^1.1.0",
+                      "from": "object.omit@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@^0.1.3",
+                          "from": "for-own@>=0.1.3 <0.2.0",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@^0.1.4",
+                              "from": "for-in@>=0.1.4 <0.2.0",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "1.0.2",
-                          "from": "isobject@^1.0.0",
+                          "from": "isobject@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.2",
-                      "from": "parse-glob@^3.0.1",
+                      "from": "parse-glob@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "glob-base@^0.2.0",
+                          "from": "glob-base@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.1",
-                          "from": "is-dotfile@^1.0.0",
+                          "from": "is-dotfile@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@^1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "regex-cache@^0.4.2",
+                      "from": "regex-cache@>=0.4.2 <0.5.0",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "is-equal-shallow@^0.1.1",
+                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "is-primitive@^2.0.0",
+                          "from": "is-primitive@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -792,71 +792,71 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "arrify@^1.0.0",
+              "from": "arrify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@^0.1.5",
+              "from": "async-each@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "glob-parent@^1.0.0",
+              "from": "glob-parent@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@^1.0.0",
+              "from": "is-binary-path@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.3.1",
-                  "from": "binary-extensions@^1.0.0",
+                  "from": "binary-extensions@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "is-glob@^1.1.3",
+              "from": "is-glob@>=1.1.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
             },
             "readdirp": {
               "version": "1.4.0",
-              "from": "readdirp@^1.3.0",
+              "from": "readdirp@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "graceful-fs@~4.1.2",
+                  "from": "graceful-fs@>=4.1.2 <4.2.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@~0.2.12",
+                  "from": "minimatch@>=0.2.12 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.5",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26-2",
+                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -866,12 +866,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -880,12 +880,12 @@
             },
             "fsevents": {
               "version": "0.3.8",
-              "from": "fsevents@^0.3.1",
+              "from": "fsevents@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
               "dependencies": {
                 "nan": {
                   "version": "2.0.5",
-                  "from": "nan@^2.0.2",
+                  "from": "nan@>=2.0.2 <3.0.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
                 }
               }
@@ -894,61 +894,61 @@
         },
         "commander": {
           "version": "2.8.1",
-          "from": "commander@^2.6.0",
+          "from": "commander@>=2.6.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "dependencies": {
             "graceful-readlink": {
               "version": "1.0.1",
-              "from": "graceful-readlink@>= 1.0.0",
+              "from": "graceful-readlink@>=1.0.0",
               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "convert-source-map": {
           "version": "1.1.1",
-          "from": "convert-source-map@^1.1.0",
+          "from": "convert-source-map@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
         },
         "fs-readdir-recursive": {
           "version": "0.1.2",
-          "from": "fs-readdir-recursive@^0.1.0",
+          "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
         },
         "glob": {
           "version": "5.0.14",
-          "from": "glob@5.x",
+          "from": "glob@>=5.0.5 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@^2.0.1",
+              "from": "minimatch@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -962,12 +962,12 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@^1.3.0",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -976,17 +976,17 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@^3.2.0",
+          "from": "lodash@>=3.2.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "output-file-sync": {
           "version": "1.1.1",
-          "from": "output-file-sync@^1.1.0",
+          "from": "output-file-sync@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@^0.5.1",
+              "from": "mkdirp@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
@@ -998,24 +998,24 @@
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@^4.0.0",
+              "from": "xtend@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "path-exists": {
           "version": "1.0.0",
-          "from": "path-exists@^1.0.0",
+          "from": "path-exists@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@^1.0.0",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@^0.4.0",
+          "from": "source-map@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
@@ -1027,7 +1027,7 @@
         },
         "slash": {
           "version": "1.0.0",
-          "from": "slash@^1.0.0",
+          "from": "slash@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
         }
       }
@@ -1039,73 +1039,73 @@
     },
     "eslint": {
       "version": "1.1.0",
-      "from": "eslint@>=0.8.0 || ~1.0.0-rc-0",
+      "from": "eslint@>=0.8.0||>=1.0.0-rc-0 <1.1.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.1.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@^1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "concat-stream": {
           "version": "1.5.0",
-          "from": "concat-stream@^1.4.6",
+          "from": "concat-stream@>=1.4.6 <2.0.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "typedarray": {
               "version": "0.0.6",
-              "from": "typedarray@~0.0.5",
+              "from": "typedarray@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
             },
             "readable-stream": {
               "version": "2.0.2",
-              "from": "readable-stream@^2.0.0",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -1115,17 +1115,17 @@
                 },
                 "process-nextick-args": {
                   "version": "1.0.2",
-                  "from": "process-nextick-args@~1.0.0",
+                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.1",
-                  "from": "util-deprecate@~1.0.1",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                 }
               }
@@ -1134,7 +1134,7 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@^2.1.1",
+          "from": "debug@>=2.1.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
@@ -1146,12 +1146,12 @@
         },
         "doctrine": {
           "version": "0.6.4",
-          "from": "doctrine@^0.6.2",
+          "from": "doctrine@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
           "dependencies": {
             "esutils": {
               "version": "1.1.6",
-              "from": "esutils@^1.1.6",
+              "from": "esutils@>=1.1.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
             },
             "isarray": {
@@ -1163,152 +1163,152 @@
         },
         "escape-string-regexp": {
           "version": "1.0.3",
-          "from": "escape-string-regexp@^1.0.2",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
         },
         "escope": {
           "version": "3.2.0",
-          "from": "escope@^3.2.0",
+          "from": "escope@>=3.2.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
           "dependencies": {
             "es6-map": {
               "version": "0.1.1",
-              "from": "es6-map@^0.1.1",
+              "from": "es6-map@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "d@~0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.7",
-                  "from": "es5-ext@~0.10.4",
+                  "from": "es5-ext@>=0.10.4 <0.11.0",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@~2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "es6-iterator@~0.1.1",
+                  "from": "es6-iterator@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@~2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "es6-set": {
                   "version": "0.1.1",
-                  "from": "es6-set@~0.1.1",
+                  "from": "es6-set@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
                 },
                 "es6-symbol": {
                   "version": "0.1.1",
-                  "from": "es6-symbol@~0.1.1",
+                  "from": "es6-symbol@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                 },
                 "event-emitter": {
                   "version": "0.3.3",
-                  "from": "event-emitter@~0.3.1",
+                  "from": "event-emitter@>=0.3.1 <0.4.0",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                 }
               }
             },
             "es6-weak-map": {
               "version": "0.1.4",
-              "from": "es6-weak-map@^0.1.2",
+              "from": "es6-weak-map@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
               "dependencies": {
                 "d": {
                   "version": "0.1.1",
-                  "from": "d@~0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.7",
-                  "from": "es5-ext@~0.10.6",
+                  "from": "es5-ext@>=0.10.6 <0.11.0",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
                 },
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "es6-iterator@~0.1.3",
+                  "from": "es6-iterator@>=0.1.3 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                 },
                 "es6-symbol": {
                   "version": "2.0.1",
-                  "from": "es6-symbol@~2.0.1",
+                  "from": "es6-symbol@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                 }
               }
             },
             "esrecurse": {
               "version": "3.1.1",
-              "from": "esrecurse@^3.1.1",
+              "from": "esrecurse@>=3.1.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
             },
             "estraverse": {
               "version": "3.1.0",
-              "from": "estraverse@^3.1.0",
+              "from": "estraverse@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
             }
           }
         },
         "espree": {
-          "version": "2.2.3",
-          "from": "espree@^2.2.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.3.tgz"
+          "version": "2.2.4",
+          "from": "espree@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.4.tgz"
         },
         "estraverse": {
           "version": "4.1.0",
-          "from": "estraverse@^4.1.0",
+          "from": "estraverse@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
         },
         "estraverse-fb": {
           "version": "1.3.1",
-          "from": "estraverse-fb@^1.3.1",
+          "from": "estraverse-fb@>=1.3.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
         },
         "globals": {
           "version": "8.3.0",
-          "from": "globals@^8.3.0",
+          "from": "globals@>=8.3.0 <9.0.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-8.3.0.tgz"
         },
         "inquirer": {
           "version": "0.9.0",
-          "from": "inquirer@^0.9.0",
+          "from": "inquirer@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
           "dependencies": {
             "ansi-regex": {
               "version": "2.0.0",
-              "from": "ansi-regex@^2.0.0",
+              "from": "ansi-regex@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             },
             "cli-width": {
               "version": "1.0.1",
-              "from": "cli-width@^1.0.1",
+              "from": "cli-width@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
             },
             "figures": {
               "version": "1.3.5",
-              "from": "figures@^1.3.5",
+              "from": "figures@>=1.3.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@^3.3.1",
+              "from": "lodash@>=3.3.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "readline2": {
               "version": "0.1.1",
-              "from": "readline2@^0.1.1",
+              "from": "readline2@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
               "dependencies": {
                 "mute-stream": {
@@ -1318,12 +1318,12 @@
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@^2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.0.0",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -1332,17 +1332,17 @@
             },
             "run-async": {
               "version": "0.1.0",
-              "from": "run-async@^0.1.0",
+              "from": "run-async@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@^1.3.0",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -1351,139 +1351,139 @@
             },
             "rx-lite": {
               "version": "2.5.2",
-              "from": "rx-lite@^2.5.2",
+              "from": "rx-lite@>=2.5.2 <3.0.0",
               "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz"
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@^2.3.6",
+              "from": "through@>=2.3.6 <3.0.0",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "is-my-json-valid": {
           "version": "2.12.1",
-          "from": "is-my-json-valid@^2.10.0",
+          "from": "is-my-json-valid@>=2.10.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
           "dependencies": {
             "generate-function": {
               "version": "2.0.0",
-              "from": "generate-function@^2.0.0",
+              "from": "generate-function@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
             },
             "generate-object-property": {
               "version": "1.2.0",
-              "from": "generate-object-property@^1.1.0",
+              "from": "generate-object-property@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
               "dependencies": {
                 "is-property": {
                   "version": "1.0.2",
-                  "from": "is-property@^1.0.0",
+                  "from": "is-property@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                 }
               }
             },
             "jsonpointer": {
               "version": "1.1.0",
-              "from": "jsonpointer@^1.1.0",
+              "from": "jsonpointer@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@^4.0.0",
+              "from": "xtend@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "js-yaml": {
           "version": "3.3.1",
-          "from": "js-yaml@^3.2.5",
+          "from": "js-yaml@>=3.2.5 <4.0.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.2",
-              "from": "argparse@~1.0.2",
+              "from": "argparse@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>= 3.2.0 < 4.0.0",
+                  "from": "lodash@>=3.2.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "sprintf-js@~1.0.2",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.2.0",
-              "from": "esprima@~2.2.0",
+              "from": "esprima@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
             }
           }
         },
         "lodash.clonedeep": {
           "version": "3.0.2",
-          "from": "lodash.clonedeep@^3.0.1",
+          "from": "lodash.clonedeep@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
           "dependencies": {
             "lodash._baseclone": {
               "version": "3.3.0",
-              "from": "lodash._baseclone@^3.0.0",
+              "from": "lodash._baseclone@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
                   "version": "3.0.0",
-                  "from": "lodash._arraycopy@^3.0.0",
+                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
                 },
                 "lodash._arrayeach": {
                   "version": "3.0.0",
-                  "from": "lodash._arrayeach@^3.0.0",
+                  "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
                 },
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "lodash._baseassign@^3.0.0",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "lodash._basecopy@^3.0.0",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     }
                   }
                 },
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "from": "lodash._basefor@^3.0.0",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@^3.0.0",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 },
                 "lodash.keys": {
                   "version": "3.1.2",
-                  "from": "lodash.keys@^3.0.0",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "lodash._getnative@^3.0.0",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
                       "version": "3.0.4",
-                      "from": "lodash.isarguments@^3.0.0",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     }
                   }
@@ -1492,98 +1492,98 @@
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "from": "lodash._bindcallback@^3.0.0",
+              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             }
           }
         },
         "lodash.merge": {
           "version": "3.3.2",
-          "from": "lodash.merge@^3.3.2",
+          "from": "lodash.merge@>=3.3.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
           "dependencies": {
             "lodash._arraycopy": {
               "version": "3.0.0",
-              "from": "lodash._arraycopy@^3.0.0",
+              "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
             },
             "lodash._arrayeach": {
               "version": "3.0.0",
-              "from": "lodash._arrayeach@^3.0.0",
+              "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
             },
             "lodash._createassigner": {
               "version": "3.1.1",
-              "from": "lodash._createassigner@^3.0.0",
+              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "dependencies": {
                 "lodash._bindcallback": {
                   "version": "3.0.1",
-                  "from": "lodash._bindcallback@^3.0.0",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                 },
                 "lodash._isiterateecall": {
                   "version": "3.0.9",
-                  "from": "lodash._isiterateecall@^3.0.0",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                 },
                 "lodash.restparam": {
                   "version": "3.6.1",
-                  "from": "lodash.restparam@^3.0.0",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                 }
               }
             },
             "lodash._getnative": {
               "version": "3.9.1",
-              "from": "lodash._getnative@^3.0.0",
+              "from": "lodash._getnative@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
             },
             "lodash.isarguments": {
               "version": "3.0.4",
-              "from": "lodash.isarguments@^3.0.0",
+              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
             },
             "lodash.isarray": {
               "version": "3.0.4",
-              "from": "lodash.isarray@^3.0.0",
+              "from": "lodash.isarray@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
             },
             "lodash.isplainobject": {
               "version": "3.2.0",
-              "from": "lodash.isplainobject@^3.0.0",
+              "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "from": "lodash._basefor@^3.0.0",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
                 }
               }
             },
             "lodash.istypedarray": {
               "version": "3.0.2",
-              "from": "lodash.istypedarray@^3.0.0",
+              "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@^3.0.0",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
             },
             "lodash.keysin": {
               "version": "3.0.8",
-              "from": "lodash.keysin@^3.0.0",
+              "from": "lodash.keysin@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
             },
             "lodash.toplainobject": {
               "version": "3.0.0",
-              "from": "lodash.toplainobject@^3.0.0",
+              "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
               "dependencies": {
                 "lodash._basecopy": {
                   "version": "3.0.1",
-                  "from": "lodash._basecopy@^3.0.0",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                 }
               }
@@ -1592,37 +1592,37 @@
         },
         "lodash.omit": {
           "version": "3.1.0",
-          "from": "lodash.omit@^3.1.0",
+          "from": "lodash.omit@>=3.1.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
           "dependencies": {
             "lodash._arraymap": {
               "version": "3.0.0",
-              "from": "lodash._arraymap@^3.0.0",
+              "from": "lodash._arraymap@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
             },
             "lodash._basedifference": {
               "version": "3.0.3",
-              "from": "lodash._basedifference@^3.0.0",
+              "from": "lodash._basedifference@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
               "dependencies": {
                 "lodash._baseindexof": {
                   "version": "3.1.0",
-                  "from": "lodash._baseindexof@^3.0.0",
+                  "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
                 },
                 "lodash._cacheindexof": {
                   "version": "3.0.2",
-                  "from": "lodash._cacheindexof@^3.0.0",
+                  "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
                 },
                 "lodash._createcache": {
                   "version": "3.1.2",
-                  "from": "lodash._createcache@^3.0.0",
+                  "from": "lodash._createcache@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "lodash._getnative@^3.0.0",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     }
                   }
@@ -1631,80 +1631,80 @@
             },
             "lodash._baseflatten": {
               "version": "3.1.4",
-              "from": "lodash._baseflatten@^3.0.0",
+              "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
               "dependencies": {
                 "lodash.isarguments": {
                   "version": "3.0.4",
-                  "from": "lodash.isarguments@^3.0.0",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@^3.0.0",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
             "lodash._bindcallback": {
               "version": "3.0.1",
-              "from": "lodash._bindcallback@^3.0.0",
+              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
             },
             "lodash._pickbyarray": {
               "version": "3.0.2",
-              "from": "lodash._pickbyarray@^3.0.0",
+              "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
             },
             "lodash._pickbycallback": {
               "version": "3.0.0",
-              "from": "lodash._pickbycallback@^3.0.0",
+              "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
                   "version": "3.0.2",
-                  "from": "lodash._basefor@^3.0.0",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
                 }
               }
             },
             "lodash.keysin": {
               "version": "3.0.8",
-              "from": "lodash.keysin@^3.0.0",
+              "from": "lodash.keysin@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
               "dependencies": {
                 "lodash.isarguments": {
                   "version": "3.0.4",
-                  "from": "lodash.isarguments@^3.0.0",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@^3.0.0",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "lodash.restparam@^3.0.0",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             }
           }
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@^2.0.1",
+          "from": "minimatch@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
-              "from": "brace-expansion@^1.0.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "balanced-match@^0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
@@ -1718,81 +1718,81 @@
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@^2.0.0",
+          "from": "object-assign@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         },
         "optionator": {
           "version": "0.5.0",
-          "from": "optionator@^0.5.0",
+          "from": "optionator@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
           "dependencies": {
             "prelude-ls": {
               "version": "1.1.2",
-              "from": "prelude-ls@~1.1.1",
+              "from": "prelude-ls@>=1.1.1 <1.2.0",
               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
             },
             "deep-is": {
               "version": "0.1.3",
-              "from": "deep-is@~0.1.2",
+              "from": "deep-is@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             },
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@~0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "type-check": {
               "version": "0.3.1",
-              "from": "type-check@~0.3.1",
+              "from": "type-check@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
             },
             "levn": {
               "version": "0.2.5",
-              "from": "levn@~0.2.5",
+              "from": "levn@>=0.2.5 <0.3.0",
               "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
             },
             "fast-levenshtein": {
-              "version": "1.0.6",
-              "from": "fast-levenshtein@~1.0.0",
-              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+              "version": "1.0.7",
+              "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@^1.0.0",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "path-is-inside": {
           "version": "1.0.1",
-          "from": "path-is-inside@^1.0.1",
+          "from": "path-is-inside@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.4",
-          "from": "strip-json-comments@~1.0.1",
+          "from": "strip-json-comments@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@~0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         },
         "user-home": {
           "version": "1.1.1",
-          "from": "user-home@^1.0.0",
+          "from": "user-home@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
         },
         "xml-escape": {
           "version": "1.0.0",
-          "from": "xml-escape@~1.0.0",
+          "from": "xml-escape@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
         }
       }
     },
     "eslint-plugin-react": {
       "version": "2.7.1",
-      "from": "eslint-plugin-react@^2.7.0",
+      "from": "eslint-plugin-react@>=2.7.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-2.7.1.tgz"
     },
     "esprima": {
@@ -1801,9 +1801,9 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
     },
     "esprima-fb": {
-      "version": "15001.1001.0-dev-harmony-fb",
-      "from": "esprima-fb@^15001.1.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+      "version": "15001.1.0-dev-harmony-fb",
+      "from": "esprima-fb@15001.1.0-dev-harmony-fb",
+      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
     },
     "glob": {
       "version": "4.0.6",
@@ -1812,39 +1812,39 @@
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "graceful-fs@^3.0.2",
+          "from": "graceful-fs@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@~2.0.1",
+          "from": "inherits@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "minimatch@^1.0.0",
+          "from": "minimatch@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "once": {
           "version": "1.3.2",
-          "from": "once@^1.3.0",
+          "from": "once@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@1",
+              "from": "wrappy@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
@@ -1858,17 +1858,17 @@
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
@@ -1878,37 +1878,37 @@
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@~0.4.13",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@~0.1.2",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@~3.2.9",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@0.3",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.5",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -1917,149 +1917,149 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@~3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2.12",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@~1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "abbrev@1",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.8",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "which@~1.0.5",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@~2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@~1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@~0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.2",
-          "from": "grunt-legacy-log@~0.1.0",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "dependencies": {
             "grunt-legacy-log-utils": {
               "version": "0.1.1",
-              "from": "grunt-legacy-log-utils@^0.1.1",
+              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@~2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -2078,12 +2078,12 @@
       "dependencies": {
         "prettysize": {
           "version": "0.0.3",
-          "from": "prettysize@~0.0.2",
+          "from": "prettysize@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz"
         },
         "aws-sdk": {
           "version": "2.0.31",
-          "from": "aws-sdk@~2.0.0-rc4",
+          "from": "aws-sdk@>=2.0.0-rc4 <2.1.0",
           "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
           "dependencies": {
             "xml2js": {
@@ -2107,17 +2107,17 @@
         },
         "css-parse": {
           "version": "2.0.0",
-          "from": "css-parse@~2.0.0",
+          "from": "css-parse@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
           "dependencies": {
             "css": {
               "version": "2.2.1",
-              "from": "css@^2.0.0",
+              "from": "css@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@^0.1.38",
+                  "from": "source-map@>=0.1.38 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -2129,34 +2129,34 @@
                 },
                 "source-map-resolve": {
                   "version": "0.3.1",
-                  "from": "source-map-resolve@^0.3.0",
+                  "from": "source-map-resolve@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
                   "dependencies": {
                     "source-map-url": {
                       "version": "0.3.0",
-                      "from": "source-map-url@~0.3.0",
+                      "from": "source-map-url@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
                     },
                     "atob": {
                       "version": "1.1.2",
-                      "from": "atob@~1.1.0",
+                      "from": "atob@>=1.1.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.2.tgz"
                     },
                     "resolve-url": {
                       "version": "0.2.1",
-                      "from": "resolve-url@~0.2.1",
+                      "from": "resolve-url@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
                     }
                   }
                 },
                 "urix": {
                   "version": "0.1.0",
-                  "from": "urix@^0.1.0",
+                  "from": "urix@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.0",
+                  "from": "inherits@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -2165,107 +2165,107 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "grunt-autoprefixer": {
       "version": "3.0.3",
-      "from": "grunt-autoprefixer@^3.0.0",
+      "from": "grunt-autoprefixer@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.3.tgz",
       "dependencies": {
         "autoprefixer-core": {
           "version": "5.2.1",
-          "from": "autoprefixer-core@^5.1.7",
+          "from": "autoprefixer-core@>=5.1.7 <6.0.0",
           "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
           "dependencies": {
             "browserslist": {
               "version": "0.4.0",
-              "from": "browserslist@~0.4.0",
+              "from": "browserslist@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
             },
             "num2fraction": {
               "version": "1.1.0",
-              "from": "num2fraction@^1.1.0",
+              "from": "num2fraction@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz"
             },
             "caniuse-db": {
               "version": "1.0.30000265",
-              "from": "caniuse-db@^1.0.30000214",
+              "from": "caniuse-db@>=1.0.30000214 <2.0.0",
               "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000265.tgz"
             }
           }
         },
         "chalk": {
           "version": "1.0.0",
-          "from": "chalk@~1.0.0",
+          "from": "chalk@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "has-ansi@^1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@^1.1.0",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@^2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@^1.1.0",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "supports-color@^1.3.0",
+              "from": "supports-color@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
         },
         "diff": {
           "version": "1.3.2",
-          "from": "diff@~1.3.0",
+          "from": "diff@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz"
         },
         "postcss": {
           "version": "4.1.16",
-          "from": "postcss@^4.1.11",
+          "from": "postcss@>=4.1.11 <5.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
           "dependencies": {
             "es6-promise": {
               "version": "2.3.0",
-              "from": "es6-promise@~2.3.0",
+              "from": "es6-promise@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@~0.4.2",
+              "from": "source-map@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
@@ -2277,7 +2277,7 @@
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@~2.1.8",
+              "from": "js-base64@>=2.1.8 <2.2.0",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
@@ -2291,7 +2291,7 @@
       "dependencies": {
         "bytesize": {
           "version": "0.2.0",
-          "from": "bytesize@~0.2.0",
+          "from": "bytesize@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/bytesize/-/bytesize-0.2.0.tgz",
           "dependencies": {
             "humanize": {
@@ -2310,17 +2310,17 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@^0.9.0",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "pad-stdio": {
           "version": "1.0.0",
-          "from": "pad-stdio@^1.0.0",
+          "from": "pad-stdio@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/pad-stdio/-/pad-stdio-1.0.0.tgz",
           "dependencies": {
             "lpad": {
               "version": "1.0.0",
-              "from": "lpad@^1.0.0",
+              "from": "lpad@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/lpad/-/lpad-1.0.0.tgz"
             }
           }
@@ -2334,7 +2334,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.1",
+          "from": "rimraf@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
@@ -2346,46 +2346,46 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -2399,7 +2399,7 @@
       "dependencies": {
         "requirejs": {
           "version": "2.1.20",
-          "from": "requirejs@~2.1",
+          "from": "requirejs@>=2.1.0 <2.2.0",
           "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz"
         }
       }
@@ -2411,93 +2411,93 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@^1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@^3.8.0",
+          "from": "lodash@>=3.8.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "maxmin": {
           "version": "1.1.0",
-          "from": "maxmin@^1.0.0",
+          "from": "maxmin@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
           "dependencies": {
             "figures": {
               "version": "1.3.5",
-              "from": "figures@^1.0.1",
+              "from": "figures@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
             },
             "gzip-size": {
               "version": "1.0.0",
-              "from": "gzip-size@^1.0.0",
+              "from": "gzip-size@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.0",
-                  "from": "concat-stream@^1.4.1",
+                  "from": "concat-stream@>=1.4.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@~0.0.5",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.2",
-                      "from": "readable-stream@~2.0.0",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -2507,17 +2507,17 @@
                         },
                         "process-nextick-args": {
                           "version": "1.0.2",
-                          "from": "process-nextick-args@~1.0.0",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "util-deprecate@~1.0.1",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
@@ -2526,12 +2526,12 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "browserify-zlib@^0.1.4",
+                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
                       "version": "0.2.7",
-                      "from": "pako@~0.2.0",
+                      "from": "pako@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
                     }
                   }
@@ -2540,54 +2540,54 @@
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "pretty-bytes@^1.0.0",
+              "from": "pretty-bytes@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "meow@^3.1.0",
+                  "from": "meow@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@^1.0.0",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@^1.0.1",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@^1.0.0",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.2",
-                      "from": "indent-string@^1.1.0",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@^1.1.0",
+                          "from": "repeating@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@^1.0.0",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@^1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -2598,12 +2598,12 @@
                     },
                     "minimist": {
                       "version": "1.1.3",
-                      "from": "minimist@^1.1.0",
+                      "from": "minimist@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                     },
                     "object-assign": {
                       "version": "3.0.0",
-                      "from": "object-assign@^3.0.0",
+                      "from": "object-assign@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                     }
                   }
@@ -2614,12 +2614,12 @@
         },
         "uglify-js": {
           "version": "2.4.24",
-          "from": "uglify-js@^2.4.19",
+          "from": "uglify-js@>=2.4.19 <3.0.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.6",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
@@ -2636,22 +2636,22 @@
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@~1.0.0",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.5.4",
-              "from": "yargs@~3.5.4",
+              "from": "yargs@>=3.5.4 <3.6.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@^1.0.2",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "decamelize@^1.0.0",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "window-size": {
@@ -2682,49 +2682,49 @@
       "dependencies": {
         "gaze": {
           "version": "0.5.1",
-          "from": "gaze@~0.5.1",
+          "from": "gaze@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "globule@~0.1.0",
+              "from": "globule@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "1.0.2",
-                  "from": "lodash@~1.0.1",
+                  "from": "lodash@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "glob@~3.1.21",
+                  "from": "glob@>=3.1.21 <3.2.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
                       "version": "1.2.3",
-                      "from": "graceful-fs@~1.2.0",
+                      "from": "graceful-fs@>=1.2.0 <1.3.0",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                     },
                     "inherits": {
                       "version": "1.0.0",
-                      "from": "inherits@1",
+                      "from": "inherits@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@~0.2.11",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.5",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -2740,27 +2740,27 @@
           "dependencies": {
             "qs": {
               "version": "0.5.6",
-              "from": "qs@~0.5.2",
+              "from": "qs@>=0.5.2 <0.6.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
             },
             "faye-websocket": {
               "version": "0.4.4",
-              "from": "faye-websocket@~0.4.3",
+              "from": "faye-websocket@>=0.4.3 <0.5.0",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
             },
             "noptify": {
               "version": "0.0.3",
-              "from": "noptify@~0.0.3",
+              "from": "noptify@>=0.0.3 <0.1.0",
               "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "2.0.0",
-                  "from": "nopt@~2.0.0",
+                  "from": "nopt@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@1",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
@@ -2769,19 +2769,19 @@
             },
             "debug": {
               "version": "0.7.4",
-              "from": "debug@~0.7.0",
+              "from": "debug@>=0.7.0 <0.8.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9",
+          "from": "async@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }
@@ -2793,7 +2793,7 @@
       "dependencies": {
         "socket.io": {
           "version": "1.0.6",
-          "from": "socket.io@~1.0.4",
+          "from": "socket.io@>=1.0.4 <1.1.0",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.0.6.tgz",
           "dependencies": {
             "engine.io": {
@@ -2813,17 +2813,17 @@
                   "dependencies": {
                     "commander": {
                       "version": "0.6.1",
-                      "from": "commander@~0.6.1",
+                      "from": "commander@>=0.6.1 <0.7.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                     },
                     "nan": {
                       "version": "0.3.2",
-                      "from": "nan@~0.3.0",
+                      "from": "nan@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "tinycolor@0.x",
+                      "from": "tinycolor@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
@@ -2930,17 +2930,17 @@
                       "dependencies": {
                         "commander": {
                           "version": "0.6.1",
-                          "from": "commander@~0.6.1",
+                          "from": "commander@>=0.6.1 <0.7.0",
                           "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
                         },
                         "nan": {
                           "version": "0.3.2",
-                          "from": "nan@~0.3.0",
+                          "from": "nan@>=0.3.0 <0.4.0",
                           "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
                         },
                         "tinycolor": {
                           "version": "0.0.1",
-                          "from": "tinycolor@0.x",
+                          "from": "tinycolor@>=0.0.0 <1.0.0",
                           "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                         },
                         "options": {
@@ -2994,7 +2994,7 @@
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@~1.0.0",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
@@ -3013,7 +3013,7 @@
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@~1.0.0",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
@@ -3059,7 +3059,7 @@
                   "dependencies": {
                     "better-assert": {
                       "version": "1.0.2",
-                      "from": "better-assert@~1.0.0",
+                      "from": "better-assert@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "dependencies": {
                         "callsite": {
@@ -3135,27 +3135,27 @@
         },
         "win-spawn": {
           "version": "2.0.0",
-          "from": "win-spawn@~2.0.0",
+          "from": "win-spawn@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
         },
         "ua-parser-js": {
           "version": "0.7.9",
-          "from": "ua-parser-js@~0.7.0",
+          "from": "ua-parser-js@>=0.7.0 <0.8.0",
           "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.9.tgz"
         },
         "express": {
           "version": "4.4.5",
-          "from": "express@~4.4.4",
+          "from": "express@>=4.4.4 <4.5.0",
           "resolved": "https://registry.npmjs.org/express/-/express-4.4.5.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.0.7",
-              "from": "accepts@~1.0.5",
+              "from": "accepts@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "1.0.2",
-                  "from": "mime-types@~1.0.0",
+                  "from": "mime-types@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "negotiator": {
@@ -3299,22 +3299,22 @@
         },
         "weinre": {
           "version": "2.0.0-pre-I0Z7U9OV",
-          "from": "weinre@~2.0.0-pre-HH0SN197",
+          "from": "weinre@>=2.0.0-pre-HH0SN197 <2.1.0",
           "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
           "dependencies": {
             "express": {
               "version": "2.5.11",
-              "from": "express@2.5.x",
+              "from": "express@>=2.5.0 <2.6.0",
               "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
               "dependencies": {
                 "connect": {
                   "version": "1.9.2",
-                  "from": "connect@1.x",
+                  "from": "connect@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
                   "dependencies": {
                     "formidable": {
                       "version": "1.0.17",
-                      "from": "formidable@1.0.x",
+                      "from": "formidable@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
                     }
                   }
@@ -3326,7 +3326,7 @@
                 },
                 "qs": {
                   "version": "0.4.2",
-                  "from": "qs@0.4.x",
+                  "from": "qs@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
                 },
                 "mkdirp": {
@@ -3338,26 +3338,26 @@
             },
             "nopt": {
               "version": "3.0.3",
-              "from": "nopt@3.0.x",
+              "from": "nopt@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@1",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "underscore": {
               "version": "1.7.0",
-              "from": "underscore@1.7.x",
+              "from": "underscore@>=1.7.0 <1.8.0",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
             }
           }
         },
         "array.prototype.findindex": {
           "version": "0.1.1",
-          "from": "array.prototype.findindex@~0.1.1",
+          "from": "array.prototype.findindex@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-0.1.1.tgz"
         }
       }
@@ -3374,124 +3374,124 @@
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@~0.2.11",
+              "from": "minimatch@>=0.2.11 <0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.5",
-                  "from": "lru-cache@2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@~1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1.2.0",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "css-parse": {
           "version": "1.4.0",
-          "from": "css-parse@~1.4.0",
+          "from": "css-parse@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.4.0.tgz"
         },
         "humanize": {
           "version": "0.0.9",
-          "from": "humanize@~0.0.7",
+          "from": "humanize@>=0.0.7 <0.1.0",
           "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz"
         }
       }
     },
     "grunt-eslint": {
       "version": "15.0.0",
-      "from": "grunt-eslint@^15.0.0",
+      "from": "grunt-eslint@>=15.0.0 <16.0.0",
       "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-15.0.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@^1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "eslint": {
           "version": "0.23.0",
-          "from": "eslint@^0.23.0",
+          "from": "eslint@>=0.23.0 <0.24.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-0.23.0.tgz",
           "dependencies": {
             "concat-stream": {
               "version": "1.5.0",
-              "from": "concat-stream@^1.4.6",
+              "from": "concat-stream@>=1.4.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "typedarray@~0.0.5",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.2",
-                  "from": "readable-stream@~2.0.0",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -3501,17 +3501,17 @@
                     },
                     "process-nextick-args": {
                       "version": "1.0.2",
-                      "from": "process-nextick-args@~1.0.0",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.1",
-                      "from": "util-deprecate@~1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
@@ -3520,7 +3520,7 @@
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@^2.1.1",
+              "from": "debug@>=2.1.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
@@ -3532,12 +3532,12 @@
             },
             "doctrine": {
               "version": "0.6.4",
-              "from": "doctrine@^0.6.2",
+              "from": "doctrine@>=0.6.2 <0.7.0",
               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.6.4.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "1.1.6",
-                  "from": "esutils@^1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                 },
                 "isarray": {
@@ -3549,152 +3549,152 @@
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "escope": {
               "version": "3.2.0",
-              "from": "escope@^3.1.0",
+              "from": "escope@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
               "dependencies": {
                 "es6-map": {
                   "version": "0.1.1",
-                  "from": "es6-map@^0.1.1",
+                  "from": "es6-map@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "d@~0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "es5-ext@~0.10.4",
+                      "from": "es5-ext@>=0.10.4 <0.11.0",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                       "dependencies": {
                         "es6-symbol": {
                           "version": "2.0.1",
-                          "from": "es6-symbol@~2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                         }
                       }
                     },
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "es6-iterator@~0.1.1",
+                      "from": "es6-iterator@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                       "dependencies": {
                         "es6-symbol": {
                           "version": "2.0.1",
-                          "from": "es6-symbol@~2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                         }
                       }
                     },
                     "es6-set": {
                       "version": "0.1.1",
-                      "from": "es6-set@~0.1.1",
+                      "from": "es6-set@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
                     },
                     "es6-symbol": {
                       "version": "0.1.1",
-                      "from": "es6-symbol@~0.1.1",
+                      "from": "es6-symbol@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                     },
                     "event-emitter": {
                       "version": "0.3.3",
-                      "from": "event-emitter@~0.3.1",
+                      "from": "event-emitter@>=0.3.1 <0.4.0",
                       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                     }
                   }
                 },
                 "es6-weak-map": {
                   "version": "0.1.4",
-                  "from": "es6-weak-map@^0.1.2",
+                  "from": "es6-weak-map@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "d@~0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "es5-ext@~0.10.6",
+                      "from": "es5-ext@>=0.10.4 <0.11.0",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
                     },
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "es6-iterator@~0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                     },
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@~2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "esrecurse": {
                   "version": "3.1.1",
-                  "from": "esrecurse@^3.1.1",
+                  "from": "esrecurse@>=3.1.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
                 },
                 "estraverse": {
                   "version": "3.1.0",
-                  "from": "estraverse@^3.1.0",
+                  "from": "estraverse@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
                 }
               }
             },
             "espree": {
-              "version": "2.2.3",
-              "from": "espree@^2.0.1",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.3.tgz"
+              "version": "2.2.4",
+              "from": "espree@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.4.tgz"
             },
             "estraverse": {
               "version": "2.0.0",
-              "from": "estraverse@^2.0.0",
+              "from": "estraverse@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-2.0.0.tgz"
             },
             "estraverse-fb": {
               "version": "1.3.1",
-              "from": "estraverse-fb@^1.3.1",
+              "from": "estraverse-fb@>=1.3.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "globals": {
               "version": "8.3.0",
-              "from": "globals@^8.0.0",
+              "from": "globals@>=8.0.0 <9.0.0",
               "resolved": "https://registry.npmjs.org/globals/-/globals-8.3.0.tgz"
             },
             "inquirer": {
               "version": "0.8.5",
-              "from": "inquirer@^0.8.2",
+              "from": "inquirer@>=0.8.2 <0.9.0",
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@^1.1.1",
+                  "from": "ansi-regex@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "cli-width": {
                   "version": "1.0.1",
-                  "from": "cli-width@^1.0.1",
+                  "from": "cli-width@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
                 },
                 "figures": {
                   "version": "1.3.5",
-                  "from": "figures@^1.3.5",
+                  "from": "figures@>=1.3.5 <2.0.0",
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>= 3.2.0 < 4.0.0",
+                  "from": "lodash@>=3.3.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "readline2@^0.1.1",
+                  "from": "readline2@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "mute-stream": {
@@ -3704,99 +3704,99 @@
                     },
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "strip-ansi@^2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
                     }
                   }
                 },
                 "rx": {
                   "version": "2.5.3",
-                  "from": "rx@^2.4.3",
+                  "from": "rx@>=2.2.27 <3.0.0",
                   "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@^2.3.6",
+                  "from": "through@>=2.3.6 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.12.1",
-              "from": "is-my-json-valid@^2.10.0",
+              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "generate-function@^2.0.0",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "generate-object-property@^1.1.0",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "is-property@^1.0.0",
+                      "from": "is-property@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "1.1.0",
-                  "from": "jsonpointer@^1.1.0",
+                  "from": "jsonpointer@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "xtend@^4.0.0",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
             },
             "js-yaml": {
               "version": "3.3.1",
-              "from": "js-yaml@^3.2.5",
+              "from": "js-yaml@>=3.2.5 <4.0.0",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "argparse@~1.0.2",
+                  "from": "argparse@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>= 3.2.0 < 4.0.0",
+                      "from": "lodash@>=3.2.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "sprintf-js@~1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.2.0",
-                  "from": "esprima@~2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@^2.0.1",
+              "from": "minimatch@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -3810,69 +3810,69 @@
             },
             "object-assign": {
               "version": "2.1.1",
-              "from": "object-assign@^2.0.0",
+              "from": "object-assign@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "optionator": {
               "version": "0.5.0",
-              "from": "optionator@^0.5.0",
+              "from": "optionator@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
                 "prelude-ls": {
                   "version": "1.1.2",
-                  "from": "prelude-ls@~1.1.1",
+                  "from": "prelude-ls@>=1.1.1 <1.2.0",
                   "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                 },
                 "deep-is": {
                   "version": "0.1.3",
-                  "from": "deep-is@~0.1.2",
+                  "from": "deep-is@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "wordwrap@~0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 },
                 "type-check": {
                   "version": "0.3.1",
-                  "from": "type-check@~0.3.1",
+                  "from": "type-check@>=0.3.1 <0.4.0",
                   "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                 },
                 "levn": {
                   "version": "0.2.5",
-                  "from": "levn@~0.2.5",
+                  "from": "levn@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                 },
                 "fast-levenshtein": {
-                  "version": "1.0.6",
-                  "from": "fast-levenshtein@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                  "version": "1.0.7",
+                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@^1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "strip-json-comments@~1.0.1",
+              "from": "strip-json-comments@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "text-table": {
               "version": "0.2.0",
-              "from": "text-table@~0.2.0",
+              "from": "text-table@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@^1.0.0",
+              "from": "user-home@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             },
             "xml-escape": {
               "version": "1.0.0",
-              "from": "xml-escape@~1.0.0",
+              "from": "xml-escape@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
             }
           }
@@ -3881,12 +3881,12 @@
     },
     "grunt-frequency-graph": {
       "version": "0.1.6",
-      "from": "grunt-frequency-graph@^0.1.6",
+      "from": "grunt-frequency-graph@>=0.1.6 <0.2.0",
       "resolved": "https://registry.npmjs.org/grunt-frequency-graph/-/grunt-frequency-graph-0.1.6.tgz",
       "dependencies": {
         "asset-frequency-graph": {
           "version": "0.3.1",
-          "from": "asset-frequency-graph@^0.3.0",
+          "from": "asset-frequency-graph@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/asset-frequency-graph/-/asset-frequency-graph-0.3.1.tgz",
           "dependencies": {
             "async": {
@@ -3901,7 +3901,7 @@
               "dependencies": {
                 "shelljs": {
                   "version": "0.3.0",
-                  "from": "shelljs@~0.3.0",
+                  "from": "shelljs@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
                 }
               }
@@ -3913,34 +3913,34 @@
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@^2.0.1",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -3954,12 +3954,12 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@^1.3.0",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -3968,32 +3968,32 @@
             },
             "gzip-size": {
               "version": "1.0.0",
-              "from": "gzip-size@^1.0.0",
+              "from": "gzip-size@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.0",
-                  "from": "concat-stream@^1.4.1",
+                  "from": "concat-stream@>=1.4.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "typedarray@~0.0.5",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.2",
-                      "from": "readable-stream@~2.0.0",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -4003,17 +4003,17 @@
                         },
                         "process-nextick-args": {
                           "version": "1.0.2",
-                          "from": "process-nextick-args@~1.0.0",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "util-deprecate@~1.0.1",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
@@ -4022,12 +4022,12 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "browserify-zlib@^0.1.4",
+                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
                       "version": "0.2.7",
-                      "from": "pako@~0.2.0",
+                      "from": "pako@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
                     }
                   }
@@ -4103,7 +4103,7 @@
                           "dependencies": {
                             "esprima-fb": {
                               "version": "8001.1001.0-dev-harmony-fb",
-                              "from": "esprima-fb@~8001.1001.0-dev-harmony-fb",
+                              "from": "esprima-fb@>=8001.1001.0-dev-harmony-fb <8001.1002.0",
                               "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
                             },
                             "source-map": {
@@ -4217,7 +4217,7 @@
                         },
                         "esprima-fb": {
                           "version": "8001.1001.0-dev-harmony-fb",
-                          "from": "esprima-fb@~8001.1001.0-dev-harmony-fb",
+                          "from": "esprima-fb@>=8001.1001.0-dev-harmony-fb <8001.1002.0",
                           "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
                         },
                         "source-map": {
@@ -4255,59 +4255,59 @@
             },
             "moment": {
               "version": "2.10.6",
-              "from": "moment@^2.9.0",
+              "from": "moment@>=2.9.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "pretty-bytes@^1.0.2",
+              "from": "pretty-bytes@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "meow@^3.1.0",
+                  "from": "meow@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@^1.0.0",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@^1.0.1",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@^1.0.0",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.2",
-                      "from": "indent-string@^1.1.0",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@^1.1.0",
+                          "from": "repeating@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@^1.0.0",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@^1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -4318,12 +4318,12 @@
                     },
                     "minimist": {
                       "version": "1.1.3",
-                      "from": "minimist@^1.1.0",
+                      "from": "minimist@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                     },
                     "object-assign": {
                       "version": "3.0.0",
-                      "from": "object-assign@^3.0.0",
+                      "from": "object-assign@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                     }
                   }
@@ -4337,12 +4337,12 @@
             },
             "uglify-js": {
               "version": "2.4.24",
-              "from": "uglify-js@^2.4.16",
+              "from": "uglify-js@>=2.4.16 <3.0.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@~0.2.6",
+                  "from": "async@>=0.2.6 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
@@ -4359,22 +4359,22 @@
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@~1.0.0",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.5.4",
-                  "from": "yargs@~3.5.4",
+                  "from": "yargs@>=3.5.4 <3.6.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@^1.0.2",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "decamelize": {
                       "version": "1.0.0",
-                      "from": "decamelize@^1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                     },
                     "window-size": {
@@ -4394,9 +4394,9 @@
           }
         },
         "aws-sdk": {
-          "version": "2.1.44",
-          "from": "aws-sdk@^2.1.8",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.44.tgz",
+          "version": "2.1.45",
+          "from": "aws-sdk@>=2.1.8 <3.0.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.45.tgz",
           "dependencies": {
             "sax": {
               "version": "0.5.3",
@@ -4417,7 +4417,7 @@
         },
         "es6-promise": {
           "version": "2.3.0",
-          "from": "es6-promise@^2.0.1",
+          "from": "es6-promise@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
         }
       }
@@ -4429,12 +4429,12 @@
       "dependencies": {
         "which": {
           "version": "1.0.9",
-          "from": "which@~1.0.5",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "win-spawn": {
           "version": "2.0.0",
-          "from": "win-spawn@~2.0.0",
+          "from": "win-spawn@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
         }
       }
@@ -4446,68 +4446,68 @@
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jscs": {
           "version": "1.13.1",
-          "from": "jscs@~1.13.0",
+          "from": "jscs@>=1.13.0 <1.14.0",
           "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.0.0",
-              "from": "chalk@~1.0.0",
+              "from": "chalk@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@^2.0.1",
+                  "from": "ansi-styles@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "1.0.3",
-                  "from": "has-ansi@^1.0.3",
+                  "from": "has-ansi@>=1.0.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     },
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "get-stdin@^4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@^2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "1.3.1",
-                  "from": "supports-color@^1.3.0",
+                  "from": "supports-color@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                 }
               }
             },
             "cli-table": {
               "version": "0.3.1",
-              "from": "cli-table@~0.3.1",
+              "from": "cli-table@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
               "dependencies": {
                 "colors": {
@@ -4519,12 +4519,12 @@
             },
             "commander": {
               "version": "2.6.0",
-              "from": "commander@~2.6.0",
+              "from": "commander@>=2.6.0 <2.7.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "esprima": {
               "version": "1.2.5",
-              "from": "esprima@^1.2.5",
+              "from": "esprima@>=1.2.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "esprima-harmony-jscs": {
@@ -4534,88 +4534,88 @@
             },
             "estraverse": {
               "version": "1.9.3",
-              "from": "estraverse@^1.9.3",
+              "from": "estraverse@>=1.9.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@~0.1.2",
+              "from": "exit@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "glob": {
               "version": "5.0.14",
-              "from": "glob@^5.0.1",
+              "from": "glob@>=5.0.1 <6.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@^1.3.0",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@^1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "lodash.assign": {
               "version": "3.0.0",
-              "from": "lodash.assign@~3.0.0",
+              "from": "lodash.assign@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "lodash._baseassign@^3.0.0",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "lodash._basecopy@^3.0.0",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     },
                     "lodash.keys": {
                       "version": "3.1.2",
-                      "from": "lodash.keys@^3.0.0",
+                      "from": "lodash.keys@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "dependencies": {
                         "lodash._getnative": {
                           "version": "3.9.1",
-                          "from": "lodash._getnative@^3.0.0",
+                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                         },
                         "lodash.isarguments": {
                           "version": "3.0.4",
-                          "from": "lodash.isarguments@^3.0.0",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.4",
-                          "from": "lodash.isarray@^3.0.0",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                         }
                       }
@@ -4624,22 +4624,22 @@
                 },
                 "lodash._createassigner": {
                   "version": "3.1.1",
-                  "from": "lodash._createassigner@^3.0.0",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
                       "version": "3.0.1",
-                      "from": "lodash._bindcallback@^3.0.0",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "lodash._isiterateecall@^3.0.0",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     },
                     "lodash.restparam": {
                       "version": "3.6.1",
-                      "from": "lodash.restparam@^3.0.0",
+                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                     }
                   }
@@ -4648,17 +4648,17 @@
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@^2.0.1",
+              "from": "minimatch@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@^1.0.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "balanced-match@^0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
@@ -4672,44 +4672,44 @@
             },
             "pathval": {
               "version": "0.1.1",
-              "from": "pathval@~0.1.1",
+              "from": "pathval@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
             },
             "prompt": {
               "version": "0.2.14",
-              "from": "prompt@~0.2.14",
+              "from": "prompt@>=0.2.14 <0.3.0",
               "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "dependencies": {
                 "pkginfo": {
                   "version": "0.3.0",
-                  "from": "pkginfo@0.x.x",
+                  "from": "pkginfo@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
                 },
                 "read": {
                   "version": "1.0.6",
-                  "from": "read@1.0.x",
+                  "from": "read@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.5",
-                      "from": "mute-stream@~0.0.4",
+                      "from": "mute-stream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "revalidator": {
                   "version": "0.1.8",
-                  "from": "revalidator@0.1.x",
+                  "from": "revalidator@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
                 },
                 "utile": {
                   "version": "0.2.1",
-                  "from": "utile@0.2.x",
+                  "from": "utile@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@~0.2.9",
+                      "from": "async@>=0.2.9 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "deep-equal": {
@@ -4719,54 +4719,54 @@
                     },
                     "i": {
                       "version": "0.3.3",
-                      "from": "i@0.3.x",
+                      "from": "i@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                     },
                     "ncp": {
                       "version": "0.4.2",
-                      "from": "ncp@0.4.x",
+                      "from": "ncp@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                     },
                     "rimraf": {
                       "version": "2.4.2",
-                      "from": "rimraf@2.x.x",
+                      "from": "rimraf@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz"
                     }
                   }
                 },
                 "winston": {
                   "version": "0.8.3",
-                  "from": "winston@0.8.x",
+                  "from": "winston@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@0.2.x",
+                      "from": "async@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "colors": {
                       "version": "0.6.2",
-                      "from": "colors@0.6.x",
+                      "from": "colors@>=0.6.0 <0.7.0",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
                     },
                     "cycle": {
                       "version": "1.0.3",
-                      "from": "cycle@1.0.x",
+                      "from": "cycle@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                     },
                     "eyes": {
                       "version": "0.1.8",
-                      "from": "eyes@0.1.x",
+                      "from": "eyes@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                     },
                     "isstream": {
                       "version": "0.1.2",
-                      "from": "isstream@0.1.x",
+                      "from": "isstream@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "stack-trace": {
                       "version": "0.0.9",
-                      "from": "stack-trace@0.0.x",
+                      "from": "stack-trace@>=0.0.0 <0.1.0",
                       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                     }
                   }
@@ -4775,54 +4775,54 @@
             },
             "strip-json-comments": {
               "version": "1.0.4",
-              "from": "strip-json-comments@~1.0.2",
+              "from": "strip-json-comments@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
             },
             "vow-fs": {
               "version": "0.3.4",
-              "from": "vow-fs@~0.3.4",
+              "from": "vow-fs@>=0.3.4 <0.4.0",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@^1.4.2",
+                  "from": "node-uuid@>=1.4.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "vow-queue": {
                   "version": "0.4.2",
-                  "from": "vow-queue@^0.4.1",
+                  "from": "vow-queue@>=0.4.1 <0.5.0",
                   "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@^4.3.1",
+                  "from": "glob@>=4.3.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@^1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@^1.3.0",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -4833,12 +4833,12 @@
             },
             "xmlbuilder": {
               "version": "2.6.4",
-              "from": "xmlbuilder@^2.6.1",
+              "from": "xmlbuilder@>=2.6.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@^3.5.0",
+                  "from": "lodash@>=3.5.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 }
               }
@@ -4847,12 +4847,12 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "vow": {
           "version": "0.4.10",
-          "from": "vow@~0.4.1",
+          "from": "vow@>=0.4.1 <0.5.0",
           "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.10.tgz"
         }
       }
@@ -4864,7 +4864,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
@@ -4881,51 +4881,51 @@
       "dependencies": {
         "psi": {
           "version": "0.1.6",
-          "from": "psi@^0.1.1",
+          "from": "psi@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/psi/-/psi-0.1.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@^0.5.1",
+              "from": "chalk@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@^1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.0",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@^0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@^0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@^0.2.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@^0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
@@ -4937,69 +4937,69 @@
               "dependencies": {
                 "googleapis": {
                   "version": "1.1.5",
-                  "from": "googleapis@^1.0.2",
+                  "from": "googleapis@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-1.1.5.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@~0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "gapitoken": {
                       "version": "0.1.5",
-                      "from": "gapitoken@~0.1.2",
+                      "from": "gapitoken@>=0.1.2 <0.2.0",
                       "resolved": "https://registry.npmjs.org/gapitoken/-/gapitoken-0.1.5.tgz",
                       "dependencies": {
                         "jws": {
                           "version": "3.0.0",
-                          "from": "jws@~3.0.0",
+                          "from": "jws@>=3.0.0 <3.1.0",
                           "resolved": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
                           "dependencies": {
                             "jwa": {
                               "version": "1.0.2",
-                              "from": "jwa@~1.0.0",
+                              "from": "jwa@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
                               "dependencies": {
                                 "base64url": {
                                   "version": "0.0.6",
-                                  "from": "base64url@~0.0.4",
+                                  "from": "base64url@>=0.0.4 <0.1.0",
                                   "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
                                 },
                                 "buffer-equal-constant-time": {
                                   "version": "1.0.1",
-                                  "from": "buffer-equal-constant-time@^1.0.1",
+                                  "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
                                 },
                                 "ecdsa-sig-formatter": {
                                   "version": "1.0.2",
-                                  "from": "ecdsa-sig-formatter@^1.0.0",
+                                  "from": "ecdsa-sig-formatter@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
                                   "dependencies": {
                                     "asn1.js": {
                                       "version": "2.2.0",
-                                      "from": "asn1.js@^2.0.3",
+                                      "from": "asn1.js@>=2.0.3 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz",
                                       "dependencies": {
                                         "bn.js": {
                                           "version": "2.2.0",
-                                          "from": "bn.js@^2.0.0",
+                                          "from": "bn.js@>=2.0.0 <3.0.0",
                                           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
                                         },
                                         "inherits": {
                                           "version": "2.0.1",
-                                          "from": "inherits@^2.0.1",
+                                          "from": "inherits@>=2.0.1 <3.0.0",
                                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                         },
                                         "minimalistic-assert": {
                                           "version": "1.0.0",
-                                          "from": "minimalistic-assert@^1.0.0",
+                                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                                         }
                                       }
                                     },
                                     "base64-url": {
                                       "version": "1.2.1",
-                                      "from": "base64-url@^1.2.1",
+                                      "from": "base64-url@>=1.2.1 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                                     }
                                   }
@@ -5008,32 +5008,32 @@
                             },
                             "base64url": {
                               "version": "1.0.4",
-                              "from": "base64url@~1.0.4",
+                              "from": "base64url@>=1.0.4 <1.1.0",
                               "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
                               "dependencies": {
                                 "concat-stream": {
                                   "version": "1.4.10",
-                                  "from": "concat-stream@~1.4.7",
+                                  "from": "concat-stream@>=1.4.7 <1.5.0",
                                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                                   "dependencies": {
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@~2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "typedarray": {
                                       "version": "0.0.6",
-                                      "from": "typedarray@~0.0.5",
+                                      "from": "typedarray@>=0.0.5 <0.1.0",
                                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                                     },
                                     "readable-stream": {
                                       "version": "1.1.13",
-                                      "from": "readable-stream@~1.1.9",
+                                      "from": "readable-stream@>=1.1.9 <1.2.0",
                                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                                       "dependencies": {
                                         "core-util-is": {
                                           "version": "1.0.1",
-                                          "from": "core-util-is@~1.0.0",
+                                          "from": "core-util-is@>=1.0.0 <1.1.0",
                                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                         },
                                         "isarray": {
@@ -5043,7 +5043,7 @@
                                         },
                                         "string_decoder": {
                                           "version": "0.10.31",
-                                          "from": "string_decoder@~0.10.x",
+                                          "from": "string_decoder@>=0.10.0 <0.11.0",
                                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                         }
                                       }
@@ -5052,49 +5052,49 @@
                                 },
                                 "meow": {
                                   "version": "2.0.0",
-                                  "from": "meow@~2.0.0",
+                                  "from": "meow@>=2.0.0 <2.1.0",
                                   "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
                                   "dependencies": {
                                     "camelcase-keys": {
                                       "version": "1.0.0",
-                                      "from": "camelcase-keys@^1.0.0",
+                                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                                       "dependencies": {
                                         "camelcase": {
                                           "version": "1.2.1",
-                                          "from": "camelcase@^1.0.1",
+                                          "from": "camelcase@>=1.0.1 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                                         },
                                         "map-obj": {
                                           "version": "1.0.1",
-                                          "from": "map-obj@^1.0.0",
+                                          "from": "map-obj@>=1.0.0 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                                         }
                                       }
                                     },
                                     "indent-string": {
                                       "version": "1.2.2",
-                                      "from": "indent-string@^1.1.0",
+                                      "from": "indent-string@>=1.1.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                                       "dependencies": {
                                         "get-stdin": {
                                           "version": "4.0.1",
-                                          "from": "get-stdin@^4.0.1",
+                                          "from": "get-stdin@>=4.0.1 <5.0.0",
                                           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                                         },
                                         "repeating": {
                                           "version": "1.1.3",
-                                          "from": "repeating@^1.1.0",
+                                          "from": "repeating@>=1.1.0 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                                           "dependencies": {
                                             "is-finite": {
                                               "version": "1.0.1",
-                                              "from": "is-finite@^1.0.0",
+                                              "from": "is-finite@>=1.0.0 <2.0.0",
                                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                               "dependencies": {
                                                 "number-is-nan": {
                                                   "version": "1.0.0",
-                                                  "from": "number-is-nan@^1.0.0",
+                                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                                 }
                                               }
@@ -5105,12 +5105,12 @@
                                     },
                                     "minimist": {
                                       "version": "1.1.3",
-                                      "from": "minimist@^1.1.0",
+                                      "from": "minimist@>=1.1.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                                     },
                                     "object-assign": {
                                       "version": "1.0.0",
-                                      "from": "object-assign@^1.0.0",
+                                      "from": "object-assign@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
                                     }
                                   }
@@ -5121,27 +5121,27 @@
                         },
                         "request": {
                           "version": "2.60.0",
-                          "from": "request@^2.54.0",
+                          "from": "request@>=2.54.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
                           "dependencies": {
                             "bl": {
                               "version": "1.0.0",
-                              "from": "bl@~1.0.0",
+                              "from": "bl@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
                               "dependencies": {
                                 "readable-stream": {
                                   "version": "2.0.2",
-                                  "from": "readable-stream@~2.0.0",
+                                  "from": "readable-stream@>=2.0.0 <2.1.0",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "core-util-is@~1.0.0",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@~2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
@@ -5151,17 +5151,17 @@
                                     },
                                     "process-nextick-args": {
                                       "version": "1.0.2",
-                                      "from": "process-nextick-args@~1.0.0",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "string_decoder@~0.10.x",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.1",
-                                      "from": "util-deprecate@~1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                                     }
                                   }
@@ -5170,61 +5170,61 @@
                             },
                             "caseless": {
                               "version": "0.11.0",
-                              "from": "caseless@~0.11.0",
+                              "from": "caseless@>=0.11.0 <0.12.0",
                               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                             },
                             "extend": {
                               "version": "3.0.0",
-                              "from": "extend@~3.0.0",
+                              "from": "extend@>=3.0.0 <3.1.0",
                               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                             },
                             "forever-agent": {
                               "version": "0.6.1",
-                              "from": "forever-agent@~0.6.0",
+                              "from": "forever-agent@>=0.6.0 <0.7.0",
                               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                             },
                             "form-data": {
                               "version": "1.0.0-rc3",
-                              "from": "form-data@~1.0.0-rc1",
+                              "from": "form-data@>=1.0.0-rc1 <1.1.0",
                               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
                               "dependencies": {
                                 "async": {
                                   "version": "1.4.2",
-                                  "from": "async@^1.4.0",
+                                  "from": "async@>=1.4.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                                 }
                               }
                             },
                             "json-stringify-safe": {
                               "version": "5.0.1",
-                              "from": "json-stringify-safe@~5.0.0",
+                              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                             },
                             "mime-types": {
                               "version": "2.1.4",
-                              "from": "mime-types@~2.1.2",
+                              "from": "mime-types@>=2.1.2 <2.2.0",
                               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
                               "dependencies": {
                                 "mime-db": {
                                   "version": "1.16.0",
-                                  "from": "mime-db@~1.16.0",
+                                  "from": "mime-db@>=1.16.0 <1.17.0",
                                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
                                 }
                               }
                             },
                             "node-uuid": {
                               "version": "1.4.3",
-                              "from": "node-uuid@~1.4.0",
+                              "from": "node-uuid@>=1.4.0 <1.5.0",
                               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                             },
                             "qs": {
                               "version": "4.0.0",
-                              "from": "qs@~4.0.0",
+                              "from": "qs@>=4.0.0 <4.1.0",
                               "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
                             },
                             "tunnel-agent": {
                               "version": "0.4.1",
-                              "from": "tunnel-agent@~0.4.0",
+                              "from": "tunnel-agent@>=0.4.0 <0.5.0",
                               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                             },
                             "tough-cookie": {
@@ -5234,12 +5234,12 @@
                             },
                             "http-signature": {
                               "version": "0.11.0",
-                              "from": "http-signature@~0.11.0",
+                              "from": "http-signature@>=0.11.0 <0.12.0",
                               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                               "dependencies": {
                                 "assert-plus": {
                                   "version": "0.1.5",
-                                  "from": "assert-plus@^0.1.5",
+                                  "from": "assert-plus@>=0.1.5 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                                 },
                                 "asn1": {
@@ -5256,161 +5256,161 @@
                             },
                             "oauth-sign": {
                               "version": "0.8.0",
-                              "from": "oauth-sign@~0.8.0",
+                              "from": "oauth-sign@>=0.8.0 <0.9.0",
                               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                             },
                             "hawk": {
                               "version": "3.1.0",
-                              "from": "hawk@~3.1.0",
+                              "from": "hawk@>=3.1.0 <3.2.0",
                               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
                               "dependencies": {
                                 "hoek": {
                                   "version": "2.14.0",
-                                  "from": "hoek@2.x.x",
+                                  "from": "hoek@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                                 },
                                 "boom": {
                                   "version": "2.8.0",
-                                  "from": "boom@^2.8.x",
+                                  "from": "boom@>=2.8.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                                 },
                                 "cryptiles": {
                                   "version": "2.0.4",
-                                  "from": "cryptiles@2.x.x",
+                                  "from": "cryptiles@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                                 },
                                 "sntp": {
                                   "version": "1.0.9",
-                                  "from": "sntp@1.x.x",
+                                  "from": "sntp@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                                 }
                               }
                             },
                             "aws-sign2": {
                               "version": "0.5.0",
-                              "from": "aws-sign2@~0.5.0",
+                              "from": "aws-sign2@>=0.5.0 <0.6.0",
                               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                             },
                             "stringstream": {
                               "version": "0.0.4",
-                              "from": "stringstream@~0.0.4",
+                              "from": "stringstream@>=0.0.4 <0.1.0",
                               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                             },
                             "combined-stream": {
                               "version": "1.0.5",
-                              "from": "combined-stream@~1.0.1",
+                              "from": "combined-stream@>=1.0.1 <1.1.0",
                               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                               "dependencies": {
                                 "delayed-stream": {
                                   "version": "1.0.0",
-                                  "from": "delayed-stream@~1.0.0",
+                                  "from": "delayed-stream@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                                 }
                               }
                             },
                             "isstream": {
                               "version": "0.1.2",
-                              "from": "isstream@~0.1.1",
+                              "from": "isstream@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                             },
                             "har-validator": {
                               "version": "1.8.0",
-                              "from": "har-validator@^1.6.1",
+                              "from": "har-validator@>=1.6.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                               "dependencies": {
                                 "bluebird": {
                                   "version": "2.9.34",
-                                  "from": "bluebird@^2.9.30",
+                                  "from": "bluebird@>=2.9.30 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
                                 },
                                 "chalk": {
                                   "version": "1.1.0",
-                                  "from": "chalk@^1.0.0",
+                                  "from": "chalk@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
                                   "dependencies": {
                                     "ansi-styles": {
                                       "version": "2.1.0",
-                                      "from": "ansi-styles@^2.1.0",
+                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                                     },
                                     "escape-string-regexp": {
                                       "version": "1.0.3",
-                                      "from": "escape-string-regexp@^1.0.2",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                                     },
                                     "has-ansi": {
                                       "version": "2.0.0",
-                                      "from": "has-ansi@^2.0.0",
+                                      "from": "has-ansi@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                       "dependencies": {
                                         "ansi-regex": {
                                           "version": "2.0.0",
-                                          "from": "ansi-regex@^2.0.0",
+                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
                                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                         }
                                       }
                                     },
                                     "strip-ansi": {
                                       "version": "3.0.0",
-                                      "from": "strip-ansi@^3.0.0",
+                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                       "dependencies": {
                                         "ansi-regex": {
                                           "version": "2.0.0",
-                                          "from": "ansi-regex@^2.0.0",
+                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
                                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                         }
                                       }
                                     },
                                     "supports-color": {
                                       "version": "2.0.0",
-                                      "from": "supports-color@^2.0.0",
+                                      "from": "supports-color@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "commander": {
                                   "version": "2.8.1",
-                                  "from": "commander@^2.8.1",
+                                  "from": "commander@>=2.8.1 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                                   "dependencies": {
                                     "graceful-readlink": {
                                       "version": "1.0.1",
-                                      "from": "graceful-readlink@>= 1.0.0",
+                                      "from": "graceful-readlink@>=1.0.0",
                                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                                     }
                                   }
                                 },
                                 "is-my-json-valid": {
                                   "version": "2.12.1",
-                                  "from": "is-my-json-valid@^2.12.0",
+                                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
                                   "dependencies": {
                                     "generate-function": {
                                       "version": "2.0.0",
-                                      "from": "generate-function@^2.0.0",
+                                      "from": "generate-function@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                                     },
                                     "generate-object-property": {
                                       "version": "1.2.0",
-                                      "from": "generate-object-property@^1.1.0",
+                                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                                       "dependencies": {
                                         "is-property": {
                                           "version": "1.0.2",
-                                          "from": "is-property@^1.0.0",
+                                          "from": "is-property@>=1.0.0 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                                         }
                                       }
                                     },
                                     "jsonpointer": {
                                       "version": "1.1.0",
-                                      "from": "jsonpointer@^1.1.0",
+                                      "from": "jsonpointer@>=1.1.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                                     },
                                     "xtend": {
                                       "version": "4.0.0",
-                                      "from": "xtend@^4.0.0",
+                                      "from": "xtend@>=4.0.0 <5.0.0",
                                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                                     }
                                   }
@@ -5423,22 +5423,22 @@
                     },
                     "request": {
                       "version": "2.51.0",
-                      "from": "request@~2.51.0",
+                      "from": "request@>=2.51.0 <2.52.0",
                       "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                       "dependencies": {
                         "bl": {
                           "version": "0.9.4",
-                          "from": "bl@~0.9.0",
+                          "from": "bl@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.33",
-                              "from": "readable-stream@~1.0.26",
+                              "from": "readable-stream@>=1.0.26 <1.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "core-util-is@~1.0.0",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                 },
                                 "isarray": {
@@ -5448,12 +5448,12 @@
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@~0.10.x",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
@@ -5462,27 +5462,27 @@
                         },
                         "caseless": {
                           "version": "0.8.0",
-                          "from": "caseless@~0.8.0",
+                          "from": "caseless@>=0.8.0 <0.9.0",
                           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                         },
                         "forever-agent": {
                           "version": "0.5.2",
-                          "from": "forever-agent@~0.5.0",
+                          "from": "forever-agent@>=0.5.0 <0.6.0",
                           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                         },
                         "form-data": {
                           "version": "0.2.0",
-                          "from": "form-data@~0.2.0",
+                          "from": "form-data@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                           "dependencies": {
                             "mime-types": {
                               "version": "2.0.14",
-                              "from": "mime-types@~2.0.3",
+                              "from": "mime-types@>=2.0.3 <2.1.0",
                               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                               "dependencies": {
                                 "mime-db": {
                                   "version": "1.12.0",
-                                  "from": "mime-db@~1.12.0",
+                                  "from": "mime-db@>=1.12.0 <1.13.0",
                                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                                 }
                               }
@@ -5491,27 +5491,27 @@
                         },
                         "json-stringify-safe": {
                           "version": "5.0.1",
-                          "from": "json-stringify-safe@~5.0.0",
+                          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                         },
                         "mime-types": {
                           "version": "1.0.2",
-                          "from": "mime-types@~1.0.1",
+                          "from": "mime-types@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                         },
                         "node-uuid": {
                           "version": "1.4.3",
-                          "from": "node-uuid@~1.4.0",
+                          "from": "node-uuid@>=1.4.0 <1.5.0",
                           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                         },
                         "qs": {
                           "version": "2.3.3",
-                          "from": "qs@~2.3.1",
+                          "from": "qs@>=2.3.1 <2.4.0",
                           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                         },
                         "tunnel-agent": {
                           "version": "0.4.1",
-                          "from": "tunnel-agent@~0.4.0",
+                          "from": "tunnel-agent@>=0.4.0 <0.5.0",
                           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                         },
                         "tough-cookie": {
@@ -5521,12 +5521,12 @@
                         },
                         "http-signature": {
                           "version": "0.10.1",
-                          "from": "http-signature@~0.10.0",
+                          "from": "http-signature@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                           "dependencies": {
                             "assert-plus": {
                               "version": "0.1.5",
-                              "from": "assert-plus@^0.1.5",
+                              "from": "assert-plus@>=0.1.5 <0.2.0",
                               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                             },
                             "asn1": {
@@ -5543,7 +5543,7 @@
                         },
                         "oauth-sign": {
                           "version": "0.5.0",
-                          "from": "oauth-sign@~0.5.0",
+                          "from": "oauth-sign@>=0.5.0 <0.6.0",
                           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                         },
                         "hawk": {
@@ -5553,39 +5553,39 @@
                           "dependencies": {
                             "hoek": {
                               "version": "0.9.1",
-                              "from": "hoek@0.9.x",
+                              "from": "hoek@>=0.9.0 <0.10.0",
                               "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                             },
                             "boom": {
                               "version": "0.4.2",
-                              "from": "boom@0.4.x",
+                              "from": "boom@>=0.4.0 <0.5.0",
                               "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                             },
                             "cryptiles": {
                               "version": "0.2.2",
-                              "from": "cryptiles@0.2.x",
+                              "from": "cryptiles@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                             },
                             "sntp": {
                               "version": "0.2.4",
-                              "from": "sntp@0.2.x",
+                              "from": "sntp@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                             }
                           }
                         },
                         "aws-sign2": {
                           "version": "0.5.0",
-                          "from": "aws-sign2@~0.5.0",
+                          "from": "aws-sign2@>=0.5.0 <0.6.0",
                           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                         },
                         "stringstream": {
                           "version": "0.0.4",
-                          "from": "stringstream@~0.0.4",
+                          "from": "stringstream@>=0.0.4 <0.1.0",
                           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                         },
                         "combined-stream": {
                           "version": "0.0.7",
-                          "from": "combined-stream@~0.0.5",
+                          "from": "combined-stream@>=0.0.5 <0.1.0",
                           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                           "dependencies": {
                             "delayed-stream": {
@@ -5599,83 +5599,83 @@
                     },
                     "string-template": {
                       "version": "0.2.1",
-                      "from": "string-template@~0.2.0",
+                      "from": "string-template@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
                     }
                   }
                 },
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "minimist@^0.2.0",
+                  "from": "minimist@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "valid-url": {
                   "version": "1.0.9",
-                  "from": "valid-url@^1.0.9",
+                  "from": "valid-url@>=1.0.9 <2.0.0",
                   "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz"
                 }
               }
             },
             "minimist": {
               "version": "1.1.3",
-              "from": "minimist@^1.1.0",
+              "from": "minimist@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
             },
             "prepend-http": {
               "version": "1.0.2",
-              "from": "prepend-http@^1.0.0",
+              "from": "prepend-http@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "pretty-bytes@^1.0.0",
+              "from": "pretty-bytes@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "meow@^3.1.0",
+                  "from": "meow@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@^1.0.0",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@^1.0.1",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@^1.0.0",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.2",
-                      "from": "indent-string@^1.1.0",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@^1.1.0",
+                          "from": "repeating@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@^1.0.0",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@^1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -5686,7 +5686,7 @@
                     },
                     "object-assign": {
                       "version": "3.0.0",
-                      "from": "object-assign@^3.0.0",
+                      "from": "object-assign@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                     }
                   }
@@ -5704,12 +5704,12 @@
       "dependencies": {
         "postcss": {
           "version": "4.0.6",
-          "from": "postcss@~4.0.6",
+          "from": "postcss@>=4.0.6 <4.1.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.2.0",
-              "from": "source-map@~0.2.0",
+              "from": "source-map@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "dependencies": {
                 "amdefine": {
@@ -5721,58 +5721,58 @@
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@~2.1.7",
+              "from": "js-base64@>=2.1.7 <2.2.0",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
         },
         "chalk": {
           "version": "1.0.0",
-          "from": "chalk@~1.0.0",
+          "from": "chalk@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "has-ansi@^1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@^1.1.0",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@^2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "supports-color@^1.3.0",
+              "from": "supports-color@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
@@ -5786,122 +5786,122 @@
       "dependencies": {
         "each-async": {
           "version": "1.1.1",
-          "from": "each-async@^1.0.0",
+          "from": "each-async@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "onetime@^1.0.0",
+              "from": "onetime@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
             "set-immediate-shim": {
               "version": "1.0.1",
-              "from": "set-immediate-shim@^1.0.0",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
             }
           }
         },
         "node-sass": {
           "version": "3.2.0",
-          "from": "node-sass@^3.0.0",
+          "from": "node-sass@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.2.0.tgz",
           "dependencies": {
             "async-foreach": {
               "version": "0.1.3",
-              "from": "async-foreach@^0.1.3",
+              "from": "async-foreach@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
             },
             "chalk": {
               "version": "1.1.0",
-              "from": "chalk@^1.0.0",
+              "from": "chalk@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "gaze": {
               "version": "0.5.1",
-              "from": "gaze@^0.5.1",
+              "from": "gaze@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
               "dependencies": {
                 "globule": {
                   "version": "0.1.0",
-                  "from": "globule@~0.1.0",
+                  "from": "globule@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "1.0.2",
-                      "from": "lodash@~1.0.1",
+                      "from": "lodash@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                     },
                     "glob": {
                       "version": "3.1.21",
-                      "from": "glob@~3.1.21",
+                      "from": "glob@>=3.1.21 <3.2.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "1.2.3",
-                          "from": "graceful-fs@~1.2.0",
+                          "from": "graceful-fs@>=1.2.0 <1.3.0",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                         },
                         "inherits": {
                           "version": "1.0.0",
-                          "from": "inherits@1",
+                          "from": "inherits@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@~0.2.11",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.6.5",
-                          "from": "lru-cache@2",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "sigmund@~1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
@@ -5912,44 +5912,44 @@
             },
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@^4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "glob": {
               "version": "5.0.14",
-              "from": "glob@^5.0.3",
+              "from": "glob@>=5.0.3 <6.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@^2.0.1",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -5963,63 +5963,63 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@^1.3.0",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@^1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@^3.1.0",
+              "from": "meow@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@^1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@^1.0.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@^1.0.0",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.2",
-                  "from": "indent-string@^1.1.0",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@^1.1.0",
+                      "from": "repeating@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@^1.0.0",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@^1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -6030,92 +6030,92 @@
                 },
                 "minimist": {
                   "version": "1.1.3",
-                  "from": "minimist@^1.1.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@^3.0.0",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
             },
             "nan": {
               "version": "1.9.0",
-              "from": "nan@^1.8.4",
+              "from": "nan@>=1.8.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
             },
             "npmconf": {
               "version": "2.1.2",
-              "from": "npmconf@^2.1.1",
+              "from": "npmconf@>=2.1.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.9",
-                  "from": "config-chain@~1.1.8",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
                   "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
                   "dependencies": {
                     "proto-list": {
                       "version": "1.2.4",
-                      "from": "proto-list@~1.2.1",
+                      "from": "proto-list@>=1.2.1 <1.3.0",
                       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.0",
+                  "from": "inherits@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "from": "ini@^1.2.0",
+                  "from": "ini@>=1.2.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "nopt": {
                   "version": "3.0.3",
-                  "from": "nopt@~3.0.1",
+                  "from": "nopt@>=3.0.1 <3.1.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@1",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@~1.3.0",
+                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@^0.1.0",
+                  "from": "osenv@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@^1.0.0",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "os-tmpdir@^1.0.0",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "semver": {
                   "version": "4.3.6",
-                  "from": "semver@2 || 3 || 4",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 },
                 "uid-number": {
@@ -6127,51 +6127,51 @@
             },
             "pangyp": {
               "version": "2.3.0",
-              "from": "pangyp@^2.2.0",
+              "from": "pangyp@>=2.2.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.0.tgz",
               "dependencies": {
                 "fstream": {
                   "version": "1.0.7",
-                  "from": "fstream@~1.0.3",
+                  "from": "fstream@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.0",
+                      "from": "inherits@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@~4.3.5",
+                  "from": "glob@>=4.3.5 <4.4.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@^1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@^1.3.0",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -6180,22 +6180,22 @@
                 },
                 "graceful-fs": {
                   "version": "3.0.8",
-                  "from": "graceful-fs@~3.0.5",
+                  "from": "graceful-fs@>=3.0.5 <3.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@~2.0.1",
+                  "from": "minimatch@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -6209,44 +6209,44 @@
                 },
                 "nopt": {
                   "version": "3.0.3",
-                  "from": "nopt@~3.0.1",
+                  "from": "nopt@>=3.0.1 <3.1.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@1",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "npmlog": {
                   "version": "1.0.0",
-                  "from": "npmlog@~1.0.0",
+                  "from": "npmlog@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
                   "dependencies": {
                     "ansi": {
                       "version": "0.3.0",
-                      "from": "ansi@~0.3.0",
+                      "from": "ansi@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                     },
                     "are-we-there-yet": {
                       "version": "1.0.4",
-                      "from": "are-we-there-yet@~1.0.0",
+                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                       "dependencies": {
                         "delegates": {
                           "version": "0.1.0",
-                          "from": "delegates@^0.1.0",
+                          "from": "delegates@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
                         },
                         "readable-stream": {
                           "version": "1.1.13",
-                          "from": "readable-stream@^1.1.13",
+                          "from": "readable-stream@>=1.1.13 <2.0.0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
@@ -6256,12 +6256,12 @@
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@~0.10.x",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@~2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -6270,12 +6270,12 @@
                     },
                     "gauge": {
                       "version": "1.0.2",
-                      "from": "gauge@~1.0.2",
+                      "from": "gauge@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                       "dependencies": {
                         "has-unicode": {
                           "version": "1.0.0",
-                          "from": "has-unicode@^1.0.0",
+                          "from": "has-unicode@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
                         }
                       }
@@ -6284,39 +6284,39 @@
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@0",
+                  "from": "osenv@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@^1.0.0",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "os-tmpdir@^1.0.0",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "request": {
                   "version": "2.51.0",
-                  "from": "request@~2.51.0",
+                  "from": "request@>=2.51.0 <2.52.0",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "0.9.4",
-                      "from": "bl@~0.9.0",
+                      "from": "bl@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "readable-stream@~1.0.26",
+                          "from": "readable-stream@>=1.0.26 <1.1.0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
@@ -6326,12 +6326,12 @@
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@~0.10.x",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@~2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -6340,32 +6340,32 @@
                     },
                     "caseless": {
                       "version": "0.8.0",
-                      "from": "caseless@~0.8.0",
+                      "from": "caseless@>=0.8.0 <0.9.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                     },
                     "forever-agent": {
                       "version": "0.5.2",
-                      "from": "forever-agent@~0.5.0",
+                      "from": "forever-agent@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                     },
                     "form-data": {
                       "version": "0.2.0",
-                      "from": "form-data@~0.2.0",
+                      "from": "form-data@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.9.2",
-                          "from": "async@~0.9.0",
+                          "from": "async@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                         },
                         "mime-types": {
                           "version": "2.0.14",
-                          "from": "mime-types@~2.0.3",
+                          "from": "mime-types@>=2.0.3 <2.1.0",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                           "dependencies": {
                             "mime-db": {
                               "version": "1.12.0",
-                              "from": "mime-db@~1.12.0",
+                              "from": "mime-db@>=1.12.0 <1.13.0",
                               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                             }
                           }
@@ -6374,27 +6374,27 @@
                     },
                     "json-stringify-safe": {
                       "version": "5.0.1",
-                      "from": "json-stringify-safe@~5.0.0",
+                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "mime-types": {
                       "version": "1.0.2",
-                      "from": "mime-types@~1.0.1",
+                      "from": "mime-types@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                     },
                     "node-uuid": {
                       "version": "1.4.3",
-                      "from": "node-uuid@~1.4.0",
+                      "from": "node-uuid@>=1.4.0 <1.5.0",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                     },
                     "qs": {
                       "version": "2.3.3",
-                      "from": "qs@~2.3.1",
+                      "from": "qs@>=2.3.1 <2.4.0",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.1",
-                      "from": "tunnel-agent@~0.4.0",
+                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                     },
                     "tough-cookie": {
@@ -6404,12 +6404,12 @@
                     },
                     "http-signature": {
                       "version": "0.10.1",
-                      "from": "http-signature@~0.10.0",
+                      "from": "http-signature@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.5",
-                          "from": "assert-plus@^0.1.5",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                         },
                         "asn1": {
@@ -6426,7 +6426,7 @@
                     },
                     "oauth-sign": {
                       "version": "0.5.0",
-                      "from": "oauth-sign@~0.5.0",
+                      "from": "oauth-sign@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                     },
                     "hawk": {
@@ -6436,39 +6436,39 @@
                       "dependencies": {
                         "hoek": {
                           "version": "0.9.1",
-                          "from": "hoek@0.9.x",
+                          "from": "hoek@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                         },
                         "boom": {
                           "version": "0.4.2",
-                          "from": "boom@0.4.x",
+                          "from": "boom@>=0.4.0 <0.5.0",
                           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                         },
                         "cryptiles": {
                           "version": "0.2.2",
-                          "from": "cryptiles@0.2.x",
+                          "from": "cryptiles@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                         },
                         "sntp": {
                           "version": "0.2.4",
-                          "from": "sntp@0.2.x",
+                          "from": "sntp@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                         }
                       }
                     },
                     "aws-sign2": {
                       "version": "0.5.0",
-                      "from": "aws-sign2@~0.5.0",
+                      "from": "aws-sign2@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                     },
                     "stringstream": {
                       "version": "0.0.4",
-                      "from": "stringstream@~0.0.4",
+                      "from": "stringstream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@~0.0.5",
+                      "from": "combined-stream@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
@@ -6482,17 +6482,17 @@
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@~2.2.8",
+                  "from": "rimraf@>=2.2.8 <2.3.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "semver": {
                   "version": "4.3.6",
-                  "from": "semver@~4.3.6",
+                  "from": "semver@>=4.3.6 <4.4.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 },
                 "tar": {
                   "version": "1.0.3",
-                  "from": "tar@~1.0.3",
+                  "from": "tar@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
                   "dependencies": {
                     "block-stream": {
@@ -6502,41 +6502,41 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "which": {
                   "version": "1.0.9",
-                  "from": "which@~1.0.8",
+                  "from": "which@>=1.0.8 <1.1.0",
                   "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
                 }
               }
             },
             "request": {
               "version": "2.60.0",
-              "from": "request@^2.55.0",
+              "from": "request@>=2.55.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "1.0.0",
-                  "from": "bl@~1.0.0",
+                  "from": "bl@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.2",
-                      "from": "readable-stream@~2.0.0",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
@@ -6546,17 +6546,17 @@
                         },
                         "process-nextick-args": {
                           "version": "1.0.2",
-                          "from": "process-nextick-args@~1.0.0",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "util-deprecate@~1.0.1",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
@@ -6565,61 +6565,61 @@
                 },
                 "caseless": {
                   "version": "0.11.0",
-                  "from": "caseless@~0.11.0",
+                  "from": "caseless@>=0.11.0 <0.12.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "extend": {
                   "version": "3.0.0",
-                  "from": "extend@~3.0.0",
+                  "from": "extend@>=3.0.0 <3.1.0",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "forever-agent@~0.6.0",
+                  "from": "forever-agent@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "1.0.0-rc3",
-                  "from": "form-data@~1.0.0-rc1",
+                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "1.4.2",
-                      "from": "async@^1.4.0",
+                      "from": "async@>=1.4.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.4",
-                  "from": "mime-types@~2.1.2",
+                  "from": "mime-types@>=2.1.2 <2.2.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.16.0",
-                      "from": "mime-db@~1.16.0",
+                      "from": "mime-db@>=1.16.0 <1.17.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@~1.4.0",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "4.0.0",
-                  "from": "qs@~4.0.0",
+                  "from": "qs@>=4.0.0 <4.1.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "tunnel-agent@~0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
@@ -6629,12 +6629,12 @@
                 },
                 "http-signature": {
                   "version": "0.11.0",
-                  "from": "http-signature@~0.11.0",
+                  "from": "http-signature@>=0.11.0 <0.12.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
@@ -6651,115 +6651,115 @@
                 },
                 "oauth-sign": {
                   "version": "0.8.0",
-                  "from": "oauth-sign@~0.8.0",
+                  "from": "oauth-sign@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                 },
                 "hawk": {
                   "version": "3.1.0",
-                  "from": "hawk@~3.1.0",
+                  "from": "hawk@>=3.1.0 <3.2.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.14.0",
-                      "from": "hoek@2.x.x",
+                      "from": "hoek@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
                       "version": "2.8.0",
-                      "from": "boom@^2.8.x",
+                      "from": "boom@>=2.8.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "cryptiles@2.x.x",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@1.x.x",
+                      "from": "sntp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "combined-stream@~1.0.1",
+                  "from": "combined-stream@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@~1.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@~0.1.1",
+                  "from": "isstream@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "1.8.0",
-                  "from": "har-validator@^1.6.1",
+                  "from": "har-validator@>=1.6.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "dependencies": {
                     "bluebird": {
                       "version": "2.9.34",
-                      "from": "bluebird@^2.9.30",
+                      "from": "bluebird@>=2.9.30 <3.0.0",
                       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
                     },
                     "commander": {
                       "version": "2.8.1",
-                      "from": "commander@^2.8.1",
+                      "from": "commander@>=2.8.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "graceful-readlink@>= 1.0.0",
+                          "from": "graceful-readlink@>=1.0.0",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.12.1",
-                      "from": "is-my-json-valid@^2.12.0",
+                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "from": "generate-function@^2.0.0",
+                          "from": "generate-function@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "generate-object-property@^1.1.0",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "from": "is-property@^1.0.0",
+                              "from": "is-property@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "1.1.0",
-                          "from": "jsonpointer@^1.1.0",
+                          "from": "jsonpointer@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.0",
-                          "from": "xtend@^4.0.0",
+                          "from": "xtend@>=4.0.0 <5.0.0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                         }
                       }
@@ -6770,52 +6770,52 @@
             },
             "sass-graph": {
               "version": "2.0.1",
-              "from": "sass-graph@^2.0.0",
+              "from": "sass-graph@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@^3.8.0",
+                  "from": "lodash@>=3.8.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "yargs": {
-                  "version": "3.18.0",
-                  "from": "yargs@^3.8.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.18.0.tgz",
+                  "version": "3.19.0",
+                  "from": "yargs@>=3.8.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.19.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@^1.0.2",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@^2.1.0",
+                      "from": "cliui@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.1",
-                          "from": "center-align@^0.1.1",
+                          "from": "center-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@^0.1.1",
+                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.0",
-                                  "from": "kind-of@^2.0.0",
+                                  "from": "kind-of@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@^1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@^1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -6824,27 +6824,27 @@
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@^0.1.1",
+                          "from": "right-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@^0.1.1",
+                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.0",
-                                  "from": "kind-of@^2.0.0",
+                                  "from": "kind-of@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@^1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@^1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -6860,17 +6860,17 @@
                     },
                     "decamelize": {
                       "version": "1.0.0",
-                      "from": "decamelize@^1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.2",
-                      "from": "window-size@^0.1.1",
+                      "from": "window-size@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
                     },
                     "y18n": {
                       "version": "3.0.0",
-                      "from": "y18n@^3.0.0",
+                      "from": "y18n@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.0.0.tgz"
                     }
                   }
@@ -6881,7 +6881,7 @@
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "object-assign@^2.0.0",
+          "from": "object-assign@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         }
       }
@@ -6903,53 +6903,53 @@
           "dependencies": {
             "lodash-node": {
               "version": "2.4.1",
-              "from": "lodash-node@~2.4.1",
+              "from": "lodash-node@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
             }
           }
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@^0.5.1",
+          "from": "chalk@0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.0",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -6963,46 +6963,46 @@
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@~0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "ansi-styles@^1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@^0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@^0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@^0.2.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "supports-color@^0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -7011,127 +7011,127 @@
     },
     "grunt-svgmin": {
       "version": "2.0.1",
-      "from": "grunt-svgmin@^2.0.0",
+      "from": "https://registry.npmjs.org/grunt-svgmin/-/grunt-svgmin-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-svgmin/-/grunt-svgmin-2.0.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@^1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.0.1",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "each-async": {
           "version": "1.1.1",
-          "from": "each-async@^1.0.0",
+          "from": "each-async@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "onetime@^1.0.0",
+              "from": "onetime@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
             "set-immediate-shim": {
               "version": "1.0.1",
-              "from": "set-immediate-shim@^1.0.0",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
             }
           }
         },
         "log-symbols": {
           "version": "1.0.2",
-          "from": "log-symbols@^1.0.0",
+          "from": "log-symbols@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
         },
         "pretty-bytes": {
           "version": "1.0.4",
-          "from": "pretty-bytes@^1.0.1",
+          "from": "pretty-bytes@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@^4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@^3.3.0",
+              "from": "meow@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@^1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@^1.0.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@^1.0.0",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.2",
-                  "from": "indent-string@^1.1.0",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@^1.1.0",
+                      "from": "repeating@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@^1.0.0",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@^1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -7142,12 +7142,12 @@
                 },
                 "minimist": {
                   "version": "1.1.3",
-                  "from": "minimist@^1.1.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@^3.0.0",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
@@ -7155,69 +7155,69 @@
           }
         },
         "svgo": {
-          "version": "0.5.5",
-          "from": "svgo@^0.5.0",
-          "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.5.5.tgz",
+          "version": "0.5.6",
+          "from": "svgo@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.5.6.tgz",
           "dependencies": {
             "sax": {
               "version": "1.1.1",
-              "from": "sax@~1.1.1",
+              "from": "sax@>=1.1.1 <1.2.0",
               "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.1.tgz"
             },
             "coa": {
               "version": "1.0.1",
-              "from": "coa@~1.0.1",
+              "from": "coa@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
               "dependencies": {
                 "q": {
                   "version": "1.4.1",
-                  "from": "q@^1.1.2",
+                  "from": "q@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                 }
               }
             },
             "js-yaml": {
               "version": "3.3.1",
-              "from": "js-yaml@3.x",
+              "from": "js-yaml@>=3.3.1 <3.4.0",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "argparse@~1.0.2",
+                  "from": "argparse@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>= 3.2.0 < 4.0.0",
+                      "from": "lodash@>=3.2.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "sprintf-js@~1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.2.0",
-                  "from": "esprima@~2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                 }
               }
             },
             "colors": {
               "version": "1.1.2",
-              "from": "colors@~1.1.2",
+              "from": "colors@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
             },
             "whet.extend": {
               "version": "0.9.9",
-              "from": "whet.extend@~0.9.9",
+              "from": "whet.extend@>=0.9.9 <0.10.0",
               "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@~0.5.1",
+              "from": "mkdirp@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
@@ -7248,12 +7248,12 @@
           "dependencies": {
             "commander": {
               "version": "1.1.1",
-              "from": "commander@~1.1.1",
+              "from": "commander@>=1.1.1 <1.2.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
               "dependencies": {
                 "keypress": {
                   "version": "0.1.0",
-                  "from": "keypress@0.1.x",
+                  "from": "keypress@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                 }
               }
@@ -7269,29 +7269,29 @@
       "dependencies": {
         "optimist": {
           "version": "0.3.7",
-          "from": "optimist@~0.3",
+          "from": "optimist@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@~0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.3.6",
-          "from": "uglify-js@~2.3",
+          "from": "uglify-js@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.6",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@~0.1.7",
+              "from": "source-map@>=0.1.7 <0.2.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
@@ -7307,7 +7307,7 @@
     },
     "jasmine-core": {
       "version": "2.3.4",
-      "from": "jasmine-core@^2.3.2",
+      "from": "jasmine-core@>=2.3.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
     },
     "jit-grunt": {
@@ -7327,165 +7327,165 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@^1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "core-js": {
           "version": "0.9.18",
-          "from": "core-js@^0.9.17",
+          "from": "core-js@>=0.9.17 <0.10.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.9.18.tgz"
         },
         "glob": {
           "version": "5.0.14",
-          "from": "glob@^5.0.10",
+          "from": "glob@>=5.0.5 <6.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@^1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@^1.3.0",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@^1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "graceful-fs@^3.0.8",
+          "from": "graceful-fs@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "jspm-github": {
           "version": "0.12.2",
-          "from": "jspm-github@^0.12.2",
+          "from": "jspm-github@>=0.12.2 <0.13.0",
           "resolved": "https://registry.npmjs.org/jspm-github/-/jspm-github-0.12.2.tgz",
           "dependencies": {
             "decompress-zip": {
               "version": "0.1.0",
-              "from": "decompress-zip@^0.1.0",
+              "from": "decompress-zip@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
               "dependencies": {
                 "binary": {
                   "version": "0.3.0",
-                  "from": "binary@^0.3.0",
+                  "from": "binary@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                   "dependencies": {
                     "chainsaw": {
                       "version": "0.1.0",
-                      "from": "chainsaw@~0.1.0",
+                      "from": "chainsaw@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.3.9",
-                          "from": "traverse@>=0.3.0 <0.4",
+                          "from": "traverse@>=0.3.0 <0.4.0",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                         }
                       }
                     },
                     "buffers": {
                       "version": "0.1.1",
-                      "from": "buffers@~0.1.1",
+                      "from": "buffers@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                     }
                   }
                 },
                 "mkpath": {
                   "version": "0.1.0",
-                  "from": "mkpath@^0.1.0",
+                  "from": "mkpath@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
                 },
                 "nopt": {
                   "version": "3.0.3",
-                  "from": "nopt@^3.0.1",
+                  "from": "nopt@>=3.0.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@1",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "q": {
                   "version": "1.4.1",
-                  "from": "q@^1.1.2",
+                  "from": "q@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@^1.1.8",
+                  "from": "readable-stream@>=1.1.8 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -7495,12 +7495,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -7512,12 +7512,12 @@
                   "dependencies": {
                     "nopt": {
                       "version": "1.0.10",
-                      "from": "nopt@~1.0.10",
+                      "from": "nopt@>=1.0.10 <1.1.0",
                       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
                       "dependencies": {
                         "abbrev": {
                           "version": "1.0.7",
-                          "from": "abbrev@1",
+                          "from": "abbrev@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                         }
                       }
@@ -7528,27 +7528,27 @@
             },
             "netrc": {
               "version": "0.1.3",
-              "from": "netrc@^0.1.3",
+              "from": "netrc@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.3.tgz"
             },
             "request": {
               "version": "2.53.0",
-              "from": "request@~2.53.0",
+              "from": "request@>=2.53.0 <2.54.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@~0.9.0",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@~1.0.26",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -7558,12 +7558,12 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -7572,56 +7572,56 @@
                 },
                 "caseless": {
                   "version": "0.9.0",
-                  "from": "caseless@~0.9.0",
+                  "from": "caseless@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@~0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@~0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@~2.0.1",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "mime-db@~1.12.0",
+                      "from": "mime-db@>=1.12.0 <1.13.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@~1.4.0",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@~2.3.1",
+                  "from": "qs@>=2.3.1 <2.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "tunnel-agent@~0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
@@ -7631,12 +7631,12 @@
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@~0.10.0",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
@@ -7653,49 +7653,49 @@
                 },
                 "oauth-sign": {
                   "version": "0.6.0",
-                  "from": "oauth-sign@~0.6.0",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@~2.3.0",
+                  "from": "hawk@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.14.0",
-                      "from": "hoek@2.x.x",
+                      "from": "hoek@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
                       "version": "2.8.0",
-                      "from": "boom@2.x.x",
+                      "from": "boom@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "cryptiles@2.x.x",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@1.x.x",
+                      "from": "sntp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@~0.0.5",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -7707,46 +7707,46 @@
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@~0.1.1",
+                  "from": "isstream@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 }
               }
             },
             "rimraf": {
               "version": "2.3.4",
-              "from": "rimraf@~2.3.2",
+              "from": "rimraf@>=2.3.2 <2.4.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@^4.4.2",
+                  "from": "glob@>=4.4.2 <5.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@^1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@^1.3.0",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -7757,7 +7757,7 @@
             },
             "tar": {
               "version": "1.0.3",
-              "from": "tar@~1.0.3",
+              "from": "tar@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
@@ -7767,29 +7767,29 @@
                 },
                 "fstream": {
                   "version": "1.0.7",
-                  "from": "fstream@^1.0.2",
+                  "from": "fstream@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "which": {
               "version": "1.1.1",
-              "from": "which@^1.0.9",
+              "from": "which@>=1.0.9 <2.0.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "is-absolute@^0.1.7",
+                  "from": "is-absolute@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
-                      "from": "is-relative@^0.1.0",
+                      "from": "is-relative@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
@@ -7800,27 +7800,27 @@
         },
         "jspm-npm": {
           "version": "0.23.4",
-          "from": "jspm-npm@^0.23.2",
+          "from": "jspm-npm@>=0.23.2 <0.24.0",
           "resolved": "https://registry.npmjs.org/jspm-npm/-/jspm-npm-0.23.4.tgz",
           "dependencies": {
             "request": {
               "version": "2.58.0",
-              "from": "request@~2.58.0",
+              "from": "request@>=2.58.0 <2.59.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@~0.9.0",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@~1.0.26",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -7830,12 +7830,12 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -7844,37 +7844,37 @@
                 },
                 "caseless": {
                   "version": "0.10.0",
-                  "from": "caseless@~0.10.0",
+                  "from": "caseless@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
                 },
                 "extend": {
                   "version": "2.0.1",
-                  "from": "extend@~2.0.1",
+                  "from": "extend@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "forever-agent@~0.6.0",
+                  "from": "forever-agent@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "1.0.0-rc3",
-                  "from": "form-data@~1.0.0-rc1",
+                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "1.4.2",
-                      "from": "async@^1.4.0",
+                      "from": "async@>=1.4.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.4",
-                      "from": "mime-types@^2.1.3",
+                      "from": "mime-types@>=2.1.3 <3.0.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.16.0",
-                          "from": "mime-db@~1.16.0",
+                          "from": "mime-db@>=1.16.0 <1.17.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
                         }
                       }
@@ -7883,34 +7883,34 @@
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@~2.0.1",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "mime-db@~1.12.0",
+                      "from": "mime-db@>=1.12.0 <1.13.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@~1.4.0",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "3.1.0",
-                  "from": "qs@~3.1.0",
+                  "from": "qs@>=3.1.0 <3.2.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "tunnel-agent@~0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
@@ -7920,12 +7920,12 @@
                 },
                 "http-signature": {
                   "version": "0.11.0",
-                  "from": "http-signature@~0.11.0",
+                  "from": "http-signature@>=0.11.0 <0.12.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
@@ -7942,115 +7942,115 @@
                 },
                 "oauth-sign": {
                   "version": "0.8.0",
-                  "from": "oauth-sign@~0.8.0",
+                  "from": "oauth-sign@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@~2.3.0",
+                  "from": "hawk@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.14.0",
-                      "from": "hoek@2.x.x",
+                      "from": "hoek@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
                       "version": "2.8.0",
-                      "from": "boom@2.x.x",
+                      "from": "boom@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "cryptiles@2.x.x",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@1.x.x",
+                      "from": "sntp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "combined-stream@~1.0.1",
+                  "from": "combined-stream@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@~1.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@~0.1.1",
+                  "from": "isstream@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "1.8.0",
-                  "from": "har-validator@^1.6.1",
+                  "from": "har-validator@>=1.6.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "dependencies": {
                     "bluebird": {
                       "version": "2.9.34",
-                      "from": "bluebird@^2.9.30",
+                      "from": "bluebird@>=2.9.30 <3.0.0",
                       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
                     },
                     "commander": {
                       "version": "2.8.1",
-                      "from": "commander@^2.8.1",
+                      "from": "commander@>=2.8.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "graceful-readlink@>= 1.0.0",
+                          "from": "graceful-readlink@>=1.0.0",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.12.1",
-                      "from": "is-my-json-valid@^2.12.0",
+                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "from": "generate-function@^2.0.0",
+                          "from": "generate-function@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "generate-object-property@^1.1.0",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "from": "is-property@^1.0.0",
+                              "from": "is-property@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "1.1.0",
-                          "from": "jsonpointer@^1.1.0",
+                          "from": "jsonpointer@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.0",
-                          "from": "xtend@^4.0.0",
+                          "from": "xtend@>=4.0.0 <5.0.0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                         }
                       }
@@ -8061,12 +8061,12 @@
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@^1.1.6",
+              "from": "resolve@>=1.1.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "rmdir": {
               "version": "1.1.0",
-              "from": "rmdir@~1.1.0",
+              "from": "rmdir@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/rmdir/-/rmdir-1.1.0.tgz",
               "dependencies": {
                 "node.flow": {
@@ -8081,12 +8081,12 @@
                       "dependencies": {
                         "is": {
                           "version": "0.2.7",
-                          "from": "is@~0.2.6",
+                          "from": "is@>=0.2.6 <0.3.0",
                           "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz"
                         },
                         "object-keys": {
                           "version": "0.4.0",
-                          "from": "object-keys@~0.4.0",
+                          "from": "object-keys@>=0.4.0 <0.5.0",
                           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                         }
                       }
@@ -8097,7 +8097,7 @@
             },
             "tar": {
               "version": "1.0.3",
-              "from": "tar@~1.0.3",
+              "from": "tar@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
@@ -8107,29 +8107,29 @@
                 },
                 "fstream": {
                   "version": "1.0.7",
-                  "from": "fstream@^1.0.2",
+                  "from": "fstream@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "which": {
               "version": "1.1.1",
-              "from": "which@^1.1.1",
+              "from": "which@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "is-absolute@^0.1.7",
+                  "from": "is-absolute@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
-                      "from": "is-relative@^0.1.0",
+                      "from": "is-relative@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
@@ -8140,54 +8140,54 @@
         },
         "jspm-registry": {
           "version": "0.4.0",
-          "from": "jspm-registry@^0.4.0",
+          "from": "jspm-registry@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/jspm-registry/-/jspm-registry-0.4.0.tgz"
         },
         "liftoff": {
           "version": "2.1.0",
-          "from": "liftoff@^2.1.0",
+          "from": "liftoff@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.1.0.tgz",
           "dependencies": {
             "extend": {
               "version": "2.0.1",
-              "from": "extend@^2.0.1",
+              "from": "extend@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
             },
             "findup-sync": {
               "version": "0.2.1",
-              "from": "findup-sync@^0.2.1",
+              "from": "findup-sync@>=0.2.1 <0.3.0",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@~4.3.0",
+                  "from": "glob@>=4.3.0 <4.4.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@^1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@^1.3.0",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -8198,34 +8198,34 @@
             },
             "flagged-respawn": {
               "version": "0.3.1",
-              "from": "flagged-respawn@^0.3.1",
+              "from": "flagged-respawn@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
             },
             "rechoir": {
               "version": "0.6.2",
-              "from": "rechoir@^0.6.0",
+              "from": "rechoir@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@^1.1.6",
+              "from": "resolve@>=1.1.6 <2.0.0",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             }
           }
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@^2.0.8",
+          "from": "minimatch@>=2.0.8 <3.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
-              "from": "brace-expansion@^1.0.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "balanced-match@^0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
@@ -8239,7 +8239,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@~0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
@@ -8251,32 +8251,32 @@
         },
         "ncp": {
           "version": "2.0.0",
-          "from": "ncp@^2.0.0",
+          "from": "ncp@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
         },
         "request": {
           "version": "2.60.0",
-          "from": "request@^2.58.0",
+          "from": "request@>=2.58.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
           "dependencies": {
             "bl": {
               "version": "1.0.0",
-              "from": "bl@~1.0.0",
+              "from": "bl@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.2",
-                  "from": "readable-stream@~2.0.0",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
@@ -8286,17 +8286,17 @@
                     },
                     "process-nextick-args": {
                       "version": "1.0.2",
-                      "from": "process-nextick-args@~1.0.0",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.1",
-                      "from": "util-deprecate@~1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
@@ -8305,61 +8305,61 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@~0.11.0",
+              "from": "caseless@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@~3.0.0",
+              "from": "extend@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@~0.6.0",
+              "from": "forever-agent@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "from": "form-data@~1.0.0-rc1",
+              "from": "form-data@>=1.0.0-rc1 <1.1.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.4.2",
-                  "from": "async@^1.4.0",
+                  "from": "async@>=1.4.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@~5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.4",
-              "from": "mime-types@~2.1.2",
+              "from": "mime-types@>=2.1.2 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.16.0",
-                  "from": "mime-db@~1.16.0",
+                  "from": "mime-db@>=1.16.0 <1.17.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@~1.4.0",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "qs": {
               "version": "4.0.0",
-              "from": "qs@~4.0.0",
+              "from": "qs@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.1",
-              "from": "tunnel-agent@~0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "tough-cookie": {
@@ -8369,12 +8369,12 @@
             },
             "http-signature": {
               "version": "0.11.0",
-              "from": "http-signature@~0.11.0",
+              "from": "http-signature@>=0.11.0 <0.12.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@^0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -8391,115 +8391,115 @@
             },
             "oauth-sign": {
               "version": "0.8.0",
-              "from": "oauth-sign@~0.8.0",
+              "from": "oauth-sign@>=0.8.0 <0.9.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "hawk": {
               "version": "3.1.0",
-              "from": "hawk@~3.1.0",
+              "from": "hawk@>=3.1.0 <3.2.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.14.0",
-                  "from": "hoek@2.x.x",
+                  "from": "hoek@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                 },
                 "boom": {
                   "version": "2.8.0",
-                  "from": "boom@^2.8.x",
+                  "from": "boom@>=2.8.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
-                  "from": "cryptiles@2.x.x",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@1.x.x",
+                  "from": "sntp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@~0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@~0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@~1.0.1",
+              "from": "combined-stream@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@~1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@~0.1.1",
+              "from": "isstream@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "1.8.0",
-              "from": "har-validator@^1.6.1",
+              "from": "har-validator@>=1.6.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "dependencies": {
                 "bluebird": {
                   "version": "2.9.34",
-                  "from": "bluebird@^2.9.30",
+                  "from": "bluebird@>=2.9.30 <3.0.0",
                   "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
                 },
                 "commander": {
                   "version": "2.8.1",
-                  "from": "commander@^2.8.1",
+                  "from": "commander@>=2.8.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>= 1.0.0",
+                      "from": "graceful-readlink@>=1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.1",
-                  "from": "is-my-json-valid@^2.12.0",
+                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@^2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@^1.1.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@^1.0.0",
+                          "from": "is-property@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "1.1.0",
-                      "from": "jsonpointer@^1.1.0",
+                      "from": "jsonpointer@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "xtend@^4.0.0",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -8510,44 +8510,44 @@
         },
         "rimraf": {
           "version": "2.4.2",
-          "from": "rimraf@^2.4.0",
+          "from": "rimraf@>=2.4.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz"
         },
         "rsvp": {
           "version": "3.0.21",
-          "from": "rsvp@^3.0.18",
+          "from": "rsvp@>=3.0.18 <4.0.0",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.21.tgz"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@^4.3.6",
+          "from": "semver@>=4.3.6 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         },
         "systemjs": {
-          "version": "0.18.9",
-          "from": "systemjs@^0.18.2",
-          "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.18.9.tgz",
+          "version": "0.18.10",
+          "from": "systemjs@>=0.18.2 <0.19.0",
+          "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.18.10.tgz",
           "dependencies": {
             "es6-module-loader": {
-              "version": "0.17.5",
-              "from": "es6-module-loader@^0.17.4",
-              "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.5.tgz"
+              "version": "0.17.6",
+              "from": "es6-module-loader@>=0.17.4 <0.18.0",
+              "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.6.tgz"
             },
             "when": {
               "version": "3.7.3",
-              "from": "when@^3.7.2",
+              "from": "when@>=3.7.2 <4.0.0",
               "resolved": "https://registry.npmjs.org/when/-/when-3.7.3.tgz"
             }
           }
         },
         "systemjs-builder": {
           "version": "0.12.2",
-          "from": "systemjs-builder@^0.12.1",
+          "from": "systemjs-builder@>=0.12.1 <0.13.0",
           "resolved": "https://registry.npmjs.org/systemjs-builder/-/systemjs-builder-0.12.2.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@^0.4.2",
+              "from": "source-map@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
@@ -8566,39 +8566,39 @@
           "dependencies": {
             "commander": {
               "version": "2.6.0",
-              "from": "commander@2.6",
+              "from": "commander@>=2.6.0 <2.7.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "glob": {
               "version": "4.3.5",
-              "from": "glob@4.3",
+              "from": "glob@>=4.3.0 <4.4.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@^1.3.0",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -8607,12 +8607,12 @@
             },
             "semver": {
               "version": "2.3.2",
-              "from": "semver@2.x",
+              "from": "semver@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "source-map-support@~0.2.8",
+              "from": "source-map-support@>=0.2.8 <0.3.0",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
@@ -8633,12 +8633,12 @@
         },
         "uglify-js": {
           "version": "2.4.24",
-          "from": "uglify-js@~2.4.23",
+          "from": "uglify-js@>=2.4.23 <2.5.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.6",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
@@ -8655,22 +8655,22 @@
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@~1.0.0",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.5.4",
-              "from": "yargs@~3.5.4",
+              "from": "yargs@>=3.5.4 <3.6.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@^1.0.2",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "decamelize@^1.0.0",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "window-size": {
@@ -8691,7 +8691,7 @@
     },
     "jspm-bower-endpoint": {
       "version": "0.3.2",
-      "from": "jspm-bower-endpoint@^0.3.2",
+      "from": "jspm-bower-endpoint@>=0.3.2 <0.4.0",
       "resolved": "https://registry.npmjs.org/jspm-bower-endpoint/-/jspm-bower-endpoint-0.3.2.tgz",
       "dependencies": {
         "bower": {
@@ -8701,7 +8701,7 @@
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "abbrev@^1.0.5",
+              "from": "abbrev@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             },
             "archy": {
@@ -8711,32 +8711,32 @@
             },
             "bower-config": {
               "version": "0.6.1",
-              "from": "bower-config@^0.6.0",
+              "from": "bower-config@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@~2.0.0",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "mout": {
                   "version": "0.9.1",
-                  "from": "mout@~0.9.0",
+                  "from": "mout@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
                 },
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "optimist@~0.6.0",
+                  "from": "optimist@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.3",
-                      "from": "wordwrap@~0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     },
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "minimist@~0.0.1",
+                      "from": "minimist@>=0.0.1 <0.1.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
@@ -8750,59 +8750,59 @@
             },
             "bower-json": {
               "version": "0.4.0",
-              "from": "bower-json@^0.4.0",
+              "from": "bower-json@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
               "dependencies": {
                 "deep-extend": {
                   "version": "0.2.11",
-                  "from": "deep-extend@~0.2.5",
+                  "from": "deep-extend@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@~2.0.0",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "intersect": {
                   "version": "0.0.3",
-                  "from": "intersect@~0.0.3",
+                  "from": "intersect@>=0.0.3 <0.1.0",
                   "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
                 }
               }
             },
             "bower-registry-client": {
               "version": "0.2.4",
-              "from": "bower-registry-client@^0.2.1",
+              "from": "bower-registry-client@>=0.2.1 <0.3.0",
               "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.4.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@~0.2.8",
+                  "from": "async@>=0.2.8 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "bower-config": {
                   "version": "0.5.2",
-                  "from": "bower-config@~0.5.0",
+                  "from": "bower-config@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
                   "dependencies": {
                     "mout": {
                       "version": "0.9.1",
-                      "from": "mout@~0.9.0",
+                      "from": "mout@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
                     },
                     "optimist": {
                       "version": "0.6.1",
-                      "from": "optimist@~0.6.0",
+                      "from": "optimist@>=0.6.0 <0.7.0",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.3",
-                          "from": "wordwrap@~0.0.2",
+                          "from": "wordwrap@>=0.0.2 <0.1.0",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         },
                         "minimist": {
                           "version": "0.0.10",
-                          "from": "minimist@~0.0.1",
+                          "from": "minimist@>=0.0.1 <0.1.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                         }
                       }
@@ -8816,32 +8816,32 @@
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@~2.0.0",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "lru-cache": {
                   "version": "2.3.1",
-                  "from": "lru-cache@~2.3.0",
+                  "from": "lru-cache@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
                 },
                 "request": {
                   "version": "2.51.0",
-                  "from": "request@~2.51.0",
+                  "from": "request@>=2.51.0 <2.52.0",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "0.9.4",
-                      "from": "bl@~0.9.0",
+                      "from": "bl@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "readable-stream@~1.0.26",
+                          "from": "readable-stream@>=1.0.26 <1.1.0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
@@ -8851,12 +8851,12 @@
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@~0.10.x",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@~2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -8865,32 +8865,32 @@
                     },
                     "caseless": {
                       "version": "0.8.0",
-                      "from": "caseless@~0.8.0",
+                      "from": "caseless@>=0.8.0 <0.9.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                     },
                     "forever-agent": {
                       "version": "0.5.2",
-                      "from": "forever-agent@~0.5.0",
+                      "from": "forever-agent@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                     },
                     "form-data": {
                       "version": "0.2.0",
-                      "from": "form-data@~0.2.0",
+                      "from": "form-data@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.9.2",
-                          "from": "async@~0.9.0",
+                          "from": "async@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                         },
                         "mime-types": {
                           "version": "2.0.14",
-                          "from": "mime-types@~2.0.3",
+                          "from": "mime-types@>=2.0.3 <2.1.0",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                           "dependencies": {
                             "mime-db": {
                               "version": "1.12.0",
-                              "from": "mime-db@~1.12.0",
+                              "from": "mime-db@>=1.12.0 <1.13.0",
                               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                             }
                           }
@@ -8899,27 +8899,27 @@
                     },
                     "json-stringify-safe": {
                       "version": "5.0.1",
-                      "from": "json-stringify-safe@~5.0.0",
+                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "mime-types": {
                       "version": "1.0.2",
-                      "from": "mime-types@~1.0.1",
+                      "from": "mime-types@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                     },
                     "node-uuid": {
                       "version": "1.4.3",
-                      "from": "node-uuid@~1.4.0",
+                      "from": "node-uuid@>=1.4.0 <1.5.0",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                     },
                     "qs": {
                       "version": "2.3.3",
-                      "from": "qs@~2.3.1",
+                      "from": "qs@>=2.3.1 <2.4.0",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.1",
-                      "from": "tunnel-agent@~0.4.0",
+                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                     },
                     "tough-cookie": {
@@ -8929,12 +8929,12 @@
                     },
                     "http-signature": {
                       "version": "0.10.1",
-                      "from": "http-signature@~0.10.0",
+                      "from": "http-signature@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.5",
-                          "from": "assert-plus@^0.1.5",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                         },
                         "asn1": {
@@ -8951,7 +8951,7 @@
                     },
                     "oauth-sign": {
                       "version": "0.5.0",
-                      "from": "oauth-sign@~0.5.0",
+                      "from": "oauth-sign@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                     },
                     "hawk": {
@@ -8961,39 +8961,39 @@
                       "dependencies": {
                         "hoek": {
                           "version": "0.9.1",
-                          "from": "hoek@0.9.x",
+                          "from": "hoek@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                         },
                         "boom": {
                           "version": "0.4.2",
-                          "from": "boom@0.4.x",
+                          "from": "boom@>=0.4.0 <0.5.0",
                           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                         },
                         "cryptiles": {
                           "version": "0.2.2",
-                          "from": "cryptiles@0.2.x",
+                          "from": "cryptiles@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                         },
                         "sntp": {
                           "version": "0.2.4",
-                          "from": "sntp@0.2.x",
+                          "from": "sntp@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                         }
                       }
                     },
                     "aws-sign2": {
                       "version": "0.5.0",
-                      "from": "aws-sign2@~0.5.0",
+                      "from": "aws-sign2@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                     },
                     "stringstream": {
                       "version": "0.0.4",
-                      "from": "stringstream@~0.0.4",
+                      "from": "stringstream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@~0.0.5",
+                      "from": "combined-stream@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
@@ -9007,17 +9007,17 @@
                 },
                 "request-replay": {
                   "version": "0.2.0",
-                  "from": "request-replay@~0.2.0",
+                  "from": "request-replay@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "rimraf@~2.2.0",
+                  "from": "rimraf@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@~0.3.5",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 }
               }
@@ -9029,65 +9029,65 @@
               "dependencies": {
                 "redeyed": {
                   "version": "0.4.4",
-                  "from": "redeyed@~0.4.0",
+                  "from": "redeyed@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
                   "dependencies": {
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "esprima@~1.0.4",
+                      "from": "esprima@>=1.0.4 <1.1.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     }
                   }
                 },
                 "ansicolors": {
                   "version": "0.2.1",
-                  "from": "ansicolors@~0.2.1",
+                  "from": "ansicolors@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
                 }
               }
             },
             "chalk": {
               "version": "1.1.0",
-              "from": "chalk@^1.0.0",
+              "from": "chalk@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
@@ -9099,114 +9099,114 @@
             },
             "configstore": {
               "version": "0.3.2",
-              "from": "configstore@^0.3.2",
+              "from": "configstore@>=0.3.2 <0.4.0",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
               "dependencies": {
                 "js-yaml": {
                   "version": "3.3.1",
-                  "from": "js-yaml@^3.1.0",
+                  "from": "js-yaml@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "1.0.2",
-                      "from": "argparse@~1.0.2",
+                      "from": "argparse@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                       "dependencies": {
                         "lodash": {
                           "version": "3.10.1",
-                          "from": "lodash@>= 3.2.0 < 4.0.0",
+                          "from": "lodash@>=3.2.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                         },
                         "sprintf-js": {
                           "version": "1.0.3",
-                          "from": "sprintf-js@~1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "2.2.0",
-                      "from": "esprima@~2.2.0",
+                      "from": "esprima@>=2.2.0 <2.3.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "2.1.1",
-                  "from": "object-assign@^2.0.0",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@^0.1.0",
+                  "from": "osenv@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@^1.0.0",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "os-tmpdir@^1.0.0",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "uuid": {
                   "version": "2.0.1",
-                  "from": "uuid@^2.0.1",
+                  "from": "uuid@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                 },
                 "xdg-basedir": {
                   "version": "1.0.1",
-                  "from": "xdg-basedir@^1.0.0",
+                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
                 }
               }
             },
             "decompress-zip": {
               "version": "0.1.0",
-              "from": "decompress-zip@^0.1.0",
+              "from": "decompress-zip@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
               "dependencies": {
                 "binary": {
                   "version": "0.3.0",
-                  "from": "binary@^0.3.0",
+                  "from": "binary@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                   "dependencies": {
                     "chainsaw": {
                       "version": "0.1.0",
-                      "from": "chainsaw@~0.1.0",
+                      "from": "chainsaw@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.3.9",
-                          "from": "traverse@>=0.3.0 <0.4",
+                          "from": "traverse@>=0.3.0 <0.4.0",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                         }
                       }
                     },
                     "buffers": {
                       "version": "0.1.1",
-                      "from": "buffers@~0.1.1",
+                      "from": "buffers@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                     }
                   }
                 },
                 "mkpath": {
                   "version": "0.1.0",
-                  "from": "mkpath@^0.1.0",
+                  "from": "mkpath@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@^1.1.8",
+                  "from": "readable-stream@>=1.1.8 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -9216,12 +9216,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -9233,7 +9233,7 @@
                   "dependencies": {
                     "nopt": {
                       "version": "1.0.10",
-                      "from": "nopt@~1.0.10",
+                      "from": "nopt@>=1.0.10 <1.1.0",
                       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
                     }
                   }
@@ -9242,39 +9242,39 @@
             },
             "fstream": {
               "version": "1.0.7",
-              "from": "fstream@^1.0.3",
+              "from": "fstream@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.0",
+                  "from": "inherits@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "fstream-ignore": {
               "version": "1.0.2",
-              "from": "fstream-ignore@^1.0.2",
+              "from": "fstream-ignore@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@^2.0.1",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -9290,51 +9290,51 @@
             },
             "github": {
               "version": "0.2.4",
-              "from": "github@^0.2.3",
+              "from": "github@>=0.2.3 <0.3.0",
               "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
               "dependencies": {
                 "mime": {
                   "version": "1.3.4",
-                  "from": "mime@^1.2.11",
+                  "from": "mime@>=1.2.11 <2.0.0",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 }
               }
             },
             "glob": {
               "version": "4.5.3",
-              "from": "glob@^4.3.2",
+              "from": "glob@>=4.3.2 <5.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@^1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@^2.0.1",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -9348,12 +9348,12 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@^1.3.0",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -9362,7 +9362,7 @@
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@^3.0.5",
+              "from": "graceful-fs@>=3.0.5 <4.0.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "inquirer": {
@@ -9372,129 +9372,129 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@^1.1.0",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "chalk": {
                   "version": "0.5.1",
-                  "from": "chalk@^0.5.0",
+                  "from": "chalk@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "1.1.0",
-                      "from": "ansi-styles@^1.1.0",
+                      "from": "ansi-styles@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@^1.0.0",
+                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "0.1.0",
-                      "from": "has-ansi@^0.1.0",
+                      "from": "has-ansi@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@^0.2.1",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "0.3.0",
-                      "from": "strip-ansi@^0.3.0",
+                      "from": "strip-ansi@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@^0.2.1",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "0.2.0",
-                      "from": "supports-color@^0.2.0",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                     }
                   }
                 },
                 "cli-color": {
                   "version": "0.3.3",
-                  "from": "cli-color@~0.3.2",
+                  "from": "cli-color@>=0.3.2 <0.4.0",
                   "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "d@~0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "es5-ext@~0.10.6",
+                      "from": "es5-ext@>=0.10.6 <0.11.0",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                       "dependencies": {
                         "es6-iterator": {
                           "version": "0.1.3",
-                          "from": "es6-iterator@~0.1.3",
+                          "from": "es6-iterator@>=0.1.3 <0.2.0",
                           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                         },
                         "es6-symbol": {
                           "version": "2.0.1",
-                          "from": "es6-symbol@~2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                         }
                       }
                     },
                     "memoizee": {
                       "version": "0.3.9",
-                      "from": "memoizee@~0.3.8",
+                      "from": "memoizee@>=0.3.8 <0.4.0",
                       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
                       "dependencies": {
                         "es6-weak-map": {
                           "version": "0.1.4",
-                          "from": "es6-weak-map@~0.1.4",
+                          "from": "es6-weak-map@>=0.1.4 <0.2.0",
                           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                           "dependencies": {
                             "es6-iterator": {
                               "version": "0.1.3",
-                              "from": "es6-iterator@~0.1.3",
+                              "from": "es6-iterator@>=0.1.3 <0.2.0",
                               "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                             },
                             "es6-symbol": {
                               "version": "2.0.1",
-                              "from": "es6-symbol@~2.0.1",
+                              "from": "es6-symbol@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                             }
                           }
                         },
                         "event-emitter": {
                           "version": "0.3.3",
-                          "from": "event-emitter@~0.3.3",
+                          "from": "event-emitter@>=0.3.3 <0.4.0",
                           "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                         },
                         "lru-queue": {
                           "version": "0.1.0",
-                          "from": "lru-queue@0.1",
+                          "from": "lru-queue@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                         },
                         "next-tick": {
                           "version": "0.2.2",
-                          "from": "next-tick@~0.2.2",
+                          "from": "next-tick@>=0.2.2 <0.3.0",
                           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                         }
                       }
                     },
                     "timers-ext": {
                       "version": "0.1.0",
-                      "from": "timers-ext@0.1",
+                      "from": "timers-ext@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                       "dependencies": {
                         "next-tick": {
                           "version": "0.2.2",
-                          "from": "next-tick@~0.2.2",
+                          "from": "next-tick@>=0.2.2 <0.3.0",
                           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                         }
                       }
@@ -9503,12 +9503,12 @@
                 },
                 "figures": {
                   "version": "1.3.5",
-                  "from": "figures@^1.3.2",
+                  "from": "figures@>=1.3.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "lodash@~2.4.1",
+                  "from": "lodash@>=2.4.1 <2.5.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "mute-stream": {
@@ -9518,82 +9518,82 @@
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "readline2@~0.1.0",
+                  "from": "readline2@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "strip-ansi@^2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
                     }
                   }
                 },
                 "rx": {
                   "version": "2.5.3",
-                  "from": "rx@^2.2.27",
+                  "from": "rx@>=2.2.27 <3.0.0",
                   "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@~2.3.4",
+                  "from": "through@>=2.3.4 <2.4.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
             },
             "insight": {
               "version": "0.5.3",
-              "from": "insight@^0.5.0",
+              "from": "insight@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@^0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "lodash.debounce": {
                   "version": "3.1.1",
-                  "from": "lodash.debounce@^3.0.1",
+                  "from": "lodash.debounce@>=3.0.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "lodash._getnative@^3.0.0",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "2.1.1",
-                  "from": "object-assign@^2.0.0",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                 },
                 "os-name": {
                   "version": "1.0.3",
-                  "from": "os-name@^1.0.0",
+                  "from": "os-name@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
                   "dependencies": {
                     "osx-release": {
                       "version": "1.1.0",
-                      "from": "osx-release@^1.0.0",
+                      "from": "osx-release@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "1.1.3",
-                          "from": "minimist@^1.1.0",
+                          "from": "minimist@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                         }
                       }
                     },
                     "win-release": {
                       "version": "1.0.0",
-                      "from": "win-release@^1.0.0",
+                      "from": "win-release@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
                     }
                   }
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "tough-cookie@^0.12.1",
+                  "from": "tough-cookie@>=0.12.1 <0.13.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
@@ -9607,32 +9607,32 @@
             },
             "is-root": {
               "version": "1.0.0",
-              "from": "is-root@^1.0.0",
+              "from": "is-root@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
             },
             "junk": {
               "version": "1.0.2",
-              "from": "junk@^1.0.0",
+              "from": "junk@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz"
             },
             "lockfile": {
               "version": "1.0.1",
-              "from": "lockfile@^1.0.0",
+              "from": "lockfile@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
             },
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@^2.5.0",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "nopt": {
               "version": "3.0.3",
-              "from": "nopt@^3.0.1",
+              "from": "nopt@>=3.0.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz"
             },
             "opn": {
               "version": "1.0.2",
-              "from": "opn@^1.0.1",
+              "from": "opn@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
             },
             "p-throttler": {
@@ -9642,7 +9642,7 @@
               "dependencies": {
                 "q": {
                   "version": "0.9.7",
-                  "from": "q@~0.9.2",
+                  "from": "q@>=0.9.2 <0.10.0",
                   "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
                 }
               }
@@ -9654,12 +9654,12 @@
               "dependencies": {
                 "read": {
                   "version": "1.0.6",
-                  "from": "read@~1.0.4",
+                  "from": "read@>=1.0.4 <1.1.0",
                   "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.5",
-                      "from": "mute-stream@~0.0.4",
+                      "from": "mute-stream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                     }
                   }
@@ -9673,17 +9673,17 @@
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@~0.9.0",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@~1.0.26",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
@@ -9693,12 +9693,12 @@
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -9707,56 +9707,56 @@
                 },
                 "caseless": {
                   "version": "0.9.0",
-                  "from": "caseless@~0.9.0",
+                  "from": "caseless@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@~0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "async@~0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@~2.0.1",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "mime-db@~1.12.0",
+                      "from": "mime-db@>=1.12.0 <1.13.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "node-uuid@~1.4.0",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "qs@~2.3.1",
+                  "from": "qs@>=2.3.1 <2.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
-                  "from": "tunnel-agent@~0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 },
                 "tough-cookie": {
@@ -9766,12 +9766,12 @@
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@~0.10.0",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
@@ -9788,49 +9788,49 @@
                 },
                 "oauth-sign": {
                   "version": "0.6.0",
-                  "from": "oauth-sign@~0.6.0",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@~2.3.0",
+                  "from": "hawk@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.14.0",
-                      "from": "hoek@2.x.x",
+                      "from": "hoek@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
                       "version": "2.8.0",
-                      "from": "boom@2.x.x",
+                      "from": "boom@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "cryptiles@2.x.x",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "sntp@1.x.x",
+                      "from": "sntp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@~0.0.5",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -9842,7 +9842,7 @@
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "isstream@~0.1.1",
+                  "from": "isstream@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 }
               }
@@ -9854,7 +9854,7 @@
               "dependencies": {
                 "throttleit": {
                   "version": "0.0.2",
-                  "from": "throttleit@~0.0.2",
+                  "from": "throttleit@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
                 }
               }
@@ -9866,44 +9866,44 @@
             },
             "rimraf": {
               "version": "2.4.2",
-              "from": "rimraf@^2.2.8",
+              "from": "rimraf@>=2.2.8 <3.0.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
               "dependencies": {
                 "glob": {
                   "version": "5.0.14",
-                  "from": "glob@^5.0.14",
+                  "from": "glob@>=5.0.14 <6.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@^1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@^2.0.1",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.0",
-                          "from": "brace-expansion@^1.0.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.2.0",
-                              "from": "balanced-match@^0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                             },
                             "concat-map": {
@@ -9917,19 +9917,19 @@
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@^1.3.0",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@^1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
@@ -9938,64 +9938,64 @@
             },
             "semver": {
               "version": "2.3.2",
-              "from": "semver@^2.3.0",
+              "from": "semver@>=2.3.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "shell-quote": {
               "version": "1.4.3",
-              "from": "shell-quote@^1.4.2",
+              "from": "shell-quote@>=1.4.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@~0.0.0",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 },
                 "array-filter": {
                   "version": "0.0.1",
-                  "from": "array-filter@~0.0.0",
+                  "from": "array-filter@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
                 },
                 "array-reduce": {
                   "version": "0.0.0",
-                  "from": "array-reduce@~0.0.0",
+                  "from": "array-reduce@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
                 },
                 "array-map": {
                   "version": "0.0.0",
-                  "from": "array-map@~0.0.0",
+                  "from": "array-map@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
                 }
               }
             },
             "stringify-object": {
               "version": "1.0.1",
-              "from": "stringify-object@^1.0.0",
+              "from": "stringify-object@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
             },
             "tar-fs": {
               "version": "1.8.1",
-              "from": "tar-fs@^1.4.1",
+              "from": "tar-fs@>=1.4.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.8.1.tgz",
               "dependencies": {
                 "pump": {
                   "version": "1.0.0",
-                  "from": "pump@^1.0.0",
+                  "from": "pump@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "end-of-stream@^1.0.0",
+                      "from": "end-of-stream@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@^1.3.1",
+                      "from": "once@>=1.3.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -10004,27 +10004,27 @@
                 },
                 "tar-stream": {
                   "version": "1.2.1",
-                  "from": "tar-stream@^1.1.2",
+                  "from": "tar-stream@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "1.0.0",
-                      "from": "bl@^1.0.0",
+                      "from": "bl@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
                     },
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "end-of-stream@^1.0.0",
+                      "from": "end-of-stream@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "dependencies": {
                         "once": {
                           "version": "1.3.2",
-                          "from": "once@~1.3.0",
+                          "from": "once@>=1.3.0 <1.4.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -10033,17 +10033,17 @@
                     },
                     "readable-stream": {
                       "version": "2.0.2",
-                      "from": "readable-stream@^2.0.0",
+                      "from": "readable-stream@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
@@ -10053,24 +10053,24 @@
                         },
                         "process-nextick-args": {
                           "version": "1.0.2",
-                          "from": "process-nextick-args@~1.0.0",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "util-deprecate@~1.0.1",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "xtend@^4.0.0",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -10084,32 +10084,32 @@
             },
             "update-notifier": {
               "version": "0.3.2",
-              "from": "update-notifier@^0.3.0",
+              "from": "update-notifier@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
               "dependencies": {
                 "is-npm": {
                   "version": "1.0.0",
-                  "from": "is-npm@^1.0.0",
+                  "from": "is-npm@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
                 },
                 "latest-version": {
                   "version": "1.0.1",
-                  "from": "latest-version@^1.0.0",
+                  "from": "latest-version@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
                   "dependencies": {
                     "package-json": {
                       "version": "1.2.0",
-                      "from": "package-json@^1.0.0",
+                      "from": "package-json@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
                       "dependencies": {
                         "got": {
                           "version": "3.3.1",
-                          "from": "got@^3.2.0",
+                          "from": "got@>=3.2.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
                           "dependencies": {
                             "duplexify": {
                               "version": "3.4.2",
-                              "from": "duplexify@^3.2.0",
+                              "from": "duplexify@>=3.2.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                               "dependencies": {
                                 "end-of-stream": {
@@ -10119,12 +10119,12 @@
                                   "dependencies": {
                                     "once": {
                                       "version": "1.3.2",
-                                      "from": "once@^1.3.0",
+                                      "from": "once@>=1.3.0 <1.4.0",
                                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                                       "dependencies": {
                                         "wrappy": {
                                           "version": "1.0.1",
-                                          "from": "wrappy@1",
+                                          "from": "wrappy@>=1.0.0 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                         }
                                       }
@@ -10133,17 +10133,17 @@
                                 },
                                 "readable-stream": {
                                   "version": "2.0.2",
-                                  "from": "readable-stream@^2.0.0",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "core-util-is@~1.0.0",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@2",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
@@ -10153,17 +10153,17 @@
                                     },
                                     "process-nextick-args": {
                                       "version": "1.0.2",
-                                      "from": "process-nextick-args@~1.0.0",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "string_decoder@~0.10.x",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.1",
-                                      "from": "util-deprecate@~1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                                     }
                                   }
@@ -10172,76 +10172,76 @@
                             },
                             "infinity-agent": {
                               "version": "2.0.3",
-                              "from": "infinity-agent@^2.0.0",
+                              "from": "infinity-agent@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
                             },
                             "is-redirect": {
                               "version": "1.0.0",
-                              "from": "is-redirect@^1.0.0",
+                              "from": "is-redirect@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
                             },
                             "is-stream": {
                               "version": "1.0.1",
-                              "from": "is-stream@^1.0.0",
+                              "from": "is-stream@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
-                              "from": "lowercase-keys@^1.0.0",
+                              "from": "lowercase-keys@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                             },
                             "nested-error-stacks": {
                               "version": "1.0.1",
-                              "from": "nested-error-stacks@^1.0.0",
+                              "from": "nested-error-stacks@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
                               "dependencies": {
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@~2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
                             },
                             "object-assign": {
                               "version": "3.0.0",
-                              "from": "object-assign@^3.0.0",
+                              "from": "object-assign@>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                             },
                             "prepend-http": {
                               "version": "1.0.2",
-                              "from": "prepend-http@^1.0.0",
+                              "from": "prepend-http@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
                             },
                             "read-all-stream": {
                               "version": "3.0.1",
-                              "from": "read-all-stream@^3.0.0",
+                              "from": "read-all-stream@>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
                               "dependencies": {
                                 "pinkie-promise": {
                                   "version": "1.0.0",
-                                  "from": "pinkie-promise@^1.0.0",
+                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "1.0.0",
-                                      "from": "pinkie@^1.0.0",
+                                      "from": "pinkie@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                     }
                                   }
                                 },
                                 "readable-stream": {
                                   "version": "2.0.2",
-                                  "from": "readable-stream@^2.0.0",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "core-util-is@~1.0.0",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "inherits@~2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
@@ -10251,17 +10251,17 @@
                                     },
                                     "process-nextick-args": {
                                       "version": "1.0.2",
-                                      "from": "process-nextick-args@~1.0.0",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "string_decoder@~0.10.x",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.1",
-                                      "from": "util-deprecate@~1.0.1",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                                     }
                                   }
@@ -10270,39 +10270,39 @@
                             },
                             "timed-out": {
                               "version": "2.0.0",
-                              "from": "timed-out@^2.0.0",
+                              "from": "timed-out@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                             }
                           }
                         },
                         "registry-url": {
                           "version": "3.0.3",
-                          "from": "registry-url@^3.0.0",
+                          "from": "registry-url@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
                           "dependencies": {
                             "rc": {
                               "version": "1.1.0",
-                              "from": "rc@^1.0.1",
+                              "from": "rc@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.0.tgz",
                               "dependencies": {
                                 "minimist": {
                                   "version": "1.1.3",
-                                  "from": "minimist@^1.1.0",
+                                  "from": "minimist@>=1.1.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                                 },
                                 "deep-extend": {
                                   "version": "0.2.11",
-                                  "from": "deep-extend@~0.2.5",
+                                  "from": "deep-extend@>=0.2.5 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                                 },
                                 "strip-json-comments": {
                                   "version": "0.1.3",
-                                  "from": "strip-json-comments@0.1.x",
+                                  "from": "strip-json-comments@>=0.1.0 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                                 },
                                 "ini": {
                                   "version": "1.3.4",
-                                  "from": "ini@~1.3.0",
+                                  "from": "ini@>=1.3.0 <1.4.0",
                                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                                 }
                               }
@@ -10315,29 +10315,29 @@
                 },
                 "semver-diff": {
                   "version": "2.0.0",
-                  "from": "semver-diff@^2.0.0",
+                  "from": "semver-diff@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
                   "dependencies": {
                     "semver": {
                       "version": "4.3.6",
-                      "from": "semver@^4.0.0",
+                      "from": "semver@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                     }
                   }
                 },
                 "string-length": {
                   "version": "1.0.1",
-                  "from": "string-length@^1.0.0",
+                  "from": "string-length@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
                   "dependencies": {
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@^3.0.0",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@^2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
@@ -10348,22 +10348,22 @@
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@^1.1.0",
+              "from": "user-home@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             },
             "which": {
               "version": "1.1.1",
-              "from": "which@^1.0.8",
+              "from": "which@>=1.0.8 <2.0.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "is-absolute@^0.1.7",
+                  "from": "is-absolute@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
-                      "from": "is-relative@^0.1.0",
+                      "from": "is-relative@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
@@ -10384,17 +10384,17 @@
         },
         "mout": {
           "version": "0.11.0",
-          "from": "mout@^0.11.0",
+          "from": "mout@>=0.11.0 <0.12.0",
           "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.0.tgz"
         },
         "q": {
           "version": "1.4.1",
-          "from": "q@^1.2.0",
+          "from": "q@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@^4.3.0",
+          "from": "semver@>=4.3.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
@@ -10406,7 +10406,7 @@
       "dependencies": {
         "di": {
           "version": "0.0.1",
-          "from": "di@~0.0.1",
+          "from": "di@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
         },
         "socket.io": {
@@ -10426,22 +10426,22 @@
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "ws@0.4.x",
+                  "from": "ws@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "commander@~2.1.0",
+                      "from": "commander@>=2.1.0 <2.2.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "nan@~1.0.0",
+                      "from": "nan@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "tinycolor@0.x",
+                      "from": "tinycolor@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
@@ -10494,64 +10494,64 @@
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@^1.1.0",
+              "from": "anymatch@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
                   "version": "2.2.0",
-                  "from": "micromatch@^2.1.5",
+                  "from": "micromatch@>=2.1.5 <3.0.0",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "arr-diff@^1.0.1",
+                      "from": "arr-diff@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
                           "version": "0.2.3",
-                          "from": "array-slice@^0.2.2",
+                          "from": "array-slice@>=0.2.2 <0.3.0",
                           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
-                      "from": "array-unique@^0.2.1",
+                      "from": "array-unique@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "braces@^1.8.0",
+                      "from": "braces@>=1.8.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@^1.8.1",
+                          "from": "expand-range@>=1.8.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.2",
-                              "from": "fill-range@^2.1.0",
+                              "from": "fill-range@>=2.1.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "is-number@^1.1.2",
+                                  "from": "is-number@>=1.1.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
                                   "version": "1.0.2",
-                                  "from": "isobject@^1.0.0",
+                                  "from": "isobject@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "randomatic@^1.1.0",
+                                  "from": "randomatic@>=1.1.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@^1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -10560,36 +10560,36 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@^0.2.0",
+                          "from": "preserve@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "repeat-element@^1.1.0",
+                          "from": "repeat-element@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.3",
-                      "from": "expand-brackets@^0.1.1",
+                      "from": "expand-brackets@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
                       "dependencies": {
                         "is-posix-bracket": {
                           "version": "0.1.0",
-                          "from": "is-posix-bracket@^0.1.0",
+                          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz"
                         }
                       }
                     },
                     "extglob": {
                       "version": "0.3.1",
-                      "from": "extglob@^0.3.0",
+                      "from": "extglob@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
                       "dependencies": {
                         "ansi-green": {
                           "version": "0.1.1",
-                          "from": "ansi-green@^0.1.1",
+                          "from": "ansi-green@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
                           "dependencies": {
                             "ansi-wrap": {
@@ -10601,85 +10601,85 @@
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@^1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "success-symbol": {
                           "version": "0.1.0",
-                          "from": "success-symbol@^0.1.0",
+                          "from": "success-symbol@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
                         }
                       }
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@^2.0.0",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "kind-of@^1.1.0",
+                      "from": "kind-of@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
                       "version": "1.1.0",
-                      "from": "object.omit@^1.1.0",
+                      "from": "object.omit@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@^0.1.3",
+                          "from": "for-own@>=0.1.3 <0.2.0",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@^0.1.4",
+                              "from": "for-in@>=0.1.4 <0.2.0",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
                           "version": "1.0.2",
-                          "from": "isobject@^1.0.0",
+                          "from": "isobject@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.2",
-                      "from": "parse-glob@^3.0.1",
+                      "from": "parse-glob@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "glob-base@^0.2.0",
+                          "from": "glob-base@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.1",
-                          "from": "is-dotfile@^1.0.0",
+                          "from": "is-dotfile@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@^1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "regex-cache@^0.4.2",
+                      "from": "regex-cache@>=0.4.2 <0.5.0",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "is-equal-shallow@^0.1.1",
+                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "is-primitive@^2.0.0",
+                          "from": "is-primitive@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -10690,59 +10690,59 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "arrify@^1.0.0",
+              "from": "arrify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@^0.1.5",
+              "from": "async-each@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "glob-parent@^1.0.0",
+              "from": "glob-parent@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@^1.0.0",
+              "from": "is-binary-path@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.3.1",
-                  "from": "binary-extensions@^1.0.0",
+                  "from": "binary-extensions@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "is-glob@^1.1.3",
+              "from": "is-glob@>=1.1.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@^1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
               "version": "1.4.0",
-              "from": "readdirp@^1.3.0",
+              "from": "readdirp@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "graceful-fs@~4.1.2",
+                  "from": "graceful-fs@>=4.1.2 <4.2.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26-2",
+                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -10752,12 +10752,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -10766,12 +10766,12 @@
             },
             "fsevents": {
               "version": "0.3.8",
-              "from": "fsevents@^0.3.1",
+              "from": "fsevents@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
               "dependencies": {
                 "nan": {
                   "version": "2.0.5",
-                  "from": "nan@^2.0.2",
+                  "from": "nan@>=2.0.2 <3.0.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
                 }
               }
@@ -10780,27 +10780,27 @@
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@~3.2.7",
+          "from": "glob@>=3.2.7 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@0.3",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.5",
-                  "from": "lru-cache@2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@~1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -10809,39 +10809,39 @@
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@~0.2",
+          "from": "minimatch@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "http-proxy": {
           "version": "0.10.4",
-          "from": "http-proxy@~0.10",
+          "from": "http-proxy@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
           "dependencies": {
             "pkginfo": {
               "version": "0.3.0",
-              "from": "pkginfo@0.3.x",
+              "from": "pkginfo@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "utile": {
               "version": "0.2.1",
-              "from": "utile@~0.2.1",
+              "from": "utile@>=0.2.1 <0.3.0",
               "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@~0.2.9",
+                  "from": "async@>=0.2.9 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "deep-equal": {
@@ -10851,12 +10851,12 @@
                 },
                 "i": {
                   "version": "0.3.3",
-                  "from": "i@0.3.x",
+                  "from": "i@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                 },
                 "ncp": {
                   "version": "0.4.2",
-                  "from": "ncp@0.4.x",
+                  "from": "ncp@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                 }
               }
@@ -10865,64 +10865,64 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@~0.6.0",
+          "from": "optimist@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@~0.0.2",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@~0.0.1",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.5",
+          "from": "rimraf@>=2.2.5 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "q": {
           "version": "0.9.7",
-          "from": "q@~0.9.7",
+          "from": "q@>=0.9.7 <0.10.0",
           "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@~1.2.11",
+          "from": "mime@>=1.2.11 <1.3.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "log4js": {
           "version": "0.6.26",
-          "from": "log4js@~0.6.3",
+          "from": "log4js@>=0.6.3 <0.7.0",
           "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.26.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.0",
+              "from": "async@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@~1.0.2",
+              "from": "readable-stream@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
@@ -10932,19 +10932,19 @@
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@~4.3.3",
+              "from": "semver@>=4.3.3 <4.4.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "underscore": {
@@ -10956,24 +10956,24 @@
         },
         "useragent": {
           "version": "2.0.10",
-          "from": "useragent@~2.0.4",
+          "from": "useragent@>=2.0.4 <2.1.0",
           "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.10.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
-              "from": "lru-cache@2.2.x",
+              "from": "lru-cache@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
             }
           }
         },
         "graceful-fs": {
           "version": "2.0.3",
-          "from": "graceful-fs@~2.0.1",
+          "from": "graceful-fs@>=2.0.1 <2.1.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
         },
         "connect": {
           "version": "2.26.6",
-          "from": "connect@~2.26.0",
+          "from": "connect@>=2.26.0 <2.27.0",
           "resolved": "https://registry.npmjs.org/connect/-/connect-2.26.6.tgz",
           "dependencies": {
             "basic-auth-connect": {
@@ -10983,7 +10983,7 @@
             },
             "body-parser": {
               "version": "1.8.4",
-              "from": "body-parser@~1.8.4",
+              "from": "body-parser@>=1.8.4 <1.9.0",
               "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
               "dependencies": {
                 "iconv-lite": {
@@ -11022,7 +11022,7 @@
             },
             "cookie-parser": {
               "version": "1.3.5",
-              "from": "cookie-parser@~1.3.3",
+              "from": "cookie-parser@>=1.3.3 <1.4.0",
               "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
               "dependencies": {
                 "cookie": {
@@ -11044,22 +11044,22 @@
             },
             "compression": {
               "version": "1.1.2",
-              "from": "compression@~1.1.2",
+              "from": "compression@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@~1.1.2",
+                  "from": "accepts@>=1.1.3 <1.2.0",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@~2.0.4",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@~1.12.0",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
@@ -11073,26 +11073,26 @@
                 },
                 "compressible": {
                   "version": "2.0.5",
-                  "from": "compressible@~2.0.1",
+                  "from": "compressible@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.5.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.16.0",
-                      "from": "mime-db@>= 1.16.0 < 2",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
+                      "version": "1.17.0",
+                      "from": "mime-db@>=1.16.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.17.0.tgz"
                     }
                   }
                 },
                 "vary": {
                   "version": "1.0.1",
-                  "from": "vary@~1.0.0",
+                  "from": "vary@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
                 }
               }
             },
             "connect-timeout": {
               "version": "1.3.0",
-              "from": "connect-timeout@~1.3.0",
+              "from": "connect-timeout@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
               "dependencies": {
                 "ms": {
@@ -11104,12 +11104,12 @@
             },
             "csurf": {
               "version": "1.6.6",
-              "from": "csurf@~1.6.2",
+              "from": "csurf@>=1.6.2 <1.7.0",
               "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
               "dependencies": {
                 "csrf": {
                   "version": "2.0.7",
-                  "from": "csrf@~2.0.5",
+                  "from": "csrf@>=2.0.5 <2.1.0",
                   "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.7.tgz",
                   "dependencies": {
                     "base64-url": {
@@ -11119,7 +11119,7 @@
                     },
                     "rndm": {
                       "version": "1.1.0",
-                      "from": "rndm@~1.1.0",
+                      "from": "rndm@>=1.1.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz"
                     },
                     "scmp": {
@@ -11129,12 +11129,12 @@
                     },
                     "uid-safe": {
                       "version": "1.1.0",
-                      "from": "uid-safe@~1.1.0",
+                      "from": "uid-safe@>=1.1.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
                           "version": "1.1.2",
-                          "from": "native-or-bluebird@~1.1.2",
+                          "from": "native-or-bluebird@>=1.1.2 <1.2.0",
                           "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
                         }
                       }
@@ -11143,17 +11143,17 @@
                 },
                 "http-errors": {
                   "version": "1.2.8",
-                  "from": "http-errors@~1.2.8",
+                  "from": "http-errors@>=1.2.8 <1.3.0",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "statuses": {
                       "version": "1.2.1",
-                      "from": "statuses@1",
+                      "from": "statuses@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                     }
                   }
@@ -11162,7 +11162,7 @@
             },
             "debug": {
               "version": "2.0.0",
-              "from": "debug@~2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
                 "ms": {
@@ -11179,22 +11179,22 @@
             },
             "errorhandler": {
               "version": "1.2.4",
-              "from": "errorhandler@~1.2.2",
+              "from": "errorhandler@>=1.2.2 <1.3.0",
               "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.4.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@~1.1.2",
+                  "from": "accepts@>=1.1.3 <1.2.0",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@~2.0.1",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@~1.12.0",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
@@ -11215,7 +11215,7 @@
             },
             "express-session": {
               "version": "1.8.2",
-              "from": "express-session@~1.8.2",
+              "from": "express-session@>=1.8.2 <1.9.0",
               "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
               "dependencies": {
                 "crc": {
@@ -11230,29 +11230,29 @@
                   "dependencies": {
                     "mz": {
                       "version": "1.3.0",
-                      "from": "mz@1",
+                      "from": "mz@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
                           "version": "1.2.0",
-                          "from": "native-or-bluebird@1",
+                          "from": "native-or-bluebird@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
                         },
                         "thenify": {
                           "version": "3.1.0",
-                          "from": "thenify@3",
+                          "from": "thenify@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz"
                         },
                         "thenify-all": {
                           "version": "1.6.0",
-                          "from": "thenify-all@1",
+                          "from": "thenify-all@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
                         }
                       }
                     },
                     "base64-url": {
                       "version": "1.2.1",
-                      "from": "base64-url@1",
+                      "from": "base64-url@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     }
                   }
@@ -11288,7 +11288,7 @@
             },
             "method-override": {
               "version": "2.2.0",
-              "from": "method-override@~2.2.0",
+              "from": "method-override@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
               "dependencies": {
                 "methods": {
@@ -11298,14 +11298,14 @@
                 },
                 "vary": {
                   "version": "1.0.1",
-                  "from": "vary@~1.0.0",
+                  "from": "vary@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
                 }
               }
             },
             "morgan": {
               "version": "1.3.2",
-              "from": "morgan@~1.3.2",
+              "from": "morgan@>=1.3.2 <1.4.0",
               "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
               "dependencies": {
                 "basic-auth": {
@@ -11334,12 +11334,12 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@~1.1.9",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -11349,31 +11349,31 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "stream-counter": {
                   "version": "0.2.0",
-                  "from": "stream-counter@~0.2.0",
+                  "from": "stream-counter@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
                 }
               }
             },
             "on-headers": {
               "version": "1.0.0",
-              "from": "on-headers@~1.0.0",
+              "from": "on-headers@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
             },
             "parseurl": {
               "version": "1.3.0",
-              "from": "parseurl@~1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
             },
             "qs": {
@@ -11383,17 +11383,17 @@
             },
             "response-time": {
               "version": "2.0.1",
-              "from": "response-time@~2.0.1",
+              "from": "response-time@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz"
             },
             "serve-favicon": {
               "version": "2.1.7",
-              "from": "serve-favicon@~2.1.5",
+              "from": "serve-favicon@>=2.1.5 <2.2.0",
               "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
               "dependencies": {
                 "etag": {
                   "version": "1.5.1",
-                  "from": "etag@~1.5.0",
+                  "from": "etag@>=1.5.0 <1.6.0",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
                   "dependencies": {
                     "crc": {
@@ -11412,22 +11412,22 @@
             },
             "serve-index": {
               "version": "1.2.1",
-              "from": "serve-index@~1.2.1",
+              "from": "serve-index@>=1.2.1 <1.3.0",
               "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@~1.1.0",
+                  "from": "accepts@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@~2.0.4",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@~1.12.0",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
@@ -11448,7 +11448,7 @@
             },
             "serve-static": {
               "version": "1.6.5",
-              "from": "serve-static@~1.6.4",
+              "from": "serve-static@>=1.6.4 <1.7.0",
               "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
               "dependencies": {
                 "escape-html": {
@@ -11468,7 +11468,7 @@
                     },
                     "etag": {
                       "version": "1.4.0",
-                      "from": "etag@~1.4.0",
+                      "from": "etag@>=1.4.0 <1.5.0",
                       "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
                       "dependencies": {
                         "crc": {
@@ -11497,7 +11497,7 @@
                     },
                     "range-parser": {
                       "version": "1.0.2",
-                      "from": "range-parser@~1.0.2",
+                      "from": "range-parser@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
                     }
                   }
@@ -11511,17 +11511,17 @@
             },
             "type-is": {
               "version": "1.5.7",
-              "from": "type-is@~1.5.2",
+              "from": "type-is@>=1.5.2 <1.6.0",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@~2.0.1",
+                  "from": "mime-types@>=2.0.9 <2.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "mime-db@~1.12.0",
+                      "from": "mime-db@>=1.12.0 <1.13.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
@@ -11530,7 +11530,7 @@
             },
             "vhost": {
               "version": "3.0.1",
-              "from": "vhost@~3.0.0",
+              "from": "vhost@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.1.tgz"
             },
             "pause": {
@@ -11542,7 +11542,7 @@
         },
         "source-map": {
           "version": "0.1.43",
-          "from": "source-map@~0.1.31",
+          "from": "source-map@>=0.1.38 <0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
@@ -11561,17 +11561,17 @@
       "dependencies": {
         "which": {
           "version": "1.1.1",
-          "from": "which@^1.0.9",
+          "from": "which@>=1.0.9 <2.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "from": "is-absolute@^0.1.7",
+              "from": "is-absolute@>=0.1.7 <0.2.0",
               "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
-                  "from": "is-relative@^0.1.0",
+                  "from": "is-relative@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                 }
               }
@@ -11587,12 +11587,12 @@
       "dependencies": {
         "coffee-script": {
           "version": "1.7.1",
-          "from": "coffee-script@~1.7",
+          "from": "coffee-script@>=1.7.0 <1.8.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@~0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             }
           }
@@ -11606,69 +11606,69 @@
       "dependencies": {
         "istanbul": {
           "version": "0.3.17",
-          "from": "istanbul@~0.3.0",
+          "from": "istanbul@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.17.tgz",
           "dependencies": {
             "esprima": {
               "version": "2.4.1",
-              "from": "esprima@2.4.x",
+              "from": "esprima@>=2.4.0 <2.5.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.4.1.tgz"
             },
             "escodegen": {
               "version": "1.6.1",
-              "from": "escodegen@1.6.x",
+              "from": "escodegen@>=1.6.0 <1.7.0",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
               "dependencies": {
                 "estraverse": {
                   "version": "1.9.3",
-                  "from": "estraverse@^1.9.1",
+                  "from": "estraverse@>=1.9.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                 },
                 "esutils": {
                   "version": "1.1.6",
-                  "from": "esutils@^1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                 },
                 "esprima": {
                   "version": "1.2.5",
-                  "from": "esprima@^1.2.2",
+                  "from": "esprima@>=1.2.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                 },
                 "optionator": {
                   "version": "0.5.0",
-                  "from": "optionator@^0.5.0",
+                  "from": "optionator@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                   "dependencies": {
                     "prelude-ls": {
                       "version": "1.1.2",
-                      "from": "prelude-ls@~1.1.1",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                     },
                     "deep-is": {
                       "version": "0.1.3",
-                      "from": "deep-is@~0.1.2",
+                      "from": "deep-is@>=0.1.2 <0.2.0",
                       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                     },
                     "type-check": {
                       "version": "0.3.1",
-                      "from": "type-check@~0.3.1",
+                      "from": "type-check@>=0.3.1 <0.4.0",
                       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                     },
                     "levn": {
                       "version": "0.2.5",
-                      "from": "levn@~0.2.5",
+                      "from": "levn@>=0.2.5 <0.3.0",
                       "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                     },
                     "fast-levenshtein": {
-                      "version": "1.0.6",
-                      "from": "fast-levenshtein@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                      "version": "1.0.7",
+                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@~0.1.40",
+                  "from": "source-map@>=0.1.40 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -11687,19 +11687,19 @@
               "dependencies": {
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "optimist@^0.6.1",
+                  "from": "optimist@>=0.6.1 <0.7.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "minimist@~0.0.1",
+                      "from": "minimist@>=0.0.1 <0.1.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@^0.1.40",
+                  "from": "source-map@>=0.1.40 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
@@ -11711,17 +11711,17 @@
                 },
                 "uglify-js": {
                   "version": "2.3.6",
-                  "from": "uglify-js@~2.3",
+                  "from": "uglify-js@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "async@~0.2.6",
+                      "from": "async@>=0.2.6 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "optimist@~0.3.5",
+                      "from": "optimist@>=0.3.5 <0.4.0",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
                     }
                   }
@@ -11730,27 +11730,27 @@
             },
             "nopt": {
               "version": "3.0.3",
-              "from": "nopt@3.x",
+              "from": "nopt@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz"
             },
             "fileset": {
               "version": "0.2.1",
-              "from": "fileset@0.2.x",
+              "from": "fileset@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@2.x",
+                  "from": "minimatch@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
@@ -11764,29 +11764,29 @@
                 },
                 "glob": {
                   "version": "5.0.14",
-                  "from": "glob@5.x",
+                  "from": "glob@>=5.0.0 <6.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@^1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@^1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
@@ -11795,71 +11795,71 @@
             },
             "which": {
               "version": "1.0.9",
-              "from": "which@1.0.x",
+              "from": "which@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             },
             "async": {
               "version": "1.4.2",
-              "from": "async@1.x",
+              "from": "async@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "supports-color@1.3.x",
+              "from": "supports-color@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             },
             "abbrev": {
               "version": "1.0.7",
-              "from": "abbrev@1.0.x",
+              "from": "abbrev@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             },
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@0.0.x",
+              "from": "wordwrap@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@1.1.x",
+              "from": "resolve@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "js-yaml": {
               "version": "3.3.1",
-              "from": "js-yaml@3.x",
+              "from": "js-yaml@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "argparse@~1.0.2",
+                  "from": "argparse@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>= 3.2.0 < 4.0.0",
+                      "from": "lodash@>=3.2.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "sprintf-js@~1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.2.0",
-                  "from": "esprima@~2.2.0",
+                  "from": "esprima@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@1.x",
+              "from": "once@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -11868,7 +11868,7 @@
         },
         "dateformat": {
           "version": "1.0.11",
-          "from": "dateformat@~1.0.6",
+          "from": "dateformat@>=1.0.6 <1.1.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
           "dependencies": {
             "get-stdin": {
@@ -11883,39 +11883,39 @@
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@^1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@^1.0.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@^1.0.0",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.2",
-                  "from": "indent-string@^1.1.0",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@^1.1.0",
+                      "from": "repeating@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@^1.0.0",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "number-is-nan@^1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -11926,12 +11926,12 @@
                 },
                 "minimist": {
                   "version": "1.1.3",
-                  "from": "minimist@^1.1.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@^3.0.0",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
@@ -11940,17 +11940,17 @@
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@~0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.6.5",
-              "from": "lru-cache@2",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "sigmund@~1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
@@ -11974,32 +11974,32 @@
     },
     "karma-jspm": {
       "version": "1.1.6",
-      "from": "git://github.com/rich-nguyen/karma-jspm.git#1.1.6",
+      "from": "rich-nguyen/karma-jspm#1.1.6",
       "resolved": "git://github.com/rich-nguyen/karma-jspm.git#491f43be0891f1a0a598f3e5e7bdb27a6f5bf050",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "from": "glob@~3.2",
+          "from": "glob@>=3.2.0 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.0",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@0.3",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.5",
-                  "from": "lru-cache@2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@~1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -12015,7 +12015,7 @@
     },
     "karma-phantomjs-shim": {
       "version": "1.0.0",
-      "from": "karma-phantomjs-shim@^1.0.0",
+      "from": "karma-phantomjs-shim@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-shim/-/karma-phantomjs-shim-1.0.0.tgz"
     },
     "karma-requirejs": {
@@ -12035,7 +12035,7 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.0",
+          "from": "colors@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         }
       }
@@ -12047,121 +12047,121 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.10",
+          "from": "async@>=0.2.10 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cson": {
           "version": "1.6.2",
-          "from": "cson@~1.6.2",
+          "from": "cson@>=1.6.2 <1.7.0",
           "resolved": "https://registry.npmjs.org/cson/-/cson-1.6.2.tgz",
           "dependencies": {
             "ambi": {
               "version": "2.2.0",
-              "from": "ambi@^2.2.0",
+              "from": "ambi@>=2.2.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.2.0.tgz",
               "dependencies": {
                 "typechecker": {
                   "version": "2.0.8",
-                  "from": "typechecker@~2.0.7",
+                  "from": "typechecker@>=2.0.7 <2.1.0",
                   "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz"
                 }
               }
             },
             "coffee-script": {
               "version": "1.8.0",
-              "from": "coffee-script@~1.8.0",
+              "from": "coffee-script@>=1.8.0 <1.9.0",
               "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "mkdirp@~0.3.5",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 }
               }
             },
             "extract-opts": {
               "version": "2.2.0",
-              "from": "extract-opts@~2.2.0",
+              "from": "extract-opts@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-2.2.0.tgz",
               "dependencies": {
                 "typechecker": {
                   "version": "2.0.8",
-                  "from": "typechecker@~2.0.7",
+                  "from": "typechecker@>=2.0.7 <2.1.0",
                   "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz"
                 }
               }
             },
             "js2coffee": {
               "version": "0.3.5",
-              "from": "js2coffee@~0.3.5",
+              "from": "js2coffee@>=0.3.5 <0.4.0",
               "resolved": "https://registry.npmjs.org/js2coffee/-/js2coffee-0.3.5.tgz",
               "dependencies": {
                 "coffee-script": {
                   "version": "1.7.1",
-                  "from": "coffee-script@~1.7.1",
+                  "from": "coffee-script@>=1.7.1 <1.8.0",
                   "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.3.5",
-                      "from": "mkdirp@~0.3.5",
+                      "from": "mkdirp@>=0.3.5 <0.4.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                     }
                   }
                 },
                 "file": {
                   "version": "0.2.2",
-                  "from": "file@~0.2.1",
+                  "from": "file@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/file/-/file-0.2.2.tgz"
                 },
                 "nopt": {
                   "version": "3.0.3",
-                  "from": "nopt@~3.0.1",
+                  "from": "nopt@>=3.0.1 <3.1.0",
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "abbrev@1",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "underscore@~1.6.0",
+                  "from": "underscore@>=1.6.0 <1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 }
               }
             },
             "requirefresh": {
               "version": "1.1.2",
-              "from": "requirefresh@~1.1.2",
+              "from": "requirefresh@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-1.1.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@~3.2.6",
+          "from": "glob@>=3.2.6 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@0.3",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.5",
-                  "from": "lru-cache@2",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@~1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -12170,61 +12170,61 @@
         },
         "jit-grunt": {
           "version": "0.8.0",
-          "from": "jit-grunt@~0.8.0",
+          "from": "jit-grunt@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz"
         },
         "js-yaml": {
           "version": "3.0.2",
-          "from": "js-yaml@~3.0.1",
+          "from": "js-yaml@>=3.0.1 <3.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@~1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "load-grunt-tasks": {
           "version": "0.3.0",
-          "from": "load-grunt-tasks@~0.3.0",
+          "from": "load-grunt-tasks@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
           "dependencies": {
             "globule": {
               "version": "0.2.0",
-              "from": "globule@~0.2.0",
+              "from": "globule@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@~0.2.11",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.5",
-                      "from": "lru-cache@2",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@~1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -12233,77 +12233,77 @@
             },
             "findup-sync": {
               "version": "0.1.3",
-              "from": "findup-sync@~0.1.2",
+              "from": "findup-sync@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@~2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "megalog": {
       "version": "0.1.0",
-      "from": "megalog@",
+      "from": "megalog@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/megalog/-/megalog-0.1.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@^1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@^3.8.0",
+          "from": "lodash@>=3.8.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "window-size": {
           "version": "0.1.2",
-          "from": "window-size@^0.1.0",
+          "from": "window-size@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
         }
       }
@@ -12332,22 +12332,22 @@
       "dependencies": {
         "dnode": {
           "version": "1.2.1",
-          "from": "dnode@~1.2.0",
+          "from": "dnode@>=1.2.0 <1.3.0",
           "resolved": "https://registry.npmjs.org/dnode/-/dnode-1.2.1.tgz",
           "dependencies": {
             "dnode-protocol": {
               "version": "0.2.2",
-              "from": "dnode-protocol@~0.2.2",
+              "from": "dnode-protocol@>=0.2.2 <0.3.0",
               "resolved": "https://registry.npmjs.org/dnode-protocol/-/dnode-protocol-0.2.2.tgz"
             },
             "jsonify": {
               "version": "0.0.0",
-              "from": "jsonify@~0.0.0",
+              "from": "jsonify@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             },
             "weak": {
               "version": "0.4.1",
-              "from": "weak@~0.4.1",
+              "from": "weak@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/weak/-/weak-0.4.1.tgz",
               "dependencies": {
                 "bindings": {
@@ -12357,7 +12357,7 @@
                 },
                 "nan": {
                   "version": "1.8.4",
-                  "from": "nan@~1.8.4",
+                  "from": "nan@>=1.8.4 <1.9.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                 }
               }
@@ -12366,12 +12366,12 @@
         },
         "win-spawn": {
           "version": "2.0.0",
-          "from": "win-spawn@~2.0.0",
+          "from": "win-spawn@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
         },
         "traverse": {
           "version": "0.6.6",
-          "from": "traverse@~0.6.3",
+          "from": "traverse@>=0.6.3 <0.7.0",
           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
         }
       }
@@ -12403,70 +12403,70 @@
           "dependencies": {
             "config-chain": {
               "version": "1.1.9",
-              "from": "config-chain@~1.1.8",
+              "from": "config-chain@>=1.1.8 <1.2.0",
               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "proto-list@~1.2.1",
+                  "from": "proto-list@>=1.2.1 <1.3.0",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.0",
+              "from": "inherits@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
               "version": "1.3.4",
-              "from": "ini@^1.2.0",
+              "from": "ini@>=1.2.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             },
             "nopt": {
               "version": "3.0.3",
-              "from": "nopt@~3.0.1",
+              "from": "nopt@>=3.0.1 <3.1.0",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@1",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@~1.3.0",
+              "from": "once@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "osenv@^0.1.0",
+              "from": "osenv@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@^1.0.0",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@^1.0.0",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@2 || 3 || 4",
+              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "uid-number": {
@@ -12488,17 +12488,17 @@
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "bl@~0.9.0",
+              "from": "bl@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@~1.0.26",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
@@ -12508,12 +12508,12 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -12522,37 +12522,37 @@
             },
             "caseless": {
               "version": "0.6.0",
-              "from": "caseless@~0.6.0",
+              "from": "caseless@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
             },
             "forever-agent": {
               "version": "0.5.2",
-              "from": "forever-agent@~0.5.0",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "qs": {
               "version": "1.2.2",
-              "from": "qs@~1.2.0",
+              "from": "qs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@~5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "1.0.2",
-              "from": "mime-types@~1.0.1",
+              "from": "mime-types@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
             },
             "node-uuid": {
               "version": "1.4.3",
-              "from": "node-uuid@~1.4.0",
+              "from": "node-uuid@>=1.4.0 <1.5.0",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.1",
-              "from": "tunnel-agent@~0.4.0",
+              "from": "tunnel-agent@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             },
             "tough-cookie": {
@@ -12562,12 +12562,12 @@
             },
             "form-data": {
               "version": "0.1.4",
-              "from": "form-data@~0.1.0",
+              "from": "form-data@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@~0.0.4",
+                  "from": "combined-stream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
@@ -12579,24 +12579,24 @@
                 },
                 "mime": {
                   "version": "1.2.11",
-                  "from": "mime@~1.2.11",
+                  "from": "mime@>=1.2.11 <1.3.0",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
                 },
                 "async": {
                   "version": "0.9.2",
-                  "from": "async@~0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "http-signature@~0.10.0",
+              "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@^0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "asn1": {
@@ -12613,7 +12613,7 @@
             },
             "oauth-sign": {
               "version": "0.4.0",
-              "from": "oauth-sign@~0.4.0",
+              "from": "oauth-sign@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
             },
             "hawk": {
@@ -12623,34 +12623,34 @@
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "hoek@0.9.x",
+                  "from": "hoek@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "boom@0.4.x",
+                  "from": "boom@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "cryptiles@0.2.x",
+                  "from": "cryptiles@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "sntp@0.2.x",
+                  "from": "sntp@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.5.0",
-              "from": "aws-sign2@~0.5.0",
+              "from": "aws-sign2@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
-              "from": "stringstream@~0.0.4",
+              "from": "stringstream@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             }
           }
@@ -12662,19 +12662,19 @@
           "dependencies": {
             "throttleit": {
               "version": "0.0.2",
-              "from": "throttleit@~0.0.2",
+              "from": "throttleit@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.2",
+          "from": "rimraf@>=2.2.2 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "which@~1.0.5",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         }
       }
@@ -12686,7 +12686,7 @@
     },
     "requirejs": {
       "version": "2.1.20",
-      "from": "requirejs@~2.1",
+      "from": "requirejs@>=2.1.0 <2.2.0",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz"
     },
     "shoe": {
@@ -12696,7 +12696,7 @@
       "dependencies": {
         "sockjs": {
           "version": "0.3.1",
-          "from": "sockjs@git://github.com/substack/sockjs-node.git#npm",
+          "from": "git://github.com/substack/sockjs-node.git#npm",
           "resolved": "git://github.com/substack/sockjs-node.git#49090a1212ba2e7216c1cf36415de3c5c74e1901",
           "dependencies": {
             "node-uuid": {
@@ -12713,7 +12713,7 @@
         },
         "sockjs-client": {
           "version": "0.0.0-unreleasable",
-          "from": "sockjs-client@git://github.com/substack/sockjs-client.git#browserify-npm",
+          "from": "git://github.com/substack/sockjs-client.git#browserify-npm",
           "resolved": "git://github.com/substack/sockjs-client.git#40d48d06b4dba884416bf88a051f76ca3c8ffcae"
         }
       }
@@ -12725,58 +12725,58 @@
       "dependencies": {
         "sax": {
           "version": "0.6.1",
-          "from": "sax@~0.6.0",
+          "from": "sax@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
         },
         "coa": {
           "version": "0.4.1",
-          "from": "coa@~0.4.0",
+          "from": "coa@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/coa/-/coa-0.4.1.tgz",
           "dependencies": {
             "q": {
               "version": "0.9.7",
-              "from": "q@~0.9.6",
+              "from": "q@>=0.9.6 <0.10.0",
               "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
             }
           }
         },
         "js-yaml": {
           "version": "2.1.3",
-          "from": "js-yaml@~2.1.0",
+          "from": "js-yaml@>=2.1.0 <2.2.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@~ 0.1.11",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@~1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@~2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.0",
+          "from": "colors@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "whet.extend": {
           "version": "0.9.9",
-          "from": "whet.extend@~0.9.9",
+          "from": "whet.extend@>=0.9.9 <0.10.0",
           "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
         }
       }
@@ -12788,148 +12788,148 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "chalk@^1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@^2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "date-time": {
           "version": "1.0.0",
-          "from": "date-time@^1.0.0",
+          "from": "date-time@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
         },
         "figures": {
           "version": "1.3.5",
-          "from": "figures@^1.0.0",
+          "from": "figures@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "pretty-ms": {
           "version": "1.4.0",
-          "from": "pretty-ms@^1.0.0",
+          "from": "pretty-ms@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@^4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@^1.0.1",
+              "from": "is-finite@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "dependencies": {
                 "number-is-nan": {
                   "version": "1.0.0",
-                  "from": "number-is-nan@^1.0.0",
+                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                 }
               }
             },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@^3.3.0",
+              "from": "meow@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@^1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@^1.0.1",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@^1.0.0",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
                   "version": "1.2.2",
-                  "from": "indent-string@^1.1.0",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@^1.1.0",
+                      "from": "repeating@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
                     }
                   }
                 },
                 "minimist": {
                   "version": "1.1.3",
-                  "from": "minimist@^1.1.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@^3.0.0",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
             },
             "parse-ms": {
               "version": "1.0.0",
-              "from": "parse-ms@^1.0.0",
+              "from": "parse-ms@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz"
             },
             "plur": {
               "version": "1.0.0",
-              "from": "plur@^1.0.0",
+              "from": "plur@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@^0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "btoa": "1.1.2",
     "eslint-plugin-react": "^2.7.0",
     "esprima": "1.2.2",
-    "esprima-fb": "^15001.1.0-dev-harmony-fb",
+    "esprima-fb": "15001.1.0-dev-harmony-fb",
     "glob": "4.0.6",
     "grunt": "0.4.5",
     "grunt-asset-hash": "0.1.6",


### PR DESCRIPTION
This is to workaround the bug in https://github.com/svg/svgo/issues/413, which is causing some of our SVGs to break (such as `arrow-down-icon`).
