### PR TITLE
Extend life of MembersAreaSwitch by 3 months

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -455,7 +455,7 @@ object Switches {
     "gu-members-area",
     "If this switch is on, content flagged with membershipAccess will be protected",
     safeState = On,
-    sellByDate = new LocalDate(2015, 8, 30),
+    sellByDate = new LocalDate(2015, 11, 30),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
This is still a switched-feature because it's requires a Membership API and the only one we've got is tied to the low-performance of Salesforce. Work is upcoming to create an API that can handle the required traffic, at which point we'll be able to remove this switch:

https://trello.com/c/1JBlnP3V/43-member-data-api-create-webhook-endpoint-to-receive-updates-from-salesforce

https://github.com/guardian/membership-attribute-service

Follows on from https://github.com/guardian/frontend/pull/8999

cc @gklopper @davidrapson @blackyjnz @JuliaBellis
