### PR TITLE
Adds penalty tries to the rugby scoreboard. 

### DIFF
--- a/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
+++ b/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
@@ -77,6 +77,8 @@ object Parser {
     }
   }
 
+  private val eventScoreAssignedToTeam = "0"
+
   def parseLiveEventsStatsToGetScoreEvents(body: String): Seq[ScoreEvent] = {
     val data = XML.loadString(body)
 
@@ -92,7 +94,7 @@ object Parser {
 
     scoreEventsData.flatMap { scoreEventData =>
       val player = players.find(_.id == (scoreEventData \ "@player_id").text).orElse {
-        if((scoreEventData \ "@player_id").text == "0") {
+        if((scoreEventData \ "@player_id").text == eventScoreAssignedToTeam) {
           fakePlayerForTeam(teamNode, scoreEventData)
         } else None
       }
@@ -117,7 +119,7 @@ object Parser {
     val team = teams.find(team => team.id == (scoreEventData \ "@team_id").text)
     val scoreType = ScoreType.withName((scoreEventData \ "@type").text)
     val name = if(scoreType == ScoreType.PenaltyTry) "Penalty" else ""
-    team.map(t => Player(id = "0", name = name, team = t))
+    team.map(t => Player(id = (scoreEventData \ "@player_id").text, name = name, team = t))
   }
 
   private def getTeams(teamNodes: NodeSeq): Seq[Team] = {

--- a/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
+++ b/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
@@ -87,17 +87,42 @@ object Parser {
       ScoreType.values.exists(_.toString == eventType)
     }
 
-    val players = getPlayers(data \ "TeamDetail" \ "Team")
+    val teamNode = data \ "TeamDetail" \ "Team"
+    val players = getPlayers(teamNode)
 
     scoreEventsData.flatMap { scoreEventData =>
-      val player = players.find(_.id == (scoreEventData \ "@player_id").text)
+      val player = players.find(_.id == (scoreEventData \ "@player_id").text).orElse {
+        if((scoreEventData \ "@player_id").text == "0") {
+          fakePlayerForTeam(teamNode, scoreEventData)
+        } else None
+      }
+
       player.map { p =>
+        val initalScoreType = ScoreType.withName((scoreEventData \ "@type").text)
+        //merge Penalty Tries into Try events
+        val scoreType: ScoreType.Value = if(initalScoreType == ScoreType.PenaltyTry) ScoreType.`Try` else initalScoreType
+
         ScoreEvent(
           player = p,
           minute = (scoreEventData \ "@minute").text,
-          `type` = ScoreType.withName((scoreEventData \ "@type").text)
+          `type` = scoreType
         )
       }
+    }
+  }
+
+  //when a score event has player=0 this means a team event e.g. Penalty Try
+  private def fakePlayerForTeam(teamNodes: NodeSeq, scoreEventData: NodeSeq): Option[Player] = {
+    val teams = getTeams(teamNodes)
+    val team = teams.find(team => team.id == (scoreEventData \ "@team_id").text)
+    val scoreType = ScoreType.withName((scoreEventData \ "@type").text)
+    val name = if(scoreType == ScoreType.PenaltyTry) "Penalty" else ""
+    team.map(t => Player(id = "0", name = name, team = t))
+  }
+
+  private def getTeams(teamNodes: NodeSeq): Seq[Team] = {
+    teamNodes.map { teamData =>
+      Team((teamData \ "@team_id").text, (teamData \ "@team_name").text)
     }
   }
 
@@ -172,13 +197,13 @@ object Parser {
     val teams = data \ "TeamDetail" \ "Team"
 
     val teamsStats: Seq[TeamStat] = teams.map { team =>
-      
+
       val teamStatDataRaw =  team \ "TeamStats" \ "TeamStat"
 
-      /* MetaData.append is extremly slow as it tries to normalize all attributes each time we append, so we chain attributes manually */ 
+      /* MetaData.append is extremly slow as it tries to normalize all attributes each time we append, so we chain attributes manually */
       val allAttributes = chainAttributes(teamStatDataRaw.map(_.attributes))
       val teamStatData = <TeamStat />.copy(attributes = allAttributes)
-      
+
       TeamStat(
         name = (team \ "@team_name").text,
         id = (teamStatData \ "@id").text.toLong,
@@ -238,7 +263,7 @@ object Parser {
     val data = XML.loadString(body)
     val groupsData = data \ "comp" \ "group"
 
-    groupsData.map { group => 
+    groupsData.map { group =>
       val name = (group \ "@name").text
       val teamData = group \ "team"
       val teams = teamData.map { team =>

--- a/sport/app/rugby/model/rugby.scala
+++ b/sport/app/rugby/model/rugby.scala
@@ -78,6 +78,7 @@ object ScoreType extends Enumeration {
   val Conversion = Value("Conversion")
   val Penalty = Value("Penalty")
   val DropGoal = Value("Drop goal")
+  val PenaltyTry = Value("Penalty Try")
 }
 
 trait Status

--- a/sport/app/rugby/views/fragments/matchSummary.scala.html
+++ b/sport/app/rugby/views/fragments/matchSummary.scala.html
@@ -7,6 +7,7 @@
 @status() = {
     @theMatch.status match {
         case Result      => { <abbr class="m-status">FT</abbr> }
+        case HalfTime    => { <abbr class="m-status">HT</abbr> }
         case FirstHalf   => { <abbr class="m-status">1st</abbr> }
         case SecondHalf  => { <abbr class="m-status">2nd</abbr> }
         case _ => {}

--- a/sport/test/resources/rugby/feed/live-events-stats.xml
+++ b/sport/test/resources/rugby/feed/live-events-stats.xml
@@ -7,6 +7,7 @@
         <Event minute="0" period="First Half" player_id="0" second="0" team_id="550" type="First Half Start" />
         <Event minute="6" period="First Half" player_id="8805" second="44" team_id="650" type="Penalty" />
         <Event minute="10" period="First Half" player_id="19083" second="51" team_id="550" type="Try" />
+        <Event minute="12" period="First Half" player_id="0" second="11" team_id="550" type="Penalty Try"/>
         <Event minute="12" period="First Half" player_id="9938" second="16" team_id="550" type="Conversion" />
         <Event minute="16" period="First Half" player_id="19857" second="36" team_id="650" temporary="Blood Replacement" type="Sub On" />
         <Event minute="16" period="First Half" player_id="10719" second="36" team_id="650" temporary="Blood Replacement" type="Sub Off" />

--- a/sport/test/rugby/model/MatchParserTest.scala
+++ b/sport/test/rugby/model/MatchParserTest.scala
@@ -67,11 +67,11 @@ import scala.io.Source
 
       val scoreEvents = rugby.feed.Parser.parseLiveEventsStatsToGetScoreEvents(liveEventsStatsData)
 
-      scoreEvents.size should be(9)
+      scoreEvents.size should be(10)
 
       val tryScoreEvents = scoreEvents.filter(_.`type` == ScoreType.`Try`)
 
-      tryScoreEvents.size should be(4)
+      tryScoreEvents.size should be(5)
 
       val topTryScorer: Seq[ScoreEvent] = tryScoreEvents.filter(_.player.id == "19083")
       topTryScorer.size should be(2)
@@ -80,6 +80,12 @@ import scala.io.Source
 
       topTryScorer.head.player.team.id should be("550")
       topTryScorer.head.player.team.name should be("England")
+
+      val penaltyTry = tryScoreEvents.filter(_.player.id == "0")
+      penaltyTry.size should be (1)
+      penaltyTry.head.player.name should be("Penalty")
+      penaltyTry.head.minute should be ("12")
+      penaltyTry.head.player.team.name should be("England")
     }
 
      "should parse team stats correctly" in {
@@ -106,7 +112,7 @@ import scala.io.Source
       england.lineouts_lost should be(3)
       england.mauls_won should be(4)
       england.mauls_lost should be(1)
-      england.mauls_total should be(5) 
+      england.mauls_total should be(5)
       england.penalties_conceded should be(9)
       england.penalty_conceded_dissent should be(0)
       england.penalty_conceded_delib_knock_on should be(0)
@@ -132,7 +138,7 @@ import scala.io.Source
       england.scrums_won should be(5)
       england.scrums_lost should be(2)
       england.scrums_total should be(7)
-    
+
       val france = matchStat.teams.last
     }
 
@@ -141,7 +147,7 @@ import scala.io.Source
       val tables = rugby.feed.Parser.parseGroupTables(tablesData)
 
       tables.size should be(4)
-      tables.head.name should be("Pool A") 
+      tables.head.name should be("Pool A")
       val fiji = tables.head.teams.head
       fiji.name should be("Fiji")
       fiji.rank should be(1)


### PR DESCRIPTION
Penalty tries come through as a different score event from the Opta feed (it's not documented :disappointed: )
`
<Event minute="12" period="First Half" player_id="0" second="11" team_id="550" type="Penalty Try"/>
`

Note the player_id=0 which is not a player on a team. This seems to be the standard on the events feed that events not assigned to a player. However our code assumes every score event is assigned to a player. In the penalty try case I have created a fake player with the name `Penalty` and wrapped this up with the Try events.

Before:
<img width="807" alt="screen shot 2015-09-21 at 11 53 08" src="https://cloud.githubusercontent.com/assets/944375/9990194/5d3a36de-6057-11e5-9ad8-e006437fb13b.png">

After:
<img width="831" alt="screen shot 2015-09-21 at 11 23 42" src="https://cloud.githubusercontent.com/assets/944375/9990197/61b2f138-6057-11e5-8826-a37a56985db1.png">

cc @mchv @rich-nguyen 
