### PR TITLE
Allow Mobile Responsive Takeovers on Any Front

### DIFF
--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -64,10 +64,7 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
   val topSlotTakeovers = dateSort {
     lineItems filter { lineItem =>
       lineItem.costType == "CPD" &&
-        lineItem.targeting.adUnits.exists { adUnit =>
-          val prefix = adUnit.path.mkString("/").stripSuffix("/ng").stripSuffix("/front")
-          prefix.endsWith("/uk") || prefix.endsWith("/us") || prefix.endsWith("/au")
-        } &&
+        lineItem.targetsNetworkOrSectionFrontDirectly &&
         lineItem.targeting.geoTargetsIncluded.exists { geoTarget =>
           geoTarget.locationType == "COUNTRY" && (
             geoTarget.name == "United Kingdom" ||
@@ -76,7 +73,8 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
             )
         } &&
         lineItem.creativeSizes.contains(responsiveSize) &&
-        lineItem.startTime.isBefore(DateTime.now.plusDays(1))
+        lineItem.startTime.isBefore(DateTime.now.plusDays(1)) &&
+        lineItem.endTime.isDefined
     }
   }
 

--- a/admin/app/views/commercial/slotTop.scala.html
+++ b/admin/app/views/commercial/slotTop.scala.html
@@ -6,7 +6,7 @@
     <p>This slot will only open if there is an ad that:</p>
     <ul>
         <li>Has the CPD cost type</li>
-        <li>Targets a network front ad unit</li>
+        <li>Targets a network or section front ad unit directly</li>
         <li>Targets the responsive size (88x70)</li>
         <li>Targets the countries UK, US or Australia</li>
     </ul>

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -225,6 +225,13 @@ case class GuLineItem(id: Long,
   val inlineMerchandisingTargetedSeries: Seq[String] = targeting.customTargetSets.flatMap(_.inlineMerchandisingTargetedSeries).distinct
   val inlineMerchandisingTargetedContributors: Seq[String] = targeting.customTargetSets.flatMap(_.inlineMerchandisingTargetedContributors).distinct
 
+  lazy val targetsNetworkOrSectionFrontDirectly: Boolean = {
+    targeting.adUnits.exists { adUnit =>
+      val path = adUnit.path
+      (path.length == 3 || path.length == 4) && path(2) == "front"
+    }
+  }
+
   def targetsSectionFrontDirectly(sectionId: String): Boolean = {
     targeting.adUnits.exists { adUnit =>
       val path = adUnit.path

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -87,8 +87,7 @@ case class PressedPage(id: String,
   override def hasPageSkin(edition: Edition) = DfpAgent.isPageSkinned(adUnitSuffix, edition)
 
   override def sizeOfTakeoverAdsInSlot(slot: AdSlot, edition: Edition): Seq[AdSize] = {
-    if (isNetworkFront) DfpAgent.sizeOfTakeoverAdsInSlot(slot, adUnitSuffix, edition)
-    else Nil
+    DfpAgent.sizeOfTakeoverAdsInSlot(slot, adUnitSuffix, edition)
   }
 
   override def hasAdInBelowTopNavSlot(edition: Edition): Boolean = {

--- a/common/test/common/dfp/GuLineItemTest.scala
+++ b/common/test/common/dfp/GuLineItemTest.scala
@@ -22,7 +22,10 @@ class GuLineItemTest extends FlatSpec with Matchers {
 
   "targetsSectionFrontDirectly" should
     "be true for a section front targeted directly" in {
-    val targetedAdUnits = Seq(GuAdUnit("id", Seq("theguardian.com", "business", "front")))
+    val targetedAdUnits = Seq(
+      GuAdUnit("id", Seq("theguardian.com")),
+      GuAdUnit("id", Seq("theguardian.com", "business", "front"))
+    )
     lineItem(targetedAdUnits).targetsSectionFrontDirectly("business") shouldBe true
   }
 


### PR DESCRIPTION
Previously mobile responsive takeovers were only possible on network fronts.  Now we check and open the top ad slot if necessary on any network or curated section front.
