### PR TITLE
adding bullet point styling to amp pages

### DIFF
--- a/common/app/views/fragments/amp/mainStylesheetAMP.scala.html
+++ b/common/app/views/fragments/amp/mainStylesheetAMP.scala.html
@@ -247,5 +247,22 @@
         transform: rotate(180deg);
     }
 
+    @* Bullet Points related styling below *@
+    .bullet {
+        font-size: 0.00625rem;
+        color: transparent;
+    }
+
+    .bullet:before {
+        display: inline-block;
+        content: '';
+        -webkit-border-radius: 0.375rem;
+        border-radius: 0.375rem;
+        height: 0.75rem;
+        width: 0.75rem;
+        margin-right: 0.125rem;
+        background-color: #bdbdbd;
+    }
+
     @fragments.amp.tonalStylesheet()
 </style>


### PR DESCRIPTION
BEFORE:
![image](https://cloud.githubusercontent.com/assets/8774970/9908545/11eecf4c-5c8c-11e5-8c3b-30545e59148b.png)

AFTER:
![image](https://cloud.githubusercontent.com/assets/8774970/9908536/0aad24a4-5c8c-11e5-8118-ee5b8451425b.png)

cc @johnduffell 
