### PR TITLE
Use the correct content attribute for printing crossword

### DIFF
--- a/static/src/stylesheets/module/crosswords/_accessible.scss
+++ b/static/src/stylesheets/module/crosswords/_accessible.scss
@@ -20,7 +20,7 @@
     padding-left: 2em;
 
     &:before {
-        content: attr(value);
+        content: attr(data-number);
         position: absolute;
         left: 0;
         font-weight: bold;

--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -193,7 +193,7 @@ p {
 
 .crossword__clue {
     &:before {
-        content: attr(value);
+        content: attr(data-number);
         font-weight: bold;
         margin-right: .5rem;
     }


### PR DESCRIPTION
The crossword number disappeared from the printout, this adds it back in
