### PR TITLE
Clean up liveblogs on core

### DIFF
--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -57,7 +57,7 @@
 
                         <div class="js-top-marker"></div>
                         @if(article.hasKeyEvents) {
-                            <div class="blog__timeline blog__dropdown js-live-blog__key-events">
+                            <div class="blog__timeline blog__dropdown js-live-blog__key-events modern-visible">
                                 <div class="blog__timeline-container js-live-blog__timeline-container" data-component="timeline">
                                     @fragments.dropdown("Key events", Some("key-events"), false) {
                                         <ul class="timeline js-live-blog__timeline u-unstyled"></ul>

--- a/common/app/views/fragments/dropdown.scala.html
+++ b/common/app/views/fragments/dropdown.scala.html
@@ -11,10 +11,10 @@
         @fragments.inlineSvg("dropdown-mask", "icon", List("control", "modern-visible"))
     </button>
 
-    <label class="dropdown__toggle-label modern-hidden"
+    <label class="dropdown__toggle-label u-h"
            aria-controls="@hash"
            for="@{hash}__label">Show</label>
-    <input class="dropdown__toggle modern-hidden"
+    <input class="dropdown__toggle u-h"
             aria-controls="@hash"
             type="checkbox"
             id="@{hash}__label" />

--- a/common/app/views/fragments/liveFilter.scala.html
+++ b/common/app/views/fragments/liveFilter.scala.html
@@ -1,5 +1,5 @@
 @(isLive: Boolean)
-<div class="live-toolbar js-live-toolbar">
+<div class="live-toolbar js-live-toolbar modern-visible">
     <div class="live-toggler-wrapper" data-component="live-toggle" data-link-name="live-toolbar">
         <button class="u-button-reset popup__toggle live-toggler__label" data-link-name="order-by" data-toggle="popup--live-blog">Order by</button>
         <ul class="popup popup__group is-off popup--live-blog">

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -527,6 +527,10 @@ $block-padding-right: $gs-gutter;
             display: block !important; //Overrides JS active state
         }
     }
+
+    .is-not-modern & {
+        border-top: 0;
+    }
 }
 
 /* Timeline


### PR DESCRIPTION
Before:
![screen shot 2015-09-22 at 16 44 20](https://cloud.githubusercontent.com/assets/2236852/10023315/657307fc-6149-11e5-8478-766855688e06.png)

After:
![screen shot 2015-09-22 at 16 44 07](https://cloud.githubusercontent.com/assets/2236852/10023319/6ab5cd3a-6149-11e5-9fe0-e2fdab0642ac.png)

Mostly just hides the screenreader toggles. Things like 'order by' and 'key events' are all handled in JS currently, so just hiding them for now.
