### PR TITLE
removing video icons that are not being used anymore

### DIFF
--- a/static/src/images/global/video-icon-black.svg
+++ b/static/src/images/global/video-icon-black.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="36" height="23"><path fill="#333" d="M3.2 0l-3.2 3.3v16.4l3.3 3.3h18.7v-23h-18.8m30.4 1l-8.6 8v5l8.6 8h2.4v-21h-2.4"/></svg>

--- a/static/src/images/global/video-icon-grey.svg
+++ b/static/src/images/global/video-icon-grey.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="36" height="23"><path fill="#767676" d="M3.2 0l-3.2 3.3v16.4l3.3 3.3h18.7v-23h-18.8m30.4 1l-8.6 8v5l8.6 8h2.4v-21h-2.4"/></svg>

--- a/static/src/images/global/video-icon-white.svg
+++ b/static/src/images/global/video-icon-white.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="36" height="23"><path fill="#fff" d="M3.2 0l-3.2 3.3v16.4l3.3 3.3h18.7v-23h-18.8m30.4 1l-8.6 8v5l8.6 8h2.4v-21h-2.4"/></svg>

--- a/static/src/stylesheets/module/_icons.scss
+++ b/static/src/stylesheets/module/_icons.scss
@@ -23,13 +23,6 @@ blockquote.quoted:before {
     vertical-align: top;
     margin-top: 1px;
     @include icon(image);
-
-    .element-video & {
-        @include icon(video-icon-grey);
-        width: 16px !important;
-        height: 12px !important;
-        margin-top: $gs-baseline/6;
-    }
 }
 
 .centered-icon {

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -78,10 +78,6 @@
         width: .8em;
         @include icon(volume-high-white, $with-width: false);
     }
-    .content--media--video & {
-        width: 1.04em;
-        @include icon(video-icon-white, $with-width: false);
-    }
     .content--gallery &,
     .content--image & {
         width: .9em;


### PR DESCRIPTION
Deleting these video icons, as they don't seems to be used anywhere on the site.

See issue #10241 for more details.
