### PR TITLE
Membership Message UK variant tests

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -935,12 +935,12 @@ object Switches {
     exposeClientSide = false
   )
 
-  val ABMembershipMessageVariants = Switch(
+  val ABMembershipMessageUk = Switch(
     "A/B Tests",
-    "ab-membership-message-variants",
-    "Switch for the Membership message A/B variants test",
+    "ab-membership-message-uk",
+    "Switch for the UK Membership message A/B variants test",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 8, 20),
+    sellByDate = new LocalDate(2015, 9, 21),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -8,7 +8,7 @@ define([
     'common/modules/analytics/mvt-cookie',
     'common/modules/experiments/tests/liveblog-notifications',
     'common/modules/experiments/tests/high-commercial-component',
-    'common/modules/experiments/tests/membership-message',
+    'common/modules/experiments/tests/membership-message-uk',
     'common/modules/experiments/tests/membership-message-usa',
     'common/modules/experiments/tests/adblock-sticky-banner'
 ], function (
@@ -21,7 +21,7 @@ define([
     mvtCookie,
     LiveblogNotifications,
     HighCommercialComponent,
-    MembershipMessage,
+    MembershipMessageUK,
     MembershipMessageUSA,
     AdblockStickyBanner
 ) {
@@ -29,7 +29,7 @@ define([
     var TESTS = _.flatten([
         new LiveblogNotifications(),
         new HighCommercialComponent(),
-        new MembershipMessage(),
+        new MembershipMessageUK(),
         new MembershipMessageUSA(),
         new AdblockStickyBanner()
     ]);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-uk.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-uk.js
@@ -30,7 +30,7 @@ define([
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Loyal visitors will be interested in becoming a Supporter';
-        this.audienceCriteria = 'UK edition visitors who have seen at least 10 pages, message shown only on article pages';
+        this.audienceCriteria = 'UK edition visitors who have seen more than 10 pages, message shown only on article pages';
         this.dataLinkNames = 'membership message, hide, read more';
         this.idealOutcome = 'Users will sign up as a Supporter';
 
@@ -40,7 +40,7 @@ define([
              * - Exclude mobile/small-screen devices
              * - Only show for UK edition
              * - Only show on Article pages
-             * - Only show to visitors who have viewed at least 10 pages.
+             * - Only show to visitors who have viewed more than 10 pages.
              */
             var alreadyVisited = storage.local.get('alreadyVisited') || 0;
             return !detect.adblockInUse &&

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-uk.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-uk.js
@@ -18,43 +18,49 @@ define([
     svgs
 ) {
 
+    var messageId = 'membership-message-uk';
+
     return function () {
 
-        this.id = 'MembershipMessageVariants';
-        this.start = '2015-07-13';
-        this.expiry = '2015-08-20';
+        this.id = 'MembershipMessageUk';
+        this.start = '2015-08-16';
+        this.expiry = '2015-09-21';
         this.author = 'David Rapson';
-        this.description = 'Test if loyal users are encouraged to join Membership as a Supporter';
+        this.description = 'Test if loyal visitors in the UK edition are encouraged to join Membership as a Supporter';
         this.audience = 1;
         this.audienceOffset = 0;
-        this.successMeasure = 'Loyal users will be interested in becoming a Supporter';
-        this.audienceCriteria = 'Users who have seen 10 or more pages, message shown only on article pages';
-        this.dataLinkNames = 'supporter message, hide, read more';
+        this.successMeasure = 'Loyal visitors will be interested in becoming a Supporter';
+        this.audienceCriteria = 'UK edition visitors who have seen at least 10 pages, message shown only on article pages';
+        this.dataLinkNames = 'membership message, hide, read more';
         this.idealOutcome = 'Users will sign up as a Supporter';
 
         this.canRun = function () {
             /**
-             * Exclude adblock users to avoid conflicts with similar adblock Supporter message,
-             * only show to users who have viewed 10 or more pages.
+             * - Exclude adblock users to avoid conflicts with similar adblock Supporter message
+             * - Exclude mobile/small-screen devices
+             * - Only show for UK edition
+             * - Only show on Article pages
+             * - Only show to visitors who have viewed at least 10 pages.
              */
             var alreadyVisited = storage.local.get('alreadyVisited') || 0;
             return !detect.adblockInUse &&
+                detect.getBreakpoint() !== 'mobile' &&
                 config.page.edition === 'UK' &&
                 config.page.contentType === 'Article' &&
-                alreadyVisited > 9;
+                alreadyVisited > 10;
         };
 
         this.variants = [{
             id: 'A',
             test: function () {
-                new Message('membership-message-variants', {
+                new Message(messageId, {
                     pinOnHide: false,
                     siteMessageLinkName: 'membership message',
                     siteMessageCloseBtn: 'hide'
                 }).show(template(messageTemplate, {
-                    supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=MEMBERSHIP_SUBSCRIBER_LOYALTY_BANNER_A',
-                    messageText: 'Become a Guardian Member and support fearless investigative journalism',
-                    linkText: 'Become a supporter',
+                    supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=MEMBERSHIP_SUPPORTER_BANNER_UK_A',
+                    messageText: '“Become a Guardian Member and support independent journalism” – George Monbiot',
+                    linkText: 'Find out more',
                     arrowWhiteRight: svgs('arrowWhiteRight')
                 }));
             }
@@ -62,13 +68,13 @@ define([
         {
             id: 'B',
             test: function () {
-                new Message('membership-message-variants', {
+                new Message(messageId, {
                     pinOnHide: false,
                     siteMessageLinkName: 'membership message',
                     siteMessageCloseBtn: 'hide'
                 }).show(template(messageTemplate, {
-                    supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=MEMBERSHIP_SUBSCRIBER_LOYALTY_BANNER_B',
-                    messageText: '"If you read the Guardian, join the Guardian" Polly Toynbee.',
+                    supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=MEMBERSHIP_SUPPORTER_BANNER_UK_B',
+                    messageText: '“Support and become part of the Guardian” – Hugh Muir',
                     linkText: 'Find out more',
                     arrowWhiteRight: svgs('arrowWhiteRight')
                 }));

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -416,7 +416,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
  * Membership message A/B test
  */
 .site-message--membership-message,
-.site-message--membership-message-variants,
+.site-message--membership-message-uk,
 .site-message--membership-message-usa {
     background: colour(news-main-2);
 }


### PR DESCRIPTION
Following on from https://github.com/guardian/frontend/pull/10051 this PR adds two new quotes for the UK supporter banner.

A: “Become a Guardian Member and support independent journalism.” - George Monbiot

![uk-message-a](https://cloud.githubusercontent.com/assets/123386/9303756/c37c9d00-44d8-11e5-8997-f3f7e8740e63.png)

B: “Support and become part of the Guardian” - Hugh Muir

![uk-message-b](https://cloud.githubusercontent.com/assets/123386/9303757/c63594d4-44d8-11e5-9e05-2116450f378a.png)

Note: As soon as the Membership tier information is available on theguardian.com I'll be graduating this message away from being a A/B test.

@stephanfowler @OliverJAsh 
