### PR TITLE
suppress save for later on short pages

### DIFF
--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -22,22 +22,15 @@
     }
     @if(content.showBottomSocialButtons) {
         <hr/>
-        @if(SaveForLaterSwitch.isSwitchedOn) {
             <div class="u-cf">
                 <div data-component="share" class="submeta__share">
                     @fragments.social(content)
                 </div>
-                <div class="js-save-for-later submeta__save-for-later" data-position="bottom"></div>
+                @if(SaveForLaterSwitch.isSwitchedOn) {
+                    <div class="js-save-for-later submeta__save-for-later" data-position="bottom"></div>
+                }
                 @fragments.syndication(content)
             </div>
-        } else {
-            <div class="u-cf">
-                <div data-component="share" class="submeta__share">
-                    @fragments.social(content)
-                </div>
-                @fragments.syndication(content)
-            </div>
-        }
     } else {
         @fragments.syndication(content)
     }

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -39,13 +39,6 @@
             </div>
         }
     } else {
-        @if(SaveForLaterSwitch.isSwitchedOn) {
-            <div class="u-cf">
-                <div class="js-save-for-later submeta__save-for-later" data-position="bottom"></div>
-                @fragments.syndication(content)
-            </div>
-        } else {
-            @fragments.syndication(content)
-        }
+        @fragments.syndication(content)
     }
 </div>


### PR DESCRIPTION
Don't duplicate sfl for later on short pages - as per social share buttons. 
Red arrows indicate where the buttons were: 

@Jholder112233 - I was going to do some silly javascript, but that's _much_ cleaner. Look OK?

![deduped-sfl](https://cloud.githubusercontent.com/assets/986155/9544413/7bb4b5d6-4d78-11e5-90a6-1b2c6864fb9a.png)

![deduped-sfl-mob](https://cloud.githubusercontent.com/assets/986155/9544418/84540e26-4d78-11e5-802b-690101bc9b6d.png)
