### PR TITLE
Reversing DFP template removal

### DIFF
--- a/static/src/javascripts/bootstraps/creatives.js
+++ b/static/src/javascripts/bootstraps/creatives.js
@@ -2,13 +2,17 @@ define([
     'common/modules/commercial/creatives/branded-component',
     'common/modules/commercial/creatives/commercial-component',
     'common/modules/commercial/creatives/gu-style-comcontent',
+    'common/modules/commercial/creatives/expandable',
+    'common/modules/commercial/creatives/expandable-v2',
     'common/modules/commercial/creatives/expandable-v3',
     'common/modules/commercial/creatives/expandable-video',
     'common/modules/commercial/creatives/expandable-video-v2',
+    'common/modules/commercial/creatives/fluid250',
     'common/modules/commercial/creatives/fluid250-v3',
     'common/modules/commercial/creatives/fluid250-v4',
     'common/modules/commercial/creatives/fluid250GoogleAndroid',
     'common/modules/commercial/creatives/foundation-funded-logo',
+    'common/modules/commercial/creatives/scrollable-mpu',
     'common/modules/commercial/creatives/scrollable-mpu-v2',
     'common/modules/commercial/creatives/template'
 ], function () {});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable-v2.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable-v2.js
@@ -1,0 +1,184 @@
+define([
+    'bean',
+    'bonzo',
+    'fastdom',
+    'common/utils/_',
+    'common/utils/$',
+    'common/utils/detect',
+    'common/utils/mediator',
+    'common/utils/storage',
+    'common/utils/template',
+    'common/views/svgs',
+    'text!common/views/commercial/creatives/expandable-v2.html'
+], function (
+    bean,
+    bonzo,
+    fastdom,
+    _,
+    $,
+	detect,
+    mediator,
+    storage,
+    template,
+    svgs,
+    expandableV2Tpl
+) {
+
+    /**
+     * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10028247
+     */
+    var ExpandableV2 = function ($adSlot, params) {
+        this.$adSlot      = $adSlot;
+        this.params       = params;
+        this.isClosed     = true;
+
+        if (detect.isBreakpoint({min: 'tablet'})) {
+            this.closedHeight = 250;
+            this.openedHeight = 500;
+        } else {
+            this.closedHeight = 150;
+            this.openedHeight = 300;
+        }
+
+        _.bindAll(this, 'updateBgPosition', 'listener');
+    };
+
+    /**
+     * TODO: rather blunt instrument this, due to the fact *most* mobile devices don't have a fixed
+     * background-attachment - need to make this more granular
+     */
+    ExpandableV2.hasScrollEnabled = !detect.isIOS() && !detect.isAndroid();
+
+    ExpandableV2.prototype.updateBgPosition = function () {
+        var scrollY = window.pageYOffset,
+            viewportHeight = bonzo.viewport().height,
+            adSlotTop = this.$adSlot.offset().top,
+            that = this;
+
+        var adHeight = (this.isClosed) ? this.closedHeight : this.openedHeight;
+        var inViewB = ((scrollY + viewportHeight) > adSlotTop);
+        var inViewT = ((scrollY - (adHeight * 2)) < adSlotTop + 20);
+        var topCusp = (inViewT &&
+            ((scrollY + (viewportHeight * 0.4) - adHeight) > adSlotTop)) ?
+            'true' : 'false';
+        var bottomCusp = (inViewB &&
+            (scrollY + (viewportHeight * 0.5)) < adSlotTop) ?
+            'true' : 'false';
+        var bottomScroll = (bottomCusp === 'true') ?
+            50 - ((scrollY + (viewportHeight * 0.5) - adSlotTop) * -0.2) : 50;
+        var topScroll = (topCusp === 'true') ?
+            ((scrollY + (viewportHeight * 0.4) - adSlotTop - adHeight) * 0.2) : 0;
+
+        switch (this.params.backgroundImagePType) {
+            case 'split':
+                this.scrollAmount = bottomScroll + topScroll + '%';
+                fastdom.write(function () {
+                    $('.ad-exp--expand-scrolling-bg').css('background-repeat', 'no-repeat');
+                });
+                break;
+            case 'fixed':
+                this.scrollAmount = (scrollY - adSlotTop) + 'px';
+                break;
+            case 'parallax':
+                this.scrollAmount = ((scrollY - adSlotTop) * 0.15) + '%';
+                break;
+        }
+
+        fastdom.write(function () {
+            $('.ad-exp--expand-scrolling-bg').css('background-position', '50%' + that.scrollAmount);
+        });
+    };
+
+    ExpandableV2.prototype.listener = function () {
+        var that = this;
+        if ((window.pageYOffset + bonzo.viewport().height) > (this.$adSlot.offset().top + this.openedHeight)) {
+            // expires in 1 week
+            var week = 1000 * 60 * 60 * 24 * 7;
+
+            storage.local.set('gu.commercial.expandable.' + this.params.ecid, true, { expires: Date.now() + week });
+            fastdom.write(function () {
+                that.$button.toggleClass('button-spin');
+                $('.ad-exp__open-chevron').toggleClass('chevron-down');
+                that.$ad.css('height', that.openedHeight);
+                that.isClosed = false;
+            });
+            return true;
+        }
+    };
+
+    ExpandableV2.prototype.create = function () {
+        var videoHeight = this.closedHeight - 24,
+            videoWidth = (videoHeight * 16) / 9,
+            leftMargin = (this.params.videoPositionH === 'center' ?
+                'margin-left: ' + videoWidth / -2 + 'px; ' : ''
+            ),
+            leftPosition = (this.params.videoPositionH === 'left' ?
+                'left: ' + this.params.videoHorizSpace + 'px; ' : ''
+            ),
+            rightPosition = (this.params.videoPositionH === 'right' ?
+                'right: ' + this.params.videoHorizSpace + 'px; ' : ''
+            ),
+            videoDesktop = {
+                video: (this.params.videoURL !== '') ?
+                    '<iframe id="myYTPlayer" width="' + videoWidth + '" height="' + videoHeight + '" src="' + this.params.videoURL + '?rel=0&amp;controls=0&amp;showinfo=0&amp;title=0&amp;byline=0&amp;portrait=0" frameborder="0" class="expandable_video expandable_video--horiz-pos-' + this.params.videoPositionH + '" style="' + leftMargin + leftPosition + rightPosition + '"></iframe>' : ''
+            },
+            showmoreArrow = {
+                showArrow: (this.params.showMoreType === 'arrow-only' || this.params.showMoreType === 'plus-and-arrow') ?
+                    '<button class="ad-exp__open-chevron ad-exp__open">' + svgs('arrowdownicon') + '</button>' : ''
+            },
+            showmorePlus = {
+                showPlus: (this.params.showMoreType === 'plus-only' || this.params.showMoreType === 'plus-and-arrow') ?
+                    '<button class="ad-exp__close-button ad-exp__open">' + svgs('closeCentralIcon') + '</button>' : ''
+            },
+            scrollingbg = {
+                scrollbg: (this.params.backgroundImagePType !== '' || this.params.backgroundImagePType !== 'none') ?
+                    '<div class="ad-exp--expand-scrolling-bg" style="background-image: url(' + this.params.backgroundImageP + '); background-position: ' + this.params.backgroundImagePPosition + ' 50%;"></div>' : ''
+            },
+            $expandablev2 = $.create(template(expandableV2Tpl, { data: _.merge(this.params, showmoreArrow, showmorePlus, videoDesktop, scrollingbg) }));
+
+        var domPromise = new Promise(function (resolve) {
+            fastdom.write(function () {
+
+                this.$ad     = $('.ad-exp--expand', $expandablev2).css('height', this.closedHeight);
+                this.$button = $('.ad-exp__open', $expandablev2);
+
+                $('.ad-exp-collapse__slide', $expandablev2).css('height', this.closedHeight);
+
+                if (this.params.trackingPixel) {
+                    this.$adSlot.before('<img src="' + this.params.trackingPixel + this.params.cacheBuster + '" class="creative__tracking-pixel" height="1px" width="1px"/>');
+                }
+
+                $expandablev2.appendTo(this.$adSlot);
+
+                resolve();
+            }.bind(this));
+        }.bind(this));
+
+        if (!storage.local.get('gu.commercial.expandable.' + this.params.ecid)) {
+            mediator.on('window:throttledScroll', this.listener);
+        }
+
+        bean.on(this.$adSlot[0], 'click', '.ad-exp__open', function () {
+            fastdom.write(function () {
+                $('.ad-exp__close-button').toggleClass('button-spin');
+                $('.ad-exp__open-chevron').toggleClass('chevron-down');
+                this.$ad.css('height', this.isClosed ? this.openedHeight : this.closedHeight);
+                this.isClosed = !this.isClosed;
+            }.bind(this));
+        }.bind(this));
+
+        if (ExpandableV2.hasScrollEnabled) {
+            // update bg position
+            this.updateBgPosition();
+
+            mediator.on('window:throttledScroll', this.updateBgPosition);
+            // to be safe, also update on window resize
+            mediator.on('window:resize', this.updateBgPosition);
+        }
+
+        return domPromise;
+    };
+
+    return ExpandableV2;
+
+});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/expandable.js
@@ -1,0 +1,84 @@
+define([
+    'bean',
+    'bonzo',
+    'fastdom',
+    'common/utils/_',
+    'common/utils/$',
+    'common/utils/mediator',
+    'common/utils/storage',
+    'common/utils/template',
+    'text!common/views/commercial/creatives/expandable.html'
+], function (
+    bean,
+    bonzo,
+    fastdom,
+    _,
+    $,
+    mediator,
+    storage,
+    template,
+    expandableTpl
+) {
+
+    /**
+     * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10028247
+     */
+    var Expandable = function ($adSlot, params) {
+        this.$adSlot      = $adSlot;
+        this.params       = params;
+        this.isClosed     = true;
+        this.closedHeight = Math.min(bonzo.viewport().height / 3, 300);
+        this.openedHeight = Math.min(bonzo.viewport().height * 2 / 3, 600);
+
+        _.bindAll(this, 'listener');
+    };
+
+    Expandable.prototype.listener = function () {
+        var that = this;
+        if ((window.pageYOffset + bonzo.viewport().height) > (this.$ad.offset().top + this.openedHeight)) {
+            // expires in 1 week
+            var week = 1000 * 60 * 60 * 24 * 7;
+
+            // TODO - needs to have a creative-specific id
+            storage.local.set('gu.commercial.expandable.an-expandable', true, { expires: Date.now() + week });
+
+            fastdom.write(function () {
+                that.$button.toggleClass('button-spin');
+                that.$ad.css('height', that.openedHeight);
+                that.isClosed = false;
+            });
+
+            return true;
+        }
+    };
+
+    Expandable.prototype.create = function () {
+        var $expandable = $.create(template(expandableTpl, { data: this.params }));
+
+        this.$ad     = $('.ad-exp--expand', $expandable);
+        this.$button = $('.ad-exp__close-button', $expandable);
+
+        fastdom.write(function () {
+            this.$ad.css('height', this.closedHeight);
+            $('.ad-exp-collapse__slide', $expandable).css('height', this.closedHeight);
+            if (this.params.trackingPixel) {
+                this.$adSlot.before('<img src="' + this.params.trackingPixel + this.params.cacheBuster + '" class="creative__tracking-pixel" height="1px" width="1px"/>');
+            }
+            $expandable.appendTo(this.$adSlot);
+        }.bind(this));
+
+        if (!storage.local.get('gu.commercial.expandable.an-expandable')) {
+            mediator.on('window:throttledScroll', this.listener);
+        }
+
+        bean.on(this.$button[0], 'click', function () {
+            this.$button.toggleClass('button-spin');
+            this.$ad.css('height', this.isClosed ? this.openedHeight : this.closedHeight);
+            this.isClosed = !this.isClosed;
+        }.bind(this));
+
+    };
+
+    return Expandable;
+
+});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fluid250.js
@@ -1,0 +1,51 @@
+define([
+    'bean',
+    'bonzo',
+    'common/utils/_',
+    'common/utils/$',
+    'common/utils/mediator',
+    'common/utils/storage',
+    'common/utils/template',
+    'text!common/views/commercial/creatives/fluid250.html'
+], function (
+    bean,
+    bonzo,
+    _,
+    $,
+    mediator,
+    storage,
+    template,
+    fluid250Tpl
+) {
+    var Fluid250 = function ($adSlot, params) {
+        this.$adSlot = $adSlot;
+        this.params = params;
+    };
+
+    Fluid250.prototype.create = function () {
+
+        var templateOptions = {
+                showLabel: (this.params.showAdLabel === 'hide') ?
+                'creative__label--hidden' : ''
+            },
+            leftPosition = (this.params.videoPositionH === 'left' ?
+                ' left: ' + this.params.videoHorizSpace + 'px;' : ''
+            ),
+            rightPosition = (this.params.videoPositionH === 'right' ?
+                ' right: ' + this.params.videoHorizSpace + 'px;' : ''
+            ),
+            videoDesktop = {
+                video: (this.params.videoURL !== '') ?
+                    '<iframe width="409px" height="230px" src="' + this.params.videoURL + '?rel=0&amp;controls=0&amp;showinfo=0&amp;title=0&amp;byline=0&amp;portrait=0" frameborder="0" class="fluid250_video fluid250_video--desktop fluid250_video--vert-pos-' + this.params.videoPositionV + ' fluid250_video--horiz-pos-' + this.params.videoPositionH + '" style="' + leftPosition + rightPosition + '"></iframe>' : ''
+            };
+
+        $.create(template(fluid250Tpl, { data: _.merge(this.params, templateOptions, videoDesktop) })).appendTo(this.$adSlot);
+
+        if (this.params.trackingPixel) {
+            this.$adSlot.before('<img src="' + this.params.trackingPixel + this.params.cacheBuster + '" class="creative__tracking-pixel" height="1px" width="1px"/>');
+        }
+    };
+
+    return Fluid250;
+
+});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/scrollable-mpu.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/scrollable-mpu.js
@@ -1,0 +1,66 @@
+define([
+    'fastdom',
+    'common/utils/$',
+    'common/utils/_',
+    'common/utils/detect',
+    'common/utils/mediator',
+    'common/utils/template',
+    'text!common/views/commercial/creatives/scrollable-mpu.html'
+], function (
+    fastdom,
+    $,
+    _,
+    detect,
+    mediator,
+    template,
+    scrollableMpuTpl
+) {
+
+    /**
+     * https://www.google.com/dfp/59666047#delivery/CreateCreativeTemplate/creativeTemplateId=10026567
+     */
+    var ScrollableMpu = function ($adSlot, params) {
+        this.$adSlot = $adSlot;
+        this.params  = params;
+
+        _.bindAll(this, 'updateBgPosition');
+    };
+
+    /**
+     * TODO: rather blunt instrument this, due to the fact *most* mobile devices don't have a fixed
+     * background-attachment - need to make this more granular
+     */
+    ScrollableMpu.hasScrollEnabled = !detect.isIOS() && !detect.isAndroid();
+
+    ScrollableMpu.prototype.updateBgPosition = function () {
+        var position = window.pageYOffset - this.$scrollableMpu.offset().top;
+        fastdom.write(function () {
+            $('.creative--scrollable-mpu-image').css('background-position', '100% ' + position + 'px');
+        });
+    };
+
+    ScrollableMpu.prototype.create = function () {
+        var templateOptions = {
+            clickMacro:       this.params.clickMacro,
+            destination:      this.params.destination,
+            image:            ScrollableMpu.hasScrollEnabled ? this.params.image : this.params.staticImage,
+            stillImage:       ScrollableMpu.hasScrollEnabled && this.params.stillImage ?
+                '<div class="creative--scrollable-mpu-static-image" style="background-image: url(' + this.params.stillImage + ');"></div>' : '',
+            trackingPixelImg: this.params.trackingPixel ?
+                '<img src="' + this.params.trackingPixel + '" width="1" height="1" />' : ''
+        };
+        this.$scrollableMpu = $.create(template(scrollableMpuTpl, templateOptions)).appendTo(this.$adSlot);
+
+        if (ScrollableMpu.hasScrollEnabled) {
+            // update bg position
+            fastdom.read(this.updateBgPosition);
+
+            mediator.on('window:throttledScroll', this.updateBgPosition);
+            // to be safe, also update on window resize
+            mediator.on('window:resize', this.updateBgPosition);
+        }
+    };
+
+    return ScrollableMpu;
+
+});

