### PR TITLE
fix background colour of media network slice items

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -190,6 +190,10 @@ $fc-item-gutter: $gs-gutter / 4;
     .u-faux-block-link--hover,
     .fc-item__media-wrapper {
         background-color: colour(neutral-6);
+
+        .fc-slice--nav-list--media & {
+            background-color: inherit;
+        }
     }
 
     .u-faux-block-link--hover {


### PR DESCRIPTION
before:
![screen shot 2015-09-08 at 11 10 03](https://cloud.githubusercontent.com/assets/1064734/9732320/e3c12312-561a-11e5-93db-914d0e1e63b3.png)

after:
![screen shot 2015-09-08 at 11 10 09](https://cloud.githubusercontent.com/assets/1064734/9732322/e6c17094-561a-11e5-9c62-4013de27d804.png)
