### PR TITLE
Fix dev image path property with malformed protocol

### DIFF
--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -5,7 +5,7 @@
 tag_indexes.bucket=aws-frontend-pressed
 
 assets.path=/assets/
-images.path=http//i.guimcode.co.uk.global.prod.fastly.net
+images.path=http://i.guimcode.co.uk.global.prod.fastly.net
 static.path=http://static.guim.co.uk
 static.securePath=https://static-secure.guim.co.uk
 staticSport.path=http://sport.guim.co.uk


### PR DESCRIPTION
There's a typo in the DEV.properties images.path entry - we're missing a colon on the http prototcol.

If you're currently having an issue with the GalleryTemplate test moaning about the image path in a Twitter card, this is your culprit.
