### PR TITLE
Crosswords: when printing, stop clues from overlapping

### DIFF
--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -169,11 +169,6 @@ p {
 .crossword__clues {
     clear: both;
     font-size: 12px;
-    margin-left: 1cm !important;
-}
-
-.crossword__clue {
-    list-style-position: outside;
 }
 
 .crossword__clues--across,


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/921609/9759676/c45bcd3e-56e6-11e5-812e-23b28f67b10d.png)

After:
![image](https://cloud.githubusercontent.com/assets/921609/9759669/b9eb2124-56e6-11e5-8b9a-068b410dff19.png)
