### PR TITLE
Set sensible timeouts for the Web Service API

### DIFF
--- a/onward/conf/application.conf
+++ b/onward/conf/application.conf
@@ -38,6 +38,15 @@ play {
 
   ws {
     compressionEnabled: true
+
+    timeout {
+        #The maximum time to wait when connecting to the remote host (default is 120 seconds).
+        connection: 1000ms
+        #The maximum time the request can stay idle (connection is established but waiting for more data) (default is 120 seconds).
+        idle: 1000ms
+        #The total time you accept a request to take (it will be interrupted even if the remote host is still sending data) (default is 120 seconds).
+        request: 2000ms
+    }
   }
 }
 


### PR DESCRIPTION
We noticed with the Weather API that `WS.url(...).get()` does not have sensible timeouts as a default (everything is 120 seconds).

We are setting some sensible defaults in Onward and once tested will roll them out everywhere.
