### PR TITLE
Ie8 images

### DIFF
--- a/common/app/templates/headerInlineJS/bootCurl.scala.js
+++ b/common/app/templates/headerInlineJS/bootCurl.scala.js
@@ -99,6 +99,11 @@ require([
         }
     };
 
+    // IE8 and below use attachEvent
+    if (!window.addEventListener) {
+        window.addEventListener = window.attachEvent;
+    }
+
     // Report unhandled promise rejections
     // https://github.com/cujojs/when/blob/master/docs/debug-api.md#browser-window-events
     window.addEventListener('unhandledRejection', function (event) {

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
@@ -51,7 +51,8 @@ define([
             if (config.switches.audienceScienceGateway && storedSegments) {
                 segments = _(_.pairs(storedSegments[section]))
                     .filter(function (placement) {
-                        return placement[1].default;
+                        //keyword `default` written in dot notation throws an exception IE8
+                        return placement[1]['default']; //eslint-disable-line
                     })
                     .map(function (placement) {
                         return ['pq_' + placement[0], 'T'];


### PR DESCRIPTION
Going part way to solving https://github.com/guardian/frontend/issues/9844 and finishing [this](https://trello.com/c/qv21Bc9w/38-ie8-no-images-for-1-of-users) story in Trello. 

The problem was that only the first few images were loading in IE8. This was caused by two separate exceptions. The first was the use of `addEventListener` which doesn't work in IE8 or older browsers. The 2nd was the use of a reserved word `default`.

Now Images load fine...

![image](https://cloud.githubusercontent.com/assets/8774970/9736480/4e35af92-5639-11e5-8a0e-1808544e9d45.png)
