### PR TITLE
Ensure the rugby scores component is on a white background similar to football

### DIFF
--- a/static/src/javascripts/bootstraps/sport.js
+++ b/static/src/javascripts/bootstraps/sport.js
@@ -55,6 +55,8 @@ define([
 
             // Rugby score returns the match nav too, to optimise calls.
             scoreBoard.fetched = function (resp) {
+                $('.content--liveblog').addClass('content--liveblog--rugby');
+
                 $.create(resp.nav).first().each(function (nav) {
                     // There ought to be exactly two tabs; match report and min-by-min
                     if ($('.tabs__tab', nav).length === 2) {

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -808,7 +808,7 @@ $timeline-width: 15px;
     }
 }
 
-.content--liveblog.section-football { // Football overrides
+.content--liveblog.section-football, .content--liveblog--rugby  { // Football & rugby overrides
     .tonal__header {
         background-color: #ffffff;
 


### PR DESCRIPTION
The live blog rugby scores were on a red background during the game which was not readable. I've updated this to be white similar to football.
