### PR TITLE
Block quote overlapping text when there's a float

### DIFF
--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -105,6 +105,7 @@
         // TODO: Write mixin for this
         margin-left: initial;
         margin-left: unset;
+        overflow: auto;
     }
 }
 


### PR DESCRIPTION
Before:
![screen shot 2015-10-06 at 17 05 35](https://cloud.githubusercontent.com/assets/14570016/10314938/48923688-6c4f-11e5-8a0d-9acc18b2b43c.png)

After:
![screen shot 2015-10-06 at 17 05 44](https://cloud.githubusercontent.com/assets/14570016/10314937/487e0c08-6c4f-11e5-8beb-89762ce091d9.png)
