### PR TITLE
On preview when content from Content API is not found,

### DIFF
--- a/preview/app/PreviewErrorHandler.scala
+++ b/preview/app/PreviewErrorHandler.scala
@@ -1,0 +1,27 @@
+import javax.inject._
+
+import com.gu.contentapi.client.GuardianContentApiError
+import play.api.http.DefaultHttpErrorHandler
+import play.api._
+import play.api.mvc._
+import play.api.mvc.Results._
+import play.api.routing.Router
+import scala.concurrent._
+
+class PreviewErrorHandler @Inject() (
+    env: Environment,
+    config: Configuration,
+    sourceMapper: OptionalSourceMapper,
+    router: Provider[Router]
+  ) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) {
+
+  override def onServerError(request: RequestHeader, exception: Throwable) = {
+    exception match  {
+      case GuardianContentApiError(statusCode, statusMessage) if statusCode == 404 =>
+        Future.successful(NotFound(views.html.not_found(request.path)))
+      case _ =>
+        super.onServerError(request, exception)
+    }
+  }
+
+}

--- a/preview/app/views/not_found.scala.html
+++ b/preview/app/views/not_found.scala.html
@@ -1,0 +1,42 @@
+@(path: String)
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            body {
+                font-family: 'Guardian Egyptian Text', Georgia, serif;
+                margin-top: 10%;
+                margin-left: 20%;
+                margin-right: 20%; 
+                background: white;
+                color: rgb(51, 51, 51);
+            }
+
+            h1 {
+                font-weight: bold;
+            }
+
+            a, a:visited {
+                color: #005689;
+                text-decoration: none;
+            }
+
+        </style>
+    </head>
+    <body>
+        <h1> 404 - Content could not be found</h1>
+        <p>
+        The content could not be found.        
+        Several reasons are possible:
+
+        <ul>
+            <li> Path is incorrect. Please check <b> @path </b>  </li>
+            <li> Content has not yet been indexed in the Content API</li>
+        </ul>
+        </p>
+
+        <p>If the path is correct and content does not show up after 30 seconds, please report the problem to <a href="mailto:central.production@@guardian.co.uk">central.production@@guardian.co.uk</a></p>
+
+
+    </body>
+</html>

--- a/preview/conf/application.conf
+++ b/preview/conf/application.conf
@@ -45,6 +45,11 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    errorHandler: "PreviewErrorHandler"
+  }
+
 }
 
 guardian: {


### PR DESCRIPTION
On preview when content from Content API is not found, frontend returns a `500` error and an exception message to the end user. The associated changes add a play error handler to return a `404` and display a better message to the end user.
- Before

<img width="741" alt="screen shot 2015-08-17 at 21 13 55" src="https://cloud.githubusercontent.com/assets/615085/9326111/5572f57c-458f-11e5-9aef-6e4d3fc422b8.png">
- After 

<img width="1263" alt="screen shot 2015-08-17 at 21 13 39" src="https://cloud.githubusercontent.com/assets/615085/9326144/99ce395c-458f-11e5-8ad3-563b38b4b2d6.png">
