### PR TITLE
Stop riffraff throttling errors

### DIFF
--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -23,7 +23,7 @@ trait AdminLifecycle extends GlobalSettings with Logging {
       model.abtests.AbTestJob.run()
     }
 
-    Jobs.schedule("LoadBalancerLoadJob", "* 0/15 * * * ?") {
+    Jobs.schedule("LoadBalancerLoadJob", "0 4/15 * * * ?") {
       LoadBalancer.refresh()
     }
 
@@ -107,6 +107,7 @@ trait AdminLifecycle extends GlobalSettings with Logging {
   }
 
   override def onStart(app: play.api.Application) {
+    log.info("onStart started")
     super.onStart(app)
     descheduleJobs()
     scheduleJobs()
@@ -117,6 +118,7 @@ trait AdminLifecycle extends GlobalSettings with Logging {
       OmnitureReportJob.run()
       VideoEncodingsJob.run()
     }
+    log.info("onStart finished")
   }
 
   override def onStop(app: play.api.Application) {

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -107,7 +107,6 @@ trait AdminLifecycle extends GlobalSettings with Logging {
   }
 
   override def onStart(app: play.api.Application) {
-    log.info("onStart started")
     super.onStart(app)
     descheduleJobs()
     scheduleJobs()
@@ -118,7 +117,6 @@ trait AdminLifecycle extends GlobalSettings with Logging {
       OmnitureReportJob.run()
       VideoEncodingsJob.run()
     }
-    log.info("onStart finished")
   }
 
   override def onStop(app: play.api.Application) {

--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -1,6 +1,5 @@
 package tools
 
-import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest
 import common.{Logging, AkkaAgent}
 import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient
 import scala.collection.JavaConversions._

--- a/admin/app/tools/LoadBalancer.scala
+++ b/admin/app/tools/LoadBalancer.scala
@@ -42,9 +42,7 @@ object LoadBalancer extends Logging {
     credentials.foreach{ credentials =>
       val client = new AmazonElasticLoadBalancingClient(credentials)
       client.setEndpoint(AwsEndpoints.elb)
-      val request = new DescribeLoadBalancersRequest()
-      request.setLoadBalancerNames(loadBalancers.map(_.id))
-      val elbs = client.describeLoadBalancers(request).getLoadBalancerDescriptions
+      val elbs = client.describeLoadBalancers().getLoadBalancerDescriptions
       client.shutdown()
       val newLoadBalancers = loadBalancers.map{ lb =>
         lb.copy(url = elbs.find(_.getLoadBalancerName == lb.id).map(_.getDNSName))

--- a/admin/conf/application-logger.xml
+++ b/admin/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Every 15 minutes we get throttling errors from riffraff because we're hitting AWS too hard.

Seems like this is because we were refreshing the ELB details every second for one minute every 15 minutes.

This PR changes it to only run on the minute.  Also I've made it offset by 4 minutes - then if it causes problems in future we can narrow it down more easily.

I have also made it log full stack traces but in reality I'd like to know why we don't already?

Also I've made it only request details for ELB names it's interested in - although it will fall over if one of those is deleted.  Is that a good idea?

@gklopper what do you think?  It's used by the main radiator page for the latency so I didn't remove the whole job in the end.
@rich-nguyen it was indeed running every second for the whole minute (and most of those were getting queued and run in a lump)
