### PR TITLE
extending SplitOlderIpadSwitch to give us time to discuss core taking over all the ipads

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -292,7 +292,7 @@ trait FeatureSwitches {
     "ipad-split-capabilities",
     "If switched on then this gives older ipads the stripped down front but full articles",
     safeState = On,
-    sellByDate = new LocalDate(2015, 9, 30),
+    sellByDate = new LocalDate(2015, 11, 30),
     exposeClientSide = false
   )
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -292,7 +292,7 @@ trait FeatureSwitches {
     "ipad-split-capabilities",
     "If switched on then this gives older ipads the stripped down front but full articles",
     safeState = On,
-    sellByDate = new LocalDate(2015, 11, 30),
+    sellByDate = new LocalDate(2015, 12, 1),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
Eventually we will probably extend core to all the ipads but this needs to be discussed and done right - so for now just extending the switch
