### PR TITLE
Item prop changes for liveblogs

### DIFF
--- a/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
+++ b/common/app/views/fragments/meta/bylineLiveBlockImage.scala.html
@@ -3,7 +3,7 @@
     @profileTag.contributorImagePath.map{ src =>
         <img class="liveblog-block-byline__img" src="@ImgSrc(src, Item300)" alt="@profileTag.name" />
     }
-    <p class="liveblog-block-byline__name">@profileTag.name</p>
+    <p class="liveblog-block-byline__name" itemprop="author">@profileTag.name</p>
 </div>
 
 

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -202,6 +202,10 @@ case class LiveBlogLinkedData(isLiveBlog: Boolean)(implicit val request: Request
         el.select(".block-time.published-time time").foreach { time =>
           time.attr("itemprop", "datePublished")
         }
+        el.select(".block-title").foreach { title =>
+          title.attr("itemprop", "headline")
+
+        }
         if (noByline) blockElements.addClass("block-elements--no-byline")
         blockElements.foreach { body =>
           body.attr("itemprop", "articleBody")


### PR DESCRIPTION
Adds itemprop="headline" to liveblock title. Adds itemprop="author" to the contributor name in the liveblog block.

A repeat of https://github.com/guardian/frontend/pull/10612 without changing the where itemprop="articleBody" is defined as @gtrufitt made an alternative and better solution in https://github.com/guardian/frontend/pull/10647

cc @johnduffell 
