### PR TITLE
upgrade to scalatest 2.2.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
   val romeModules = "org.rometools" % "rome-modules" % "1.0"
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.11.5" % "test"
   val scalajTime = "org.scalaj" % "scalaj-time_2.10.2" % "0.7"
-  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.1" % Test
+  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % Test
   val scalaz = "org.scalaz" %% "scalaz-core" % "7.0.6"
   val seeGuice = "com.tzavellas" % "sse-guice" % "0.7.1"
   val seleniumJava = "org.seleniumhq.selenium" % "selenium-java" % seleniumVersion


### PR DESCRIPTION
With latest jre we are seeing this error running tests locally - `Uncaught exception when running tests: java.net.NoRouteToHostException: No route to host` in ObjectInputStream
we came across this thread: https://github.com/scalatest/scalatest/issues/248 and it seems there's a fix in 2.2.4.  The tests pass in 2.2.5 so I'm upgrading to that.

cc/ @NataliaLKB 
