### PR TITLE
Enables friendlies in pre-prod environment. 

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -833,6 +833,15 @@ object Switches {
     exposeClientSide = true
   )
 
+  val RugbyWorldCupFriendlies = Switch(
+    "Feature",
+    "rugby-world-cup-friendlies-for-pre-prod",
+    "If this switch is on rugby world cup scores will be load in Friendlies too (only use in CODE)",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 11, 6),
+    exposeClientSide = false
+  )
+
   val WeatherSwitch = Switch(
     "Feature",
     "weather",

--- a/sport/app/rugby/feed/OptaFeed.scala
+++ b/sport/app/rugby/feed/OptaFeed.scala
@@ -29,7 +29,7 @@ case class RugbyOptaFeedException(message: String) extends RuntimeException(mess
 
 object OptaFeed extends ExecutionContexts with Logging {
 
-  private val events =
+  private def events =
     if(Configuration.environment.isNonProd && conf.Switches.RugbyWorldCupFriendlies.isSwitchedOn) List(WarmupWorldCup2015, WorldCup2015)
     else List(WorldCup2015)
 


### PR DESCRIPTION
Put this behind a switch so we can get pre-prod to behave like Prod. Note turning this from on to off requires a re-deploy (of Code) as the agents will not clear out the friendlies data and I didn't want to alter the code around agents so close to the competition. Is there a better way to do this? 
