### PR TITLE
changing canonical url to weburl, not request url

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -117,13 +117,13 @@ class CanonicalLink {
     "page"
   )
 
-  def apply(implicit request: RequestHeader): String = {
+  def apply(implicit request: RequestHeader, webUrl: String): String = {
     val queryString = {
       val q = significantParams.flatMap(key => request.getQueryString(key).map(value => s"$key=${value.urlEncoded}"))
         .sorted.mkString("&")
       if (q.isEmpty) "" else s"?$q"
     }
-    s"${scheme(request)}://${request.host}${request.path}$queryString"
+    s"$webUrl$queryString"
   }
 }
 

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -63,7 +63,7 @@
 }
 
 @if(!item.shouldGoogleIndex) { <meta name="robots" content="noindex"> }
-<link rel="canonical" href="@item.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request))" />
+<link rel="canonical" href="@item.canonicalUrl.map(LinkTo(_)).getOrElse(CanonicalLink(request, item.webUrl))" />
 
 <meta name="apple-mobile-web-app-title" content="Guardian" />
 <meta name="application-name" content="The Guardian" />


### PR DESCRIPTION
So that AMP pages point to the original document, not the amp document.

cc @johnduffell 
