### PR TITLE
Adblock message small bug fixes

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -21,9 +21,9 @@ define([
 ) {
     function init() {
         var alreadyVisted = storage.local.get('alreadyVisited') || 0,
-            adblockLink = 'https://membership.theguardian.com/about/supporter?INTCMP=adb-mv';
+            adblockLink = 'https://membership.theguardian.com?INTCMP=adb-mv';
 
-        if (detect.getBreakpoint() !== 'mobile' && detect.adblockInUse && config.switches.adblock && alreadyVisted) {
+        if (detect.getBreakpoint() !== 'mobile' && detect.adblockInUse && config.switches.adblock && alreadyVisted > 1) {
             new Message('adblock', {
                 pinOnHide: false,
                 siteMessageLinkName: 'adblock message variant',


### PR DESCRIPTION
Two minor fixes for the adblock message:
- `alreadyVisited` cookie is being incremented now before the adblock message module, so we need to check if its value is bigger than 1 not 0
- the new membership hope page link is updated