--- a/static/src/javascripts/projects/common/views/commercial/creatives/expandable-v2.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/expandable-v2.html
@@ -1,0 +1,48 @@
+<div class="creative--expandable">
+    <div class="ad-slot__label adFullWidth__label facia-container--layout-front" data-test-id="ad-slot-label">
+        <div class="facia-container__inner">Advertisement</div>
+    </div>
+    <div class="ad-exp--expand l-side-margins mobile-only" style="background-color: <%=data.backgroundColor%>">
+        <div class="facia-container__inner facia-container__inner--full-span" style="background: url('<%=data.backgroundImageM%>') <%=data.backgroundRepeatM%> <%=data.backgroundPositionM%>;">
+            <%=data.showPlus%>
+            <%=data.showArrow%>
+            <div class="ad-exp-collapse__slide slide-1" style="background: <%=data.slide1BGColor%> url('<%=data.slide1BGImageM%>') <%=data.slide1BGImageRepeatM%> <%=data.slide1BGImagePositionM%>;">
+                <a href="<%=data.clickMacro%><%=data.link%>" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('<%=data.slide1Layer1BGImageM%>') <%=data.slide1Layer1BGImageRepeatM%> <%=data.slide1Layer1BGImagePositionM%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('<%=data.slide1Layer2BGImageM%>') <%=data.slide1Layer2BGImageRepeatM%> <%=data.slide1Layer2BGImagePositionM%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('<%=data.slide1Layer3BGImageM%>') <%=data.slide1Layer3BGImageRepeatM%> <%=data.slide1Layer3BGImagePositionM%>;"></div>
+                </a>
+            </div>
+            <div class="ad-exp-collapse__slide slide-2" style="background: <%=data.slide2BGColor%> url('<%=data.slide2BGImageM%>') <%=data.slide2BGImagePositionM%> <%=data.slide2BGImageRepeatM%>;">
+                <%=data.video%>
+                <a href="<%=data.clickMacro%><%=data.link%>" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('<%=data.slide2Layer1BGImageM%>') <%=data.slide2Layer1BGImageRepeatM%> <%=data.slide2Layer1BGImagePositionM%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('<%=data.slide2Layer2BGImageM%>') <%=data.slide2Layer2BGImageRepeatM%> <%=data.slide2Layer2BGImagePositionM%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('<%=data.slide2Layer3BGImageM%>') <%=data.slide2Layer3BGImageRepeatM%> <%=data.slide2Layer3BGImagePositionM%>;"></div>
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="ad-exp--expand l-side-margins hide-until-tablet" style="background-color: <%=data.backgroundColor%>">
+        <div class="facia-container__inner facia-container__inner--full-span" style="background: url('<%=data.backgroundImage%>') <%=data.backgroundRepeat%> <%=data.backgroundPosition%>;">
+            <%=data.showPlus%>
+            <%=data.showArrow%>
+            <%=data.scrollbg%>
+            <div class="ad-exp-collapse__slide slide-1" style="background: <%=data.slide1BGColor%> url('<%=data.slide1BGImage%>') <%=data.slide1BGImageRepeat%> <%=data.slide1BGImagePosition%>;">
+                <a href="<%=data.clickMacro%><%=data.link%>" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('<%=data.slide1Layer1BGImage%>') <%=data.slide1Layer1BGImageRepeat%> <%=data.slide1Layer1BGImagePosition%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('<%=data.slide1Layer2BGImage%>') <%=data.slide1Layer2BGImageRepeat%> <%=data.slide1Layer2BGImagePosition%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background : url('<%=data.slide1Layer3BGImage%>') <%=data.slide1Layer3BGImageRepeat%> <%=data.slide1Layer3BGImagePosition%>;"></div>
+                </a>
+            </div>
+            <div class="ad-exp-collapse__slide slide-2" style="background: <%=data.slide2BGColor%> url('<%=data.slide2BGImage%>') <%=data.slide2BGImagePosition%> <%=data.slide2BGImageRepeat%>;">
+                <%=data.video%>
+                <a href="<%=data.clickMacro%><%=data.link%>" target="_new">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('<%=data.slide2Layer1BGImage%>') <%=data.slide2Layer1BGImageRepeat%> <%=data.slide2Layer1BGImagePosition%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('<%=data.slide2Layer2BGImage%>') <%=data.slide2Layer2BGImageRepeat%> <%=data.slide2Layer2BGImagePosition%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('<%=data.slide2Layer3BGImage%>') <%=data.slide2Layer3BGImageRepeat%> <%=data.slide2Layer3BGImagePosition%>;"></div>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/expandable.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/expandable.html
@@ -1,0 +1,25 @@
+<div class="creative--expandable creative--expandable-ga">
+    <div class="ad-slot__label adFullWidth__label facia-container--layout-front" data-test-id="ad-slot-label">
+        <div class="facia-container__inner">Advertisement</div>
+    </div>
+    <div class="ad-exp--expand l-side-margins">
+        <div class="facia-container__inner facia-container__inner--full-span">
+            <button class="ad-exp__close-button">
+                <i class="i i-close-icon-white-small"></i>
+            </button>
+            <a href="<%=data.clickMacro%><%=data.link%>" target="_new">
+                <div class="ad-exp-collapse__slide slide-1" style="background-image: url('<%=data.slide1%>');">
+                    <div class="ad-exp__cta" style="background-image: url('<%=data.cta%>');"></div>
+                    <div class="ad-exp__logo" style="background-image: url('<%=data.logo%>');"></div>
+                </div>
+                <div class="ad-exp-collapse__slide slide-2" style="background-image: url('<%=data.slide2%>');">
+                    <div class="ad-exp__text-1 mobile-only" style="background-image: url('<%=data.textMobile%>');"></div>
+                    <div class="ad-exp__text-1 hide-until-tablet" style="background-image: url('<%=data.text%>');"></div>
+                </div>
+            </a>
+        </div>
+    </div>
+    <div class="ad-slot__label--wrapper facia-container__inner facia-container__inner--full-span">
+        <div class="ad-slot__label"></div>
+    </div>
+</div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/fluid250.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/fluid250.html
@@ -1,0 +1,50 @@
+<div class="ad-slot__label creative--fluid250__label fc-container--layout-front <%=data.showLabel%>" data-test-id="ad-slot-label">
+    <div class="fc-container__inner">Advertisement</div>
+</div>
+<div class="creative--fluid250 l-side-margins hide-until-tablet creative--fluid250__height--<%=data.creativeHeight%>" style="
+        background-color: <%=data.backgroundColor%>;
+        background-image: url(<%=data.backgroundImage%>);
+        background-position: <%=data.backgroundPosition%>;
+        background-repeat: <%=data.backgroundRepeat%>;
+    ">
+    <a href="<%=data.clickMacro%><%=data.link%>" target="_blank">
+        <div class="gs-container">
+            <%=data.video%>
+            <div class="fluid250_layer fluid250_layer1" style="
+                background-image: url(<%=data.layerOneBGImage%>);
+                background-position: <%=data.layerOneBGPosition%>;
+            "></div>
+            <div class="fluid250_layer fluid250_layer2" style="
+                background-image: url(<%=data.layerTwoBGImage%>);
+                background-position: <%=data.layerTwoBGPosition%>;
+            "></div>
+            <div class="fluid250_layer fluid250_layer3" style="
+                background-image: url(<%=data.layerThreeBGImage%>);
+                background-position: <%=data.layerThreeBGPosition%>;
+            "></div>
+        </div>
+    </a>
+</div>
+<div class="creative--fluid250 l-side-margins mobile-only" style="
+        background-color: <%=data.backgroundColor%>;
+        background-image: url(<%=data.backgroundImageM%>);
+        background-position: <%=data.backgroundPositionM%>;
+        background-repeat: <%=data.backgroundRepeatM%>;
+    ">
+    <a href="<%=data.link%>" target="_blank">
+        <div class="gs-container">
+            <div class="fluid250_layer fluid250_layer1" style="
+                background-image: url(<%=data.layerOneBGImageM%>);
+                background-position: <%=data.layerOneBGPositionM%>;
+            "></div>
+            <div class="fluid250_layer fluid250_layer2" style="
+                background-image: url(<%=data.layerTwoBGImageM%>);
+                background-position: <%=data.layerTwoBGPositionM%>;
+            "></div>
+            <div class="fluid250_layer fluid250_layer3" style="
+                background-image: url(<%=data.layerThreeBGImageM%>);
+                background-position: <%=data.layerThreeBGPositionM%>;
+            "></div>
+        </div>
+    </a>
+</div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/scrollable-mpu.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/scrollable-mpu.html
@@ -1,0 +1,9 @@
+<a class="creative--scrollable-mpu"
+    href="<%=clickMacro%><%=destination%>"
+    target="_new">
+    <div class="creative--scrollable-mpu-inner">
+        <%=stillImage%>
+        <div class="creative--scrollable-mpu-image" style="background-image: url('<%=image%>');"></div>
+    </div>
+</a>
+<%=trackingPixelImg%>

