### PR TITLE
only use IDs in crossword lookups

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -108,7 +108,10 @@ object CrosswordSearchController extends Controller with ExecutionContexts {
   def lookup() = Action.async { implicit request =>
     lookupForm.bindFromRequest.get match {
       case CrosswordLookup(id) =>
-        val search = LiveContentApi.search(Edition(request)).section("crosswords").q(id.toString)
+        val search = LiveContentApi.search(Edition(request))
+          .section("crosswords")
+          .orderBy("oldest") // puzzles are posted before solutions
+          .q(id.toString)
 
         LiveContentApi.getResponse(search).map { response =>
           response.results match {

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -70,10 +70,11 @@ object CrosswordSearchController extends Controller with ExecutionContexts {
 
   val lookupForm = Form(
     mapping(
-      "type" -> text,
       "id" -> number
     )(CrosswordLookup.apply)(CrosswordLookup.unapply)
   )
+
+  def noResults()(implicit request: RequestHeader) = Cached(7.days)(Ok(views.html.crosswordsNoResults(CrosswordSearchPage)))
 
   def search() = Action.async { implicit request =>
     searchForm.bindFromRequest.fold(
@@ -91,7 +92,7 @@ object CrosswordSearchController extends Controller with ExecutionContexts {
 
         LiveContentApi.getResponse(maybeSetter.showFields("all")).map { response =>
           response.results match {
-            case Nil => Cached(7.days)(Ok(views.html.crosswordsNoResults(CrosswordSearchPage)))
+            case Nil => noResults
 
             case results =>
               val section = Section(ApiSection("crosswords", "Crosswords search results", "http://www.theguardian.com/crosswords/search", "", Nil))

--- a/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
@@ -72,15 +72,6 @@
             <div class="form-fields__inline">
                 <ul>
                     <li class="form-field">
-                        <label class="label" for="crossword-type">Type</label>
-                        <select id="type" name="type">
-                        @page.crosswordTypes.map { crosswordType =>
-                            <option value="@crosswordType">@crosswordType</option>
-                        }
-                        </select>
-                    </li>
-
-                    <li class="form-field">
                         <label class="label" for="crossword-id">ID</label>
                         <input type="text" class="text-input" name="id" id="id" />
                     </li>


### PR DESCRIPTION
There's no need for the crossword type field in the lookup form, since IDs are unique across types.

This gets rid of that field and changes the way the lookup works to actually search for the content and redirect instead of just building a URL.
