### PR TITLE
Collect Sponsorship Data in Omniture

### DIFF
--- a/common/app/views/fragments/commercial/adSlot.scala.html
+++ b/common/app/views/fragments/commercial/adSlot.scala.html
@@ -5,13 +5,17 @@
     showLabel: Boolean = true,
     refresh: Boolean = true,
     outOfPage: Boolean = false,
-    forceDisplay: Boolean = false
+    forceDisplay: Boolean = false,
+    contentSponsor: Option[String] = None,
+    paidForContentType: Option[String] = None
 )(placeholderContent: Html)
 
 <div
     id="dfp-ad--@name"
     class="js-ad-slot ad-slot ad-slot--dfp ad-slot--@name @adTypes.map{ adType =>ad-slot--@adType}.mkString(" ")@if(forceDisplay) { ad-slot--force-display}"
     data-link-name="ad slot @name"
+    @for(sponsor <- contentSponsor) { data-sponsor="@sponsor" }
+    @for(paidForType <- paidForContentType) { data-sponsorship="@paidForType" }
     data-test-id="ad-slot-@name"
     data-name="@name"
     @if(!showLabel){ data-label="false" }

--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -33,7 +33,9 @@
                 Map("mobile" -> Seq("1,1", s"$adSlotWidth,90")),
                 showLabel = false,
                 refresh = false,
-                forceDisplay = content.sponsor.nonEmpty
+                forceDisplay = content.sponsor.nonEmpty,
+                contentSponsor = content.sponsor,
+                paidForContentType = content.sponsorshipType
             ) {
                 @content.sponsor.map { sponsor =>
                     <div class="ad-slot--paid-for-badge__inner ad-slot__content--placeholder">

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -30,7 +30,7 @@ define([
 ) {
     var R2_STORAGE_KEY = 's_ni', // DO NOT CHANGE THIS, ITS IS SHARED WITH R2. BAD THINGS WILL HAPPEN!
         NG_STORAGE_KEY = 'gu.analytics.referrerVars',
-        standardProps = 'channel,prop1,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,' +
+        standardProps = 'channel,prop1,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop38,prop47,' +
             'prop51,prop61,prop64,prop65,prop74,prop40,prop63,eVar7,eVar37,eVar38,eVar39,eVar50,eVar24,eVar60,eVar51,' +
             'eVar31,eVar18,eVar32,eVar40,list1,list2,list3,events';
 
@@ -177,6 +177,14 @@ define([
         }
 
         this.s.prop73 = detect.isFacebookApp() ? 'facebook app' : detect.isTwitterApp() ? 'twitter app' : null;
+
+        // Sponsored content
+        this.s.prop38 = _.uniq($('[data-sponsorship]')).map(function (n) {
+            var sponsorshipType = n.getAttribute('data-sponsorship');
+            var maybeSponsor = n.getAttribute('data-sponsor');
+            var sponsor = maybeSponsor ? maybeSponsor : 'unknown';
+            return sponsorshipType + ':' + sponsor;
+        }).toString();
 
 
         this.s.linkTrackVars = standardProps;

--- a/static/src/javascripts/test/spec/common/analytics/omniture.spec.js
+++ b/static/src/javascripts/test/spec/common/analytics/omniture.spec.js
@@ -91,7 +91,7 @@ describe('omniture', function () {
         omniture.go();
         omniture.trackLink('link object', 'outer:link');
 
-        expect(s.linkTrackVars).toBe('channel,prop1,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop47,prop51,prop61,prop64,prop65,prop74,prop40,prop63,eVar7,eVar37,eVar38,eVar39,eVar50,eVar24,eVar60,eVar51,eVar31,eVar18,eVar32,eVar40,list1,list2,list3,events');
+        expect(s.linkTrackVars).toBe('channel,prop1,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop38,prop47,prop51,prop61,prop64,prop65,prop74,prop40,prop63,eVar7,eVar37,eVar38,eVar39,eVar50,eVar24,eVar60,eVar51,eVar31,eVar18,eVar32,eVar40,list1,list2,list3,events');
         expect(s.linkTrackEvents).toBe('event37');
         expect(s.events).toBe('event37');
     });


### PR DESCRIPTION
Stores sponsorship data in prop38.

Eg.
- Ad feature page:
  ![image](https://cloud.githubusercontent.com/assets/1722550/9955352/28dfd2de-5de8-11e5-8243-5467a8b85b51.png)
- Ad feature front:
  ![image](https://cloud.githubusercontent.com/assets/1722550/9955381/6cbb5b04-5de8-11e5-8e6e-f92185762a1b.png)
- Front with multiple sponsored containers:
  ![image](https://cloud.githubusercontent.com/assets/1722550/9955337/0a4611f8-5de8-11e5-91e5-94a0fe97602c.png)
