### PR TITLE
Move css detection out of isModern

### DIFF
--- a/common/app/templates/headerInlineJS/featureDetection.scala.js
+++ b/common/app/templates/headerInlineJS/featureDetection.scala.js
@@ -46,23 +46,23 @@
         docClass += ' no-svg';
     }
 
+    if (testCssSupport('flex') || testCssSupport('-ms-flex') || testCssSupport('-webkit-flex') || testCssSupport('-moz-box-flex') || testCssSupport('-webkit-box-flex')) {
+        docClass += ' has-flex';
+    } else {
+        docClass += ' has-no-flex';
+    }
+
+    if (testCssSupport('flex-wrap') || testCssSupport('-ms-flex-wrap') || testCssSupport('-webkit-flex-wrap')) {
+        docClass += ' has-flex-wrap';
+    } else {
+        docClass += ' has-no-flex-wrap';
+    }
+
+    if (testCssSupport('position', 'fixed')) {
+        docClass += ' has-fixed';
+    }
+
     if (window.guardian.isModernBrowser) {
-        if (testCssSupport('flex') || testCssSupport('-ms-flex') || testCssSupport('-webkit-flex') || testCssSupport('-moz-box-flex') || testCssSupport('-webkit-box-flex')) {
-            docClass += ' has-flex';
-        } else {
-            docClass += ' has-no-flex';
-        }
-
-        if (testCssSupport('flex-wrap') || testCssSupport('-ms-flex-wrap') || testCssSupport('-webkit-flex-wrap')) {
-            docClass += ' has-flex-wrap';
-        } else {
-            docClass += ' has-no-flex-wrap';
-        }
-
-        if (testCssSupport('position', 'fixed')) {
-            docClass += ' has-fixed';
-        }
-
         docClass = docClass.replace(/\bis-not-modern\b/g, 'is-modern');
     }
 

--- a/common/app/templates/headerInlineJS/featureDetection.scala.js
+++ b/common/app/templates/headerInlineJS/featureDetection.scala.js
@@ -16,26 +16,29 @@
         if (valueIsDefined && ('CSS' in window && 'supports' in window.CSS)) {
             return window.CSS.supports(prop, value);
         } else {
-            var elm = document.createElement('test');
-            prop = cssToDOM(prop);
-            if (elm.style[prop] !== undefined) {
-                if (valueIsDefined) {
-                    var before = elm.style[prop];
-                    try {
-                        elm.style[prop] = value;
-                    } catch (e) {}
-                    if (elm.style[prop] !== before) {
-                        elm = null;
-                        return true;
-                    } else {
-                        elm = null;
-                        return false;
+            try {
+                var elm = document.createElement('test');
+                prop = cssToDOM(prop);
+                if (elm.style[prop] !== undefined) {
+                    if (valueIsDefined) {
+                        var before = elm.style[prop];
+                        try {
+                            elm.style[prop] = value;
+                        } catch (e) {}
+                        if (elm.style[prop] !== before) {
+                            elm = null;
+                            return true;
+                        } else {
+                            elm = null;
+                            return false;
+                        }
                     }
+                    elm = null;
+                    return true;
                 }
-                elm = null;
-                return true;
+            } catch (e) {
+                return false;
             }
-            return false;
         }
     }
 


### PR DESCRIPTION
Just because we say your JS skills are not modern (maybe we're disabling the app) doesn't mean you can't render modern CSS. This removes the CSS feature detection from the `guardian.isModernBrowser` requirement

/cc @stephanfowler 
