### PR TITLE
fixing sprite position for pinterest icon #9792

### DIFF
--- a/data/database/8bb257850133445ae218a26e38560dd141f667e78b9d063a488a722f7ca2c656
+++ b/data/database/8bb257850133445ae218a26e38560dd141f667e78b9d063a488a722f7ca2c656
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -176,8 +176,9 @@ category: Common
     background-color: colour(social-pinterest);
 
     .i {
-        background-size: 49% !important;
-        background-position: 45% center !important;
+        margin: auto;
+        position: absolute;
+        top: 0; left: 0; bottom: 0; right: 0;
     }
 
     &:hover {

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -174,7 +174,9 @@ category: Common
 
 .social-icon--pinterest {
     background-color: colour(social-pinterest);
-
+    
+    // The pinterest icon needs to be centered within the span due to its small width/height
+    
     .i {
         margin: auto;
         position: absolute;


### PR DESCRIPTION
Fixing pinterest icon in ie8 issue #9792.

BEFORE:
￼
![image](https://cloud.githubusercontent.com/assets/8774970/9578087/0eb45086-4fdf-11e5-8445-24fe15a68ec4.png)

AFTER:

![image](https://cloud.githubusercontent.com/assets/8774970/9578077/fcef4ef0-4fde-11e5-9474-8f2f1dceae35.png)
