### PR TITLE
Discussion relative timestamps: fix default setting

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -37,9 +37,13 @@ define([
 
 var PREF_RELATIVE_TIMESTAMPS = 'discussion.enableRelativeTimestamps';
 var shouldMakeTimestampsRelative = function () {
+    // Default to true
+    var prefValue = userPrefs.get(PREF_RELATIVE_TIMESTAMPS) !== null
+        ? userPrefs.get(PREF_RELATIVE_TIMESTAMPS)
+        : true;
     return !config.switches.discussionCrosswordsOptionalRelativeTimestampSwitch
         || (config.switches.discussionCrosswordsOptionalRelativeTimestampSwitch
-            && userPrefs.get(PREF_RELATIVE_TIMESTAMPS));
+            && prefValue);
 };
 
 var Comments = function(options) {

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -229,8 +229,6 @@ Loader.prototype.initToolbar = function() {
             ? userPrefs.get(PREF_RELATIVE_TIMESTAMPS)
             : true;
         updateLabelText(prefValue);
-        // Set the default
-        userPrefs.set(PREF_RELATIVE_TIMESTAMPS, prefValue);
 
         this.on('click', '.js-timestamps-dropdown .popup__action', function(e) {
             bean.fire(qwery('.js-timestamps-dropdown [data-toggle]')[0], 'click');

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -225,7 +225,7 @@ Loader.prototype.initToolbar = function() {
 
         var PREF_RELATIVE_TIMESTAMPS = 'discussion.enableRelativeTimestamps';
         // Default to true
-        var prefValue = typeof userPrefs.get(PREF_RELATIVE_TIMESTAMPS) !== 'undefined'
+        var prefValue = userPrefs.get(PREF_RELATIVE_TIMESTAMPS) !== null
             ? userPrefs.get(PREF_RELATIVE_TIMESTAMPS)
             : true;
         updateLabelText(prefValue);


### PR DESCRIPTION
Beforehand we only set the default during toolbar initialisation (which occurs after comments initialisation), and what's more, the default was only set in crossword sections. This fixes those issues.
