### PR TITLE
Add copy warning

### DIFF
--- a/applications/app/views/offlinePage.scala.html
+++ b/applications/app/views/offlinePage.scala.html
@@ -24,6 +24,8 @@
     @fragments.stylesheetLinksEnable()
 
     <script>
+        @* DO NOT COPY. We do not want to couple other things to the jspm test.
+        Crossword related things is the only exception. Please use curl instead. *@
         @Html(Static.systemJs.setupFragment)
 
         @* Service worker only caches the bundles, so the offline page can only ask for those.


### PR DESCRIPTION
Adding this because I noticed people were copying it, and thus coupling more things to the JspmTest.
