### PR TITLE
Fix SystemJS plugin

### DIFF
--- a/static/src/javascripts/es6/projects/common/utils/svg.js
+++ b/static/src/javascripts/es6/projects/common/utils/svg.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 export function translate(load) {
-    const moduleId = load.metadata.loaderArgument.split('!')[0];
+    const moduleId = load.name.split('!')[0];
     const relativeModuleId = moduleId.match(new RegExp('^' + System.baseURL + '(.*).svg$'))[1];
     const prefix = 'inline-',
           data = _.rest(relativeModuleId.split('/')),


### PR DESCRIPTION
Broken by the new SystemJS https://github.com/systemjs/systemjs/releases/tag/0.18.11

We should upgrade to the new beta of jspm (https://github.com/jspm/jspm-cli/releases/tag/0.16.0-beta.6) or the new major version (https://github.com/jspm/jspm-cli/releases/tag/0.16.0) which contain version locking for SystemJS, so this won't happen again.
