### PR TITLE
Crosswords: fix grid size in IE

### DIFF
--- a/static/src/stylesheets/module/crosswords/_grid.scss
+++ b/static/src/stylesheets/module/crosswords/_grid.scss
@@ -78,7 +78,6 @@ $stickyClueHeight: $stickyClueVerticalPadding * 2 + ($stickyClueLineHeight * $st
 }
 
 .crossword__grid {
-    width: 100%;
-    height: auto;
+    // SVGs are inline by default
     display: block;
 }

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -17,9 +17,15 @@
         .crossword__container__game {
             @include mq(tablet) {
                 margin-left: 0 - $size;
-                width: $size;
-                height: $size;
             }
+        }
+
+        // Because the parent is floated, it has no dimensions, so we must
+        // define dimensions for the grid. (SVGs use viewBox which require
+        // the parent to have dimensions)
+        .crossword__container__grid-wrapper {
+            width: $size;
+            height: $size;
         }
 
         .crossword__controls {


### PR DESCRIPTION
Broken by https://github.com/guardian/frontend/pull/10421/files#diff-4ceabf46c6f2a019f90b3221fecb586bR17

Before:

![image](https://cloud.githubusercontent.com/assets/921609/9758310/bc77e994-56dd-11e5-9af2-51946c232e9b.png)
