### PR TITLE
use secure url for amp-pixel

### DIFF
--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -34,7 +34,7 @@ trait Requests {
     private val networkFronts = Edition.all.map(_.id).map(id => s"/$id")
 
     // see http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html#x-forwarded-proto
-    lazy val isSecure: Boolean = r.headers.get("X-Forwarded-Proto").exists(_.equalsIgnoreCase("https"))
+    lazy val isSecure: Boolean = r.headers.get("X-Forwarded-Proto").exists(_.equalsIgnoreCase("https")) || isAmp // TODO tidyup - remove isAmp when amp is served over https anyway
 
     //This is a header reliably set by jQuery for AJAX requests used in facia-tool
     lazy val isXmlHttpRequest: Boolean = r.headers.get("X-Requested-With").contains("XMLHttpRequest")

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -16,7 +16,6 @@
         <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
-        <script custom-element="amp-pixel" src="https://cdn.ampproject.org/v0/amp-pixel-0.1.js" async></script>
     </head>
     <body>
         @defining(s"${request.host}${request.path}") { path =>


### PR DESCRIPTION
amp-pixel just errors if I use a non secure url, so changing to secure.

@NataliaLKB @JustinPinner 
