### PR TITLE
Adding a 1 second delay to AWS start beacons in an attempt to resolve signal loss issues

### DIFF
--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -13,8 +13,10 @@
             *@
             var cssLoader = window.useRAFforCSS ? '-raf' : '';
 
-            // send immediate beacon
-            (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + identifier + '-start' + cssLoader + '.gif';
+            // send immediate beacon - adding a 1 second delay to see if this resolves signal loss issues on Android and Windows7
+            window.setTimeout(function () {
+                (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + identifier + '-start' + cssLoader + '.gif';
+            }, 1000);
 
             // send second after 5 seconds, if we're still around
             window.setTimeout(function () {


### PR DESCRIPTION
So currently Android and Windows7 beacons show greater beacon count for after 5 seconds than the beacon count sent at start.

Its possible that our start counts for iphone's are suppressed by a similar issue but that our %loss is great enough that the effect is dampened and not as visible.

The idea behind this change is that we hold off for one second to give the devices time to sort themselves out a bit before sending the start beacon.

This is a very blunt instrument and I am seeing it more as an experiment than anything else.
If you can suggest a better way to resolve the issue (and pair with me to get it done) I would be grateful.
