### PR TITLE
Update rugby's agent structure

### DIFF
--- a/sport/app/rugby/jobs/RugbyStatsJob.scala
+++ b/sport/app/rugby/jobs/RugbyStatsJob.scala
@@ -21,8 +21,7 @@ trait RugbyStatsJob extends ExecutionContexts with Logging {
   def sendLiveScores(scoreData: Future[Seq[Match]]) : Future[Any] = {
     scoreData.flatMap { matches =>
       Future.sequence(matches.map { aMatch =>
-        val date = dateFormat.print(aMatch.date)
-        val key = createKey(aMatch, date)
+        val key = createKey(aMatch)
         liveScoreMatches.alter {_ + (key -> aMatch)}
       })
     }.recover {
@@ -34,8 +33,7 @@ trait RugbyStatsJob extends ExecutionContexts with Logging {
   def fixturesAndResults(fixturesAndResults: Future[Seq[Match]]) : Future[Any] = {
     fixturesAndResults.flatMap { matches =>
       Future.sequence(matches.map { aMatch =>
-        val date = dateFormat.print(aMatch.date)
-        val key = createKey(aMatch, date)
+        val key = createKey(aMatch)
         fixturesAndResultsMatches.alter {_ +  (key -> aMatch)}
       })
     }.recover {
@@ -44,7 +42,8 @@ trait RugbyStatsJob extends ExecutionContexts with Logging {
     }
   }
 
-  private def createKey(aMatch: Match, date: String): String = {
+  private def createKey(aMatch: Match): String = {
+    val date = dateFormat.print(aMatch.date)
     s"$date/${aMatch.homeTeam.id}/${aMatch.awayTeam.id}"
   }
 
@@ -64,11 +63,4 @@ trait RugbyStatsJob extends ExecutionContexts with Logging {
   private def isValidMatch(year: String, month: String, day: String, team1: String, team2: String, rugbyMatch: Match): Boolean = {
     rugbyMatch.hasTeam(team1) && rugbyMatch.hasTeam(team2) && dateFormat.print(rugbyMatch.date) == s"$year/$month/$day"
   }
-
-  private object Date {
-    private val dateTimeParser = DateTimeFormat.forPattern("yyyy/MM/dd")
-
-    def apply(dateTime: String) = dateTimeParser.parseDateTime(dateTime)
-  }
-
 }

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -16,7 +16,6 @@ import conf.{SportConfiguration, FootballClient, Configuration}
 import pa.Http
 import io.Source
 import org.joda.time.LocalDate
-import rugby.model.MatchParserTest
 import scala.concurrent.Future
 
 class SportTestSuite extends Suites (
@@ -38,7 +37,8 @@ class SportTestSuite extends Suites (
   new LiveMatchesFeatureTest,
   new MatchFeatureTest,
   new ResultsFeatureTest,
-  new MatchParserTest
+  new rugby.model.MatchParserTest,
+  new rugby.jobs.RugbyStatsJobTest
 ) with SingleServerSuite with FootballTestData {
 
   override lazy val port: Int = conf.HealthCheck.testPort

--- a/sport/test/rugby/jobs/RugbyStatsJobTest.scala
+++ b/sport/test/rugby/jobs/RugbyStatsJobTest.scala
@@ -1,0 +1,58 @@
+package rugby.jobs
+
+import org.joda.time.DateTime
+import org.scalatest._
+import org.scalatest.concurrent.Eventually
+import test.ConfiguredTestSuite
+import rugby.model._
+import scala.concurrent.Future
+import scala.language.reflectiveCalls
+
+@DoNotDiscover class RugbyStatsJobTest extends FreeSpec with ShouldMatchers with ConfiguredTestSuite with Eventually {
+
+  "RugbyStatsJob" - {
+    "should update a live match with new score data" in {
+
+      val testDate = new DateTime(2015, 8, 24, 0, 0)
+
+      val (homeTeamOld, homeTeamNew, awayTeamOld, awayTeamNew) = (
+        Team("1", "home", Some(10)),
+        Team("1", "home", Some(20)),
+        Team("2", "away", Some(30)),
+        Team("2", "away", Some(40)))
+
+      val (oldMatch, newMatch) = (
+        Match(
+          date = testDate,
+          id = "match id",
+          homeTeam = homeTeamOld,
+          awayTeam = awayTeamOld
+        ),
+        Match(
+          date = testDate.plusSeconds(1),
+          id = "match id",
+          homeTeam = homeTeamNew,
+          awayTeam = awayTeamNew
+        ))
+
+      val testStatsJob = new RugbyStatsJob {
+        def allFixtures = fixturesAndResultsMatches.get()
+        def liveMatches = liveScoreMatches.get()
+      }
+
+      testStatsJob.allFixtures.size should be(0)
+      testStatsJob.liveMatches.size should be(0)
+
+      testStatsJob.sendLiveScores(Future.successful(List(oldMatch)))
+
+      eventually {
+        testStatsJob.allFixtures.size should be(0)
+        testStatsJob.liveMatches.size should be(1)
+
+        val matchData = testStatsJob.getLiveScore("2015", "08", "24", "1", "2")
+
+        matchData shouldBe defined
+      }
+    }
+  }
+}

--- a/sport/test/rugby/jobs/RugbyStatsJobTest.scala
+++ b/sport/test/rugby/jobs/RugbyStatsJobTest.scala
@@ -10,49 +10,71 @@ import scala.language.reflectiveCalls
 
 @DoNotDiscover class RugbyStatsJobTest extends FreeSpec with ShouldMatchers with ConfiguredTestSuite with Eventually {
 
+  val testDate = new DateTime(2015, 8, 24, 0, 0)
+
+  val (homeTeamOld, homeTeamNew, awayTeamOld, awayTeamNew) = (
+    Team("1", "home", Some(10)),
+    Team("1", "home", Some(20)),
+    Team("2", "away", Some(30)),
+    Team("2", "away", Some(40)))
+
+  val (oldMatch, newMatch) = (
+    Match(
+      date = testDate,
+      id = "match id",
+      homeTeam = homeTeamOld,
+      awayTeam = awayTeamOld
+    ),
+    Match(
+      date = testDate.plusSeconds(1),
+      id = "match id",
+      homeTeam = homeTeamNew,
+      awayTeam = awayTeamNew
+    ))
+
   "RugbyStatsJob" - {
     "should update a live match with new score data" in {
-
-      val testDate = new DateTime(2015, 8, 24, 0, 0)
-
-      val (homeTeamOld, homeTeamNew, awayTeamOld, awayTeamNew) = (
-        Team("1", "home", Some(10)),
-        Team("1", "home", Some(20)),
-        Team("2", "away", Some(30)),
-        Team("2", "away", Some(40)))
-
-      val (oldMatch, newMatch) = (
-        Match(
-          date = testDate,
-          id = "match id",
-          homeTeam = homeTeamOld,
-          awayTeam = awayTeamOld
-        ),
-        Match(
-          date = testDate.plusSeconds(1),
-          id = "match id",
-          homeTeam = homeTeamNew,
-          awayTeam = awayTeamNew
-        ))
 
       val testStatsJob = new RugbyStatsJob {
         def allFixtures = fixturesAndResultsMatches.get()
         def liveMatches = liveScoreMatches.get()
       }
 
-      testStatsJob.allFixtures.size should be(0)
-      testStatsJob.liveMatches.size should be(0)
+      testStatsJob.allFixtures.size should be (0)
+      testStatsJob.liveMatches.size should be (0)
 
       testStatsJob.sendLiveScores(Future.successful(List(oldMatch)))
 
       eventually {
         testStatsJob.allFixtures.size should be(0)
         testStatsJob.liveMatches.size should be(1)
+      }
+
+      val oldMatchData = testStatsJob.getLiveScore("2015", "08", "24", "1", "2")
+
+      oldMatchData shouldBe defined
+      oldMatchData.flatMap(_.homeTeam.score) should be (Some(10))
+
+      testStatsJob.sendLiveScores(Future.successful(List(newMatch)))
+
+      eventually {
+        testStatsJob.allFixtures.size should be(0)
+        testStatsJob.liveMatches.size should be(1)
 
         val matchData = testStatsJob.getLiveScore("2015", "08", "24", "1", "2")
-
-        matchData shouldBe defined
+        matchData.flatMap(_.homeTeam.score) should be (Some(20))
       }
     }
+
+    "should find a match even when the team ids are reversed" in {
+      val testStatsJob = new RugbyStatsJob {}
+
+      testStatsJob.sendLiveScores(Future.successful(List(oldMatch)))
+
+      eventually {
+        testStatsJob.getLiveScore("2015", "08", "24", "2", "1") shouldBe defined
+      }
+    }
+
   }
 }


### PR DESCRIPTION
This fixes a problem where score updates for a live rugby match were not being reflected on the rugby page.

Added some tests, and changed the agent system so that we can test the rugby job a little easier
