### PR TITLE
prefer PDF crossword for printing where possible

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -16,13 +16,16 @@
             <h1 itemprop="headline" class="content__headline js-score">@Html(crosswordPage.crossword.name)</h1>
             @if( gridVisable ) {
                 <div class="crossword__links">
-                    <a class="crossword__link js-print-crossword">Print</a>
+                    @crosswordPage.crossword.pdf match {
+                        case Some(pdf) => {
+                            <a class="crossword__link" href="@pdf" target="_blank">Print</a>
+                        }
 
-                    <a class="crossword__link" href="@LinkTo(s"/crosswords/accessible/${crosswordPage.crossword.crosswordType}/${crosswordPage.crossword.number}")"> | Accessible version </a>
+                        case None => {
+                            <a class="crossword__link js-print-crossword">Print</a>
+                        }
+                    }
 
-                @crosswordPage.crossword.pdf.map { pdf =>
-                    | <a class="crossword__link" href="@pdf" target="_blank">PDF version</a>
-                }
                 </div>
             }
 

--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -26,6 +26,7 @@
                         }
                     }
 
+                    | <a class="crossword__link" href="@LinkTo(s"/crosswords/accessible/${crosswordPage.crossword.crosswordType}/${crosswordPage.crossword.number}")">Accessible version</a>
                 </div>
             }
 


### PR DESCRIPTION
We've had a few complaints about the print CSS for crosswords. The biggest problem is the grid not showing up at all, which is down to background colour printing not being enabled in the system settings. 

Since there's no way to control printer settings from the browser, and no simple set of instructions that'll work for any system, I think we should avoid using the system print dialog and make the PDF version the sole option for printing wherever it's available. If we don't have a PDF, the "Print" link will fall back to using the system dialog.
