### PR TITLE
Ensure static project's artifact upload has the right acl

### DIFF
--- a/dev/teamcity/dist-publish-assets-tc
+++ b/dev/teamcity/dist-publish-assets-tc
@@ -28,10 +28,10 @@ echo "Uploading artifact and build manifest to S3"
 
 set +u
 if [[ -z $BUILD_NUMBER ]]; then
-  BUILD_NUMBER=dev-build
+  BUILD_NUMBER=1
 fi
 if [[ -z $BUILD_VCS_NUMBER ]]; then
-  BUILD_VCS_NUMBER=dev-vcs-build
+  BUILD_VCS_NUMBER=0
 fi
 if [[ -z $RIFF_RAFF_ARTIFACT_BUCKET ]]; then
   RIFF_RAFF_ARTIFACT_BUCKET=aws-frontend-teamcity
@@ -52,8 +52,8 @@ sed -e "s|<%build_number%>|$BUILD_NUMBER|" \
     -e "s|<%branch%>|$BUILD_VCS_BRANCH|" \
     static/build-template.json | tee $static_folder/build.json
 
-aws s3 cp $static_folder/build.json     s3://$RIFF_RAFF_BUILD_BUCKET/dotcom:static/$BUILD_NUMBER/build.json    --region=eu-west-1
-aws s3 cp $static_folder/artifacts.zip  s3://$RIFF_RAFF_ARTIFACT_BUCKET/dotcom:static/$BUILD_NUMBER/artifacts.zip --region=eu-west-1
+aws s3api put-object --acl bucket-owner-full-control --region=eu-west-1 --bucket $RIFF_RAFF_BUILD_BUCKET --key dotcom:static/$BUILD_NUMBER/build.json  --body $static_folder/build.json
+aws s3api put-object --acl bucket-owner-full-control --region=eu-west-1 --bucket $RIFF_RAFF_ARTIFACT_BUCKET --key dotcom:static/$BUILD_NUMBER/artifacts.zip --body $static_folder/artifacts.zip
 
 set +o xtrace
 echo "##teamcity[publishArtifacts '$static_folder/artifacts.zip => static']"


### PR DESCRIPTION
Using static as a project to investigate the riff raff upload on aws teamcity. The riff raff build file cannot be read without the correct acl.
