### PR TITLE
Fallback for immersive interactives for core & no js users

### DIFF
--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -2,21 +2,17 @@
 @import common.Edition
 @import views.support.TrailCssClasses.articleToneClass
 
-@if(page.interactive.isImmersive) {
-    @bodyRaw(page.interactive)
-} else {
-    @body(page.interactive)
-}
+@body(page.interactive, page.interactive.isImmersive)
 
-@bodyRaw(interactive: model.Interactive) = {
-    @page.interactive.body.map { body =>
-        @HtmlFormat.raw(body)
+@figureEl(interactive: model.Interactive) = {
+    @page.interactive.figureEl.map { figure =>
+        @HtmlFormat.raw(figure)
     }.getOrElse {
         <figure class="interactive" data-interactive="@{conf.Configuration.interactive.url}@{request.path.drop(1)}/boot.js"></figure>
     }
 }
 
-@body(interactive: model.Interactive) = {
+@body(interactive: model.Interactive, isImmersive: Boolean) = {
     <div class="l-side-margins">
         <article class="@RenderClasses(
                 Map(
@@ -37,15 +33,18 @@
                     </div>
                 </div>
 
-                <div class="gs-container" data-test-id="interactive-content-body">
+                <div class="gs-container" xdata-test-id="interactive-content-body">
                     <div class="content__main-column content__main-column--interactive">
-                        @bodyRaw(interactive)
+                        @if(!isImmersive) {
+                            @figureEl(interactive)
+                        }
+                        @HtmlFormat.raw(interactive.fallbackEl)
                     </div>
                 </div>
 
                 <div class="gs-container u-cf">
                     <div class="content__main-column content__meta-footer">
-                    @fragments.contentMeta(interactive, showBadge = false)
+                        @fragments.contentMeta(interactive, showBadge = false)
                     </div>
                 </div>
             </div>
@@ -54,4 +53,8 @@
         @fragments.contentFooter(interactive, page.related)
 
     </div>
+
+    @if(isImmersive) {
+        @figureEl(interactive)
+    }
 }

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -4,9 +4,9 @@
 
 @body(page.interactive, page.interactive.isImmersive)
 
-@figureEl(interactive: model.Interactive) = {
-    @page.interactive.figureEl.map { figure =>
-        @HtmlFormat.raw(figure)
+@bodyRaw(interactive: model.Interactive) = {
+    @page.interactive.body.map { body =>
+        @HtmlFormat.raw(body)
     }.getOrElse {
         <figure class="interactive" data-interactive="@{conf.Configuration.interactive.url}@{request.path.drop(1)}/boot.js"></figure>
     }
@@ -36,9 +36,10 @@
                 <div class="gs-container" data-test-id="interactive-content-body">
                     <div class="content__main-column content__main-column--interactive">
                         @if(!isImmersive) {
-                            @figureEl(interactive)
+                            @bodyRaw(interactive)
+                        } else {
+                            @HtmlFormat.raw(interactive.fallbackEl)
                         }
-                        @HtmlFormat.raw(interactive.fallbackEl)
                     </div>
                 </div>
 
@@ -55,6 +56,6 @@
     </div>
 
     @if(isImmersive) {
-        @figureEl(interactive)
+        @interactive.figureEl.map(HtmlFormat.raw(_))
     }
 }

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -33,7 +33,7 @@
                     </div>
                 </div>
 
-                <div class="gs-container" xdata-test-id="interactive-content-body">
+                <div class="gs-container" data-test-id="interactive-content-body">
                     <div class="content__main-column content__main-column--interactive">
                         @if(!isImmersive) {
                             @figureEl(interactive)

--- a/applications/test/InteractiveControllerTest.scala
+++ b/applications/test/InteractiveControllerTest.scala
@@ -12,9 +12,4 @@ import scala.collection.JavaConversions._
     val result = controllers.InteractiveController.renderInteractive(url)(TestRequest(url))
     status(result) should be(200)
   }
-
-  it should "hide all ui for immersive content"  in goTo("/lifeandstyle/ng-interactive/2015/feb/12/watch-me-date") { browser =>
-    import browser._
-    $(".content__head").length should be (0)
-  }
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -620,17 +620,6 @@ class Interactive(delegate: contentapi.Content) extends Content(delegate) {
     "twitter:card" -> "summary_large_image"
   )
 
-//  lazy val fallbackEl = {
-//    val inner = body.map(Jsoup.parseBodyFragment(_).getElementsByTag("figure").html())
-//    val noscript: Option[Int] = inner.map(Jsoup.parseBodyFragment(_).getElementsByTag("noscript").length)
-//
-//    if(noscript > 0) {
-//      inner
-//    } else {
-//      inner.map(Jsoup.parseBodyFragment(_).getElementsByTag("noscript").first().outerHtml())
-//    }
-//  }
-
   lazy val fallbackEl = {
     val noscriptEls = Jsoup.parseBodyFragment(body.getOrElse("")).getElementsByTag("noscript")
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -619,6 +619,30 @@ class Interactive(delegate: contentapi.Content) extends Content(delegate) {
     "twitter:title" -> linkText,
     "twitter:card" -> "summary_large_image"
   )
+
+//  lazy val fallbackEl = {
+//    val inner = body.map(Jsoup.parseBodyFragment(_).getElementsByTag("figure").html())
+//    val noscript: Option[Int] = inner.map(Jsoup.parseBodyFragment(_).getElementsByTag("noscript").length)
+//
+//    if(noscript > 0) {
+//      inner
+//    } else {
+//      inner.map(Jsoup.parseBodyFragment(_).getElementsByTag("noscript").first().outerHtml())
+//    }
+//  }
+
+  lazy val fallbackEl = {
+    val noscriptEls = Jsoup.parseBodyFragment(body.getOrElse("")).getElementsByTag("noscript")
+
+    if (noscriptEls.length > 0) {
+      noscriptEls.html()
+    } else {
+      Jsoup.parseBodyFragment(body.getOrElse("")).getElementsByTag("figure").html()
+    }
+  }
+
+  lazy val figureEl = body.map(Jsoup.parseBodyFragment(_).getElementsByTag("figure").html("").outerHtml())
+
 }
 
 object Interactive {
@@ -630,8 +654,6 @@ class ImageContent(delegate: contentapi.Content) extends Content(delegate) with 
   override lazy val lightboxImages: Seq[ImageContainer] = mainFiltered
   override lazy val contentType = GuardianContentTypes.ImageContent
   override lazy val analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}"
-
-
 
   override def cards: List[(String, String)] = super.cards ++ List(
     "twitter:card" -> "photo"

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -131,11 +131,6 @@ define([
                 navigation.init();
             },
 
-            initImmersiveInteractives: function () {
-                console.log("foo2");
-                //$('.l-side-margins').addClass('u-h');
-            },
-
             initialiseStickyHeader: function () {
                 if (config.switches.viewability && !(config.page.isProd && config.page.contentType === 'Interactive') && config.page.contentType !== 'Crossword') {
                     sticky.init();
@@ -400,7 +395,6 @@ define([
                 ['c-top-nav', modules.initialiseTopNavItems],
                 ['c-init-nav', modules.initialiseNavigation],
                 ['c-sticky-header', modules.initialiseStickyHeader],
-                ['c-immersive-hide', modules.initImmersiveInteractives],
                 ['c-toggles', modules.showToggles],
                 ['c-dates', modules.showRelativeDates],
                 ['c-clickstream', modules.initClickstream],

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -131,6 +131,11 @@ define([
                 navigation.init();
             },
 
+            initImmersiveInteractives: function () {
+                console.log("foo2");
+                //$('.l-side-margins').addClass('u-h');
+            },
+
             initialiseStickyHeader: function () {
                 if (config.switches.viewability && !(config.page.isProd && config.page.contentType === 'Interactive') && config.page.contentType !== 'Crossword') {
                     sticky.init();
@@ -395,6 +400,7 @@ define([
                 ['c-top-nav', modules.initialiseTopNavItems],
                 ['c-init-nav', modules.initialiseNavigation],
                 ['c-sticky-header', modules.initialiseStickyHeader],
+                ['c-immersive-hide', modules.initImmersiveInteractives],
                 ['c-toggles', modules.showToggles],
                 ['c-dates', modules.showRelativeDates],
                 ['c-clickstream', modules.initClickstream],

--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -42,7 +42,7 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
         }
     }
 
-    .is-immersive & {
+    .js-on.is-modern .is-immersive & {
         display: none;
     }
 

--- a/static/src/stylesheets/module/content/_article.scss
+++ b/static/src/stylesheets/module/content/_article.scss
@@ -58,3 +58,7 @@
     }
 }
 
+.js-on.is-modern .is-immersive .l-side-margins {
+    display: none;
+}
+

--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -1,4 +1,4 @@
-.content--interactive {
+.js-on.is-modern .content--interactive {
     padding: 0;
 
     .content__headline {
@@ -13,9 +13,11 @@
     }
 
     .content__main-column--interactive {
-        @include mq(desktop) {
-            max-width: none;
-            margin: 0;
+        .js-on.is-modern & {
+            @include mq(desktop) {
+                max-width: none;
+                margin: 0;
+            }
         }
     }
 
@@ -150,5 +152,26 @@
         .content__meta-container {
             border: 0;
         }
+    }
+}
+
+.is-not-modern {
+    .content__meta-footer {
+        display: none;
+    }
+
+    .content__head .content__dateline {
+        display: none;
+    }
+
+    .content__main-column--interactive {
+        border-top: 1px dotted colour(neutral-5);
+        padding-top: $gs-baseline/2;
+    }
+}
+
+.is-immersive {
+    figure.element {
+        margin: 0;
     }
 }

--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -13,11 +13,9 @@
     }
 
     .content__main-column--interactive {
-        .js-on.is-modern & {
-            @include mq(desktop) {
-                max-width: none;
-                margin: 0;
-            }
+        @include mq(desktop) {
+            max-width: none;
+            margin: 0;
         }
     }
 

--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -166,7 +166,7 @@
     .content__main-column--interactive {
         border-top: 1px dotted colour(neutral-5);
         padding-top: $gs-baseline/2;
-        min-height: $gs-baseline*10;
+        min-height: $gs-baseline*20;
     }
 }
 

--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -17,6 +17,7 @@
             max-width: none;
             margin: 0;
         }
+
     }
 
     .meta__numbers {
@@ -165,6 +166,7 @@
     .content__main-column--interactive {
         border-top: 1px dotted colour(neutral-5);
         padding-top: $gs-baseline/2;
+        min-height: $gs-baseline*10;
     }
 }
 


### PR DESCRIPTION
If you currently try to load an 'immersive' interactive whilst opted in to the Core site, you get a blank page:

![screen shot 2015-09-16 at 17 50 55](https://cloud.githubusercontent.com/assets/2236852/9911749/939e0152-5c9b-11e5-93e3-d74adc5ba761.png)

With these changes it'll put the 'content' field of the Interactive embed into an article looking page for Core and no JS users:
![screen shot 2015-09-16 at 17 53 29](https://cloud.githubusercontent.com/assets/2236852/9911820/e4af4358-5c9b-11e5-9dba-2155c27d9a9a.png)

I'll test this on a wide variety of interactives before merging and speak to Visuals regarding the changes.

This also tweaks the styling of the non-immersive interactive template for non-js/core users, but only so that it matches the above screenshot.

Q: Do we need to explain to users that they're seeing a stripped back view?
