### PR TITLE
Fix clue URL bug

### DIFF
--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -651,15 +651,15 @@ export default function () {
                 const idMatch = hashEvent.newURL.match(/#.*/);
                 const newEntryId = idMatch && idMatch[0].replace('#', '');
 
-                const entry = _.find(crosswordComponent.props.data.entries, { id: newEntryId });
+                const newEntry = _.find(crosswordComponent.props.data.entries, { id: newEntryId });
                 const focussedEntry = crosswordComponent.clueInFocus();
-                const isNewEntry = focussedEntry.id !== entry.id;
+                const isNewEntry = focussedEntry.id !== newEntry.id;
                 // Only focus the first cell in the new clue if it's not already
                 // focussed. When focussing a cell in a new clue, we update the
                 // hash fragment afterwards, in which case we do not want to
                 // reset focus to the first cell.
-                if (entry && focussedEntry && isNewEntry) {
-                    crosswordComponent.focusFirstCellInClue(entry);
+                if (newEntry && focussedEntry && isNewEntry) {
+                    crosswordComponent.focusFirstCellInClue(newEntry);
                 }
             });
         } else {

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -658,7 +658,7 @@ export default function () {
                 // focussed. When focussing a cell in a new clue, we update the
                 // hash fragment afterwards, in which case we do not want to
                 // reset focus to the first cell.
-                if (newEntry && focussedEntry && isNewEntry) {
+                if (newEntry && (focussedEntry ? isNewEntry : true)) {
                     crosswordComponent.focusFirstCellInClue(newEntry);
                 }
             });

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -345,6 +345,7 @@ class Crossword extends React.Component {
         }
     }
 
+    // Focus corresponding clue for a given cell
     focusClue (x, y, direction) {
         const clues = helpers.cluesFor(this.clueMap, x, y);
         const clue = clues[direction];
@@ -362,11 +363,9 @@ class Crossword extends React.Component {
         }
     }
 
-    focusClueById (entryId) {
-        const entry = _.find(this.props.data.entries, { id: entryId });
-        if (entry) {
-            this.focusClue(entry.position.x, entry.position.y, entry.direction);
-        }
+    // Focus first cell in given clue
+    focusFirstCellInClue(entry) {
+        this.focusClue(entry.position.x, entry.position.y, entry.direction);
     }
 
     focusCurrentCell () {
@@ -643,12 +642,25 @@ export default function () {
             const crosswordComponent = React.render(<Crossword data={crosswordData} />, element);
 
             const entryId = window.location.hash.replace('#', '');
-            crosswordComponent.focusClueById(entryId);
+            const entry = _.find(crosswordComponent.props.data.entries, { id: entryId });
+            if (entry) {
+                crosswordComponent.focusFirstCellInClue(entry);
+            }
 
             window.addEventListener('hashchange', hashEvent => {
                 const idMatch = hashEvent.newURL.match(/#.*/);
                 const newEntryId = idMatch && idMatch[0].replace('#', '');
-                crosswordComponent.focusClueById(newEntryId);
+
+                const entry = _.find(crosswordComponent.props.data.entries, { id: newEntryId });
+                const focussedEntry = crosswordComponent.clueInFocus();
+                const isNewEntry = focussedEntry.id !== entry.id;
+                // Only focus the first cell in the new clue if it's not already
+                // focussed. When focussing a cell in a new clue, we update the
+                // hash fragment afterwards, in which case we do not want to
+                // reset focus to the first cell.
+                if (entry && focussedEntry && isNewEntry) {
+                    crosswordComponent.focusFirstCellInClue(entry);
+                }
             });
         } else {
             throw 'JavaScript crossword without associated data in data-crossword-data';


### PR DESCRIPTION
When selecting a cell within a new clue (a clue that is not currently foccussed), the clue URL code was causing the selection to be reset to the first cell within that clue.

We update the URL when you focus a new clue, but in the event listener for `hashchange`, we only want to update the focus if the clue has not already been foccussed (i.e. by selection). An example of when we do want to update the focus is when you navigate using the browser history.
