### PR TITLE
Extend chapter-headings switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -29,7 +29,7 @@ trait FeatureSwitches {
     "chapter-headings",
     "If this switch is turned on, we will add a block of chapter headings to the top of article pages",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 10, 7),
+    sellByDate = new LocalDate(2015, 11, 7),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
Still waiting for the design of these chapter headings to be finalised. The functionality was put in behind a switch for testing.
