### PR TITLE
Interactive template style fixes

### DIFF
--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -42,7 +42,7 @@
         border-bottom: 0;
 
         .meta__number {
-            @include mq(desktop) {
+            @include mq(tablet) {
                 float: right;
                 border-left: 1px solid colour(neutral-5);
                 padding-left: $gs-gutter / 2;
@@ -63,7 +63,7 @@
         }
 
         .meta__social {
-            @include mq(desktop) {
+            @include mq(tablet) {
                 float: left;
                 position: relative;
                 z-index: 2;

--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -42,20 +42,32 @@
         border-bottom: 0;
 
         .meta__number {
-            float: right;
-            border-left: 1px solid colour(neutral-5);
-            padding-left: $gs-gutter / 2;
+            @include mq(desktop) {
+                float: right;
+                border-left: 1px solid colour(neutral-5);
+                padding-left: $gs-gutter / 2;
+
+                &:first-child {
+                    padding-right: 0;
+                }
+            }
 
             @include mq($until: mobile) {
                 position: relative;
                 top: $gs-baseline;
             }
+
+            &:last-child {
+                padding-right: $gs-gutter / 2;
+            }
         }
 
         .meta__social {
-            float: left;
-            position: relative;
-            z-index: 2;
+            @include mq(desktop) {
+                float: left;
+                position: relative;
+                z-index: 2;
+            }
         }
 
         @include mq(leftCol) {


### PR DESCRIPTION
Just clearing up a number of clashes and bugs that I have noticed on the interactive template recently.

Before:
![screen shot 2015-09-08 at 15 53 22](https://cloud.githubusercontent.com/assets/2236852/9738240/89341882-5642-11e5-8228-841fe1eb4962.png)
![screen shot 2015-09-08 at 15 53 31](https://cloud.githubusercontent.com/assets/2236852/9738241/8934f0fe-5642-11e5-81a9-4c508e290d3b.png)

After:
![screen shot 2015-09-08 at 15 53 44](https://cloud.githubusercontent.com/assets/2236852/9738248/8f0235b4-5642-11e5-8638-9536161f865e.png)
![screen shot 2015-09-08 at 15 53 51](https://cloud.githubusercontent.com/assets/2236852/9738249/8f0468de-5642-11e5-8171-dff0e7c6a008.png)
