### PR TITLE
Add Draft pressing to facia-press

### DIFF
--- a/facia-press/app/controllers/Application.scala
+++ b/facia-press/app/controllers/Application.scala
@@ -57,4 +57,17 @@ object Application extends Controller with ExecutionContexts {
   def pressDraftForPath(path: String) = Action.async {
     handlePressRequest(path, "draft")(DraftFapiFrontPress.pressByPathId)
   }
+
+  def pressDraftForAll() = Action.async {
+    ConfigAgent.getPathIds.foldLeft(Future.successful(List[(String, Result)]())){ case (lastFuture, path) =>
+      lastFuture
+        .flatMap(l => handlePressRequest(path, "draft")(DraftFapiFrontPress.pressByPathId)
+        .map(path -> _)
+        .map(l :+ _))
+    }.map { pressedPaths =>
+      Ok(s"Pressed ${pressedPaths.length} paths on DRAFT: ${pressedPaths.map{ case (a, b) => (a, b.header.status)}}")}
+    .recover { case t: Throwable =>
+        InternalServerError(s"Error pressing all paths on draft: $t")
+    }
+  }
 }

--- a/facia-press/app/controllers/Application.scala
+++ b/facia-press/app/controllers/Application.scala
@@ -61,13 +61,12 @@ object Application extends Controller with ExecutionContexts {
   def pressDraftForAll() = Action.async {
     ConfigAgent.getPathIds.foldLeft(Future.successful(List[(String, Result)]())){ case (lastFuture, path) =>
       lastFuture
-        .flatMap(l => handlePressRequest(path, "draft")(DraftFapiFrontPress.pressByPathId)
-        .map(path -> _)
-        .map(l :+ _))
+        .flatMap(resultList => handlePressRequest(path, "draft")(DraftFapiFrontPress.pressByPathId)
+          .map(path -> _)
+          .map(resultList :+ _))
     }.map { pressedPaths =>
       Ok(s"Pressed ${pressedPaths.length} paths on DRAFT: ${pressedPaths.map{ case (a, b) => (a, b.header.status)}}")}
     .recover { case t: Throwable =>
-        InternalServerError(s"Error pressing all paths on draft: $t")
-    }
+        InternalServerError(s"Error pressing all paths on draft: $t")}
   }
 }

--- a/facia-press/conf/routes
+++ b/facia-press/conf/routes
@@ -6,4 +6,5 @@ GET        /pressed/fronts      controllers.Application.generateFrontJson()
 GET        /pressed/live/*path    controllers.Application.generateLivePressedFor(path)
 
 GET        /press/live/*path    controllers.Application.pressLiveForPath(path)
+POST       /press/draft/all     controllers.Application.pressDraftForAll()
 GET        /press/draft/*path   controllers.Application.pressDraftForPath(path)

--- a/facia-press/conf/routes
+++ b/facia-press/conf/routes
@@ -5,6 +5,6 @@ GET        /debug/config        controllers.Application.showCurrentConfig
 GET        /pressed/fronts      controllers.Application.generateFrontJson()
 GET        /pressed/live/*path    controllers.Application.generateLivePressedFor(path)
 
-GET        /press/live/*path    controllers.Application.pressLiveForPath(path)
-POST       /press/draft/all     controllers.Application.pressDraftForAll()
-GET        /press/draft/*path   controllers.Application.pressDraftForPath(path)
+POST        /press/live/*path    controllers.Application.pressLiveForPath(path)
+POST        /press/draft/all     controllers.Application.pressDraftForAll()
+POST        /press/draft/*path   controllers.Application.pressDraftForPath(path)


### PR DESCRIPTION
This allows us to press all of `draft` off of a `facia-press` box in times of need.

We have used this a few times, so I think we should keep the sequential code. Probably not the most ideal solution, but better than nothing.

@kelvin-chappell 
