### PR TITLE
Fix Container Descriptions

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -5,7 +5,7 @@
 @import layout.{DescriptionMetaHeader, LoneDateHeadline, MetaDataHeader}
 
 @containerDefinition.customHeader.map { customHeader =>
-    <div class="fc-container__header js-container__header__outer">
+    <div class="fc-container__header">
         @customHeader match {
             case metaDataHeader: MetaDataHeader => {
                 @dateHeadline(metaDataHeader.dateHeadline, containerDefinition.dateLink)

--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -1,12 +1,11 @@
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
 
-@import views.html.fragments.containers.facia_cards.{date, latestUpdate}
-@import layout.{MetaDataHeader, LoneDateHeadline, DescriptionMetaHeader}
 @import fragments.containers.facia_cards.{dateHeadline, descriptionHeadline, standardHeaderMeta}
 @import fragments.nav.treats
+@import layout.{DescriptionMetaHeader, LoneDateHeadline, MetaDataHeader}
 
 @containerDefinition.customHeader.map { customHeader =>
-    <div class="fc-container__header js-container__header">
+    <div class="fc-container__header js-container__header__outer">
         @customHeader match {
             case metaDataHeader: MetaDataHeader => {
                 @dateHeadline(metaDataHeader.dateHeadline, containerDefinition.dateLink)


### PR DESCRIPTION
So that containers can show a logo and a description without breaking the page.

![image](https://cloud.githubusercontent.com/assets/1722550/9812549/01026c08-5876-11e5-9c99-fac38f2ce300.png)
