### PR TITLE
The syndication "Reuse this content" button is here to stay.

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -923,15 +923,6 @@ object Switches {
     exposeClientSide = false
   )
 
-  val SyndicationReprintEnabledSwitch = Switch (
-    "Feature",
-    "syndication-reprint-enabled",
-    "Toggle on/off the syndication button on all pages (for desktop or above only)",
-    safeState = Off,
-    sellByDate = new LocalDate(2015, 9, 30),
-    exposeClientSide = true
-  )
-
   // A/B Tests
 
   val ABLiveblogNotifications = Switch(

--- a/common/app/views/fragments/syndication.scala.html
+++ b/common/app/views/fragments/syndication.scala.html
@@ -1,8 +1,6 @@
 @(content: model.Content, position: String = "bottom")(implicit request: RequestHeader)
 @import views.support.URLEncode
-@import conf.Switches.SyndicationReprintEnabledSwitch
 
-@if(SyndicationReprintEnabledSwitch.isSwitchedOn) {
     <div class="submeta__syndication">
         <ul class="syndication--@position u-unstyled">
             <li class="syndication__item">
@@ -16,4 +14,3 @@
             </li>
         </ul>
     </div>
-}

--- a/data/database/f1124091ad9371f5ec7cde05d6c71cf9a24a6ae7b17aa30f0ae180fb1bb45bdd
+++ b/data/database/f1124091ad9371f5ec7cde05d6c71cf9a24a6ae7b17aa30f0ae180fb1bb45bdd
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}


### PR DESCRIPTION
Ditch the switch. For now anyway. We'll see how well it has performed in a couple of months, but so far the effect has been positive.
