### PR TITLE
Update scala to 2.11.7

### DIFF
--- a/common/app/common/authentication.scala
+++ b/common/app/common/authentication.scala
@@ -6,9 +6,9 @@ import play.api.mvc._
 
 trait AuthLogging {
   self: Logging =>
-  def log[U](msg: String, request: Request[AnyContent]) {
+  def log[Any](msg: String, request: Request[AnyContent]) {
     request match {
-      case auth: Security.AuthenticatedRequest[AnyContent, U] => log.info(auth.user + ": " + msg)
+      case auth: Security.AuthenticatedRequest[_, _] => log.info(auth.user + ": " + msg)
       case _ => throw new IllegalStateException("Expected an authenticated request")
     }
   }

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -20,7 +20,7 @@ trait Prototypes {
       "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings","-Xfatal-warnings"),
     doc in Compile <<= target.map(_ / "none"),
     incOptions := incOptions.value.withNameHashing(true),
-    scalaVersion := "2.11.4",
+    scalaVersion := "2.11.7",
     initialize := {
       val _ = initialize.value
       assert(sys.props("java.specification.version") == "1.8",


### PR DESCRIPTION
The update solves `170` bugs in the scala compiler since `2.11.4`.
Few examples of issues fixed that may affect us:
- exponential compile time - [SI-880](https://issues.scala-lang.org/browse/SI-880)
- jline ThreadLocal class loader leak - [SI-7673](https://issues.scala-lang.org/browse/SI-7673)
- ArrayBuffer.insert and insertAll are very slow - [SI-9043](https://issues.scala-lang.org/browse/SI-9043)
