### PR TITLE
update crossword beta link

### DIFF
--- a/common/app/views/fragments/crosswordsOptOutBanner.scala.html
+++ b/common/app/views/fragments/crosswordsOptOutBanner.scala.html
@@ -6,7 +6,7 @@
     <div class="site-message--crosswords" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message">
         <div class="gs-container">
             <div class="u-cf">
-                You're viewing a new version of the Guardian's crosswords.<a href="@LinkTo("/crosswords/crossword-blog/2015/sep/11/beta-testing-new-guardian-crossword-site")">Read more here..</a>
+                You're viewing a new version of the Guardian's crosswords. <a href="@LinkTo("/crosswords/crossword-blog/2015/sep/11/beta-testing-new-guardian-crossword-site")">Read more here. </a>
             </div>
         </div>
     </div>

--- a/common/app/views/fragments/crosswordsOptOutBanner.scala.html
+++ b/common/app/views/fragments/crosswordsOptOutBanner.scala.html
@@ -6,7 +6,7 @@
     <div class="site-message--crosswords" data-link-name="release message" role="dialog" aria-label="welcome" aria-describedby="site-message__message">
         <div class="gs-container">
             <div class="u-cf">
-                You're viewing a new beta version of the Guardian's crosswords. To return to the current version, <a href="@LinkTo("/crosswords/optout")">click here.</a>
+                You're viewing a new version of the Guardian's crosswords.<a href="@LinkTo("/crosswords/crossword-blog/2015/sep/11/beta-testing-new-guardian-crossword-site")">Read more here..</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Updates the text and target of the crosswords optout link - so it's no longer an optout link and points to the latest crossword blog ..
