### PR TITLE
Track Sponsored Content in Omniture

### DIFF
--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -58,7 +58,8 @@ case class JavaScriptPage(metaData: MetaData)(implicit request: RequestHeader) {
         else Configuration.id.webappUrl
       )),
       ("pushNotificationsHost", JsString(Configuration.pushNotifications.host))
-    ) ++ metaData.sponsorshipType.map{s => Map("sponsorshipType" -> JsString(s))}.getOrElse(Nil)
+    ) ++ metaData.sponsor.map { sponsor => Map("sponsor" -> JsString(sponsor)) }.getOrElse(Nil)
+      ++ metaData.sponsorshipType.map { s => Map("sponsorshipType" -> JsString(s)) }.getOrElse(Nil)
       ++ metaData.sponsorshipTag.map{tag => Map("sponsorshipTag" -> JsString(tag.name))}.getOrElse(Nil))
   }
 

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -109,7 +109,7 @@ define([
 
     Omniture.prototype.populateEventProperties = function (linkName) {
 
-        this.s.linkTrackVars = 'channel,prop1,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,' +
+        this.s.linkTrackVars = 'channel,prop1,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop38,prop47,' +
                                'prop51,prop61,prop64,prop65,prop74,eVar7,eVar37,eVar38,eVar39,eVar50,events';
         this.s.linkTrackEvents = 'event37';
         this.s.events = 'event37';
@@ -215,6 +215,9 @@ define([
 
         this.s.prop31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
         this.s.eVar31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
+
+        // Sponsored Content Flag
+        this.s.prop38    = config.page.sponsorshipType + ':' + config.page.sponsor;
 
         this.s.prop40    = detect.adblockInUse || detect.getFirefoxAdblockPlusInstalled();
 


### PR DESCRIPTION
This change populates s.prop38 'Sponsored Content Flag (p38)'.
