### PR TITLE
Amp footer illusion

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/ads.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/ads.scala.html
@@ -2,15 +2,18 @@
     background: #f6f6f6;
     border-top: 0.0625rem solid #dfdfdf;
     float: left;
-    height: 275px;
+    height: 272px;
     width: 300px;
-    margin-right: 0.75rem;
+    margin: 0.25rem 1.25rem 0.75rem 0;
 }
 
-@@media (max-width: 500px) {
+@@media (max-width: 550px) {
     .amp-ad-container {
-        float: none;
-        margin: 0 auto;
+    clear: both;
+    float: none;
+    width: auto;
+    text-align: center;
+    margin-right: 0;
     }
 }
 

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -12,7 +12,14 @@
     .main-body {
         background: #fff;
         max-width: 600px;
-        margin: 0 auto;
+        margin: 0 auto 1.5em auto;
+        padding-bottom: 1.5rem;
+    }
+
+    @@media (max-width: 600px) {
+    .main-body {
+        margin-bottom: 0;
+        }
     }
 
     a {

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -121,8 +121,10 @@
         font-style: italic;
     }
 
-    .u-cf:after {
+    .u-cf:after, .main-body:after {
         clear: both;
+        content: "";
+        display: block;
     }
 
     .u-cf:after, .u-cf:before {

--- a/common/app/views/fragments/amp/stylesheets/richLinks.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/richLinks.scala.html
@@ -1,41 +1,33 @@
 .element-rich-link--not-upgraded {
     float: left;
-    margin: 0.25rem 0.625rem 0.375rem 0;
+    width: 292px;
+    margin: 0.25rem 0.625rem 0.75rem 0;
     padding: 4px;
     background-color: #f6f6f6;
     border-top: 1px solid #bdbdbd;
+    margin-right: 1.25rem;
+    font-size: 1.25rem;
 }
 
-@@media (max-width: 29.99rem) {
+.element-rich-link--not-upgraded p {
+    margin: 0;
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+}
+
+@@media (max-width: 550px) {
     .element-rich-link--not-upgraded {
     width: 8.125rem;
     font-size: 0.875rem;
     }
-}
-
-@@media (min-width: 30rem) {
-    .element-rich-link--not-upgraded {
-    width: 13.75rem;
-    margin-right: 1.25rem;
-    font-size: 1.25rem;
+    .element-rich-link--not-upgraded p {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
     }
 }
 
 .element-rich-link--not-upgraded span {
     display: none;
-}
-
-.element-rich-link--not-upgraded p {
-    margin: 0;
-    font-size: 0.875rem;
-    line-height: 1.125rem;
-}
-
-@@media (min-width: 30rem) {
-    .element-rich-link--not-upgraded p {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
-    }
 }
 
 .element-rich-link--not-upgraded a {


### PR DESCRIPTION
Added a bit of breathing space to the base of the page, so users understand the article has finished. 

Before
![screen shot 2015-09-28 at 17 27 34](https://cloud.githubusercontent.com/assets/14570016/10141889/df92e7ca-6606-11e5-9a97-7cb9a73b3882.png)

After
![screen shot 2015-09-28 at 17 27 17](https://cloud.githubusercontent.com/assets/14570016/10141888/df92544a-6606-11e5-8158-9b5b1aba1c11.png)
