### PR TITLE
Rugby scores auto refresh for liveblogs that are active

### DIFF
--- a/sport/app/rugby/views/fragments/scoreEvents.scala.html
+++ b/sport/app/rugby/views/fragments/scoreEvents.scala.html
@@ -30,7 +30,7 @@
 
 
 
-<div class="match-summary match-summary--responsive">
+<div class="match-summary match-summary--responsive rugby-stats">
     @if(homeTeamScorers.nonEmpty || awayTeamScorers.nonEmpty) {
         <table class="match-summary__rugby-table">
             <tr class="mobile-only">

--- a/static/src/javascripts/bootstraps/sport.js
+++ b/static/src/javascripts/bootstraps/sport.js
@@ -49,7 +49,7 @@ define([
             var scoreBoard = new ScoreBoard({
                 pageType: pageType,
                 parent: $h,
-                autoupdated: false,
+                autoupdated: config.page.isLive,
                 responseDataKey: 'matchSummary',
                 endpoint: config.page.rugbyMatch + '.json?page=' + encodeURIComponent(config.page.pageId)});
 

--- a/static/src/javascripts/bootstraps/sport.js
+++ b/static/src/javascripts/bootstraps/sport.js
@@ -60,6 +60,7 @@ define([
                 $.create(resp.nav).first().each(function (nav) {
                     // There ought to be exactly two tabs; match report and min-by-min
                     if ($('.tabs__tab', nav).length === 2) {
+                        $('.js-sport-tabs').empty();
                         $('.js-sport-tabs').append(nav);
                     }
                 });
@@ -73,6 +74,9 @@ define([
                 } else {
                     var $scoreEventsTabletUp = $.create(contentString);
                     $scoreEventsTabletUp.addClass('hide-on-mobile');
+
+                    $('.rugby-stats').remove()
+
                     $('.score-container').after($scoreEventsTabletUp);
                 }
 

--- a/static/src/javascripts/bootstraps/sport.js
+++ b/static/src/javascripts/bootstraps/sport.js
@@ -75,7 +75,7 @@ define([
                     var $scoreEventsTabletUp = $.create(contentString);
                     $scoreEventsTabletUp.addClass('hide-on-mobile');
 
-                    $('.rugby-stats').remove()
+                    $('.rugby-stats').remove();
 
                     $('.score-container').after($scoreEventsTabletUp);
                 }


### PR DESCRIPTION
Paired with @rich-nguyen to fix auto-refresh for rugby scores for active live blogs. Previously the scores and tabs would be appended rather than replaced. 
@OliverJAsh would you mind having a look over this?