--- a/static/src/javascripts/test/spec/common/commercial/creatives/expandable.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/creatives/expandable.spec.js
@@ -1,0 +1,38 @@
+import Expandable from 'common/modules/commercial/creatives/expandable';
+import qwery from 'qwery';
+import fixtures from 'helpers/fixtures';
+import fastdom from 'fastdom';
+
+var fixturesConfig = {
+    id: 'expandable-ad-slot',
+    fixtures: [
+        '<div class="expandable-ad-slot"></div>'
+    ]
+};
+
+describe('Expandable', function () {
+
+    var expandable,
+        $fixturesContainer;
+
+    it('should exist', function () {
+        expect(Expandable).toBeDefined();
+    });
+
+    it('should be always defined', function () {
+        $fixturesContainer = fixtures.render(fixturesConfig);
+        expandable = new Expandable(qwery('.expandable-ad-slot', $fixturesContainer), {});
+        expect(expandable).toBeDefined();
+    });
+
+    it('should always have expand and close buttons', function (done) {
+        $fixturesContainer = fixtures.render(fixturesConfig);
+        new Expandable(qwery('.expandable-ad-slot', $fixturesContainer), {}).create();
+        fastdom.defer(function () {
+            expect(qwery('.ad-exp--expand').length).toBe(1);
+            expect(qwery('.ad-exp__close-button').length).toBe(1);
+            done();
+        });
+    });
+
+});

