### PR TITLE
Crosswords: add warning colour on buttons in confirm state

### DIFF
--- a/static/src/javascripts/es6/projects/common/modules/crosswords/confirm-button.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/confirm-button.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 export default class ConfirmButton extends React.Component {
     constructor (props) {
@@ -21,8 +22,15 @@ export default class ConfirmButton extends React.Component {
         const inner = this.state.confirming ?
             'Confirm ' + this.props.text.toLowerCase() : this.props.text;
 
+        const className = classNames({
+            [this.props.className]: true,
+            'crossword__controls__button--confirm': this.state.confirming
+        });
+
         return (
-            <button {...this.props} onClick={this.confirm.bind(this)}>
+            <button {...this.props}
+                onClick={this.confirm.bind(this)}
+                className={className}>
                 {inner}
             </button>
         );

--- a/static/src/stylesheets/module/crosswords/_controls.scss
+++ b/static/src/stylesheets/module/crosswords/_controls.scss
@@ -10,6 +10,13 @@
         color: colour(neutral-2);
     }
 
+    // Extra specificity needed to overcome above rule
+    .crossword__controls__button--confirm {
+        background-color: colour(comment-support-3);
+        color: #000000;
+        border: none;
+    }
+
     .button--crossword--current {
         @include button-colour(
             $fill-colour: lighten(colour(crosswordAccent2), 30%),


### PR DESCRIPTION
We've had a few users reporting the check all button doesn't work. In actual fact, these users did not see the button change to it's confirm state.

This change colours the button orange when it is in its confirm state, so the user will hopefully notice the CTA.

![1](https://cloud.githubusercontent.com/assets/921609/9768371/3060cc12-571b-11e5-9a67-ad77ef6a87ba.gif)

/cc @ScottPainterGNM 
