### PR TITLE
explicitly closing `amp-img` tag

### DIFF
--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -91,7 +91,7 @@
         height="@largestImage.height"
         class="maxed responsive-img"
         itemprop="contentUrl"
-        alt="@ImgSrc.getFallbackAsset(picture).flatMap(_.altText).getOrElse("")" />
+        alt="@ImgSrc.getFallbackAsset(picture).flatMap(_.altText).getOrElse("")" ></amp-img>
     }
 } else {
 


### PR DESCRIPTION
cc @johnduffell 
