### PR TITLE
amp ads - better placement

### DIFF
--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -16,28 +16,71 @@ object AmpAdCleaner extends HtmlCleaner {
     element.after("""<div class="amp-ad-container"><amp-ad width=300 height=250 type="doubleclick" json='{"targeting":{"sc":["1"]}}' data-slot="/59666047/theguardian.com/uk"></amp-ad></div>""")
   }
 
+  object AdRepel {
+    def apply(before: Int, after: Int, element: Element): AdRepel = {
+      AdRepel(before, after, element.text().length, element)
+    }
+  }
+  case class AdRepel(before: Int, after: Int, length: Int, element: Element)
+
   def findElementsNeedingAdsAfter(children: List[Element]): List[Element] = {
-    @tailrec
-    def rec(charsUntilAd: Int, adsAfter: List[Element], elements: List[Element]): (Int, List[Element]) = {
-      elements match {
-        case Nil => (charsUntilAd, adsAfter)
-        case element :: rest =>
-          val paraLength = element.text().length
-          if (charsUntilAd - paraLength <= 0 && paraLength > DONT_INTERLEAVE_SMALL_PARA) {
-            val newAdsAfter = element :: adsAfter
-            if (newAdsAfter.length == AD_LIMIT)
-              (-1/*not used*/, newAdsAfter)
-            else
-              rec(CHARS_BETWEEN_ADS, newAdsAfter, rest)
-          } else
-            rec(charsUntilAd - paraLength, adsAfter, rest)
+
+    val ALLOWED = 0
+    val DISALLOWED = 1
+
+    // create the contstraints for each paragraph how far before and after we can have it
+    val constraints = children.map { element =>
+
+      def para = element.tagName() != "p"
+      def short = element.text().length < DONT_INTERLEAVE_SMALL_PARA
+
+      if (para) {
+        // don't put an ad before or too close after an embed
+        AdRepel(300, 200, element)
+      } else if (short) {
+        // don't interleave ads between small paragraphs
+        AdRepel(DISALLOWED, DISALLOWED, element)
+      } else {
+        AdRepel(ALLOWED, ALLOWED, element)
       }
     }
-    val (charsUntilAd, adsAfter) = rec(CHARS_BETWEEN_ADS, Nil, children)
-    if (adsAfter.length < AD_LIMIT && charsUntilAd != CHARS_BETWEEN_ADS)
-      children.last :: adsAfter
-    else
-      adsAfter
+
+    // propagate the constraints across the paragraphs forwards and then backwards
+    val propagatedConstraints = constraints.foldLeft((Nil: List[AdRepel], CHARS_BETWEEN_ADS)){ case ((accu, charsTilAd), currentElement) =>
+
+      val newCharsTilAd = charsTilAd - currentElement.length
+      def carryForwardRepel = currentElement.after < newCharsTilAd
+
+      if (carryForwardRepel) {
+        (currentElement.copy(after = newCharsTilAd) :: accu, newCharsTilAd)
+      } else {
+        (currentElement :: accu, currentElement.after)
+      }
+
+    }._1.foldLeft((Nil: List[AdRepel], 0)){ case ((accu, charsTilAd), currentElement) =>
+
+      val newCharsTilAd = charsTilAd - currentElement.length
+      def carryBackwardRepel = currentElement.before < newCharsTilAd
+
+      if (carryBackwardRepel) {
+        (currentElement.copy(before = newCharsTilAd) :: accu, newCharsTilAd)
+      } else {
+        (currentElement :: accu, currentElement.before)
+      }
+
+    }._1
+
+    // now if the repel forward and backward is zero (or less) then we can put in an ad
+    propagatedConstraints.sliding(2).foldLeft((Nil: List[Element], 0)){ case ((accu, charsTilAd), List(firstElement, secondElement)) =>
+
+      if (accu.length < AD_LIMIT && charsTilAd <= 0 && firstElement.after <= 0 && secondElement.before <= 0) {
+        (firstElement.element :: accu, CHARS_BETWEEN_ADS)
+      } else {
+        (accu, charsTilAd - firstElement.length)
+      }
+
+    }._1
+
   }
 
   override def clean(document: Document): Document = {

--- a/common/test/views/support/cleaner/AmpAdCleanerTest.scala
+++ b/common/test/views/support/cleaner/AmpAdCleanerTest.scala
@@ -8,12 +8,12 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
 
   val tenChars = "qwertyasdf"
 
-   "AmpAdCleaner" should "add an advert after 700 chars as well as the end one" in {
+   "AmpAdCleaner" should "add an advert after 700 chars" in {
      val doc = s"""<html><body><p>${tenChars * 70}</p><p>${tenChars * 70}</p></body></html>"""
      val document: Document = Jsoup.parse(doc)
      val result: Document = AmpAdCleaner.clean(document)
 
-     result.getElementsByTag("amp-ad").size should be(2)
+     result.getElementsByTag("amp-ad").size should be(1)
 
    }
 
@@ -22,12 +22,12 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
     val document: Document = Jsoup.parse(doc)
     val result: Document = AmpAdCleaner.clean(document)
 
-    result.getElementsByTag("amp-ad").size.should(be(1))
+    result.getElementsByTag("amp-ad").size.should(be(0))
 
   }
 
   "AmpAdCleaner" should "only add 2 ads in total" in {
-    val doc = s"""<html><body>${s"<p>${tenChars * 70}</p>" * 3}</body></html>"""
+    val doc = s"""<html><body>${s"<p>${tenChars * 70}</p>" * 4}</body></html>"""
     val document: Document = Jsoup.parse(doc)
     val result: Document = AmpAdCleaner.clean(document)
 
@@ -40,8 +40,35 @@ class AmpAdCleanerTest extends FlatSpec with Matchers {
     val document: Document = Jsoup.parse(doc)
     val result: Document = AmpAdCleaner.clean(document)
 
+    result.getElementsByTag("amp-ad").size should be(0)
+
+  }
+
+  "AmpAdCleaner" should "not put an ad directly before something that isn't a p e.g. an image" in {
+    val doc = s"""<html><body><p>${tenChars * 70}</p><p>${tenChars * 29}asdfqwert</p><aside></aside></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = AmpAdCleaner.clean(document)
+
+    result.getElementsByTag("amp-ad").size should be(0)
+
+  }
+
+  "AmpAdCleaner" should "not put an ad directly after something that isn't a p e.g. an image" in {
+    val doc = s"""<html><body><p>${tenChars * 70}</p><aside></aside><p>${tenChars * 19}asdfqwert</p></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = AmpAdCleaner.clean(document)
+
+    result.getElementsByTag("amp-ad").size should be(0)
+
+  }
+
+  "AmpAdCleaner" should "put an ad far enough after something that isn't a p e.g. an image" in {
+    val doc = s"""<html><body><p>${tenChars * 70}</p><aside></aside><p>${tenChars * 20}</p><p>${tenChars * 20}</p></body></html>"""
+    val document: Document = Jsoup.parse(doc)
+    val result: Document = AmpAdCleaner.clean(document)
+
     result.getElementsByTag("amp-ad").size should be(1)
 
   }
 
- }
+}


### PR DESCRIPTION
I have rewritten the amp ad insertion code to find spaces better.  Here are some useful test articles.
- [broken](http://www.theguardian.com/us-news/2015/sep/26/obama-africa-hiv-aids-treatment-women/amp)
- [article](http://www.theguardian.com/commentisfree/2015/aug/08/eliminate-hiv-by-2030-regular-testing/amp)
- [long](http://www.theguardian.com/cities/2015/jun/25/london-developers-viability-planning-affordable-social-housing-regeneration-oliver-wainwright/amp)
- [article](http://www.theguardian.com/commentisfree/2015/sep/28/hipsters-property-developers-gentrification-cereal-killer-cafe/amp)
- [article](http://www.theguardian.com/uk-news/2015/sep/28/cereal-killer-cafe-protestors-plan-target-jack-the-ripper-museum/amp)

I won't explain the changes here because it needs to be clear what the code now does from the test and the code, however if that's not the case, let me know so I'll update it.

@NataliaLKB take a look
@adamnfish I'm sure I said I'd tag you when I shipped the code I'm just deleting, but I didn't, so here it is
