### PR TITLE
Put breaking news container on its own layer

### DIFF
--- a/static/src/stylesheets/module/onward/_breaking-news.scss
+++ b/static/src/stylesheets/module/onward/_breaking-news.scss
@@ -10,6 +10,7 @@ $breaking-news-close-icon-width: 32px;
     opacity: 1;
     transform: translateY(0);
     box-shadow: 0 -1px 2px fade-out(#000000, .8);
+    backface-visibility: hidden;
 
     a,
     .button {


### PR DESCRIPTION
Even when it's empty, the browser's still repainting…
### before

![screen recording 2015-08-28 at 12 12 pm](https://cloud.githubusercontent.com/assets/867233/9545155/d6791ff6-4d7e-11e5-8c40-75292bb16868.gif)
### after

![screen recording 2015-08-28 at 12 12 pm-2](https://cloud.githubusercontent.com/assets/867233/9545161/dc88a646-4d7e-11e5-8f97-4bbca27ff07a.gif)