--- a/static/src/javascripts/test/spec/common/commercial/creatives/expandablev2.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/creatives/expandablev2.spec.js
@@ -1,0 +1,47 @@
+import ExpandableV2 from 'common/modules/commercial/creatives/expandable-v2';
+import fixtures from 'helpers/fixtures';
+import $ from 'common/utils/$';
+
+var fixturesConfig = {
+    id: 'expandablev2-ad-slot',
+    fixtures: [
+        '<div class="expandablev2-ad-slot"></div>'
+    ]
+};
+
+describe('Expandable v2', function () {
+
+    var expandablev2,
+        $fixturesContainer;
+
+    it('should exist', function () {
+        expect(ExpandableV2).toBeDefined();
+    });
+
+    it('should be always defined', function () {
+        $fixturesContainer = fixtures.render(fixturesConfig);
+        expandablev2 = new ExpandableV2($('.expandablev2-ad-slot'), {});
+        expect(expandablev2).toBeDefined();
+    });
+
+    it('should always have expand, open and collapse buttons', function (done) {
+        $fixturesContainer = fixtures.render(fixturesConfig);
+        new ExpandableV2($('.expandablev2-ad-slot', $fixturesContainer), {})
+        .create().then(function () {
+            expect($('.ad-exp--expand').length).toBeGreaterThan(0);
+            expect($('.ad-exp-collapse__slide').length).toBeGreaterThan(0);
+            done();
+        });
+    });
+
+    it('should have show more button', function (done) {
+        $fixturesContainer = fixtures.render(fixturesConfig);
+        new ExpandableV2($('.expandablev2-ad-slot', $fixturesContainer), {
+            showMoreType: 'plus-only'
+        }).create().then(function () {
+            expect($('.ad-exp__close-button').length).toBeGreaterThan(0);
+            done();
+        });
+    });
+
+});

