### PR TITLE
Facia cards response performance fixes

### DIFF
--- a/data/database/2cb5ab3c7900f4c0b7814a200303e1d9fc370323104ef6a875be727c8cbedbb2
+++ b/data/database/2cb5ab3c7900f4c0b7814a200303e1d9fc370323104ef6a875be727c8cbedbb2
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/bccf5026cbb647ab8c0bff1408b4e4c58f33410b5d06b1cefd9df866e6ef5e1a
+++ b/data/database/bccf5026cbb647ab8c0bff1408b4e4c58f33410b5d06b1cefd9df866e6ef5e1a
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/d3e07c161d0a1d34371037a7522df35b1059e7878bc6aa23e01079cacb612ac9
+++ b/data/database/d3e07c161d0a1d34371037a7522df35b1059e7878bc6aa23e01079cacb612ac9
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/static/src/javascripts/projects/common/modules/ui/faux-block-link.js
+++ b/static/src/javascripts/projects/common/modules/ui/faux-block-link.js
@@ -24,8 +24,6 @@ define([
             });
         };
 
-        bean.on(document.body, 'touchstart', overlaySelector, showIntentToClick);
-        bean.on(document.body, 'touchend', overlaySelector, removeIntentToClick);
         bean.on(document.body, 'mouseenter', overlaySelector, showIntentToClick);
         bean.on(document.body, 'mouseleave', overlaySelector, removeIntentToClick);
     };

--- a/static/src/javascripts/projects/common/modules/ui/faux-block-link.js
+++ b/static/src/javascripts/projects/common/modules/ui/faux-block-link.js
@@ -24,7 +24,9 @@ define([
             });
         };
 
+        // mouseover
         bean.on(document.body, 'mouseenter', overlaySelector, showIntentToClick);
+        // mouseout
         bean.on(document.body, 'mouseleave', overlaySelector, removeIntentToClick);
     };
 });

--- a/static/src/stylesheets/base/_faux-block-link.scss
+++ b/static/src/stylesheets/base/_faux-block-link.scss
@@ -54,6 +54,12 @@ a.u-faux-block-link__overlay {
     // this line is needed as all elements have a solid black
     // background in high contrast mode
     opacity: 0;
+
+    // Override the default user agent stylesheet so we don't incur a "Layout"
+    // each time the user taps a link.
+    &:focus {
+        outline: none;
+    }
 }
 // Underline cta when block is hovered
 .u-faux-block-link--hover .u-faux-block-link__cta {

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -188,19 +188,14 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 
     .u-faux-block-link--hover {
-        // For touch devices we want to reduce the time before the click event
-        // as much as possible, because browsers on touch devices give feedback
-        // at the end of the click event.
-        @include mq(desktop) {
-            background-color: colour(neutral-6);
+        background-color: colour(neutral-6);
 
-            .fc-item__image-container {
-                background-color: #000000;
+        .fc-item__image-container {
+            background-color: #000000;
 
-                // This should be changed to fc-item__image when Imager allows class names to be adapted from inline elements
-                .responsive-img {
-                    opacity: .9;
-                }
+            // This should be changed to fc-item__image when Imager allows class names to be adapted from inline elements
+            .responsive-img {
+                opacity: .9;
             }
         }
 

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -188,14 +188,19 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 
     .u-faux-block-link--hover {
-        background-color: colour(neutral-6);
+        // For touch devices we want to reduce the time before the click event
+        // as much as possible, because browsers on touch devices give feedback
+        // at the end of the click event.
+        @include mq(desktop) {
+            background-color: colour(neutral-6);
 
-        .fc-item__image-container {
-            background-color: #000000;
+            .fc-item__image-container {
+                background-color: #000000;
 
-            // This should be changed to fc-item__image when Imager allows class names to be adapted from inline elements
-            .responsive-img {
-                opacity: .9;
+                // This should be changed to fc-item__image when Imager allows class names to be adapted from inline elements
+                .responsive-img {
+                    opacity: .9;
+                }
             }
         }
 


### PR DESCRIPTION
I want the website to feel as fast as the app. According to the [RAIL guidelines](https://www.youtube.com/watch?v=2ksXo2_Lfl0&feature=youtu.be), we should respond to the user in 100ms.

Browsers on touch devices show feedback to the user when they click on a link in the form of an overlay (blue on Android, grey on iOS). This fires at the end of the `click` event, so you really want to reduce the time between `touchend` and the end of the `click` event as much as possible.

Before (150ms between `touchend` and `click`):
![untitled-0](https://cloud.githubusercontent.com/assets/921609/9303507/5addf232-44d6-11e5-9eed-6eb88462544b.gif)

<img width="1792" alt="screen shot 2015-08-17 at 11 50 54" src="https://cloud.githubusercontent.com/assets/921609/9303489/3d37e918-44d6-11e5-8b26-a4ba3a419aff.png">

After (20ms between `touchend` and `click`):
![untitled-1](https://cloud.githubusercontent.com/assets/921609/9303653/8e582906-44d7-11e5-8a5e-7430e52896d4.gif)

![image](https://cloud.githubusercontent.com/assets/921609/9303613/4376bc40-44d7-11e5-9834-76f71865d7bf.png)
