### PR TITLE
Rugby nav data tweak

### DIFF
--- a/data/database/7c4aa5b1aa9cbcf204aac6f21a9ef54efa313e3bde762f0b4558e4e711c739cd
+++ b/data/database/7c4aa5b1aa9cbcf204aac6f21a9ef54efa313e3bde762f0b4558e4e711c739cd
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/b87dedbeffd4c9498337ebc6bb697cb668776de6f52dd2ac74b6ce23897ccf1f
+++ b/data/database/b87dedbeffd4c9498337ebc6bb697cb668776de6f52dd2ac74b6ce23897ccf1f
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/sport/app/rugby/feed/CapiFeed.scala
+++ b/sport/app/rugby/feed/CapiFeed.scala
@@ -3,6 +3,7 @@ package rugby.feed
 import common.{Edition, Logging, ExecutionContexts}
 import conf.LiveContentApi
 import model.Content
+import org.joda.time.DateTimeZone
 import rugby.jobs.RugbyStatsJob
 import rugby.model.Match
 
@@ -40,7 +41,7 @@ object CapiFeed extends ExecutionContexts with Logging {
       .fromDate(matchDate.toDateTimeAtStartOfDay)
       .toDate(matchDate.plusDays(2).toDateTimeAtStartOfDay)
     ).flatMap { response =>
-        val navContent = response.results.map(Content(_))
+        val navContent = response.results.map(Content(_)).filter(_.webPublicationDate.toDateTime(DateTimeZone.UTC).toLocalDate.isEqual(matchDate))
         (for {
           matchReport <- navContent.find(_.isMatchReport)
           liveBlog <- navContent.find(_.isLiveBlog)

--- a/static/src/javascripts/projects/common/modules/sport/score-board.js
+++ b/static/src/javascripts/projects/common/modules/sport/score-board.js
@@ -62,6 +62,10 @@ define([
         this.render(this.placeholder);
     };
 
+    ScoreBoard.prototype.error = function () {
+        this.placeholder.innerHTML = '';
+    }
+
     return ScoreBoard;
 
 }); // define

--- a/static/src/javascripts/projects/common/modules/sport/score-board.js
+++ b/static/src/javascripts/projects/common/modules/sport/score-board.js
@@ -64,7 +64,7 @@ define([
 
     ScoreBoard.prototype.error = function () {
         this.placeholder.innerHTML = '';
-    }
+    };
 
     return ScoreBoard;
 


### PR DESCRIPTION
This ensures that we only use the same-day match report in the rugby tabs. And if the client fails to load the nav/match score, then the 'fetching...' message is removed. This will happen on the next-day match report.
