### PR TITLE
Prevent overlapping jobs

### DIFF
--- a/common/app/common/jobs.scala
+++ b/common/app/common/jobs.scala
@@ -12,7 +12,7 @@ import Play.current
 object Jobs extends Logging {
   private val scheduler = StdSchedulerFactory.getDefaultScheduler()
   private val jobs = mutable.Map[String, () => Unit]()
-  private val outstanding = mutable.Map[String,AtomicInteger]().withDefault(_=>new AtomicInteger(0))
+  private val outstanding = mutable.Map[String,AtomicInteger]().withDefaultValue(new AtomicInteger(0))
 
   class FunctionJob extends Job {
     def execute(context: JobExecutionContext) {

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -72,6 +72,11 @@ object SystemMetrics extends implicits.Numbers {
     () => new File("/").getTotalSpace / 1048576
   )
 
+  object ThreadCountMetric extends GaugeMetric("thread-count", "Thread Count",
+    () => ManagementFactory.getThreadMXBean.getThreadCount,
+    StandardUnit.Count
+  )
+
   // yeah, casting to com.sun.. ain't too pretty
   object TotalPhysicalMemoryMetric extends GaugeMetric("total-physical-memory", "Total physical memory",
     () => ManagementFactory.getOperatingSystemMXBean match {
@@ -378,11 +383,19 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
   def applicationName: String
   def applicationMetrics: List[FrontendMetric] = List(FilterCacheHit, FilterCacheMiss) ++ PaMetrics.all
 
-  def systemMetrics: List[FrontendMetric] = List(SystemMetrics.MaxHeapMemoryMetric,
-    SystemMetrics.UsedHeapMemoryMetric, SystemMetrics.TotalPhysicalMemoryMetric, SystemMetrics.FreePhysicalMemoryMetric,
-    SystemMetrics.AvailableProcessorsMetric, SystemMetrics.BuildNumberMetric, SystemMetrics.FreeDiskSpaceMetric,
-    SystemMetrics.TotalDiskSpaceMetric, SystemMetrics.MaxFileDescriptorsMetric,
-    SystemMetrics.OpenFileDescriptorsMetric) ++ SystemMetrics.garbageCollectors.flatMap{ gc => List(
+  def systemMetrics: List[FrontendMetric] = List(
+    SystemMetrics.MaxHeapMemoryMetric,
+    SystemMetrics.UsedHeapMemoryMetric,
+    SystemMetrics.TotalPhysicalMemoryMetric,
+    SystemMetrics.FreePhysicalMemoryMetric,
+    SystemMetrics.AvailableProcessorsMetric,
+    SystemMetrics.BuildNumberMetric,
+    SystemMetrics.FreeDiskSpaceMetric,
+    SystemMetrics.TotalDiskSpaceMetric,
+    SystemMetrics.MaxFileDescriptorsMetric,
+    SystemMetrics.OpenFileDescriptorsMetric,
+    SystemMetrics.ThreadCountMetric
+  ) ++ SystemMetrics.garbageCollectors.flatMap{ gc => List(
       GaugeMetric(s"${gc.name}-gc-count-per-min" , "Used heap memory (MB)",
         () => gc.gcCount.toLong,
         StandardUnit.Count


### PR DESCRIPTION
the admin box in CODE and PROD keeps dying because of a thread leak (gets up to 12000+ threads!) causing memory exhaustion.

The quartz scheduler will happily create threads every time a job is run even if the previous instances are still running.

I have added something firstly to monitor thread count on the boxes to cloudwatch, but also to decline to start a job if the previous one is still running.  I suspect FastlyCloudwatchLoadJob but I need to see it in prod as it's not leaking as quickly locally.

I have made it add a log line when it declines to start a new job, but I am not sure whether we should be notifying ourselves more loudly if a job isn't running.

@gklopper 
