### PR TITLE
Outbrain load

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -37,6 +37,11 @@ define([
         }
 
         if (config.switches.thirdPartiesLater) {
+            if (config.switches.newOutbrain) {
+                outbrain.init();
+            } else {
+                outbrain.load();
+            }
             // Load third parties after first ad was rendered
             mediator.once('modules:commercial:dfp:rendered', function () {
                 loadOther();
@@ -51,11 +56,6 @@ define([
     function loadOther() {
         imrWorldwide.load();
         remarketing.load();
-        if (config.switches.newOutbrain) {
-            outbrain.init();
-        } else {
-            outbrain.load();
-        }
         krux.load();
     }
 


### PR DESCRIPTION
Outbrain third party component logic needs to be called sooner as the instantly loaded merchandising component was triggering 'rendered' event before outbrain was initialised causing it to not load at all.

@kelvin-chappell 
