### PR TITLE
Fix issue with more-tags link displaying in core

### DIFF
--- a/common/app/views/fragments/keywordList.scala.html
+++ b/common/app/views/fragments/keywordList.scala.html
@@ -34,7 +34,7 @@
 
                 @if(hiddenKeywords.nonEmpty) {
 
-                    <li class="inline-list__item js-more-tags more-tags modern-hidden">
+                    <li class="inline-list__item more-tags js-more-tags">
                         <button class="u-button-reset js-more-tags__link button button--small button--tag @tone.map("button--tone-" + _ + "-variant").getOrElse("button--tertiary") button--more"
                            data-link-name="more-tags">More…</button>
                     </li>

--- a/static/src/javascripts/projects/common/modules/onward/more-tags.js
+++ b/static/src/javascripts/projects/common/modules/onward/more-tags.js
@@ -9,15 +9,16 @@ define([
     $,
     bean
 ) {
+    var ACTIVE_STATE = 'is-available';
 
     function MoreTags() {
         this.init = function () {
             var $more = $('.js-more-tags');
             if ($more.length !== 0) {
-                $more.removeClass('modern-hidden');
+                $more.addClass(ACTIVE_STATE);
                 bean.on(document.querySelector('.js-more-tags__link'), 'click', function () {
                     $('.modern-hidden-tag').removeClass('modern-hidden');
-                    $more.addClass('modern-hidden');
+                    $more.removeClass(ACTIVE_STATE);
                 });
             }
         };

--- a/static/src/javascripts/test/spec/common/onward/more-tags.spec.js
+++ b/static/src/javascripts/test/spec/common/onward/more-tags.spec.js
@@ -3,6 +3,9 @@ import MoreTags from 'common/modules/onward/more-tags';
 import fixtures from 'helpers/fixtures';
 
 describe('MoreTabs', function () {
+
+    var ACTIVE_STATE = 'is-available';
+
     beforeEach(function () {
         fixtures.render({
             id: 'more-tags-fixtures',
@@ -60,7 +63,7 @@ describe('MoreTabs', function () {
 
         new MoreTags().init();
 
-        expect($('.js-more-tags').hasClass('modern-hidden')).toBeFalsy();
+        expect($('.js-more-tags').hasClass(ACTIVE_STATE)).toBeTruthy();
 
         // but the tags should remain hidden
         expect($('.modern-hidden-tag').hasClass('modern-hidden')).toBeTruthy();
@@ -75,7 +78,7 @@ describe('MoreTabs', function () {
         expect($('.modern-hidden-tag').hasClass('modern-hidden')).toBeFalsy();
 
         // but the more link should now be hidden
-        expect($('.js-more-tags').hasClass('modern-hidden')).toBeTruthy();
+        expect($('.js-more-tags').hasClass(ACTIVE_STATE)).toBeFalsy();
     });
 });
 

--- a/static/src/stylesheets/module/_tag-list.scss
+++ b/static/src/stylesheets/module/_tag-list.scss
@@ -31,11 +31,15 @@
     }
 }
 
+.more-tags {
+    display: none;
+
+    &.is-available {
+        display: inline;
+    }
+}
+
 .show-more-tags {
     vertical-align: bottom;
     display: inline-block;
-}
-
-.more-tags { //fix for IE8/9 bug
-    display: inline;
 }


### PR DESCRIPTION
Spotted an issue in core where the more tags link is still shown.

**Before**
![screen shot 2015-09-24 at 12 08 01](https://cloud.githubusercontent.com/assets/123386/10071984/ed6c7400-62b5-11e5-99f7-0cae14d62693.png)

**After**
![screen shot 2015-09-24 at 11 56 01](https://cloud.githubusercontent.com/assets/123386/10071988/f28ef610-62b5-11e5-893a-9f9c5ca85876.png)

**Enhanced**
![screen shot 2015-09-24 at 12 07 31](https://cloud.githubusercontent.com/assets/123386/10071993/f9a72468-62b5-11e5-9870-c32b1f6e3437.png)

@sndrs 
