### PR TITLE
Trim project dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,11 +7,20 @@ object Dependencies {
   val identityLibVersion = "3.46"
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
+  val awsVersion = "1.9.16"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.3.5"
   val apacheCommonsMath3 = "org.apache.commons" % "commons-math3" % "3.2"
-  val awsSdk = "com.amazonaws" % "aws-java-sdk" % "1.9.16"
+  val awsCore = "com.amazonaws" % "aws-java-sdk-core" % awsVersion
+  val awsCloudwatch = "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion
+  val awsDynamodb = "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion
+  val awsKinesis = "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion
+  val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % awsVersion
+  val awsSes = "com.amazonaws" % "aws-java-sdk-ses" % awsVersion
+  val awsSns = "com.amazonaws" % "aws-java-sdk-sns" % awsVersion
+  val awsSqs = "com.amazonaws" % "aws-java-sdk-sqs" % awsVersion
+  val awsElasticloadbalancing = "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion
   val commonsHttpClient = "commons-httpclient" % "commons-httpclient" % "3.1"
   val commonsIo = "commons-io" % "commons-io" % "2.4"
   val contentApiClient = "com.gu" %% "content-api-client" % "6.6"

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -17,7 +17,12 @@ object Frontend extends Build with Prototypes {
     libraryDependencies ++= Seq(
       akkaAgent,
       apacheCommonsMath3,
-      awsSdk,
+      awsCore,
+      awsCloudwatch,
+      awsDynamodb,
+      awsS3,
+      awsSns,
+      awsSqs,
       contentApiClient,
       faciaScalaClient,
       filters,
@@ -107,7 +112,9 @@ object Frontend extends Build with Prototypes {
       jquery,
       jqueryui,
       lodash,
-      react
+      react,
+      awsElasticloadbalancing,
+      awsSes
     ),
     RoutesKeys.routesImport += "bindables._",
     RoutesKeys.routesImport += "org.joda.time.LocalDate"
@@ -115,7 +122,8 @@ object Frontend extends Build with Prototypes {
 
   val faciaTool = application("facia-tool").dependsOn(commonWithTests).aggregate(common).settings(
     libraryDependencies ++= Seq(
-      playJsonVariants
+      playJsonVariants,
+      awsKinesis
     )
   )
 

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -116,5 +116,13 @@ trait Prototypes {
     )
     .settings(name in Universal := applicationName)
     .settings(topLevelDirectory in Universal := Some(applicationName))
+    .settings(mappings in Universal := {
+        val universalMappings: Seq[(File,String)] = (mappings in Universal).value
+
+        // Remove any jars that we don't need at runtime.
+        universalMappings filter {
+          case (file, name) =>  ! name.endsWith("scala-compiler-2.11.1.jar")
+        }
+    })
   }
 }


### PR DESCRIPTION
This should reduce the size of the uploaded artifact that team city has to process. The good (or bad) news is that our dependency file size is multplied by the number of projects we have, so savings (or costs) are keenly felt.
