### PR TITLE
For narrow breakpoints make sure the fc-item__media-wrapper follows the fc-item

### DIFF
--- a/static/src/stylesheets/inline/story-package.scss
+++ b/static/src/stylesheets/inline/story-package.scss
@@ -65,7 +65,8 @@
     }
 
     // Item Level
-    .fc-item {
+    .fc-item,
+    .fc-item__media-wrapper {
         // This shouldn't need to be important but too specific selectors on some tones force it to be
         background-color: colour(story-package) !important;
 


### PR DESCRIPTION
Before
![screen shot 2015-09-14 at 16 44 14](https://cloud.githubusercontent.com/assets/944375/9855788/76ade916-5b08-11e5-81f1-b87aa2c7ea4b.png)

After
![screen shot 2015-09-14 at 17 45 41](https://cloud.githubusercontent.com/assets/944375/9855800/7db195dc-5b08-11e5-8cb5-d6150654176b.png)
