### PR TITLE
remove srcset from amp article images

### DIFF
--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -84,8 +84,9 @@
 @if(amp) {
     @picture.largestImage.map { largestImage =>
         <amp-img src="@ImgSrc.getFallbackUrl(picture)"
+        @*srcset is broken, remiving until this is resolved: https://github.com/ampproject/amphtml/issues/172
         srcset="@ImgSrc.srcset(picture, widths)"
-        sizes="@widths.sizes"
+        sizes="@widths.sizes"*@
         layout="responsive"
         width="@largestImage.width"
         height="@largestImage.height"


### PR DESCRIPTION
there is an issue open at the moment where it doesn't accept the width on the last source so removing for now to stop the big red box
@NataliaLKB 
