### PR TITLE
Point 'become a member' link to membership homepage, via identity

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -19,7 +19,7 @@
                         <div class="brand-bar__item brand-bar__item--profile
                                     brand-bar__item--has-control brand-bar__item--register
                                     popup-container has-popup js-profile-register">
-                            <a href="@Configuration.id.url/register?skipConfirmation=true&INTCMP=DOTCOM_HEADER_BECOMEMEMBER&returnUrl=@URLEncode("https://membership.theguardian.com/join/friend/enter-details")"
+                            <a href="@Configuration.id.url/register?skipConfirmation=true&INTCMP=DOTCOM_HEADER_BECOMEMEMBER&returnUrl=@URLEncode(Configuration.id.membershipUrl)"
                                 data-link-name="Register link"
                                 class="brand-bar__item--action">
                                     @fragments.inlineSvg("profile-add-36", "icon", List("rounded-icon", "control__icon-wrapper"))


### PR DESCRIPTION
Currently the 'become a member' link in the top nav bar takes you identity to sign-in/register, and then to the 'Become a Friend' page in Membership, which expects you to enter details and sign up then and there. This has two problems:
1. for non-members, it provides very little detail about what the benefits of membership are
2. for existing paid members (an unlikely but possible case), it will assume they want to downgrade their membership tier to free, which is obviously a very undesirable outcome

This PR changes the returnUrl passed to identity to redirect to the Membership homepage instead. It is a  hopefully less controversial version of [this abandoned PR](https://github.com/guardian/frontend/pull/10780), which proposed skipping identity altogether and going straight to the Membership homepage from theguardian.com. It was abandoned because it needs some clearer evidence from A/B testing that it will be beneficial. Hopefully the reasons outlined above provide a strong enough justification for this change without the need for A/B testing.

@davidrapson @gklopper @dominickendrick @crifmulholland 
