### PR TITLE
Simplify Positioning of Outbrain Container on Articles

### DIFF
--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -1,40 +1,24 @@
 @(content: model.Content, related: model.RelatedContent, cssClass: String = "")(implicit request: RequestHeader)
-
-@import conf.Switches
+@import views.support.ContentFooterContainersLayout
 
 <div class="content-footer @if(cssClass){content-footer--@cssClass}">
 
     @fragments.discussionFooter(content.isCommentable, content.isClosedForComments, content.shortUrlId)
 
-    @* majority of footer components we don't want to appear on advertisement feature articles *@
-    @if(!content.isAdvertisementFeature) {
-        @if(!content.shouldHideAdverts) {
-            <div class="fc-container fc-container--commercial-high">
-            @fragments.commercial.commercialComponentHigh()
-            </div>
-        }
-
+    @ContentFooterContainersLayout(content, related, content.isAdvertisementFeature) {
         @fragments.storyPackagePlaceholder(content, related)
-        @if(content.showFooterContainers && !content.shouldHideAdverts && Switches.OutbrainSwitch.isSwitchedOn) {
-            <div class="fc-container fc-container--outbrain hide-on-childrens-books-site js-outbrain">
-            @fragments.outbrainPlaceholder()
-            </div>
-        }
+    } {
         @fragments.onwardPlaceholder()
-
-        @if(content.isCommentable) {
-            <div class="js-repositioned-comments content__repositioned-comments"></div>
-        }
-
+    } {
+        <div class="js-repositioned-comments content__repositioned-comments"></div>
+    } {
         @fragments.mostPopularPlaceholder(content.section)
-
-        @if(!content.shouldHideAdverts) {
-            <div class="fc-container fc-container--commercial">
-            @fragments.commercial.commercialComponent()
-            </div>
-        }
-    } else {
-        @fragments.storyPackagePlaceholder(content, related)
+    } {
+        <div class="fc-container fc-container--commercial-high">@fragments.commercial.commercialComponentHigh()</div>
+    } {
+        <div class="fc-container fc-container--commercial">@fragments.commercial.commercialComponent()</div>
+    } {
+        <div class="fc-container fc-container--outbrain hide-on-childrens-books-site js-outbrain">@fragments.outbrainPlaceholder()</div>
     }
 
 </div>

--- a/common/app/views/support/ContentFooterContainersLayout.scala
+++ b/common/app/views/support/ContentFooterContainersLayout.scala
@@ -28,11 +28,7 @@ object ContentFooterContainersLayout {
 
       def includeOutbrainPlaceholder(htmlBlocks: Seq[Html]): Seq[Html] = {
         if (content.showFooterContainers && !content.shouldHideAdverts && OutbrainSwitch.isSwitchedOn) {
-          if (htmlBlocks.size > 2) {
-            (htmlBlocks.take(3) :+ outbrainPlaceholder) ++ htmlBlocks.drop(3)
-          } else {
-            (htmlBlocks.take(2) :+ outbrainPlaceholder) ++ htmlBlocks.drop(2)
-          }
+          (htmlBlocks.take(2) :+ outbrainPlaceholder) ++ htmlBlocks.drop(2)
         } else htmlBlocks
       }
 

--- a/common/app/views/support/ContentFooterContainersLayout.scala
+++ b/common/app/views/support/ContentFooterContainersLayout.scala
@@ -1,0 +1,54 @@
+package views.support
+
+import conf.Switches.OutbrainSwitch
+import model.{Content, RelatedContent}
+import play.twirl.api.{Html, HtmlFormat}
+
+import scala.collection.immutable.Seq
+
+object ContentFooterContainersLayout {
+
+  def apply(content: Content, related: RelatedContent, isAdvertisementFeature: Boolean)
+           (storyPackagePlaceholder: => Html)
+           (onwardPlaceholder: => Html)
+           (commentsPlaceholder: => Html)
+           (mostPopularPlaceholder: => Html)
+           (highRelevanceCommercialComponent: => Html)
+           (standardCommercialComponent: => Html)
+           (outbrainPlaceholder: Html): Html = {
+
+    val htmlBlocks = if (isAdvertisementFeature) {
+
+      // majority of footer components we don't want to appear on advertisement feature articles
+      Seq(storyPackagePlaceholder)
+
+    } else {
+
+      def optional(p: => Boolean, htmlBlock: => Html): Option[Html] = if (p) Some(htmlBlock) else None
+
+      def includeOutbrainPlaceholder(htmlBlocks: Seq[Html]): Seq[Html] = {
+        if (content.showFooterContainers && !content.shouldHideAdverts && OutbrainSwitch.isSwitchedOn) {
+          if (htmlBlocks.size > 2) {
+            (htmlBlocks.take(3) :+ outbrainPlaceholder) ++ htmlBlocks.drop(3)
+          } else {
+            (htmlBlocks.take(2) :+ outbrainPlaceholder) ++ htmlBlocks.drop(2)
+          }
+        } else htmlBlocks
+      }
+
+      val apartFromOutbrain = Seq(
+        optional(!content.shouldHideAdverts, highRelevanceCommercialComponent),
+        optional(related.hasStoryPackage && content.showInRelated, storyPackagePlaceholder),
+        Some(onwardPlaceholder),
+        optional(content.isCommentable, commentsPlaceholder),
+        Some(mostPopularPlaceholder),
+        optional(!content.shouldHideAdverts, standardCommercialComponent)
+      ).flatten
+
+      includeOutbrainPlaceholder(apartFromOutbrain)
+    }
+
+    HtmlFormat.fill(htmlBlocks)
+  }
+
+}

--- a/common/test/views/support/ContentFooterContainersLayoutTest.scala
+++ b/common/test/views/support/ContentFooterContainersLayoutTest.scala
@@ -10,9 +10,11 @@ class ContentFooterContainersLayoutTest extends FlatSpec with Matchers {
 
   OutbrainSwitch.switchOn()
 
-  private def contentItem(shouldHideAdverts: Boolean = false, commentable: Boolean = true): Content = {
+  private def contentItem(showInRelatedContent: Boolean = true,
+                          shouldHideAdverts: Boolean = false,
+                          commentable: Boolean = true): Content = {
     new Article(FixtureTemplates.emptyApiContent.copy(fields = Some(Map(
-      "showInRelatedContent" -> "true",
+      "showInRelatedContent" -> showInRelatedContent.toString,
       "shouldHideAdverts" -> shouldHideAdverts.toString,
       "commentable" -> commentable.toString
     ))))
@@ -41,7 +43,7 @@ class ContentFooterContainersLayoutTest extends FlatSpec with Matchers {
   it should "show all footer containers in right order by default" in {
     val html = buildHtml(contentItem(), relatedContent())
     html.toString shouldBe
-      "highRelevanceCommercialHtml storyPackageHtml onwardHtml outbrainHtml commentsHtml mostPopularHtml " +
+      "highRelevanceCommercialHtml storyPackageHtml outbrainHtml onwardHtml commentsHtml mostPopularHtml " +
         "standardCommercialHtml "
   }
 
@@ -57,8 +59,13 @@ class ContentFooterContainersLayoutTest extends FlatSpec with Matchers {
 
   it should "omit commits when article won't allow them" in {
     val html = buildHtml(contentItem(commentable = false), relatedContent())
-    html.toString shouldBe "highRelevanceCommercialHtml storyPackageHtml onwardHtml outbrainHtml mostPopularHtml " +
-      "standardCommercialHtml "
+    html.toString shouldBe
+      "highRelevanceCommercialHtml storyPackageHtml outbrainHtml onwardHtml mostPopularHtml standardCommercialHtml "
+  }
 
+  it should "omit story package placeholder when there's no story package to show" in {
+    val html = buildHtml(contentItem(showInRelatedContent = false), relatedContent())
+    html.toString shouldBe
+      "highRelevanceCommercialHtml onwardHtml outbrainHtml commentsHtml mostPopularHtml standardCommercialHtml "
   }
 }

--- a/common/test/views/support/ContentFooterContainersLayoutTest.scala
+++ b/common/test/views/support/ContentFooterContainersLayoutTest.scala
@@ -1,0 +1,64 @@
+package views.support
+
+import conf.Switches.OutbrainSwitch
+import contentapi.FixtureTemplates
+import model.{Article, Content, RelatedContent}
+import org.scalatest.{FlatSpec, Matchers}
+import play.twirl.api.Html
+
+class ContentFooterContainersLayoutTest extends FlatSpec with Matchers {
+
+  OutbrainSwitch.switchOn()
+
+  private def contentItem(shouldHideAdverts: Boolean = false, commentable: Boolean = true): Content = {
+    new Article(FixtureTemplates.emptyApiContent.copy(fields = Some(Map(
+      "showInRelatedContent" -> "true",
+      "shouldHideAdverts" -> shouldHideAdverts.toString,
+      "commentable" -> commentable.toString
+    ))))
+  }
+
+  private def relatedContent(): RelatedContent = RelatedContent(Seq(contentItem()))
+
+  private def buildHtml(content: Content, related: RelatedContent, isAdFeature: Boolean = false): Html = {
+    ContentFooterContainersLayout(content, related, isAdFeature) {
+      Html("storyPackageHtml ")
+    } {
+      Html("onwardHtml ")
+    } {
+      Html("commentsHtml ")
+    } {
+      Html("mostPopularHtml ")
+    } {
+      Html("highRelevanceCommercialHtml ")
+    } {
+      Html("standardCommercialHtml ")
+    } {
+      Html("outbrainHtml ")
+    }
+  }
+
+  it should "show all footer containers in right order by default" in {
+    val html = buildHtml(contentItem(), relatedContent())
+    html.toString shouldBe
+      "highRelevanceCommercialHtml storyPackageHtml onwardHtml outbrainHtml commentsHtml mostPopularHtml " +
+        "standardCommercialHtml "
+  }
+
+  it should "omit commercial containers on sensitive content" in {
+    val html = buildHtml(contentItem(shouldHideAdverts = true), relatedContent())
+    html.toString shouldBe "storyPackageHtml onwardHtml commentsHtml mostPopularHtml "
+  }
+
+  it should "just show the story package on ad features" in {
+    val html = buildHtml(contentItem(), relatedContent(), isAdFeature = true)
+    html.toString shouldBe "storyPackageHtml "
+  }
+
+  it should "omit commits when article won't allow them" in {
+    val html = buildHtml(contentItem(commentable = false), relatedContent())
+    html.toString shouldBe "highRelevanceCommercialHtml storyPackageHtml onwardHtml outbrainHtml mostPopularHtml " +
+      "standardCommercialHtml "
+
+  }
+}


### PR DESCRIPTION
The positioning of the outbrain component is a bit complicated to do in a template.

This moves the logic of container order beneath articles into a separate support class so that the template builds the container content and the support class decides in which order to show them.

/cc @uplne 
