### PR TITLE
AMP changes for contributor images. Yes we have to specify width & height :(

### DIFF
--- a/article/app/views/articleAMP.scala.html
+++ b/article/app/views/articleAMP.scala.html
@@ -2,5 +2,5 @@
 @import conf.switches.Switches._
 
 @mainAMP(model.article){
-    @fragments.articleBody(model, true)
+    @fragments.articleBody(model, amp = true)
 }

--- a/common/app/views/fragments/meta/bylineImage.scala.html
+++ b/common/app/views/fragments/meta/bylineImage.scala.html
@@ -1,11 +1,20 @@
 @(tags: model.Tags)(implicit request: RequestHeader)
 
 @import views.support.{ImgSrc, Item300}
+@import common.RichRequestHeader
 
 @tags.contributors.headOption.map { profile =>
     @profile.contributorLargeImagePath.map{ src =>
         <div class="byline-img">
+        @if(request.isAmp) {
+            @if(tags.tones.exists(_.isComment)) {
+                <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="180" height="150" />
+            } else {
+                <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="79" height="66" />
+            }
+        } else {
             <img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" />
+        }
         </div>
     }
 }


### PR DESCRIPTION
The `layout = "responsive"` attribute just doesn't seem to work, and we have to specify the dimensions of the image element up-front, so we have a slightly hacktastic way to do it. If you know a better way that can be specified in html with these constraints, I'd be happy to hear it.

@johnduffell @jennysivapalan @stephanfowler - whaddya think?  
