### PR TITLE
adding `VideoEmbedCleaner` to the main cleaner

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -9,6 +9,7 @@ object MainCleaner {
  def apply(article: Article, html: String)(implicit request: RequestHeader) = {
       implicit val edition = Edition(request)
       withJsoup(BulletCleaner(html))(
+        VideoEmbedCleaner(article),
         PictureCleaner(article),
         MainFigCaptionCleaner
       )


### PR DESCRIPTION
Making sure video embeds in the main block are being cleaned appropriately.

Before (note that this isn't full screen):
![image](https://cloud.githubusercontent.com/assets/8774970/9361252/6fbc0190-4692-11e5-931f-3396d792cd0b.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/9361260/7ab55b00-4692-11e5-9c2b-6dfd6f945528.png)
