### PR TITLE
add extra cache controls to NoCache

### DIFF
--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -49,7 +49,7 @@ object Cached extends implicits.Dates {
 }
 
 object NoCache {
-  def apply(result: Result): Result = result.withHeaders("Cache-Control" -> "no-cache", "Pragma" -> "no-cache")
+  def apply(result: Result): Result = result.withHeaders("Cache-Control" -> "no-cache, no-store, must-revalidate, max-age=0", "Pragma" -> "no-cache")
 }
 
 case class NoCache[A](action: Action[A]) extends Action[A] {
@@ -58,7 +58,7 @@ case class NoCache[A](action: Action[A]) extends Action[A] {
 
     action(request) map { response =>
       response.withHeaders(
-        ("Cache-Control", "no-cache, no-store, must-revalidate"),
+        ("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0"),
         ("Pragma", "no-cache"),
         ("Expires", "0")
       )


### PR DESCRIPTION
Previously `NoCache` only set `Cache-Control: no-cache`, we now set `no-cache, no-store, must-revalidate`.

This should fix an issue with `/crosswords/search/results` being cached by Fastly despite using `NoCache`.

@rich-nguyen
