### PR TITLE
Crossword display group clues

### DIFF
--- a/applications/app/crosswords/CrosswordData.scala
+++ b/applications/app/crosswords/CrosswordData.scala
@@ -14,6 +14,7 @@ object Entry {
   def fromCrosswordEntry(entry: CrosswordEntry): Entry = Entry(
     entry.id,
     entry.number.getOrElse(0),
+    entry.humanNumber.getOrElse("0"),
     entry.clue.getOrElse(""),
     entry.direction.getOrElse(""),
     entry.length.getOrElse(0),
@@ -27,6 +28,7 @@ object Entry {
 case class Entry(
   id: String,
   number: Int,
+  humanNumber: String,
   clue: String,
   direction: String,
   length: Int,

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
@@ -23,10 +23,11 @@ class Clue extends React.Component {
             <li className={classNames({
                     'crossword__clue': true,
                     'crossword__clue--answered': this.props.hasAnswered,
-                    'crossword__clue--selected': this.props.isSelected
+                    'crossword__clue--selected': this.props.isSelected,
+                    'crossword__clue--display-group-order' : JSON.stringify(this.props.number) !== this.props.displayNumber
                 })}
                 onClick={this.onClick}
-                value={parseInt(this.props.number, 10)}
+                value={this.props.displayNumber}
                 /* jscs:disable disallowDanglingUnderscores */
                 dangerouslySetInnerHTML={{__html: this.props.clue}}
                 /* jscs:enable disallowDanglingUnderscores */
@@ -44,7 +45,8 @@ export default class Clues extends React.Component {
             .map((clue) =>
                 <Clue
                     key={clue.entry.id}
-                    number={clue.entry.number + '.'}
+                    number={clue.entry.number}
+                    displayNumber={clue.entry.humanNumber}
                     clue={clue.entry.clue}
                     hasAnswered={clue.hasAnswered}
                     isSelected={clue.isSelected}

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
@@ -24,10 +24,10 @@ class Clue extends React.Component {
                     'crossword__clue': true,
                     'crossword__clue--answered': this.props.hasAnswered,
                     'crossword__clue--selected': this.props.isSelected,
-                    'crossword__clue--display-group-order' : JSON.stringify(this.props.number) !== this.props.displayNumber
+                    'crossword__clue--display-group-order' : JSON.stringify(this.props.number) !== this.props.humanNumber
                 })}
                 onClick={this.onClick}
-                value={this.props.displayNumber}
+                value={this.props.humanNumber}
                 /* jscs:disable disallowDanglingUnderscores */
                 dangerouslySetInnerHTML={{__html: this.props.clue}}
                 /* jscs:enable disallowDanglingUnderscores */
@@ -46,7 +46,7 @@ export default class Clues extends React.Component {
                 <Clue
                     key={clue.entry.id}
                     number={clue.entry.number}
-                    displayNumber={clue.entry.humanNumber}
+                    humanNumber={clue.entry.humanNumber}
                     clue={clue.entry.clue}
                     hasAnswered={clue.hasAnswered}
                     isSelected={clue.isSelected}

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -184,6 +184,7 @@ class Crossword extends React.Component {
     }
 
     moveFocus (deltaX, deltaY) {
+
         const cell = this.state.cellInFocus;
         const x = cell.x + deltaX;
         const y = cell.y + deltaY;
@@ -342,13 +343,22 @@ class Crossword extends React.Component {
         }
     }
 
+    clueIsInFocusGroup (clue) {
+        if (this.state.cellInFocus) {
+            const cluesForCell = this.cluesFor(this.state.cellInFocus.x, this.state.cellInFocus.y);
+            return _.contains(cluesForCell[this.state.directionOfEntry].group, clue.id);
+        } else {
+            return null;
+        }
+    }
+
     cluesData () {
         return _.map(this.props.data.entries, (entry) => ({
             entry: entry,
             hasAnswered: _.every(helpers.cellsForEntry(entry), (position) => {
                 return /^[A-Z]$/.test(this.state.grid[position.x][position.y].value);
             }),
-            isSelected: this.clueInFocus() === entry
+            isSelected: this.clueIsInFocusGroup(entry)
         }));
     }
 

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -184,7 +184,6 @@ class Crossword extends React.Component {
     }
 
     moveFocus (deltaX, deltaY) {
-
         const cell = this.state.cellInFocus;
         const x = cell.x + deltaX;
         const y = cell.y + deltaY;

--- a/static/src/stylesheets/module/crosswords/_clues.scss
+++ b/static/src/stylesheets/module/crosswords/_clues.scss
@@ -35,3 +35,12 @@
 .crossword__clue--answered {
     color: colour(neutral-2);
 }
+
+.crossword__clue--display-group-order {
+
+    padding-left: 0px;
+
+    &:before {
+        position: relative;
+    }
+}

--- a/static/src/stylesheets/module/crosswords/_clues.scss
+++ b/static/src/stylesheets/module/crosswords/_clues.scss
@@ -40,7 +40,8 @@
 
     padding-left: 0px;
 
+    //For grouped clues we display 11.12,23 accross instead of just a number
     &:before {
-        position: relative;
+        position: initial;
     }
 }


### PR DESCRIPTION
For the clues like the mega-clue in http://www.theguardian.com/crosswords/cryptic/26666 ( 2 down ), change the way the clue is displayed so that the order of the word is included ( as shown ). Also, when such a clue is selected highlight all constituent.

![clue-nomenclature](https://cloud.githubusercontent.com/assets/986155/9738528/d5e04646-5643-11e5-8f9e-15ab2972cfd9.png)

![clue-hilite](https://cloud.githubusercontent.com/assets/986155/9738529/d5e3a2a0-5643-11e5-91dd-c55b48dd7a8d.png)
