### PR TITLE
Fix for signed in user nav on mobile on core 

### DIFF
--- a/common/app/views/fragments/footerJavaScript.scala.html
+++ b/common/app/views/fragments/footerJavaScript.scala.html
@@ -67,7 +67,10 @@
                     if ($signInLinkElem) {
                         var userId = getUserIdFromCookie();
                         if(userId) {
-                            $signInLinkElem.removeAttribute('href');
+                            $signInLinkElem.setAttribute('href', $signInLinkElem.getAttribute('href').replace('signin', 'user/id/' + userId));
+                            $signInLinkElem.addEventListener("click", function(e) {
+                                e.preventDefault();
+                            });
                         } else {
                             $signInLinkElem.setAttribute('href', $signInLinkElem.getAttribute('href').replace('signin', 'public/edit/'));
                         }

--- a/common/app/views/fragments/footerJavaScript.scala.html
+++ b/common/app/views/fragments/footerJavaScript.scala.html
@@ -67,7 +67,6 @@
                     if ($signInLinkElem) {
                         var userId = getUserIdFromCookie();
                         if(userId) {
-                            $signInLinkElem.setAttribute('href', $signInLinkElem.getAttribute('href').replace('signin', 'user/id/' + userId));
                             $signInLinkElem.addEventListener("click", function(e) {
                                 e.preventDefault();
                             });

--- a/common/app/views/fragments/footerJavaScript.scala.html
+++ b/common/app/views/fragments/footerJavaScript.scala.html
@@ -67,7 +67,7 @@
                     if ($signInLinkElem) {
                         var userId = getUserIdFromCookie();
                         if(userId) {
-                            $signInLinkElem.setAttribute('href', $signInLinkElem.getAttribute('href').replace('signin', 'user/id/' + userId));
+                            $signInLinkElem.removeAttribute('href');
                         } else {
                             $signInLinkElem.setAttribute('href', $signInLinkElem.getAttribute('href').replace('signin', 'public/edit/'));
                         }

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -99,7 +99,7 @@
             <a class="brand-bar__item--action" data-link-name="au : topNav : masterclasses"
                 href="http://www.theguardian.com/guardian-masterclasses/guardian-masterclasses-australia">masterclasses</a>
         </div>
-        <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--more modern-visible">
+        <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--more">
             <a class="brand-bar__item--action popup__toggle"
                data-toggle="top-bar__popup--more" data-link-name="topNav : more"
                aria-haspopup="true" aria-controls="guardian-services-top-menu">


### PR DESCRIPTION
Currently have a problem where you click the hover menu to open it, but the element you click is a link so you go to your profile page.

This brings it back in line with non-core user experience.

Fix for:
![prpfiledropdown](https://cloud.githubusercontent.com/assets/2236852/10220612/be7e44bc-6840-11e5-9f22-57d448695df2.gif)

cc @sndrs this works in my testing. Safe to do?
