### PR TITLE
Only Fetch Recently Changed Data from DFP

### DIFF
--- a/admin/app/dfp/DfpDataCacheJob.scala
+++ b/admin/app/dfp/DfpDataCacheJob.scala
@@ -6,12 +6,20 @@ import common.{ExecutionContexts, Logging}
 import conf.switches.Switches
 import conf.switches.Switches.DfpCachingSwitch
 import org.joda.time.DateTime
+import play.api.libs.json.Json
 import play.api.libs.json.Json.{toJson, _}
 import tools.Store
 
 import scala.concurrent.Future
 
 object DfpDataCacheJob extends ExecutionContexts with Logging {
+
+  case class LineItemLoadSummary(prevCount: Int,
+                                 loadThreshold: Option[DateTime],
+                                 current: Seq[GuLineItem],
+                                 recentlyAddedIds: Iterable[Long],
+                                 recentlyModifiedIds: Iterable[Long],
+                                 recentlyRemovedIds: Iterable[Long])
 
   def run(): Future[Unit] = Future {
     if (DfpCachingSwitch.isSwitchedOn) {
@@ -47,7 +55,93 @@ object DfpDataCacheJob extends ExecutionContexts with Logging {
   }
 
   private def loadLineItems(): DfpDataExtractor = {
-    DfpDataExtractor(DfpDataHydrator().loadCurrentLineItems())
+    val hydrator = DfpDataHydrator()
+
+    def fetchCachedLineItems(): Seq[GuLineItem] = {
+      val maybeLineItems = for {
+        json <- Store.getDfpLineItemsReport()
+        lineItemReport <- Json.parse(json).asOpt[LineItemReport]
+      } yield lineItemReport.lineItems
+      maybeLineItems getOrElse Nil
+    }
+
+    val start = System.currentTimeMillis
+    val lineItems = {
+      if (Switches.DfpCacheRecentOnly.isSwitchedOn) {
+        val loadSummary = loadLineItems(
+          fetchCachedLineItems(),
+          hydrator.loadLineItemsModifiedSince,
+          hydrator.loadCurrentLineItems()
+        )
+        def report(ids: Iterable[Long]): String = if (ids.isEmpty) "None" else ids.mkString(", ")
+        log.info(s"Cached line item count was ${loadSummary.prevCount}")
+        for (threshold <- loadSummary.loadThreshold) {
+          log.info(s"Last modified time of cached line items: $threshold")
+        }
+        log.info(s"Added: ${report(loadSummary.recentlyAddedIds)}")
+        log.info(s"Modified: ${report(loadSummary.recentlyModifiedIds)}")
+        log.info(s"Removed: ${report(loadSummary.recentlyRemovedIds)}")
+        log.info(s"Cached line item count now ${loadSummary.current.size}")
+        loadSummary.current
+      } else hydrator.loadCurrentLineItems()
+    }
+    val loadDuration = System.currentTimeMillis - start
+    log.info(s"Loading line items took $loadDuration ms")
+
+    DfpDataExtractor(lineItems)
+  }
+
+  def loadLineItems(cachedLineItems: => Seq[GuLineItem],
+                    lineItemsModifiedSince: DateTime => Seq[GuLineItem],
+                    allReadyOrDeliveringLineItems: => Seq[GuLineItem]): LineItemLoadSummary = {
+
+    if (cachedLineItems.isEmpty) {
+
+      LineItemLoadSummary(
+        prevCount = allReadyOrDeliveringLineItems.size,
+        loadThreshold = None,
+        current = allReadyOrDeliveringLineItems,
+        recentlyAddedIds = allReadyOrDeliveringLineItems.map(_.id),
+        recentlyModifiedIds = Nil,
+        recentlyRemovedIds = Nil
+      )
+
+    } else {
+
+      val threshold = cachedLineItems.map(_.lastModified).maxBy(_.getMillis)
+      val recentlyModified = lineItemsModifiedSince(threshold)
+      val (readyOrDeliveringModified, otherModified) =
+        recentlyModified partition (Seq("READY", "DELIVERING") contains _.status)
+
+      if (recentlyModified.isEmpty) {
+        LineItemLoadSummary(
+          prevCount = cachedLineItems.size,
+          loadThreshold = Some(threshold),
+          current = cachedLineItems,
+          recentlyAddedIds = Nil,
+          recentlyModifiedIds = Nil,
+          recentlyRemovedIds = Nil
+        )
+      } else {
+
+        def idToLineItem(lineItems: Seq[GuLineItem]) = lineItems.map(item => item.id -> item).toMap
+        val cachedIdToLineItem = idToLineItem(cachedLineItems)
+        val readyOrDeliveringIdToLineItem = idToLineItem(readyOrDeliveringModified)
+        val otherModifiedIds = otherModified.map(_.id)
+        val added = readyOrDeliveringIdToLineItem -- cachedIdToLineItem.keys
+        val modified = readyOrDeliveringIdToLineItem filterKeys cachedIdToLineItem.keySet.contains
+        val removed = cachedIdToLineItem filterKeys otherModifiedIds.contains
+        val lineItems = cachedIdToLineItem ++ added ++ modified -- removed.keys
+        LineItemLoadSummary(
+          prevCount = cachedLineItems.size,
+          loadThreshold = Some(threshold),
+          lineItems.values.toSeq.sortBy(_.id),
+          recentlyAddedIds = added.keys,
+          recentlyModifiedIds = modified.keys,
+          recentlyRemovedIds = removed.keys
+        )
+      }
+    }
   }
 
   private def write(data: DfpDataExtractor): Unit = {

--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -132,6 +132,14 @@ class DfpDataHydrator extends Logging {
     loadLineItems(currentLineItems)
   }
 
+  def loadLineItemsModifiedSince(threshold:JodaDateTime): Seq[GuLineItem] = {
+    val recentlyModified = new StatementBuilder()
+      .where("lastModifiedDateTime > :threshold")
+      .withBindVariableValue("threshold", threshold.getMillis)
+
+    loadLineItems(recentlyModified)
+  }
+
   def loadAllAdFeatures(): Seq[GuLineItem] = {
     val allSponsored = new StatementBuilder()
       .where("lineItemType = :sponsoredType AND status != :draftStatus")
@@ -332,6 +340,7 @@ class DfpDataHydrator extends Logging {
       date.getDay,
       time.getHour,
       time.getMinute,
+      time.getSecond,
       DateTimeZone.forID(time.getTimeZoneID))
   }
 

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -1,0 +1,96 @@
+package dfp
+
+import common.dfp.{GuLineItem, GuTargeting}
+import org.joda.time.DateTime
+import org.scalatest._
+
+class DfpDataCacheJobTest extends FlatSpec with Matchers {
+
+  private def lineItem(id: Long, name: String, completed: Boolean = false): GuLineItem = {
+    GuLineItem(id,
+      name,
+      startTime = DateTime.now.withTimeAtStartOfDay,
+      endTime = None,
+      isPageSkin = false,
+      sponsor = None,
+      status = if (completed) "COMPLETED" else "READY",
+      costType = "CPM",
+      creativeSizes = Nil,
+      targeting = GuTargeting(adUnits = Nil,
+        geoTargetsIncluded = Nil,
+        geoTargetsExcluded = Nil,
+        customTargetSets = Nil),
+      lastModified = DateTime.now.withTimeAtStartOfDay)
+  }
+
+  private val cachedLineItems = Seq(lineItem(1, "a"), lineItem(2, "b"), lineItem(3, "c"))
+  private val allReadyOrDeliveringLineItems = Nil
+
+  "loadLineItems" should "dedup line items that have changed in an unknown way" in {
+    def lineItemsModifiedSince(threshold: DateTime) = Seq(
+      lineItem(1, "a"),
+      lineItem(2, "b"),
+      lineItem(3, "c")
+    )
+
+    val lineItems = DfpDataCacheJob.loadLineItems(
+      cachedLineItems,
+      lineItemsModifiedSince,
+      allReadyOrDeliveringLineItems
+    )
+
+    lineItems.prevCount shouldBe 3
+    lineItems.recentlyAddedIds shouldBe empty
+    lineItems.recentlyModifiedIds shouldBe Set(1, 2, 3)
+    lineItems.recentlyRemovedIds shouldBe empty
+    lineItems.current.size shouldBe 3
+    lineItems.current shouldBe Seq(lineItem(1, "a"), lineItem(2, "b"), lineItem(3, "c"))
+  }
+
+  it should "dedup line items that have changed in a known way" in {
+    def lineItemsModifiedSince(threshold: DateTime) = Seq(
+      lineItem(1, "d"),
+      lineItem(2, "e"),
+      lineItem(4, "f")
+    )
+
+    val lineItems = DfpDataCacheJob.loadLineItems(
+      cachedLineItems,
+      lineItemsModifiedSince,
+      allReadyOrDeliveringLineItems
+    )
+
+    lineItems.prevCount shouldBe 3
+    lineItems.recentlyAddedIds shouldBe Set(4)
+    lineItems.recentlyModifiedIds shouldBe Set(1, 2)
+    lineItems.recentlyRemovedIds shouldBe empty
+    lineItems.current.size shouldBe 4
+    lineItems.current shouldBe Seq(
+      lineItem(1, "d"),
+      lineItem(2, "e"),
+      lineItem(3, "c"),
+      lineItem(4, "f")
+    )
+  }
+
+  it should "omit line items whose state has changed to no longer be ready or delivering" in {
+    def lineItemsModifiedSince(threshold: DateTime) = Seq(
+      lineItem(1, "a", completed = true),
+      lineItem(2, "e"),
+      lineItem(4, "f")
+    )
+
+    val lineItems = DfpDataCacheJob.loadLineItems(
+      cachedLineItems,
+      lineItemsModifiedSince,
+      allReadyOrDeliveringLineItems
+    )
+
+    lineItems.prevCount shouldBe 3
+    lineItems.recentlyAddedIds shouldBe Set(4)
+    lineItems.recentlyModifiedIds shouldBe Set(2)
+    lineItems.recentlyRemovedIds shouldBe Set(1)
+    lineItems.current.size shouldBe 3
+    lineItems.current shouldBe Seq(lineItem(2, "e"), lineItem(3, "c"), lineItem(4, "f"))
+  }
+}

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -24,6 +24,15 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
+  val DfpCacheRecentOnly = Switch(
+    "Commercial",
+    "dfp-cache-recent-only",
+    "Admin will only update cached data with recent changes in DFP.",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 11, 4),
+    exposeClientSide = false
+  )
+
   val CommercialSwitch = Switch(
     "Commercial",
     "commercial",


### PR DESCRIPTION
This change reduces the time to load data from DFP from ~90s to ~5s.

As the process runs every 2 mins this should reduce some of the load on the Admin box.
