### PR TITLE
Add supporting to lite.json

### DIFF
--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -20,11 +20,15 @@ trait FapiFrontJsonLite extends ExecutionContexts{
     pressedPage.collections.map(getCollection)
 
   private def getCollection(pressedCollection: PressedCollection): JsValue =
-    Json.obj(
-      "displayName" -> pressedCollection.displayName,
-      "href" -> pressedCollection.href,
-      "id" -> pressedCollection.id,
-      "content" -> pressedCollection.curatedPlusBackfillDeduplicated.filterNot(isLinkSnap).map(getContent))
+    JsObject(
+      Json.obj(
+        "displayName" -> pressedCollection.displayName,
+        "href" -> pressedCollection.href,
+        "id" -> pressedCollection.id,
+        "content" -> pressedCollection.curatedPlusBackfillDeduplicated.filterNot(isLinkSnap).map(getContent))
+      .fields
+      .filterNot{ case (_, v) => v == JsNull})
+
 
   private def isLinkSnap(faciaContent: FaciaContent) = faciaContent match {
     case _: LinkSnap => true

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -39,7 +39,8 @@ trait FapiFrontJsonLite extends ExecutionContexts{
         "shortUrl" -> faciaContent.shortUrl,
         "id" -> faciaContent.maybeContent.map(_.id),
         "group" -> faciaContent.group,
-        "frontPublicationDate" -> faciaContent.maybeFrontPublicationDate)
+        "frontPublicationDate" -> faciaContent.maybeFrontPublicationDate,
+        "supporting" -> getSupporting(faciaContent))
       .fields
       .filterNot{ case (_, v) => v == JsNull})
   }

--- a/facia/app/controllers/front/FrontJson.scala
+++ b/facia/app/controllers/front/FrontJson.scala
@@ -1,6 +1,6 @@
 package controllers.front
 
-import com.gu.facia.api.models.{CollectionConfig, FaciaContent, Groups, LinkSnap}
+import com.gu.facia.api.models._
 import common.{ExecutionContexts, Logging, S3Metrics}
 import conf.Configuration
 import implicits.FaciaContentImplicits._
@@ -42,6 +42,12 @@ trait FapiFrontJsonLite extends ExecutionContexts{
         "frontPublicationDate" -> faciaContent.maybeFrontPublicationDate)
       .fields
       .filterNot{ case (_, v) => v == JsNull})
+  }
+
+  private def getSupporting(faciaContent: FaciaContent): JsValue = faciaContent match {
+    case curatedContent: CuratedContent
+      if curatedContent.supportingContent.nonEmpty => JsArray(curatedContent.supportingContent.map(getContent))
+    case _ => JsNull
   }
 }
 


### PR DESCRIPTION
The data team need data from the fronts and `lite.json` almost fulfills their requirements. All that is missing is `supporting` content on items.

This adds a `supporting` key to the `lite.json` files with supporting items. If there are no supporting items then no supporting key gets added.

This also cleans up at collection level **null**s that may exist, a common one being `href`.
## Risk

In the spirit of M and M, what risk does this have? Low

In the past, changing this has broken shuttlerun from indexing. This then stopped `editorsPicks` from working. This was due to the parser not being able to handle nulls.

I would say this change is low because it just adds a new key to the `json` and removes some **nulls**.

@stephanfowler @rich-nguyen @mchv 

---

![supportingitems](https://cloud.githubusercontent.com/assets/445472/10305376/ca33f358-6c17-11e5-85d8-c80de2c6b97c.png)
#### Href Null

![collectionlevelnull](https://cloud.githubusercontent.com/assets/445472/10305378/cba1cddc-6c17-11e5-8531-6e6e493e12a4.png)
