### PR TITLE
Give healthchecks a bit of leeway to run in tests.

### DIFF
--- a/admin/test/services/AdminHealthcheckTest.scala
+++ b/admin/test/services/AdminHealthcheckTest.scala
@@ -1,15 +1,16 @@
 package services
 
+import common.TestWsConfig
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import play.api.libs.ws.WS
 import test.ConfiguredTestSuite
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-@DoNotDiscover class AdminHealthCheckTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class AdminHealthCheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with TestWsConfig {
 
   "Healthchecks" should "pass" in goTo("/admin"){ browser =>
 
-    Await.result(WS.url(withHost(s"/_healthcheck")).get(), 10.seconds).status should be (200)
+    Await.result(WS.clientUrl(withHost(s"/_healthcheck")).get(), 10.seconds).status should be (200)
   }
 }

--- a/applications/test/services/ApplicationsHealthcheckTest.scala
+++ b/applications/test/services/ApplicationsHealthcheckTest.scala
@@ -1,14 +1,15 @@
 package services
 
+import common.TestWsConfig
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import play.api.libs.ws.WS
 import test.ConfiguredTestSuite
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-@DoNotDiscover class ApplicationsHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class ApplicationsHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with TestWsConfig {
 
   "Healthchecks" should "fail when sections are not laoded" in goTo("/world/iraq"){ browser =>
-    Await.result(WS.url(s"http://localhost:$port/_healthcheck").get(), 10.seconds).body should be ("Sections have not loaded from Content API")
+    Await.result(WS.clientUrl(s"http://localhost:$port/_healthcheck").get(), 10.seconds).body should be ("Sections have not loaded from Content API")
   }
 }

--- a/commercial/test/services/CommercialHealthcheckTest.scala
+++ b/commercial/test/services/CommercialHealthcheckTest.scala
@@ -1,15 +1,16 @@
 package services
 
