### PR TITLE
Fix Ophan ad timing anomalies

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp-ophan-tracking.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-ophan-tracking.js
@@ -1,9 +1,8 @@
 define([
-    'raven',
-    'common/utils/detect'
-], function (raven, detect) {
+    'raven'
+], function (raven) {
 
-    function attachListeners(googletag) {
+    function trackPerformance(googletag, renderStartTime) {
         var adTimings = {};
         spyOnAdDebugTimings();
         reportAdsAndTimingsOnRender();
@@ -43,8 +42,10 @@ define([
 
             googletag.pubads().addEventListener('slotRenderEnded', raven.wrap(function reportAdToOphan(event) {
                 require(['ophan/ng'], function (ophan) {
-                    var renderStart = detect.getTimeOfDomComplete(),
-                        slotId = event.slot.getSlotId().getDomId(),
+                    console.log(document.readyState, renderStartTime);
+                    console.log('domLoaded', window.performance.timing.domInteractive);
+
+                    var slotId = event.slot.getSlotId().getDomId(),
                         slotTiming = adTimings[slotId] || {};
 
                     function lineItemIdOrEmpty(event) {
@@ -60,10 +61,10 @@ define([
                             slot: event.slot.getSlotId().getDomId(),
                             campaignId: lineItemIdOrEmpty(event),
                             creativeId: event.creativeId,
-                            timeToRenderEnded: new Date().getTime() - renderStart,
+                            timeToRenderEnded: new Date().getTime() - renderStartTime,
 
                             // overall time to make an ad request
-                            timeToAdRequest: safeDiff(renderStart, slotTiming.fetch),
+                            timeToAdRequest: safeDiff(renderStartTime, slotTiming.fetch),
 
                             // delay between requesting and receiving an ad
                             adRetrievalTime: safeDiff(slotTiming.fetch, slotTiming.receive),
@@ -86,6 +87,6 @@ define([
     }
 
     return {
-        attachListeners : attachListeners
+        trackPerformance : trackPerformance
     };
 });

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-ophan-tracking.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-ophan-tracking.js
@@ -42,6 +42,8 @@ define([
 
             googletag.pubads().addEventListener('slotRenderEnded', raven.wrap(function reportAdToOphan(event) {
                 require(['ophan/ng'], function (ophan) {
+                    console.log(document.readyState, renderStartTime);
+
                     var slotId = event.slot.getSlotId().getDomId(),
                         slotTiming = adTimings[slotId] || {};
 
@@ -58,7 +60,7 @@ define([
                             slot: event.slot.getSlotId().getDomId(),
                             campaignId: lineItemIdOrEmpty(event),
                             creativeId: event.creativeId,
-                            timeToRenderEnded: new Date().getTime() - renderStartTime,
+                            timeToRenderEnded: safeDiff(renderStartTime, new Date().getTime()),
 
                             // overall time to make an ad request
                             timeToAdRequest: safeDiff(renderStartTime, slotTiming.fetch),

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-ophan-tracking.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-ophan-tracking.js
@@ -42,7 +42,6 @@ define([
 
             googletag.pubads().addEventListener('slotRenderEnded', raven.wrap(function reportAdToOphan(event) {
                 require(['ophan/ng'], function (ophan) {
-                    console.log(document.readyState, renderStartTime);
 
                     var slotId = event.slot.getSlotId().getDomId(),
                         slotTiming = adTimings[slotId] || {};

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-ophan-tracking.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-ophan-tracking.js
@@ -42,9 +42,6 @@ define([
 
             googletag.pubads().addEventListener('slotRenderEnded', raven.wrap(function reportAdToOphan(event) {
                 require(['ophan/ng'], function (ophan) {
-                    console.log(document.readyState, renderStartTime);
-                    console.log('domLoaded', window.performance.timing.domInteractive);
-
                     var slotId = event.slot.getSlotId().getDomId(),
                         slotTiming = adTimings[slotId] || {};
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -110,6 +110,7 @@ define([
                 });
             }
         },
+        renderStartTime = null,
 
         recordFirstAdRendered = _.once(function () {
             beacon.beaconCounts('ad-render');
@@ -119,7 +120,7 @@ define([
          * Initial commands
          */
         setListeners = function () {
-            dfpOphanTracking.attachListeners(googletag);
+            dfpOphanTracking.trackPerformance(googletag, renderStartTime);
 
             googletag.pubads().addEventListener('slotRenderEnded', raven.wrap(function (event) {
                 rendered = true;
@@ -256,6 +257,9 @@ define([
 
             window.googletag.cmd.push = raven.wrap({ deep: true }, window.googletag.cmd.push);
 
+            window.googletag.cmd.push(function () {
+                renderStartTime = new Date().getTime();
+            });
             window.googletag.cmd.push(setListeners);
             window.googletag.cmd.push(setPageTargeting);
             window.googletag.cmd.push(defineSlots);

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -109,15 +109,6 @@ define([
         return totalTime;
     }
 
-    function getTimeOfDomComplete(performance) {
-        var perf = performance || window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
-        if (perf && perf.timing) {
-            return perf.timing.domComplete;
-        } else {
-            return new Date().getTime();
-        }
-    }
-
     function isReload() {
         var perf = window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
         if (!!perf && !!perf.navigation) {
@@ -499,7 +490,6 @@ define([
         pageVisible: pageVisible,
         hasWebSocket: hasWebSocket,
         getPageSpeed: getPageSpeed,
-        getTimeOfDomComplete: getTimeOfDomComplete,
         breakpoints: breakpoints,
         fontHinting: fontHinting(),
         isModernBrowser: isModernBrowser,


### PR DESCRIPTION
There is a bug in our Ophan GPT ad timing tracking, caused by us assuming GPT begins rendering ads upon DOMComplete, when it can actually start rendering beforehand. This caused various anomalies in our data for last week.

Here, we're now recording the start render time as the time the first GPT command gets executed, which should be when the third party script has been fetched and the JS thread is free to run it (i.e. has no other async scripts queued).
