### PR TITLE
Generate imgix hash from percent-encoded UTF-8 bytes

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -110,7 +110,7 @@ object ImgSrc extends Logging {
         .filter(const(ImageServerSwitch.isSwitchedOn))
         .filter(const(isSupportedImage))
         .map { host =>
-          val signedPath = ImageUrlSigner.sign(s"${uri.getPath}${imageType.resizeString}", host.token)
+          val signedPath = ImageUrlSigner.sign(s"${uri.getRawPath}${imageType.resizeString}", host.token)
           s"$imageHost/img/${host.prefix}$signedPath"
         }.getOrElse(url)
     } catch {


### PR DESCRIPTION
Before we used getPath to hash for imgix, however this unencodes any percent encoded octets.  Then it presumably turns them into codepoints.  This resulted in the wrong hash.
Now I have changed it to get the raw (percent-encoded) path and encode that to match imgix's library.

I have also updated their docs to make it clear, and they were super happy about that: https://github.com/imgix/imgix-blueprint/pull/7

Credit to @paperboyo for diagnosing the problem.  This should do the trick, although I only tested that I didn't break things so far, not that it fixed the original case, as that's working anyway now.
