### PR TITLE
Scrollable clues at tablet breakpoint

### DIFF
--- a/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
@@ -2,6 +2,7 @@
 
 import classNames from 'classnames';
 import React from 'react';
+import bean from 'bean';
 
 import _ from 'common/utils/_';
 
@@ -41,6 +42,23 @@ class Clue extends React.Component {
 }
 
 export default class Clues extends React.Component {
+    constructor (props) {
+        super(props);
+        this.state = { showGradient: true };
+    }
+
+    componentDidMount () {
+        const node = React.findDOMNode(this.refs.clues);
+        const height = node.scrollHeight - node.clientHeight;
+
+        bean.on(node, 'scroll', e => {
+            const showGradient = height - e.currentTarget.scrollTop > 20;
+
+            if (this.state.showGradient !== showGradient) {
+                this.setState({ showGradient: showGradient });
+            }
+        });
+    }
 
     render () {
         const headerClass = 'crossword__clues-header';
@@ -65,19 +83,23 @@ export default class Clues extends React.Component {
             );
 
         return (
-            <div className='crossword__clues'>
-                <div className='crossword__clues--across'>
-                    <h3 className={headerClass}>Across</h3>
-                    <ol className='crossword__clues-list'>
-                        {cluesByDirection('across')}
-                    </ol>
+            <div className={'crossword__clues--wrapper ' + (this.state.showGradient ? '' : 'hide-gradient')}>
+                <div className='crossword__clues' ref='clues'>
+                    <div className='crossword__clues--across'>
+                        <h3 className={headerClass}>Across</h3>
+                        <ol className='crossword__clues-list'>
+                            {cluesByDirection('across')}
+                        </ol>
+                    </div>
+                    <div className='crossword__clues--down'>
+                        <h3 className={headerClass}>Down</h3>
+                        <ol className='crossword__clues-list'>
+                            {cluesByDirection('down')}
+                        </ol>
+                    </div>
                 </div>
-                <div className='crossword__clues--down'>
-                    <h3 className={headerClass}>Down</h3>
-                    <ol className='crossword__clues-list'>
-                        {cluesByDirection('down')}
-                    </ol>
-                </div>
+
+                <div className='crossword__clues__gradient'></div>
             </div>
         );
     }

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
@@ -3,6 +3,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import bean from 'bean';
+import fastdom from 'fastdom';
 
 import _ from 'common/utils/_';
 import detect from 'common/utils/detect';
@@ -70,7 +71,7 @@ export default class Clues extends React.Component {
         const tablet = detect.getBreakpoint() === 'tablet';
 
         if (tablet && (!prev.focussed || prev.focussed.id !== this.props.focussed.id)) {
-            this.scrollIntoView(this.props.focussed);
+            fastdom.read(() => this.scrollIntoView(this.props.focussed));
         }
     }
 

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/clues.js
@@ -67,7 +67,9 @@ export default class Clues extends React.Component {
      * Scroll clues into view when they're activated (i.e. clicked in the grid)
      */
     componentDidUpdate (prev) {
-        if (!prev.focussed || prev.focussed.id !== this.props.focussed.id) {
+        const tablet = detect.getBreakpoint() === 'tablet';
+
+        if (tablet && (!prev.focussed || prev.focussed.id !== this.props.focussed.id)) {
             this.scrollIntoView(this.props.focussed);
         }
     }
@@ -78,7 +80,7 @@ export default class Clues extends React.Component {
         const visible = node.offsetTop - buffer > this.$cluesNode.scrollTop &&
                         node.offsetTop + buffer < this.$cluesNode.scrollTop + this.$cluesNode.clientHeight;
 
-        if (!visible && detect.getBreakpoint() === 'tablet') {
+        if (!visible) {
             const offset = node.offsetTop - (this.$cluesNode.clientHeight / 2);
             scroller.scrollTo(offset, 250, 'easeOutQuad', this.$cluesNode);
         }

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -570,7 +570,7 @@ class Crossword extends React.Component {
         );
 
         return (
-            <div className={`crossword__container crossword__container--${this.props.data.crosswordType}`}>
+            <div className={`crossword__container crossword__container--${this.props.data.crosswordType} crossword__container--react`}>
                 <div className='crossword__container__game' ref='game'>
                     <div className='crossword__sticky-clue-wrapper' ref='stickyClueWrapper'>
                         <div

--- a/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/es6/projects/common/modules/crosswords/main.js
@@ -627,6 +627,7 @@ class Crossword extends React.Component {
                 />
                 <Clues
                     clues={this.cluesData()}
+                    focussed={focussed}
                     focusClue={this.focusClue}
                     setReturnPosition={this.setReturnPosition}
                 />

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -59,10 +59,13 @@
 
 .crossword__clues--wrapper,
 .crossword__clues {
-    height: xword-grid-dimensions(15) + ($gs-baseline * 10);
+    @include mq(tablet) {
+        height: xword-grid-dimensions(15) + ($gs-baseline * 10);
+    }
 }
 
 .crossword__clues {
+    position: relative;
     width: 100%;
     clear: both;
     overflow: scroll;

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -57,15 +57,20 @@
     clear: both;
 }
 
+.crossword__clues--wrapper,
+.crossword__clues {
+    height: xword-grid-dimensions(15) + ($gs-baseline * 10);
+}
+
 .crossword__clues {
     width: 100%;
     clear: both;
+    overflow: scroll;
+    -webkit-overflow-scrolling: touch;
 
     @include mq(tablet) {
         clear: none;
         padding-left: $gs-gutter;
-        display: table;
-        table-layout: fixed;
         box-sizing: border-box;
 
         noscript & {
@@ -74,6 +79,30 @@
 
         .crossword__container--accessible & {
             width: initial;
+        }
+    }
+
+    @include mq(desktop) {
+        display: table;
+        table-layout: fixed;
+        height: auto;
+        background: none;
+    }
+}
+
+.crossword__clues__gradient {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    height: 120px;
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #ffffff);
+    display: none;
+
+    @include mq($from: tablet, $until: desktop) {
+        display: block;
+
+        .hide-gradient & {
+            display: none;
         }
     }
 }

--- a/static/src/stylesheets/module/crosswords/_layout.scss
+++ b/static/src/stylesheets/module/crosswords/_layout.scss
@@ -57,39 +57,19 @@
     clear: both;
 }
 
-.crossword__clues--wrapper,
-.crossword__clues {
-    @include mq(tablet) {
-        height: xword-grid-dimensions(15) + ($gs-baseline * 10);
-    }
-}
-
-.crossword__clues {
-    position: relative;
-    width: 100%;
-    clear: both;
-    overflow: scroll;
-    -webkit-overflow-scrolling: touch;
-
-    @include mq(tablet) {
-        clear: none;
-        padding-left: $gs-gutter;
-        box-sizing: border-box;
-
-        noscript & {
-            width: 85%;
-        }
-
-        .crossword__container--accessible & {
-            width: initial;
+// scrollable clues - only on tablets not in accessible view
+.crossword__container--react {
+    & .crossword__clues--wrapper,
+    & .crossword__clues {
+        @include mq(tablet) {
+            height: xword-grid-dimensions(15) + ($gs-baseline * 10);
         }
     }
 
-    @include mq(desktop) {
-        display: table;
-        table-layout: fixed;
-        height: auto;
-        background: none;
+    & .crossword__clues {
+        position: relative;
+        overflow: scroll;
+        -webkit-overflow-scrolling: touch;
     }
 }
 
@@ -107,6 +87,34 @@
         .hide-gradient & {
             display: none;
         }
+    }
+}
+
+.crossword__clues {
+    width: 100%;
+    clear: both;
+
+    @include mq(tablet) {
+        clear: none;
+        padding-left: $gs-gutter;
+        box-sizing: border-box;
+
+        noscript & {
+            width: 85%;
+        }
+
+        .crossword__container--accessible & {
+            display: table;
+            table-layout: fixed;
+            width: initial;
+        }
+    }
+
+    @include mq(desktop) {
+        display: table;
+        table-layout: fixed;
+        height: auto;
+        background: none;
     }
 }
 


### PR DESCRIPTION
We've had a few complaints from tablet users about having to scroll up and down too much when reading the list of clues. 

This limits the height of the clues to around the same size as the crossword and makes it scrollable. It also jumps to the appropriate clue (if not already visible) when you click a cell in the grid.

This depends on a change to `scroller` (#10770) to allow an element to be passed in.

![oct 05 2015 15 16](https://cloud.githubusercontent.com/assets/1064734/10282732/38713ac8-6b74-11e5-82b1-5900657e2c6e.gif)
