### PR TITLE
Update 'check this', 'reveal this' and 'clear this' to work on grouped clues

### DIFF
--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -376,11 +376,7 @@ class Crossword extends React.Component {
     }
 
     allHighlightedClues () {
-        return _.filter(this.props.data.entries, (entry) => {
-            if (this.clueIsInFocusGroup(entry)) {
-                return entry;
-            }
-        });
+        return _.filter(this.props.data.entries, this.clueIsInFocusGroup, this);
     }
 
     clueIsInFocusGroup (clue) {
@@ -471,23 +467,17 @@ class Crossword extends React.Component {
 
     onCheck () {
         // 'Check this' checks single and grouped clues
-        _.forEach(this.allHighlightedClues(), (entry) => {
-            this.check(entry);
-        });
+        _.forEach(this.allHighlightedClues(), this.check, this);
         this.save();
     }
 
     onSolution () {
-        _.forEach(this.props.data.entries, (entry) => {
-            this.cheat(entry);
-        });
+        _.forEach(this.props.data.entries, this.cheat, this);
         this.save();
     }
 
     onCheckAll () {
-        _.forEach(this.props.data.entries, (entry) => {
-            this.check(entry);
-        });
+        _.forEach(this.props.data.entries, this.check, this);
         this.save();
     }
 

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -439,6 +439,7 @@ class Crossword extends React.Component {
                 grid: helpers.mapGrid(this.state.grid, (cell, gridX, gridY) => {
                     if (_.some(badCells, bad => bad.x === gridX && bad.y === gridY)) {
                         cell.isError = true;
+                        cell.value = '';
                     }
 
                     return cell;

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -461,7 +461,7 @@ class Crossword extends React.Component {
     }
 
     onCheat () {
-        this.cheat(this.clueInFocus());
+        _.forEach(this.allHighlightedClues(), this.cheat, this);
         this.save();
     }
 
@@ -493,7 +493,8 @@ class Crossword extends React.Component {
     }
 
     onClearSingle () {
-        const cellsInFocus = helpers.cellsForEntry(this.clueInFocus());
+        // Merge arrays of cells from all highlighted clues
+        const cellsInFocus = [].concat.apply([], _.map(this.allHighlightedClues(), helpers.cellsForEntry, this));
 
         this.setState({
             grid: helpers.mapGrid(this.state.grid, (cell, gridX, gridY) => {

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -375,6 +375,14 @@ class Crossword extends React.Component {
         }
     }
 
+    allHighlightedClues () {
+        return _.filter(this.props.data.entries, (entry) => {
+            if (this.clueIsInFocusGroup(entry)) {
+                return entry;
+            }
+        });
+    }
+
     clueIsInFocusGroup (clue) {
         if (this.state.cellInFocus) {
             const cluesForCell = this.cluesFor(this.state.cellInFocus.x, this.state.cellInFocus.y);
@@ -462,7 +470,10 @@ class Crossword extends React.Component {
     }
 
     onCheck () {
-        this.check(this.clueInFocus());
+        // 'Check this' checks single and grouped clues
+        _.forEach(this.allHighlightedClues(), (entry) => {
+                this.check(entry);
+        });
         this.save();
     }
 

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -472,7 +472,7 @@ class Crossword extends React.Component {
     onCheck () {
         // 'Check this' checks single and grouped clues
         _.forEach(this.allHighlightedClues(), (entry) => {
-                this.check(entry);
+            this.check(entry);
         });
         this.save();
     }

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -494,7 +494,7 @@ class Crossword extends React.Component {
 
     onClearSingle () {
         // Merge arrays of cells from all highlighted clues
-        const cellsInFocus = [].concat.apply([], _.map(this.allHighlightedClues(), helpers.cellsForEntry, this));
+        const cellsInFocus = _.flatten(_.map(this.allHighlightedClues(), helpers.cellsForEntry, this));
 
         this.setState({
             grid: helpers.mapGrid(this.state.grid, (cell, gridX, gridY) => {


### PR DESCRIPTION
Fixes issue #10529
## Before

![before](https://cloud.githubusercontent.com/assets/638051/9909363/cbf90ba2-5c8f-11e5-86d5-c8cec8c67e81.gif)
## After

![after](https://cloud.githubusercontent.com/assets/638051/9909365/cdc14288-5c8f-11e5-82ca-86daa22003d0.gif)

cc/ @NathanielBennett @OliverJAsh @desbo (Nathaniel - you probably know the group stuff better than me, so shout if you can see a cleaner way!)
