### PR TITLE
Amp article main image metadata

### DIFF
--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -39,6 +39,10 @@
             <meta itemprop="representativeOfPage" content="true">
         }
 
+        @if(amp) {
+            <meta itemprop="url" content="@ImgSrc.getFallbackUrl(picture)">
+        }
+
         @lightbox{
             @image(picture, widthsByBreakpoint, imageOption, isMain)
         }

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -40,7 +40,7 @@
         }
 
         @if(amp) {
-            <meta itemprop="url" content="@ImgSrc.getFallbackUrl(picture)">
+            <meta itemprop="url" content="@ImgSrc.getAmpMetaUrl(picture)">
         }
 
         @lightbox{

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -40,7 +40,7 @@
         }
 
         @if(amp) {
-            <meta itemprop="url" content="@ImgSrc.getAmpMetaUrl(picture)">
+            <meta itemprop="url" content="@ImgSrc.getFallbackUrl(picture)">
         }
 
         @lightbox{

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -158,18 +158,6 @@ object ImgSrc extends Logging {
     }
   }
 
-  def getAmpMetaUrl(imageContainer: ImageContainer): Option[String] = {
-    // must be https
-    getFallbackUrl(imageContainer).map { src =>
-      if (!src.startsWith("https")){
-        val (first, last) = src.splitAt(4)
-        first + "s" + last
-      } else {
-        src
-      }
-    }
-  }
-
   def getFallbackAsset(imageContainer: ImageContainer): Option[ImageAsset] = {
     Item300.elementFor(imageContainer)
   }

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -158,6 +158,18 @@ object ImgSrc extends Logging {
     }
   }
 
+  def getAmpMetaUrl(imageContainer: ImageContainer): Option[String] = {
+    // must be https
+    getFallbackUrl(imageContainer).map { src =>
+      if (!src.startsWith("https")){
+        val (first, last) = src.splitAt(4)
+        first + "s" + last
+      } else {
+        src
+      }
+    }
+  }
+
   def getFallbackAsset(imageContainer: ImageContainer): Option[ImageAsset] = {
     Item300.elementFor(imageContainer)
   }


### PR DESCRIPTION
AMP requires at least a main image url in metadata. This adds it for all images and forces it / them to https, which may or may not be necessary.
