### PR TITLE
Add List Variables to the list of things we track.

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -32,7 +32,7 @@ define([
         NG_STORAGE_KEY = 'gu.analytics.referrerVars',
         standardProps = 'channel,prop1,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,' +
             'prop51,prop61,prop64,prop65,prop74,prop40,prop63,eVar7,eVar37,eVar38,eVar39,eVar50,eVar24,eVar60,eVar51,' +
-            'eVar31,eVar18,eVar32,eVar40,events';
+            'eVar31,eVar18,eVar32,eVar40,listVar1,listVar2,listVar3,events';
 
     function Omniture() {
         this.s = window.s;

--- a/static/src/javascripts/test/spec/common/analytics/omniture.spec.js
+++ b/static/src/javascripts/test/spec/common/analytics/omniture.spec.js
@@ -91,7 +91,7 @@ describe('omniture', function () {
         omniture.go();
         omniture.trackLink('link object', 'outer:link');
 
-        expect(s.linkTrackVars).toBe('channel,prop1,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,prop51,prop61,prop64,prop65,prop74,prop40,prop63,eVar7,eVar37,eVar38,eVar39,eVar50,eVar24,eVar60,eVar51,eVar31,eVar18,eVar32,eVar40,events');
+        expect(s.linkTrackVars).toBe('channel,prop1,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,prop51,prop61,prop64,prop65,prop74,prop40,prop63,eVar7,eVar37,eVar38,eVar39,eVar50,eVar24,eVar60,eVar51,eVar31,eVar18,eVar32,eVar40,listVar1,listVar2,listVar3,events');
         expect(s.linkTrackEvents).toBe('event37');
         expect(s.events).toBe('event37');
     });


### PR DESCRIPTION
These were previously on the "page view" call so we did not need them in this list.

Now they are on the "topup" call so they will not be sent unless we specify them.
