### PR TITLE
Make inlinejs off swtich work

### DIFF
--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -95,7 +95,7 @@ object InlineJs {
     } else {
       val md5 = new String(MessageDigest.getInstance("MD5").digest(codeToCompile.getBytes))
 
-      lazy val compiledCode = if (Switches.InlineJsSwitch.isSwitchedOn) {
+      lazy val compiledCode = if (Switches.MinifyInlineJsSwitch.isSwitchedOn) {
         JsMinifier.unsafeCompileWithStandardOptimisation(codeToCompile)
       } else {
         JsMinifier.unsafeCompileWithWhitespaceOptimisation(codeToCompile)

--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -90,18 +90,18 @@ object InlineJs {
   private val memoizedMap: TrieMap[String, String] = TrieMap()
 
   def apply(codeToCompile: String)(implicit application: Application): Html = {
-    if (Switches.InlineJsSwitch.isSwitchedOn) {
-      if (Play.isDev) {
-        Html(JsMinifier.unsafeCompileWithWhitespaceOptimisation(codeToCompile))
-      } else {
-        val md5 = new String(MessageDigest.getInstance("MD5").digest(codeToCompile.getBytes))
-        lazy val compiledCode: String =
-          JsMinifier.unsafeCompileWithStandardOptimisation(codeToCompile)
-
-        Html(memoizedMap.getOrElseUpdate(md5, compiledCode))
-      }
+    if (Play.isDev) {
+      Html(JsMinifier.unsafeCompileWithWhitespaceOptimisation(codeToCompile))
     } else {
-      Html(codeToCompile)
+      val md5 = new String(MessageDigest.getInstance("MD5").digest(codeToCompile.getBytes))
+
+      lazy val compiledCode = if (Switches.InlineJsSwitch.isSwitchedOn) {
+        JsMinifier.unsafeCompileWithStandardOptimisation(codeToCompile)
+      } else {
+        JsMinifier.unsafeCompileWithWhitespaceOptimisation(codeToCompile)
+      }
+
+      Html(memoizedMap.getOrElseUpdate(md5, compiledCode))
     }
   }
 }

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -105,10 +105,10 @@ object Switches {
   lazy val never = new LocalDate(2100, 1, 1)
 
   // Performance
-  val InlineJsSwitch = Switch(
+  val MinifyInlineJsSwitch = Switch(
     "Performance",
-    "inline-js",
-    "If this switch is on, InlineJs object will use the closure compiler",
+    "minify-inline-js",
+    "If this switch is on, InlineJs objects will be minified by closure compiler",
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false

--- a/common/app/conf/switches.scala
+++ b/common/app/conf/switches.scala
@@ -108,7 +108,7 @@ object Switches {
   val MinifyInlineJsSwitch = Switch(
     "Performance",
     "minify-inline-js",
-    "If this switch is on, InlineJs objects will be minified by closure compiler",
+    "If this switch is on, InlineJs output will be minified by closure compiler",
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false


### PR DESCRIPTION
It will always transpile ES6 to ES3, but only perform white-space minification if the switch is off (or in dev)

cc @janua 
