### PR TITLE
Update clues content attr and styling for IE11

### DIFF
--- a/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
@@ -27,7 +27,7 @@ class Clue extends React.Component {
                     'crossword__clue--display-group-order' : JSON.stringify(this.props.number) !== this.props.humanNumber
                 })}
                 onClick={this.onClick}
-                value={this.props.humanNumber}
+                data-number={this.props.humanNumber} // Use data attr instead of value as value removes everything after first comma
                 /* jscs:disable disallowDanglingUnderscores */
                 dangerouslySetInnerHTML={{__html: this.props.clue}}
                 /* jscs:enable disallowDanglingUnderscores */

--- a/static/src/stylesheets/module/crosswords/_clues.scss
+++ b/static/src/stylesheets/module/crosswords/_clues.scss
@@ -19,7 +19,7 @@
     padding-left: 2em;
 
     &:before {
-        content: attr(value);
+        content: attr(data-number);
         position: absolute;
         left: 0;
         font-weight: bold;
@@ -42,6 +42,8 @@
 
     //For grouped clues we display 11.12,23 accross instead of just a number
     &:before {
-        position: initial;
+        padding-right: 2em; // Match the padding of non-grouped clues, but wrap only grouped clues underneath the number
+        position: static;
+        left: auto;
     }
 }

--- a/static/src/stylesheets/module/crosswords/_clues.scss
+++ b/static/src/stylesheets/module/crosswords/_clues.scss
@@ -40,6 +40,6 @@
 
 //For grouped clues we display 11.12,23 accross instead of just a number
 .crossword__clue--display-group-order:before {
-    padding-right: 0.875rem; // 14px - Matches the padding of non-grouped clues
+    padding-right: .875em; // 14px - Matches the width between double digit numbers and clue of non-grouped clues
 }
 

--- a/static/src/stylesheets/module/crosswords/_clues.scss
+++ b/static/src/stylesheets/module/crosswords/_clues.scss
@@ -40,6 +40,6 @@
 
 //For grouped clues we display 11.12,23 accross instead of just a number
 .crossword__clue--display-group-order:before {
-    padding-right: 2em; // Match the padding of non-grouped clues
+    padding-right: 0.875rem; // 14px - Matches the padding of non-grouped clues
 }
 

--- a/static/src/stylesheets/module/crosswords/_clues.scss
+++ b/static/src/stylesheets/module/crosswords/_clues.scss
@@ -20,8 +20,10 @@
 
     &:before {
         content: attr(data-number);
-        position: absolute;
-        left: 0;
+        display: inline-block;
+        min-width: 2em;
+        margin-left: -2em;
+        position: static;
         font-weight: bold;
         -webkit-font-smoothing: initial;
     }
@@ -36,14 +38,8 @@
     color: colour(neutral-2);
 }
 
-.crossword__clue--display-group-order {
-
-    padding-left: 0px;
-
-    //For grouped clues we display 11.12,23 accross instead of just a number
-    &:before {
-        padding-right: 2em; // Match the padding of non-grouped clues, but wrap only grouped clues underneath the number
-        position: static;
-        left: auto;
-    }
+//For grouped clues we display 11.12,23 accross instead of just a number
+.crossword__clue--display-group-order:before {
+    padding-right: 2em; // Match the padding of non-grouped clues
 }
+


### PR DESCRIPTION
Clues were overlapping and not showing all the values in IE10 & 11.
## Before

![screen shot 2015-09-14 at 17 29 03 copy](https://cloud.githubusercontent.com/assets/638051/9855608/3d270a16-5b07-11e5-97d2-e80b66a0fd43.png)
## After
### IE11

![image](https://cloud.githubusercontent.com/assets/638051/9871383/41aa7576-5b8b-11e5-86c9-2bf9db3b9d03.png)
### Chrome

![image](https://cloud.githubusercontent.com/assets/638051/9871368/213ea0d2-5b8b-11e5-8fda-e57b4dcfa24e.png)

Fixes #10474