--- a/static/src/javascripts/test/spec/common/commercial/creatives/fluid250.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/creatives/fluid250.spec.js
@@ -1,0 +1,42 @@
+import qwery from 'qwery';
+import $ from 'common/utils/$';
+import fixtures from 'helpers/fixtures';
+import Fluid250 from 'common/modules/commercial/creatives/fluid250';
+
+var fixturesConfig = {
+    id: 'ad-slot',
+    fixtures: [
+        '<div class="ad-slot"></div>'
+    ]
+};
+
+describe('Fluid 250', function () {
+
+    var fluid250,
+        $fixturesContainer;
+
+    it('should exist', function () {
+        expect(Fluid250).toBeDefined();
+    });
+
+    it('should be defined', function () {
+        $fixturesContainer = fixtures.render(fixturesConfig);
+
+        fluid250 = new Fluid250($('.ad-slot', $fixturesContainer), {});
+        expect(fluid250).toBeDefined();
+    });
+
+    it('ad slot should have a video iframe with proper styles', function () {
+        $fixturesContainer = fixtures.render(fixturesConfig);
+
+        new Fluid250($('.ad-slot', $fixturesContainer), {
+            videoPositionH: 'left',
+            videoHorizSpace: 10,
+            videoPositionV: 'top',
+            videoURL: 'exampleVideoUrl'
+        }).create();
+        expect(qwery('.fluid250_video--vert-pos-top', '.ad-slot').length).toBe(1);
+        expect(qwery('.fluid250_video--horiz-pos-left', '.ad-slot').length).toBe(1);
+    });
+
+});

--- a/static/src/javascripts/test/spec/common/commercial/creatives/scrollable-mpu.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/creatives/scrollable-mpu.spec.js
@@ -1,0 +1,9 @@
+import ScrollableMpu from 'common/modules/commercial/creatives/scrollable-mpu';
+
+describe('Scrollable MPU', function () {
+
+    it('should exist', function () {
+        expect(ScrollableMpu).toBeDefined();
+    });
+
+});


### PR DESCRIPTION
Reversing https://github.com/guardian/frontend/pull/10642 manually as Adops have found out that these old templates are still in use.
