### PR TITLE
Sustain 10592 Double bullet

### DIFF
--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -128,12 +128,16 @@
     @include faux-bullet-point;
 }
 
-.from-content-api ul > li,
-.content__standfirst ul > li {
-    @include faux-bullet-point($right-space: 4px);
+.from-content-api ul,
+.content__standfirst ul {
+    list-style: none;
 
-    > p:first-child { // this stops line breaking for the following bullet point format: <ul><li><p>text</p></li></ul>
-        display: inline;
+    > li {
+        @include faux-bullet-point($right-space: 4px);
+
+        > p:first-child { // this stops line breaking for the following bullet point format: <ul><li><p>text</p></li></ul>
+            display: inline;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -128,16 +128,12 @@
     @include faux-bullet-point;
 }
 
-.from-content-api ul,
-.content__standfirst ul {
-    list-style: none;
+.from-content-api ul > li,
+.content__standfirst ul > li {
+    @include faux-bullet-point($right-space: 4px);
 
-    > li {
-        @include faux-bullet-point($right-space: 4px);
-
-        > p:first-child { // this stops line breaking for the following bullet point format: <ul><li><p>text</p></li></ul>
-            display: inline;
-        }
+    > p:first-child { // this stops line breaking for the following bullet point format: <ul><li><p>text</p></li></ul>
+        display: inline;
     }
 }
 

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -37,7 +37,7 @@
     }
     > li, // sometimes HTML is malformed on purpose by editors
     > ol,
-    > blockquote > ul,
+    > blockquote ul,
     > ul {
         list-style: none;
     }


### PR DESCRIPTION
Fix content styles if using bullets in blockquotes - #10592
## Before

![image](https://cloud.githubusercontent.com/assets/638051/10017322/440c5b8c-6125-11e5-9c7f-89d929c2c455.png)
## After

![image](https://cloud.githubusercontent.com/assets/638051/10017328/4e5e75fc-6125-11e5-9573-86f5a215bafb.png)
