### PR TITLE
extend quiz switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -283,7 +283,7 @@ trait FeatureSwitches {
     "quiz-scores-service",
     "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 10, 1),
+    sellByDate = new LocalDate(2015, 12, 1),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
The quizzes are still in use, because despite tools having made a new quiz editor, we haven't done the frontend work to make it useful.  As a result they're still using the beta tool to make quizzes so the quiz scores service is still providing value.
