### PR TITLE
Remove ad slots when DFP advertising disabled

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -345,6 +345,10 @@ define([
             displayed = true;
         },
         addSlot = function ($adSlot) {
+            if (!commercialFeatures.dfpAdvertising) {
+                throw new Error('DFP advertising is disabled');
+            }
+
             var slotId = $adSlot.attr('id'),
                 displayAd = function ($adSlot) {
                     slots[slotId] = {
@@ -365,6 +369,10 @@ define([
             }
         },
         refreshSlot = function ($adSlot) {
+            if (!commercialFeatures.dfpAdvertising) {
+                throw new Error('DFP advertising is disabled');
+            }
+
             var slot = slots[$adSlot.attr('id')].slot;
             if (slot) {
                 googletag.pubads().refresh([slot]);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -267,15 +267,7 @@ define([
                 });
             });
         },
-
-        /**
-         * Public functions
-         */
-        init = function (options) {
-            if (!commercialFeatures.dfpAdvertising) {
-                return false;
-            }
-
+        setupAdvertising = function (options) {
             var opts = _.defaults(options || {}, {
                 resizeTimeout: 2000
             });
@@ -310,7 +302,17 @@ define([
 
             // show sponsorship placeholder if adblock detected
             showSponsorshipPlaceholder();
+        },
 
+        /**
+         * Public functions
+         */
+        init = function (options) {
+            if (commercialFeatures.dfpAdvertising) {
+                setupAdvertising(options);
+            } else {
+                $(adSlotSelector).remove();
+            }
             return dfp;
         },
         instantLoad = function () {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -345,10 +345,6 @@ define([
             displayed = true;
         },
         addSlot = function ($adSlot) {
-            if (!commercialFeatures.dfpAdvertising) {
-                throw new Error('DFP advertising is disabled');
-            }
-
             var slotId = $adSlot.attr('id'),
                 displayAd = function ($adSlot) {
                     slots[slotId] = {
@@ -369,10 +365,6 @@ define([
             }
         },
         refreshSlot = function ($adSlot) {
-            if (!commercialFeatures.dfpAdvertising) {
-                throw new Error('DFP advertising is disabled');
-            }
-
             var slot = slots[$adSlot.attr('id')].slot;
             if (slot) {
                 googletag.pubads().refresh([slot]);

--- a/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
@@ -142,9 +142,7 @@ describe('DFP', function () {
         });
 
         it('hides all ad slots', function () {
-            commercialFeatures.dfpAdvertising = false;
             dfp.init();
-
             const remainingAdSlots = document.querySelectorAll('.js-ad-slot');
             expect(remainingAdSlots.length).toBe(0);
         });
@@ -152,6 +150,12 @@ describe('DFP', function () {
         it('still returns a DFP object', function () {
             const returnValue = dfp.init();
             expect(returnValue).toBe(dfp);
+        });
+
+        it('calling methods on the disabled DFP object throws exceptions', function() {
+            dfp.init();
+            expect(dfp.addSlot).toThrowError('DFP advertising is disabled');
+            expect(dfp.refreshSlot).toThrowError('DFP advertising is disabled');
         });
     });
 

--- a/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
@@ -152,7 +152,7 @@ describe('DFP', function () {
             expect(returnValue).toBe(dfp);
         });
 
-        it('calling methods on the disabled DFP object throws exceptions', function() {
+        it('calling methods on the disabled DFP object throws exceptions', function () {
             dfp.init();
             expect(dfp.addSlot).toThrowError('DFP advertising is disabled');
             expect(dfp.refreshSlot).toThrowError('DFP advertising is disabled');

--- a/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
@@ -136,9 +136,23 @@ describe('DFP', function () {
         expect(dfp.init()).toBe(dfp);
     });
 
-    it('should not run if disabled in commercial features', function () {
-        commercialFeatures.dfpAdvertising = false;
-        expect(dfp.init()).toBe(false);
+    describe('when all DFP advertising is disabled', function () {
+        beforeEach(function () {
+            commercialFeatures.dfpAdvertising = false;
+        });
+
+        it('hides all ad slots', function () {
+            commercialFeatures.dfpAdvertising = false;
+            dfp.init();
+
+            const remainingAdSlots = document.querySelectorAll('.js-ad-slot');
+            expect(remainingAdSlots.length).toBe(0);
+        });
+
+        it('still returns a DFP object', function () {
+            const returnValue = dfp.init();
+            expect(returnValue).toBe(dfp);
+        });
     });
 
     it('should get the slots', function () {

--- a/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
@@ -151,12 +151,6 @@ describe('DFP', function () {
             const returnValue = dfp.init();
             expect(returnValue).toBe(dfp);
         });
-
-        it('calling methods on the disabled DFP object throws exceptions', function () {
-            dfp.init();
-            expect(dfp.addSlot).toThrowError('DFP advertising is disabled');
-            expect(dfp.refreshSlot).toThrowError('DFP advertising is disabled');
-        });
     });
 
     it('should get the slots', function () {


### PR DESCRIPTION
This resolves an issue [in production] on the childrens' book site, where a big grey box appears above the nav:

![image](https://cloud.githubusercontent.com/assets/3148617/10311081/289c7922-6c3d-11e5-86b1-7eaac8732aba.png)

Previously, we would run dfp.js on these pages, and allow GPT to strip out empty ad slots. Now, we have a dfpAdvertising flag which can be set to false, and stops DFP running entirely. One advantage of this is it means pages on the childrens' book site should never request or load the GPT script. But it means we lose GPT's native functionality for removing empty ad slots.

This change makes dfp.js strip out ad slots itself if the dfpAdvertising flag is set to false. So the ugly grey box disappears:

![image](https://cloud.githubusercontent.com/assets/3148617/10311209/b72913e4-6c3d-11e5-9100-3fcc410a3e4d.png)

@Calanthe @uplne 
