### PR TITLE
Updated AMP bullet styles

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -93,7 +93,7 @@
         font-size: 1rem;
         line-height: 1.25rem;
         margin-top: 0;
-        margin-bottom: 0.375rem;
+        margin-bottom: 1.5rem;
     }
 
     .contact {
@@ -181,7 +181,7 @@
         color: transparent;
     }
 
-    .bullet:before {
+    .bullet:before, .tonal__standfirst ul>li:before {
         display: inline-block;
         content: '';
         -webkit-border-radius: 0.375rem;
@@ -190,6 +190,12 @@
         width: 0.75rem;
         margin-right: 0.125rem;
         background-color: #bdbdbd;
+    }
+
+    .content__standfirst>ul, .content__standfirst>ol {
+        margin: 0;
+        padding: 0;
+        list-style: none;
     }
 
     @fragments.amp.stylesheets.tones()

--- a/common/app/views/fragments/amp/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/tones.scala.html
@@ -46,7 +46,15 @@
 }
 
 .tonal--tone-analysis .tonal__standfirst {
-    background-color: #4bc6df;
+    background-color: #f6f6f6;
+}
+
+.tonal--tone-analysis .tonal__header {
+    background-color: #f1f1f1;
+}
+
+.tonal--tone-analysis .content__standfirst {
+    color: #767676;
 }
 
 .tonal--tone-live .tonal__standfirst,
@@ -62,7 +70,7 @@
     background-color: #63717a;
 }
 
-.tonal--tone-news .tone-colour {
+.tonal--tone-news .tone-colour, .tonal--tone-analysis .tonal__header .content__headline {
     color: #005689;
 }
 
@@ -75,7 +83,8 @@
     background-color: #efefec;
 }
 
-.tonal--tone-comment .tonal__header .content__labels {
+.tonal--tone-comment .tonal__header .content__labels,
+.tonal--tone-analysis .tonal__header .content__labels {
     border-bottom-color: rgba(118,118,118,0.3);
 }
 
@@ -103,8 +112,9 @@
     color: #fdadba;
 }
 
-.tonal--tone-feature .tonal__standfirst .bullet:before, 
-.tonal--tone-feature .tonal__standfirst ul>li:before {
+.tonal--tone-feature .tonal__standfirst ul>li:before,
+.tonal--tone-comment .tonal__standfirst ul>li:before,
+.tonal--tone-review .tonal__standfirst ul>li:before {
     background-color: rgba(255,255,255,0.4);
 }
 
@@ -153,7 +163,6 @@
     color: #005689;
 }
 
-.tonal--tone-analysis .tonal__header .content__section-label__link,
 .tonal--tone-analysis .tone-colour {
     color: #4bc6df;
 }


### PR DESCRIPTION
Few tweaks and updates for standfirst bullet styles in AMP. 

Before
![screen shot 2015-09-29 at 11 21 51](https://cloud.githubusercontent.com/assets/14570016/10162259/027167e4-66a2-11e5-96d3-e117dd9c5f72.png)

After
![screen shot 2015-09-29 at 11 22 08](https://cloud.githubusercontent.com/assets/14570016/10162258/02705b88-66a2-11e5-9c30-85a47f2e8299.png)
