### PR TITLE
Mobile ads fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -6,6 +6,7 @@ define([
     'common/utils/$',
     'common/utils/_',
     'common/utils/config',
+    'common/utils/detect',
     'common/modules/commercial/create-ad-slot',
     'common/modules/user-prefs'
 ], function (
@@ -16,6 +17,7 @@ define([
     $,
     _,
     config,
+    detect,
     createAdSlot,
     userPrefs
 ) {
@@ -68,12 +70,15 @@ define([
                     return new Promise(function (resolve) {
                         fastdom.write(function () {
                             // add a tablet+ ad to the slice
-                            $adSlice
-                                .removeClass('fc-slice__item--no-mpu')
-                                .append($tabletAdSlot);
-                            // add a mobile advert after the container
-                            $mobileAdSlot
-                                .insertAfter($.ancestor($adSlice[0], 'fc-container'));
+                            if (detect.getBreakpoint() !== 'mobile') {
+                                $adSlice
+                                    .removeClass('fc-slice__item--no-mpu')
+                                    .append($tabletAdSlot);
+                            } else {
+                                // add a mobile advert after the container
+                                $mobileAdSlot
+                                    .insertAfter($.ancestor($adSlice[0], 'fc-container'));
+                            }
 
                             resolve(null);
                         });

--- a/static/src/javascripts/test/spec/common/commercial/slice-adverts.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/slice-adverts.spec.js
@@ -18,13 +18,6 @@ describe('Slice Adverts', function () {
         sliceAdverts, config, detect;
 
     beforeEach(function (done) {
-        /*injector.mock({
-            'common/utils/detect': {
-                getBreakpoint: function () {
-                    return 'desktop';
-                }
-            }
-        });*/
         injector.test(['common/modules/commercial/slice-adverts', 'common/utils/config', 'common/utils/detect'], function () {
             sliceAdverts = arguments[0];
             config = arguments[1];
@@ -65,9 +58,6 @@ describe('Slice Adverts', function () {
     });
 
     it('should remove the "fc-slice__item--no-mpu" class', function (done) {
-        detect.getBreakpoint = function () {
-            return 'desktop';
-        };
         sliceAdverts.init();
 
         fastdom.defer(function () {

--- a/static/src/javascripts/test/spec/common/commercial/slice-adverts.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/slice-adverts.spec.js
@@ -15,17 +15,30 @@ describe('Slice Adverts', function () {
         },
         $fixtureContainer,
         injector = new Injector(),
-        sliceAdverts, config;
+        sliceAdverts, config, detect;
 
     beforeEach(function (done) {
-        injector.test(['common/modules/commercial/slice-adverts', 'common/utils/config'], function () {
+        /*injector.mock({
+            'common/utils/detect': {
+                getBreakpoint: function () {
+                    return 'desktop';
+                }
+            }
+        });*/
+        injector.test(['common/modules/commercial/slice-adverts', 'common/utils/config', 'common/utils/detect'], function () {
             sliceAdverts = arguments[0];
             config = arguments[1];
+            detect = arguments[2];
+
             config.page = {
                 pageId: 'uk/commentisfree'
             };
             config.switches = {
                 standardAdverts: true
+            };
+
+            detect.getBreakpoint = function () {
+                return 'desktop';
             };
 
             $fixtureContainer = fixtures.render(fixturesConfig);
@@ -42,16 +55,19 @@ describe('Slice Adverts', function () {
         expect(sliceAdverts).toBeDefined();
     });
 
-    it('should only create a maximum of 6 advert slots', function (done) {
+    it('should only create a maximum of 3 advert slots', function (done) {
         sliceAdverts.init();
 
         fastdom.defer(function () {
-            expect(qwery('.ad-slot', $fixtureContainer).length).toEqual(6);
+            expect(qwery('.ad-slot', $fixtureContainer).length).toEqual(3);
             done();
         });
     });
 
     it('should remove the "fc-slice__item--no-mpu" class', function (done) {
+        detect.getBreakpoint = function () {
+            return 'desktop';
+        };
         sliceAdverts.init();
 
         fastdom.defer(function () {
@@ -70,11 +86,8 @@ describe('Slice Adverts', function () {
             var $adSlots = $('.ad-slot', $fixtureContainer).map(function (slot) { return $(slot); });
 
             expect($adSlots[0].data('name')).toEqual('inline1');
-            expect($adSlots[1].data('name')).toEqual('inline1');
-            expect($adSlots[2].data('name')).toEqual('inline2');
-            expect($adSlots[3].data('name')).toEqual('inline2');
-            expect($adSlots[4].data('name')).toEqual('inline3');
-            expect($adSlots[5].data('name')).toEqual('inline3');
+            expect($adSlots[1].data('name')).toEqual('inline2');
+            expect($adSlots[2].data('name')).toEqual('inline3');
 
             done();
         });
@@ -147,7 +160,8 @@ describe('Slice Adverts', function () {
         });
     });
 
-    it('should add one slot for tablet, one slot for mobile after container', function (done) {
+    //TODO: get data if we need to reintroduce this again
+    xit('should add one slot for tablet, one slot for mobile after container', function (done) {
         sliceAdverts.init();
 
         fastdom.defer(function () {

--- a/static/src/javascripts/test/spec/common/commercial/slice-adverts.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/slice-adverts.spec.js
@@ -93,6 +93,23 @@ describe('Slice Adverts', function () {
         });
     });
 
+    it('should have the correct ad names on mobile', function (done) {
+        detect.getBreakpoint = function () {
+            return 'mobile';
+        };
+        sliceAdverts.init();
+
+        fastdom.defer(function () {
+            var $adSlots = $('.ad-slot', $fixtureContainer).map(function (slot) { return $(slot); });
+
+            expect($adSlots[0].data('name')).toEqual('inline1');
+            expect($adSlots[1].data('name')).toEqual('inline2');
+            expect($adSlots[2].data('name')).toEqual('inline3');
+
+            done();
+        });
+    });
+
     it('should have the correct size mappings', function (done) {
         sliceAdverts.init();
 


### PR DESCRIPTION
Ads are not being served for mobile devices on fronts:
<img width="363" alt="screen shot 2015-08-25 at 14 12 20" src="https://cloud.githubusercontent.com/assets/2579465/9467403/56eeb964-4b33-11e5-98ac-fc40a25d42fb.png">

Bug has something to do with adding two divs for adslot for mobile and tablet+ to be able to deliver responsive experience.

This will fix the issue however it will turn off responsive behaviour till we will find what is causing the issue.

@Calanthe @jbreckmckye 
