### PR TITLE
ensuring expand svg is the correct size on all images

### DIFF
--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -159,11 +159,9 @@
         display: none;
     }
 
-    &.inline-expand-image {
-        svg {
-            width: 50%;
-            height: 50%;
-        }
+    &.inline-expand-image svg {
+        width: 50%;
+        height: 50%;
     }
 
     .element--thumbnail:hover & {

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -157,8 +157,10 @@
         height: 33px;
         margin: $gs-baseline/3 $gs-gutter/5;
         display: none;
+    }
 
-        .inline-expand-image {
+    &.inline-expand-image {
+        svg {
             width: 50%;
             height: 50%;
         }


### PR DESCRIPTION
fixing bug #10169 : 

![image](https://cloud.githubusercontent.com/assets/8774970/9303976/3246f5ee-44db-11e5-95c8-9a07c3787d08.png)

Now: 

![image](https://cloud.githubusercontent.com/assets/8774970/9303998/57a5a6aa-44db-11e5-9728-7812a0d219bc.png)
