### PR TITLE
Amp twitter embeds

### DIFF
--- a/article/app/views/articleAMP.scala.html
+++ b/article/app/views/articleAMP.scala.html
@@ -196,6 +196,10 @@
             .content__mobile-full-width, .media-primary {
                 margin: 0;
             }
+            @* Fix for amp images specific styling *@
+            .-amp-fill-content {
+                height: auto !important;
+            }
 
             figure.element {
                 margin: 1rem 0 0.75rem;
@@ -253,6 +257,7 @@
         </style>
         @fragments.metaData(metaData)
         <script src="https://www.gstatic.com/amphtml/v0.js"></script>
+        <script custom-element="amp-twitter" src="https://www.gstatic.com/amphtml/v0/amp-twitter-0.1.js"async></script>
     </head>
     <body>
         @* @fragments.header(metaData) *@

--- a/article/app/views/articleAMP.scala.html
+++ b/article/app/views/articleAMP.scala.html
@@ -197,7 +197,7 @@
                 margin: 0;
             }
             @* Fix for amp images specific styling *@
-            .-amp-fill-content {
+            img.-amp-fill-content {
                 height: auto !important;
             }
 
@@ -223,7 +223,7 @@
                 position: absolute;
             }
 
-             @* Pullquote related styling below *@
+            @* Pullquote related styling below *@
             .element-pullquote .inline-quote {
                 margin-bottom: 0.375rem;
                 display: block;
@@ -257,7 +257,7 @@
         </style>
         @fragments.metaData(metaData)
         <script src="https://www.gstatic.com/amphtml/v0.js"></script>
-        <script custom-element="amp-twitter" src="https://www.gstatic.com/amphtml/v0/amp-twitter-0.1.js"async></script>
+        <script element="amp-twitter" src="https://www.gstatic.com/amphtml/v0/amp-twitter-0.1.js"async></script>
     </head>
     <body>
         @* @fragments.header(metaData) *@

--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -36,7 +36,7 @@ object BodyCleaner {
         InBodyElementCleaner,
         InBodyLinkCleaner("in body link"),
         BlockNumberCleaner,
-        new TweetCleaner(article),
+        new TweetCleaner(article, amp),
         WitnessCleaner,
         TagLinker(article),
         TableEmbedComplimentaryToP,

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -402,7 +402,7 @@ case class TruncateCleaner(limit: Int)(implicit val edition: Edition, implicit v
   }
 }
 
-class TweetCleaner(content: Content) extends HtmlCleaner {
+class TweetCleaner(content: Content, amp: Boolean) extends HtmlCleaner {
 
   import conf.Switches.TwitterImageFallback
 
@@ -420,32 +420,42 @@ class TweetCleaner(content: Content) extends HtmlCleaner {
 
       tweet.getElementsByClass("twitter-tweet").foreach { element =>
 
-        val el = element.clone()
-        if (el.children.size > 1) {
-          val body = el.child(0).attr("class", "tweet-body")
-
-          val date = el.child(1).attr("class", "tweet-date")
-          val user = el.ownText()
-          val userEl = document.createElement("span").attr("class", "tweet-user").text(user)
-          val link = document.createElement("a").attr("href", date.attr("href")).attr("style", "display: none;")
-
-          element.empty().attr("class", "js-tweet tweet")
-
-          if (TwitterImageFallback.isSwitchedOn) {
-            tweetImage.foreach { image =>
-              val img = document.createElement("img")
-              img.attr("src", image)
-              img.attr("alt", "")
-              img.attr("rel", "nofollow")
-              img.addClass("js-tweet-main-image tweet-main-image")
-              element.appendChild(img)
-            }
+        if (amp) {
+          tweetData.foreach { elem =>
+            element.tagName("amp-twitter")
+            element.attr("layout", "responsive")
+            element.attr("data-tweetId", elem.id)
+            element.attr("data-​c​ards", "hidden")
+            element.attr("width", "486")
+            element.attr("height", "100")
           }
+        } else {
+          val el = element.clone()
+          if (el.children.size > 1) {
+            val body = el.child(0).attr("class", "tweet-body")
 
-          element.appendChild(userEl).appendChild(date).appendChild(body).appendChild(link)
+            val date = el.child(1).attr("class", "tweet-date")
+            val user = el.ownText()
+            val userEl = document.createElement("span").attr("class", "tweet-user").text(user)
+            val link = document.createElement("a").attr("href", date.attr("href")).attr("style", "display: none;")
+
+            element.empty().attr("class", "js-tweet tweet")
+
+            if (TwitterImageFallback.isSwitchedOn) {
+              tweetImage.foreach { image =>
+                val img = document.createElement("img")
+                img.attr("src", image)
+                img.attr("alt", "")
+                img.attr("rel", "nofollow")
+                img.addClass("js-tweet-main-image tweet-main-image")
+                element.appendChild(img)
+              }
+            }
+
+            element.appendChild(userEl).appendChild(date).appendChild(body).appendChild(link)
+          }
         }
       }
-
     }
     document
   }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -422,18 +422,23 @@ class TweetCleaner(content: Content, amp: Boolean) extends HtmlCleaner {
 
         if (amp) {
           tweetData.foreach { elem =>
+            element.empty()
             element.tagName("amp-twitter")
-            element.attr("layout", "responsive")
             element.attr("data-tweetId", elem.id)
             element.attr("data-​c​ards", "hidden")
+            element.attr("layout", "responsive")
             element.attr("width", "486")
-            element.attr("height", "100")
+            // temporary fix to give tweets with an image a larger height
+            if (elem.firstImage.size > 0) {
+              element.attr("height", "600")
+            } else {
+              element.attr("height", "200")
+            }
           }
         } else {
           val el = element.clone()
           if (el.children.size > 1) {
             val body = el.child(0).attr("class", "tweet-body")
-
             val date = el.child(1).attr("class", "tweet-date")
             val user = el.ownText()
             val userEl = document.createElement("span").attr("class", "tweet-user").text(user)


### PR DESCRIPTION
This PR makes twitter embeds in the right format for AMP pages:

![image](https://cloud.githubusercontent.com/assets/8774970/9847578/bbfc6b0a-5ad1-11e5-9794-d159991effb8.png)

cc @johnduffell 
