### PR TITLE
Setting min-height for popular container

### DIFF
--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -229,6 +229,7 @@ Hence why a greater depth of selector specificity is needed.
 
         .tabs__pane {
             width: (100% / 3) * 2;
+            min-height: 300px;
         }
     }
 }


### PR DESCRIPTION
Fix for the MPU getting cut off when there are fewer than 10 items in the popular list:

![screen shot 2015-09-24 at 11 17 37](https://cloud.githubusercontent.com/assets/3763718/10070961/f7121c1a-62ad-11e5-95ad-0b3e452a834b.png)

http://www.theguardian.com/gnmeducationcentre/2015/aug/20/cartoon-and-art-family-day-saturday-10-october-kings-place-london-n1
