### PR TITLE
Don't show related content where there is a series tag AND a story package

### DIFF
--- a/static/src/javascripts/bootstraps/trail.js
+++ b/static/src/javascripts/bootstraps/trail.js
@@ -62,36 +62,36 @@ define([
     }
 
     function initRelated() {
-        insertOrProximity('.js-related', function () {
-            var opts = {
-                excludeTags: []
-            };
+        if (!(config.page.seriesId || config.page.blogIds)) {
+            insertOrProximity('.js-related', function () {
+                var opts = {
+                    excludeTags: []
+                };
 
-            // exclude ad features from non-ad feature content
-            if (config.page.sponsorshipType !== 'advertisement-features') {
-                opts.excludeTags.push('tone/advertisement-features');
-            }
-            // don't want to show professional network content on videos or interactives
-            if ('contentType' in config.page &&
-                contains(['video', 'interactive'], config.page.contentType.toLowerCase())) {
-                opts.excludeTags.push('guardian-professional/guardian-professional');
-            }
-            new Related(opts).renderRelatedComponent();
-        });
+                // exclude ad features from non-ad feature content
+                if (config.page.sponsorshipType !== 'advertisement-features') {
+                    opts.excludeTags.push('tone/advertisement-features');
+                }
+                // don't want to show professional network content on videos or interactives
+                if ('contentType' in config.page &&
+                    contains(['video', 'interactive'], config.page.contentType.toLowerCase())) {
+                    opts.excludeTags.push('guardian-professional/guardian-professional');
+                }
+                new Related(opts).renderRelatedComponent();
+            });
+        }
     }
 
     function initOnwardContent() {
-        if (!config.page.hasStoryPackage) {
-            insertOrProximity('.js-onward', function () {
-                if ((config.page.seriesId || config.page.blogIds) && config.page.showRelatedContent) {
-                    new Onward(qwery('.js-onward'));
-                } else if (config.page.tones !== '') {
-                    $('.js-onward').each(function (c) {
-                        new TonalComponent().fetch(c, 'html');
-                    });
-                }
-            });
-        }
+        insertOrProximity('.js-onward', function () {
+            if ((config.page.seriesId || config.page.blogIds) && config.page.showRelatedContent) {
+                new Onward(qwery('.js-onward'));
+            } else if (config.page.tones !== '') {
+                $('.js-onward').each(function (c) {
+                    new TonalComponent().fetch(c, 'html');
+                });
+            }
+        });
     }
 
     function initDiscussion() {

--- a/static/src/javascripts/bootstraps/trail.js
+++ b/static/src/javascripts/bootstraps/trail.js
@@ -81,15 +81,17 @@ define([
     }
 
     function initOnwardContent() {
-        insertOrProximity('.js-onward', function () {
-            if ((config.page.seriesId || config.page.blogIds) && config.page.showRelatedContent) {
-                new Onward(qwery('.js-onward'));
-            } else if (config.page.tones !== '') {
-                $('.js-onward').each(function (c) {
-                    new TonalComponent().fetch(c, 'html');
-                });
-            }
-        });
+        if (!config.page.hasStoryPackage) {
+            insertOrProximity('.js-onward', function () {
+                if ((config.page.seriesId || config.page.blogIds) && config.page.showRelatedContent) {
+                    new Onward(qwery('.js-onward'));
+                } else if (config.page.tones !== '') {
+                    $('.js-onward').each(function (c) {
+                        new TonalComponent().fetch(c, 'html');
+                    });
+                }
+            });
+        }
     }
 
     function initDiscussion() {


### PR DESCRIPTION
Sustain trello board task: https://trello.com/c/7bf3QFNf
Where there is a series tag, show the story package, but not the generic 'related content' container ( add the if statement on line 95, essentially ) 

This page will retain 'More on this story' 'http://www.theguardian.com/commentisfree/2014/sep/01/celebrity-naked-photo-leak-2014-nude-women

This page will lose 'Related content': http://www.theguardian.com/lifeandstyle/wordofmouth/2015/aug/27/can-craft-beer-really-be-defined-were-about-to-find-out ()it has a series/blog tag) 

This  wont: http://www.theguardian.com/lifeandstyle/2015/aug/26/best-cookbooks-all-time-chosen-by-experts
