### PR TITLE
Hide expand icon on images for Core/no JS users

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -91,7 +91,7 @@
                     itemprop="contentUrl" />
                 }
 
-                @fragments.inlineSvg("expand-image", "icon", List("centered-icon rounded-icon gallery2__fullscreen"))
+                @fragments.inlineSvg("expand-image", "icon", List("centered-icon rounded-icon gallery2__fullscreen modern-visible"))
             </a>
 
             <div class="gallery2__figcaption">

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -68,7 +68,7 @@
     @lightboxIndex.map { index =>
         <a href="#img-@index" class="article__img-container js-gallerythumbs" data-link-name="Launch Article Lightbox" data-is-ajax>
                 @imageHtml
-                @fragments.inlineSvg("expand-image", "icon", List("centered-icon rounded-icon article__fullscreen"))
+                @fragments.inlineSvg("expand-image", "icon", List("centered-icon rounded-icon article__fullscreen modern-visible"))
         </a>
         @shareInfo.map { case (shareLinks, contentType) =>
             @share.blockLevelSharing(s"img-$index", shareLinks, contentType)

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -179,6 +179,10 @@
         }
     }
 
+    .is-not-modern & {
+        display: none;
+    }
+
     @if $old-ie {
         display: none;
     }

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -179,10 +179,6 @@
         }
     }
 
-    .is-not-modern & {
-        display: none;
-    }
-
     @if $old-ie {
         display: none;
     }


### PR DESCRIPTION
This expand icon doesn't work without app.js, so let's hide it.

![screen shot 2015-09-22 at 13 58 50](https://cloud.githubusercontent.com/assets/2236852/10018922/261dcab8-6132-11e5-8c79-3bb2c8becd37.png)
