### PR TITLE
Hide the footer burger icon block on core

### DIFF
--- a/common/app/views/fragments/nav/navigationFooter.scala.html
+++ b/common/app/views/fragments/nav/navigationFooter.scala.html
@@ -12,7 +12,7 @@
                         @fragments.nav.topNavigation(metaData, navigation)
                     </div>
                 </div>
-                <a class="navigation-toggle js-navigation-toggle" href="#footer-nav" data-link-name="nav : allSections" data-target-nav="js-navigation-footer">
+                <a class="navigation-toggle js-navigation-toggle modern-visible" href="#footer-nav" data-link-name="nav : allSections" data-target-nav="js-navigation-footer">
                     <i class="burger-icon"></i>
                     <span class="navigation-toggle-label navigation-toggle-label--open"
                     aria-haspopup="true" aria-controls="all-sections-popup" aria-label="view all sections">all<span class="navigation-toggle-label__extra"> sections</span></span>


### PR DESCRIPTION
This burger icon does nothing in the footer on core as it links to itself.

We discussed a couple of options, but after trying a few of them, this one makes the most sense to me.

Before:
![screen shot 2015-10-02 at 14 54 04](https://cloud.githubusercontent.com/assets/2236852/10248107/77b5d4f2-6915-11e5-86d8-dd7316be3503.png)

After: 
![screen shot 2015-10-02 at 14 53 40](https://cloud.githubusercontent.com/assets/2236852/10248098/63df9418-6915-11e5-97b0-4daa16e97bee.png)
