### PR TITLE
Change CAPI endpoint

### DIFF
--- a/facia-end-to-end/conf/routes
+++ b/facia-end-to-end/conf/routes
@@ -61,7 +61,7 @@ POST        /treats/*collectionId                                           cont
 
 # endpoints for proxying https
 GET         /switches                                                       controllers.SwitchesProxy.getSwitches()
-GET         /api/proxy/*path                                                controllers.FaciaContentApiProxy.capi(path)
+GET         /api/preview/*path                                              controllers.FaciaContentApiProxy.capiPreview(path)
 GET         /api/live/*path                                                 controllers.FaciaContentApiProxy.capiLive(path)
 GET         /http/proxy/*url                                                controllers.FaciaContentApiProxy.http(url)
 GET         /json/proxy/*absUrl                                             controllers.FaciaContentApiProxy.json(absUrl)

--- a/facia-end-to-end/conf/routes
+++ b/facia-end-to-end/conf/routes
@@ -62,6 +62,7 @@ POST        /treats/*collectionId                                           cont
 # endpoints for proxying https
 GET         /switches                                                       controllers.SwitchesProxy.getSwitches()
 GET         /api/proxy/*path                                                controllers.FaciaContentApiProxy.capi(path)
+GET         /api/live/*path                                                 controllers.FaciaContentApiProxy.capiLive(path)
 GET         /http/proxy/*url                                                controllers.FaciaContentApiProxy.http(url)
 GET         /json/proxy/*absUrl                                             controllers.FaciaContentApiProxy.json(absUrl)
 GET         /ophan/*path                                                    controllers.FaciaContentApiProxy.ophan(path)

--- a/facia-tool/app/controllers/FaciaContentApiProxy.scala
+++ b/facia-tool/app/controllers/FaciaContentApiProxy.scala
@@ -35,10 +35,29 @@ object FaciaContentApiProxy extends Controller with Logging with ExecutionContex
     }
   }
 
+  def capiLive(path: String) = APIAuthAction.async { request =>
+    FaciaToolMetrics.ProxyCount.increment()
+    val queryString = request.queryString.filter(_._2.exists(_.nonEmpty)).map { p =>
+       "%s=%s".format(p._1, p._2.head.urlEncoded)
+    }.mkString("&")
+
+    val contentApiHost = Configuration.contentApi.contentApiLiveHost
+
+    val url = s"$contentApiHost/$path?$queryString${Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
+
+    Logger.info("Proxying tag API query to: %s".format(url, request))
+
+    WS.url(url).get().map { response =>
+      Cached(60) {
+        Ok(rewriteBody(response.body)).as("application/javascript")
+      }
+    }
+  }
+
   def http(url: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
 
-    WS.url(url).withPreviewAuth.get().map { response =>
+    WS.url(url).get().map { response =>
       Cached(60) {
         Ok(response.body).as("text/html")
       }
@@ -65,11 +84,11 @@ object FaciaContentApiProxy extends Controller with Logging with ExecutionContex
     val ophanApiHost = Configuration.ophanApi.host.get
     val ophanKey = Configuration.ophanApi.key.map(key => s"&api-key=$key").getOrElse("")
 
-    val url = s"$ophanApiHost/$path?$queryString&$paths&ophanKey"
+    val url = s"$ophanApiHost/$path?$queryString&$paths&$ophanKey"
 
     Logger.info("Proxying ophan request to: %s".format(url, request))
 
-    WS.url(url).withPreviewAuth.get().map { response =>
+    WS.url(url).get().map { response =>
       Cached(60) {
         Ok(response.body).as("application/json")
       }

--- a/facia-tool/app/controllers/FaciaContentApiProxy.scala
+++ b/facia-tool/app/controllers/FaciaContentApiProxy.scala
@@ -16,7 +16,7 @@ object FaciaContentApiProxy extends Controller with Logging with ExecutionContex
   override lazy val actorSystem = ActorSystem()
   import play.api.Play.current
 
-  def capi(path: String) = APIAuthAction.async { request =>
+  def capiPreview(path: String) = APIAuthAction.async { request =>
     FaciaToolMetrics.ProxyCount.increment()
     val queryString = request.queryString.filter(_._2.exists(_.nonEmpty)).map { p =>
        "%s=%s".format(p._1, p._2.head.urlEncoded)

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -48,6 +48,7 @@ POST        /treats/*collectionId                    controllers.FaciaToolContro
 # endpoints for proxying https
 GET         /switches                                controllers.SwitchesProxy.getSwitches()
 GET         /api/proxy/*path                         controllers.FaciaContentApiProxy.capi(path)
+GET         /api/live/*path                          controllers.FaciaContentApiProxy.capiLive(path)
 GET         /http/proxy/*url                         controllers.FaciaContentApiProxy.http(url)
 GET         /json/proxy/*absUrl                      controllers.FaciaContentApiProxy.json(absUrl)
 GET         /ophan/*path                             controllers.FaciaContentApiProxy.ophan(path)

--- a/facia-tool/conf/routes
+++ b/facia-tool/conf/routes
@@ -47,7 +47,7 @@ POST        /treats/*collectionId                    controllers.FaciaToolContro
 
 # endpoints for proxying https
 GET         /switches                                controllers.SwitchesProxy.getSwitches()
-GET         /api/proxy/*path                         controllers.FaciaContentApiProxy.capi(path)
+GET         /api/preview/*path                       controllers.FaciaContentApiProxy.capiPreview(path)
 GET         /api/live/*path                          controllers.FaciaContentApiProxy.capiLive(path)
 GET         /http/proxy/*url                         controllers.FaciaContentApiProxy.http(url)
 GET         /json/proxy/*absUrl                      controllers.FaciaContentApiProxy.json(absUrl)

--- a/facia-tool/public/js/constants/defaults.js
+++ b/facia-tool/public/js/constants/defaults.js
@@ -67,7 +67,7 @@ export default {
     mainDomain:            'www.theguardian.com',
 
     apiBase:               '',
-    apiSearchBase:         '/api/proxy',
+    apiSearchBase:         '/api/preview',
     apiLiveBase:           '/api/live',
     apiSearchParams:       [
         'show-elements=video',

--- a/facia-tool/public/js/constants/defaults.js
+++ b/facia-tool/public/js/constants/defaults.js
@@ -68,6 +68,7 @@ export default {
 
     apiBase:               '',
     apiSearchBase:         '/api/proxy',
+    apiLiveBase:           '/api/live',
     apiSearchParams:       [
         'show-elements=video',
         'show-tags=all',

--- a/facia-tool/public/js/modules/content-api.js
+++ b/facia-tool/public/js/modules/content-api.js
@@ -266,8 +266,7 @@ function dateYyyymmdd() {
 }
 
 function fetchLatest (options) {
-    var url = CONST.apiSearchBase + '/',
-        propName, term, filter;
+    var propName, term, filter;
 
     options = _.extend({
         article: '',
@@ -281,6 +280,8 @@ function fetchLatest (options) {
     term = options.term;
     filter = options.filter;
 
+    var url = (options.isDraft ? CONST.apiSearchBase : CONST.apiLiveBase) + '/';
+
     if (options.article) {
         term = options.article;
         propName = 'content';
@@ -288,10 +289,10 @@ function fetchLatest (options) {
     } else {
         term = encodeURIComponent(term.trim());
         propName = 'results';
-        url += 'search?' + CONST.apiSearchParams;
+        url += (options.isDraft ? 'content/scheduled?' : 'search?') + CONST.apiSearchParams;
         url += options.isDraft ?
-            '&content-set=-web-live&order-by=oldest&use-date=scheduled-publication&from-date=' + dateYyyymmdd() :
-            '&content-set=web-live&order-by=newest';
+            '&order-by=oldest&from-date=' + dateYyyymmdd() :
+            '&order-by=newest';
         url += '&page-size=' + options.pageSize;
         url += '&page=' + options.page;
         url += term ? '&q=' + term : '';

--- a/facia-tool/test/public/mocks/search.js
+++ b/facia-tool/test/public/mocks/search.js
@@ -12,7 +12,7 @@ function parse (string) {
 
 class Search extends Mock {
     constructor() {
-        super(/\/api\/proxy\/search\?(.+)/, ['queryString']);
+        super(/\/api\/live\/search\?(.+)/, ['queryString']);
 
         this.latestArticles = {
             response: {

--- a/facia-tool/test/public/spec/capi.spec.js
+++ b/facia-tool/test/public/spec/capi.spec.js
@@ -2,7 +2,6 @@ import _ from 'underscore';
 import sinon from 'sinon';
 import {CONST} from 'modules/vars';
 import * as capi from 'modules/content-api';
-import Mock from 'mock/search';
 import {scope} from 'test/utils/mockjax';
 import * as cache from 'modules/cache';
 import modalDialog from 'modules/modal-dialog';
@@ -21,13 +20,13 @@ describe('Content API', function () {
         };
 
     beforeEach(function () {
-        this.mock = new Mock();
+        this.scope = scope();
         this.defaultCapiBatchSize = CONST.capiBatchSize;
         CONST.capiBatchSize = 3;
     });
 
     afterEach(function () {
-        this.mock.dispose();
+        this.scope.clear();
         CONST.capiBatchSize = this.defaultCapiBatchSize;
     });
 
@@ -35,13 +34,15 @@ describe('Content API', function () {
         capi.decorateItems([]).then(function () {
             // Just make sure the callback is called for empty arrays
             expect(true).toBe(true);
-            done();
-        });
+        })
+        .then(done)
+        .catch(done.fail);
     });
 
     it('decorateItems in one batch', function (done) {
-        this.mock.set({
-            'internal-code/page/capi1,internal-code/page/capi2,internal-code/page/capi3': {
+        this.scope({
+            url: /\/api\/proxy\/search\?ids=.+capi1,.+capi2,.+capi3/,
+            responseText: {
                 response: {
                     results: [{
                         fields: {
@@ -65,18 +66,20 @@ describe('Content API', function () {
             createArticle('capi3')
         ];
 
-        capi.decorateItems(articles).then(function () {
+        capi.decorateItems(articles).then(() => {
             // Just make sure the callback is called for empty arrays
             _.each(articles, function (article) {
                 expect(article.addCapiData.called).toBe(true);
             });
-            done();
-        });
+        })
+        .then(done)
+        .catch(done.fail);
     });
 
     it('decorateItems in multiple batches', function (done) {
-        this.mock.set({
-            'internal-code/page/batch1,internal-code/page/batch2,internal-code/page/batch3': {
+        this.scope({
+            url: /\/api\/proxy\/search\?ids=.+batch1,.+batch2,.+batch3/,
+            responseText: {
                 response: {
                     results: [{
                         fields: {
@@ -92,8 +95,10 @@ describe('Content API', function () {
                         }
                     }]
                 }
-            },
-            'internal-code/page/batch4': {
+            }
+        }, {
+            url: /\/api\/proxy\/search\?ids=.+batch4/,
+            responseText: {
                 response: {
                     results: [{
                         fields: {
@@ -110,23 +115,17 @@ describe('Content API', function () {
             createArticle('batch4')
         ];
 
-        capi.decorateItems(articles).then(function () {
+        capi.decorateItems(articles).then(() => {
             // Just make sure the callback is called for empty arrays
             _.each(articles, function (article) {
                 expect(article.addCapiData.called).toBe(true);
             });
-            done();
-        });
+        })
+        .then(done)
+        .catch(done.fail);
     });
 
     describe('fetchContent', function () {
-        beforeEach(function () {
-            this.scope = scope();
-        });
-        afterEach(function () {
-            this.scope.clear();
-        });
-
         it('fails if no response', function (done) {
             this.scope({
                 url: CONST.apiSearchBase + '/capi-url',

--- a/facia-tool/test/public/spec/capi.spec.js
+++ b/facia-tool/test/public/spec/capi.spec.js
@@ -41,7 +41,7 @@ describe('Content API', function () {
 
     it('decorateItems in one batch', function (done) {
         this.scope({
-            url: /\/api\/proxy\/search\?ids=.+capi1,.+capi2,.+capi3/,
+            url: /\/api\/preview\/search\?ids=.+capi1,.+capi2,.+capi3/,
             responseText: {
                 response: {
                     results: [{
@@ -78,7 +78,7 @@ describe('Content API', function () {
 
     it('decorateItems in multiple batches', function (done) {
         this.scope({
-            url: /\/api\/proxy\/search\?ids=.+batch1,.+batch2,.+batch3/,
+            url: /\/api\/preview\/search\?ids=.+batch1,.+batch2,.+batch3/,
             responseText: {
                 response: {
                     results: [{
@@ -97,7 +97,7 @@ describe('Content API', function () {
                 }
             }
         }, {
-            url: /\/api\/proxy\/search\?ids=.+batch4/,
+            url: /\/api\/preview\/search\?ids=.+batch4/,
             responseText: {
                 response: {
                     results: [{

--- a/facia-tool/test/public/spec/clipboard.spec.js
+++ b/facia-tool/test/public/spec/clipboard.spec.js
@@ -27,7 +27,7 @@ describe('Clipboard', function () {
         });
         this.scope = mockjax.scope();
         this.scope({
-            url: '/api/proxy/piuccio*',
+            url: '/api/preview/piuccio*',
             responseText: {}
         });
         this.originaldetectPendingChangesInClipboard = CONST.detectPendingChangesInClipboard;

--- a/facia-tool/test/public/spec/collections.front.spec.js
+++ b/facia-tool/test/public/spec/collections.front.spec.js
@@ -183,7 +183,7 @@ describe('Front', function () {
             url: '/stories-visible/long',
             responseText: {}
         }, {
-            url: '/api/proxy/search?ids=' + encodeURIComponent('internal-code/page/') + '1*',
+            url: '/api/preview/search?ids=' + encodeURIComponent('internal-code/page/') + '1*',
             responseText: {
                 response: {
                     results: [{
@@ -202,7 +202,7 @@ describe('Front', function () {
                 }
             }
         }, {
-            url: '/api/proxy/search?ids=' + encodeURIComponent('internal-code/page/') + '3*',
+            url: '/api/preview/search?ids=' + encodeURIComponent('internal-code/page/') + '3*',
             responseText: {
                 response: {
                     results: [{

--- a/facia-tool/test/public/spec/latest.articles.model.spec.js
+++ b/facia-tool/test/public/spec/latest.articles.model.spec.js
@@ -12,7 +12,7 @@ describe('Latest articles', function() {
 
     it('whole list should filter out articles', function (done) {
         this.scope({
-            url: /\/api\/proxy\/content\/scheduled(\?.+)/,
+            url: /\/api\/preview\/content\/scheduled(\?.+)/,
             urlParams: ['queryString'],
             response: function (request) {
                 var urlParams = parse(request.urlParams.queryString);
@@ -92,7 +92,7 @@ describe('Latest articles', function() {
 
     it('all results empty response', function (done) {
         this.scope({
-            url: /\/api\/proxy\/content\/scheduled(\?.+)/,
+            url: /\/api\/preview\/content\/scheduled(\?.+)/,
             responseText: {
                 response: {
                     status: 'ok',
@@ -112,7 +112,7 @@ describe('Latest articles', function() {
 
     it('searches an article', function (done) {
         this.scope({
-            url: /\/api\/proxy\/uk-news\/important\/stuff\?(.+)/,
+            url: /\/api\/preview\/uk-news\/important\/stuff\?(.+)/,
             responseText: {
                 status: 'ok',
                 response: {
@@ -141,7 +141,7 @@ describe('Latest articles', function() {
 
     it('network fail', function (done) {
         this.scope({
-            url: /\/api\/proxy\/uk-news\/less\/important.*/,
+            url: /\/api\/preview\/uk-news\/less\/important.*/,
             responseText: 'Server error',
             status: 500
         });

