### PR TITLE
use GET for crossword searches

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -77,7 +77,7 @@ object CrosswordSearchController extends Controller with ExecutionContexts {
 
   def search() = Action.async { implicit request =>
     searchForm.bindFromRequest.fold(
-      empty => Future.successful(Cached(60)(Ok(views.html.crosswordSearch(CrosswordSearchPage)))),
+      empty => Future.successful(Cached(7.days)(Ok(views.html.crosswordSearch(CrosswordSearchPage)))),
 
       params => {
         val withoutSetter = LiveContentApi.item(s"crosswords/series/${params.crosswordType}")
@@ -91,13 +91,13 @@ object CrosswordSearchController extends Controller with ExecutionContexts {
 
         LiveContentApi.getResponse(maybeSetter.showFields("all")).map { response =>
           response.results match {
-            case Nil => Cached(60)(Ok(views.html.crosswordsNoResults(CrosswordSearchPage)))
+            case Nil => Cached(7.days)(Ok(views.html.crosswordsNoResults(CrosswordSearchPage)))
 
             case results =>
               val section = Section(ApiSection("crosswords", "Crosswords search results", "http://www.theguardian.com/crosswords/search", "", Nil))
               val page = IndexPage(section, results.map(Content(_)))
 
-              Cached(60)(Ok(views.html.index(page)))
+              Cached(15.minutes)(Ok(views.html.index(page)))
           }
         }
       }
@@ -109,7 +109,7 @@ object CrosswordSearchController extends Controller with ExecutionContexts {
       case CrosswordLookup(crosswordType, id) =>
         Redirect(s"$crosswordType/$id")
       case _ =>
-        Cached(60)(Ok(views.html.crosswordsNoResults(CrosswordSearchPage)))
+        Cached(7.days)(Ok(views.html.crosswordsNoResults(CrosswordSearchPage)))
     }
   }
 

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -59,13 +59,27 @@ object CrosswordsController extends Controller with ExecutionContexts {
 }
 
 object CrosswordSearchController extends Controller with ExecutionContexts {
-  def searchForm() = Action { implicit request =>
-    Cached(60)(Ok(views.html.crosswordSearch(CrosswordSearchPage)))
-  }
+  val searchForm = Form(
+    mapping(
+      "crossword_type" -> nonEmptyText,
+      "month" -> number,
+      "year" -> number,
+      "setter" -> optional(text)
+    )(CrosswordSearch.apply)(CrosswordSearch.unapply)
+  )
+
+  val lookupForm = Form(
+    mapping(
+      "type" -> text,
+      "id" -> number
+    )(CrosswordLookup.apply)(CrosswordLookup.unapply)
+  )
 
   def search() = Action.async { implicit request =>
-    CrosswordSearch.fromRequest(request) match {
-      case Some(params) =>
+    searchForm.bindFromRequest.fold(
+      empty => Future.successful(Cached(60)(Ok(views.html.crosswordSearch(CrosswordSearchPage)))),
+
+      params => {
         val withoutSetter = LiveContentApi.item(s"crosswords/series/${params.crosswordType}")
           .stringParam("from-date", params.fromDate.toString("yyyy-MM-dd"))
           .stringParam("to-date", params.toDate.toString("yyyy-MM-dd"))
@@ -77,31 +91,21 @@ object CrosswordSearchController extends Controller with ExecutionContexts {
 
         LiveContentApi.getResponse(maybeSetter.showFields("all")).map { response =>
           response.results match {
-            case Nil =>
-              NoCache(Ok(views.html.crosswordsNoResults(CrosswordSearchPage)))
+            case Nil => Cached(60)(Ok(views.html.crosswordsNoResults(CrosswordSearchPage)))
 
             case results =>
               val section = Section(ApiSection("crosswords", "Crosswords search results", "http://www.theguardian.com/crosswords/search", "", Nil))
               val page = IndexPage(section, results.map(Content(_)))
 
-              NoCache(Ok(views.html.index(page)))
+              Cached(60)(Ok(views.html.index(page)))
           }
         }
-
-      case None =>
-        Future.successful(NotFound)
-    }
+      }
+    )
   }
 
   def lookup() = Action { implicit request =>
-    val form = Form(
-      mapping(
-        "type" -> text,
-        "id" -> number
-      )(CrosswordLookup.apply)(CrosswordLookup.unapply)
-    )
-
-    form.bindFromRequest.get match {
+    lookupForm.bindFromRequest.get match {
       case CrosswordLookup(crosswordType, id) =>
         Redirect(s"$crosswordType/$id")
       case _ =>
@@ -109,27 +113,12 @@ object CrosswordSearchController extends Controller with ExecutionContexts {
     }
   }
 
-  case class CrosswordSearch(
-    crosswordType: String,
-    fromDate: DateTime,
-    toDate: DateTime,
-    setter: Option[String])
-
-  object CrosswordSearch {
-    def fromRequest(request: Request[AnyContent]): Option[CrosswordSearch] = {
-      for {
-        formMap <- request.body.asFormUrlEncoded
-        crosswordType <- formMap.get("crossword-type").map(_.mkString)
-        month <- formMap.get("month").map(_.mkString.toInt)
-        year <- formMap.get("year").map(_.mkString.toInt)
-      } yield {
-        val setter = formMap.get("setter").map(_.mkString.toLowerCase).filter(_.nonEmpty)
-        val fromDate = new DateTime(year, month, 1, 0, 0)
-        val toDate = fromDate.dayOfMonth.withMaximumValue
-
-        CrosswordSearch(crosswordType, fromDate, toDate, setter)
-      }
-    }
+  case class CrosswordSearch(crosswordType: String,
+                             month: Int,
+                             year: Int,
+                             setter: Option[String]) {
+    val fromDate = new DateTime(year, month, 1, 0, 0)
+    val toDate = fromDate.dayOfMonth.withMaximumValue
   }
 
   case class CrosswordLookup(crosswordType: String, id: Int)

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -5,7 +5,7 @@ import common.{Edition, ExecutionContexts}
 import conf.{LiveContentApi, Static}
 import crosswords.{AccessibleCrosswordRows, CrosswordData, CrosswordPage, CrosswordSearchPage, CrosswordSvg}
 import model.{Cached, Cors, _}
-import org.joda.time.DateTime
+import org.joda.time.LocalDate
 import play.api.data.Forms._
 import play.api.data._
 import play.api.mvc.{Action, Controller, RequestHeader, Result, _}
@@ -117,7 +117,7 @@ object CrosswordSearchController extends Controller with ExecutionContexts {
                              month: Int,
                              year: Int,
                              setter: Option[String]) {
-    val fromDate = new DateTime(year, month, 1, 0, 0)
+    val fromDate = new LocalDate(year, month, 1)
     val toDate = fromDate.dayOfMonth.withMaximumValue
   }
 

--- a/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
@@ -1,6 +1,6 @@
 @(page: crosswords.CrosswordSearchPage)(implicit request: RequestHeader)
 
-<form class="form" method="post" action="/crosswords/search/results">
+<form class="form" method="get" action="/crosswords/search">
     <fieldset class="fieldset">
         <div class="fieldset__heading">
             <h2 class="form__heading">Search</h2>
@@ -11,8 +11,8 @@
             <div class="form-fields__inline">
                 <ul>
                     <li class="form-field">
-                        <label class="label" for="crossword-type">Type</label>
-                        <select id="crossword-type" name="crossword-type">
+                        <label class="label" for="crossword_type">Type</label>
+                        <select id="crossword_type" name="crossword_type">
                             @page.crosswordTypes.map { crosswordType =>
                                 <option value="@crosswordType">@crosswordType</option>
                             }
@@ -61,7 +61,7 @@
     </fieldset>
 </form>
 
-<form class="form" method="post" action="/crosswords/lookup">
+<form class="form" method="get" action="/crosswords/lookup">
     <fieldset class="fieldset">
         <div class="fieldset__heading">
             <h2 class="form__heading">Lookup</h2>

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -15,9 +15,8 @@ GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|
 GET        /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id     controllers.CrosswordsController.accessibleCrossword(crosswordType: String, id: Int)
 
 # Crosswords search
-GET         /crosswords/search                                                                                               controllers.CrosswordSearchController.searchForm()
-POST        /crosswords/search/results                                                                                       controllers.CrosswordSearchController.search()
-POST        /crosswords/lookup                                                                                               controllers.CrosswordSearchController.lookup()
+GET            /crosswords/search                                                                                                controllers.CrosswordSearchController.search()
+GET            /crosswords/lookup                                                                                                controllers.CrosswordSearchController.lookup()
 
 GET        /index/subjects                                                      controllers.TagIndexController.keywords()
 GET        /index/subjects/*index                                               controllers.TagIndexController.keyword(index)

--- a/common/app/dev/DevParametersLifecycle.scala
+++ b/common/app/dev/DevParametersLifecycle.scala
@@ -58,7 +58,9 @@ trait DevParametersLifecycle extends GlobalSettings with implicits.Requests {
         !request.uri.startsWith("/px.gif")  && // diagnostics box
         !request.uri.startsWith("/ab.gif") &&
         !request.uri.startsWith("/js.gif") &&
-        !request.uri.startsWith("/tech-feedback")
+        !request.uri.startsWith("/tech-feedback") &&
+        !request.uri.startsWith("/crosswords/search") &&
+        !request.uri.startsWith("/crosswords/lookup")
       ) {
         val illegalParams = request.queryString.keySet.filterNot(allowedParams.contains(_))
         if (illegalParams.nonEmpty) {

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -28,9 +28,8 @@ GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|
 GET        /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id     controllers.CrosswordsController.accessibleCrossword(crosswordType: String, id: Int)
 
 # Crosswords search
-GET            /crosswords/search                                                                                                controllers.CrosswordSearchController.searchForm()
-POST           /crosswords/search/results                                                                                        controllers.CrosswordSearchController.search()
-POST           /crosswords/lookup                                                                                                controllers.CrosswordSearchController.lookup()
+GET            /crosswords/search                                                                                                controllers.CrosswordSearchController.search()
+GET            /crosswords/lookup                                                                                                controllers.CrosswordSearchController.lookup()
 
 # Business data
 GET        /business-data/stocks.json                 controllers.StocksController.stocks


### PR DESCRIPTION
Use GET instead of POST for crossword searches. This has a few benefits:
- allows caching
- allows users to bookmark searches
- more compliant with specs

I had to make a few changes to the way we strip query parameters for this to work, including in [fastly](https://github.com/guardian/fastly-edge-cache/pull/471)
