### PR TITLE
hide the label for save for later on crossword pages

### DIFF
--- a/static/src/javascripts/projects/common/modules/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/save-for-later.js
@@ -136,7 +136,8 @@ define([
                 icon: bookmarkSvg,
                 isSaved: options.isSaved,
                 position: $saver.attr('data-position'),
-                config: config
+                config: config,
+                showLabel: config.page.contentType !== 'Crossword'
             };
             if (options.url) {
                 $saver.html(template(saveLink,

--- a/static/src/javascripts/projects/common/views/save-for-later/save-link.html
+++ b/static/src/javascripts/projects/common/views/save-for-later/save-link.html
@@ -4,6 +4,8 @@
    href="<%= url %>">
     <%= icon %>
     <!-- Not logged in -->
-    <span class="save-for-later__label save-for-later__label--save">Save for later</span>
-    <span class="save-for-later__label save-for-later__label--saved">Article saved</span>
+    <% if (showLabel) { %>
+        <span class="save-for-later__label save-for-later__label--save">Save for later</span>
+        <span class="save-for-later__label save-for-later__label--saved">Article saved</span>
+    <% } %>
 </a>


### PR DESCRIPTION
Hides the 'Save for Later' label on crossword pages and just shows the bookmark icon 

Before: 
![cw-sfl-before](https://cloud.githubusercontent.com/assets/986155/10161048/3adcc730-6699-11e5-8c67-17836e0cdd36.png)

After: 
![cw-sfl-after](https://cloud.githubusercontent.com/assets/986155/10161053/4c17f4ca-6699-11e5-993f-0d7c368374f6.png)
