### PR TITLE
Re-add Firefox Adblock Plus tracking to Omniture Adblock figures

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -216,7 +216,7 @@ define([
         this.s.prop31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
         this.s.eVar31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
 
-        this.s.prop40    = detect.adblockInUse || detect.firefoxAdblockPlusInstalled;
+        this.s.prop40    = detect.adblockInUse || detect.getFirefoxAdblockPlusInstalled();
 
         this.s.prop47    = config.page.edition || '';
 

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -216,7 +216,7 @@ define([
         this.s.prop31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
         this.s.eVar31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
 
-        this.s.prop40    = detect.adblockInUse;
+        this.s.prop40    = detect.adblockInUse || detect.firefoxAdblockPlusInstalled;
 
         this.s.prop47    = config.page.edition || '';
 

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -457,7 +457,7 @@ define([
     }
 
     /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
-    function firefoxAdblockPlusInstalled() {
+    function getFirefoxAdblockPlusInstalled() {
         var sacrificialAd = createSacrificialAd();
         var adUnitMozBinding = sacrificialAd.css('-moz-binding');
         if (adUnitMozBinding) {
@@ -504,7 +504,7 @@ define([
         fontHinting: fontHinting(),
         isModernBrowser: isModernBrowser,
         adblockInUse: adblockInUse(),
-        firefoxAdblockPlusInstalled: firefoxAdblockPlusInstalled()
+        getFirefoxAdblockPlusInstalled: getFirefoxAdblockPlusInstalled
     };
     return detect;
 });

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -446,20 +446,31 @@ define([
     }
 
     function adblockInUse() {
-        var sacrificialAd = createSacrificalAd();
+        var sacrificialAd = createSacrificialAd();
         var contentBlocked = isHidden(sacrificialAd);
         sacrificialAd.remove();
         return contentBlocked;
 
-        function createSacrificalAd() {
-            var sacrificialAd = $.create('<div class="ad_unit" style="position: absolute; left: -9999px; height: 10px">&nbsp;</div>');
-            sacrificialAd.appendTo(document.body);
-            return sacrificialAd;
-        }
-
         function isHidden(bonzoElement) {
             return bonzoElement.css('display') === 'none';
         }
+    }
+
+    /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
+    function firefoxAdblockPlusInstalled() {
+        var sacrificialAd = createSacrificialAd();
+        var adUnitMozBinding = sacrificialAd.css('-moz-binding');
+        if (adUnitMozBinding) {
+            return adUnitMozBinding.match('elemhidehit') !== null;
+        } else {
+            return false;
+        }
+    }
+
+    function createSacrificialAd() {
+        var sacrificialAd = $.create('<div class="ad_unit" style="position: absolute; left: -9999px; height: 10px">&nbsp;</div>');
+        sacrificialAd.appendTo(document.body);
+        return sacrificialAd;
     }
 
     detect = {
@@ -492,7 +503,8 @@ define([
         breakpoints: breakpoints,
         fontHinting: fontHinting(),
         isModernBrowser: isModernBrowser,
-        adblockInUse: adblockInUse()
+        adblockInUse: adblockInUse(),
+        firefoxAdblockPlusInstalled: firefoxAdblockPlusInstalled()
     };
     return detect;
 });


### PR DESCRIPTION
The Omniture Adblock tracking metric - prop40 - currently uses the 'adblockInUse' property in the detect module. We've recently changed this to avoid it returning false positives when a Firefox Adblock Plus user whitelists our domain. However, the new adblock test will miss Firefox Adblock Plus users entirely, which means the Omniture adblocker figures now undercount rather than overcount.

After speaking to Matt Kopfka, we'd like to continue including Firefox Adblock Plus users with the Omniture Adblock metric, even if that means slightly overcounting in the edge case of those users whitelisting us.

This change adds a new test to detect.js and calls it within Omniture.js.
