### PR TITLE
Avoid forced synchronous layouts

### DIFF
--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -1,6 +1,7 @@
 /*eslint-disable no-new*/
 /* TODO - fix module constructors */
 define([
+    'fastdom',
     'bean',
     'bonzo',
     'qwery',
@@ -54,6 +55,7 @@ define([
     'text!common/views/international-control-message.html',
     'bootstraps/identity-common'
 ], function (
+    fastdom,
     bean,
     bonzo,
     qwery,
@@ -230,8 +232,8 @@ define([
 
             // Adds a global window:throttledScroll event to mediator, which throttles
             // scroll events until there's a spare animationFrame.
-            // Callbacks of all listeners to window:throttledScroll are run in the
-            // same animationFrame, meaning they can all perform DOM reads for free
+            // Callbacks of all listeners to window:throttledScroll are run in a
+            // fastdom.read, meaning they can all perform DOM reads for free
             // (after the first one that needs layout triggers it).
             // However, this means it's VITAL that all writes in callbacks are delegated to fastdom
             throttledScrollEvent: function () {
@@ -239,7 +241,10 @@ define([
                 window.addEventListener('scroll', function () {
                     if (!running) {
                         running = true;
-                        requestAnimationFrame(function () {
+                        // Use fastdom to avoid forced synchronous layout:
+                        // https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing#avoid-forced-synchronous-layouts
+                        // *Fastdom guarantees that reads will come before writes*
+                        fastdom.read(function () {
                             mediator.emitEvent('window:throttledScroll');
                             running = false;
                         });


### PR DESCRIPTION
Inside our throttledScroll event, we request an animation frame, which allows consumers of the event to freely read from the DOM/layout. If consumers want to write to the DOM/layout, they use `fastdom.write`.

`fastdom.write` will request _another animation frame_. **This write animation frame appears to execute before the read animation frame**, causing a [forced synchronous layout](https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing#avoid-forced-synchronous-layouts) (see timeline below). Essentially, we should never write then read—because writes invalidate layout, and the read requires the browser to recalculate layout prematurely, outside of its usual lifecycle.

If we use `fastdom.read` instead of scheduling our own animation frame, fastdom will flush [_reads then writes_](https://github.com/wilsonpage/fastdom/blob/a20293848431773f16cdc64b249273573864e06a/index.js#L246-L254) together in a single animation frame, which avoids forced synchronous layout.

/cc @sndrs 
# Before, with forced synchronous layout

![bad](https://cloud.githubusercontent.com/assets/921609/9735598/d1f35146-5633-11e5-83a4-7eac13886da1.png)
# After, without forced synchronous layout

![good](https://cloud.githubusercontent.com/assets/921609/9735594/cc502034-5633-11e5-87c6-593fb0d10e7b.png)
