### PR TITLE
Lazyloading fix for pageskin

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -291,8 +291,7 @@ define([
             window.googletag.cmd.push(setPageTargeting);
             window.googletag.cmd.push(defineSlots);
 
-            // We do not want lazy loading on pageskins because it messes up the roadblock
-            if (config.switches.viewability && !(config.page.hasPageSkin && detect.getBreakpoint() === 'wide')) {
+            if (shouldLazyLoad()) {
                 window.googletag.cmd.push(displayLazyAds);
             } else {
                 window.googletag.cmd.push(displayAds);
@@ -372,6 +371,10 @@ define([
         },
         getSlots = function () {
             return slots;
+        },
+        shouldLazyLoad = function () {
+            // We do not want lazy loading on pageskins because it messes up the roadblock
+            return config.switches.viewability && !(config.page.hasPageSkin && detect.getBreakpoint() === 'wide');
         },
 
         /**
@@ -680,10 +683,11 @@ define([
          * Module
          */
         dfp = {
-            init:        init,
-            addSlot:     addSlot,
-            refreshSlot: refreshSlot,
-            getSlots:    getSlots,
+            init:           init,
+            addSlot:        addSlot,
+            refreshSlot:    refreshSlot,
+            getSlots:       getSlots,
+            shouldLazyLoad: shouldLazyLoad,
 
             // testing
             reset: function () {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -292,7 +292,7 @@ define([
             window.googletag.cmd.push(defineSlots);
 
             // We do not want lazy loading on pageskins because it messes up the roadblock
-            if (config.switches.viewability && (!config.page.hasPageSkin || (config.page.hasPageSkin && detect.getBreakpoint() !== 'wide'))) {
+            if (config.switches.viewability && !(config.page.hasPageSkin && detect.getBreakpoint() === 'wide')) {
                 window.googletag.cmd.push(displayLazyAds);
             } else {
                 window.googletag.cmd.push(displayAds);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -292,7 +292,7 @@ define([
             window.googletag.cmd.push(defineSlots);
 
             // We do not want lazy loading on pageskins because it messes up the roadblock
-            if (config.switches.viewability && !config.page.hasPageSkin) {
+            if (config.switches.viewability && (!config.page.hasPageSkin || (config.page.hasPageSkin && detect.getBreakpoint() !== 'wide'))) {
                 window.googletag.cmd.push(displayLazyAds);
             } else {
                 window.googletag.cmd.push(displayAds);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -291,7 +291,7 @@ define([
             window.googletag.cmd.push(setPageTargeting);
             window.googletag.cmd.push(defineSlots);
 
-            if (shouldLazyLoad()) {
+            if (_shouldLazyLoad()) {
                 window.googletag.cmd.push(displayLazyAds);
             } else {
                 window.googletag.cmd.push(displayAds);
@@ -371,10 +371,6 @@ define([
         },
         getSlots = function () {
             return slots;
-        },
-        shouldLazyLoad = function () {
-            // We do not want lazy loading on pageskins because it messes up the roadblock
-            return config.switches.viewability && !(config.page.hasPageSkin && detect.getBreakpoint() === 'wide');
         },
 
         /**
@@ -678,6 +674,13 @@ define([
                 return keyword.split('/').pop();
             });
         },
+        /**
+         * Used privately but exposed pnly for unit testing
+         * */
+        _shouldLazyLoad = function () {
+            // We do not want lazy loading on pageskins because it messes up the roadblock
+            return config.switches.viewability && !(config.page.hasPageSkin && detect.getBreakpoint() === 'wide');
+        },
 
         /**
          * Module
@@ -687,7 +690,7 @@ define([
             addSlot:        addSlot,
             refreshSlot:    refreshSlot,
             getSlots:       getSlots,
-            shouldLazyLoad: shouldLazyLoad,
+            shouldLazyLoad: _shouldLazyLoad,
 
             // testing
             reset: function () {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -291,7 +291,7 @@ define([
             window.googletag.cmd.push(setPageTargeting);
             window.googletag.cmd.push(defineSlots);
 
-            if (_shouldLazyLoad()) {
+            if (shouldLazyLoad()) {
                 window.googletag.cmd.push(displayLazyAds);
             } else {
                 window.googletag.cmd.push(displayAds);
@@ -674,10 +674,7 @@ define([
                 return keyword.split('/').pop();
             });
         },
-        /**
-         * Used privately but exposed pnly for unit testing
-         * */
-        _shouldLazyLoad = function () {
+        shouldLazyLoad = function () {
             // We do not want lazy loading on pageskins because it messes up the roadblock
             return config.switches.viewability && !(config.page.hasPageSkin && detect.getBreakpoint() === 'wide');
         },
@@ -690,7 +687,8 @@ define([
             addSlot:        addSlot,
             refreshSlot:    refreshSlot,
             getSlots:       getSlots,
-            shouldLazyLoad: _shouldLazyLoad,
+            // Used privately but exposed only for unit testing
+            shouldLazyLoad: shouldLazyLoad,
 
             // testing
             reset: function () {

--- a/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
@@ -109,9 +109,7 @@ describe('DFP', function () {
                 defineSizeMapping: sinon.spy(function () { return window.googletag; }),
                 setTargeting: sinon.spy(function () { return window.googletag; }),
                 enableServices: sinon.spy(),
-                display: sinon.spy(),
-                displayLazyAds: sinon.spy(function () { return window.googletag; }),
-                displayAds: sinon.spy(function () { return window.googletag; })
+                display: sinon.spy()
             };
             //jscs:disable disallowEmptyBlocks
             ophanTracking.trackPerformance = ()=> {

--- a/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
@@ -37,7 +37,7 @@ describe('DFP', function () {
             };
         },
         injector = new Injector(),
-        dfp, config, commercialFeatures;
+        dfp, config, detect, commercialFeatures;
 
     beforeEach(function (done) {
 
@@ -45,12 +45,14 @@ describe('DFP', function () {
             'common/modules/commercial/dfp',
             'common/utils/config',
             'common/modules/commercial/dfp-ophan-tracking',
-            'common/modules/commercial/commercial-features'
+            'common/modules/commercial/commercial-features',
+            'common/utils/detect'
         ], function () {
             dfp = arguments[0];
             config = arguments[1];
             let ophanTracking = arguments[2];
             commercialFeatures = arguments[3];
+            detect = arguments[4];
 
             config.switches = {
                 commercialComponents: true,
@@ -107,7 +109,9 @@ describe('DFP', function () {
                 defineSizeMapping: sinon.spy(function () { return window.googletag; }),
                 setTargeting: sinon.spy(function () { return window.googletag; }),
                 enableServices: sinon.spy(),
-                display: sinon.spy()
+                display: sinon.spy(),
+                displayLazyAds: sinon.spy(),
+                displayAds: sinon.spy()
             };
             //jscs:disable disallowEmptyBlocks
             ophanTracking.trackPerformance = ()=> {
@@ -210,6 +214,33 @@ describe('DFP', function () {
         dfp.init();
         window.googletag.cmd.forEach(function (func) { func(); });
         expect(window.googletag.defineOutOfPageSlot).toHaveBeenCalledWith('/123456/theguardian.com/front', 'dfp-ad-html-slot');
+    });
+
+    describe('pageskin loading', function () {
+
+        it('should lazy load ads when there is no pageskin', function () {
+            detect.getBreakpoint = function () {
+                return 'wide';
+            };
+            config.switches.viewability = true;
+            config.page.hasPageSkin = false;
+            dfp.init();
+            window.googletag.cmd.forEach(function (func) { func(); });
+            expect(window.googletag.pubads().displayLazyAds).toHaveBeenCalled();
+        });
+
+        xit('should lazy load ads when there is a pageskin and breakpoint is lower than wide', function () {
+            dfp.init();
+            window.googletag.cmd.forEach(function (func) { func(); });
+            expect(window.googletag.pubads().setTargeting).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
+        });
+
+        xit('should not lazy load ads when there is a pageskin and breakpoint is wide', function () {
+            dfp.init();
+            window.googletag.cmd.forEach(function (func) { func(); });
+            expect(window.googletag.pubads().setTargeting).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
+        });
+
     });
 
     describe('keyword targeting', function () {

--- a/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/dfp.spec.js
@@ -110,8 +110,8 @@ describe('DFP', function () {
                 setTargeting: sinon.spy(function () { return window.googletag; }),
                 enableServices: sinon.spy(),
                 display: sinon.spy(),
-                displayLazyAds: sinon.spy(),
-                displayAds: sinon.spy()
+                displayLazyAds: sinon.spy(function () { return window.googletag; }),
+                displayAds: sinon.spy(function () { return window.googletag; })
             };
             //jscs:disable disallowEmptyBlocks
             ophanTracking.trackPerformance = ()=> {
@@ -224,21 +224,25 @@ describe('DFP', function () {
             };
             config.switches.viewability = true;
             config.page.hasPageSkin = false;
-            dfp.init();
-            window.googletag.cmd.forEach(function (func) { func(); });
-            expect(window.googletag.pubads().displayLazyAds).toHaveBeenCalled();
+            expect(dfp.shouldLazyLoad()).toBe(true);
         });
 
-        xit('should lazy load ads when there is a pageskin and breakpoint is lower than wide', function () {
-            dfp.init();
-            window.googletag.cmd.forEach(function (func) { func(); });
-            expect(window.googletag.pubads().setTargeting).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
+        it('should lazy load ads when there is a pageskin and breakpoint is lower than wide', function () {
+            detect.getBreakpoint = function () {
+                return 'desktop';
+            };
+            config.switches.viewability = true;
+            config.page.hasPageSkin = true;
+            expect(dfp.shouldLazyLoad()).toBe(true);
         });
 
-        xit('should not lazy load ads when there is a pageskin and breakpoint is wide', function () {
-            dfp.init();
-            window.googletag.cmd.forEach(function (func) { func(); });
-            expect(window.googletag.pubads().setTargeting).toHaveBeenCalledWith('k', ['korea', 'ukraine']);
+        it('should not lazy load ads when there is a pageskin and breakpoint is wide', function () {
+            detect.getBreakpoint = function () {
+                return 'wide';
+            };
+            config.switches.viewability = true;
+            config.page.hasPageSkin = true;
+            expect(dfp.shouldLazyLoad()).toBe(false);
         });
 
     });


### PR DESCRIPTION
This PR leaves lazy loading on for non-wide breakpoints when a pageskin campaign is serving.
