### PR TITLE
Switch to syndication tracking values that show up in Omniture

### DIFF
--- a/common/app/views/fragments/syndication.scala.html
+++ b/common/app/views/fragments/syndication.scala.html
@@ -7,7 +7,7 @@
         <ul class="syndication--@position u-unstyled">
             <li class="syndication__item">
                 <a class="syndication__action"
-                data-component="meta-syndication"
+                data-link-name="meta-syndication-@content.syndicationType"
                 href="http://syndication.theguardian.com/automation/?url=@URLEncode(content.webUrl)&type=@content.syndicationType&internalpagecode=@content.internalPageCode"
                 target="_blank"
                 title="Reuse this content">

--- a/data/database/8b4cf5f7f7f2e2f8d1f2d99e2dabe5a94d881efc7682a697c39f58802797af72
+++ b/data/database/8b4cf5f7f7f2e2f8d1f2d99e2dabe5a94d881efc7682a697c39f58802797af72
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}


### PR DESCRIPTION
Apparently, tracking via data-component means the data ends up in the data warehouse somewhere and is difficult to extract, but using data-link-name brings it out through the Omniture interface.

While switching this over, I also opted to make the tracking codes more specific to show which types of content attract the most syndication interaction.
