### PR TITLE
Revert sbt version to 0.13.8

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.8


### PR DESCRIPTION
This breaks our build because of horrible dependency issues.

We will attempt to update it ourselves again but it will require more work than just the version bump.

@rich-nguyen @mchv 
