### PR TITLE
crossword print fixes

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -16,14 +16,10 @@
             <h1 itemprop="headline" class="content__headline js-score">@Html(crosswordPage.crossword.name)</h1>
             @if( gridVisable ) {
                 <div class="crossword__links">
-                    @crosswordPage.crossword.pdf match {
-                        case Some(pdf) => {
-                            <a class="crossword__link" href="@pdf" target="_blank">PDF version</a>
-                        }
+                    <a class="crossword__link js-print-crossword">Print</a>
 
-                        case None => {
-                            <a class="crossword__link js-print-crossword">Print</a>
-                        }
+                    @crosswordPage.crossword.pdf.map { pdf =>
+                            | <a class="crossword__link" href="@pdf" target="_blank">PDF version</a>
                     }
 
                     | <a class="crossword__link" href="@LinkTo(s"/crosswords/accessible/${crosswordPage.crossword.crosswordType}/${crosswordPage.crossword.number}")">Accessible version</a>

--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -129,13 +129,13 @@ p {
 
 .crossword__grid-wrapper {
     float: left;
-    width: 50% !important;
-    margin-right: 3% !important;
-    margin-bottom: 64px !important;
+    width: 9cm !important;
+    margin-bottom: 1cm !important;
 }
 
 .crossword__grid {
-    background-color: #000000 !important;
+    background-color: #7c7c7c !important;
+    -webkit-print-color-adjust: exact; // allow background colour printing
 }
 
 .crossword__controls,
@@ -148,11 +148,13 @@ p {
 }
 
 .crossword__clues {
+    clear: both;
     font-size: 12px;
 }
-
+.crossword__clues--across,
 .crossword__clues--down {
-    margin-top: 24px !important;
+    width: 50% !important;
+    display: inline-block;
 }
 
 .crossword__links {


### PR DESCRIPTION
based on user feedback:
- restore the print link
- change cell colour to grey (saves ink)
- use cm units for grid size (should make printing consistent across environments)
