### PR TITLE
More dedupe

### DIFF
--- a/admin/app/Global.scala
+++ b/admin/app/Global.scala
@@ -5,11 +5,13 @@ import dfp.DfpDataCacheLifecycle
 import model.AdminLifecycle
 import ophan.SurgingContentAgentLifecycle
 import play.api.mvc.{RequestHeader, Results, WithFilters}
+import services.ConfigAgentLifecycle
 
 import scala.concurrent.Future
 
 object Global extends WithFilters(Gzipper)
   with AdminLifecycle
+  with ConfigAgentLifecycle
   with SwitchboardLifecycle
   with CloudWatchApplicationMetrics
   with Results

--- a/admin/app/controllers/admin/WhatIsDeduped.scala
+++ b/admin/app/controllers/admin/WhatIsDeduped.scala
@@ -26,8 +26,12 @@ object WhatIsDeduped extends Controller with Logging with ExecutionContexts {
        response.json.validate[DedupedFrontResult] match {
          case JsSuccess(dedupedFrontResult, _) =>
            Cached(60)(Ok(views.html.dedupedOnPath(Configuration.environment.stage, dedupedFrontResult)))
-         case JsError(errors) => NoCache(NotFound)
+         case JsError(errors) => NoCache(NotFound(s"$path Not Found"))
        }
+     }.recover {
+       case t: Throwable =>
+         log.error(s"Error with deduped request: $t")
+         InternalServerError(s"Something went wrong with request to: $url")
      }
    }
 


### PR DESCRIPTION
The `ConfigAgentLifecycle` is needed to run on `admin` so that the `paths` can be displayed on the what is deduped page.

Also better logging out of when things go wrong.
