### PR TITLE
Fix auto fresh football

### DIFF
--- a/static/src/javascripts/bootstraps/sport.js
+++ b/static/src/javascripts/bootstraps/sport.js
@@ -49,7 +49,7 @@ define([
             var scoreBoard = new ScoreBoard({
                 pageType: pageType,
                 parent: $h,
-                autoupdated: config.page.isLive,
+                autoupdated: false,
                 responseDataKey: 'matchSummary',
                 endpoint: config.page.rugbyMatch + '.json?page=' + encodeURIComponent(config.page.pageId)});
 

--- a/static/src/javascripts/projects/common/modules/sport/score-board.js
+++ b/static/src/javascripts/projects/common/modules/sport/score-board.js
@@ -1,12 +1,14 @@
 define([
     'bonzo',
     'common/utils/detect',
+    'common/utils/$',
     'common/utils/template',
     'common/modules/component',
     'text!common/views/sport/score-container.html'
 ], function (
     bonzo,
     detect,
+    $,
     template,
     component,
     scoreContainerHtml
@@ -44,7 +46,10 @@ define([
     ScoreBoard.prototype.componentClass = 'match-summary';
 
     ScoreBoard.prototype.prerender = function () {
-        this.placeholder.innerHTML = '';
+        var scoreLoadingPlaceholder = $('.score__loading', $(this.placeholder));
+        if (scoreLoadingPlaceholder.length) {
+            scoreLoadingPlaceholder.remove()
+        }
     };
 
     ScoreBoard.prototype.ready = function () {

--- a/static/src/javascripts/projects/common/modules/sport/score-board.js
+++ b/static/src/javascripts/projects/common/modules/sport/score-board.js
@@ -48,7 +48,7 @@ define([
     ScoreBoard.prototype.prerender = function () {
         var scoreLoadingPlaceholder = $('.score__loading', $(this.placeholder));
         if (scoreLoadingPlaceholder.length) {
-            scoreLoadingPlaceholder.remove()
+            scoreLoadingPlaceholder.remove();
         }
     };
 


### PR DESCRIPTION
Paired with @OliverJAsh to fix refresh of scores for football live scores. Before the refresh just rendered a blank space as it could not find the parent node. Now we only do this for the first fetch.

Also removed refresh of rugby live scores as the component does not replace the live score but instead appends to it.

cc @rich-nguyen 
