### PR TITLE
reinstate save-for-later-on-containers

### DIFF
--- a/common/app/views/fragments/items/facia_cards/meta.scala.html
+++ b/common/app/views/fragments/items/facia_cards/meta.scala.html
@@ -24,6 +24,10 @@
                     @item.shortUrl.map { url => value="@url" }>
             @fragments.inlineSvg("cross", "icon") Remove
             </button>
+        } else {
+            <button class="js-save-for-later-link fc-save-for-later u-faux-block-link__promote  is-hidden">
+            @fragments.inlineSvg("bookmark", "icon", List("inline-tone-fill"))
+            </button>
         }
     }
 </aside>

--- a/static/src/javascripts/projects/common/modules/onward/tonal.js
+++ b/static/src/javascripts/projects/common/modules/onward/tonal.js
@@ -49,6 +49,7 @@ define([
         var container = document.body.querySelector('.tone-feature');
         mediator.emit('page:new-content', container);
         mediator.emit('ui:images:upgradePictures');
+        mediator.emit('modules:tonal:loaded');
         register.end('tonal-content');
     };
 

--- a/static/src/javascripts/projects/common/modules/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/save-for-later.js
@@ -37,7 +37,18 @@ define([
             saveThisArticle: '.js-save-for-later',
             saveThisVideo: '.js-save-for-later-video',
             saveThisArticleButton: '.js-save-for-later__button',
-            profileDropdownCount: '.brand-bar__item--saved-for-later-count'
+            onwardContainer: '.js-onward',
+            relatedContainer: '.js-related',
+            showMoreContainer: '.js-show-more',
+            itemMeta: '.js-item__meta',
+            itemSaveLink: '.js-save-for-later-link',
+            itemSaveLinkHeading: '.save-for-later-link__heading',
+            profileDropdownCount: '.brand-bar__item--saved-for-later-count',
+            fcItemIsSaved: 'fc-save-for-later--is-saved'
+        };
+        this.attributes = {
+            containerItemShortUrl: 'data-loyalty-short-url',
+            containerItemDataId: 'data-id'
         };
 
         this.isContent = !/Network Front|Section|Tag/.test(config.page.contentType);
@@ -48,13 +59,21 @@ define([
             'save',
             'delete',
             'onSaveArticle',
-            'onDeleteArticle'
+            'onDeleteArticle',
+            'createSaveFaciaItemHandler',
+            'createDeleteFaciaItemHandler',
+            'signUserInToSaveArticle'
         );
     }
 
     var bookmarkSvg = svgs('bookmark', ['rounded-icon']),
         shortUrl = (config.page.shortUrl || '').replace('http://gu.com', ''),
         savedPlatformAnalytics = 'web:' + detect.getUserAgent.browser + ':' + detect.getBreakpoint();
+
+    var getCustomEventProperties = function (contentId) {
+        var prefix = config.page.contentType.match(/^Network Front|Section$/) ? 'Front' : 'Content';
+        return { prop74: prefix + 'ContainerSave:' + contentId };
+    };
 
     SaveForLater.prototype.init = function () {
         var userLoggedIn = identity.isUserLoggedIn();
@@ -86,16 +105,22 @@ define([
                         this.userData = resp.savedArticles;
                     }
 
-                    this.renderSaveButtonsInArticle();
+                    this.prepareFaciaItemLinks(true);
+
+                    if (this.isContent) {
+                        this.renderSaveButtonsInArticle();
+                    }
                 }.bind(this));
         } else {
-            var url = template('<%= idUrl%>/save-content?returnUrl=<%= returnUrl%>&shortUrl=<%= shortUrl%>&platform=<%= platform%>&INTCMP=SFL-SO', {
-                idUrl: config.page.idUrl,
-                returnUrl: encodeURIComponent(document.location.href),
-                shortUrl: shortUrl,
-                platform: savedPlatformAnalytics
-            });
-            this.renderArticleSaveButton({ url: url, isSaved: false });
+            if (this.isContent) {
+                var url = template('<%= idUrl%>/save-content?returnUrl=<%= returnUrl%>&shortUrl=<%= shortUrl%>&platform=<%= platform%>&INTCMP=SFL-SO', {
+                    idUrl: config.page.idUrl,
+                    returnUrl: encodeURIComponent(document.location.href),
+                    shortUrl: shortUrl,
+                    platform: savedPlatformAnalytics
+                });
+                this.renderArticleSaveButton({ url: url, isSaved: false });
+            }
         }
 
     };
