### PR TITLE
add support for amp-youtube

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -5,7 +5,7 @@ import layout.ContentWidths.MainMedia
 import model.Article
 import play.api.mvc.RequestHeader
 import views.support._
-import views.support.cleaner.{VideoEmbedCleaner, CmpParamCleaner, AmpAdCleaner}
+import views.support.cleaner.{AmpVideoEmbedCleaner, VideoEmbedCleaner, CmpParamCleaner, AmpAdCleaner}
 
 object MainMediaWidths {
 
@@ -23,7 +23,7 @@ object MainCleaner {
  def apply(article: Article, html: String, amp: Boolean)(implicit request: RequestHeader) = {
       implicit val edition = Edition(request)
       withJsoup(BulletCleaner(html))(
-        VideoEmbedCleaner(article, amp),
+        if (amp) AmpVideoEmbedCleaner(article) else VideoEmbedCleaner(article),
         PictureCleaner(article, amp),
         MainFigCaptionCleaner
       )
@@ -42,7 +42,6 @@ object BodyCleaner {
       TagLinker(article),
       TableEmbedComplimentaryToP,
       R2VideoCleaner(article),
-      VideoEmbedCleaner(article, amp),
       PictureCleaner(article, amp),
       LiveBlogDateFormatter(article.isLiveBlog),
       LiveBlogLinkedData(article.isLiveBlog),
@@ -57,6 +56,13 @@ object BodyCleaner {
       PullquoteCleaner,
       CmpParamCleaner
     )
-    withJsoup(BulletCleaner(html))((if (amp) AmpAdCleaner :: cleaners else cleaners) :_*)
+    val nonAmpCleaners = List(
+      VideoEmbedCleaner(article)
+    )
+    val ampOnlyCleaners = List(
+      AmpAdCleaner,
+      AmpVideoEmbedCleaner(article)
+    )
+    withJsoup(BulletCleaner(html))((if (amp) ampOnlyCleaners else nonAmpCleaners) ++ cleaners :_*)
   }
 }

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -13,6 +13,7 @@
         @fragments.amp.stylesheets.main()
         <script src="https://cdn.ampproject.org/v0.js" @if(Play.isDev) { development } async></script>
         <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
+        <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
     </head>
     <body>
         <div class="main-body">

--- a/common/app/views/support/cleaner/AmpVideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpVideoEmbedCleaner.scala
@@ -1,0 +1,67 @@
+package views.support.cleaner
+
+import java.net.URL
+
+import model.{Article, VideoAsset, VideoElement}
+import org.jsoup.nodes.{Document, Element}
+import views.support.{HtmlCleaner, Item640}
+
+import scala.collection.JavaConversions._
+
+case class AmpVideoEmbedCleaner(article: Article) extends HtmlCleaner {
+
+  def cleanAmpVideos(document: Document): Unit = {
+    document.getElementsByTag("video").foreach(video => {
+      video.tagName("amp-video")
+      video.removeAttr("data-media-id")
+      video.removeAttr("poster")
+
+      // Need to hard code aspect ratio 5:3 for Amp pages.
+      video.attr("width", "5")
+      video.attr("height", "3")
+      // Layout responsive keeps the aspect ratio, but ignores the height and width attributes above
+      video.attr("layout", "responsive")
+      video.attr("controls", "")
+
+      video.getElementsByTag("source").foreach(source => {
+        val videoSrc = source.attr("src")
+        // All videos need to start with https for AMP.
+        // Temperary code until all videos returned from CAPI are https
+        if (!videoSrc.startsWith("https")) {
+          val (first, last) = videoSrc.splitAt(4);
+          val newSrc = first + "s" + last
+          source.attr("src", newSrc)
+        }
+      })
+    })
+  }
+
+  def cleanAmpYouTube(document: Document) = {
+
+    document.getElementsByClass("element-video").filter { element: Element =>
+      element.getElementsByTag("iframe").length != 0
+    }.foreach { element: Element =>
+      element.getElementsByTag("iframe").map { element: Element =>
+        element.remove()
+      }
+      val youtubeUrl = element.attr("data-canonical-url")
+      val youtubeId = youtubeUrl.split("v=").last
+      val youtube = document.createElement("amp-youtube")
+      youtube.attr("video-id", youtubeId)
+      youtube.attr("width", "5")
+      youtube.attr("height", "3")
+      youtube.attr("layout", "responsive")
+      element.appendChild(youtube)
+    }
+
+  }
+
+  override def clean(document: Document): Document = {
+
+    cleanAmpVideos(document)
+    cleanAmpYouTube(document)
+
+    document
+  }
+
+}

--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -7,33 +7,7 @@ import org.jsoup.nodes.{Document, Element}
 import views.support.{HtmlCleaner, Item640}
 import scala.collection.JavaConversions._
 
-case class VideoEmbedCleaner(article: Article, amp: Boolean) extends HtmlCleaner {
-
-  def cleaningAmpVideos(document: Document): Unit = {
-    document.getElementsByTag("video").foreach(video => {
-      video.tagName("amp-video")
-      video.removeAttr("data-media-id")
-      video.removeAttr("poster")
-
-      // Need to hard code aspect ratio 5:3 for Amp pages.
-      video.attr("width", "5")
-      video.attr("height", "3")
-      // Layout responsive keeps the aspect ratio, but ignores the height and width attributes above
-      video.attr("layout", "responsive")
-      video.attr("controls", "")
-
-      video.getElementsByTag("source").foreach(source => {
-        val videoSrc = source.attr("src")
-        // All videos need to start with https for AMP.
-        // Temperary code until all videos returned from CAPI are https
-        if (!videoSrc.startsWith("https")) {
-          val (first, last) = videoSrc.splitAt(4);
-          val newSrc = first + "s" + last
-          source.attr("src", newSrc)
-        }
-      })
-    })
-  }
+case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
   def addShareButtons(document: Document): Unit = {
     document.getElementsByClass("element-video").foreach(element => {
@@ -57,7 +31,7 @@ case class VideoEmbedCleaner(article: Article, amp: Boolean) extends HtmlCleaner
     })
   }
 
-  def cleaningVideo(document: Document): Unit = {
+  def cleanVideo(document: Document): Unit = {
     if (!article.isLiveBlog) {
       addShareButtons(document)
     }
@@ -122,14 +96,10 @@ case class VideoEmbedCleaner(article: Article, amp: Boolean) extends HtmlCleaner
       element.child(0).wrap("<div class=\"embed-video-wrapper u-responsive-ratio u-responsive-ratio--hd\"></div>")
     }
 
-    if (amp) {
-      cleaningAmpVideos(document)
-    } else {
-      cleaningVideo(document)
+    cleanVideo(document)
 
-      document.getElementsByClass("element-witness--main").foreach { element: Element =>
-        element.select("iframe").wrap("<div class=\"u-responsive-ratio u-responsive-ratio--hd\"></div>")
-      }
+    document.getElementsByClass("element-witness--main").foreach { element: Element =>
+      element.select("iframe").wrap("<div class=\"u-responsive-ratio u-responsive-ratio--hd\"></div>")
     }
 
     document


### PR DESCRIPTION
validation fix - add support for amp-youtube instead of using iframes illegally
[example article](http://www.thegulocal.com/artanddesign/architecture-design-blog/2014/jul/18/balls-vagina-both-airbnb-logo-internet-parodies/amp)
@JustinPinner @stephanfowler 
