### PR TITLE
Ensure the SNS client is instantiated once and not many times

### DIFF
--- a/common/app/services/Notification.scala
+++ b/common/app/services/Notification.scala
@@ -12,7 +12,7 @@ trait Notification extends Logging with ExecutionContexts {
 
   val topic: String
 
-  def sns: Option[AmazonSNSAsyncClient] = Configuration.aws.credentials.map{ credentials =>
+  lazy val sns: Option[AmazonSNSAsyncClient] = Configuration.aws.credentials.map{ credentials =>
     val client = new AmazonSNSAsyncClient(credentials)
     client.setEndpoint(AwsEndpoints.sns)
     client


### PR DESCRIPTION
Following on from https://github.com/guardian/frontend/pull/10464 I tracked it down to the sending of notifications causing the thread count issue. @mchv helped me to debug through this and spotted that we are instantiating a new client every time we send a notification. I've changed the offending `def` to a `val`. 

Massive thanks to @mchv! (Though I still want the :rose: to win :rugby_football: :trophy: and not :rooster:  )
