### PR TITLE
fix #10194: initialise save for later on fronts

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -357,7 +357,7 @@ define([
 
 
             saveForLater: function () {
-                if (config.switches.saveForLater && !/Network Front|Section|Tag/.test(config.page.contentType)) {
+                if (config.switches.saveForLater) {
                     var saveForLater = new SaveForLater();
                     saveForLater.init();
                 }


### PR DESCRIPTION
even though there's no way of saving articles from fronts, we still need to initialise the module to show the count and icon in the profile area

@OliverJAsh 
