### PR TITLE
Don't display menus that require JS if it's not available

### DIFF
--- a/static/src/stylesheets/module/nav/_brand-bar.scss
+++ b/static/src/stylesheets/module/nav/_brand-bar.scss
@@ -182,6 +182,13 @@
     }
 }
 
+.is-not-modern {
+    .brand-bar__item--more,
+    .brand-bar__item--edition {
+        display: none;
+    }
+}
+
 .brand-bar__item--masterclasses {
     .brand-bar__item--right--au-edition & {
         // Hide on mobile


### PR DESCRIPTION
The "more" and "edition" menus both require Javascript in order to be useful. We shouldn't display them if the browser does not have JS support.

With JS:
![screen shot 2015-08-21 at 14 49 15](https://cloud.githubusercontent.com/assets/690395/9409820/dc5a4a4a-4814-11e5-86b3-3017caf09ade.png)

Without JS:
![screen shot 2015-08-21 at 14 49 51](https://cloud.githubusercontent.com/assets/690395/9409832/ec98c27e-4814-11e5-9303-c99b5dc2de62.png)
