### PR TITLE
Item prop changes for liveblogs

### DIFF
--- a/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
+++ b/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
@@ -3,7 +3,7 @@
     @profileTag.contributorImagePath.map{ src =>
         <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
     }
-    <p class="liveblog-block-byline__name">@profileTag.name</p>
+    <p class="liveblog-block-byline__name" itemprop="author">@profileTag.name</p>
 </div>
 
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -298,6 +298,10 @@ case class LiveBlogLinkedData(isLiveBlog: Boolean)(implicit val request: Request
         el.select(".block-time.published-time time").foreach { time =>
           time.attr("itemprop", "datePublished")
         }
+        el.select(".block-title").foreach { title =>
+          title.attr("itemprop", "headline")
+
+        }
         el.select(".block-elements").foreach { body =>
           body.attr("itemprop", "articleBody")
         }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -303,6 +303,7 @@ case class LiveBlogLinkedData(isLiveBlog: Boolean)(implicit val request: Request
 
         }
         el.select(".block-elements").foreach { blockElements =>
+          //itemprop needs to go around children but not the author tag which is added in BloggerBylineImage
           val container = body.createElement("div")
           container.attr("itemprop", "articleBody")
           // Get children before mutating

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -302,8 +302,13 @@ case class LiveBlogLinkedData(isLiveBlog: Boolean)(implicit val request: Request
           title.attr("itemprop", "headline")
 
         }
-        el.select(".block-elements").foreach { body =>
-          body.attr("itemprop", "articleBody")
+        el.select(".block-elements").foreach { blockElements =>
+          val container = body.createElement("div")
+          container.attr("itemprop", "articleBody")
+          // Get children before mutating
+          val children = blockElements.children()
+          blockElements.prependChild(container)
+          container.insertChildren(0, children)
         }
       }
     }


### PR DESCRIPTION
There was a request to make some changes to the itemprop data for liveblogs from Google:
- Adds `itemprop="headline"` to liveblock title
- Moves the `itemprop="articleBody"` out of the block-elements div but into the children. This is because some blocks have the contributor at the top which Google don't want in the articleBody markup.
- Adds `itemprop="author"` to the contributor name in the liveblog block.

cc @johnduffell 
