### PR TITLE
Crosswords: fix grid stretching on mobile

### DIFF
--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -24,8 +24,10 @@
         // define dimensions for the grid. (SVGs use viewBox which require
         // the parent to have dimensions)
         .crossword__container__grid-wrapper {
-            width: $size;
-            height: $size;
+            @include mq(tablet) {
+                width: $size;
+                height: $size;
+            }
         }
 
         .crossword__controls {


### PR DESCRIPTION
Broken by https://github.com/guardian/frontend/pull/10439/files

Before:
![image](https://cloud.githubusercontent.com/assets/921609/9794717/a1444606-57e4-11e5-9fd9-df90e74b7200.png)

After:
![image](https://cloud.githubusercontent.com/assets/921609/9794706/91f6a9c8-57e4-11e5-8d95-bac716f833a6.png)
