### PR TITLE
For matches that haven't started still show an endpoint for them with the start time

### DIFF
--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -28,7 +28,6 @@ object MatchesController extends Controller with Logging with ExecutionContexts 
     val matchOpt =  RugbyStatsJob.getLiveScore(year, month, day, team1, team2)
       .map ( m => m.copy( venue = matchFixture.flatMap(_.venue)))
       .orElse(matchFixture)
-      .filter(m => m.awayTeam.score.isDefined && m.homeTeam.score.isDefined)
     val currentPage = request.getParameter("page")
 
     matchOpt.map { aMatch =>

--- a/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
+++ b/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
@@ -10,9 +10,9 @@ import scala.xml.{NodeSeq, XML}
 object Parser {
 
   private object Date {
-    private val dateTimeParser = DateTimeFormat.forPattern("yyyyMMdd")
+    private val dateTimeParser = DateTimeFormat.forPattern("yyyyMMdd HH:mm:ss")
 
-    def apply(dateTime: String) = dateTimeParser.parseDateTime(dateTime)
+    def apply(date: String, time: String) = dateTimeParser.parseDateTime(s"$date $time")
   }
 
   def parseLiveScores(body: String): Seq[Match] = {
@@ -34,7 +34,7 @@ object Parser {
       } yield {
 
         Match(
-          date = Date((game \ "@game_date").text),
+          date = Date((game \ "@game_date").text, (game \ "@time").text),
           id = (game \ "@id").text,
           homeTeam = homeTeam,
           awayTeam = awayTeam,
@@ -62,7 +62,7 @@ object Parser {
         awayTeam <- getTeamWithResult(teamNodes, teams, "away")
       } yield {
         Match(
-          date = Date((fixture \ "@game_date").text),
+          date = Date((fixture \ "@game_date").text, (fixture \ "@time").text),
           id = (fixture \ "@id").text,
           homeTeam = homeTeam,
           awayTeam = awayTeam,

--- a/sport/test/rugby/model/MatchParserTest.scala
+++ b/sport/test/rugby/model/MatchParserTest.scala
@@ -20,7 +20,7 @@ import scala.io.Source
       firstResult.homeTeam.score should be(Some(41))
       firstResult.awayTeam.name should be("Australia")
       firstResult.awayTeam.score should be(Some(13))
-      firstResult.date should be(new org.joda.time.DateTime(2015, 8, 15, 0, 0))
+      firstResult.date should be(new org.joda.time.DateTime(2015, 8, 15, 8, 35))
       firstResult.venue should be (None)
 
       val futureResult = liveScores.find(_.id == "2873").get
@@ -43,7 +43,7 @@ import scala.io.Source
       firstResult.homeTeam.score should be(Some(16))
       firstResult.awayTeam.name should be("New Zealand")
       firstResult.awayTeam.score should be(Some(25))
-      firstResult.date should be(new org.joda.time.DateTime(2015, 7, 8, 0, 0))
+      firstResult.date should be(new org.joda.time.DateTime(2015, 7, 8, 3, 0))
       firstResult.venue should be (Some("Apia Park"))
       firstResult.competitionName should be ("International")
 


### PR DESCRIPTION
We override the headline with the rugby score for a live blog (simialar to football). When the rugby match hasn't started though we display a blank area. This PR fixes this by allowing all matches to be fetched on the api score endpoint and ensuring we fetch the time of the match from the feed to display the fixture time.

This was the live blog for last week's game before it started (note I fixed the red background earlier this week #10357)
<img width="1157" alt="screen shot 2015-08-29 at 14 28 53" src="https://cloud.githubusercontent.com/assets/944375/9682900/d7ba69ae-5302-11e5-9ec8-ca054787365b.png">

After:
<img width="771" alt="screen shot 2015-09-04 at 12 42 47" src="https://cloud.githubusercontent.com/assets/944375/9682904/df34c152-5302-11e5-8a49-01e20c4c7338.png">

cc @rich-nguyen 
