### PR TITLE
Fix commercial namespace

### DIFF
--- a/commercial/app/views/commercial/support/StaticPages.scala
+++ b/commercial/app/views/commercial/support/StaticPages.scala
@@ -1,6 +1,6 @@
 package views.commercial.support
 
-import common.commercial.StaticPage
+import common.StaticPage
 import model.MetaData
 
 object StaticPages {

--- a/common/app/common/StaticPage.scala
+++ b/common/app/common/StaticPage.scala
@@ -1,6 +1,6 @@
-package common.commercial
+package common
 
-import model.GuardianContentTypes.Interactive
+import model.GuardianContentTypes._
 import model.MetaData
 
 trait StaticPage extends MetaData {

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -1,7 +1,7 @@
 package views.support
 
 import common.Maps.RichMap
-import common.{Edition, InternationalEdition, commercial}
+import common.{StaticPage, Edition, InternationalEdition}
 import conf.Configuration
 import conf.Configuration.environment
 import conf.Switches.IdentitySocialOAuthSwitch
@@ -45,7 +45,7 @@ case class JavaScriptPage(metaData: MetaData)(implicit request: RequestHeader) {
       ("omitMPUs", JsBoolean(metaData.omitMPUsFromContainers(edition))),
       ("shouldHideAdverts", JsBoolean(metaData match {
         case c: Content if c.shouldHideAdverts => true
-        case p: commercial.StaticPage => true
+        case p: StaticPage => true
         case CommercialExpiryPage(_) => true
         case _ => false
       })),


### PR DESCRIPTION
Lots of package clashing with commit 2c0661c.

I have moved `StaticPage` from `common.commercial` to `common`.

There are imports for all templates for `common._` and `views.html._` which meant that the package/namespace `commercial` got imported twice on `admin`. (There is a `commercial` package in `admin`)

@kelvin-chappell @rich-nguyen @NathanielBennett 

``` scala
[error] /home/fcarr/Documents/frontend/admin/app/views/commercial/slotTop.scala.html:15: reference to commercial is ambiguous;
[error] it is imported twice in the same scope by
[error] import common._
[error] and import views.html._
[error]     @commercial.fragments.slot(slotReport)
[error]      ^
[error] /home/fcarr/Documents/frontend/admin/app/views/commercial/slotTopAboveNav.scala.html:15: reference to commercial is ambiguous;
[error] it is imported twice in the same scope by
[error] import common._
[error] and import views.html._
[error]     @commercial.fragments.slot(slotReport)
[error]      ^
[error] /home/fcarr/Documents/frontend/admin/app/views/commercial/slotTopBelowNav.scala.html:13: reference to commercial is ambiguous;
[error] it is imported twice in the same scope by
[error] import common._
[error] and import views.html._
[error]     @commercial.fragments.slot(slotReport)
[error]      ^
[error] three errors found
```
