### PR TITLE
Proper progressive enhancement for Tweets with images

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -447,6 +447,7 @@ class TweetCleaner(content: Content) extends HtmlCleaner {
               val img = document.createElement("img")
               img.attr("src", image)
               img.attr("alt", "")
+              img.attr("rel", "nofollow")
               img.addClass("js-tweet-main-image tweet-main-image")
               element.appendChild(img)
             }

--- a/static/src/javascripts/projects/common/modules/article/twitter.js
+++ b/static/src/javascripts/projects/common/modules/article/twitter.js
@@ -21,32 +21,14 @@ define([
     detect,
     mediator
 ) {
-    var body = qwery('.js-liveblog-body'),
-        fallbackImagesCleared = false;
-
-    function dontEnhanceBreakpoint() {
-        return detect.getBreakpoint() === 'mobile';
-    }
-
-    // while not pretty, this is necessary for when you change breakpoints
-    // (i.e. stretch the browser and then narrow it again).
-    function clearFallbackImages() {
-        if (!fallbackImagesCleared) {
-            qwery('.js-tweet-main-image').forEach(function (image) {
-                fastdom.write(function () {
-                    $(image).remove();
-                });
-            });
-            fallbackImagesCleared = true;
-        }
-    }
+    var body = qwery('.js-liveblog-body');
 
     function bootstrap() {
         mediator.on('window:throttledScroll', _.debounce(enhanceTweets, 200));
     }
 
     function enhanceTweets() {
-        if (dontEnhanceBreakpoint() || !config.switches.enhanceTweets) {
+        if (detect.getBreakpoint() === 'mobile' || !config.switches.enhanceTweets) {
             return;
         }
 
@@ -56,8 +38,6 @@ define([
             viewportHeight      = bonzo.viewport().height,
             nativeTweetElements = qwery('blockquote.twitter-tweet'),
             scrollTop           = window.pageYOffset;
-
-        clearFallbackImages();
 
         tweetElements.forEach(function (element) {
             var $el = bonzo(element),

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -403,10 +403,6 @@ $block-padding-right: $gs-gutter;
     background-repeat: no-repeat;
     border-top: 1px dotted colour(neutral-3);
 
-    @include mq($until: tablet) {
-        clear: left;
-    }
-
     .block-time + .block-elements .element-tweet:first-child & {
         border-top: 0;
     }
@@ -416,6 +412,7 @@ $block-padding-right: $gs-gutter;
 }
 .tweet,
 .from-content-api blockquote.tweet {
+    display: inline-block;
     border-left-width: 0;
     padding: $gs-baseline/2 0 0;
     margin-bottom: $gs-baseline;
@@ -429,13 +426,17 @@ $block-padding-right: $gs-gutter;
     }
 
     @include mq(tablet) {
-        margin-left: $block-padding-left;
+
+        // forcing this max-width because that is the width of
+        // the 'upgrade' from Twitter and we don't want it jumping
+        // on upgrade
+        max-width: 500px;
+
         margin-right: $block-padding-right;
     }
 }
 // Temporary fix to issue #1674
 .from-content-api blockquote.tweet {
-    display: block;
     width: auto;
 }
 // End temporary fix
@@ -458,9 +459,6 @@ $block-padding-right: $gs-gutter;
 .tweet-main-image {
     width: 100%;
     margin-bottom: $gs-gutter;
-    @include mq(tablet) {
-        display: none;
-    }
 }
 
 .tweet-date {


### PR DESCRIPTION
Images now display inline at all breakpoints and there is a much smoother progressive enhancement which means the page does not jump (or jumps very little compared to how it used to).
