### PR TITLE
ensuring that rich link image only shows on tone-comment

### DIFF
--- a/onward/app/views/fragments/richLinkBody.scala.html
+++ b/onward/app/views/fragments/richLinkBody.scala.html
@@ -37,7 +37,12 @@
         }
 
         <div class="rich-link__header">
-            <h1 class="rich-link__title">@fragments.inlineSvg("quote", "icon")<a class="rich-link__link">@Html(kicker.toString.replaceAll("^\\s+", "") + content.headline)</a></h1>
+            <h1 class="rich-link__title">
+                @if( toneClass(content) == "tone-comment" ) {
+                    @fragments.inlineSvg("quote", "icon")
+                }
+                <a class="rich-link__link">@Html(kicker.toString.replaceAll("^\\s+", "") + content.headline)</a>
+            </h1>
             @if(!content.isMedia && CardStyle.fromContent(content.delegate) == Comment) {
                 <div class="rich-link__byline">@content.byline.map { byline => @Html(byline) }</div>
             }


### PR DESCRIPTION
Fixing a bug introduced in #10551 
