### PR TITLE
Revert "Item prop changes for liveblogs"

### DIFF
--- a/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
+++ b/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
@@ -3,7 +3,7 @@
     @profileTag.contributorImagePath.map{ src =>
         <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
     }
-    <p class="liveblog-block-byline__name" itemprop="author">@profileTag.name</p>
+    <p class="liveblog-block-byline__name">@profileTag.name</p>
 </div>
 
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -200,18 +200,8 @@ case class LiveBlogLinkedData(isLiveBlog: Boolean)(implicit val request: Request
         el.select(".block-time.published-time time").foreach { time =>
           time.attr("itemprop", "datePublished")
         }
-        el.select(".block-title").foreach { title =>
-          title.attr("itemprop", "headline")
-
-        }
-        el.select(".block-elements").foreach { blockElements =>
-          //itemprop needs to go around children but not the author tag which is added in BloggerBylineImage
-          val container = body.createElement("div")
-          container.attr("itemprop", "articleBody")
-          // Get children before mutating
-          val children = blockElements.children()
-          blockElements.prependChild(container)
-          container.insertChildren(0, children)
+        el.select(".block-elements").foreach { body =>
+          body.attr("itemprop", "articleBody")
         }
       }
     }


### PR DESCRIPTION
Reverts guardian/frontend#10612

The change to add the extra `div` causes this
<img width="899" alt="screen shot 2015-09-23 at 15 05 04" src="https://cloud.githubusercontent.com/assets/944375/10047121/8134aa02-6204-11e5-8b5c-5809e95331b5.png">

:blush: 
