### PR TITLE
Parallax fix for responsive banner ad

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250-v3.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250-v3.js
@@ -39,11 +39,7 @@ define([
             case 'parallax':
                 fastdom.read(function () {
                     this.scrollAmount = Math.ceil((window.pageYOffset - this.$adSlot.offset().top) * 0.3 * -1) + 20;
-                    if (this.scrollAmount >= -80 && this.scrollAmount < 0) {
-                        this.scrollAmountP = this.scrollAmount + '%';
-                    } else {
-                        this.scrollAmountP = '20%';
-                    }
+                    this.scrollAmountP = this.scrollAmount + '%';
                 }.bind(this));
                 fastdom.write(function () {
                     $('.ad-scrolling-bg', $(this.$adSlot)).addClass('ad-scrolling-bg-parallax').css('background-position', '50%' + this.scrollAmountP);

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250-v4.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250-v4.js
@@ -39,11 +39,7 @@ define([
             case 'parallax':
                 fastdom.read(function () {
                     this.scrollAmount = Math.ceil((window.pageYOffset - this.$adSlot.offset().top) * 0.3 * -1) + 20;
-                    if (this.scrollAmount >= -80 && this.scrollAmount < 0) {
-                        this.scrollAmountP = this.scrollAmount + '%';
-                    } else {
-                        this.scrollAmountP = '20%';
-                    }
+                    this.scrollAmountP = this.scrollAmount + '%';
                 }.bind(this));
                 fastdom.write(function () {
                     $('.ad-scrolling-bg', $(this.$adSlot)).addClass('ad-scrolling-bg-parallax').css('background-position', '50%' + this.scrollAmountP);


### PR DESCRIPTION
Reverting changes from https://github.com/guardian/frontend/pull/9851 to fix the parallax option for top and bottom responsive banner ad for versions 3 and 4.

The advert which initiated https://github.com/guardian/frontend/pull/9851 has been tested with the change and behaves correctly: http://www.theguardian.com/uk/sport?adtest=6
