### PR TITLE
adding video-icon back into headline contact

### DIFF
--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -13,6 +13,7 @@
                 @fragments.meta.metaInline(content)
 
                 <h1 class="content__headline js-score" itemprop="headline">
+                    @fragments.inlineSvg("video-icon", "icon")
                     @Html(content.headline)
                 </h1>
 

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -78,13 +78,18 @@
         width: .8em;
         @include icon(volume-high-white, $with-width: false);
     }
+    .content--media--video & {
+        content: none;
+    }
     .content--gallery &,
     .content--image & {
         width: .9em;
         @include icon(camera-white-large, $with-width: false);
     }
 }
-
+.content--media--video .inline-video-icon {
+    margin-right: .1em;
+}
 
 /* Media item
    ========================================================================== */


### PR DESCRIPTION
Fixing issue of missing video icon next to the headline
