### PR TITLE
allow 10 seconds for WS responses when running in tests

### DIFF
--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -102,7 +102,10 @@ trait SingleServerSuite extends OneServerPerSuite with TestSettings with OneBrow
       additionalConfiguration = Map(
         ("application.secret", "this_is_not_a_real_secret_just_for_tests"),
         ("guardian.projectName", "test-project"),
-        ("ws.compressionEnabled", true)
+        ("ws.compressionEnabled", true),
+        ("ws.timeout.connection", "10000"),// when running healthchecks on a cold app it can time out
+        ("ws.timeout.idle", "10000"),
+        ("ws.timeout.request", "10000")
       )
   )
 }

--- a/onward/conf/application-logger.xml
+++ b/onward/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Our tests were failing because the healthcheck test (of onward) was taking more than 1 second due to the ap starting cold.
This PR changes it so the timeout for running in test mode is 10 seconds.
