### PR TITLE
Reviews linked data hack

### DIFF
--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -48,6 +48,8 @@
                 @content.imdb.map { imdbId =>
                     <div itemprop="itemReviewed" itemscope itemtype="http://schema.org/Movie">
                         <link itemprop="sameAs" href="http://www.imdb.com/title/@imdbId/">
+                        @* we're not the authority on the film name, but just to keep google validator happy
+                        *@<meta itemprop="name" content="Slow West"/>
                     </div>
                 }
 


### PR DESCRIPTION
Just trying to put in a hack because google validator thinks that film name is essential.  We're not sure if that's why our stars and critic snippets [isn't showing up](https://www.google.com/?gfe_rd=cr&ei=ELsOVtbYK43j8wedkLjQBg&gws_rd=cr&fg=1#q=slow+west+film+review) so we're just trying this temporarily.
This article is marked up as follows: http://www.theguardian.com/film/2015/jun/28/slow-west-review-mark-kermode

```
<div itemprop="itemReviewed" itemscope itemtype="http://schema.org/Movie">
  <link itemprop="sameAs" href="http://www.imdb.com/title/tt3205376/">
</div>
```

however we get this error:
https://developers.google.com/structured-data/testing-tool?url=http%253A%252F%252Fwww.theguardian.com%252Ffilm%252F2015%252Fjun%252F28%252Fslow-west-review-mark-kermode
![image](https://cloud.githubusercontent.com/assets/7304387/10252598/6547b7ac-6930-11e5-97ca-240b69831415.png)
Unfortunately we're not the authority on the film name, we should just link to the IMDB database as per the promise of linked data.  However we'll see what this experiment shows.
@crifmulholland 
