### PR TITLE
clustered jspm bundling

### DIFF
--- a/cluster-bundle.js
+++ b/cluster-bundle.js
@@ -126,10 +126,14 @@ function writeConfig() {
         return processedBundles[key];
     });
 
-    console.log(bundles);
-
     var configFilePath = path.join(jspmBaseUrl, 'systemjs-bundle-config.js');
     var configFileData = 'System.config({ bundles: ' + JSON.stringify(bundles, null, '\t') + ' })';
+
+    console.log('writing to %s', configFilePath);
+    fs.writeFile(configFilePath, configFileData, function (e) {
+        if (e) return process.exit(1);
+        process.exit(0);
+    });
 }
 
 function updateBundles(message) {
@@ -151,7 +155,11 @@ function writeConfig() {
     var configFileData = 'System.config({ bundles: ' + JSON.stringify(configs, null, '\t') + ' })';
 
     console.log('writing to %s', configFilePath);
-    fs.writeFile(configFilePath, configFileData, process.exit(0).bind());
+
+    fs.writeFile(configFilePath, configFileData, function (e) {
+        if (e) return process.exit(1);
+        process.exit(0);
+    });
 }
 
 if (cluster.isMaster) {

--- a/cluster-bundle.js
+++ b/cluster-bundle.js
@@ -163,6 +163,8 @@ function writeConfig() {
 }
 
 if (cluster.isMaster) {
+    console.log('using', numCPUs, 'cores');
+
     for (var i = 0; i < numCPUs; i++) {
         var worker = cluster.fork({ num: i });
 
@@ -197,7 +199,7 @@ if (cluster.isMaster) {
         }, {});
 
         process.send({ id: process.env.num, configs: configs });
-        process.exit();
+        process.exit(0);
     }).catch(function (err) {
         console.error(err);
         process.exit(1);

--- a/cluster-bundle.js
+++ b/cluster-bundle.js
@@ -100,9 +100,10 @@ function makeDirectory(bundle) {
 function writeBundleToDisk(bundle) {
     var bundleFileName = path.join(prefixPath, bundle.uri);
 
-    return new Promise(function (resolve) {
+    return new Promise(function (resolve, reject) {
         console.log('writing to %s', bundleFileName);
-        fs.writeFile(bundleFileName, bundle.source + '\n//# sourceMappingURL=' + path.basename(bundleFileName) + '.map', function () {
+        fs.writeFile(bundleFileName, bundle.source + '\n//# sourceMappingURL=' + path.basename(bundleFileName) + '.map', function (e) {
+            if (e) return reject(e);
             resolve(bundle);
         });
     });
@@ -111,9 +112,10 @@ function writeBundleToDisk(bundle) {
 function writeBundleMapToDisk(bundle) {
     var bundleMapFileName = path.join(prefixPath, bundle.uri) + '.map';
 
-    return new Promise(function (resolve) {
+    return new Promise(function (resolve, reject) {
         console.log('writing to %s', bundleMapFileName);
-        fs.writeFile(bundleMapFileName, bundle.sourceMap, function () {
+        fs.writeFile(bundleMapFileName, bundle.sourceMap, function (e) {
+            if (e) return reject(e);
             resolve(bundle);
         });
     });

--- a/cluster-bundle.js
+++ b/cluster-bundle.js
@@ -1,0 +1,195 @@
+/*eslint-env node*/
+'use strict';
+
+var numCPUs = require('os').cpus().length;
+
+var cluster = require('cluster');
+var path = require('path');
+var crypto = require('crypto');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+
+var jspm = require('jspm');
+var builder = new jspm.Builder();
+// Temporary hack, as per https://github.com/systemjs/systemjs/issues/533#issuecomment-113525639
+global.System = builder.loader;
+// Execute the IIFE
+global.systemJsRuntime = false;
+require(path.join(__dirname, 'static/src/systemjs-normalize'));
+
+var jspmBaseUrl = 'static/src';
+var prefixPath = 'static/hash';
+var bundlesUri = 'bundles';
+
+var bundleConfigs = split([
+    ['core + system-script + domready', 'core'],
+    ['es6/bootstraps/crosswords - core', 'crosswords'],
+    ['bootstraps/accessibility - core - bootstraps/app - bootstraps/facia', 'accessibility'],
+    ['bootstraps/app - core', 'app'],
+    ['bootstraps/commercial - core', 'commercial'],
+    ['bootstraps/sudoku - core - bootstraps/app', 'sudoku'],
+    ['bootstraps/image-content - core - bootstraps/app', 'image-content'],
+    ['bootstraps/facia - core - bootstraps/app', 'facia'],
+    ['bootstraps/football - core - bootstraps/app', 'football'],
+    ['bootstraps/preferences - core - bootstraps/app', 'preferences'],
+    ['bootstraps/membership - core - bootstraps/app', 'membership'],
+    ['bootstraps/article - core - bootstraps/app', 'article'],
+    ['bootstraps/liveblog - core - bootstraps/app', 'liveblog'],
+    ['bootstraps/gallery - core - bootstraps/app', 'gallery'],
+    ['bootstraps/trail - core - bootstraps/app', 'trail'],
+    ['bootstraps/profile - core - bootstraps/app', 'profile'],
+    ['bootstraps/ophan - core', 'ophan'],
+    ['bootstraps/admin - core', 'admin'],
+    // Odd issue when bundling admin with core: https://github.com/jspm/jspm-cli/issues/806
+    // ['bootstraps/admin', 'admin'],
+    ['bootstraps/video-player - core', 'video-player'],
+    ['bootstraps/video-embed - core', 'video-embed'],
+    // Odd issue when bundling admin with core: https://github.com/jspm/jspm-cli/issues/806
+    // ['bootstraps/video-embed', 'video-embed'],
+    ['bootstraps/dev - core - bootstraps/app', 'dev'],
+    ['bootstraps/creatives - core - bootstraps/app', 'creatives'],
+    ['zxcvbn', 'zxcvbn']
+], numCPUs);
+
+var processedBundles = {};
+
+// from http://stackoverflow.com/questions/8188548/splitting-a-js-array-into-n-arrays
+function split(a, n) {
+    var len = a.length,out = [], i = 0;
+    while (i < len) {
+        var size = Math.ceil((len - i) / n--);
+        out.push(a.slice(i, i += size));
+    }
+    return out;
+}
+
+var getHash = function (outputSource) {
+    return crypto.createHash('md5')
+        .update(outputSource)
+        .digest('hex');
+};
+
+builder.config({
+    minify: true,
+    sourceMaps: true,
+    sourceMapContents: true
+});
+
+function processBuild(moduleExpression, outName) {
+    return function (bundle) {
+        var hash = getHash(bundle.source);
+
+        // The id is the first part of the arithmetic expression, the string up to the first space character.
+        bundle.id = /^[^\s]*/.exec(moduleExpression)[0];
+        // Relative to jspm client base URL
+        bundle.uri = path.join(bundlesUri, outName, hash, outName + '.js');
+
+        return bundle;
+    };
+}
+
+function makeDirectory(bundle) {
+    return new Promise(function (resolve, reject) {
+        mkdirp(path.dirname(path.join(prefixPath, bundle.uri)), function (e) {
+            if (e) return reject(e);
+            resolve(bundle);
+        });
+    });
+}
+
+function writeBundleToDisk(bundle) {
+    var bundleFileName = path.join(prefixPath, bundle.uri);
+
+    return new Promise(function (resolve) {
+        console.log('writing to %s', bundleFileName);
+        fs.writeFile(bundleFileName, bundle.source + '\n//# sourceMappingURL=' + path.basename(bundleFileName) + '.map', function () {
+            resolve(bundle);
+        });
+    });
+}
+
+function writeBundleMapToDisk(bundle) {
+    var bundleMapFileName = path.join(prefixPath, bundle.uri) + '.map';
+
+    return new Promise(function (resolve) {
+        console.log('writing to %s', bundleMapFileName);
+        fs.writeFile(bundleMapFileName, bundle.sourceMap, function () {
+            resolve(bundle);
+        });
+    });
+}
+
+function writeConfig() {
+    var bundles = Object.keys(processedBundles).map(function (key) {
+        return processedBundles[key];
+    });
+
+    console.log(bundles);
+
+    var configFilePath = path.join(jspmBaseUrl, 'systemjs-bundle-config.js');
+    var configFileData = 'System.config({ bundles: ' + JSON.stringify(bundles, null, '\t') + ' })';
+}
+
+function updateBundles(message) {
+    processedBundles[message.id] = message.configs;
+}
+
+function writeConfig() {
+    var configs = Object.keys(processedBundles).reduce(function (acc, key) {
+        var bundles = processedBundles[key];
+
+        Object.keys(bundles).map(function (bundleKey) {
+            acc[bundleKey] = bundles[bundleKey];
+        });
+
+        return acc;
+    }, {});
+
+    var configFilePath = path.join(jspmBaseUrl, 'systemjs-bundle-config.js');
+    var configFileData = 'System.config({ bundles: ' + JSON.stringify(configs, null, '\t') + ' })';
+
+    console.log('writing to %s', configFilePath);
+    fs.writeFile(configFilePath, configFileData, process.exit(0).bind());
+}
+
+if (cluster.isMaster) {
+    for (var i = 0; i < numCPUs; i++) {
+        var worker = cluster.fork({ num: i });
+
+        worker.on('message', updateBundles);
+    }
+
+    cluster.on('exit', function (worker, code) {
+        if (code !== 0) return process.exit(code);
+
+        for (var id in cluster.workers) {
+            if (cluster.workers[id].isConnected()) return;
+        }
+
+        writeConfig();
+    });
+} else {
+    var configs = bundleConfigs[process.env.num];
+
+    Promise.all(configs.map(function (config) {
+        var moduleExpression = config[0];
+        var outName = config[1];
+
+        return builder.build(moduleExpression, null)
+            .then(processBuild(moduleExpression, outName))
+            .then(makeDirectory)
+            .then(writeBundleToDisk)
+            .then(writeBundleMapToDisk);
+    })).then(function (bundles) {
+        var configs = bundles.reduce(function (accumulator, bundle) {
+            accumulator[bundle.uri.replace('.js', '')] = [bundle.id];
+            return accumulator;
+        }, {});
+
+        process.send({ id: process.env.num, configs: configs });
+        process.exit();
+    }).catch(function (err) {
+        console.error(err);
+        process.exit(1);
+    });
+}

--- a/grunt-configs/shell.js
+++ b/grunt-configs/shell.js
@@ -52,7 +52,7 @@ module.exports = function(grunt, options) {
 
         jspmBundleStatic: {
             command:
-                'node ./bundle',
+                'node ./cluster-bundle',
             options: {
                 execOptions: {
                     cwd: '.'


### PR DESCRIPTION
This uses node's [cluster](https://nodejs.org/api/cluster.html) library for multi-core jspm bundling.

The list of bundles is divided between each CPU core, each one works on a separate set of modules, and the results are sent back to the master process to write `systemjs-bundle-config.js`. 

On my laptop (4 cores) it takes 25-30 seconds to complete instead of about 2 minutes. Our agents have 8 cores available to node so should be even quicker :speedboat: :racehorse: 
