### PR TITLE
Update README to clearly state visa restriction on hiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 We're hiring!
 --------
-Ever thought about joining us?<br/>
+Ever thought about joining us and have the right to work in the UK?<br/>
 http://developers.theguardian.com/join-the-team.html
 
 Frontend


### PR DESCRIPTION
When applying for positions, the application page after login, states: "To apply for this vacancy you must already have the right to work in the UK."
If this statement is true for developer positions too, it might be a good idea to make this clear in this page readme page too.
