### PR TITLE
Test iPad core experience for fronts

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -318,7 +318,7 @@ object Switches {
     "Performance",
     "ipad-core-fronts",
     "Serve core fronts to a random percentage of crash-prone ipad users",
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2015, 10, 31),
     exposeClientSide = true
   )

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -318,7 +318,7 @@ object Switches {
     "Performance",
     "ipad-core-fronts",
     "Serve core fronts to a random percentage of crash-prone ipad users",
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2015, 10, 31),
     exposeClientSide = true
   )

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -314,6 +314,15 @@ object Switches {
     exposeClientSide = true
   )
 
+  val ServeCoreFrontsToSomeIpadsSwitch = Switch(
+    "Performance",
+    "ipad-core-fronts",
+    "Serve core fronts to a random percentage of crash-prone ipad users",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 10, 31),
+    exposeClientSide = true
+  )
+
   // Commercial
   val NoMobileTopAdSwitch = Switch(
     "Commercial",

--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -4,18 +4,53 @@
 @if(IphoneConfidence.isSwitchedOn && Seq("uk", "us", "au").contains(item.id)) {
 
     (function (window, navigator) {
-        function logDevice(model, device) {
-            var identifier = device + '-' + model;
+        var coreOptedIn = function () {
+            try {
+                var corePref = window.localStorage.getItem('gu.prefs.force-core');
+                if (corePref) {
+                    if ((JSON.parse(corePref).value) === "on") {
+                        return true;
+                    }
+                }
+                return false;
+            } catch (e) {
+                return false;
+            }
+        };
 
-            // send immediate beacon - adding 1 second delay in an attempt to resolve signal loss on Android and Windows7
-            window.setTimeout(function () {
-                (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + identifier + '-start.gif';
-            }, 1000);
+
+        function logDevice(model, device) {
+            var identifier = function() {
+                var id = device + '-' + model;
+                if ((device === 'ipad' && model === '3orLater')) {
+                    if (coreOptedIn()) {
+                        return id + '-core-opted-in';
+                    }
+                    if (window.serveCoreFronts) {
+                        return id + '-core-fronts';
+                    }
+                }
+                return id;
+            };
+
+            // send immediate beacon
+            (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + identifier() + '-start.gif';
 
             // send second after 5 seconds, if we're still around
             window.setTimeout(function () {
-                (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + identifier + '-after-5.gif';
+                (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + identifier() + '-after-5.gif';
             }, 5000);
+
+            // send another after 10 seconds
+            window.setTimeout(function () {
+                (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + identifier() + '-after-10.gif';
+            }, 10000);
+
+            // send last one after 60 seconds
+            window.setTimeout(function () {
+                (new Image()).src = window.guardian.config.page.beaconUrl + '/count/' + identifier() + '-after-60.gif';
+            }, 60000);
+
         }
 
         if (navigator.platform === 'iPhone' || navigator.platform === 'iPad') {
@@ -53,21 +88,23 @@
             }
         }
 
-        // This is a subset of the navigator.platform values used by Android. We may need to add more to capture more devices
-        if ((navigator.platform === 'Linux armv7l') || (navigator.platform === 'Linux aarch64') || (navigator.platform === 'Android')) {
-            var isNexus5 = /.*Nexus 5 */.test(navigator.userAgent);
-
-            if (isNexus5) {
-                logDevice('nexus5', 'android');
-            }
-        }
-
-        // Send AWS beacons for Windows7 Chrome & Opera users (user agent is almost identical). This is so we have a indicator of loss on something which we are confident is stable
-        if (navigator.platform === 'Win32') {
-            if ((/Windows NT 6.1; WOW64/.test(navigator.userAgent)) && (/Chrome/.test(navigator.userAgent))) {
-                logDevice('chrome', 'windows7');
-            }
-        }
+        // KILL THESE WHILE THE IPAD CORE TEST IS RUNNING TO SAVE £££s ON AWS BEACON COSTS
+        // ** REMEMBER TO UPDATE diagnostics/app/model/diagnostics/analytics/Metric.scala IF RE-ENABLING **
+        //// This is a subset of the navigator.platform values used by Android. We may need to add more to capture more devices
+        //if ((navigator.platform === 'Linux armv7l') || (navigator.platform === 'Linux aarch64') || (navigator.platform === 'Android')) {
+        //    var isNexus5 = /.*Nexus 5 */.test(navigator.userAgent);
+        //
+        //    if (isNexus5) {
+        //        logDevice('nexus5', 'android');
+        //    }
+        //}
+        //
+        //// Send AWS beacons for Windows7 Chrome & Opera users (user agent is almost identical). This is so we have a indicator of loss on something which we are confident is stable
+        //if (navigator.platform === 'Win32') {
+        //    if ((/Windows NT 6.1; WOW64/.test(navigator.userAgent)) && (/Chrome/.test(navigator.userAgent))) {
+        //        logDevice('chrome', 'windows7');
+        //    }
+        //}
 
     })(window, navigator);
 }

--- a/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
+++ b/common/app/templates/headerInlineJS/cloudwatchBeacons.scala.js
@@ -87,10 +87,9 @@
                 logDevice('4', 'iphone');
             }
         }
-
-        // KILL THESE WHILE THE IPAD CORE TEST IS RUNNING TO SAVE £££s ON AWS BEACON COSTS
-        // ** REMEMBER TO UPDATE diagnostics/app/model/diagnostics/analytics/Metric.scala IF RE-ENABLING **
-        //// This is a subset of the navigator.platform values used by Android. We may need to add more to capture more devices
+@* KILL THESE WHILE THE IPAD CORE TEST IS RUNNING TO SAVE £££s ON AWS BEACON COSTS
+        (REMEMBER TO UPDATE diagnostics/app/model/diagnostics/analytics/Metric.scala IF RE-ENABLING)
+        // This is a subset of the navigator.platform values used by Android. We may need to add more to capture more devices
         //if ((navigator.platform === 'Linux armv7l') || (navigator.platform === 'Linux aarch64') || (navigator.platform === 'Android')) {
         //    var isNexus5 = /.*Nexus 5 */.test(navigator.userAgent);
         //
@@ -105,6 +104,6 @@
         //        logDevice('chrome', 'windows7');
         //    }
         //}
-
+*@
     })(window, navigator);
 }

--- a/common/app/templates/headerInlineJS/shouldEnhance.scala.js
+++ b/common/app/templates/headerInlineJS/shouldEnhance.scala.js
@@ -30,8 +30,8 @@
         return false;
     };
 
