### PR TITLE
Amp video

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -23,7 +23,7 @@ object MainCleaner {
  def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader) = {
       implicit val edition = Edition(request)
       withJsoup(BulletCleaner(html))(
-        VideoEmbedCleaner(article),
+        VideoEmbedCleaner(article, amp),
         PictureCleaner(article, amp),
         MainFigCaptionCleaner
       )
@@ -42,7 +42,7 @@ object BodyCleaner {
       TagLinker(article),
       TableEmbedComplimentaryToP,
       R2VideoCleaner(article),
-      VideoEmbedCleaner(article),
+      VideoEmbedCleaner(article, amp),
       PictureCleaner(article, amp),
       LiveBlogDateFormatter(article.isLiveBlog),
       LiveBlogLinkedData(article.isLiveBlog),

--- a/common/app/views/fragments/amp/embedStylesheet.scala.html
+++ b/common/app/views/fragments/amp/embedStylesheet.scala.html
@@ -45,7 +45,7 @@ figure.element {
 }
 
 @* Video related styling below *@
-.gu-media-wrapper {
+.gu-media-wrapper, amp-video {
     background: #000000;
 }
 

--- a/common/app/views/fragments/amp/embedStylesheet.scala.html
+++ b/common/app/views/fragments/amp/embedStylesheet.scala.html
@@ -45,6 +45,10 @@ figure.element {
 }
 
 @* Video related styling below *@
+.gu-media-wrapper {
+    background: #000000;
+}
+
 .u-responsive-ratio {
     width: 100%;
     padding-bottom: 56.25%;

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -91,7 +91,7 @@ case class R2VideoCleaner(article: Article) extends HtmlCleaner {
 
 }
 
-case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
+case class VideoEmbedCleaner(article: Article, amp: Boolean) extends HtmlCleaner {
 
   override def clean(document: Document): Document = {
     document.getElementsByClass("element-video").filter { element: Element =>
@@ -100,83 +100,108 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
       element.child(0).wrap("<div class=\"embed-video-wrapper u-responsive-ratio u-responsive-ratio--hd\"></div>")
     }
 
-    if(!article.isLiveBlog) {
-      document.getElementsByClass("element-video").foreach( element => {
-        val shortUrl = element.attr("data-short-url")
-        val webUrl = element.attr("data-canonical-url")
-        val blockId = element.attr("data-media-id")
-        val mediaPath = element.attr("data-video-poster")
-        val mediaTitle = element.attr("data-video-name")
+    if (amp) {
+      document.getElementsByTag("video").foreach( video => {
+        video.tagName("amp-video")
+        video.removeAttr("data-media-id")
+        video.removeAttr("poster")
 
-        if(!shortUrl.isEmpty) {
-          val html = views.html.fragments.share.blockLevelSharing(blockId, article.elementShares(shortLinkUrl = shortUrl, webLinkUrl = webUrl,  mediaPath = Some(mediaPath), title = mediaTitle), article.contentType)
-          element.child(0).after(html.toString())
-          element.addClass("fig--has-shares")
-          element.addClass("fig--narrow-caption")
-          // add extra margin if there is no caption to fit the share buttons
-          val figcaption = element.getElementsByTag("figcaption")
-          if(figcaption.length < 1) {
-            element.addClass("fig--no-caption")
+        // Need to hard code aspect ratio 5:3 for Amp pages.
+        video.attr("width", "5")
+        video.attr("height", "3")
+        // Layout responsive keeps the aspect ratio, but ignores the height and width attributes above
+        video.attr("layout", "responsive")
+        video.attr("controls", "")
+
+        video.getElementsByTag("source").foreach( source => {
+          val videoSrc = source.attr("src")
+          // All videos need to start with https for AMP.
+          // Temperary code until all videos returned from CAPI are https
+          if(!videoSrc.startsWith("https")) {
+            val (first, last) = videoSrc.splitAt(4);
+            val newSrc = first + "s" + last
+            source.attr("src", newSrc)
           }
-        }
-      })
-    }
-
-    document.getElementsByClass("element-video").foreach { figure: Element =>
-      val canonicalUrl = figure.attr("data-canonical-url")
-
-      figure.getElementsByClass("gu-video").foreach { element: Element =>
-
-        element
-          .removeClass("gu-video")
-          .addClass("js-gu-media--enhance gu-media gu-media--video")
-          .wrap("<div class=\"gu-media-wrapper gu-media-wrapper--video u-responsive-ratio u-responsive-ratio--hd\"></div>")
-
-        val flashMediaElement = conf.Static("flash/components/mediaelement/flashmediaelement.swf").path
-
-        val mediaId = element.attr("data-media-id")
-        val asset = findVideoFromId(mediaId)
-
-        element.getElementsByTag("source").remove()
-
-        val sourceHTML: String = getVideoAssets(mediaId).map { videoAsset =>
-          videoAsset.encoding.map { encoding =>
-            s"""<source src="${encoding.url}" type="${encoding.format}"></source>"""
-          }.getOrElse("")
-        }.mkString("")
-
-        element.append(sourceHTML)
-
-        // add the poster url
-        asset.flatMap(_.image).flatMap(Item640.bestFor).map(_.toString()).foreach { url =>
-          element.attr("poster", url)
-        }
-
-        asset.foreach(video => {
-          element.append(
-            s"""<object type="application/x-shockwave-flash" data="$flashMediaElement" width="620" height="350">
-                <param name="allowFullScreen" value="true" />
-                <param name="movie" value="$flashMediaElement" />
-                <param name="flashvars" value="controls=true&amp;file=${video.url.getOrElse("")}" />
-                Sorry, your browser is unable to play this video.
-              </object>""")
-
         })
+      })
+    } else {
+      if(!article.isLiveBlog) {
+        document.getElementsByClass("element-video").foreach( element => {
+          val shortUrl = element.attr("data-short-url")
+          val webUrl = element.attr("data-canonical-url")
+          val blockId = element.attr("data-media-id")
+          val mediaPath = element.attr("data-video-poster")
+          val mediaTitle = element.attr("data-video-name")
 
-        findVideoApiElement(mediaId).foreach{ videoElement =>
-          element.attr("data-block-video-ads", videoElement.blockVideoAds.toString)
-          if(!canonicalUrl.isEmpty && videoElement.embeddable) {
-            element.attr("data-embeddable", "true")
-            element.attr("data-embed-path", new URL(canonicalUrl).getPath.stripPrefix("/"))
-          } else {
-            element.attr("data-embeddable", "false")
+          if(!shortUrl.isEmpty) {
+            val html = views.html.fragments.share.blockLevelSharing(blockId, article.elementShares(shortLinkUrl = shortUrl, webLinkUrl = webUrl,  mediaPath = Some(mediaPath), title = mediaTitle), article.contentType)
+            element.child(0).after(html.toString())
+            element.addClass("fig--has-shares")
+            element.addClass("fig--narrow-caption")
+            // add extra margin if there is no caption to fit the share buttons
+            val figcaption = element.getElementsByTag("figcaption")
+            if(figcaption.length < 1) {
+              element.addClass("fig--no-caption")
+            }
+          }
+        })
+      }
+
+      document.getElementsByClass("element-video").foreach { figure: Element =>
+        val canonicalUrl = figure.attr("data-canonical-url")
+        figure.getElementsByClass("gu-video").foreach { element: Element =>
+          element
+            .removeClass("gu-video")
+            .addClass("js-gu-media--enhance gu-media gu-media--video")
+            .wrap("<div class=\"gu-media-wrapper gu-media-wrapper--video u-responsive-ratio u-responsive-ratio--hd\"></div>")
+
+          val flashMediaElement = conf.Static("flash/components/mediaelement/flashmediaelement.swf").path
+
+          val mediaId = element.attr("data-media-id")
+
+          val asset = findVideoFromId(mediaId)
+
+          element.getElementsByTag("source").remove()
+
+          val sourceHTML: String = getVideoAssets(mediaId).map { videoAsset =>
+            videoAsset.encoding.map { encoding =>
+              s"""<source src="${encoding.url}" type="${encoding.format}"></source>"""
+            }.getOrElse("")
+          }.mkString("")
+
+          element.append(sourceHTML)
+
+          // add the poster url
+          asset.flatMap(_.image).flatMap(Item640.bestFor).map(_.toString()).foreach { url =>
+            element.attr("poster", url)
+          }
+
+          asset.foreach(video => {
+            element.append(
+              s"""<object type="application/x-shockwave-flash" data="$flashMediaElement" width="620" height="350">
+                  <param name="allowFullScreen" value="true" />
+                  <param name="movie" value="$flashMediaElement" />
+                  <param name="flashvars" value="controls=true&amp;file=${video.url.getOrElse("")}" />
+                  Sorry, your browser is unable to play this video.
+                </object>""")
+
+          })
+
+          findVideoApiElement(mediaId).foreach{ videoElement =>
+            element.attr("data-block-video-ads", videoElement.blockVideoAds.toString)
+            if(!canonicalUrl.isEmpty && videoElement.embeddable) {
+              element.attr("data-embeddable", "true")
+              element.attr("data-embed-path", new URL(canonicalUrl).getPath.stripPrefix("/"))
+            } else {
+              element.attr("data-embeddable", "false")
+            }
           }
         }
       }
-    }
 
-    document.getElementsByClass("element-witness--main").foreach { element: Element =>
-      element.select("iframe").wrap("<div class=\"u-responsive-ratio u-responsive-ratio--hd\"></div>")
+      document.getElementsByClass("element-witness--main").foreach { element: Element =>
+        element.select("iframe").wrap("<div class=\"u-responsive-ratio u-responsive-ratio--hd\"></div>")
+      }
     }
 
     document


### PR DESCRIPTION
For amp pages, ensuring the tag `amp-video` is used. Also added a black background for when the video isn't quite the correct aspect ratio.

Before:
![image](https://cloud.githubusercontent.com/assets/8774970/9991606/60e3e940-6063-11e5-9e46-ffd71ce7e978.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/9991609/6c982440-6063-11e5-924e-a505c49e0e71.png)

cc @johnduffell 
