### PR TITLE
Allow override of redirect url for authentication in Preview

### DIFF
--- a/standalone/app/controllers/OAuthLoginController.scala
+++ b/standalone/app/controllers/OAuthLoginController.scala
@@ -15,7 +15,7 @@ object OAuthLoginController extends Controller with ExecutionContexts with impli
 
   val LOGIN_ORIGIN_KEY = "loginOriginUrl"
   val ANTI_FORGERY_KEY = "antiForgeryToken"
-  val forbiddenNoCredentials = Forbidden("You do not have OAuth credentials set")
+  val forbiddenNoCredentials = Forbidden("Invalid OAuth credentials set")
   val googleAuthConfig: Option[GoogleAuthConfig] = Configuration.standalone.oauthCredentials.map { cred =>
     GoogleAuthConfig(
       cred.oauthClientId,     // The client ID from the dev console
@@ -27,6 +27,8 @@ object OAuthLoginController extends Controller with ExecutionContexts with impli
     )
   }
 
+  lazy val validRedirectDomain = """^(\w+:\/\/[^/]+\.(?:dev-)?gutools\.co\.uk\/.*)$""".r
+
   // this is the only place we use LoginAuthAction - to prevent authentication redirect loops
   def login = Action { request =>
       Ok(views.html.standalone_auth(projectName, "Dev", UserIdentity.fromRequest(request)))
@@ -36,7 +38,7 @@ object OAuthLoginController extends Controller with ExecutionContexts with impli
   Redirect to Google with anti forgery token (that we keep in session storage - note that flashing is NOT secure)
    */
   def loginAction = Action.async { implicit request =>
-    googleAuthConfig.map(checkIsSecure).map(overrideRedirectUrl).map { config =>
+    googleAuthConfig.flatMap(overrideRedirectUrl).map(checkIsSecure).map { config =>
       val antiForgeryToken = GoogleAuth.generateAntiForgeryToken()
       GoogleAuth.redirectToGoogle(config, antiForgeryToken).map {
         _.withSession {
@@ -57,10 +59,12 @@ object OAuthLoginController extends Controller with ExecutionContexts with impli
     }
   }
 
+  // Allow redirect url to be overridden via request params. Only allows gutools.co.uk
   private def overrideRedirectUrl(config: GoogleAuthConfig)(implicit request: RequestHeader) = {
     request.getQueryString("redirect-url") match {
-      case Some(url) => config.copy(redirectUrl = url)
-      case _ => config
+      case Some(validRedirectDomain(url)) => Some(config.copy(redirectUrl = url))
+      case None => Some(config)
+      case _ => None
     }
   }
 
@@ -70,7 +74,7 @@ object OAuthLoginController extends Controller with ExecutionContexts with impli
   will return a Future[UserIdentity] if the authentication is successful. If unsuccessful then the Future will fail.
    */
   def oauth2Callback = Action.async { implicit request =>
-    googleAuthConfig.map(checkIsSecure).map(overrideRedirectUrl).map { config =>
+    googleAuthConfig.flatMap(overrideRedirectUrl).map(checkIsSecure).map { config =>
       request.session.get(ANTI_FORGERY_KEY) match {
         case None =>
           Future.successful(Redirect(routes.OAuthLoginController.login())


### PR DESCRIPTION
Small change to enable overriding the `redirect_url` used for Google OAuth on Preview (and training-preview).

Passing `redirect-url` as a query parameter to `/login` and `/oauth2callback` will ensure that Google redirects the client to `redirect-url` instead of `/oauth2callback` for authentication and validation.

Required for a proxy to preview in the new mobile viewer: guardian/editorial-viewer#10
