### PR TITLE
Remove bullets from all uls where there is a faux bullet point

### DIFF
--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -128,12 +128,16 @@
     @include faux-bullet-point;
 }
 
-.from-content-api ul > li,
-.content__standfirst ul > li {
-    @include faux-bullet-point($right-space: 4px);
+.from-content-api ul,
+.content__standfirst ul {
+    list-style: none;
 
-    > p:first-child { // this stops line breaking for the following bullet point format: <ul><li><p>text</p></li></ul>
-        display: inline;
+    > li {
+        @include faux-bullet-point($right-space: 4px);
+
+        > p:first-child { // this stops line breaking for the following bullet point format: <ul><li><p>text</p></li></ul>
+            display: inline;
+        }
     }
 }
 


### PR DESCRIPTION
#10592 I wasn't agressive enough in removing the browser default bullet point from uls yesterday - it's not just blockquotes, so adding list-style: none to all uls that include lis with faux-bullet-point.
## Before

![image](https://cloud.githubusercontent.com/assets/638051/10046382/69b25914-6200-11e5-80a2-e7cf779da727.png)
## After

![image](https://cloud.githubusercontent.com/assets/638051/10046395/747890ca-6200-11e5-958a-a108619cafd1.png)
