### PR TITLE
Still track video viewing even when ads are blocked

### DIFF
--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -248,6 +248,11 @@ define([
                                     // Video analytics event.
                                     player.trigger(events.constructEventName('preroll:request', player));
                                     player.ima.requestAds();
+                                }, function (e) {
+                                    Raven.captureException(e, { tags: { feature: 'media' } });
+                                    // ad blocker, so just carry on without
+                                    events.bindContentEvents(player);
+                                    throw e;
                                 });
                             }
                         )();

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -249,7 +249,7 @@ define([
                                     player.trigger(events.constructEventName('preroll:request', player));
                                     player.ima.requestAds();
                                 }, function (e) {
-                                    raven.captureException(e, { tags: { feature: 'media' } });
+                                    raven.captureException(e, { tags: { feature: 'media', action: 'ads' } });
                                     // ad blocker, so just carry on without
                                     events.bindContentEvents(player);
                                     throw e;

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -249,7 +249,7 @@ define([
                                     player.trigger(events.constructEventName('preroll:request', player));
                                     player.ima.requestAds();
                                 }, function (e) {
-                                    Raven.captureException(e, { tags: { feature: 'media' } });
+                                    raven.captureException(e, { tags: { feature: 'media' } });
                                     // ad blocker, so just carry on without
                                     events.bindContentEvents(player);
                                     throw e;


### PR DESCRIPTION
Omniture/ophan wasn't happening when people were using ad blockers due to a cascading error.  Adding it back in so if ads are blocked it just carries on with the non-ads functinality rather than getting stuck in some limbo state.
FYI @kenlim 