@@ -135,6 +160,76 @@ define([
                     )
                 );
             }
+        }.bind(this));
+    };
+
+    SaveForLater.prototype.getElementsIndexedById = function (context) {
+        var elements = qwery('[' + this.attributes.containerItemShortUrl + ']', context);
+
+        return _.forEach(elements, function (el) {
+            return bonzo(el).attr(this.attributes.containerItemShortUrl);
+        }.bind(this));
+    };
+
+    SaveForLater.prototype.prepareFaciaItemLinks = function (signedIn) {
+
+        this.renderFaciaItemLinks(signedIn, document.body);
+
+        mediator.once('modules:tonal:loaded', function () {
+            this.renderFaciaItemLinks(signedIn, this.classes.onwardContainer);
+        }.bind(this));
+
+        mediator.once('modules:onward:loaded', function () {
+            this.renderFaciaItemLinks(signedIn, this.classes.onwardContainer);
+        }.bind(this));
+
+        mediator.once('modules:tonal:loaded', function () {
+            this.renderFaciaItemLinks(signedIn, this.classes.onwardContainer);
+        }.bind(this));
+
+        mediator.once('modules:related:loaded', function () {
+            this.renderFaciaItemLinks(signedIn, this.classes.relatedContainer);
+        }.bind(this));
+
+        mediator.on('modules:show-more:loaded', function () {
+            this.renderFaciaItemLinks(signedIn, this.classes.showMoreContainer);
+            $(this.classes.showMoreContainer).removeClass('js-show-more');
+        }.bind(this));
+    };
+
+    // Configure the save for later links on a front or in a container
+    SaveForLater.prototype.renderFaciaItemLinks = function (signedIn, context) {
+        var elements = this.getElementsIndexedById(context);
+
+        _.forEach(elements, function (item) {
+            var $item = $(item),
+                $itemSaveLink = $(this.classes.itemSaveLink, item),
+                shortUrl = item.getAttribute(this.attributes.containerItemShortUrl),
+                id = item.getAttribute(this.attributes.containerItemDataId),
+                isSaved = signedIn ? this.getSavedArticle(shortUrl) : false;
+
+            if (signedIn) {
+                this[isSaved ? 'createDeleteFaciaItemHandler' : 'createSaveFaciaItemHandler']($itemSaveLink[0], id, shortUrl);
+            } else {
+                bean.one($itemSaveLink[0], 'click', function (id, shortUrl) {
+                    this.signUserInToSaveArticle(id, shortUrl);
+                }.bind(this, id, shortUrl));
+            }
+
+
+            fastdom.write(function () {
+                if (isSaved) {
+                    $itemSaveLink.addClass(this.classes.fcItemIsSaved);
+                } else {
+                    var contentId = $($.ancestor($itemSaveLink[0], 'fc-item')).attr('data-id');
+                    $itemSaveLink.attr('data-custom-event-properties', JSON.stringify(getCustomEventProperties(contentId)));
+                }
+                $itemSaveLink.attr('data-link-name', isSaved ? 'Unsave' : 'Save');
+
+                // only while in test
+                $item.addClass('fc-item--has-metadata');
+                $itemSaveLink.removeClass('is-hidden');
+            }.bind(this));
         }.bind(this));
     };
 
