### PR TITLE
Catch configuration exceptions in Onward

### DIFF
--- a/onward/app/business/StocksData.scala
+++ b/onward/app/business/StocksData.scala
@@ -13,12 +13,20 @@ import scala.language.postfixOps
 
 object StocksData extends AutoRefresh[Stocks](0 seconds, 1 minute) with Logging {
   override protected def refresh(): Future[Stocks] = {
-    WS.url(Configuration.business.stocksEndpoint).get() map { response =>
-      Json.fromJson[Indices](response.json) match {
-        case JsSuccess(rawStocksData, _) => Stocks.fromFingerpost(rawStocksData)
-        case error @ JsError(_) =>
-          log.error(s"Could not read raw stocks data ${Json.stringify(JsError.toJson(error))}")
-          throw new RuntimeException("Could not read raw stocks data")
+
+    try {
+      WS.url(Configuration.business.stocksEndpoint).get() map { response =>
+        Json.fromJson[Indices](response.json) match {
+          case JsSuccess(rawStocksData, _) => Stocks.fromFingerpost(rawStocksData)
+          case error@JsError(_) =>
+            log.error(s"Could not read raw stocks data ${Json.stringify(JsError.toJson(error))}")
+            throw new RuntimeException("Could not read raw stocks data")
+        }
+      }
+    } catch {
+      case e: RuntimeException => {
+        log.error(e.getMessage)
+        Future.failed(e)
       }
     }
   }


### PR DESCRIPTION
This keeps happening during our tests, because of a badly configured onward server. Hoping this helps the healthcheck test.
