### PR TITLE
More minor updates to inline styles

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -32,13 +32,14 @@
         font-size: 1rem;
         line-height: 1.35rem;
         font-weight: 300;
-        margin: 12px 0px;
+        margin: 0px 0px 12px;
     }
 
     .from-content-api h2, .from-content-api .block-elements h2 {
         font-size: 1.125rem;
-        line-height: 1.5rem;
+        line-height: 1.4rem;
         font-weight: 900;
+        margin: 12px 0px 0px
     }
 
     .meta__contact-header {
@@ -141,7 +142,7 @@
     }
 
     .caption {
-        padding: 0.5rem 0 1.5rem 0;
+        padding-top: 0.5rem;
     }
 
     .content__dateline {
@@ -155,8 +156,10 @@
         font-family: "Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
     }
 
-    .caption, .content__meta-container {
+    .content__meta-container {
+        border-top: 0.0625rem dotted #dfdfdf;
         border-bottom: 0.0625rem dotted #dfdfdf;
+        margin-top: 16px;
     }
 
     .u-underline {


### PR DESCRIPTION
More updates to the Amp styles to fix spacing around paragraphs, H2's and image captions.

Before
![screen shot 2015-09-30 at 12 53 55](https://cloud.githubusercontent.com/assets/3416696/10192200/9adac702-6772-11e5-95d0-b6dc202bcef7.png)

After
![screen shot 2015-09-30 at 12 54 39](https://cloud.githubusercontent.com/assets/3416696/10192204/9fba4fb8-6772-11e5-94a9-1ad8612d886c.png)

Before
![screen shot 2015-09-30 at 12 55 28](https://cloud.githubusercontent.com/assets/3416696/10192208/a92b54e8-6772-11e5-90ff-4e90a9a43bff.png)

After
