### PR TITLE
Facia tool switches about to expire

### DIFF
--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -1153,31 +1153,12 @@ object Switches {
     exposeClientSide = true
   )
 
-  val FaciaDynamoArchive = Switch(
-    "Facia",
-    "facia-tool-dynamo-archive",
-    "If this switch is on, facia-tool will directly archive to DynamoDB. When this is about to expire, please " +
-      "check the DB size.",
-    safeState = Off,
-    sellByDate = new LocalDate(2015, 9, 30),
-    exposeClientSide = false
-  )
-
   val FaciaPressOnDemand = Switch(
     "Facia",
     "facia-press-on-demand",
     "If this is switched on, you can force facia to press on demand (Leave off)",
     safeState = Off,
     sellByDate = never,
-    exposeClientSide = false
-  )
-
-  val FaciaToolPutPrivate = Switch(
-    "Facia",
-    "facia-tool-put-private",
-    "If this is switched on, facia tool will put collections to S3 as private",
-    safeState = Off,
-    sellByDate = new LocalDate(2015, 9, 30),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
`FaciaDynamoArchive` is not used anymore, the new facia-tool does not even have access to that DB. We'll figure out another way to do auditing. Might be a good idea to delete the old database.

`FaciaToolPutPrivate` was never turned on, we'll switch it on by default when we migrate collection to a new bucket, for the moment we can live with public collections.

cc @janua 
