### PR TITLE
Crosswords: remove auto focus

### DIFF
--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -64,18 +64,6 @@ class Crossword extends React.Component {
     }
 
     componentDidMount () {
-        // focus the first clue if we're above mobile
-        if (detect.isBreakpoint({ min: 'tablet' })) {
-            const firstClue = _.reduceRight(_.sortBy(this.props.data.entries, 'direction'), function (prev, current) {
-                return (helpers.isAcross(current) && (prev.number < current.number ? prev : current));
-            });
-            this.focusClue(
-                firstClue.position.x,
-                firstClue.position.y,
-                firstClue.direction
-            );
-        }
-
         // Sticky clue
         const $stickyClueWrapper = $(React.findDOMNode(this.refs.stickyClueWrapper));
         const $grid = $(React.findDOMNode(this.refs.grid));


### PR DESCRIPTION
We shouldn't be stealing focus when the page loads, because keyboard/screenreader users will have to navigate back up to the top of the page.

There is also a bug whereby, if we autofocus 1-across and the user taps the first cell to open the keyboard, the selection alternates to 1-down. This will be avoided if we don't autofocus.
