### PR TITLE
adding table styling

### DIFF
--- a/common/app/views/fragments/amp/mainStylesheet.scala.html
+++ b/common/app/views/fragments/amp/mainStylesheet.scala.html
@@ -1,17 +1,16 @@
 <style amp-custom>
-    html {
-        background: rgba(51,51,51,0.05);
-    }
-
     body {
         font-family: Georgia,serif;
         font-size: 100%;
         line-height: 1.5rem;
         color: #333;
-        background: #fff;
-        margin: 0;
+        background: rgba(51,51,51,0.05);
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
+    }
+
+    .main-body {
+        background: #fff;
         max-width: 600px;
         margin: 0 auto;
     }
@@ -171,4 +170,5 @@
     @fragments.amp.embedStylesheet()
     @fragments.amp.quoteStylesheet()
     @fragments.amp.richLinkStylesheet()
+    @fragments.amp.tableStylesheet()
 </style>

--- a/common/app/views/fragments/amp/tableStylesheet.scala.html
+++ b/common/app/views/fragments/amp/tableStylesheet.scala.html
@@ -1,0 +1,95 @@
+figure.element-table {
+    margin: 0 0.1rem 0 1.25rem;
+    float: right;
+    width: 18.75rem;
+}
+
+@@media (max-width: 500px) {
+    figure.element-table {
+        width: 100%;
+        margin: 0 0.125rem;
+    }
+}
+
+.player-card {
+    padding: 0.75rem 0.625rem;
+    background: #f6f6f6;
+    border-top: 0.0625rem solid #005689;
+    color: #333;
+}
+
+.player-card__player {
+    margin-bottom: 1.5rem;
+    min-height: 6.25rem;
+    padding-right: 6.25rem;
+}
+
+@@media (max-width: 500px) {
+    .player-card__player {
+        min-height: 5rem;
+    }
+}
+
+.player-card__image-container {
+    float: right;
+}
+
+.player-card__image {
+    -webkit-border-radius: 62.5rem;
+    border-radius: 62.5rem;
+    height: 6.25rem;
+    width: 6.25rem;
+    float: right;
+}
+@@media (max-width: 500px) {
+    .player-card__image {
+        height: 5rem;
+        width: 5rem;
+    }
+}
+
+.player-card__name {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+    font-family: Georgia,serif;
+    font-weight: 900;
+    font-weight: normal;
+}
+
+.player-card__stats {
+    margin: 0;
+}
+
+.player-card__position,
+.player-card__stat-name,
+.player-card__stat-value {
+    font-family: "Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+}
+
+.player-card__stat-name, .player-card__stat-value {
+    font-size: 0.8125rem;
+    line-height: 1.125rem;
+
+}
+
+.player-card__position {
+    font-size: 0.875rem;
+    line-height: 1.375rem;
+    color: #005689;
+}
+
+.player-card__stat-name {
+    display: block;
+    float: left;
+    font-weight: normal;
+    padding: 0.25rem 0 0.5rem;
+}
+
+.player-card__stat-value {
+    border-top: 0.0625rem solid #bdbdbd;
+    font-weight: bold;
+    padding-left: 85%;
+    text-align: right;
+    margin: 0;
+    padding: 0.25rem 0 0.5rem;
+}

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -9,26 +9,28 @@
         <link rel="canonical" href="/@metaData.id" />
         <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
         <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
-        @fragments.amp.mainStylesheetAMP()
+        @fragments.amp.mainStylesheet()
         @fragments.metaData(metaData)
         <script src="https://cdn.ampproject.org/v0.js" @if(Play.isDev) { development } async></script>
         <script element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
     </head>
     <body>
-        @* @fragments.header(metaData) *@
-        <header class="main-header">
-            <a href="@LinkTo{/}" class="logo-wrapper">
-                @fragments.inlineSvg("guardian-logo-160", "logo")
-            </a>
-        </header>
-        @body
-        @* <h1>Sample document</h1>
-        <p>
-            Some text
-            <amp-img src=sample.jpg width=300 height=300 layout="responsive"/>
-        </p>
-        <cat-ad width=100% height=300>
-                <!-- <script>document.write(…)</script> -->
-        </cat-ad>*@
+        <div class="main-body">
+            @* @fragments.header(metaData) *@
+            <header class="main-header">
+                <a href="@LinkTo{/}" class="logo-wrapper">
+                    @fragments.inlineSvg("guardian-logo-160", "logo")
+                </a>
+            </header>
+            @body
+            @* <h1>Sample document</h1>
+            <p>
+                Some text
+                <amp-img src=sample.jpg width=300 height=300 layout="responsive"/>
+            </p>
+            <cat-ad width=100% height=300>
+                    <!-- <script>document.write(…)</script> -->
+            </cat-ad>*@
+        </div>
     </body>
 </html>


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/8774970/10017105/af1fe3a0-6123-11e5-9579-79fdc1e9f84b.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/10017120/cc51e626-6123-11e5-9c91-d9d328fc423e.png)

![image](https://cloud.githubusercontent.com/assets/8774970/10017097/a0499754-6123-11e5-952a-0f583726e299.png)

cc @johnduffell . I also added in the div wrapper so that we could still use `margin: 0 auto`. 
