### PR TITLE
only show anagram helper if there's an active clue

### DIFF
--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -507,8 +507,15 @@ class Crossword extends React.Component {
     }
 
     onToggleAnagramHelper () {
+        // only show anagram helper if a clue is active
+        if (!this.state.showAnagramHelper) {
+            return this.clueInFocus() && this.setState({
+                showAnagramHelper: true
+            });
+        }
+
         this.setState({
-            showAnagramHelper: !this.state.showAnagramHelper
+            showAnagramHelper: false
         });
     }
 


### PR DESCRIPTION
fixes a bug that breaks everything if you try to open the anagram helper without a clue selected 
