### PR TITLE
At the time of writing, Twitter does not like i.guim.co.uk

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -560,6 +560,10 @@ import collection.JavaConversions._
         $("meta[name='twitter:site']").getAttributes("content").head should be("@guardian")
         $("meta[name='twitter:card']").getAttributes("content").head should be("summary_large_image")
         $("meta[name='twitter:app:url:googleplay']").getAttributes("content").head should startWith("guardian://www.theguardian.com/world")
+
+        // at the time of writing, Twitter does not like i.guim.co.uk
+        // will see if I can get that fixed, but in the meantime this must be static.guim.co.uk
+        $("meta[name='twitter:image']").getAttributes("content").head should be("http://static.guim.co.uk/sys-images/Guardian/Pix/GU_front_gifs/2013/9/15/1379275550234/Irans-President-Hassan-Ro-011.jpg")
       }
     }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -95,14 +95,12 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
 
   // read this before modifying
   // https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
-  lazy val openGraphImage: String = {
-    val imageUrl = bestOpenGraphImage
-      .orElse(mainPicture.flatMap(largestImageUrl))
-      .orElse(trailPicture.flatMap(largestImageUrl))
-      .getOrElse(facebook.imageFallback)
+  lazy val openGraphImage: String = ImgSrc(rawOpenGraphImage, FacebookOpenGraphImage)
 
-    ImgSrc(imageUrl, FacebookOpenGraphImage)
-  }
+  private lazy val rawOpenGraphImage: String = bestOpenGraphImage
+    .orElse(mainPicture.flatMap(largestImageUrl))
+    .orElse(trailPicture.flatMap(largestImageUrl))
+    .getOrElse(facebook.imageFallback)
 
   lazy val shouldHideAdverts: Boolean = fields.get("shouldHideAdverts").exists(_.toBoolean)
   override lazy val isInappropriateForSponsorship: Boolean = fields.get("isInappropriateForSponsorship").exists(_.toBoolean)
@@ -240,7 +238,7 @@ class Content protected (val apiContent: ApiContentWithMeta) extends Trail with 
 
   override def cards: List[(String, String)] = super.cards ++ List(
     "twitter:app:url:googleplay" -> webUrl.replace("http", "guardian"),
-    "twitter:image" -> openGraphImage
+    "twitter:image" -> rawOpenGraphImage
   ) ++ contributorTwitterHandle.map(handle => "twitter:creator" -> s"@$handle").toList
 
   override def elements: Seq[Element] = delegate.elements


### PR DESCRIPTION
Will see if I can get that fixed, but in the meantime this must be static.guim.co.uk

I tested this hypothesis by turning off the image server in CODE.

After that images worked in the Twitter validation tool again.
