### PR TITLE
Remove jspm validation switch

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1178,16 +1178,6 @@ object Switches {
     )
   }
 
-  // Server-side variant validation test
-  val JspmValidation = Switch(
-    "Feature",
-    "disable-jspm",
-    "A test switch that can be turned on to disable the JspmTest for bucketing validation",
-    safeState = Off,
-    sellByDate = new LocalDate(2015, 8, 15),
-    exposeClientSide = false
-  )
-
   def all: Seq[SwitchTrait] = Switch.allSwitches
 
   def grouped: List[(String, Seq[SwitchTrait])] = {

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -22,15 +22,7 @@ object JspmTest extends TestDefinition(
   "jspm-test",
   "Tests our new JSPM jsavscript configuration",
   new LocalDate(2015, 9, 30)
-) {
-  override def isParticipating(implicit request: RequestHeader): Boolean = {
-    if (conf.Switches.JspmValidation.isSwitchedOff) {
-      super.isParticipating(request)
-    } else {
-      false
-    }
-  }
-}
+)
 
 object JspmControlTest extends TestDefinition(
   List(Variant7),


### PR DESCRIPTION
We learnt that the bucketing is working correctly. Which means jspm's test variant is dropping page views.
