### PR TITLE
Provide an explicit opt out value for crossword cookie

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -55,6 +55,7 @@ object CrosswordsController extends Controller with ExecutionContexts {
   private val CrosswordOptIn = "crossword_opt_in"
   private val CrosswordOptInPath= "/crosswords"
   private val CrosswordOptInMaxAge = 14.days.toSeconds.toInt
+  private val CrosswordOptOutMaxAge = 60.days.toSeconds.toInt
 
   def crosswordsOptIn = Action { implicit request =>
     Cached(60)(SeeOther("/crosswords?view=beta").withCookies(
@@ -66,10 +67,11 @@ object CrosswordsController extends Controller with ExecutionContexts {
   }
 
   def crosswordsOptOut = Action { implicit request =>
-    Cached(60)(SeeOther("/crosswords?view=old").discardingCookies(
-      DiscardingCookie(
-        CrosswordOptIn,
+    Cached(60)(SeeOther("/crosswords?view=old").withCookies(
+      Cookie(
+        CrosswordOptIn, "false",
         path = CrosswordOptInPath,
+        maxAge = Some(CrosswordOptOutMaxAge),
         domain = Some(Configuration.id.domain))))
   }
 }

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -71,7 +71,7 @@ object CrosswordPreferencesController extends Controller with PreferenceControll
   }
 
   def crosswordsOptOut = Action { implicit request =>
-    Cached(60)(SeeOther("/crosswords?view=old").withCookies(
+    Cached(60)(SeeOther("/crosswords?view=classic").withCookies(
       Cookie(
         CrosswordOptIn, "false",
         path = CrosswordOptInPath,

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -51,7 +51,9 @@ object CrosswordsController extends Controller with ExecutionContexts {
       }
     }
   }
+}
 
+object CrosswordPreferencesController extends Controller with PreferenceController {
   private val CrosswordOptIn = "crossword_opt_in"
   private val CrosswordOptInPath= "/crosswords"
   private val CrosswordOptInMaxAge = 14.days.toSeconds.toInt
@@ -63,7 +65,9 @@ object CrosswordsController extends Controller with ExecutionContexts {
         CrosswordOptIn, "true",
         path = CrosswordOptInPath,
         maxAge = Some(CrosswordOptInMaxAge),
-        domain = Some(Configuration.id.domain))))
+        domain = getShortenedDomain(request.domain)
+      )
+    ))
   }
 
   def crosswordsOptOut = Action { implicit request =>
@@ -72,6 +76,8 @@ object CrosswordsController extends Controller with ExecutionContexts {
         CrosswordOptIn, "false",
         path = CrosswordOptInPath,
         maxAge = Some(CrosswordOptOutMaxAge),
-        domain = Some(Configuration.id.domain))))
+        domain = getShortenedDomain(request.domain)
+      )
+    ))
   }
 }

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -26,8 +26,8 @@ GET        /embed/video/*path                                                   
 GET        /preferences                                                         controllers.PreferencesController.indexPrefs()
 GET        /preferences/notifications                                           controllers.PreferencesController.notificationPrefs()
 
-GET        /crosswords/optin                                                    controllers.CrosswordsController.crosswordsOptIn
-GET        /crosswords/optout                                                   controllers.CrosswordsController.crosswordsOptOut
+GET        /crosswords/optin                                                    controllers.CrosswordPreferencesController.crosswordsOptIn
+GET        /crosswords/optout                                                   controllers.CrosswordPreferencesController.crosswordsOptOut
 
 # Web App paths
 GET        /2015-05-28-2-service-worker.js                                      controllers.WebAppController.serviceWorker()

--- a/common/app/controllers/PreferenceController.scala
+++ b/common/app/controllers/PreferenceController.scala
@@ -1,10 +1,9 @@
 package controllers
 
-import play.api.mvc.{Result, Results, Cookie, RequestHeader}
 import common.LinkTo
 import conf.Configuration.site
 import model.NoCache
-import scala.util.matching.Regex
+import play.api.mvc.{Cookie, RequestHeader, Result, Results}
 
 trait PreferenceController extends Results {
 
@@ -14,7 +13,7 @@ trait PreferenceController extends Results {
     case host => LinkTo(url) startsWith host
   }
 
-  private def getShortenedDomain(domain: String) = {
+  protected def getShortenedDomain(domain: String) = {
     val regex = "^(www|dev)\\.".r
     val shortDomain = regex.replaceFirstIn(domain, ".")
 


### PR DESCRIPTION
@janua This would help identify users who have chosen not to see NextGen crosswords, and those that are eligible for being allocated a cohort (and will then be able to opt-out).
