### PR TITLE
Guardian Labs link to footer

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -242,9 +242,6 @@ trait Navigation {
     SectionLink("football", "fixtures", "Fixtures", "/football/fixtures"),
     SectionLink("football", "clubs", "Clubs", "/football/teams")
   )
-
-  //Guardian labs
-  val guardianLabs = SectionLink("guardian-professional", "guardian labs", "Guardian Labs", "/guardian-labs")
 }
 
 case class BreadcrumbItem(href: String, title: String)

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -111,7 +111,6 @@ object Uk extends Edition(
       NavItem(travel, Seq(uktravel, europetravel, usTravel)),
       NavItem(money, Seq(property, savings, pensions, borrowing, workAndCareers)),
       NavItem(science),
-      NavItem(guardianProfessional,  Seq(guardianLabs)),
       NavItem(observer),
       NavItem(todaysPaper, Seq(editorialsandletters, obituaries, g2, weekend, theGuide, saturdayreview)),
       NavItem(membership),

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -58,6 +58,8 @@
             @if(currentEdition == Us) {
                 <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
                     jobs</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo{/guardian-labs}">
+                    guardian labs</a></li>
                 <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="http://subscribe.theguardian.com/us?INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE">
                     subscribe</a></li>
             }
@@ -67,6 +69,8 @@
                     advertising</a></li>
                 <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="@LinkTo{/guardian-masterclasses/guardian-masterclasses-australia}">
                     masterclasses</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : guardian labs" href="@LinkTo{/guardian-labs}">
+                    guardian labs</a></li>
                 <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="http://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
                     subscribe</a></li>
                 <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -49,6 +49,8 @@
                     dating</a></li>
                 <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="@LinkTo{/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES}">
                     masterclasses</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : guardian labs" href="@LinkTo{/guardian-labs}">
+                    guardian labs</a></li>
                 <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="http://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">
                     subscribe</a></li>
             }


### PR DESCRIPTION
1. Removes it from the meganav
2. Adds it to the footer (uk edition)

![screen shot 2015-10-07 at 10 27 47](https://cloud.githubusercontent.com/assets/2579465/10333806/434045be-6cde-11e5-88fd-ff58ad7cec18.png)
