### PR TITLE
Discussion: make relative dates optional

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordFooter.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordFooter.scala.html
@@ -1,7 +1,7 @@
 @(crosswordPage: crosswords.CrosswordPage)(implicit request: RequestHeader)
 <div class="content-footer">
 
-    @fragments.discussionFooter(crosswordPage.isCommentable, crosswordPage.isClosedForComments, crosswordPage.shortUrlId)
+    @fragments.discussionFooter(crosswordPage, crosswordPage.isCommentable, crosswordPage.isClosedForComments, crosswordPage.shortUrlId)
 
     @if(crosswordPage.isCommentable) {
         <div class="js-repositioned-comments content__repositioned-comments"></div>

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -607,6 +607,15 @@ object Switches {
   )
 
   // Features
+  val DiscussionCrosswordsOptionalRelativeTimestampSwitch = Switch(
+    "Feature",
+    "discussion-crosswords-optional-relative-timestamp-switch",
+    "Discussion optional relative timestamp in the crossword section",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 9, 28),
+    exposeClientSide = true
+  )
+
   val InternationalEditionSwitch = Switch(
     "Feature",
     "international-edition",

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -3,7 +3,7 @@
 
 <div class="content-footer @if(cssClass){content-footer--@cssClass}">
 
-    @fragments.discussionFooter(content.isCommentable, content.isClosedForComments, content.shortUrlId)
+    @fragments.discussionFooter(content, content.isCommentable, content.isClosedForComments, content.shortUrlId)
 
     @ContentFooterContainersLayout(content, related, content.isAdvertisementFeature) {
         @fragments.storyPackagePlaceholder(content, related)

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -1,4 +1,4 @@
-@(isCommentable: Boolean, discussionClosed: Boolean, discussionId: String)(implicit request: RequestHeader)
+@(content: model.Content, isCommentable: Boolean, discussionClosed: Boolean, discussionId: String)(implicit request: RequestHeader)
 @import conf.Switches._
 
 @sectionHeading = {
@@ -28,7 +28,7 @@
 @toolbar = {
     <div class="discussion__toolbar js-discussion-toolbar u-cf">
 
-        <div class="discussion__toolbar-dropdown js-comment-order-dropdown">
+        <div class="discussion__toolbar-item js-comment-order-dropdown">
             <button class="u-button-reset popup__toggle" data-toggle="popup--comments-order"
                     aria-haspopup="true" aria-controls="comments-order-popup">Order by <span class="js-comment-order"></span></button>
 
@@ -42,7 +42,7 @@
         </div>
 
         @if(DiscussionPageSizeSwitch.isSwitchedOn) {
-            <div class="discussion__toolbar-dropdown hide-until-tablet js-comment-pagesize-dropdown sign-in-required">
+            <div class="discussion__toolbar-item hide-until-tablet js-comment-pagesize-dropdown sign-in-required">
                 <button class="u-button-reset popup__toggle" data-toggle="popup--comments-pagesize"
                         aria-haspopup="true" aria-controls="comments-pagesize-popup">Show <span class="js-comment-pagesize">25</span></button>
 
@@ -53,7 +53,7 @@
         }
 
 
-        <div class="discussion__toolbar-dropdown js-comment-threading-dropdown">
+        <div class="discussion__toolbar-item js-comment-threading-dropdown">
             <button class="u-button-reset popup__toggle" data-toggle="popup--comments-threading"
                     aria-haspopup="true" aria-controls="comments-order-threading">Threads <span class="js-comment-threading"></span></button>
 
@@ -65,6 +65,22 @@
                 }
             </ul>
         </div>
+
+        @if(DiscussionCrosswordsOptionalRelativeTimestampSwitch.isSwitchedOn
+            && content.section == "crosswords") {
+            <div class="discussion__toolbar-item js-timestamps-dropdown hide-until-tablet">
+                <button class="u-button-reset popup__toggle" data-toggle="popup--timestamp"
+                        aria-haspopup="true" aria-controls="timestamp-popup">Timestamps <span class="js-timestamps"></span></button>
+
+                <ul id="timestamp-popup" class="popup popup__group popup--timestamp is-off">
+                    @List("relative", "absolute").map { value =>
+                        <li class="popup__item">
+                            <button class="u-button-reset popup__action" data-timestamp="@value" data-link-name="comments-@value">@value</button>
+                        </li>
+                    }
+                </ul>
+            </div>
+        }
 
         <div class="discussion__pagination discussion__pagination--top js-discussion-pagination"></div>
 

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -13,7 +13,8 @@ define([
     'common/modules/discussion/api',
     'common/modules/discussion/comment-box',
     'common/modules/discussion/whole-discussion',
-    'common/modules/ui/relativedates'
+    'common/modules/ui/relativedates',
+    'common/modules/user-prefs'
 ], function(
     bean,
     bonzo,
@@ -29,9 +30,18 @@ define([
     DiscussionApi,
     CommentBox,
     WholeDiscussion,
-    relativedates
+    relativedates,
+    userPrefs
 ) {
 'use strict';
+
+var PREF_RELATIVE_TIMESTAMPS = 'discussion.enableRelativeTimestamps';
+var shouldMakeTimestampsRelative = function () {
+    return !config.switches.discussionCrosswordsOptionalRelativeTimestampSwitch
+        || (config.switches.discussionCrosswordsOptionalRelativeTimestampSwitch
+            && config.page.section === 'crosswords'
+            && userPrefs.get(PREF_RELATIVE_TIMESTAMPS));
+};
 
 var Comments = function(options) {
     this.setOptions(options);
@@ -78,15 +88,18 @@ Comments.prototype.ready = function() {
     this.on('click', this.getClass('showRepliesButton'), this.getMoreReplies);
     this.on('click', this.getClass('commentReport'), this.reportComment);
 
-    window.setInterval(
-        function () {
-            this.relativeDates();
-        }.bind(this),
-        60000
-    );
+    if (shouldMakeTimestampsRelative()) {
+        window.setInterval(
+            function () {
+                this.relativeDates();
+            }.bind(this),
+            60000
+        );
+
+        this.relativeDates();
+    }
 
     this.emit('ready');
-    this.relativeDates();
 
     this.on('click', '.js-report-comment-close', function() {
         $('.js-report-comment-form').addClass('u-h');
@@ -202,7 +215,9 @@ Comments.prototype.renderComments = function(resp) {
 
     this.postedCommentEl = resp.postedCommentHtml;
 
-    this.relativeDates();
+    if (shouldMakeTimestampsRelative()) {
+        this.relativeDates();
+    }
     this.emit('rendered', resp.paginationHtml);
 
     mediator.emit('modules:comments:renderComments:rendered');
@@ -211,7 +226,9 @@ Comments.prototype.renderComments = function(resp) {
 Comments.prototype.showHiddenComments = function(e) {
     if (e) { e.preventDefault(); }
     this.emit('first-load');
-    this.relativeDates();
+    if (shouldMakeTimestampsRelative()) {
+        this.relativeDates();
+    }
 };
 
 Comments.prototype.addMoreRepliesButtons = function (comments) {
@@ -264,7 +281,9 @@ Comments.prototype.getMoreReplies = function(event) {
         bonzo(li).addClass('u-h');
         this.emit('untruncate-thread');
 
-        this.relativeDates();
+        if (shouldMakeTimestampsRelative()) {
+            this.relativeDates();
+        }
     }.bind(this));
 };
 
@@ -442,7 +461,9 @@ Comments.prototype.addUser = function(user) {
 };
 
 Comments.prototype.relativeDates = function() {
-    relativedates.init();
+    if (shouldMakeTimestampsRelative()) {
+        relativedates.init();
+    }
 };
 
 Comments.prototype.isAllPageSizeActive = function() {

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -214,6 +214,33 @@ Loader.prototype.initToolbar = function() {
         userPrefs.set('discussion.threading', this.comments.options.threading);
         this.loadComments();
     });
+
+    if (config.switches.discussionCrosswordsOptionalRelativeTimestampSwitch
+        && config.page.section === 'crosswords') {
+        var $timestampsLabel = $('.js-timestamps');
+        var updateLabelText = function (prefValue) {
+            $timestampsLabel.text(prefValue ? 'Relative' : 'Absolute');
+        };
+        updateLabelText(prefValue);
+
+        var PREF_RELATIVE_TIMESTAMPS = 'discussion.enableRelativeTimestamps';
+        // Default to true
+        var prefValue = typeof userPrefs.get(PREF_RELATIVE_TIMESTAMPS) !== 'undefined'
+            ? userPrefs.get(PREF_RELATIVE_TIMESTAMPS)
+            : true;
+        updateLabelText(prefValue);
+        // Set the default
+        userPrefs.set(PREF_RELATIVE_TIMESTAMPS, prefValue);
+
+        this.on('click', '.js-timestamps-dropdown .popup__action', function(e) {
+            bean.fire(qwery('.js-timestamps-dropdown [data-toggle]')[0], 'click');
+            var format = bonzo(e.currentTarget).data('timestamp');
+            var prefValue = format === 'relative';
+            updateLabelText(prefValue);
+            userPrefs.set(PREF_RELATIVE_TIMESTAMPS, prefValue);
+            this.loadComments();
+        });
+    }
 };
 
 Loader.prototype.isOpenForRecommendations = function() {

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -254,7 +254,7 @@ $avatarPadding: $gs-gutter / 2;
     }
 }
 
-.discussion__toolbar-dropdown {
+.discussion__toolbar-item {
     position: relative;
     top: 1px;
     float: left;
@@ -294,6 +294,12 @@ $avatarPadding: $gs-gutter / 2;
         margin-left: $gs-gutter / 2;
         border-left: 1px solid colour(neutral-4);
     }
+}
+
+.discussion__toolbar-item__checkbox {
+    // Unset global styles
+    float: none;
+    margin-left: 0;
 }
 
 /* All comments (top level and reply)


### PR DESCRIPTION
Lots of users were asking for absolute dates, especially those in our crossword community, who race to completion when a crossword is released at midnight.

Fixes #10139

Relative (default):
![image](https://cloud.githubusercontent.com/assets/921609/9816786/005669d2-5897-11e5-8b04-029484cbe1f7.png)

Absolute:
<img width="540" alt="foo" src="https://cloud.githubusercontent.com/assets/921609/9816789/03084b64-5897-11e5-8a6c-b41b3143fc74.png">

/cc @crifmulholland 
