### PR TITLE
Sport - Parse match stats for rugby

### DIFF
--- a/common/app/common/authentication.scala
+++ b/common/app/common/authentication.scala
@@ -6,9 +6,9 @@ import play.api.mvc._
 
 trait AuthLogging {
   self: Logging =>
-  def log[U](msg: String, request: Request[AnyContent]) {
+  def log[Any](msg: String, request: Request[AnyContent]) {
     request match {
-      case auth: Security.AuthenticatedRequest[AnyContent, U] => log.info(auth.user + ": " + msg)
+      case auth: Security.AuthenticatedRequest[_, _] => log.info(auth.user + ": " + msg)
       case _ => throw new IllegalStateException("Expected an authenticated request")
     }
   }

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -16,7 +16,7 @@ trait Prototypes {
     organization := "com.gu",
     maxErrors := 20,
     javacOptions := Seq("-g","-encoding", "utf8"),
-    scalacOptions := Seq("-unchecked", "-optimise", "-deprecation", "-target:jvm-1.8",
+    scalacOptions := Seq("-unchecked", "-deprecation", "-target:jvm-1.8",
       "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings","-Xfatal-warnings"),
     doc in Compile <<= target.map(_ / "none"),
     incOptions := incOptions.value.withNameHashing(true),

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -20,7 +20,7 @@ trait Prototypes {
       "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings","-Xfatal-warnings"),
     doc in Compile <<= target.map(_ / "none"),
     incOptions := incOptions.value.withNameHashing(true),
-    scalaVersion := "2.11.4",
+    scalaVersion := "2.11.7",
     initialize := {
       val _ = initialize.value
       assert(sys.props("java.specification.version") == "1.8",

--- a/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
+++ b/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
@@ -5,7 +5,7 @@ import rugby.model._
 import rugby.model.{Team, Match, Status}
 import Status._
 
-import scala.xml.{NodeSeq, XML}
+import scala.xml.{NodeSeq, XML, MetaData, UnprefixedAttribute, Null}
 
 object Parser {
 
@@ -162,4 +162,232 @@ object Parser {
       case _ => Fixture
     }
   }
+
+
+
+  def parseLiveEventsStatsToGetMatchStat(body: String): MatchStat = {
+    val data = XML.loadString(body)
+
+    val teamsData = data \ "TeamDetail" \ "Team"
+
+    val teams: Seq[TeamStat] = teamsData.map { teamData =>
+      
+      val playersData = teamData \ "Player"
+
+      val players = playersData.map { player => 
+
+        val playerStatData = player \  "PlayerStats" \ "PlayerStat"
+
+        /* MetaData.append is extremly slow as it tries to normalize all attributes each time we append, so we chain attributes manually */ 
+        val allAttributes = chainAttributes(playerStatData.map(_.attributes))
+        val playerData = <PlayerStat />.copy(attributes = allAttributes)
+
+        PlayerStat(
+          id = (playerData \ "@id").text.toLong,
+          team_id = (playerData \ "@team_id").text.toLong,
+          game_id = (playerData \ "@game_id").text.toLong,
+          player_id = (playerData \ "@player_id").text.toLong,
+          
+          minutes = MinutesStat(
+            minutes_played_before_first_half =  (playerData \ "@minutes_played_before_first_half").text.toInt,
+            minutes_played_before_first_half_extra = (playerData \ "@minutes_played_before_first_half_extra").text.toInt,
+            minutes_played_first_half = (playerData \ "@minutes_played_first_half").text.toInt,
+            minutes_played_before_second_half = (playerData \ "@minutes_played_before_second_half").text.toInt,
+            minutes_played_before_second_half_extra = (playerData \ "@minutes_played_before_second_half_extra").text.toInt,
+            minutes_played_before_penalty_shootOut = (playerData \ "@minutes_played_before_penalty_shootOut").text.toInt,
+            minutes_played_second_half = (playerData \ "@minutes_played_second_half").text.toInt,
+            minutes_played_second_half_extra = (playerData \ "@minutes_played_second_half_extra").text.toInt,
+            minutes_played_total = (playerData \ "@minutes_played_total").text.toInt
+          ),
+
+          yellow_cards = (playerData \ "@yellow_cards").text.toInt,
+          red_card_second_yellow = (playerData \ "@red_card_second_yellow").text.toInt,
+          red_cards = (playerData \ "@red_cards").text.toInt,
+          dropped_catch = (playerData \ "@dropped_catch").text.toInt,
+          clean_breaks = (playerData \ "@clean_breaks").text.toInt,
+          goals = (playerData \ "@goals").text.toInt,
+          points = (playerData \ "@points").text.toInt,
+          passes = (playerData \ "@passes").text.toInt,
+          runs = (playerData \ "@runs").text.toInt,
+          defenders_beaten = (playerData \ "@defenders_beaten").text.toInt,
+          gain_line = (playerData \ "@gain_line").text.toInt,
+          metres = (playerData \ "@metres").text.toInt,
+          offload = (playerData \ "@offload").text.toInt,
+          pickup = (playerData \ "@pickup").text.toInt,
+          bad_passes = (playerData \ "@bad_passes").text.toInt,
+          handling_error = (playerData \ "@handling_error").text.toInt,
+          ball_out_of_play = (playerData \ "@ball_out_of_play").text.toInt,
+          tackles = (playerData \ "@tackles").text.toInt,
+          tackle_success = (playerData \ "@tackle_success").text.toFloat,
+          missed_tackles = (playerData \ "@missed_tackles").text.toInt,
+          
+          carries = CarriesStat(
+            carries_crossed_gain_line = (playerData \ "@carries_crossed_gain_line").text.toInt,
+            carries_metres = (playerData \ "@carries_metres").text.toInt,
+            carries_not_made_gain_line = (playerData \ "@carries_not_made_gain_line").text.toInt,
+            carries_support = (playerData \ "@carries_support").text.toInt
+          ),
+
+          rucks_won = (playerData \ "@rucks_won").text.toInt,
+          rucks_lost = (playerData \ "@rucks_lost").text.toInt,
+          
+          mauls = MaulsStat(
+            mauls_won = (playerData \ "@mauls_won").text.toInt,
+            mauls_won_outright = (playerData \ "@mauls_won_outright").text.toInt,
+            mauls_won_penalty = (playerData \ "@mauls_won_penalty").text.toInt,
+            mauls_won_try = (playerData \ "@mauls_won_try").text.toInt,
+            mauls_won_penalty_try = (playerData \ "@mauls_won_penalty_try").text.toInt,
+            mauls_lost = (playerData \ "@mauls_lost").text.toInt,
+            mauls_lost_outright = (playerData \ "@mauls_lost_outright").text.toInt,
+            mauls_lost_turnover = (playerData \ "@mauls_lost_turnover").text.toInt
+          ),
+
+          scrums = ScrumsStat(
+            scrums_won_penalty_try = (playerData \ "@scrums_won_penalty_try").text.toInt,
+            scrums_won_free_kick = (playerData \ "@scrums_won_free_kick").text.toInt,
+            scrums_won_pushover_try = (playerData \ "@scrums_won_pushover_try").text.toInt,
+            scrums_won_outright = (playerData \ "@scrums_won_outright").text.toInt,
+            scrums_lost_reversed = (playerData \ "@scrums_lost_reversed").text.toInt,
+            scrums_lost_outright = (playerData \ "@scrums_lost_outright").text.toInt,
+            scrums_lost_penalty = (playerData \ "@scrums_lost_penalty").text.toInt,
+            scrums_lost_free_kick = (playerData \ "@scrums_lost_free_kick").text.toInt
+          ),
+         
+          kick = KickStat(
+            kicks = (playerData \ "@kicks").text.toInt,
+            kick_charged_down = (playerData \ "@kick_charged_down").text.toInt,
+            kick_from_hand_metres = (playerData \ "@kick_from_hand_metres").text.toInt,
+            kick_metres = (playerData \ "@kick_metres").text.toInt,
+            kick_in_field = (playerData \ "@kick_in_field").text.toInt,
+            kick_in_touch = (playerData \ "@kick_in_touch").text.toInt,
+            kick_oppn_collection = (playerData \ "@kick_oppn_collection").text.toInt,
+            kick_out_of_play = (playerData \ "@kick_out_of_play").text.toInt,
+            kick_penalty_bad = (playerData \ "@kick_penalty_bad").text.toInt,
+            kick_possession_lost = (playerData \ "@kick_possession_lost").text.toInt,
+            kick_possession_retained = (playerData \ "@kick_possession_retained").text.toInt,
+            kick_percent_success = (playerData \ "@kick_percent_success").text.toFloat,
+            kick_penalty_good = (playerData \ "@kick_penalty_good").text.toInt,
+            kick_touch_in_goal = (playerData \ "@kick_touch_in_goal").text.toInt,
+            kick_try_scored = (playerData \ "@kick_try_scored").text.toInt,
+            kicks_from_hand = (playerData \ "@kicks_from_hand").text.toInt,
+            free_kick_conceded_at_lineout = (playerData \ "@free_kick_conceded_at_lineout").text.toInt,
+            free_kick_conceded_at_scrum = (playerData \ "@free_kick_conceded_at_scrum").text.toInt,
+            free_kick_conceded_in_general_play = (playerData \ "@free_kick_conceded_in_general_play").text.toInt,
+            free_kick_conceded_in_ruck_or_maul = (playerData \ "@free_kick_conceded_in_ruck_or_maul").text.toInt,
+            pc_kick_percent = (playerData \ "@pc_kick_percent").text.toFloat,
+            total_free_kicks_conceded = (playerData \ "@total_free_kicks_conceded").text.toInt,
+            kicking_competition_goals = (playerData \ "@kicking_competition_goals").text.toInt,
+            retained_kicks = (playerData \ "@retained_kicks").text.toInt,
+            true_retained_kicks = (playerData \ "@true_retained_kicks").text.toInt
+          ),
+          
+          tries = (playerData \ "@tries").text.toInt,
+          try_assist = (playerData \ "@try_assist").text.toInt,
+          try_assists = (playerData \ "@try_assists").text.toInt,
+          try_kicks = (playerData \ "@try_kicks").text.toInt,
+
+          conversion_goals = (playerData \ "@conversion_goals").text.toInt,
+          missed_conversion_goals = (playerData \ "@missed_conversion_goals").text.toInt,
+          missed_goals = (playerData \ "@missed_goals").text.toInt,
+          drop_goals_converted = (playerData \ "@drop_goals_converted").text.toInt,
+          drop_goal_missed = (playerData \ "@drop_goal_missed").text.toInt,
+          
+          lineout = LineoutStat(
+            lineout_success = (playerData \ "@lineout_success").text.toFloat,
+            lineouts_lost = (playerData \ "@lineouts_lost").text.toInt,
+            lineouts_won = (playerData \ "@lineouts_won").text.toInt,
+            lineouts_infringe_opp = (playerData \ "@lineouts_infringe_opp").text.toInt,
+            lineout_non_straight = (playerData \ "@lineout_non_straight").text.toInt,
+            lineouts_to_own_player = (playerData \ "@lineouts_to_own_player").text.toInt,
+            lineout_throw_lost_handling_error = (playerData \ "@lineout_throw_lost_handling_error").text.toInt,
+            lineout_throw_lost_free_kick = (playerData \ "@lineout_throw_lost_free_kick").text.toInt,
+            lineout_throw_lost_outright = (playerData \ "@lineout_throw_lost_outright").text.toInt,
+            lineout_throw_lost_not_straight = (playerData \ "@lineout_throw_lost_not_straight").text.toInt,
+            lineout_throw_lost_penalty = (playerData \ "@lineout_throw_lost_penalty").text.toInt,
+            lineout_throw_won_penalty = (playerData \ "@lineout_throw_won_penalty").text.toInt,
+            lineout_throw_won_tap = (playerData \ "@lineout_throw_won_tap").text.toInt,
+            lineout_throw_won_clean = (playerData \ "@lineout_throw_won_clean").text.toInt,
+            lineout_throw_won_free_kick = (playerData \ "@lineout_throw_won_free_kick").text.toInt,
+            lineout_won_opp_throw = (playerData \ "@lineout_won_opp_throw").text.toInt,
+            lineout_won_own_throw = (playerData \ "@lineout_won_own_throw").text.toInt,
+            lineout_won_steal = (playerData \ "@lineout_won_steal").text.toInt,
+            total_lineouts = (playerData \ "@total_lineouts").text.toInt
+          ),
+
+          collection = CollectionStat(
+            collection_loose_ball = (playerData \ "@collection_loose_ball").text.toInt,
+            collection_failed = (playerData \ "@collection_failed").text.toInt,
+            collection_from_kick = (playerData \ "@collection_from_kick").text.toInt,
+            collection_interception = (playerData \ "@collection_interception").text.toInt,
+            collection_success = (playerData \ "@collection_success").text.toFloat
+          ),
+
+          restart = RestartStat(
+            restart_22m = (playerData \ "@restart_22m").text.toInt,
+            restart_error_not_ten = (playerData \ "@restart_error_not_ten").text.toInt,
+            restart_error_out_of_play = (playerData \ "@restart_error_out_of_play").text.toInt,
+            restart_halfway = (playerData \ "@restart_halfway").text.toInt,
+            restarts_lost = (playerData \ "@restarts_lost").text.toInt,
+            restart_opp_error = (playerData \ "@restart_opp_error").text.toInt,
+            restart_own_player = (playerData \ "@restart_own_player").text.toInt,
+            restarts_success = (playerData \ "@restarts_success").text.toFloat,
+            restarts_won = (playerData \ "@restarts_won").text.toInt            
+          ),
+
+          penalties = PenaltiesStat(
+            penalties_conceded = (playerData \ "@penalties_conceded").text.toInt,
+            penalty_conceded_collapsing_offence = (playerData \ "@penalty_conceded_collapsing_offence").text.toInt,
+            penalty_conceded_collapsing_maul = (playerData \ "@penalty_conceded_collapsing_maul").text.toInt,
+            penalty_conceded_early_tackle = (playerData \ "@penalty_conceded_early_tackle").text.toInt,
+            penalty_conceded_delib_knock_on = (playerData \ "@penalty_conceded_delib_knock_on").text.toInt,
+            penalty_conceded_dissent = (playerData \ "@penalty_conceded_dissent").text.toInt,
+            penalty_conceded_foul_play = (playerData \ "@penalty_conceded_foul_play").text.toInt,
+            penalty_conceded_high_tackle = (playerData \ "@penalty_conceded_high_tackle").text.toInt,
+            penalty_conceded_killing_ruck = (playerData \ "@penalty_conceded_killing_ruck").text.toInt,
+            penalty_conceded_offside = (playerData \ "@penalty_conceded_offside").text.toInt,
+            penalty_conceded_other = (playerData \ "@penalty_conceded_other").text.toInt,
+            penalty_conceded_own_half = (playerData \ "@penalty_conceded_own_half").text.toInt,
+            penalty_conceded_opp_half = (playerData \ "@penalty_conceded_opp_half").text.toInt,
+            penalty_conceded_lineout_offence = (playerData \ "@penalty_conceded_lineout_offence").text.toInt,
+            penalty_conceded_line_out_offence = (playerData \ "@penalty_conceded_line_out_offence").text.toInt,
+            penalty_conceded_handling_in_ruck  = (playerData \ "@penalty_conceded_handling_in_ruck").text.toInt,
+            penalty_conceded_obstruction = (playerData \ "@penalty_conceded_obstruction").text.toInt,
+            penalty_conceded_scrum_offence = (playerData \ "@penalty_conceded_scrum_offence").text.toInt,
+            penalty_conceded_stamping = (playerData \ "@penalty_conceded_stamping").text.toInt,
+            penalty_conceded_wrong_side = (playerData \ "@penalty_conceded_wrong_side").text.toInt,
+            pen_defs = (playerData \ "@pen_defs").text,
+            pen_offs = (playerData \ "@pen_offs").text,
+            penalty_goals = (playerData \ "@penalty_goals").text.toInt,
+            missed_penalty_goals = (playerData \ "@missed_penalty_goals").text.toInt,
+            penalty_kick_for_touch_metres = (playerData \ "@penalty_kick_for_touch_metres").text.toInt
+          ),
+          
+          turnover = TurnoverStat (
+            turnover_bad_pass = (playerData \ "@turnover_bad_pass").text.toInt,
+            turnover_carried_in_touch = (playerData \ "@turnover_carried_in_touch").text.toInt,
+            turnover_carried_over = (playerData \ "@turnover_carried_over").text.toInt,
+            turnover_forward_pass = (playerData \ "@turnover_forward_pass").text.toInt,
+            turnover_kick_error = (playerData \ "@turnover_kick_error").text.toInt,
+            turnover_knock_on = (playerData \ "@turnover_knock_on").text.toInt,
+            turnover_lost_in_ruck_or_maul = (playerData \ "@turnover_lost_in_ruck_or_maul").text.toInt,
+            turnover_own_half = (playerData \ "@turnover_own_half").text.toInt,
+            turnover_opp_half = (playerData \ "@turnover_opp_half").text.toInt,
+            turnover_won = (playerData \ "@turnover_won").text.toInt,
+            turnovers_conceded = (playerData \ "@turnovers_conceded").text.toInt,
+            turnover_turnover_forward_pass = (playerData \ "@turnover_turnover_forward_pass").text.toInt
+          )
+        )
+      }
+      TeamStat((teamData \ "@team_id").text.toLong, (teamData \ "@team_name").text, players)
+    }
+    MatchStat(teams)
+  }
+
+  private def chainAttributes(attributes: Iterable[MetaData]): MetaData = {
+    attributes match {
+      case Nil => Null
+      case head :: tail => new UnprefixedAttribute(head.key, head.value, chainAttributes(tail))
+    }
+  }
+
 }

--- a/sport/app/rugby/model/rugby.scala
+++ b/sport/app/rugby/model/rugby.scala
@@ -88,3 +88,256 @@ object Status {
   object SuddenDeath extends Status           // Occurs after extra time and essentially means the first point scorer in this period wins
   object ShootOut extends Status              // This is after sudden death and involves players taking drop kicks
 }
+
+
+case class MatchStat (
+  teams: Seq[TeamStat]
+)
+
+case class TeamStat (
+  id: Long,
+  name: String,
+  players: Seq[PlayerStat]
+)
+
+case class PlayerStat (
+     
+   /* non statistics info */ 
+   id: Long,
+   team_id: Long,
+   game_id: Long,
+   player_id: Long,
+
+   /* time info */
+   minutes: MinutesStat,
+
+   /* Suspension infos */ 
+   yellow_cards: Int,
+   red_card_second_yellow: Int,
+   red_cards: Int,
+
+   /* Unknow info */ 
+   dropped_catch: Int,
+   clean_breaks: Int,
+   
+   /* General positive stats */
+   goals: Int,
+   points: Int,
+   passes: Int,
+   runs: Int,
+   defenders_beaten: Int,
+   gain_line: Int,
+   metres: Int,
+   offload: Int,
+   pickup: Int,
+
+   /* General error stats */
+   bad_passes: Int,
+   handling_error: Int,
+   ball_out_of_play: Int,
+
+   /* tackle info  */ 
+   tackles: Int,
+   tackle_success: Float,
+   missed_tackles: Int,
+
+   /* Carries info */ 
+   carries: CarriesStat,
+
+   /* Rucks info */
+   rucks_won: Int,
+   rucks_lost: Int,
+
+   /* Mauls info */
+   mauls: MaulsStat,
+
+
+   /* Scrums info */ 
+   scrums: ScrumsStat,
+
+   /* kicks info */
+   kick: KickStat,
+
+   tries: Int,
+   try_assist: Int,
+   try_assists: Int,
+   try_kicks: Int,
+
+   conversion_goals: Int,
+   missed_conversion_goals: Int,
+
+   missed_goals: Int,
+   drop_goals_converted: Int,
+   drop_goal_missed: Int,
+
+
+   /* Lineout info */
+   lineout: LineoutStat,
+   
+   /* Collection info */ 
+   collection: CollectionStat,
+
+   /* Restart info */
+   restart: RestartStat,
+
+   /* Penalties info */
+   penalties: PenaltiesStat,
+
+   /* turnover info */
+   turnover: TurnoverStat
+)
+
+
+case class MinutesStat (
+  minutes_played_before_first_half: Int,
+  minutes_played_before_first_half_extra: Int,
+  minutes_played_first_half: Int,
+  minutes_played_before_second_half: Int,
+  minutes_played_before_second_half_extra: Int,
+  minutes_played_before_penalty_shootOut: Int,
+  minutes_played_second_half: Int,
+  minutes_played_second_half_extra: Int,
+  minutes_played_total: Int
+)
+
+case class CarriesStat (
+  carries_crossed_gain_line: Int,
+  carries_metres: Int,
+  carries_not_made_gain_line: Int,
+  carries_support: Int
+)
+
+case class MaulsStat (
+  mauls_won: Int,
+  mauls_won_outright: Int,
+  mauls_won_penalty: Int,
+  mauls_won_try: Int,
+  mauls_won_penalty_try: Int,
+  mauls_lost: Int,
+  mauls_lost_outright: Int,
+  mauls_lost_turnover: Int
+)
+
+case class ScrumsStat (
+  scrums_won_penalty_try: Int,
+  scrums_won_free_kick: Int,
+  scrums_won_pushover_try: Int,
+  scrums_won_outright: Int,
+  scrums_lost_reversed: Int,
+  scrums_lost_outright: Int,
+  scrums_lost_penalty: Int,
+  scrums_lost_free_kick: Int
+)
+
+case class KickStat (
+  kicks: Int,
+  kick_charged_down: Int,
+  kick_from_hand_metres: Int,
+  kick_metres: Int,
+  kick_in_field: Int,
+  kick_in_touch: Int,
+  kick_oppn_collection: Int,
+  kick_out_of_play: Int,
+  kick_penalty_bad: Int,
+  kick_possession_lost: Int,
+  kick_possession_retained: Int,
+  kick_percent_success: Float,
+  kick_penalty_good: Int,
+  kick_touch_in_goal: Int,
+  kick_try_scored: Int,
+  kicks_from_hand: Int,
+  free_kick_conceded_at_lineout: Int,
+  free_kick_conceded_at_scrum: Int,
+  free_kick_conceded_in_general_play: Int,
+  free_kick_conceded_in_ruck_or_maul: Int,
+  pc_kick_percent: Float,
+  total_free_kicks_conceded: Int,
+  kicking_competition_goals: Int,
+  retained_kicks: Int,
+  true_retained_kicks: Int
+)
+
+case class LineoutStat (
+  lineout_success: Float,
+  lineout_non_straight: Int,
+  lineout_throw_lost_handling_error: Int,
+  lineout_throw_lost_free_kick: Int,
+  lineout_throw_lost_outright: Int,
+  lineout_throw_lost_not_straight: Int,
+  lineout_throw_lost_penalty: Int,
+  lineout_throw_won_penalty: Int,
+  lineout_throw_won_tap: Int,
+  lineout_throw_won_clean: Int,
+  lineout_throw_won_free_kick: Int,
+  lineout_won_opp_throw: Int,
+  lineout_won_own_throw: Int,
+  lineout_won_steal: Int,
+  lineouts_to_own_player: Int,
+  lineouts_lost: Int,
+  lineouts_won: Int,
+  lineouts_infringe_opp: Int,
+  total_lineouts: Int
+)
+
+case class CollectionStat (
+  collection_loose_ball: Int,
+  collection_failed: Int,
+  collection_from_kick: Int,
+  collection_interception: Int,
+  collection_success: Float
+)
+
+case class RestartStat (
+  restart_22m: Int,
+  restart_error_not_ten: Int,
+  restart_error_out_of_play: Int,
+  restart_halfway: Int,
+  restarts_lost: Int,
+  restart_opp_error: Int,
+  restart_own_player: Int,
+  restarts_success: Float,
+  restarts_won: Int
+)
+
+case class PenaltiesStat (
+   penalties_conceded: Int,
+   penalty_conceded_collapsing_offence: Int,
+   penalty_conceded_collapsing_maul: Int,
+   penalty_conceded_early_tackle: Int,
+   penalty_conceded_delib_knock_on: Int,
+   penalty_conceded_dissent: Int,
+   penalty_conceded_foul_play: Int,
+   penalty_conceded_high_tackle: Int,
+   penalty_conceded_killing_ruck: Int,
+   penalty_conceded_offside: Int,
+   penalty_conceded_other: Int,
+   penalty_conceded_own_half: Int,
+   penalty_conceded_opp_half: Int,
+   penalty_conceded_lineout_offence: Int,
+   penalty_conceded_line_out_offence: Int,
+   penalty_conceded_handling_in_ruck: Int,
+   penalty_conceded_obstruction: Int,
+   penalty_conceded_scrum_offence: Int,
+   penalty_conceded_stamping: Int,
+   penalty_conceded_wrong_side: Int,
+   pen_defs: String, /* ??? */
+   pen_offs: String, /* ??? */
+   penalty_goals: Int,
+   missed_penalty_goals: Int,
+   penalty_kick_for_touch_metres: Int
+)
+
+case class TurnoverStat (
+  turnover_bad_pass: Int,
+  turnover_carried_in_touch: Int,
+  turnover_carried_over: Int,
+  turnovers_conceded: Int,
+  turnover_forward_pass: Int,
+  turnover_kick_error: Int,
+  turnover_knock_on: Int,
+  turnover_lost_in_ruck_or_maul: Int,
+  turnover_opp_half: Int,
+  turnover_own_half: Int,
+  turnover_turnover_forward_pass: Int,
+  turnover_won: Int
+)

--- a/sport/test/rugby/model/MatchParserTest.scala
+++ b/sport/test/rugby/model/MatchParserTest.scala
@@ -76,5 +76,35 @@ import scala.io.Source
       topTryScorer.head.player.team.id should be("550")
       topTryScorer.head.player.team.name should be("England")
     }
+
+    "should parse player stats correctly" in {
+      val liveEventsStatsData = Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("rugby/feed/live-events-stats.xml")).mkString
+
+      val matchStat = rugby.feed.Parser.parseLiveEventsStatsToGetMatchStat(liveEventsStatsData)
+
+      matchStat.teams.size should be(2)
+      matchStat.teams.head.name should be("England")
+      matchStat.teams.head.players.size should be(23)
+      matchStat.teams.last.name should be("France")
+      matchStat.teams.last.players.size should be(23)
+
+      val firstEnglandPlayer = matchStat.teams.head.players.head
+
+      firstEnglandPlayer.id should be(475857)
+      firstEnglandPlayer.player_id should be(9486)
+      firstEnglandPlayer.kick.kick_from_hand_metres should be(137)
+      firstEnglandPlayer.lineout.lineout_throw_won_clean should be(1)
+      firstEnglandPlayer.collection.collection_success should be(6.00)
+      firstEnglandPlayer.tackles should be(1)
+      firstEnglandPlayer.minutes.minutes_played_total should be(49)
+
+      val lastFrancePlayer = matchStat.teams.last.players.last
+
+      lastFrancePlayer.player_id should be(19857)
+      lastFrancePlayer.turnover.turnover_won should be(1)
+      lastFrancePlayer.tackle_success should be(0.00)
+      
+
+    }
   }
 }


### PR DESCRIPTION
This is a first part of my work to try to add match statistics for rugby games during the world cup.
The associated changes are:
- Upgrade to latest scala `2.11.x` version
- Fix unchecked warning due to erasure
- Do not add `optimise` argument to scalac, due to [a scala compiler bug](https://issues.scala-lang.org/browse/SI-6782) generating a warning

```
warning: At the end of the day, could not inline @inline-marked method augmentString
```

Please not that `optimize` in scala `2.11.x` is considered a bit broken, and people recommend against using it, see [akka recommendation](http://doc.akka.io/docs/akka/snapshot/intro/getting-started.html#Do_not_use_-optimize_Scala_compiler_flag).

Scala 2.12 will use [by default a new optimizer](http://magarciaepfl.github.io/scala/).
- Update the model and parse player stats

The parsing (`parseLiveEventsStatsToGetMatchStat`) is not called apart from the test, so it should have currently no effect on `PROD`.

The next step is to parse the team stats and then display some of them using same football stats UI.
