### PR TITLE
Fix to allow space for arrow on merchandising components

### DIFF
--- a/static/src/stylesheets/module/commercial/_facia-container.scss
+++ b/static/src/stylesheets/module/commercial/_facia-container.scss
@@ -235,6 +235,10 @@
         @include fs-headline(2);
         margin-top: 0;
     }
+
+    .ad-slot--merchandising-high & {
+        padding-right: 70px;
+    }
 }
 
 /* ==========================================================================


### PR DESCRIPTION
CSS fix to allow enough space for the arrow on the merchandising component, on mobile.

![img_3792](https://cloud.githubusercontent.com/assets/3763718/10098288/23094d32-6378-11e5-9a29-0a4c596f4b98.PNG)
