### PR TITLE
Sport - rugby add team stats

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -824,6 +824,15 @@ object Switches {
     exposeClientSide = true
   )
 
+  val RugbyWorldCupMatchStatsSwitch = Switch(
+    "Feature",
+    "rugby-world-cup-match-stats",
+    "If this switch is on rugby world cup stats will be loaded in to rugby match reports and liveblogs",
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val WeatherSwitch = Switch(
     "Feature",
     "weather",

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -829,7 +829,7 @@ object Switches {
     "rugby-world-cup-match-stats",
     "If this switch is on rugby world cup stats will be loaded in to rugby match reports and liveblogs",
     safeState = Off,
-    sellByDate = never,
+    sellByDate = new LocalDate(2015, 11, 6),
     exposeClientSide = true
   )
 

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -16,7 +16,7 @@ trait Prototypes {
     organization := "com.gu",
     maxErrors := 20,
     javacOptions := Seq("-g","-encoding", "utf8"),
-    scalacOptions := Seq("-unchecked", "-optimise", "-deprecation", "-target:jvm-1.8",
+    scalacOptions := Seq("-unchecked", "-deprecation", "-target:jvm-1.8",
       "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings","-Xfatal-warnings"),
     doc in Compile <<= target.map(_ / "none"),
     incOptions := incOptions.value.withNameHashing(true),

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -20,33 +20,33 @@ trait RugbyLifecycle extends GlobalSettings with ExecutionContexts {
     }
 
     Jobs.deschedule("FixturesAndResults")
-    Jobs.schedule("FixturesAndResults", "0 0/30 * * * ?") {
+    Jobs.schedule("FixturesAndResults", "5 0/5 * * * ?") {
       RugbyStatsJob.fixturesAndResults(OptaFeed.getFixturesAndResults)
     }
 
     Jobs.deschedule("LiveEventScores")
-    Jobs.schedule("LiveEventScores", "0 * * * * ?") {
+    Jobs.schedule("LiveEventScores", "10 * * * * ?") {
       RugbyStatsJob.fetchLiveScoreEvents
     }
 
     Jobs.deschedule("PastEventScores")
-    Jobs.schedule("PastEventScores", "0 0/30 * * * ?") {
+    Jobs.schedule("PastEventScores", "15 0/5 * * * ?") {
       RugbyStatsJob.fetchPastScoreEvents
     }
 
     Jobs.deschedule("LiveMatchesStat")
-    Jobs.schedule("LiveMatchesStat", "0 * * * * ?") {
+    Jobs.schedule("LiveMatchesStat", "20 * * * * ?") {
       RugbyStatsJob.fetchLiveMatchesStat
     }
 
     Jobs.deschedule("PastMatchesStat")
-    Jobs.schedule("PastMatchesStat", "0 0/30 * * * ?") {
+    Jobs.schedule("PastMatchesStat", "25 0/5 * * * ?") {
       RugbyStatsJob.fetchPastMatchesStat
     }
 
 
     Jobs.deschedule("MatchNavArticles")
-    Jobs.schedule("MatchNavArticles", "0 0/2 * * * ?") {
+    Jobs.schedule("MatchNavArticles", "30 0/2 * * * ?") {
       RugbyStatsJob.sendMatchArticles(CapiFeed.getMatchArticles())
     }
 

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -34,6 +34,17 @@ trait RugbyLifecycle extends GlobalSettings with ExecutionContexts {
       RugbyStatsJob.fetchPastScoreEvents
     }
 
+    Jobs.deschedule("LiveMatchesStat")
+    Jobs.schedule("LiveMatchesStat", "0 * * * * ?") {
+      RugbyStatsJob.fetchLiveMatchesStat
+    }
+
+    Jobs.deschedule("PastMatchesStat")
+    Jobs.schedule("PastMatchesStat", "0 0/30 * * * ?") {
+      RugbyStatsJob.fetchPastMatchesStat
+    }
+
+
     Jobs.deschedule("MatchNavArticles")
     Jobs.schedule("MatchNavArticles", "0 0/2 * * * ?") {
       RugbyStatsJob.sendMatchArticles(CapiFeed.getMatchArticles())
@@ -48,6 +59,8 @@ trait RugbyLifecycle extends GlobalSettings with ExecutionContexts {
     AkkaAsync.after(initializationTimeout) {
       RugbyStatsJob.fetchLiveScoreEvents
       RugbyStatsJob.fetchPastScoreEvents
+      RugbyStatsJob.fetchLiveMatchesStat
+      RugbyStatsJob.fetchPastMatchesStat
       RugbyStatsJob.sendMatchArticles(CapiFeed.getMatchArticles())
     }
   }

--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -3,6 +3,7 @@ package rugby.controllers
 import common._
 
 import common.{ExecutionContexts, JsonComponent}
+import conf.Switches.RugbyWorldCupMatchStatsSwitch
 import model.{Cached, MetaData}
 import play.api.mvc.{Action, Controller}
 import play.twirl.api.Html
@@ -10,6 +11,7 @@ import rugby.jobs.RugbyStatsJob
 import rugby.model.{ScoreType, Match}
 import rugby.feed.{CapiFeed, OptaFeed}
 import rugby.model.Match
+
 
 case class MatchPage(liveScore: Match) extends MetaData {
   override lazy val id = s"/sport/rugby/api/score/${liveScore.date.toString("yyyy/MMM/dd")}/${liveScore.homeTeam.id}/${liveScore.awayTeam.id}"
@@ -34,8 +36,9 @@ object MatchesController extends Controller with Logging with ExecutionContexts 
       val matchNav = CapiFeed.findMatchArticle(aMatch).map(rugby.views.html.fragments.matchNav(_, currentPage).toString)
 
       val scoreEvents = RugbyStatsJob.getScoreEvents(aMatch.id)
-
       val (homeTeamScorers, awayTeamScorers) =  scoreEvents.partition(_.player.team.id == aMatch.homeTeam.id)
+
+      val matchStat = if (RugbyWorldCupMatchStatsSwitch.isSwitchedOn) RugbyStatsJob.getMatchStat(aMatch.id) else None
 
       val page = MatchPage(aMatch)
       Cached(60){
@@ -44,7 +47,8 @@ object MatchesController extends Controller with Logging with ExecutionContexts 
             "matchSummary" -> rugby.views.html.fragments.matchSummary(page, aMatch).toString,
             "scoreEvents" -> rugby.views.html.fragments.scoreEvents(aMatch, homeTeamScorers, awayTeamScorers).toString,
             "dropdown" -> views.html.fragments.dropdown("", isClientSideTemplate = true)(Html("")),
-            "nav" -> matchNav.getOrElse("")
+            "nav" -> matchNav.getOrElse(""),
+            "matchStat" -> rugby.views.html.fragments.matchStats(aMatch, matchStat)
           )
         else
           Ok(rugby.views.html.matchSummary(page, aMatch, homeTeamScorers, awayTeamScorers))

--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -35,10 +35,10 @@ object MatchesController extends Controller with Logging with ExecutionContexts 
     matchOpt.map { aMatch =>
       val matchNav = CapiFeed.findMatchArticle(aMatch).map(rugby.views.html.fragments.matchNav(_, currentPage).toString)
 
-      val scoreEvents = RugbyStatsJob.getScoreEvents(aMatch.id)
+      val scoreEvents = RugbyStatsJob.getScoreEvents(aMatch)
       val (homeTeamScorers, awayTeamScorers) =  scoreEvents.partition(_.player.team.id == aMatch.homeTeam.id)
 
-      val matchStat = if (RugbyWorldCupMatchStatsSwitch.isSwitchedOn) RugbyStatsJob.getMatchStat(aMatch.id) else None
+      val matchStat = if (RugbyWorldCupMatchStatsSwitch.isSwitchedOn) RugbyStatsJob.getMatchStat(aMatch) else None
 
       val page = MatchPage(aMatch)
       Cached(60){

--- a/sport/app/rugby/feed/OptaFeed.scala
+++ b/sport/app/rugby/feed/OptaFeed.scala
@@ -9,17 +9,35 @@ import rugby.model.{ScoreEvent, Match, MatchStat}
 import scala.concurrent.Future
 import scala.xml.XML
 
+sealed trait OptaEvent {
+  def competition: String
+  def season: String
+}
+
+case object WarmupWorldCup2015 extends OptaEvent {
+  override val competition = "3"
+  override val season = "2016"
+}
+
+case object WorldCup2015 extends OptaEvent {
+  override val competition = "210"
+  override val season = "2016"
+}
+
 case class RugbyOptaFeedException(message: String) extends RuntimeException(message)
 
 object OptaFeed extends ExecutionContexts with Logging {
+  
+  private val events = List(WarmupWorldCup2015, WorldCup2015)
+
   private val xmlContentType = ("Accept", "application/xml")
 
-  private def getResponse(path: String, feedParameter: String, gameParameter: Option[(String, String)] = None): Future[String] = {
+  private def getResponse(event: OptaEvent, path: String, feedParameter: String, gameParameter: Option[(String, String)] = None): Future[String] = {
 
     val endpointOpt = conf.SportConfiguration.optaRugby.endpoint
     endpointOpt.map { endpoint =>
-      val competition= "competition" -> "210"
-      val season = "season_id" -> "2016"
+      val competition = "competition" -> event.competition
+      val season = "season_id" -> event.season
       val apiKey = "psw" -> conf.SportConfiguration.optaRugby.apiKey.getOrElse("")
       val apiUser = "user" -> conf.SportConfiguration.optaRugby.apiUser.getOrElse("")
       val feedType = "feed_type" -> feedParameter
@@ -43,18 +61,28 @@ object OptaFeed extends ExecutionContexts with Logging {
     }.getOrElse(Future.failed(RugbyOptaFeedException("No endpoint for rugby found")))
   }
 
-  def getLiveScores: Future[Seq[Match]] = getResponse("/competition.php", "ru5").map(Parser.parseLiveScores)
+  def getLiveScores: Future[Seq[Match]] = {
+    val scores = events.map { event =>
+      getResponse(event, "/competition.php", "ru5").map(Parser.parseLiveScores(_, event))
+    }
+    Future.sequence(scores).map(_.flatten)    
+  }
 
-  def getFixturesAndResults: Future[Seq[Match]] = getResponse("/competition.php", "ru1").map(Parser.parseFixturesAndResults)
+  def getFixturesAndResults: Future[Seq[Match]] = {
+    val fixtures = events.map { event =>
+      getResponse(event, "/competition.php", "ru1").map(Parser.parseFixturesAndResults(_, event))
+    }
+    Future.sequence(fixtures).map(_.flatten)    
+  }
 
-  def getScoreEvents(matchId: String): Future[Seq[ScoreEvent]] = {
-    getResponse("/", "ru7", Some("game_id" -> matchId)).map { data =>
+  def getScoreEvents(rugbyMatch: Match): Future[Seq[ScoreEvent]] = {
+    getResponse(rugbyMatch.event, "/", "ru7", Some("game_id" -> rugbyMatch.id)).map { data =>
       Parser.parseLiveEventsStatsToGetScoreEvents(data)
     }
   }
 
-  def getMatchStat(matchId: String): Future[MatchStat] = {
-    getResponse("/", "ru7", Some("game_id" -> matchId)).map { data =>
+  def getMatchStat(rugbyMatch: Match): Future[MatchStat] = {
+    getResponse(rugbyMatch.event, "/", "ru7", Some("game_id" -> rugbyMatch.id)).map { data =>
       Parser.parseLiveEventsStatsToGetMatchStat(data)
     }
   }

--- a/sport/app/rugby/feed/OptaFeed.scala
+++ b/sport/app/rugby/feed/OptaFeed.scala
@@ -4,7 +4,7 @@ import common.{ExecutionContexts, Logging}
 import play.api.Play.current
 import play.api.libs.ws.{WSRequest, WS}
 import rugby.jobs.RugbyStatsJob
-import rugby.model.{ScoreEvent, Match}
+import rugby.model.{ScoreEvent, Match, MatchStat}
 
 import scala.concurrent.Future
 import scala.xml.XML
@@ -52,4 +52,11 @@ object OptaFeed extends ExecutionContexts with Logging {
       Parser.parseLiveEventsStatsToGetScoreEvents(data)
     }
   }
+
+  def getMatchStat(matchId: String): Future[MatchStat] = {
+    getResponse("/", "ru7", Some("game_id" -> matchId)).map { data =>
+      Parser.parseLiveEventsStatsToGetMatchStat(data)
+    }
+  }
+
 }

--- a/sport/app/rugby/feed/OptaFeed.scala
+++ b/sport/app/rugby/feed/OptaFeed.scala
@@ -28,7 +28,7 @@ case class RugbyOptaFeedException(message: String) extends RuntimeException(mess
 
 object OptaFeed extends ExecutionContexts with Logging {
   
-  private val events = List(WarmupWorldCup2015, WorldCup2015)
+  private val events = List(/*WarmupWorldCup2015, */WorldCup2015)
 
   private val xmlContentType = ("Accept", "application/xml")
 

--- a/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
+++ b/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
@@ -5,7 +5,7 @@ import rugby.model._
 import rugby.model.{Team, Match, Status}
 import Status._
 
-import scala.xml.{NodeSeq, XML}
+import scala.xml.{NodeSeq, XML, MetaData, UnprefixedAttribute, Null}
 
 object Parser {
 
@@ -162,4 +162,74 @@ object Parser {
       case _ => Fixture
     }
   }
+
+  def parseLiveEventsStatsToGetMatchStat(body: String): MatchStat = {
+    val data = XML.loadString(body)
+
+    val teams = data \ "TeamDetail" \ "Team"
+
+    val teamsStats: Seq[TeamStat] = teams.map { team =>
+      
+      val teamStatDataRaw =  team \ "TeamStats" \ "TeamStat"
+
+      /* MetaData.append is extremly slow as it tries to normalize all attributes each time we append, so we chain attributes manually */ 
+      val allAttributes = chainAttributes(teamStatDataRaw.map(_.attributes))
+      val teamStatData = <TeamStat />.copy(attributes = allAttributes)
+      
+      TeamStat(
+        name = (team \ "@team_name").text,
+        id = (teamStatData \ "@id").text.toLong,
+        possession = (teamStatData \ "@possession").text.toFloat,
+        territory = (teamStatData \ "@territory").text.toFloat,
+        carries_metres = (teamStatData \ "@carries_metres").text.toInt,
+        tackles = (teamStatData \ "@tackles").text.toInt,
+        missed_tackles = (teamStatData \ "@missed_tackles").text.toInt,
+        tackle_success = (teamStatData \ "@tackle_success").text.toFloat,
+        turnover_won = (teamStatData \ "@turnover_won").text.toInt,
+        turnovers_conceded = (teamStatData \ "@turnovers_conceded").text.toInt,
+        lineouts_won = (teamStatData \ "@lineouts_won").text.toInt,
+        lineouts_lost = (teamStatData \ "@lineouts_Lost").text.toInt,
+        mauls_won = (teamStatData \ "@mauls_won").text.toInt,
+        mauls_lost = (teamStatData \ "@mauls_lost").text.toInt,
+        mauls_total = (teamStatData \ "@mauls_total").text.toInt,
+
+        penalties_conceded = (teamStatData \ "@penalties_conceded").text.toInt,
+        penalty_conceded_dissent = (teamStatData \ "@penalty_conceded_dissent").text.toInt,
+        penalty_conceded_delib_knock_on = (teamStatData \ "@penalty_conceded_delib_knock_on").text.toInt,
+        penalty_conceded_early_tackle = (teamStatData \ "@penalty_conceded_early_tackle").text.toInt,
+        penalty_conceded_handling_in_ruck = (teamStatData \ "@penalty_conceded_handling_in_ruck").text.toInt,
+        penalty_conceded_high_tackle = (teamStatData \ "@penalty_conceded_high_tackle").text.toInt,
+        penalty_conceded_lineout_offence = (teamStatData \ "@penalty_conceded_lineout_offence").text.toInt,
+        penalty_conceded_collapsing = (teamStatData \ "@penalty_conceded_collapsing").text.toInt,
+        penalty_conceded_collapsing_maul = (teamStatData \ "@penalty_conceded_collapsing_maul").text.toInt,
+        penalty_conceded_collapsing_offence = (teamStatData \ "@penalty_conceded_collapsing_offence").text.toInt,
+        penalty_conceded_obstruction = (teamStatData \ "@penalty_conceded_obstruction").text.toInt,
+        penalty_conceded_offside = (teamStatData \ "@penalty_conceded_offside").text.toInt,
+        penalty_conceded_opp_half = (teamStatData \ "@penalty_conceded_opp_half").text.toInt,
+        penalty_conceded_own_half = (teamStatData \ "@penalty_conceded_own_half").text.toInt,
+        penalty_conceded_other = (teamStatData \ "@penalty_conceded_other").text.toInt,
+        penalty_conceded_scrum_offence = (teamStatData \ "@penalty_conceded_scrum_offence").text.toInt,
+        penalty_conceded_stamping = (teamStatData \ "@penalty_conceded_stamping").text.toInt,
+        penalty_conceded_wrong_side = (teamStatData \ "@penalty_conceded_wrong_side").text.toInt,
+
+        rucks_won = (teamStatData \ "@rucks_won").text.toInt,
+        rucks_lost = (teamStatData \ "@rucks_lost").text.toInt,
+        rucks_total = (teamStatData \ "@rucks_total").text.toInt,
+
+        scrums_won = (teamStatData \ "@scrums_won").text.toInt,
+        scrums_lost = (teamStatData \ "@scrums_lost").text.toInt,
+        scrums_total = (teamStatData \ "@scrums_total").text.toInt
+      )
+    }
+    MatchStat(teamsStats)
+  }
+
+  private def chainAttributes(attributes: Iterable[MetaData]): MetaData = {
+    attributes match {
+      case Nil => Null
+      case head :: tail => new UnprefixedAttribute(head.key, head.value, chainAttributes(tail))
+    }
+  }
+
+
 }

--- a/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
+++ b/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
@@ -2,7 +2,6 @@ package rugby.feed
 
 import org.joda.time.format.DateTimeFormat
 import rugby.model._
-import rugby.model.{Team, Match, Status}
 import Status._
 
 import scala.xml.{NodeSeq, XML, MetaData, UnprefixedAttribute, Null}
@@ -15,7 +14,7 @@ object Parser {
     def apply(date: String, time: String) = dateTimeParser.parseDateTime(s"$date $time")
   }
 
-  def parseLiveScores(body: String): Seq[Match] = {
+  def parseLiveScores(body: String, event: OptaEvent): Seq[Match] = {
 
     val data = XML.loadString(body)
 
@@ -40,13 +39,14 @@ object Parser {
           awayTeam = awayTeam,
           venue = None,
           competitionName = (game \ "@comp_name").text,
-          status = parseStatus(game)
+          status = parseStatus(game),
+          event = event
         )
       }
     }
   }
 
-  def parseFixturesAndResults(body: String): Seq[Match] = {
+  def parseFixturesAndResults(body: String, event: OptaEvent): Seq[Match] = {
     val data = XML.loadString(body)
 
     val fixturesData = data \ "fixture"
@@ -68,7 +68,8 @@ object Parser {
           awayTeam = awayTeam,
           venue = Some((fixture \ "@venue").text),
           competitionName = (fixture \ "@comp_name").text,
-          status = parseStatus(fixture)
+          status = parseStatus(fixture),
+          event = event
         )
       }
     }

--- a/sport/app/rugby/model/rugby.scala
+++ b/sport/app/rugby/model/rugby.scala
@@ -3,6 +3,7 @@ package rugby.model
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
 import Status._
+import rugby.feed.OptaEvent
 
 case class Match(
   date: DateTime,
@@ -11,7 +12,8 @@ case class Match(
   awayTeam: Team,
   venue: Option[String],
   competitionName: String,
-  status: Status
+  status: Status,
+  event: OptaEvent
 ) {
   def hasTeam(teamId: String) = homeTeam.id == teamId || awayTeam.id == teamId
 

--- a/sport/app/rugby/model/rugby.scala
+++ b/sport/app/rugby/model/rugby.scala
@@ -88,3 +88,55 @@ object Status {
   object SuddenDeath extends Status           // Occurs after extra time and essentially means the first point scorer in this period wins
   object ShootOut extends Status              // This is after sudden death and involves players taking drop kicks
 }
+
+case class MatchStat(
+  teams:Seq[TeamStat]
+)
+
+case class TeamStat(
+  name: String,
+  id: Long,
+  possession: Float,
+  territory: Float,
+  carries_metres: Int,
+  tackles: Int,
+  missed_tackles: Int,
+  tackle_success: Float,
+  turnover_won: Int,
+  turnovers_conceded: Int,
+
+  lineouts_won:Int,
+  lineouts_lost:Int,
+
+  mauls_won: Int,
+  mauls_lost: Int,
+  mauls_total: Int,
+
+  penalties_conceded: Int,
+  penalty_conceded_dissent: Int,
+  penalty_conceded_delib_knock_on: Int,
+  penalty_conceded_early_tackle: Int,
+  penalty_conceded_handling_in_ruck: Int,
+  penalty_conceded_high_tackle: Int,
+  penalty_conceded_lineout_offence: Int,
+  penalty_conceded_collapsing: Int,
+  penalty_conceded_collapsing_maul: Int,
+  penalty_conceded_collapsing_offence: Int,
+  penalty_conceded_obstruction: Int,
+  penalty_conceded_offside: Int,
+  penalty_conceded_opp_half: Int,
+  penalty_conceded_own_half: Int,
+  penalty_conceded_other: Int,
+  penalty_conceded_scrum_offence: Int,
+  penalty_conceded_stamping: Int,
+  penalty_conceded_wrong_side: Int,
+
+  rucks_won: Int,
+  rucks_lost: Int,
+  rucks_total: Int,
+
+  scrums_won:Int,
+  scrums_lost:Int,
+  scrums_total: Int
+
+)

--- a/sport/app/rugby/views/fragments/matchStats.scala.html
+++ b/sport/app/rugby/views/fragments/matchStats.scala.html
@@ -1,0 +1,76 @@
+@import rugby.model.Match
+@import rugby.model.MatchStat
+
+@(theMatch: Match, matchStat: Option[MatchStat])
+
+@if(matchStat.isDefined) {
+
+    @defining((matchStat.get.teams.head, matchStat.get.teams.last)) { case (firstTeam, secondTeam) =>
+
+     <div data-component="football-stats-embed" class="@RenderClasses(Map(
+                "c-match-stats" -> true
+            ))">
+
+    <h3 class="component__heading content__meta-heading">Match stats</h3>
+
+
+    <h4 class="match-stats__caption">Possession</h4>
+    <div class="football-possession">
+        <table class="match-stats bar-fight js-chart"
+                   data-chart-type="doughnut"
+                   data-chart-unit="%"
+                   data-chart-class="chart--football-possession"
+                   data-chart-width="200"
+                   data-chart-show-values="true">
+                <thead hidden>
+                    <tr>
+                        <th>@firstTeam.name</th>
+                        <th>@secondTeam.name</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                    @defining((firstTeam.possession * 100.toInt).toInt, (secondTeam.possession * 100).toInt) { case (firstPossession, secondPossession) =>
+                        <td
+                            class="bar-fight__bar bar-fight__bar--home"
+                            data-chart-value="@secondPossession"
+                            data-chart-color="#rgb(0, 171, 77)"
+                            style="background-color: rgb(0, 171, 77); width: @NudgePercent(secondPossession, firstPossession)%;">@secondPossession</td>
+                        <td
+                            class="bar-fight__bar bar-fight__bar--away"
+                            data-chart-value="@firstPossession"
+                            data-chart-color="rgb(0, 83, 166)"
+                            style="background-color: rgb(0, 83, 166); width: @NudgePercent(firstPossession, secondPossession)%;">@firstPossession</td>
+                    }  
+                    </tr>
+                </tbody>
+        </table>
+    </div>
+
+    @barfight("Meters carried", firstTeam.carries_metres, secondTeam.carries_metres)
+    @barfight("Tackles made", firstTeam.tackles, secondTeam.tackles)
+    @barfight("Tackles missed", firstTeam.missed_tackles, secondTeam.missed_tackles)
+    @barfight("Turnovers won", firstTeam.turnover_won, secondTeam.turnover_won)
+    @barfight("Penalties conceded", firstTeam.penalties_conceded, secondTeam.penalties_conceded)
+
+    </div>
+    }
+}
+
+@barfight(propertyTitle: String, firstTeamProperty: Int, secondTeamProperty: Int) = {
+    <dl class="u-cf match-stats bar-fight">
+            <dt class="match-stats__caption">@propertyTitle</dt>
+            @defining(PercentMaker(firstTeamProperty, secondTeamProperty)){ case (firstPercent, secondPercent) =>
+                <dd 
+                    class="bar-fight__bar bar-fight__bar--home"
+                    style="background-color: rgb(0, 83, 166); width: @NudgePercent(firstPercent, secondPercent)%;">
+                    @firstTeamProperty
+                </dd>
+                <dd
+                    class="bar-fight__bar bar-fight__bar--away"
+                    style="background-color: rgb(0, 171, 77); width: @NudgePercent(secondPercent, firstPercent)%;">
+                    @secondTeamProperty
+                </dd>
+            }
+    </dl>
+}

--- a/sport/app/rugby/views/fragments/matchStats.scala.html
+++ b/sport/app/rugby/views/fragments/matchStats.scala.html
@@ -15,37 +15,10 @@
 
 
     <h4 class="match-stats__caption">Possession</h4>
-    <div class="football-possession">
-        <table class="match-stats bar-fight js-chart"
-                   data-chart-type="doughnut"
-                   data-chart-unit="%"
-                   data-chart-class="chart--football-possession"
-                   data-chart-width="200"
-                   data-chart-show-values="true">
-                <thead hidden>
-                    <tr>
-                        <th>@firstTeam.name</th>
-                        <th>@secondTeam.name</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                    @defining((firstTeam.possession * 100.toInt).toInt, (secondTeam.possession * 100).toInt) { case (firstPossession, secondPossession) =>
-                        <td
-                            class="bar-fight__bar bar-fight__bar--home"
-                            data-chart-value="@secondPossession"
-                            data-chart-color="rgb(0, 171, 77)"
-                            style="background-color: rgb(0, 171, 77); width: @NudgePercent(secondPossession, firstPossession)%;">@secondPossession</td>
-                        <td
-                            class="bar-fight__bar bar-fight__bar--away"
-                            data-chart-value="@firstPossession"
-                            data-chart-color="rgb(0, 83, 166)"
-                            style="background-color: rgb(0, 83, 166); width: @NudgePercent(firstPossession, secondPossession)%;">@firstPossession</td>
-                    }  
-                    </tr>
-                </tbody>
-        </table>
-    </div>
+    @donut(firstTeam.name, secondTeam.name, firstTeam.possession, secondTeam.possession)
+
+    <h4 class="match-stats__caption">Territory</h4>
+    @donut(firstTeam.name, secondTeam.name, firstTeam.territory, secondTeam.territory)
 
     @barfight("Metres carried", firstTeam.carries_metres, secondTeam.carries_metres)
     @barfight("Tackles made", firstTeam.tackles, secondTeam.tackles)
@@ -61,7 +34,7 @@
     <dl class="u-cf match-stats bar-fight">
             <dt class="match-stats__caption">@propertyTitle</dt>
             @defining(PercentMaker(firstTeamProperty, secondTeamProperty)){ case (firstPercent, secondPercent) =>
-                <dd 
+                <dd
                     class="bar-fight__bar bar-fight__bar--home"
                     style="background-color: rgb(0, 83, 166); width: @NudgePercent(firstPercent, secondPercent)%;">
                     @firstTeamProperty
@@ -73,4 +46,38 @@
                 </dd>
             }
     </dl>
+}
+
+@donut(firstTeamName: String, secondTeamName: String, firstTeamProperty: Float, secondTeamProperty: Float) = {
+    <div class="football-possession">
+        <table class="match-stats bar-fight js-chart"
+        data-chart-type="doughnut"
+        data-chart-unit="%"
+        data-chart-class="chart--football-possession"
+        data-chart-width="200"
+        data-chart-show-values="true">
+            <thead hidden>
+                <tr>
+                    <th>@firstTeamName</th>
+                    <th>@secondTeamName</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                @defining((firstTeamProperty * 100.toInt).toInt, (secondTeamProperty * 100).toInt) { case (firstProperty, secondProperty) =>
+                <td
+                class="bar-fight__bar bar-fight__bar--home"
+                data-chart-value="@secondProperty"
+                data-chart-color="rgb(0, 171, 77)"
+                style="background-color: rgb(0, 171, 77); width: @NudgePercent(secondProperty, firstProperty)%;">@secondProperty</td>
+                <td
+                class="bar-fight__bar bar-fight__bar--away"
+                data-chart-value="@firstProperty"
+                data-chart-color="rgb(0, 83, 166)"
+                style="background-color: rgb(0, 83, 166); width: @NudgePercent(firstProperty, secondProperty)%;">@firstProperty</td>
+                }
+                </tr>
+            </tbody>
+        </table>
+    </div>
 }

--- a/sport/app/rugby/views/fragments/matchStats.scala.html
+++ b/sport/app/rugby/views/fragments/matchStats.scala.html
@@ -47,7 +47,7 @@
         </table>
     </div>
 
-    @barfight("Meters carried", firstTeam.carries_metres, secondTeam.carries_metres)
+    @barfight("Metres carried", firstTeam.carries_metres, secondTeam.carries_metres)
     @barfight("Tackles made", firstTeam.tackles, secondTeam.tackles)
     @barfight("Tackles missed", firstTeam.missed_tackles, secondTeam.missed_tackles)
     @barfight("Turnovers won", firstTeam.turnover_won, secondTeam.turnover_won)

--- a/sport/app/rugby/views/fragments/matchStats.scala.html
+++ b/sport/app/rugby/views/fragments/matchStats.scala.html
@@ -34,7 +34,7 @@
                         <td
                             class="bar-fight__bar bar-fight__bar--home"
                             data-chart-value="@secondPossession"
-                            data-chart-color="#rgb(0, 171, 77)"
+                            data-chart-color="rgb(0, 171, 77)"
                             style="background-color: rgb(0, 171, 77); width: @NudgePercent(secondPossession, firstPossession)%;">@secondPossession</td>
                         <td
                             class="bar-fight__bar bar-fight__bar--away"

--- a/sport/test/rugby/jobs/RugbyStatsJobTest.scala
+++ b/sport/test/rugby/jobs/RugbyStatsJobTest.scala
@@ -5,6 +5,7 @@ import org.scalatest._
 import org.scalatest.concurrent.Eventually
 import test.ConfiguredTestSuite
 import rugby.model._
+import rugby.feed.WarmupWorldCup2015
 import scala.concurrent.Future
 import scala.language.reflectiveCalls
 
@@ -26,7 +27,8 @@ import scala.language.reflectiveCalls
       awayTeam = awayTeamOld,
       venue = Some("kings cross"),
       competitionName = "competition",
-      status = Status.Result
+      status = Status.Result,
+      event = WarmupWorldCup2015
     ),
     Match(
       date = testDate.plusSeconds(1),
@@ -35,7 +37,8 @@ import scala.language.reflectiveCalls
       awayTeam = awayTeamNew,
       venue = Some("kings cross"),
       competitionName = "competition",
-      status = Status.Result
+      status = Status.Result,
+      event = WarmupWorldCup2015
     ))
 
   "RugbyStatsJob" - {

--- a/sport/test/rugby/model/MatchParserTest.scala
+++ b/sport/test/rugby/model/MatchParserTest.scala
@@ -76,5 +76,59 @@ import scala.io.Source
       topTryScorer.head.player.team.id should be("550")
       topTryScorer.head.player.team.name should be("England")
     }
+
+     "should parse team stats correctly" in {
+      val liveEventsStatsData = Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("rugby/feed/live-events-stats.xml")).mkString
+
+      val matchStat = rugby.feed.Parser.parseLiveEventsStatsToGetMatchStat(liveEventsStatsData)
+
+      matchStat.teams.size should be(2)
+      matchStat.teams.head.name should be("England")
+      matchStat.teams.last.name should be("France")
+
+      val england = matchStat.teams.head
+
+      england.id should be(29754)
+      england.possession should be(0.49F)
+      england.territory should be(0.50)
+      england.carries_metres should be(323)
+      england.tackles should be(103)
+      england.missed_tackles should be(25)
+      england.tackle_success should be(0.80F)
+      england.turnover_won should be(8)
+      england.turnovers_conceded should be(13)
+      england.lineouts_won should be(13)
+      england.lineouts_lost should be(3)
+      england.mauls_won should be(4)
+      england.mauls_lost should be(1)
+      england.mauls_total should be(5) 
+      england.penalties_conceded should be(9)
+      england.penalty_conceded_dissent should be(0)
+      england.penalty_conceded_delib_knock_on should be(0)
+      england.penalty_conceded_early_tackle should be(0)
+      england.penalty_conceded_handling_in_ruck should be(0)
+      england.penalty_conceded_high_tackle should be(0)
+      england.penalty_conceded_lineout_offence should be(0)
+      england.penalty_conceded_collapsing_maul should be(0)
+      england.penalty_conceded_collapsing_offence should be(0)
+      england.penalty_conceded_obstruction should be(0)
+      england.penalty_conceded_offside should be(0)
+      england.penalty_conceded_opp_half should be(6)
+      england.penalty_conceded_own_half should be(4)
+      england.penalty_conceded_other should be(9)
+      england.penalty_conceded_scrum_offence should be(0)
+      england.penalty_conceded_stamping should be(0)
+      england.penalty_conceded_wrong_side should be(0)
+
+      england.rucks_won should be(65)
+      england.rucks_lost should be(3)
+      england.rucks_total should be(68)
+
+      england.scrums_won should be(5)
+      england.scrums_lost should be(2)
+      england.scrums_total should be(7)
+    
+      val france = matchStat.teams.last
+    }
   }
 }

--- a/sport/test/rugby/model/MatchParserTest.scala
+++ b/sport/test/rugby/model/MatchParserTest.scala
@@ -1,6 +1,7 @@
 package rugby.model
 
 import org.scalatest._
+import rugby.feed.WarmupWorldCup2015
 import test.ConfiguredTestSuite
 
 import scala.io.Source
@@ -11,7 +12,7 @@ import scala.io.Source
     "should parse rugby live scores correctly" in {
       val liveScoreData = Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("rugby/feed/live-scores.xml")).mkString
 
-      val liveScores = rugby.feed.Parser.parseLiveScores(liveScoreData)
+      val liveScores = rugby.feed.Parser.parseLiveScores(liveScoreData, WarmupWorldCup2015)
 
       liveScores.size should be(4)
 
@@ -34,7 +35,7 @@ import scala.io.Source
     "should parse rugby results correctly" in {
       val fixturesAndResultsData = Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("rugby/feed/fixtures-and-results.xml")).mkString
 
-      val fixturesAndResults = rugby.feed.Parser.parseFixturesAndResults(fixturesAndResultsData)
+      val fixturesAndResults = rugby.feed.Parser.parseFixturesAndResults(fixturesAndResultsData, WarmupWorldCup2015)
 
       fixturesAndResults.size should be(26)
 

--- a/static/src/javascripts/bootstraps/liveblog.js
+++ b/static/src/javascripts/bootstraps/liveblog.js
@@ -192,7 +192,8 @@ define([
                 dropdown.addClass('dropdown--active');
                 dropdowns.updateAria(dropdown);
 
-                if (detect.isBreakpoint({ min: 'desktop' }) && config.page.keywordIds.indexOf('football/football') < 0) {
+                if (detect.isBreakpoint({ min: 'desktop' }) && config.page.keywordIds.indexOf('football/football') < 0 && config.page.keywordIds.indexOf('sport/rugby-union') < 0) {
+                    
                     topMarker = qwery('.js-top-marker')[0];
                     /*eslint-disable no-new*/
                     new Affix({

--- a/static/src/javascripts/bootstraps/liveblog.js
+++ b/static/src/javascripts/bootstraps/liveblog.js
@@ -193,7 +193,6 @@ define([
                 dropdowns.updateAria(dropdown);
 
                 if (detect.isBreakpoint({ min: 'desktop' }) && config.page.keywordIds.indexOf('football/football') < 0 && config.page.keywordIds.indexOf('sport/rugby-union') < 0) {
-                    
                     topMarker = qwery('.js-top-marker')[0];
                     /*eslint-disable no-new*/
                     new Affix({

--- a/static/src/javascripts/bootstraps/sport.js
+++ b/static/src/javascripts/bootstraps/sport.js
@@ -6,8 +6,10 @@ define([
     'common/utils/ajax',
     'common/utils/config',
     'common/utils/detect',
+    'common/modules/charts/table-doughnut',
     'common/modules/component',
-    'common/modules/sport/score-board'
+    'common/modules/sport/score-board',
+    'common/modules/ui/rhc'
 ], function (
     bonzo,
     bean,
@@ -16,8 +18,10 @@ define([
     ajax,
     config,
     detect,
+    Doughnut,
     Component,
-    ScoreBoard
+    ScoreBoard,
+    rhc
 ) {
     function cricket() {
         var cricketScore, parentEl,
@@ -79,6 +83,13 @@ define([
 
                     $('.score-container').after($scoreEventsTabletUp);
                 }
+
+                $.create('<div class="match-stats__container">'+ resp.matchStat + '</div>').each(function (container) {
+                    $('.js-chart', container).each(function (el) {
+                        new Doughnut().render(el);
+                    });
+                    rhc.addComponent(container, 3);
+                });
 
             };
 

--- a/static/src/javascripts/bootstraps/sport.js
+++ b/static/src/javascripts/bootstraps/sport.js
@@ -84,6 +84,7 @@ define([
                     $('.score-container').after($scoreEventsTabletUp);
                 }
 
+                $('.match-stats__container').remove();
                 $.create('<div class="match-stats__container">'+ resp.matchStat + '</div>').each(function (container) {
                     $('.js-chart', container).each(function (el) {
                         new Doughnut().render(el);

--- a/static/src/javascripts/bootstraps/sport.js
+++ b/static/src/javascripts/bootstraps/sport.js
@@ -85,7 +85,7 @@ define([
                 }
 
                 $('.match-stats__container').remove();
-                $.create('<div class="match-stats__container">'+ resp.matchStat + '</div>').each(function (container) {
+                $.create('<div class="match-stats__container">' + resp.matchStat + '</div>').each(function (container) {
                     $('.js-chart', container).each(function (el) {
                         new Doughnut().render(el);
                     });


### PR DESCRIPTION
The associated changes add the retrieving, parsing and displaying of team stats for rugby game match.
The display of the stats is behind a dedicated switch but requires as well the score switch to be activated. 

The changes add as well `Event` to the model, which enables to have `scores` and `stats` for both the world cup and the world cup warmup games. I think this is really useful as we can see how score and stats will be on previous games on `PROD`.
### Screenhots

<img width="223" alt="screen shot 2015-09-10 at 14 16 00" src="https://cloud.githubusercontent.com/assets/615085/9789504/754ff066-57c8-11e5-84d8-56aed3cd3229.png">

<img width="1390" alt="screen shot 2015-09-10 at 16 31 45" src="https://cloud.githubusercontent.com/assets/615085/9793873/b5453e80-57df-11e5-9b9f-6f4fc572754d.png">
## Before merging

Following issues need to be addressed:
- [X] Fix scrolling - when scrolling the match stats div overlays previous div
