### PR TITLE
Upgrade the riff raff plugin to fix upload order

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,4 +17,4 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.9")
 
 addSbtPlugin("org.jetbrains.teamcity.plugins" % "sbt-teamcity-logger" % "0.3.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.0")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.1")


### PR DESCRIPTION
I reckon this will help our issues with continuous deployment. My guess is if we upload the artifact first, then the build.json, riff raff will be happy.
