### PR TITLE
Do not serve woff2 fonts for Edge browser

### DIFF
--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -235,7 +235,8 @@ define([
             });
         };
 
-        var woff2Candidacy = /(chrome|firefox)\/([0-9]+)/.exec(ua);
+        var excludeEdge = /^(edge\/([0-9]+))/.test(ua);
+        var woff2Candidacy = excludeEdge && /(chrome|firefox)\/([0-9]+)/.exec(ua);
 
         if (!!woff2Candidacy && thisBrowserSupportsWoff2(woff2Candidacy)) {
             return 'woff2';


### PR DESCRIPTION
This tweaks the detect library so that we exclude Edge browsers from woff2 candidacy. Fixes #9992 hopefully.
