### PR TITLE
Parse as HTML, not JavaScript

### DIFF
--- a/common/app/views/fragments/javaScriptBootstraps.scala.html
+++ b/common/app/views/fragments/javaScriptBootstraps.scala.html
@@ -47,7 +47,7 @@
             }
         };
 
-        @JavaScript(Static.js.curl)
+        @Html(Static.js.curl)
 
         @Html(templates.headerInlineJS.js.bootCurl(item, curlPaths).body)
     }


### PR DESCRIPTION
Broken by https://github.com/guardian/frontend/pull/10504. This was copied from a JS file to a HTML file, but I never updated the reader function: https://github.com/guardian/frontend/pull/10504/files#diff-f19e61649c05527ea34fd7188a4ca0e0L44

My mistake for only testing in SystemJS world.
