### PR TITLE
Selection sharing: smart quotes

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -35,10 +35,10 @@ define([
         $twitterAction,
         $emailAction,
         twitterShortUrl = config.page.shortUrl + '/stw',
-        twitterHrefTemplate = 'https://twitter.com/intent/tweet?text="<%=text%>"&url=<%=url%>',
+        twitterHrefTemplate = 'https://twitter.com/intent/tweet?text=“<%=text%>”&url=<%=url%>',
         twitterMessageLimit = 115, // 140 - t.co length - 3 chars for quotes and url spacing
         emailShortUrl = config.page.shortUrl + '/sbl',
-        emailHrefTemplate = 'mailto:?subject=<%=subject%>&body="<%=selection%>" <%=url%>',
+        emailHrefTemplate = 'mailto:?subject=<%=subject%>&body=“<%=selection%>” <%=url%>',
         validAncestors = ['js-article__body', 'content__standfirst', 'block', 'caption--main', 'content__headline'],
 
     updateSelection = function () {

--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -35,10 +35,10 @@ define([
         $twitterAction,
         $emailAction,
         twitterShortUrl = config.page.shortUrl + '/stw',
-        twitterHrefTemplate = 'https://twitter.com/intent/tweet?text=\u201c<%=text%>\u201D&url=<%=url%>',
+        twitterHrefTemplate = 'https://twitter.com/intent/tweet?text=%E2%80%9C<%=text%>%E2%80%9D&url=<%=url%>',
         twitterMessageLimit = 115, // 140 - t.co length - 3 chars for quotes and url spacing
         emailShortUrl = config.page.shortUrl + '/sbl',
-        emailHrefTemplate = 'mailto:?subject=<%=subject%>&body=\u201c<%=selection%>\u201D <%=url%>',
+        emailHrefTemplate = 'mailto:?subject=<%=subject%>&body=%E2%80%9C<%=selection%>%E2%80%9D <%=url%>',
         validAncestors = ['js-article__body', 'content__standfirst', 'block', 'caption--main', 'content__headline'],
 
     updateSelection = function () {

--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -35,10 +35,10 @@ define([
         $twitterAction,
         $emailAction,
         twitterShortUrl = config.page.shortUrl + '/stw',
-        twitterHrefTemplate = 'https://twitter.com/intent/tweet?text=“<%=text%>”&url=<%=url%>',
+        twitterHrefTemplate = 'https://twitter.com/intent/tweet?text=\u201c<%=text%>\u201D&url=<%=url%>',
         twitterMessageLimit = 115, // 140 - t.co length - 3 chars for quotes and url spacing
         emailShortUrl = config.page.shortUrl + '/sbl',
-        emailHrefTemplate = 'mailto:?subject=<%=subject%>&body=“<%=selection%>” <%=url%>',
+        emailHrefTemplate = 'mailto:?subject=<%=subject%>&body=\u201c<%=selection%>\u201D <%=url%>',
         validAncestors = ['js-article__body', 'content__standfirst', 'block', 'caption--main', 'content__headline'],
 
     updateSelection = function () {


### PR DESCRIPTION
This replaces the incorrect ‘straight quotes’ with typographically correct ‘smart quotes’ within text selection sharing. Affects twitter and mailto links.

![gu-social-smartquotes](https://cloud.githubusercontent.com/assets/1971632/10193724/6cb0d20a-67b7-11e5-8d34-4c8ce9816dc7.png)
