### PR TITLE
jspm testing: test if increased payload size causes drop in uniques

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -26,7 +26,7 @@ object JspmTest extends TestDefinition(
 )
 
 object PayloadSizeTest extends TestDefinition(
-  List(Variant1),
+  List(Variant6),
   "payload-size-test",
   "To test whether increased payload size causes a drop in unique visitors and/or page views",
   new LocalDate(2015, 9, 30)

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -25,6 +25,13 @@ object JspmTest extends TestDefinition(
   new LocalDate(2015, 9, 30)
 )
 
+object PayloadSizeTest extends TestDefinition(
+  List(Variant1),
+  "payload-size-test",
+  "To test whether increased payload size causes a drop in unique visitors and/or page views",
+  new LocalDate(2015, 9, 30)
+)
+
 object JspmControlTest extends TestDefinition(
   List(Variant7),
   "jspm-control",
@@ -62,7 +69,7 @@ object ABNewFreeMembershipTest extends TestDefinition(
 )
 
 object ActiveTests extends Tests {
-  val tests: Seq[TestDefinition] = List(JspmTest, JspmControlTest, ABHeadlinesTestControl, ABHeadlinesTestVariant, ABNewFreeMembershipTest)
+  val tests: Seq[TestDefinition] = List(JspmTest, PayloadSizeTest, JspmControlTest, ABHeadlinesTestControl, ABHeadlinesTestVariant, ABNewFreeMembershipTest)
 
   def getJavascriptConfig(implicit request: RequestHeader): String = {
     val headlineTests = List(ABHeadlinesTestControl, ABHeadlinesTestVariant).filter(_.isParticipating)

--- a/common/app/views/fragments/javaScriptBootstraps.scala.html
+++ b/common/app/views/fragments/javaScriptBootstraps.scala.html
@@ -2,11 +2,17 @@
 @import conf.Switches._
 @import conf.Static
 @import conf.Configuration
+@import util.Random
 
 <script>
     @if(mvt.JspmTest.isParticipating || item.section == "crosswords") {
         @Html(templates.headerInlineJS.js.bootSystemJS(item).body)
     } else {
         @Html(templates.headerInlineJS.js.bootCurl(item, curlPaths).body)
+    }
+
+    @if(mvt.PayloadSizeTest.isParticipating) {
+        @* Add about 20kb after gzip *@
+        "@Random.alphanumeric.take(25000).mkString";
     }
 </script>


### PR DESCRIPTION
The current status of the jspm test:
# Unique visitors for last 7 days

JspmControl: 334568
JspmTest: 329235
`(1 - (JspmTest / JspmControl)) * 100` = JspmTest down by 1.59%

We added some beacons to the _very top of the page_ to clarify whether the drop is because of an error in jspm (and its subsequent parts), but the drop remained. (https://github.com/guardian/frontend/pull/10023 https://github.com/guardian/frontend/pull/10075 https://github.com/guardian/frontend/pull/10177)

We disabled the test to clarify whether the drop is a bucketing problem, but the data levelled out, therefore it is not. (https://github.com/guardian/frontend/pull/10078)

My only remaining suspicion is that the drop is because of the increased payload size:

```
$ curl --compressed --silent --write-out \%{size_download} --output /dev/null "http://www.theguardian.com/uk"
85333
# JspmTest
$ curl --compressed --silent --write-out \%{size_download} --output /dev/null "http://www.theguardian.com/uk" -H 'X-GU-mvt-variant: variant-0'
101020

101020 - 85333 = JspmTest is 15687 bytes bigger
```

To clarify if this is indeed the problem, I'm adding a test that artificially increases the payload size:

```
$ curl --compressed --silent --write-out \%{size_download} --output /dev/null "http://localhost:9000/uk"
68443
# PayloadSizeTest
$ curl --compressed --silent --write-out \%{size_download} --output /dev/null "http://localhost:9000/uk" -H 'X-GU-mvt-variant: variant-1'
88497

88497 - 68443 = PayloadSizeTest is 20054 bytes bigger
```

(I can compare the tracking for this to `JspmControl`.)
