### PR TITLE
Allow core users to change edition

### DIFF
--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -128,8 +128,8 @@
             </div>
         </div>
     }
-    <div class="brand-bar__item has-popup brand-bar__item--edition modern-visible" data-component="edition">
-        <a href="#guardian-edition-menu" class="@RenderClasses(Map(
+    <div class="brand-bar__item has-popup brand-bar__item--edition" data-component="edition">
+        <a class="@RenderClasses(Map(
             "brand-bar__item--action" -> true,
             "popup__toggle" -> true,
             "brand-bar__item--action-beta" -> InternationalEdition.isInternationalEdition(request)

--- a/static/src/stylesheets/module/_popup.scss
+++ b/static/src/stylesheets/module/_popup.scss
@@ -95,7 +95,8 @@ $control-offset: 36 + $gs-gutter/2;
     }
 
     &.is-active,
-    .is-active > & {
+    .is-active > &,
+    .is-not-modern .brand-bar__item--edition:hover & {
         @include mq(tablet) {
             &:after {
                 border-top: 0;

--- a/static/src/stylesheets/module/nav/_brand-bar.scss
+++ b/static/src/stylesheets/module/nav/_brand-bar.scss
@@ -140,6 +140,15 @@
     .l-header--is-slim & {
         display: none;
     }
+
+    .is-not-modern & {
+        &:hover,
+        &:focus {
+            .top-bar__popup--edition {
+                display: block;
+            }
+        }
+    }
 }
 
 .brand-bar__item--jobs {


### PR DESCRIPTION
Brought the edition switching menu back in for core users by having it expand on hover.

![hovernav](https://cloud.githubusercontent.com/assets/2236852/9874385/ac1996e6-5b9d-11e5-9b37-67979d6a2730.gif)

Tested on iPads/Android tablets too (it expands on click, closes when you click off it)

cc @stephanfowler 
