### PR TITLE
Separate the front press job standard frequency to it's own job

### DIFF
--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -57,7 +57,7 @@ object RefreshFrontsJob extends Logging {
   }
 
   def runStandardFrequency(): Unit = {
-    if (FrontPressJobSwitch.isSwitchedOn && Configuration.aws.frontPressSns.filter(_.nonEmpty).isDefined) {
+    if (FrontPressJobSwitchStandardFrequency.isSwitchedOn && Configuration.aws.frontPressSns.filter(_.nonEmpty).isDefined) {
       log.info("Putting press jobs on Facia Cron (Standard Frequency)")
 
       for {

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1054,6 +1054,15 @@ object Switches {
     exposeClientSide = false
   )
 
+  val FrontPressJobSwitchStandardFrequency = Switch(
+    "Facia",
+    "front-press-job-switch-standard-frequency",
+    "If this switch is on then the jobs to push and pull from SQS will run",
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
   val IphoneConfidence = Switch(
     "Performance",
     "iphone-confidence",


### PR DESCRIPTION
Continuing from #10450 I've narrowed it down to a set of jobs however the front press job standard frequency fires quite quickly after these and does a lot of sending to SNS. I'd like to eliminate this as an issue first so I've separated it into its own frequency job. By default it is off to match the `FrontPressJobSwitch` but I will make sure it is turned on as soon as this goes to PROD.

@janua is this okay? 
