### PR TITLE
Uses the PercentMaker to create the doughnut graph

### DIFF
--- a/sport/app/rugby/views/fragments/matchStats.scala.html
+++ b/sport/app/rugby/views/fragments/matchStats.scala.html
@@ -64,7 +64,7 @@
             </thead>
             <tbody>
                 <tr>
-                @defining((firstTeamProperty * 100.toInt).toInt, (secondTeamProperty * 100).toInt) { case (firstProperty, secondProperty) =>
+                @defining(PercentMaker((firstTeamProperty * 100.toInt).toInt, (secondTeamProperty * 100).toInt)) { case (firstProperty, secondProperty) =>
                 <td
                 class="bar-fight__bar bar-fight__bar--home"
                 data-chart-value="@secondProperty"


### PR DESCRIPTION
Before a rugby game the Possession and Territory doughnuts were not rendering correctly. I've updated this to behave as football which is use the [PercentMaker](https://github.com/guardian/frontend/blob/master/sport/app/football/views/support.scala#L77-L85). This combined with [NudgePercent](https://github.com/guardian/frontend/blob/master/sport/app/football/views/support.scala#L67-L75) makes the doughnut render correctly. This should have corrected the case when one team is in possession for 100% but it doesn't although this issue is only likely last a minute or so at the start of the game.

Before
<img width="285" alt="screen shot 2015-09-21 at 18 15 19" src="https://cloud.githubusercontent.com/assets/944375/9999350/dad5ca32-608d-11e5-86c6-d7fa8e2d49eb.png">

After
<img width="302" alt="screen shot 2015-09-21 at 18 22 59" src="https://cloud.githubusercontent.com/assets/944375/9999359/e0a72fb4-608d-11e5-95de-4c9bc3638068.png">

cc/ @mchv 
