### PR TITLE
Fix integration tests (partly...)

### DIFF
--- a/integrated-tests/src/test/scala/commercial/AdsTest.scala
+++ b/integrated-tests/src/test/scala/commercial/AdsTest.scala
@@ -1,66 +1,50 @@
 package integration
 
-import driver.SauceLabsWebDriver
-import org.openqa.selenium.WebDriver
-import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.WebElement
 import org.scalatest._
-import org.scalatest.selenium.{Driver, WebBrowser}
-import org.scalatest.time.{Seconds, Span}
 
 class AdsTest
   extends FlatSpec
   with Matchers
   with OptionValues
   with BeforeAndAfterAll
-  with WebBrowser
-  with Driver {
+  with SharedWebDriver {
 
-  override implicit val webDriver: WebDriver = {
-    lazy val localWebDriver = new ChromeDriver()
-    if (Config.remoteMode) SauceLabsWebDriver() else localWebDriver
+  private def findComponent(path: String, selector: String): WebElement = {
+    get(path, ads = true)
+    first(selector)
   }
 
-  implicitlyWait(Span(20, Seconds))
-
-  private def url(path: String): String = {
-    s"${Config.baseUrl}/$path?test=test#gu.prefs.switchOn=adverts"
-  }
-
-  private def findComponent(path: String, selector: String): Option[Element] = {
-    go to url(path)
-    find(cssSelector(selector))
-  }
-
-  private def findLogo(path: String, domSlotId: String): Option[Element] = {
+  private def findLogo(path: String, domSlotId: String): WebElement = {
     findComponent(path, s"#$domSlotId > div > a > img")
   }
 
-  private def shouldBeVisible(maybeComponent: => Option[Element]): Unit = {
-    withClue(s"Page source: $pageSource") {
-      maybeComponent.value shouldBe 'displayed
-    }
+  private def shouldBeVisible(maybeComponent: => WebElement): Unit = {
+//    withClue(s"Page source: ${pageSource}") {
+      maybeComponent shouldBe 'displayed
+//    }
   }
-
-  override protected def afterAll(): Unit = quit()
 
   "Ads" should "display on the sport front" in {
 
-    go to url("uk/sport")
+    implicitlyWait(20)
+
+    get("/uk/sport", ads = true)
 
     withClue("Should display top banner ad") {
-      shouldBeVisible(find(cssSelector("#dfp-ad--top-above-nav > *")))
+      shouldBeVisible(first("#dfp-ad--top-above-nav > *"))
       }
 
     withClue("Should display two MPUs") {
-      shouldBeVisible(find(cssSelector("#dfp-ad--inline1 > *")))
-      shouldBeVisible(find(cssSelector("#dfp-ad--inline2 > *")))
+      shouldBeVisible(first("#dfp-ad--inline1 > *"))
+      shouldBeVisible(first("#dfp-ad--inline2 > *"))
     }
   }
 
   "A logo" should "appear on a sponsored front" in {
     shouldBeVisible {
       findLogo(
-        path = "voluntary-sector-network/series/the-not-for-profit-debates",
+        path = "/voluntary-sector-network/series/the-not-for-profit-debates",
         domSlotId = "dfp-ad--spbadge1"
       )
     }
@@ -69,7 +53,7 @@ class AdsTest
   it should "appear on a sponsored article" in {
     shouldBeVisible {
       findLogo(
-        path = "voluntary-sector-network/2015/apr/28/help-your-organisation-embrace-and-nurture" +
+        path = "/voluntary-sector-network/2015/apr/28/help-your-organisation-embrace-and-nurture" +
           "-change-in-a-fast-moving-world",
         domSlotId = "dfp-ad--spbadge"
       )

--- a/integrated-tests/src/test/scala/package.scala
+++ b/integrated-tests/src/test/scala/package.scala
@@ -53,8 +53,8 @@ trait SharedWebDriver extends SuiteMixin { this: Suite =>
     super.run(testName, args)
   }
 
-  protected def get(path: String) = {
-    webDriver.get(s"${Config.baseUrl}$path?test=test#gu.prefs.switchOff=adverts&countmein&noads")
+  protected def get(path: String, ads: Boolean = false) = {
+    webDriver.get(s"${Config.baseUrl}$path?test=test#gu.prefs.switch${if (ads) "On" else "Off"}=adverts&countmein&${if (ads) "" else "no"}ads")
     webDriver.navigate().refresh()
   }
 
@@ -68,7 +68,9 @@ trait SharedWebDriver extends SuiteMixin { this: Suite =>
 }
 
 class IntegratedTestsSuite extends Suites (
+  new AdsTest,
   new MostPopularTest,
   new SslCertTest,
-  new ProfileCommentsTest) with SingleWebDriver {
+  new ProfileCommentsTest
+) with SingleWebDriver {
 }


### PR DESCRIPTION
The integrated tests were failing because the webdrivers were getting on top of each other between the ads test and the others.

To solve this I've just made them all user the same webdriver and the same system, and they just turn ads on and off as they need.

@kelvin-chappell seems to pass except the 2 MPUs test that's ignored by you (and the cert one)
