### PR TITLE
Add guFonts as a Closure export

### DIFF
--- a/common/app/templates/headerInlineJS/loadFonts.scala.js
+++ b/common/app/templates/headerInlineJS/loadFonts.scala.js
@@ -98,6 +98,8 @@ do you have fonts in localStorage?
                 function guFont(fontData) {
                     return fontData.css;
                 }
+                /* Closure Exports */
+                this['guFont'] = guFont;
 
                 // download font as json to store/use etc
                 function fetchFont(url, el, fontName, fontHash) {


### PR DESCRIPTION
This ensures that when `closure` replaces all the method names with shortened versions, `guFont` is still available for the `JSONP` callback to call by being in the global scope.

@sndrs 
