### PR TITLE
get hover working with slideshows

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -196,10 +196,7 @@ $fc-item-gutter: $gs-gutter / 4;
         .fc-item__image-container {
             background-color: #000000;
 
-            // This should be changed to fc-item__image when Imager allows class names to be adapted from inline elements
-            .responsive-img {
-                opacity: .9;
-            }
+            opacity: .9;
         }
 
         .u-faux-block-link__cta {


### PR DESCRIPTION
Before when you hovered over slideshows, it would clash the hover 0.9 opacity with the slideshows fading.  This hover is over anything in the media area, so doesn't make sense to apply to the individual images.  So I've changed it =)
