### PR TITLE
Hard to create collections

### DIFF
--- a/facia-tool/public/js/models/config/front.js
+++ b/facia-tool/public/js/models/config/front.js
@@ -263,7 +263,11 @@ function updateCollections (collections) {
 
     collections.forEach(collection => {
         let id = collection.id;
-        collection.updateConfig(cloneWithKey(collectionDefinition[id], id));
+        if (collectionDefinition[id]) {
+            // If the collection has no ID, it's because it was not saved yet
+            // do not update it yet
+            collection.updateConfig(cloneWithKey(collectionDefinition[id], id));
+        }
     });
 }
 


### PR DESCRIPTION
If a poll update happens in the middle of a collection creation, the collection loses its parent and thus it's lost after saving.

The logic for updates during a front creation was already unit tested, added another test for this specific use case.

Fixes #10278