+import common.TestWsConfig
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import play.api.libs.ws.WS
 import test.ConfiguredTestSuite
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
-@DoNotDiscover class CommercialHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class CommercialHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with TestWsConfig {
 
-  "Healthchecks" should ("pass") in goTo("/"){ browser =>
+  "Healthchecks" should "pass" in goTo("/"){ browser =>
 
-    Await.result(WS.url(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
+    Await.result(WS.clientUrl(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
   }
 }

--- a/common/test/common/TestWsConfig.scala
+++ b/common/test/common/TestWsConfig.scala
@@ -1,0 +1,21 @@
+package common
+
+import com.ning.http.client.AsyncHttpClient
+import com.ning.http.client.AsyncHttpClientConfig.Builder
+import play.api.libs.ws.WS
+import play.api.libs.ws.ning.NingWSClient
+import play.api.Play.current
+
+trait TestWsConfig {
+
+  implicit lazy val longTimeoutConfig = {
+    val c = WS.client.underlying.asInstanceOf[AsyncHttpClient].getConfig
+    val con = new Builder(c)
+      .setConnectTimeout(10000)
+      .setReadTimeout(10000)
+      .setRequestTimeout(10000)
+      .build()
+    new NingWSClient(con)
+  }
+
+}

--- a/data/database/255274eda63278afc626917a4fc3e6f7d7fdd5dad6ddc428de6b66ceb466be02
+++ b/data/database/255274eda63278afc626917a4fc3e6f7d7fdd5dad6ddc428de6b66ceb466be02
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/diagnostics/test/services/DiagnosticsHealthcheckTest.scala
+++ b/diagnostics/test/services/DiagnosticsHealthcheckTest.scala
@@ -1,15 +1,16 @@
 package services
 
+import common.TestWsConfig
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import play.api.libs.ws.WS
 import test.ConfiguredTestSuite
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
-@DoNotDiscover class DiagnosticsHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class DiagnosticsHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with TestWsConfig {
 
   "Healthchecks" should "pass" in goTo("/ab.gif"){ _ =>
 
-    Await.result(WS.url(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
+    Await.result(WS.clientUrl(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
   }
 }

--- a/discussion/test/services/DiscussionHealthcheckTest.scala
+++ b/discussion/test/services/DiscussionHealthcheckTest.scala
@@ -1,15 +1,16 @@
 package services
 
+import common.TestWsConfig
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import play.api.libs.ws.WS
 import test.ConfiguredTestSuite
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
-@DoNotDiscover class DiscussionHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class DiscussionHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with TestWsConfig {
 
   "Healthchecks" should "pass" in goTo("/discussion/p/37v3a"){ _ =>
 
-    Await.result(WS.url(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
+    Await.result(WS.clientUrl(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
   }
 }

--- a/facia-tool/test/services/FaciaToolHealthcheckTest.scala
+++ b/facia-tool/test/services/FaciaToolHealthcheckTest.scala
@@ -1,5 +1,6 @@
 package services
 
+import common.TestWsConfig
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import play.api.libs.ws.WS
 import test._
@@ -7,10 +8,10 @@ import test._
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
-@DoNotDiscover class FaciaToolHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class FaciaToolHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with TestWsConfig {
 
   "Healthchecks" should "pass" in goTo("/"){ _ =>
 
-    Await.result(WS.url(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
+    Await.result(WS.clientUrl(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
   }
 }

--- a/facia/test/services/FaciaHealthcheckTest.scala
+++ b/facia/test/services/FaciaHealthcheckTest.scala
@@ -1,5 +1,6 @@
 package services
 
+import common.TestWsConfig
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import play.api.libs.ws.WS
 import test._
@@ -7,13 +8,13 @@ import test._
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
-@DoNotDiscover class FaciaHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class FaciaHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with TestWsConfig {
 
   "Healthchecks" should "pass" in goTo("/uk"){ _ =>
-    Await.result(WS.url(s"http://localhost:$port/_healthcheck").get(), 10.seconds).status should be (200)
+    Await.result(WS.clientUrl(s"http://localhost:$port/_healthcheck").get(), 10.seconds).status should be (200)
   }
 
   "Cdn Healthcheck" should "pass once fronts can be served" in goTo("/uk"){ _ =>
-    Await.result(WS.url(s"http://localhost:$port/_fronts_cdn_healthcheck").get(), 10.seconds).status should be (200)
+    Await.result(WS.clientUrl(s"http://localhost:$port/_fronts_cdn_healthcheck").get(), 10.seconds).status should be (200)
   }
 }

--- a/identity/test/services/IdentityHealthcheckTest.scala
+++ b/identity/test/services/IdentityHealthcheckTest.scala
@@ -1,5 +1,6 @@
 package services
 
+import common.TestWsConfig
 import org.scalatest.{Matchers, FlatSpec}
 import play.api.libs.ws.WS
 import test._
@@ -7,12 +8,12 @@ import test._
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
-class IdentityHealthcheckTest extends FlatSpec with Matchers {
+class IdentityHealthcheckTest extends FlatSpec with Matchers with TestWsConfig {
 
   import play.api.Play.current
 
   "Healthchecks" should "pass" in HtmlUnit("/signin"){ _ =>
 
-    Await.result(WS.url(s"http://localhost:${HtmlUnit.port}/_healthcheck").get(), 10.seconds).status should be (200)
+    Await.result(WS.clientUrl(s"http://localhost:${HtmlUnit.port}/_healthcheck").get(), 10.seconds).status should be (200)
   }
 }

--- a/onward/test/services/OnwardHealthcheckTest.scala
+++ b/onward/test/services/OnwardHealthcheckTest.scala
@@ -1,16 +1,21 @@
 package services
 
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import com.ning.http.client.AsyncHttpClient
+import com.ning.http.client.AsyncHttpClientConfig.Builder
+import common.TestWsConfig
+import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 import play.api.libs.ws.WS
+import play.api.libs.ws.ning.NingWSClient
 import test._
 
-import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.concurrent.duration._
 
-@DoNotDiscover class OnwardHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class OnwardHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with TestWsConfig {
 
   "Healthchecks" should "pass" in goTo("/most-read.json"){ _ =>
 
-    Await.result(WS.url(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
+    Await.result(WS.clientUrl(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
   }
+
 }

--- a/sport/test/services/SportHealthcheckTest.scala
+++ b/sport/test/services/SportHealthcheckTest.scala
@@ -1,5 +1,6 @@
 package services
 
+import common.TestWsConfig
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import play.api.libs.ws.WS
 import test._
@@ -7,10 +8,10 @@ import test._
 import scala.concurrent.duration._
 import scala.concurrent.Await
 
-@DoNotDiscover class SportHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class SportHealthcheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with TestWsConfig {
 
   "Healthchecks" should "pass" in goTo("/football-live"){ _ =>
 
-    Await.result(WS.url(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
+    Await.result(WS.clientUrl(s"http://localhost:${port}/_healthcheck").get(), 10.seconds).status should be (200)
   }
 }


### PR DESCRIPTION
Timeouts are a bit aggressive as these run from cold in tests.

Give them a few more seconds to pass.
