### PR TITLE
Remove jspm beacons

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -177,15 +177,6 @@ object Switches {
     exposeClientSide = false
   )
 
-  val JspmTestUniqueVisitorsBeacon = Switch(
-    "Performance",
-    "jspm-test-unique-visitors-beacon",
-    "Send beacon for unique visitors in JspmTest and JspmControl server-side test variants",
-    safeState = Off,
-    sellByDate = new LocalDate(2015, 8, 18),
-    exposeClientSide = true
-  )
-
   val RelatedContentSwitch = Switch(
     "Performance",
     "related-content",

--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -73,22 +73,5 @@
             }
         }
 
-
-        // Send beacon for unique visitors in JspmTest and JspmControl server-side test variants
-        // Requires localStorage, so modern browsers only
-        if (window.guardian.isModernBrowser && guardian.config.switches.jspmTestUniqueVisitorsBeacon) {
-            var tests = guardian.config.tests;
-            var inTest = tests.jspmTest || tests.jspmControl;
-            var localStorageKey = 'gu.jspm-test.visited';
-            // Protect browsers with localStorage but permissions disabled
-            try {
-                var visited = !!window.localStorage.getItem(localStorageKey)
-                if (!visited && inTest) {
-                    var beaconName = tests.jspmTest ? 'jspm-test' : 'jspm-control';
-                    (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + beaconName + '.gif';
-                    window.localStorage.setItem(localStorageKey, true);
-                }
-            } catch (e) {}
-        }
     })(window, navigator);
 }

--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -72,14 +72,11 @@
                 logDevice('chrome', 'windows7');
             }
         }
-    })(window, navigator);
-}
 
-@if(JspmTestUniqueVisitorsBeacon.isSwitchedOn) {
-    (function () {
+
         // Send beacon for unique visitors in JspmTest and JspmControl server-side test variants
         // Requires localStorage, so modern browsers only
-        if (window.guardian.isModernBrowser) {
+        if (window.guardian.isModernBrowser && guardian.config.switches.jspmTestUniqueVisitorsBeacon) {
             var tests = guardian.config.tests;
             var inTest = tests.jspmTest || tests.jspmControl;
             var localStorageKey = 'gu.jspm-test.visited';
@@ -93,5 +90,5 @@
                 }
             } catch (e) {}
         }
-    })();
+    })(window, navigator);
 }

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -69,8 +69,6 @@ object Metric extends Logging {
     ("android-sgs3-start-raf", CountMetric(s"android-sgs3-start-raf")),
     ("android-sgs3-after-5-raf", CountMetric(s"android-sgs3-after-5-raf")),
 
-    ("jspm-test", CountMetric(s"jspm-test")),
-    ("jspm-control", CountMetric(s"jspm-control")),
 
     ("headlines-variant-seen", CountMetric(s"headlines-variant-seen")),
     ("headlines-control-seen", CountMetric(s"headlines-control-seen")),


### PR DESCRIPTION
`JspmTest` was still ~2% less than `JspmControl`, so I think that means it's not a JavaScript error, and more likely to do with the increased payload size. We should find a way to test that.

Rich confirmed it wasn't a bucketing problem by disabling jspm for those in the test, and the number was no longer ~2% lower.
