### PR TITLE
Ensure the background of the image container matches the container around

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -188,7 +188,7 @@ $fc-item-gutter: $gs-gutter / 4;
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: colour(neutral-6);
 
         .fc-slice--nav-list--media & {

--- a/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-analysis.scss
@@ -6,7 +6,7 @@
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: darken(colour(analysis-background), 5%);
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-comment.scss
@@ -6,7 +6,7 @@
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: darken(colour(comment-background), 5%);
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-dead.scss
@@ -5,7 +5,7 @@
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: darken(colour(neutral-6), 2%);
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-editorial.scss
@@ -11,7 +11,7 @@
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: darken(colour(editorial-default), 5%);
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-external.scss
@@ -16,7 +16,7 @@
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: darken(colour(neutral-6), 3%);
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-feature.scss
@@ -10,7 +10,7 @@
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: darken(colour(feature-default), 4%);
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-live.scss
@@ -9,7 +9,7 @@
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: darken(colour(live-default), 4%);
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-media.scss
@@ -9,7 +9,7 @@
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: darken(colour(media-background), 7.5%);
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-review.scss
@@ -9,7 +9,7 @@
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: darken(colour(review-background), 6%);
     }
 

--- a/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/facia/item-tones/_tone-special-report.scss
@@ -5,7 +5,7 @@
     }
 
     .u-faux-block-link--hover,
-    .fc-item__media-wrapper {
+    .fc-item__image-container {
         background-color: darken(colour(news-support-6), 5%);
     }
 


### PR DESCRIPTION
Works for both hover and non-hover state which https://github.com/guardian/frontend/pull/10514 did not handle.

Before
<img width="757" alt="screen shot 2015-09-15 at 14 34 04" src="https://cloud.githubusercontent.com/assets/944375/9877784/e7cde4e4-5bb6-11e5-920c-7fccd2269bb9.png">

After (hover)
<img width="757" alt="screen shot 2015-09-15 at 14 34 19" src="https://cloud.githubusercontent.com/assets/944375/9877792/f3ef285a-5bb6-11e5-92b9-cd45e8b60afa.png">

After (non hover)
<img width="725" alt="screen shot 2015-09-15 at 14 34 12" src="https://cloud.githubusercontent.com/assets/944375/9877794/f7bd101e-5bb6-11e5-8303-e5759953a94a.png">

cc/ @sndrs @desbo 
