### PR TITLE
fix linked data on articles

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -72,8 +72,8 @@ import collection.JavaConversions._
         $("[itemprop=author]").last.getText should be("Phelim O'Neill")
 
         And("I should see a link to the author's page")
-        $("[itemprop=author] a[itemprop='url']")(0).getAttribute("href") should be(withHost("/profile/ben-arnold"))
-        $("[itemprop=author] a[itemprop='url']").last.getAttribute("href") should be(withHost("/profile/phelimoneill"))
+        $("[itemprop=author] a[itemprop='sameAs']")(0).getAttribute("href") should be(withHost("/profile/ben-arnold"))
+        $("[itemprop=author] a[itemprop='sameAs']").last.getAttribute("href") should be(withHost("/profile/phelimoneill"))
       }
     }
 

--- a/common/app/views/support/package.scala
+++ b/common/app/views/support/package.scala
@@ -74,7 +74,7 @@ object ContributorLinks {
       case (t, tag) =>
         t.replaceFirst(tag.name,
         s"""<span itemscope="" itemtype="http://schema.org/Person" itemprop="author">
-           |  <a rel="author" class="tone-colour" itemprop="url" data-link-name="auto tag link"
+           |  <a rel="author" class="tone-colour" itemprop="sameAs" data-link-name="auto tag link"
            |    href="${LinkTo("/"+tag.id)}"><span itemprop="name">${tag.name}</span></a></span>""".stripMargin)
     }
   }


### PR DESCRIPTION
We were saying the author url was our page about them, but actually according to official sources/authorities we should just say sameAs.
