### PR TITLE
Update share to encodeURIComponent

### DIFF
--- a/applications/test/ShareLinksTest.scala
+++ b/applications/test/ShareLinksTest.scala
@@ -22,7 +22,7 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
         pageShares.map(_.text) should be (List("Facebook", "Twitter", "Email", "Pinterest", "Google plus", "WhatsApp"))
         pageShares.map(_.href) should be (List(
           "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fsfb&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F42jcb",
-          "https://twitter.com/intent/tweet?text=2014+Wildlife+photographer+of+the+Year&url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fstw",
+          "https://twitter.com/intent/tweet?text=2014%20Wildlife%20photographer%20of%20the%20Year&url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fstw",
           "mailto:?subject=2014%20Wildlife%20photographer%20of%20the%20Year&body=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fsbl",
           "http://www.pinterest.com/pin/find/?url=http%3A%2F%2Fwww.theguardian.com%2Fenvironment%2Fgallery%2F2014%2Foct%2F22%2F2014-wildlife-photographer-of-the-year",
           "https://plus.google.com/share?url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fsgp&amp;hl=en-GB&amp;wwc=1",
@@ -45,7 +45,7 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
         elementShares.map(_.text) should be (List("Facebook", "Twitter", "Pinterest"))
         elementShares.map(_.href) should be (List(
           "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fsfb%232&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F42jcb",
-          "https://twitter.com/intent/tweet?text=2014+Wildlife+photographer+of+the+Year&url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fstw%232",
+          "https://twitter.com/intent/tweet?text=2014%20Wildlife%20photographer%20of%20the%20Year&url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fstw%232",
           "http://www.pinterest.com/pin/create/button/?description=2014+Wildlife+photographer+of+the+Year&url=http%3A%2F%2Fwww.theguardian.com%2Fenvironment%2Fgallery%2F2014%2Foct%2F22%2F2014-wildlife-photographer-of-the-year&media="))
       }
     }

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -439,7 +439,7 @@ import collection.JavaConversions._
 
         val mailShareUrl = "mailto:?subject=Mark%20Kermode's%20DVD%20round-up&body=http%3A%2F%2Fgu.com%2Fp%2F3bk2f%2Fsbl"
         val fbShareUrl = "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fgu.com%2Fp%2F3bk2f%2Fsfb&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F3bk2f"
-        val twitterShareUrl = "https://twitter.com/intent/tweet?text=Mark+Kermode%27s+DVD+round-up&url=http%3A%2F%2Fgu.com%2Fp%2F3bk2f%2Fstw"
+        val twitterShareUrl = "https://twitter.com/intent/tweet?text=Mark%20Kermode's%20DVD%20round-up&url=http%3A%2F%2Fgu.com%2Fp%2F3bk2f%2Fstw"
         val gplusShareUrl = "https://plus.google.com/share?url=http%3A%2F%2Fgu.com%2Fp%2F3bk2f%2Fsgp&amp;hl=en-GB&amp;wwc=1"
 
         Then("I should see buttons for my favourite social network")

--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -42,9 +42,9 @@ trait ShareLinks { self: Content =>
 
       case "twitter"  =>
         val text = if (this.isClimateChangeSeries) {
-          s"${title.urlEncoded} ${URLEncoder.encode("#keepitintheground", "utf-8")}"
+          s"${title.encodeURIComponent} ${URLEncoder.encode("#keepitintheground", "utf-8")}"
         } else {
-          title.urlEncoded
+          title.encodeURIComponent
         }
         Some(ShareLink("Twitter", "twitter", "Share on Twitter", s"https://twitter.com/intent/tweet?text=$text&url=$twitter"))
 


### PR DESCRIPTION
Issue #10668 - urlEncoded converts spaces to +, encodeURIComponent also converts + to %20 which works correctly in intents.

Fixes: 

![image](https://cloud.githubusercontent.com/assets/638051/10191118/3edf159c-6769-11e5-8354-be9808c0828c.png)
## Before

![image](https://cloud.githubusercontent.com/assets/638051/10191123/4ae26d80-6769-11e5-9a41-9b528a6327e6.png)
## After

![image](https://cloud.githubusercontent.com/assets/638051/10191077/01b3d658-6769-11e5-94ee-058fcb515ac6.png)

This class: 

```
implicit class string2encodings(s: String) {
    lazy val urlEncoded = URLEncoder.encode(s, "utf-8")
    lazy val javascriptEscaped = StringEscapeUtils.escapeJavaScript(s)
    lazy val encodeURIComponent = {
      URLEncoder.encode(s, "UTF-8")
        .replaceAll("\\+", "%20")
        .replaceAll("\\%21", "!")
        .replaceAll("\\%27", "'")
        .replaceAll("\\%28", "(")
        .replaceAll("\\%29", ")")
        .replaceAll("\\%7E", "~")
    }
  }
```
