### PR TITLE
Fix Container Descriptions Again

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/containerHeader.scala.html
@@ -5,7 +5,7 @@
 @import layout.{DescriptionMetaHeader, LoneDateHeadline, MetaDataHeader}
 
 @containerDefinition.customHeader.map { customHeader =>
-    <div class="fc-container__header">
+    <div class="fc-container__header js-container__header">
         @customHeader match {
             case metaDataHeader: MetaDataHeader => {
                 @dateHeadline(metaDataHeader.dateHeadline, containerDefinition.dateLink)

--- a/static/src/javascripts/projects/common/modules/commercial/badges.js
+++ b/static/src/javascripts/projects/common/modules/commercial/badges.js
@@ -67,8 +67,12 @@ define([
 
             return new Promise(function (resolve) {
                 fastdom.write(function () {
-                    $('.js-container__header', container)
-                        .after($adSlot);
+                    var $header = $('.js-container__header', container);
+                    if ($header.length === 1) {
+                        $header.after($adSlot);
+                    } else {
+                        $('.js-container__header .js-container__header', container).after($adSlot);
+                    }
 
                     resolve($adSlot);
                 });


### PR DESCRIPTION
So that containers can show a logo and a description without breaking the page.
