### PR TITLE
Frequency tasks manual and scheduled

### DIFF
--- a/admin/app/controllers/FrontPressController.scala
+++ b/admin/app/controllers/FrontPressController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import common.{ExecutionContexts, Logging}
 import controllers.admin.AuthActions
-import jobs.RefreshFrontsJob
+import jobs.{LowFrequency, StandardFrequency, HighFrequency, RefreshFrontsJob}
 import play.api.mvc.Controller
 
 object FrontPressController extends Controller with Logging with AuthLogging with ExecutionContexts {
@@ -19,15 +19,15 @@ object FrontPressController extends Controller with Logging with AuthLogging wit
   }
 
   def queueHighFrequencyFrontsForPress() = AuthActions.AuthActionTest { request =>
-    runJob(RefreshFrontsJob.runHighFrequency(), "high frequency")
+    runJob(RefreshFrontsJob.runFrequency(HighFrequency), "high frequency")
   }
 
   def queueStandardFrequencyFrontsForPress() = AuthActions.AuthActionTest { request =>
-    runJob(RefreshFrontsJob.runStandardFrequency(), "standard frequency")
+    runJob(RefreshFrontsJob.runFrequency(StandardFrequency), "standard frequency")
   }
 
   def queueLowFrequencyFrontsForPress() = AuthActions.AuthActionTest { request =>
-    runJob(RefreshFrontsJob.runLowFrequency(), "low frequency")
+    runJob(RefreshFrontsJob.runFrequency(LowFrequency), "low frequency")
   }
 
   private def runJob(didRun: Boolean, jobName: String) = {

--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -40,14 +40,14 @@ object RefreshFrontsJob extends Logging {
       StandardFrequency
   }
 
-  def runHighFrequency(): Boolean = runFrequency(HighFrequency)
+  def runHighFrequency(): Unit = if(FrontPressJobSwitch.isSwitchedOn) runFrequency(HighFrequency)
 
-  def runStandardFrequency(): Boolean = runFrequency(StandardFrequency)
+  def runStandardFrequency(): Unit = if(FrontPressJobSwitchStandardFrequency.isSwitchedOn) runFrequency(StandardFrequency)
 
-  def runLowFrequency(): Boolean = runFrequency(LowFrequency)
+  def runLowFrequency(): Unit = if(FrontPressJobSwitch.isSwitchedOn) runFrequency(LowFrequency)
 
   def runFrequency(frontType: FrontType): Boolean = {
-    if (FrontPressJobSwitch.isSwitchedOn && Configuration.aws.frontPressSns.filter(_.nonEmpty).isDefined) {
+    if (Configuration.aws.frontPressSns.filter(_.nonEmpty).isDefined) {
       log.info(s"Putting press jobs on Facia Cron $frontType")
 
       for {

--- a/admin/app/jobs/RefreshFrontsJob.scala
+++ b/admin/app/jobs/RefreshFrontsJob.scala
@@ -40,12 +40,6 @@ object RefreshFrontsJob extends Logging {
       StandardFrequency
   }
 
-  def runHighFrequency(): Unit = if(FrontPressJobSwitch.isSwitchedOn) runFrequency(HighFrequency)
-
-  def runStandardFrequency(): Unit = if(FrontPressJobSwitchStandardFrequency.isSwitchedOn) runFrequency(StandardFrequency)
-
-  def runLowFrequency(): Unit = if(FrontPressJobSwitch.isSwitchedOn) runFrequency(LowFrequency)
-
   def runFrequency(frontType: FrontType): Boolean = {
     if (Configuration.aws.frontPressSns.filter(_.nonEmpty).isDefined) {
       log.info(s"Putting press jobs on Facia Cron $frontType")

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -5,6 +5,7 @@ import java.util.TimeZone
 import common.{AkkaAsync, Jobs, Logging}
 import conf.Configuration
 import conf.Configuration.environment
+import conf.Switches._
 import football.feed.MatchDayRecorder
 import jobs._
 import play.api.GlobalSettings
@@ -41,15 +42,15 @@ trait AdminLifecycle extends GlobalSettings with Logging {
     }
 
     Jobs.scheduleEveryNMinutes("FrontPressJobHighFrequency", adminPressJobHighPushRateInMinutes) {
-      RefreshFrontsJob.runHighFrequency()
+      if(FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(HighFrequency)
     }
 
     Jobs.scheduleEveryNMinutes("FrontPressJobStandardFrequency", adminPressJobStandardPushRateInMinutes) {
-      RefreshFrontsJob.runStandardFrequency()
+      if(FrontPressJobSwitchStandardFrequency.isSwitchedOn) RefreshFrontsJob.runFrequency(StandardFrequency)
     }
 
     Jobs.scheduleEveryNMinutes("FrontPressJobLowFrequency", adminPressJobLowPushRateInMinutes) {
-      RefreshFrontsJob.runLowFrequency()
+      if(FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(LowFrequency)
     }
 
     Jobs.schedule("RebuildIndexJob", s"9 0/$adminRebuildIndexRateInMinutes * 1/1 * ? *") {

--- a/admin/app/views/press.scala.html
+++ b/admin/app/views/press.scala.html
@@ -4,7 +4,11 @@
             This is used to manually press the facia pages
         </li>
         <li>
-            Be careful how many times you run these as they fill the queue which is used by the standard jobs too.
+            <strong> Be careful: </strong>This ignores the switch state and presses the pages
+        </li>
+
+        <li>
+            <strong>Be careful: </strong> how many times you run these as they fill the queue which is used by the standard jobs too.
         </li>
     </ul>
 


### PR DESCRIPTION
In https://github.com/guardian/frontend/pull/10476 I coupled the switch to the `runFrequency`. I've separated this out so that jobs check the switch but manual pressing ignores it.  This will allow for easier testing in CODE.