-    window.shouldEnhance = !personPrefersCore() && !isOlderDevice();
-})(navigator, window)
+    window.shouldEnhance = !personPrefersCore() && !isOlderDevice() && !(@item.isFront && window.serveCoreFronts);
+})(navigator, window);
 
 
 

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -16,11 +16,13 @@
 
 @* provide some ipad users with the core view of fronts *@
 <script>
+    console.log("*** platform: " + navigator.platform);
+    console.log("*** devicePixelRatio: " + window.devicePixelRatio);
+    console.log("*** userAgent:" + navigator.userAgent);
     @if(ServeCoreFrontsToSomeIpadsSwitch.isSwitchedOn) {
         if(navigator.platform === 'iPad' &&
                 window.devicePixelRatio === 2 &&
-                /.*iPad; CPU OS ([789])_\d+.*/.test(navigator.userAgent) &&
-                Math.random() > .5) {
+                /.*iPad; CPU OS ([789])_\d+.*/.test(navigator.userAgent)) {
             window.serveCoreFronts = true;
         } else {
             window.serveCoreFronts = false;

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -17,14 +17,24 @@
 @* provide some ipad users with the core view of fronts *@
 <script>
     @if(ServeCoreFrontsToSomeIpadsSwitch.isSwitchedOn) {
-        if(navigator.platform === 'iPad' &&
+            if(navigator.platform === 'iPad' &&
                 window.devicePixelRatio === 2 &&
-                /.*iPad; CPU OS ([789])_\d+.*/.test(navigator.userAgent) &&
-                Math.random() > .5) {
-            window.serveCoreFronts = true;
-        } else {
-            window.serveCoreFronts = false;
-        }
+                /.*iPad; CPU OS ([789])_\d+.*/.test(navigator.userAgent)) {
+                try {
+                    var storage = window.localStorage;
+                    var participation = storage.getItem('gu.core-fronts-test');
+                    if (!participation) {
+                        if(Math.random() > .5) {
+                            storage.setItem('gu.core-fronts-test', 'true');
+                        } else {
+                            storage.setItem('gu.core-fronts-test', 'false');
+                        }
+                    }
+                    window.serveCoreFronts = storage.getItem('gu.core-fronts-test') === 'true';
+                } catch (e) {
+                    window.serveCoreFronts = false;
+                }
+            }
     } else {
         window.serveCoreFronts = false;
     }

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -14,6 +14,22 @@
     <script src="@Static("javascripts/components/html5shiv/html5shiv.js")"></script>
 <![endif]-->
 
+@* provide some ipad users with the core view of fronts *@
+<script>
+    @if(ServeCoreFrontsToSomeIpadsSwitch.isSwitchedOn) {
+        if(navigator.platform === 'iPad' &&
+                window.devicePixelRatio === 2 &&
+                /.*iPad; CPU OS ([789])_\d+.*/.test(navigator.userAgent) &&
+                Math.random() > .5) {
+            window.serveCoreFronts = true;
+        } else {
+            window.serveCoreFronts = false;
+        }
+    } else {
+        window.serveCoreFronts = false;
+    }
+</script>
+
 @* get the stylesheets downloading ASAP *@
 @fragments.stylesheetLinks(projectName)
 

--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -16,13 +16,11 @@
 
 @* provide some ipad users with the core view of fronts *@
 <script>
-    console.log("*** platform: " + navigator.platform);
-    console.log("*** devicePixelRatio: " + window.devicePixelRatio);
-    console.log("*** userAgent:" + navigator.userAgent);
     @if(ServeCoreFrontsToSomeIpadsSwitch.isSwitchedOn) {
         if(navigator.platform === 'iPad' &&
                 window.devicePixelRatio === 2 &&
-                /.*iPad; CPU OS ([789])_\d+.*/.test(navigator.userAgent)) {
+                /.*iPad; CPU OS ([789])_\d+.*/.test(navigator.userAgent) &&
+                Math.random() > .5) {
             window.serveCoreFronts = true;
         } else {
             window.serveCoreFronts = false;

--- a/data/database/1d5e4a104af01348f1b4557f4f6f8bcd8d96496384226e5502d3710aa8c6a69e
+++ b/data/database/1d5e4a104af01348f1b4557f4f6f8bcd8d96496384226e5502d3710aa8c6a69e
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/924a124ef5bbc157e3e7b06478c0ba4fb4171c3598abd466e80a5bb94123e7ad
+++ b/data/database/924a124ef5bbc157e3e7b06478c0ba4fb4171c3598abd466e80a5bb94123e7ad
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -48,12 +48,26 @@ object Metric extends Logging {
     ("ipad-old-after-5", CountMetric(s"ipad-old-after-5")),
     ("ipad-2orMini-start", CountMetric(s"ipad-2orMini-start")),
     ("ipad-2orMini-after-5", CountMetric(s"ipad-2orMini-after-5")),
+
     ("ipad-3orLater-start", CountMetric(s"ipad-3orLater-start")),
     ("ipad-3orLater-after-5", CountMetric(s"ipad-3orLater-after-5")),
-    ("android-nexus5-start", CountMetric(s"android-nexus5-start")),
-    ("android-nexus5-after-5", CountMetric(s"android-nexus5-after-5")),
-    ("windows7-chrome-start", CountMetric(s"windows7-chrome-start")),
-    ("windows7-chrome-after-5", CountMetric(s"windows7-chrome-after-5")),
+    ("ipad-3orLater-after-10", CountMetric(s"ipad-3orLater-after-10")),
+    ("ipad-3orLater-after-60", CountMetric(s"ipad-3orLater-after-60")),
+
+    ("ipad-3orLater-core-opted-in-start", CountMetric(s"ipad-3orLater-core-opted-in-start")),
+    ("ipad-3orLater-core-opted-in-after-5", CountMetric(s"ipad-3orLater-core-opted-in-after-5")),
+    ("ipad-3orLater-core-opted-in-after-10", CountMetric(s"ipad-3orLater-core-opted-in-after-10")),
+    ("ipad-3orLater-core-opted-in-after-60", CountMetric(s"ipad-3orLater-core-opted-in-after-60")),
+
+    ("ipad-3orLater-core-fronts-start", CountMetric(s"ipad-3orLater-core-fronts-start")),
+    ("ipad-3orLater-core-fronts-after-5", CountMetric(s"ipad-3orLater-core-fronts-after-5")),
+    ("ipad-3orLater-core-fronts-after-10", CountMetric(s"ipad-3orLater-core-fronts-after-10")),
+    ("ipad-3orLater-core-fronts-after-60", CountMetric(s"ipad-3orLater-core-fronts-after-60")),
+
+//    ("android-nexus5-start", CountMetric(s"android-nexus5-start")),
+//    ("android-nexus5-after-5", CountMetric(s"android-nexus5-after-5")),
+//    ("windows7-chrome-start", CountMetric(s"windows7-chrome-start")),
+//    ("windows7-chrome-after-5", CountMetric(s"windows7-chrome-after-5")),
 
     ("headlines-variant-seen", CountMetric(s"headlines-variant-seen")),
     ("headlines-control-seen", CountMetric(s"headlines-control-seen")),

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -46,8 +46,13 @@ object Metric extends Logging {
 
     ("ipad-old-start", CountMetric(s"ipad-old-start")),
     ("ipad-old-after-5", CountMetric(s"ipad-old-after-5")),
+    ("ipad-old-after-10", CountMetric(s"ipad-old-after-10")),
+    ("ipad-old-after-60", CountMetric(s"ipad-old-after-60")),
+
     ("ipad-2orMini-start", CountMetric(s"ipad-2orMini-start")),
     ("ipad-2orMini-after-5", CountMetric(s"ipad-2orMini-after-5")),
+    ("ipad-2orMini-after-10", CountMetric(s"ipad-2orMini-after-10")),
+    ("ipad-2orMini-after-60", CountMetric(s"ipad-2orMini-after-60")),
 
     ("ipad-3orLater-start", CountMetric(s"ipad-3orLater-start")),
     ("ipad-3orLater-after-5", CountMetric(s"ipad-3orLater-after-5")),
@@ -86,8 +91,8 @@ object Metric extends Logging {
     Seq(
       s"iphone-$model-start" -> CountMetric(s"iphone-$model-start"),
       s"iphone-$model-after-5" -> CountMetric(s"iphone-$model-after-5"),
-      s"iphone-$model-start-raf" -> CountMetric(s"iphone-$model-start-raf"),
-      s"iphone-$model-after-5-raf" -> CountMetric(s"iphone-$model-after-5-raf")
+      s"iphone-$model-after-10" -> CountMetric(s"iphone-$model-after-10"),
+      s"iphone-$model-after-60" -> CountMetric(s"iphone-$model-after-60")
     )
   )
 


### PR DESCRIPTION
We want to test if serving the core version of fronts to half of our iPad 3 traffic helps prevent crashing on those devices, and we'll monitor the effects using cloudwatch beacons.

Based on recent traffic figures, we expect the test to occur on just under 1.4M requests for fronts over a two week period.

Because it wasn't possible to set up a true A/B test for this, users are equally likely to see the core or  premium mode fronts at each request.

Finally, the test applies to all fronts, but we're currently only sending beacons on each region's main front (uk, us and au) for consistency with previous monitoring.

@michaelwmcnamara and I have run this through on a few real devices and we're happy that it's doing what it's supposed to.

@sndrs, this look ok to you too?
