### PR TITLE
remove deep linking for apps

### DIFF
--- a/applications/test/IndexMetaDataTest.scala
+++ b/applications/test/IndexMetaDataTest.scala
@@ -15,7 +15,7 @@ import play.api.test.Helpers._
     MetaDataMatcher.ensureOrganisation(result)
   }
 
-  it should "Include webpage metadata" in {
+  it should "not Include webpage metadata" in {
     val result = controllers.IndexController.render(articleUrl)(TestRequest(articleUrl))
     MetaDataMatcher.ensureWebPage(result, articleUrl)
   }

--- a/article/test/ArticleMetaDataTest.scala
+++ b/article/test/ArticleMetaDataTest.scala
@@ -15,7 +15,7 @@ import play.api.test.Helpers._
     MetaDataMatcher.ensureOrganisation(result)
   }
 
-  it should "Include webpage metadata" in {
+  it should "not Include webpage metadata" in {
     val result = controllers.ArticleController.renderArticle(articleUrl, None, None)(TestRequest(articleUrl))
     MetaDataMatcher.ensureWebPage(result, articleUrl)
 

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -113,6 +113,4 @@ case class PressedPage(id: String,
   private def optionalMapEntry(key:String, o: Option[String]): Map[String, String] =
     o.map(value => Map(key -> value)).getOrElse(Map())
 
-  override def iosType = Some("front")
-
 }

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -31,6 +31,4 @@ case class Section(private val delegate: ApiSection, override val pagination: Op
     "contentType" -> JsString("Section")
   )
 
-  override def iosType = Some("front")
-
 }

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -95,6 +95,4 @@ case class Tag(private val delegate: ApiTag, override val pagination: Option[Pag
   private def optionalMapEntry(key:String, o: Option[String]): Map[String, String] =
     o.map(value => Map(key -> value)).getOrElse(Map())
 
-  override def iosType = Some("list")
-
 }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -303,7 +303,6 @@ class Content protected (val delegate: contentapi.Content) extends Trail with Me
 
   def showFooterContainers = false
 
-  override def iosType = Some("article")
 }
 
 object Content {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -104,6 +104,9 @@ trait MetaData extends Tags {
   def iosId(referrer: String): Option[String] = iosType.map(iosType => s"$id?contenttype=$iosType&source=$referrer")
 
   // this could be article/front/list, it's a hint to the ios app to start the right engine
+  // it's only set if the content is supported in the apps
+  // TODO temporarily removed as google doesn't give you a choice not to hit the app, and some things are getting pulled in
+  // e.g sport network and crosswords.  Altogether it's abad user experience.
   def iosType: Option[String] = None
 
   def cacheSeconds = 60

--- a/common/test/metadata/MetaDataMatcher.scala
+++ b/common/test/metadata/MetaDataMatcher.scala
@@ -32,11 +32,11 @@ object MetaDataMatcher extends Matchers  {
     status(result) should be(200)
 
     val script = body.getElementsByAttributeValue("data-schema", "WebPage")
-    script.size() should be(1)
+    script.size() should be(0)
 
-    val appIndexer: JsValue = Json.parse(script.first().html())
-
-    (appIndexer \ "potentialAction" \ "target").as[String] should include(articleUrl)
+//    val appIndexer: JsValue = Json.parse(script.first().html())
+//
+//    (appIndexer \ "potentialAction" \ "target").as[String] should include(articleUrl)
 
   }
 

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -54,7 +54,7 @@ import scala.concurrent.Future
     MetaDataMatcher.ensureOrganisation(result)
   }
 
-  it should "Include webpage metadata" in {
+  it should "not Include webpage metadata" in {
     val result = faciaController.renderFront(articleUrl)(TestRequest(articleUrl))
     MetaDataMatcher.ensureWebPage(result, articleUrl)
   }


### PR DESCRIPTION
Depp linking is causing a lot of problems with hitting the app for things that aren't supported and not giving the user a choice between the web and the app.
So we should remove it for the time being until we have a better user experience.
@crifmulholland @ScottPainterGNM @PetrK-GNM @michaelwmcnamara 
