### PR TITLE
Adblock message fixed for members

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -4,6 +4,7 @@ define([
     'common/utils/detect',
     'common/utils/storage',
     'common/utils/template',
+    'common/modules/commercial/user-adblock-message',
     'common/modules/ui/message',
     'common/modules/experiments/ab',
     'common/modules/navigation/navigation',
@@ -15,6 +16,7 @@ define([
     detect,
     storage,
     template,
+    userAdblockMessage,
     Message,
     ab,
     navigation,
@@ -47,7 +49,7 @@ define([
                 }
             ]);
 
-        if (detect.getBreakpoint() !== 'mobile' && detect.adblockInUse && config.switches.adblock && alreadyVisted > 1) {
+        if (detect.getBreakpoint() !== 'mobile' && detect.adblockInUse && config.switches.adblock && alreadyVisted > 1 && !userAdblockMessage.isUserMember) {
             new Message('adblock-message', {
                 pinOnHide: false,
                 siteMessageLinkName: 'adblock message variant ' + message.id,

--- a/static/src/javascripts/projects/common/modules/commercial/user-adblock-message.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-adblock-message.js
@@ -1,0 +1,14 @@
+define([
+    'common/utils/cookies'
+], function (
+    cookies
+) {
+    //right now we assume that the user who is a member (any of 3 paid tiers) and do not want to see ads, also won't see adblock messages
+    function isUserMember() {
+        return cookies.get('gu_adfree_user') ? true : false;
+    }
+
+    return {
+        isUserMember : isUserMember()
+    };
+});


### PR DESCRIPTION
Users who use adblock and are already a member are not going to see adblock message at the bottom of the page. The `gu_adfree_user` cookie is set by the membership API. It is set for users who are members (any paid tier) and do no wish to see any ads. There will be another cookie implemented soon which will indicates users who are members but didn't necessary wish to not see any ads. When it will be done, I will rename the cookie.
