### PR TITLE
Adjust spacing on gallery caption

### DIFF
--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -56,7 +56,7 @@
 
 .gallery2__figcaption {
     @include fs-textSans(1);
-    padding-top: $gs-baseline/2;
+    padding-top: $gs-baseline/4;
     overflow: visible;
     max-height: 100%;
     position: relative;

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -56,7 +56,7 @@
 
 .gallery2__figcaption {
     @include fs-textSans(1);
-    padding-top: $gs-baseline/4;
+    padding-top: $gs-baseline / 4;
     overflow: visible;
     max-height: 100%;
     position: relative;


### PR DESCRIPTION
Before:
![screen shot 2015-09-21 at 17 10 57](https://cloud.githubusercontent.com/assets/14570016/9997380/c64aa68c-6083-11e5-9ddc-f56e52479dfc.png)

After:
![screen shot 2015-09-21 at 17 11 51](https://cloud.githubusercontent.com/assets/14570016/9997401/dfe19434-6083-11e5-9102-6fccb9795ce8.png)
