### PR TITLE
Alternate ad-block messages

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -23,7 +23,7 @@ define([
 ) {
     function init() {
         var alreadyVisted = storage.local.get('alreadyVisited') || 0,
-            adblockLink = 'https://membership.theguardian.com',
+            adblockLink = 'https://membership.theguardian.com/',
             message = _.sample([
                 {
                     id: 'monthly',

--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -1,4 +1,5 @@
 define([
+    'common/utils/_',
     'common/utils/config',
     'common/utils/detect',
     'common/utils/storage',
@@ -9,6 +10,7 @@ define([
     'text!common/views/membership-message.html',
     'common/views/svgs'
 ], function (
+    _,
     config,
     detect,
     storage,
@@ -20,23 +22,42 @@ define([
     svgs
 ) {
     function init() {
-        var alreadyVisted = storage.local.get('alreadyVisited') || 0,
-            adblockLink = 'https://membership.theguardian.com?INTCMP=adb-mv';
+        var alreadyVisted = storage.local.get('alreadyVisited') || 0;
+        var adblockLink = 'https://membership.theguardian.com';
+        var message = _.sample([
+            {
+                id: 'monthly',
+                messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter from just £5 per month',
+                linkText: 'Find out more'
+            },
+            {
+                id: 'annual',
+                messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter for just £50 per a year',
+                linkText: 'Find out more'
+            },
+            {
+                id: 'weekly',
+                messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter for less than £1 per week',
+                linkText: 'Find out more'
+            },
+            {
+                id: 'no-price',
+                messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way?',
+                linkText: 'Become a supporter today'
+            }
+        ]);
 
         if (detect.getBreakpoint() !== 'mobile' && detect.adblockInUse && config.switches.adblock && alreadyVisted > 1) {
-            new Message('adblock', {
+            new Message('adblock-message', {
                 pinOnHide: false,
-                siteMessageLinkName: 'adblock message variant',
+                siteMessageLinkName: 'adblock message variant ' + message.id,
                 siteMessageCloseBtn: 'hide'
-            }).show(template(
-                    messageTemplate,
-                    {
-                        supporterLink: adblockLink,
-                        messageText: 'We notice you\'ve got an ad-blocker switched on. Perhaps you\'d like to support the Guardian another way?',
-                        linkText: 'Become a supporter today',
-                        arrowWhiteRight: svgs('arrowWhiteRight')
-                    }
-                ));
+            }).show(template(messageTemplate, {
+                supporterLink: adblockLink + '?INTCMP=adb-mv-' + message.id,
+                messageText: message.messageText,
+                linkText: message.linkText,
+                arrowWhiteRight: svgs('arrowWhiteRight')
+            }));
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -22,30 +22,30 @@ define([
     svgs
 ) {
     function init() {
-        var alreadyVisted = storage.local.get('alreadyVisited') || 0;
-        var adblockLink = 'https://membership.theguardian.com';
-        var message = _.sample([
-            {
-                id: 'monthly',
-                messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter from just £5 per month',
-                linkText: 'Find out more'
-            },
-            {
-                id: 'annual',
-                messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter for just £50 per a year',
-                linkText: 'Find out more'
-            },
-            {
-                id: 'weekly',
-                messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter for less than £1 per week',
-                linkText: 'Find out more'
-            },
-            {
-                id: 'no-price',
-                messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way?',
-                linkText: 'Become a supporter today'
-            }
-        ]);
+        var alreadyVisted = storage.local.get('alreadyVisited') || 0,
+            adblockLink = 'https://membership.theguardian.com',
+            message = _.sample([
+                {
+                    id: 'monthly',
+                    messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter from just £5 per month',
+                    linkText: 'Find out more'
+                },
+                {
+                    id: 'annual',
+                    messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter for just £50 per a year',
+                    linkText: 'Find out more'
+                },
+                {
+                    id: 'weekly',
+                    messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter for less than £1 per week',
+                    linkText: 'Find out more'
+                },
+                {
+                    id: 'no-price',
+                    messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way?',
+                    linkText: 'Become a supporter today'
+                }
+            ]);
 
         if (detect.getBreakpoint() !== 'mobile' && detect.adblockInUse && config.switches.adblock && alreadyVisted > 1) {
             new Message('adblock-message', {

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -410,16 +410,14 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     }
 }
 
-.site-message--adblock {
-    background: colour(news-support-2);
-}
 /**
- * Membership message A/B test
+ * Membership messages
  */
+.site-message--adblock-message,
 .site-message--membership-message,
 .site-message--membership-message-uk,
 .site-message--membership-message-usa {
-    background: colour(news-main-2);
+    background: colour(membership-default);
 }
 
 /**


### PR DESCRIPTION
Updates ad-block banner to use new Members colours and displays a random version of the message, either daily, weekly, monthly or yearly prices. 

![generic](https://cloud.githubusercontent.com/assets/123386/10043034/a6709dd4-61e7-11e5-80b4-7948137b8063.png)
![weekly](https://cloud.githubusercontent.com/assets/123386/10043036/a6860c46-61e7-11e5-847b-227d22566c2d.png)
![monthly](https://cloud.githubusercontent.com/assets/123386/10043033/a66e6654-61e7-11e5-8420-2c2e56fa2488.png)
![yearly](https://cloud.githubusercontent.com/assets/123386/10043035/a680cfd8-61e7-11e5-96a7-f9c96a527133.png)

@Calanthe @uplne 
