### PR TITLE
Support for authentication using request body

### DIFF
--- a/identity/app/idapiclient/IdApi.scala
+++ b/identity/app/idapiclient/IdApi.scala
@@ -31,9 +31,10 @@ abstract class IdApi(val apiRootUrl: String, http: Http, jsonBodyParser: JsonBod
 
   // AUTH
   def authBrowser(userAuth: Auth, trackingData: TrackingData, persistent: Option[Boolean] = None): Future[Response[CookiesResponse]] = {
-    val params = buildParams(Some(userAuth), Some(trackingData), Seq("format" -> "cookies") ++ persistent.map("persistent" -> _.toString))
+    val params = buildParams(None, Some(trackingData), Seq("format" -> "cookies") ++ persistent.map("persistent" -> _.toString))
     val headers = buildHeaders(Some(userAuth))
-    val response = http.POST(apiUrl("auth"), None, params, headers)
+    val body = write(userAuth)
+    val response = http.POST(apiUrl("auth"), Some(body), params, headers)
     response map extract(jsonField("cookies"))
   }
 

--- a/identity/app/idapiclient/IdApi.scala
+++ b/identity/app/idapiclient/IdApi.scala
@@ -30,7 +30,7 @@ abstract class IdApi(val apiRootUrl: String, http: Http, jsonBodyParser: JsonBod
   }
 
   // AUTH
-  def authBrowser(userAuth: Auth, trackingData: TrackingData, persistent: Option[Boolean] = None): Future[Response[CookiesResponse]] = {
+  def authBrowser(userAuth: EmailPassword, trackingData: TrackingData, persistent: Option[Boolean] = None): Future[Response[CookiesResponse]] = {
     val params = buildParams(None, Some(trackingData), Seq("format" -> "cookies") ++ persistent.map("persistent" -> _.toString))
     val headers = buildHeaders(Some(userAuth))
     val body = write(userAuth)


### PR DESCRIPTION
Email and password credentials are now passed to the API via the request body rather than query params to prevent logging of sensitive data (passwords).
