### PR TITLE
Allow container element to be passed to scroller.scrollTo

### DIFF
--- a/static/src/javascripts/projects/common/utils/scroller.js
+++ b/static/src/javascripts/projects/common/utils/scroller.js
@@ -14,8 +14,8 @@ define([
     // scroller.scrollTo(1250, 250, 'linear'); // 250ms scroll to 1250px using linear gradient
     // scroller.scrollTo(100, 250, 'linear', document.querySelector('.container')); // 250ms scroll to 100px of scrollable container
     //   if you pass in an element, you must also specify an easing function.
-    function scrollTo(offset, duration, easeFn, el) {
-        var $container = bonzo(el || document.body),
+    function scrollTo(offset, duration, easeFn, container) {
+        var $container = bonzo(container || document.body),
             scrollEnd = offset,
             scrollFrom = $container.scrollTop(),
             scrollDist = scrollEnd - scrollFrom,

--- a/static/src/javascripts/projects/common/utils/scroller.js
+++ b/static/src/javascripts/projects/common/utils/scroller.js
@@ -12,23 +12,24 @@ define([
     // Usage:
     // scroller.scrollToElement(element, 500, 'easeOutQuad'); // 500ms scroll to element using easeOutQuad easing
     // scroller.scrollTo(1250, 250, 'linear'); // 250ms scroll to 1250px using linear gradient
-
-    function scrollTo(offset, duration, easeFn) {
-        var $body = bonzo(document.body),
+    // scroller.scrollTo(100, 250, 'linear', document.querySelector('.container')); // 250ms scroll to 100px of scrollable container
+    //   if you pass in an element, you must also specify an easing function.
+    function scrollTo(offset, duration, easeFn, el) {
+        var $container = bonzo(el || document.body),
             scrollEnd = offset,
-            scrollFrom = $body.scrollTop(),
+            scrollFrom = $container.scrollTop(),
             scrollDist = scrollEnd - scrollFrom,
             ease = easing.create(easeFn || 'easeOutQuad', duration),
             scrollFn = function () {
                 fastdom.write(function () {
-                    $body.scrollTop(scrollFrom + (ease() * scrollDist));
+                    $container.scrollTop(scrollFrom + (ease() * scrollDist));
                 });
             },
             interval = window.setInterval(scrollFn, 15);
         window.setTimeout(function () {
             window.clearInterval(interval);
             fastdom.write(function () {
-                $body.scrollTop(scrollEnd);
+                $container.scrollTop(scrollEnd);
             });
         }, duration);
 


### PR DESCRIPTION
This adds a parameter to scroll a container element rather than `document.body`. It'll allow me to scroll the clues in #10769.
