### PR TITLE
Be verbose about twitter:image

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -239,7 +239,8 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
   )
 
   override def cards: List[(String, String)] = super.cards ++ List(
-    "twitter:app:url:googleplay" -> webUrl.replace("http", "guardian")
+    "twitter:app:url:googleplay" -> webUrl.replace("http", "guardian"),
+    "twitter:image" -> openGraphImage
   ) ++ contributorTwitterHandle.map(handle => "twitter:creator" -> s"@$handle").toList
 
   override def elements: Seq[Element] = delegate.elements


### PR DESCRIPTION
It has stopped picking up the og:image version.
