### PR TITLE
Only Check for Commercial Expiry if Page Has Ad Feature Tone

### DIFF
--- a/common/app/common/dfp/PaidForTagAgent.scala
+++ b/common/app/common/dfp/PaidForTagAgent.scala
@@ -199,10 +199,11 @@ trait PaidForTagAgent {
   def isExpiredAdvertisementFeature(pageId: String,
                                     capiTags: Seq[Tag],
                                     maybeSectionId: Option[String]): Boolean = {
-    lazy val hasAdFeatureTone = capiTags exists (_.id == "tone/advertisement-features")
-    lazy val maybeDfpTag =
-      findWinningTagPair(allAdFeatureTags, capiTags, maybeSectionId, None) map (_.dfpTag)
-    isExpiredAdvertisementFeature(pageId, hasAdFeatureTone, maybeDfpTag, maybeSectionId)
+    val hasAdFeatureTone = capiTags exists (_.id == "tone/advertisement-features")
+    if (hasAdFeatureTone) {
+      lazy val maybeDfpTag = findWinningTagPair(allAdFeatureTags, capiTags, maybeSectionId, None) map (_.dfpTag)
+      isExpiredAdvertisementFeature(pageId, hasAdFeatureTone, maybeDfpTag, maybeSectionId)
+    } else false
   }
 
   def isExpiredAdvertisementFeatureFront(pageId: String,

--- a/common/test/common/dfp/PaidForTagAgentTest.scala
+++ b/common/test/common/dfp/PaidForTagAgentTest.scala
@@ -594,6 +594,12 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
     expired should be(true)
   }
 
+  "isExpiredAdvertisementFeature" should "be false for any content page without the ad feature tone" in {
+    val tags = Seq(toKeyword("section/tagName"))
+    val expired = TestPaidForTagAgent.isExpiredAdvertisementFeature("pageId", tags, None)
+    expired should be(false)
+  }
+
   it should "be false for an ad feature with multiple line items where one has no end date" in {
     val tags = Seq(toKeyword("section/tagNameMatchingMultipleLineItems"))
     TestPaidForTagAgent.isExpiredAdvertisementFeature("pageId", tags, None) should be(false)

--- a/common/test/common/dfp/PaidForTagAgentTest.scala
+++ b/common/test/common/dfp/PaidForTagAgentTest.scala
@@ -589,7 +589,7 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
   }
 
   "isExpiredAdvertisementFeature" should "be true for an expired ad feature" in {
-    val tags = Seq(toKeyword("section/tagName"))
+    val tags = Seq(toKeyword("section/tagName"), adFeatureTone)
     val expired = TestPaidForTagAgent.isExpiredAdvertisementFeature("pageId", tags, None)
     expired should be(true)
   }


### PR DESCRIPTION
This is an optimisation to avoid the possibility of expiring content that isn't commercial.
