### PR TITLE
Use the correct logo for AMP metadata

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -17,7 +17,7 @@
                 <meta itemprop="name" content="The Guardian">
                 @if(amp) {
                     @* AMP doesn't support sameAs *@
-                    <meta itemprop="logo" content="/assets/images/favicons/152x152.png">
+                    <meta itemprop="logo" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
                 } else {
                     <link itemprop="sameAs" href="http://www.theguardian.com">
                 }


### PR DESCRIPTION
Now that we have an actual logo we can reference it in our AMP metadata. So we do.
