### PR TITLE
Autoplay on video was failing

### DIFF
--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -122,7 +122,9 @@ define([
         player.one('adsready', events.ready);
 
         //If no preroll avaliable or preroll fails, cancel ad framework and init content tracking
+        /* jscs:disable disallowDanglingUnderscores */
         player.ima.onAdsLoaderError_ = events.adsFailed();
+        /* jscs:enable disallowDanglingUnderscores */
         player.one('adtimeout', events.adsFailed);
     }
 

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -113,15 +113,17 @@ define([
                 if (shouldAutoPlay(player)) {
                     player.play();
                 }
+            },
+            adsFailed: function () {
+                player.trigger('adscanceled');
+                bindContentEvents(player);
             }
         };
         player.one('adsready', events.ready);
 
         //If no preroll avaliable or preroll fails, cancel ad framework and init content tracking
-        player.one('adtimeout', function () {
-            player.trigger('adscanceled');
-            bindContentEvents(player);
-        });
+        player.ima.onAdsLoaderError_ = events.adsFailed();
+        player.one('adtimeout', events.adsFailed);
     }
 
     function kruxTracking(player, event) {


### PR DESCRIPTION
See #10672 

Some videos were not autoplaying as the ads playlist was empty, this PR updates the JS to listen to the event and continue with the normal video autoplay. 

cc/ @Calanthe 
