### PR TITLE
Point 'become a member' link to membership homepage

### DIFF
--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -19,7 +19,7 @@
                         <div class="brand-bar__item brand-bar__item--profile
                                     brand-bar__item--has-control brand-bar__item--register
                                     popup-container has-popup js-profile-register">
-                            <a href="@Configuration.id.url/register?skipConfirmation=true&INTCMP=DOTCOM_HEADER_BECOMEMEMBER&returnUrl=@URLEncode("https://membership.theguardian.com/join/friend/enter-details")"
+                            <a href="@Configuration.id.membershipUrl?INTCMP=DOTCOM_HEADER_BECOMEMEMBER"
                                 data-link-name="Register link"
                                 class="brand-bar__item--action">
                                     @fragments.inlineSvg("profile-add-36", "icon", List("rounded-icon", "control__icon-wrapper"))


### PR DESCRIPTION
This one has gone round the houses a bit. This was the change we originally wanted to make (go straight to membership homepage, not via Identity) but we referenced some pretty inconclusive A/B testing as evidence, which muddied the waters a bit.

Since we all agree that it's a confusing user journey to get taken to the Identity page without seeing any information about membership first, we've decided to go ahead and make this change without any conclusive A/B testing evidence.

@dominickendrick @crifmulholland @davidrapson 
