### PR TITLE
Most popular fix

### DIFF
--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -106,7 +106,11 @@ object DayMostPopularAgent extends Logging with ExecutionContexts {
         item: JsValue <- ophanResults.asOpt[JsArray].map(_.value).getOrElse(Nil)
         url <- (item \ "url").asOpt[String]
       } yield {
-        getResponse(LiveContentApi.item(urlToContentPath(url), Edition.defaultEdition )).map(_.content.map(Content(_)))
+        getResponse(LiveContentApi.item(urlToContentPath(url), Edition.defaultEdition ))
+          .map(_.content.map(Content(_)))
+          .fallbackTo{
+            log.error(s"Error requesting $url")
+            Future.successful(None)}
       }
 
       Future.sequence(mostRead).map { contentSeq =>

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -56,9 +56,11 @@ object GeoMostPopularAgent extends Logging with ExecutionContexts {
         item: JsValue <- ophanResults.asOpt[JsArray].map(_.value).getOrElse(Nil)
         url <- (item \ "url").asOpt[String]
       } yield {
-        getResponse(
-          LiveContentApi.item(urlToContentPath(url), Edition.defaultEdition )
-        ).map(_.content.map(Content(_)))
+        getResponse(LiveContentApi.item(urlToContentPath(url), Edition.defaultEdition))
+          .map(_.content.map(Content(_)))
+          .fallbackTo{
+            log.error(s"Error requesting $url")
+            Future.successful(None)}
       }
 
       Future.sequence(mostRead).map { contentSeq =>


### PR DESCRIPTION
When an item URL gets changed in the Content API, we are able to handle the redirect correctly.

Other things can't handle it though, such as the most popular container requests.

This fixes it by providing a fallback of None when it fails, and logging it out.

Currently most-popular is broken on UK.

![mostpopularbrokenagent](https://cloud.githubusercontent.com/assets/445472/10339443/3fac78da-6d03-11e5-8cc3-a59e65d00339.png)
