### PR TITLE
Move byline outside of the block-elements and articleBody schema

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -194,13 +194,16 @@ case class LiveBlogLinkedData(isLiveBlog: Boolean)(implicit val request: Request
     if (isLiveBlog) {
       body.select(".block").foreach { el =>
         val id = el.id()
+        val blockElements = el.select(".block-elements")
+        val noByline = el.attributes().get("data-block-contributor").isEmpty
         el.attr("itemprop", "liveBlogUpdate")
         el.attr("itemscope", "")
         el.attr("itemtype", "http://schema.org/BlogPosting")
         el.select(".block-time.published-time time").foreach { time =>
           time.attr("itemprop", "datePublished")
         }
-        el.select(".block-elements").foreach { body =>
+        if (noByline) blockElements.addClass("block-elements--no-byline")
+        blockElements.foreach { body =>
           body.attr("itemprop", "articleBody")
         }
       }
@@ -217,7 +220,7 @@ case class BloggerBylineImage(article: Article)(implicit val request: RequestHea
         if (contributorId.nonEmpty) {
           article.tags.find(_.id == contributorId).map{ contributorTag =>
             val html = views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
-            el.getElementsByClass("block-elements").headOption.foreach(_.prepend(html.toString()))
+            el.getElementsByClass("block-elements").headOption.foreach(_.before(html.toString()))
           }
         }
       }

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -231,7 +231,8 @@ $block-padding-right: $gs-gutter;
     .block-elements > .element.element-tweet,
     .block-elements > .element.element-rich-link,
     .block-elements > .element.element-witness,
-    .block-elements > .element.element--thumbnail {
+    .block-elements > .element.element--thumbnail,
+    .liveblog-block-byline {
         margin-left: $gs-gutter/2;
         margin-right: $gs-gutter/2;
         @include mq(tablet) {
@@ -240,27 +241,29 @@ $block-padding-right: $gs-gutter;
         }
     }
 
-    .block-elements {
+    /* Bylines
+       ========================================================= */
+    .liveblog-block-byline {
+        margin-bottom: $gs-baseline * .5;
+        border-bottom: 1px dotted colour(neutral-4);
+        padding-bottom: $gs-baseline * .5;
+    }
 
-        /* Bylines
-           ========================================================= */
-        .liveblog-block-byline {
-            margin-bottom: $gs-baseline * .5;
-            border-bottom: 1px dotted colour(neutral-4);
-            padding-bottom: $gs-baseline * .5;
-        }
-        .liveblog-block-byline__img {
-            display: inline;
-            border-radius: 50%;
-            max-width: 36px;
-            vertical-align: middle;
-            margin-right: $gs-gutter * .2;
-        }
-        .liveblog-block-byline__name {
-            @include fs-bodyCopy(2);
-            display: inline;
-            color: colour(neutral-1);
-        }
+    .liveblog-block-byline__img {
+        display: inline;
+        border-radius: 50%;
+        max-width: 36px;
+        vertical-align: middle;
+        margin-right: $gs-gutter * .2;
+    }
+
+    .liveblog-block-byline__name {
+        @include fs-bodyCopy(2);
+        display: inline;
+        color: colour(neutral-1);
+    }
+
+    .block-elements {
 
         /* Quotes
            ========================================================= */
@@ -371,13 +374,12 @@ $block-padding-right: $gs-gutter;
             }
         }
 
-        > .element-image:first-child,
-        > .element-video:first-child {
+        &.block-elements--no-byline > .element-image:first-child,
+        &.block-elements--no-byline > .element-video:first-child {
             @include mq(tablet) {
                 margin-top: 55px; // Extra margin top to position media below block-time
             }
         }
-
 
         > .element.element--thumbnail {
             border-bottom: 0;

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -374,7 +374,7 @@ $block-padding-right: $gs-gutter;
             }
         }
 
-        &.block-elements--no-byline > .element-image:first-child,
+        &.block-elements--no-byline > .element-image:first-child:not(.element--thumbnail),
         &.block-elements--no-byline > .element-video:first-child {
             @include mq(tablet) {
                 margin-top: 55px; // Extra margin top to position media below block-time


### PR DESCRIPTION
The byline needed to be outside of articleBody.

Please shout if there looks like anything weird in the Scala, as it is my first go...
## Chrome

![image](https://cloud.githubusercontent.com/assets/638051/10102253/5aff5fa2-6395-11e5-9dea-de7f5edd21f4.png)
<img width="714" alt="chrome byline text" src="https://cloud.githubusercontent.com/assets/638051/10102264/61b19e8c-6395-11e5-9cca-d393a2058d12.png">
<img width="723" alt="chrome no byline" src="https://cloud.githubusercontent.com/assets/638051/10102265/61b3b28a-6395-11e5-8894-4913643ea9e5.png">
<img width="443" alt="narrow byline" src="https://cloud.githubusercontent.com/assets/638051/10102267/61b7a7e6-6395-11e5-9164-00165cc30c37.png">
<img width="438" alt="narrow byline image" src="https://cloud.githubusercontent.com/assets/638051/10102266/61b544e2-6395-11e5-9921-6b49b70a241c.png">
## IE11

<img width="638" alt="ie11" src="https://cloud.githubusercontent.com/assets/638051/10102277/6acfc412-6395-11e5-9cf4-07cbf8da950c.png">
<img width="656" alt="ie11 copy" src="https://cloud.githubusercontent.com/assets/638051/10102278/6ad15d7c-6395-11e5-904d-fd8e291ba868.png">
