### PR TITLE
Separate scheduled tasks to not all run at once

### DIFF
--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -19,19 +19,24 @@ trait AdminLifecycle extends GlobalSettings with Logging {
   lazy val adminRebuildIndexRateInMinutes: Int = Configuration.indexes.adminRebuildIndexRateInMinutes
 
   private def scheduleJobs() {
+
+    //every 0, 30 seconds past the minute
     Jobs.schedule("AdminLoadJob", "0/30 * * * * ?") {
       model.abtests.AbTestJob.run()
     }
 
-    Jobs.schedule("LoadBalancerLoadJob", "0 4/15 * * * ?") {
+    //every 4, 19, 34, 49 minutes past the hour, on the 2nd second past the minute (e.g 13:04:02, 13:19:02)
+    Jobs.schedule("LoadBalancerLoadJob", "2 4/15 * * * ?") {
       LoadBalancer.refresh()
     }
 
-    Jobs.schedule("FastlyCloudwatchLoadJob", "0 0/2 * * * ?") {
+    //every 2 minutes starting 5 seconds past the minute (e.g  13:02:05, 13:04:05)
+    Jobs.schedule("FastlyCloudwatchLoadJob", "5 0/2 * * * ?") {
       FastlyCloudwatchLoadJob.run()
     }
 
-    Jobs.schedule("AnalyticsSanityCheckJob", "0 0/15 * * * ?") {
+    //every 2, 17, 32, 47 minutes past the hour, on the 12th second past the minute (e.g 13:02:12, 13:17:12)
+    Jobs.schedule("AnalyticsSanityCheckJob", "12 2/15 * * * ?") {
       AnalyticsSanityCheckJob.run()
     }
 
@@ -47,16 +52,17 @@ trait AdminLifecycle extends GlobalSettings with Logging {
       RefreshFrontsJob.runLowFrequency()
     }
 
-    Jobs.schedule("RebuildIndexJob", s"0 0/$adminRebuildIndexRateInMinutes * 1/1 * ? *") {
+    Jobs.schedule("RebuildIndexJob", s"9 0/$adminRebuildIndexRateInMinutes * 1/1 * ? *") {
       RebuildIndexJob.run()
     }
 
-    // every 30 minutes
-    Jobs.schedule("TravelOffersCacheJob", "0 1/30 * * * ? *") {
+    // every 1, 31 minutes past the hour, 14 seconds past the minute (e.g 13:01:14, 13:31:14)
+    Jobs.schedule("TravelOffersCacheJob", "14 1/30 * * * ? *") {
       TravelOffersCacheJob.run()
     }
 
-    Jobs.schedule("MatchDayRecorderJob", "0 * * * * ?") {
+    // every minute, 22 seconds past the minute (e.g 13:01:22, 13:02:22)
+    Jobs.schedule("MatchDayRecorderJob", "22 * * * * ?") {
       MatchDayRecorder.record()
     }
 
@@ -75,7 +81,8 @@ trait AdminLifecycle extends GlobalSettings with Logging {
       }
     }
 
-    Jobs.schedule("VideoEncodingsJob", "0 0/15 * * * ?") {
+    //every 7, 22, 37, 52 minutes past the hour, 28 seconds past the minute (e.g 13:07:28, 13:22:28)
+    Jobs.schedule("VideoEncodingsJob", "28 7/15 * * * ?") {
       log.info("Starting VideoEncodingsJob")
       VideoEncodingsJob.run()
     }

--- a/common/app/common/dfp/CapiLookupAgent.scala
+++ b/common/app/common/dfp/CapiLookupAgent.scala
@@ -24,9 +24,7 @@ object CapiLookupAgent extends ExecutionContexts with Logging {
     def lookup(tagType: TagType, tagName: String): Future[((TagType, String), Seq[String])] = {
       val query = LiveContentApi.tags.q(tagName).tagType(tagType.name).pageSize(50)
       val lookupResult = getResponse(query) map { response =>
-        val tags = response.results
-        log.info(s"Looking up $tagType '$tagName' gave ${tags.map(_.id)}")
-        tags
+        response.results
       } recover {
         case e: Exception =>
           log.warn(s"Failed to look up $tagType '$tagName': ${e.getMessage}")

--- a/common/app/common/jobs.scala
+++ b/common/app/common/jobs.scala
@@ -22,11 +22,13 @@ object Jobs extends Logging {
       if (outstanding.get()(name) > 0) {
         log.warn(s"didn't run scheduled job $name because the previous one is still in progress")
       } else {
+        log.info(s"Running job: $name")
         outstanding.send(map => map.updated(name, map(name) + 1))
         try {
           f()
         } finally {
           outstanding.send(map => map.updated(name, map(name) - 1))
+          log.info(s"Finished job: $name")
         }
       }
     }

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -416,7 +416,7 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
   override def onStart(app: PlayApp) {
     Jobs.deschedule("ApplicationSystemMetricsJob")
     super.onStart(app)
-
+    //run every minute, 36 seconds after the minute
     Jobs.schedule("ApplicationSystemMetricsJob", "36 * * * * ?"){
       report()
     }

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -417,7 +417,7 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
     Jobs.deschedule("ApplicationSystemMetricsJob")
     super.onStart(app)
 
-    Jobs.schedule("ApplicationSystemMetricsJob", "0 * * * * ?"){
+    Jobs.schedule("ApplicationSystemMetricsJob", "36 * * * * ?"){
       report()
     }
   }

--- a/common/app/conf/GlobalSettings.scala
+++ b/common/app/conf/GlobalSettings.scala
@@ -39,6 +39,7 @@ trait SwitchboardLifecycle extends GlobalSettings with ExecutionContexts with Lo
   override def onStart(app: Application) {
     super.onStart(app)
     Jobs.deschedule("SwitchBoardRefreshJob")
+    //run every minute, 47 seconds after the minute
     Jobs.schedule("SwitchBoardRefreshJob", "47 * * * * ?") {
       refresh()
     }

--- a/common/app/conf/GlobalSettings.scala
+++ b/common/app/conf/GlobalSettings.scala
@@ -39,7 +39,7 @@ trait SwitchboardLifecycle extends GlobalSettings with ExecutionContexts with Lo
   override def onStart(app: Application) {
     super.onStart(app)
     Jobs.deschedule("SwitchBoardRefreshJob")
-    Jobs.schedule("SwitchBoardRefreshJob", "0 * * * * ?") {
+    Jobs.schedule("SwitchBoardRefreshJob", "47 * * * * ?") {
       refresh()
     }
 

--- a/common/app/ophan/SurgingContentAgent.scala
+++ b/common/app/ophan/SurgingContentAgent.scala
@@ -63,8 +63,8 @@ trait SurgingContentAgentLifecycle extends GlobalSettings {
 
     Jobs.deschedule("SurgingContentAgentRefreshJob")
 
-    // update every 30 min
-    Jobs.schedule("SurgingContentAgentRefreshJob",  "0 0/30 * * * ?") {
+    // update every 30 min, on the 51st second past the minute (e.g 13:09:51, 13:39:51)
+    Jobs.schedule("SurgingContentAgentRefreshJob",  "51 9/30 * * * ?") {
       SurgingContentAgent.update()
     }
 

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -128,13 +128,13 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
 
 object ConfigAgent extends ConfigAgentTrait
 
-trait ConfigAgentLifecycle extends GlobalSettings {
+trait  ConfigAgentLifecycle extends GlobalSettings {
 
   override def onStart(app: Application) {
     super.onStart(app)
 
     Jobs.deschedule("ConfigAgentJob")
-    Jobs.schedule("ConfigAgentJob", "0 * * * * ?") {
+    Jobs.schedule("ConfigAgentJob", "18 * * * * ?") {
       ConfigAgent.refresh()
     }
 

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -128,7 +128,7 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
 
 object ConfigAgent extends ConfigAgentTrait
 
-trait  ConfigAgentLifecycle extends GlobalSettings {
+trait ConfigAgentLifecycle extends GlobalSettings {
 
   override def onStart(app: Application) {
     super.onStart(app)


### PR DESCRIPTION
Based on some of the work @johnduffell did in #10425 we're trying to understand which job could possibly killing the admin boxes every couple hours. Many of the jobs are set to run at the same time so I've had separated them out a bit and added comments to show what they are doing (to save the next person trying to figure this out).

Two handy links for quartz scheduler:
[Cron Triggers](http://quartz-scheduler.org/generated/2.2.1/html/qs-all/#page/Quartz_Scheduler_Documentation_Set%2Fco-trg_crontriggers.html%23)
[Quartz test a cron expression](http://www.devexp.eu/2009/08/18/quartz-test-a-cron-expression/)
