### PR TITLE
Related images not showing up on browsers that don't support srcset natively

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -1,10 +1,8 @@
 @(metaData: model.MetaData, projectName: Option[String] = None, curlPaths: Map[String, String] = Map())(head: Html)(body: Html)(implicit request: RequestHeader)
-
 @import common.{Edition, Navigation}
 @import conf.Switches._
 @import views.support.Commercial.topBelowNavSlot
 @import views.support.{Commercial, RenderClasses}
-
 <!DOCTYPE html>
 <html id="js-context" class="js-off is-not-modern id--signed-out" data-page-path="@request.path">
 

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -91,7 +91,7 @@ define([
                         // upgrade images
                         mediator.emit('modules:related:loaded', container);
                         mediator.emit('page:new-content', container);
-                        mediator.emit('ui:images:lazyLoaded');
+                        mediator.emit('ui:images:upgradePictures', container);
                         register.end(componentName);
                     },
                     error: function () {

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -91,6 +91,7 @@ define([
                         // upgrade images
                         mediator.emit('modules:related:loaded', container);
                         mediator.emit('page:new-content', container);
+                        mediator.emit('ui:images:lazyLoaded');
                         register.end(componentName);
                     },
                     error: function () {

--- a/static/src/javascripts/projects/common/modules/ui/images.js
+++ b/static/src/javascripts/projects/common/modules/ui/images.js
@@ -15,21 +15,14 @@ function (
 
     var images = {
 
-        upgradePictures: function () {
-            var images = [].slice.call($('img[srcset]', document.body));
+        upgradePictures: function (context) {
+            var images = [].slice.call($('img[srcset]', context || document.body));
             picturefill({ elements: images });
         },
 
         listen: function () {
             mediator.addListeners({
-                'ui:images:upgradePictures': function () {
-                    images.upgradePictures();
-                },
-                'ui:images:lazyLoaded': function (context) {
-                    picturefill({
-                        elements: context ? [context] : null
-                    });
-                }
+                'ui:images:upgradePictures':  images.upgradePictures
             });
         }
 

--- a/static/src/javascripts/projects/common/modules/ui/images.js
+++ b/static/src/javascripts/projects/common/modules/ui/images.js
@@ -27,7 +27,7 @@ function (
                 },
                 'ui:images:lazyLoaded': function (context) {
                     picturefill({
-                        elements: [context]
+                        elements: context ? [context] : null
                     });
                 }
             });

--- a/static/src/javascripts/projects/common/utils/picturefill.js
+++ b/static/src/javascripts/projects/common/utils/picturefill.js
@@ -405,7 +405,7 @@ define([
                 candidates,
                 options = opt || {};
 
-            elements = options.elements || pf.getAllElements();
+            elements = options.elements || pf.getAllElements;
 
             // w._browserWidth = pf.getBrowserWidth();
 

--- a/static/src/javascripts/projects/common/utils/picturefill.js
+++ b/static/src/javascripts/projects/common/utils/picturefill.js
@@ -405,7 +405,7 @@ define([
                 candidates,
                 options = opt || {};
 
-            elements = options.elements || pf.getAllElements;
+            elements = options.elements || pf.getAllElements();
 
             // w._browserWidth = pf.getBrowserWidth();
 


### PR DESCRIPTION
Issues #10610 - Picturefill was not running on the lazyloaded images in related content.

This affects:
- All IE
- Safari (no sizes syntax)
- Edge (no sizes syntax)

Utilised the images ui publish to tell picturefill to re-run - existing images [won't get re-evaluated](https://github.com/scottjehl/picturefill/blob/2.3/src/picturefill.js#L596) as picturefill caches whether it has been done already on the element.
## Safari

![image](https://cloud.githubusercontent.com/assets/638051/10045751/f5797d78-61fc-11e5-93c8-70aa962e97d5.png)
## IE10

![image](https://cloud.githubusercontent.com/assets/638051/10045770/0a0c184a-61fd-11e5-821b-34e315d1a20a.png)
# IE11

![image](https://cloud.githubusercontent.com/assets/638051/10045788/23698624-61fd-11e5-8ff0-42cd1a704c16.png)
