### PR TITLE
Update enhancedTweets scripts to more reliably load

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/twitter.js
+++ b/static/src/javascripts/projects/common/modules/article/twitter.js
@@ -21,7 +21,7 @@ define([
     detect,
     mediator
 ) {
-    var body = qwery('.js-liveblog-body');
+    var body = qwery('.js-liveblog-body, .js-article__body');
 
     function bootstrap() {
         mediator.on('window:throttledScroll', _.debounce(enhanceTweets, 200));
@@ -32,11 +32,8 @@ define([
             return;
         }
 
-        var scriptElement,
-            tweetElements       = qwery('blockquote.js-tweet'),
-            widgetScript        = qwery('#twitter-widget'),
+        var tweetElements       = qwery('blockquote.js-tweet'),
             viewportHeight      = bonzo.viewport().height,
-            nativeTweetElements = qwery('blockquote.twitter-tweet'),
             scrollTop           = window.pageYOffset;
 
         tweetElements.forEach(function (element) {
@@ -45,9 +42,17 @@ define([
             if (((scrollTop + (viewportHeight * 2.5)) > elOffset.top) && (scrollTop < (elOffset.top + elOffset.height))) {
                 fastdom.write(function () {
                     $(element).removeClass('js-tweet').addClass('twitter-tweet');
+                    // We only want to render tweets once the class has been added
+                    renderTweets();
                 });
             }
         });
+    }
+
+    function renderTweets() {
+        var scriptElement,
+            nativeTweetElements = qwery('blockquote.twitter-tweet'),
+            widgetScript = qwery('#twitter-widget');
 
         if (nativeTweetElements.length > 0) {
             if (widgetScript.length === 0) {
@@ -56,10 +61,10 @@ define([
                 scriptElement.async = true;
                 scriptElement.src = '//platform.twitter.com/widgets.js';
                 $(document.body).append(scriptElement);
-            } else {
-                if (typeof twttr !== 'undefined' && 'widgets' in twttr && 'load' in twttr.widgets) {
-                    twttr.widgets.load(body);
-                }
+            }
+
+            if (typeof twttr !== 'undefined' && 'widgets' in twttr && 'load' in twttr.widgets) {
+                twttr.widgets.load(body);
             }
         }
     }


### PR DESCRIPTION
Issue: #10496

Made some minor updates twitter.js:
- Added .js-article__body to the element selection to prevent `Uncaught TypeError: Illegal invocation` on the .load of tweets 
- Moved widget script adding and [tweet initalisation](https://dev.twitter.com/web/javascript/initialization) into renderTweets() func, and called after `fastdom.write` to ensure that tweets are initialised (previously nativeTweetElements.length > 0 was sometimes false due to the async nature of `fastdom.write`)
- Moved the load out of the else, so that if the widget script is added then load is called immediately after, not on the next debounced scroll

This improves the likelihood of all tweets becoming enhanced while a user scrolls.
