### PR TITLE
Only create the match url with the team names if both are football tags. 

### DIFF
--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -140,8 +140,9 @@ object TeamName {
 object MatchUrl {
   def apply(theMatch: FootballMatch): String = {
     (for {
-      homeTeam <- TeamMap(theMatch.homeTeam).tag.flatMap(_.url)
-      awayTeam <- TeamMap(theMatch.awayTeam).tag.flatMap(_.url)
+      homeTeam: String <- TeamMap(theMatch.homeTeam).tag.flatMap(_.url)
+      awayTeam: String <- TeamMap(theMatch.awayTeam).tag.flatMap(_.url)
+      if(homeTeam.startsWith("/football/") && awayTeam.startsWith("/football/"))
     } yield {
       s"/football/match/${theMatch.date.toString("yyyy/MMM/dd").toLowerCase}/${homeTeam.replace("/football/", "")}-v-${awayTeam.replace("/football/", "")}"
     }).getOrElse(s"/football/match/${theMatch.id}")


### PR DESCRIPTION
Fixes https://github.com/guardian/frontend/issues/10538

The tags of each football team are used to create a match url. However the code assumes all football teams are in tags starting with `/football/`. A couple examples show that some teams have been tagged starting with `/sport/`. I'm going to email central prod with the two examples from #10538 and see if we can get them changed. However to stop the pages 404-ing in the future I've added a check on the structure of the tag so that we fallback to `/football/match/${theMatch.id}` if the tags are incorrect.
