### PR TITLE
Add missing bits to boot scripts

### DIFF
--- a/common/app/templates/headerInlineJS/bootCurl.scala.js
+++ b/common/app/templates/headerInlineJS/bootCurl.scala.js
@@ -144,7 +144,7 @@ require([
         // Preference pages are served via HTTPS for service worker support.
         // These pages must not have mixed (HTTP/HTTPS) content, so
         // we disable ads (until the day comes when all ads are HTTPS).
-        if (! config.page.isPreferencesPage) {
+        if (config.switches.commercial && !config.page.isPreferencesPage) {
             require(['bootstraps/commercial'], raven.wrap(
                 { tags: { feature: 'commercial' } },
                 function (commercial) {

--- a/common/app/templates/headerInlineJS/bootSystemJS.scala.js
+++ b/common/app/templates/headerInlineJS/bootSystemJS.scala.js
@@ -104,6 +104,9 @@ System['import']('core').then(function () {
                         storage.local.set('alreadyVisited', alreadyVisted + 1);
                     }
 
+                    // Preference pages are served via HTTPS for service worker support.
+                    // These pages must not have mixed (HTTP/HTTPS) content, so
+                    // we disable ads (until the day comes when all ads are HTTPS).
                     if (config.switches.commercial && !config.page.isPreferencesPage) {
                         System['import']('bootstraps/commercial').then(raven.wrap(
                             { tags: { feature: 'commercial' } },

--- a/common/app/templates/headerInlineJS/bootSystemJS.scala.js
+++ b/common/app/templates/headerInlineJS/bootSystemJS.scala.js
@@ -77,11 +77,14 @@ System['import']('core').then(function () {
                     'common/utils/config',
                     'common/modules/experiments/ab',
                     'common/modules/ui/images',
-                    'common/modules/ui/lazy-load-images']).then(function(values) {
+                    'common/modules/ui/lazy-load-images',
+                    'common/utils/storage']).then(function(values) {
                     var config = values[0];
                     var ab = values[1];
                     var images = values[2];
                     var lazyLoadImages = values[3];
+                    var storage = values[4];
+                    var alreadyVisted;
 
                     if (guardian.isModernBrowser) {
                         ab.segmentUser();
@@ -95,6 +98,12 @@ System['import']('core').then(function () {
                     lazyLoadImages.init();
                     images.upgradePictures();
                     images.listen();
+
+                    if (guardian.isModernBrowser) {
+                        alreadyVisted = storage.local.get('alreadyVisited') || 0;
+                        storage.local.set('alreadyVisited', alreadyVisted + 1);
+                    }
+
                     if (config.switches.commercial && !config.page.isPreferencesPage) {
                         System['import']('bootstraps/commercial').then(raven.wrap(
                             { tags: { feature: 'commercial' } },

--- a/common/app/templates/headerInlineJS/bootSystemJS.scala.js
+++ b/common/app/templates/headerInlineJS/bootSystemJS.scala.js
@@ -82,8 +82,11 @@ System['import']('core').then(function () {
                     var ab = values[1];
                     var images = values[2];
                     var lazyLoadImages = values[3];
-                    ab.segmentUser();
-                    ab.run();
+
+                    if (guardian.isModernBrowser) {
+                        ab.segmentUser();
+                        ab.run();
+                    }
                     if(guardian.config.page.isFront) {
                         if(!document.addEventListener) { // IE8 and below
                             window.onload = images.upgradePictures;


### PR DESCRIPTION
Whilst we're still running the jspm test, we have two boot scripts. I ran a quick diff on the two to make sure they were still properly aligned, and they were not. This adds the bits that were missing.
