### PR TITLE
Crosswords: add margin top to crosswords to prevent accidental taps on comments link

### DIFF
--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -39,6 +39,10 @@
 
 .crossword__container {
     position: relative;
+
+    @include mq($until: tablet) {
+        margin-top: $gs-baseline;
+    }
 }
 
 .crossword__controls {


### PR DESCRIPTION
Seen a few people do this by accident, and we've had one complaint. Simple fix.