--- a/facia-tool/test/public/spec/latest.articles.model.spec.js
+++ b/facia-tool/test/public/spec/latest.articles.model.spec.js
@@ -1,49 +1,77 @@
-import _ from 'underscore';
 import * as contentApi from 'modules/content-api';
-import MockSearch from 'mock/search';
-import mockjax from 'test/utils/mockjax';
+import * as mockjax from 'test/utils/mockjax';
+import parse from 'utils/parse-query-params';
 
 describe('Latest articles', function() {
     beforeEach(function () {
-        this.mock = new MockSearch();
+        this.scope = mockjax.scope();
     });
     afterEach(function () {
-        this.mock.dispose();
+        this.scope.clear();
     });
 
     it('whole list should filter out articles', function (done) {
-        this.mock.latest([{
-            fields: {
-                headline: 'This has an header'
+        this.scope({
+            url: /\/api\/proxy\/content\/scheduled(\?.+)/,
+            urlParams: ['queryString'],
+            response: function (request) {
+                var urlParams = parse(request.urlParams.queryString);
+                expect(urlParams.page).toBe('1');
+                expect(urlParams['order-by']).toBe('oldest');
+                expect(urlParams['page-size']).toBe('50');
+                expect(urlParams.q).toBeUndefined();
+
+                this.responseText = {
+                    response: {
+                        status: 'ok',
+                        results: [{
+                            fields: {
+                                headline: 'This has an header'
+                            }
+                        }, {
+                            not: 'This doesn\'t, filter out'
+                        }]
+                    }
+                };
             }
-        }, {
-            not: 'This doesn\'t, filter out'
-        }]);
+        });
 
         contentApi.fetchLatest()
-        .then(assert(this.mock, function (request, list) {
-            expect(request.urlParams.page).toBe('1');
-            expect(request.urlParams['content-set']).toBe('-web-live');
-            expect(request.urlParams['order-by']).toBe('oldest');
-            expect(request.urlParams['page-size']).toBe('50');
-            expect(request.urlParams.q).toBeUndefined();
-
+        .then(list => {
             expect(list.results).toEqual([{
                 fields: {
                     headline: 'This has an header'
                 }
             }]);
-
-            done();
-        }));
+        })
+        .then(done)
+        .catch(done.fail);
     });
 
     it('filter out based on a search term', function (done) {
-        this.mock.latest([{
-            fields: {
-                headline: 'Filtering results'
+        this.scope({
+            url: /\/api\/live\/search(\?.+)/,
+            urlParams: ['queryString'],
+            response: function (request) {
+                var urlParams = parse(request.urlParams.queryString);
+                expect(urlParams.page).toBe('1');
+                expect(urlParams['order-by']).toBe('newest');
+                expect(urlParams['page-size']).toBe('50');
+                expect(urlParams.q).toBe('one');
+                expect(urlParams.author).toBe('me');
+
+                this.responseText = {
+                    response: {
+                        status: 'ok',
+                        results: [{
+                            fields: {
+                                headline: 'Filtering results'
+                            }
+                        }]
+                    }
+                };
             }
-        }]);
+        });
 
         contentApi.fetchLatest({
             isDraft: false,
@@ -51,38 +79,39 @@ describe('Latest articles', function() {
             filterType: 'author',
             filter: 'me'
         })
-        .then(assert(this.mock, function (request, list) {
-            expect(request.urlParams.page).toBe('1');
-            expect(request.urlParams['content-set']).toBe('web-live');
-            expect(request.urlParams['order-by']).toBe('newest');
-            expect(request.urlParams['page-size']).toBe('50');
-            expect(request.urlParams.q).toBe('one');
-            expect(request.urlParams.author).toBe('me');
-
+        .then(list => {
             expect(list.results).toEqual([{
                 fields: {
                     headline: 'Filtering results'
                 }
             }]);
-
-            done();
-        }));
+        })
+        .then(done)
+        .catch(done.fail);
     });
 
     it('all results empty response', function (done) {
-        this.mock.latest([]);
+        this.scope({
+            url: /\/api\/proxy\/content\/scheduled(\?.+)/,
+            responseText: {
+                response: {
+                    status: 'ok',
+                    results: []
+                }
+            }
+        });
 
         contentApi.fetchLatest()
-        .then(done.fail, assert(this.mock, function (request, list) {
-            expect(list instanceof Error).toBe(true);
-            expect(list.message).toMatch(/not currently returning content/i);
+        .then(done.fail, error => {
+            expect(error instanceof Error).toBe(true);
+            expect(error.message).toMatch(/not currently returning content/i);
 
             done();
-        }));
+        });
     });
 
     it('searches an article', function (done) {
-        var mockId = mockjax({
+        this.scope({
             url: /\/api\/proxy\/uk-news\/important\/stuff\?(.+)/,
             responseText: {
                 status: 'ok',
@@ -99,20 +128,19 @@ describe('Latest articles', function() {
         contentApi.fetchLatest({
             article: 'uk-news/important/stuff'
         })
-        .then(function (list) {
+        .then(list => {
             expect(list.results).toEqual([{
                 fields: {
                     headline: 'Single article'
                 }
             }]);
-
-            mockjax.clear(mockId);
-            done();
-        });
+        })
+        .then(done)
+        .catch(done.fail);
     });
 
     it('network fail', function (done) {
-        var mockId = mockjax({
+        this.scope({
             url: /\/api\/proxy\/uk-news\/less\/important.*/,
             responseText: 'Server error',
             status: 500
@@ -122,29 +150,11 @@ describe('Latest articles', function() {
             article: 'uk-news/less/important',
             term: 'ignored'
         })
-        .then(done.fail, function (error) {
+        .then(done.fail, error => {
             expect(error instanceof Error).toBe(true);
             expect(error.message).toMatch(/Content API error/i);
 
-            mockjax.clear(mockId);
             done();
         });
     });
-
-    function assert (mock, what) {
-        var promisedValue, lastRequest;
-        var wait = _.after(2, function () {
-            what(lastRequest, promisedValue);
-        });
-
-        mock.once('complete', function (request) {
-            lastRequest = request;
-            wait();
-        });
-
-        return function (value) {
-            promisedValue = value;
-            wait();
-        };
-    }
 });

--- a/facia-tool/test/public/spec/latest.articles.spec.js
+++ b/facia-tool/test/public/spec/latest.articles.spec.js
@@ -92,7 +92,7 @@ describe('Latest widget', function () {
         });
 
         this.scope({
-            url: /api\/proxy\/section/,
+            url: /api\/preview\/section/,
             responseText: {
                 response: {
                     results: [{ id: 'section-one' }, { id: 'section-two' }]


### PR DESCRIPTION
Preview content should always come from preview, but live content instead should come from live CAPI.

The field content-set is now deprecated.

Update some endpoints to prevent sending authentication when not needed.

@janua do you appreciate my copy paste of scala code?

cc/ @LATaylor-guardian