@@ -191,6 +286,91 @@ define([
         if (success) {
             this.updateSavedCount();
         }
+    };
+
+    // handle saving/deleting from fronts
+
+    SaveForLater.prototype.saveFaciaItem = function (pageId, shortUrl) {
+        this.save(pageId, shortUrl, this.onSaveFaciaItem);
+    };
+
+    SaveForLater.prototype.onSaveFaciaItem = function (link, id, shortUrl, success) {
+        var that = this;
+        if (success) {
+            this.createDeleteFaciaItemHandler(link, id, shortUrl);
+            this.updateSavedCount();
+
+            fastdom.write(function () {
+                bonzo(link)
+                    .addClass(that.classes.fcItemIsSaved)
+                    .attr('data-link-name', 'Unsave')
+                    .attr('data-custom-event-properties', '');
+            });
+        } else {
+            this.createSaveFaciaItemHandler(link, id, shortUrl);
+
+            fastdom.write(function () {
+                bonzo(qwery(that.classes.itemSaveLinkHeading, link)[0]).html('Error Saving');
+            });
+        }
+    };
+
+    SaveForLater.prototype.deleteFaciaItem = function (pageId, shortUrl) {
+        this.save(pageId, shortUrl, this.onDeleteFaciaItem);
+    };
+
+    SaveForLater.prototype.onDeleteFaciaItem = function (link, id, shortUrl, success) {
+        var that = this;
+        if (success) {
+            this.createSaveFaciaItemHandler(link, id, shortUrl);
+            this.updateSavedCount();
+
+            fastdom.write(function () {
+                var contentId = $($.ancestor(link, 'fc-item')).attr('data-id');
+                bonzo(link)
+                    .removeClass(that.classes.fcItemIsSaved)
+                    .attr('data-link-name', 'Save')
+                    .attr('data-custom-event-properties', JSON.stringify(getCustomEventProperties(contentId)));
+            });
+        } else {
+            this.createDeleteFaciaItemHandler(link, id, shortUrl);
+
+            fastdom.write(function () {
+                bonzo(qwery(that.classes.itemSaveLinkHeading, link)[0]).html('Error Removing');
+            });
+        }
+    };
+
+    //--Create container link click handlers
+    SaveForLater.prototype.createSaveFaciaItemHandler = function (link, id, shortUrl) {
+        bean.one(link, 'click',
+            this.save.bind(this,
+                id,
+                shortUrl,
+                this.onSaveFaciaItem.bind(this, link, id, shortUrl)
+            )
+        );
+    };
+
+    SaveForLater.prototype.signUserInToSaveArticle = function (id, shortUrl) {
+        var url = template('<%= idUrl%>/save-content?returnUrl=<%= returnUrl%>&shortUrl=<%= shortUrl%>&platform=<%= platform%>&articleId=<%= articleId %>&INTCMP=SFL-SO', {
+            idUrl: config.page.idUrl,
+            returnUrl: encodeURIComponent(document.location.href),
+            shortUrl: shortUrl,
+            platform: savedPlatformAnalytics,
+            articleId: id
+        });
+        window.location = url;
+    };
+
+    SaveForLater.prototype.createDeleteFaciaItemHandler = function (link, id, shortUrl) {
+        bean.one(link, 'click',
+            this.delete.bind(this,
+                id,
+                shortUrl,
+                this.onDeleteFaciaItem.bind(this, link, id, shortUrl)
+            )
+        );
     };
 
     SaveForLater.prototype.getSavedArticle = function (shortUrl) {

--- a/static/src/stylesheets/inline/story-package.scss
+++ b/static/src/stylesheets/inline/story-package.scss
@@ -6,8 +6,13 @@
     .tone-#{$tone}--item {
         .fc-item__kicker,
         .rich-link__kicker,
-        .fc-item__byline {
+        .fc-item__byline,
+        .fc-save-for-later--is-saved {
             color: $colour;
+        }
+
+        .fc-save-for-later--is-saved .inline-tone-fill {
+            fill: $colour;
         }
     }
 
@@ -108,6 +113,10 @@
         .inline-icon {
             fill: mix(#ffffff, colour(story-package), 80%);
         }
+    }
+
+    .fc-save-for-later {
+        border-color: mix(colour(story-package), #ffffff, 80%);
     }
 
     .live-pulse-icon:before {

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -557,6 +557,76 @@ $block-height: 71px;
     display: none;
 }
 
+.fc-save-for-later {
+    // reset button defaults
+    border: 0;
+    border-left: 1px solid;
+    background-color: transparent;
+    padding: 0;
+    color: transparent;
+    margin-right: 0 - ($gs-gutter / 4);
+    padding-right: ($gs-gutter / 4);
+    padding-left: $gs-gutter / 4;
+    transition: color 100ms;
+
+    &:hover,
+    &:focus,
+    &:active {
+        text-decoration: underline;
+        color: inherit;
+    }
+
+
+    &:after {
+        content: 'save';
+    }
+
+    &.fc-save-for-later--is-saved:after {
+        content: 'saved';
+    }
+
+    @include mq($until: tablet) {
+        border-left: 0;
+        float: right;
+
+        .fc-item--has-timestamp & {
+            &:after,
+            &.fc-save-for-later--is-saved:after {
+                content: '';
+            }
+        }
+    }
+
+    @include mq($from: tablet, $until: desktop) {
+        .fc-item--has-timestamp &:last-child {
+            border-left: 0;
+            padding-left: 0;
+
+            .inline-icon {
+                margin-left: 0;
+            }
+        }
+    }
+
+    .inline-icon {
+        float: right;
+        margin-left: $gs-gutter / 4;
+        margin-right: 0;
+
+        @include mq(tablet) {
+            float: left;
+            margin-right: $gs-gutter / 4;
+        }
+    }
+}
+
+.facia-page .fc-save-for-later:only-child {
+    @include mq(tablet) {
+        border: 0;
+        padding: 0;
+    }
+}
+
 .fc-item--has-cutout .fc-item__media-wrapper {
     // We never want to show the media and the cutout at the same time, hence the important
     display: none !important;

--- a/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
@@ -26,8 +26,13 @@
     .fc-item__kicker,
     .rich-link__kicker,
     .fc-item__byline,
-    .rich-link__standfirst {
+    .rich-link__standfirst,
+    .fc-save-for-later--is-saved {
         color: colour(news-support-6);
+    }
+
+    .fc-save-for-later {
+        border-color: mix(#000000, colour(analysis-background), 10%);
     }
 
     .fc-item__kicker--dreamsnap {
@@ -36,6 +41,10 @@
 
     .fc-item__meta {
         color: colour(neutral-2);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(news-support-6);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
@@ -19,8 +19,13 @@
     .rich-link__kicker,
     .fc-item__byline,
     .rich-link__byline,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(comment-default);
+    }
+
+    .fc-save-for-later {
+        border-color: mix(#000000, colour(comment-background), 10%);
     }
 
     .fc-item__kicker--dreamsnap {
@@ -36,6 +41,10 @@
         ul > li:before {
             background: colour(neutral-3);
         }
+    }
+
+    .fc-save-for-later--is-saved  .inline-tone-fill {
+        fill: colour(comment-default);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
@@ -15,8 +15,13 @@
     }
 
     .fc-item__kicker,
-    .fc-item__byline {
+    .fc-item__byline,
+    .fc-save-for-later--is-saved {
         color: colour(live-accent);
+    }
+
+    .fc-save-for-later {
+        border-color: mix(#000000, colour(neutral-7), 10%);
     }
 
     .fc-item__kicker--dreamsnap {
@@ -29,6 +34,10 @@
 
     .rich-link__arrow-icon {
         fill: colour(neutral-2);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(live-accent);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
@@ -35,9 +35,15 @@
     .fc-item__kicker,
     .fc-item__byline,
     .fc-item__standfirst,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(editorial-accent);
     }
+
+    .fc-save-for-later {
+        border-color: mix($c-headline, colour(editorial-default), 20%);
+    }
+
 
     .fc-item__kicker--dreamsnap {
         background-color: mix(#000000, colour(editorial-default), 10%);
@@ -49,6 +55,10 @@
 
     .fc-item__meta {
         color: colour(editorial-accent);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(editorial-accent);
     }
 
     .fc-sublink__title:before {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
@@ -2,8 +2,13 @@
     background-color: colour(neutral-6);
 
     .fc-item__kicker,
-    .fc-item__byline {
+    .fc-item__byline,
+    .fc-save-for-later--is-saved {
         color: colour(external-main-1);
+    }
+
+    .fc-save-for-later {
+        border-color: mix(#000000, colour(neutral-6), 10%);
     }
 
     .fc-item__kicker--dreamsnap {
@@ -18,6 +23,10 @@
     .fc-item__container:before,
     .rich-link__container:before {
         background-color: colour(external-support-1);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(external-main-1);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
@@ -35,8 +35,13 @@
     .fc-item__kicker,
     .fc-item__byline,
     .fc-item__meta,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(feature-mute);
+    }
+
+    .fc-save-for-later {
+        border-color: mix($c-headline, colour(feature-default), 20%);
     }
 
     .fc-item__kicker--dreamsnap {
@@ -69,6 +74,10 @@
 
     .fc-sublink__title:before {
         border-color: mix($c-headline, colour(feature-default), 40%);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(feature-mute);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -32,8 +32,13 @@
     .fc-item__kicker,
     .fc-item__byline,
     .fc-item__meta,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(live-mute);
+    }
+
+    .fc-save-for-later {
+        border-color: mix($c-headline, colour(live-default), 20%);
     }
 
     .rich-link__arrow-icon {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
@@ -37,8 +37,13 @@
     .fc-item__kicker,
     .rich-link__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(media-default);
+    }
+
+    .fc-save-for-later {
+        border-color: mix($c-headline, colour(media-background), 20%);
     }
 
     .fc-item__kicker:after,
@@ -55,6 +60,10 @@
     .rich-link__standfirst,
     .fc-item__meta {
         color: colour(neutral-3);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
+        fill: colour(media-default);
     }
 }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-news.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-news.scss
@@ -11,8 +11,13 @@
 
     .fc-item__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(news-default);
+    }
+
+    .fc-save-for-later {
+        border-color: mix(#000000, colour(neutral-8), 10%);
     }
 
     .fc-item__kicker--dreamsnap {
@@ -24,6 +29,10 @@
     }
 
     .rich-link__arrow-icon {
+        fill: colour(news-default);
+    }
+
+    .fc-save-for-later--is-saved .inline-tone-fill {
         fill: colour(news-default);
     }
 }

--- a/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
@@ -31,8 +31,13 @@
 
     .fc-item__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(review-accent);
+    }
+
+    .fc-save-for-later {
+        border-color: mix($c-headline, colour(review-background), 20%);
     }
 
     .fc-item__kicker--dreamsnap {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
@@ -32,8 +32,13 @@
 
     .fc-item__kicker,
     .fc-item__byline,
-    .rich-link__read-more-text {
+    .rich-link__read-more-text,
+    .fc-save-for-later--is-saved {
         color: colour(news-support-1);
+    }
+
+    .fc-save-for-later {
+        border-color: mix(#000000, colour(news-support-6), 10%);
     }
 
     .fc-item__kicker--dreamsnap {


### PR DESCRIPTION
Reinstates Save For Later on fronts and containers: Essentially reverts this: 
https://github.com/guardian/frontend/pull/10167 and the relevent bits of this: https://github.com/guardian/frontend/pull/10167, plus, we weren't putting icons and event handlers on the tonal container, so I fixed that  
