### PR TITLE
Update the contrast on the clue background

### DIFF
--- a/static/src/stylesheets/module/crosswords/_clues.scss
+++ b/static/src/stylesheets/module/crosswords/_clues.scss
@@ -14,15 +14,16 @@
     position: relative;
     cursor: pointer;
     @include fs-textSans(5);
-    padding: $gs-baseline * .25 0;
+    padding: $gs-baseline * .25 $gs-baseline;
+    padding-left: $xword-clue-number-width + $gs-baseline;
+    margin: $gs-baseline * .25 0;
     list-style-type: none;
-    padding-left: 2em;
 
     &:before {
         content: attr(data-number);
         display: inline-block;
-        min-width: 2em;
-        margin-left: -2em;
+        min-width: $xword-clue-number-width;
+        margin-left: -$xword-clue-number-width;
         position: static;
         font-weight: bold;
         -webkit-font-smoothing: initial;
@@ -31,6 +32,7 @@
 
 .crossword__clue--selected {
     font-weight: bold;
+    background-color: $xword-focussed-background-colour;
     color: $xword-focussed-colour;
 }
 
@@ -40,6 +42,6 @@
 
 //For grouped clues we display 11.12,23 accross instead of just a number
 .crossword__clue--display-group-order:before {
-    padding-right: .875em; // 14px - Matches the width between double digit numbers and clue of non-grouped clues
+    padding-right: 14px; // 14px - Matches the width between double digit numbers and clue of non-grouped clues
 }
 

--- a/static/src/stylesheets/module/crosswords/_hidden-input.scss
+++ b/static/src/stylesheets/module/crosswords/_hidden-input.scss
@@ -8,7 +8,6 @@
     width: 100%;
     height: 100%;
     text-align: center;
-    color: transparent;
     background-color: transparent;
     font-size: 16px; // stop zooming on focus
     font-family: $f-serif-text;

--- a/static/src/stylesheets/module/crosswords/_vars.scss
+++ b/static/src/stylesheets/module/crosswords/_vars.scss
@@ -6,9 +6,10 @@ $xword-cell-width-xsmall: 20px; // as above but for long (10+ letter) clues
 $xword-border-width: 1px;
 
 $xword-highlight-colour: colour(crosswordAccent2);
-$xword-focussed-colour: colour(crosswordAccent1);
+$xword-focussed-colour: #000000;
 $xword-focussed-background-colour: lighten($xword-highlight-colour, 30%);
 
+$xword-clue-number-width: 32px;
 
 $xword-grid-sizes: (
     quick: 13,


### PR DESCRIPTION
Issue #10542 - Add background colour to the clue and update text colour to ensure contrast is high enough. Also add cursor for desktop browsers.
## Before

![before](https://cloud.githubusercontent.com/assets/638051/9911993/f6e3a928-5c9c-11e5-879c-61ce6f462e63.gif)
## After

![after](https://cloud.githubusercontent.com/assets/638051/9912001/fe730a9e-5c9c-11e5-9042-18a69f1cf9fb.gif)
