### PR TITLE
Update membership commercial colours

### DIFF
--- a/static/src/stylesheets/_vars.scss
+++ b/static/src/stylesheets/_vars.scss
@@ -144,8 +144,12 @@ $frontend-palette: (
     social-gplus:           #e15440,
     social-whatsapp:        #59cb3f,
     social-linkedin:        #0071a1,
-    social-pinterest:       #b9252c
+    social-pinterest:       #b9252c,
 
+    // Membership
+    // =============================================================================
+
+    membership-default:     #bb3a7f
 );
 
 $c-top-header-background: guss-colour(guardian-brand-dark, $pasteup-palette); // one-off colour for header bg

--- a/static/src/stylesheets/module/commercial/_tones.scss
+++ b/static/src/stylesheets/module/commercial/_tones.scss
@@ -71,9 +71,8 @@
 /* .commercial--tone-membership */
 @include tone-commercial(
     membership,
-    guss-colour(news-main-2, $pasteup-palette),
-    guss-colour(news-main-1, $pasteup-palette),
-    $titleColor :colour(neutral-1)
+    colour(membership-default),
+    colour(membership-default)
 );
 
 /* .commercial--tone-live */


### PR DESCRIPTION
Minor update to change the primary colour of Membership commercial components to match the redesign. We are looking at something more custom soon like Soulmates (particularly as Membership now has it's own logo) so this is a stop-gap change.

![screen shot 2015-09-08 at 11 44 24](https://cloud.githubusercontent.com/assets/123386/9733341/3fe86a68-5622-11e5-95cb-a1eb76501e72.png)

@OliverJAsh 
