### PR TITLE
For Amp pages removes the submeta (share buttons) 

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -137,7 +137,7 @@
     }
 
     @* temporarily hiding these for demo *@
-    .inline-expand-image, .meta__extras, .submeta, .content__dateline-lm , .block-share, .witness-cta-wrapper {
+    .inline-expand-image, .meta__extras, .content__dateline-lm , .block-share, .witness-cta-wrapper {
         display: none;
     }
 

--- a/common/app/views/fragments/submeta.scala.html
+++ b/common/app/views/fragments/submeta.scala.html
@@ -1,6 +1,7 @@
 @(content: model.Content)(implicit request: RequestHeader)
 @import views.support.ContentLayout.ContentLayout
 @import conf.switches.Switches.SaveForLaterSwitch
+@import common.RichRequestHeader
 
 @toneLink = {
     @if(content.isArticle && !content.isLiveBlog) {
@@ -11,17 +12,18 @@
     }
 }
 
-<div class="submeta">
-    @if(content.keywords.filterNot(_.isSectionTag).nonEmpty) {
-        <hr/>
-        <div data-link-name="keywords" data-component="keywords">
-            @toneLink
-            <h2 class="submeta__head">Topics</h2>
-            @fragments.keywordList(content.keywords, tone = content.tagTone)
-        </div>
-    }
-    @if(content.showBottomSocialButtons) {
-        <hr/>
+@if(!request.isAmp) {
+    <div class="submeta">
+        @if(content.keywords.filterNot(_.isSectionTag).nonEmpty) {
+            <hr/>
+            <div data-link-name="keywords" data-component="keywords">
+                @toneLink
+                <h2 class="submeta__head">Topics</h2>
+                @fragments.keywordList(content.keywords, tone = content.tagTone)
+            </div>
+        }
+        @if(content.showBottomSocialButtons) {
+            <hr/>
             <div class="u-cf">
                 <div data-component="share" class="submeta__share">
                     @fragments.social(content)
@@ -31,7 +33,8 @@
                 }
                 @fragments.syndication(content)
             </div>
-    } else {
-        @fragments.syndication(content)
-    }
-</div>
+        } else {
+            @fragments.syndication(content)
+        }
+    </div>
+}


### PR DESCRIPTION
This is in order to pass the Amp validator. Previously were hiding the submeta with css but this change removes it.

Best to view this with [w=1](https://github.com/guardian/frontend/pull/10737/files?w=1)
cc @johnduffell 
