### PR TITLE
Fix team order

### DIFF
--- a/sport/app/rugby/views/fragments/matchStats.scala.html
+++ b/sport/app/rugby/views/fragments/matchStats.scala.html
@@ -58,8 +58,8 @@
         data-chart-show-values="true">
             <thead hidden>
                 <tr>
-                    <th>@firstTeamName</th>
                     <th>@secondTeamName</th>
+                    <th>@firstTeamName</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
The [current name order displayed](http://m.code.dev-theguardian.com/sport/2015/sep/05/england-ireland-rugby-world-cup-warmup-match-report) in the donut is incorrect:

<img width="336" alt="screen shot 2015-09-17 at 17 04 21" src="https://cloud.githubusercontent.com/assets/615085/9938699/7ce7ac10-5d5e-11e5-8083-9ee06831c7a3.png">
