### PR TITLE
Sticky rhc fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -42,10 +42,12 @@ define([
             // make sure the element stays within its parent
             fixedTop = Math.min(this.opts.top, this.$parent[0].getBoundingClientRect().bottom - this.$element.dim().height) + stickyHeaderHeight;
 
-            css = {
-                position: 'fixed',
-                top:      fixedTop
-            };
+            if (fixedTop > 0) {
+                css = {
+                    position: 'fixed',
+                    top:      fixedTop
+                };
+            }
         } else {
             css = {
                 position: null,


### PR DESCRIPTION
This PR fixes the bug when a gallery overlay/lightbox is clicked before the rhc MPU loads.

Before fix:
![screen shot 2015-08-24 at 12 29 53](https://cloud.githubusercontent.com/assets/489567/9439111/f0bf75fc-4a5b-11e5-82d2-4f0aba07b4cf.png)

After fix:
![screen shot 2015-08-24 at 12 30 45](https://cloud.githubusercontent.com/assets/489567/9439116/fa35e378-4a5b-11e5-9217-1fafd93a936a.png)
