### PR TITLE
Create immersive article templates and style header

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -93,7 +93,11 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
       val htmlResponse = () => if (request.isAmp) {
         views.html.articleAMP(article)
       } else {
-        views.html.article(article)
+          if (article.article.isImmersive) {
+            views.html.articleImmersive(article)
+          } else {
+            views.html.article(article)
+          }
       }
       val jsonResponse = () => views.html.fragments.articleBody(article)
       renderFormat(htmlResponse, jsonResponse, model.article, Switches.all)

--- a/article/app/views/articleImmersive.scala.html
+++ b/article/app/views/articleImmersive.scala.html
@@ -1,0 +1,7 @@
+@(model: ArticlePage)(implicit request: RequestHeader)
+@import conf.switches.Switches._
+
+@main(model.article){
+}{
+    @fragments.articleBodyImmersive(model)
+}

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -27,21 +27,9 @@
 
             @fragments.headImmersive(article)
 
-            @if(article.isFeature && article.hasShowcaseMainElement) {
-                @fragments.mainMedia(article, amp)
-            }
-
             <div class="content__main tonal__main tonal__main--@articleToneClass(article)">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--article js-content-main-column @if(article.isSudoku) {sudoku}">
-
-                        <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
-
-                        @if(!(article.isFeature && article.hasShowcaseMainElement)) {
-                            @fragments.mainMedia(article, amp)
-                        }
-
-                        @fragments.witnessCallToAction(article)
 
                         @fragments.contentMeta(article)
 

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -15,14 +15,7 @@
             <meta itemprop="mainEntityOfPage" content="@LinkTo(article.url)">
             <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
                 <meta itemprop="name" content="The Guardian">
-                @if(amp) {
-                    @* AMP doesn't support sameAs *@
-                    <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
-                        <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
-                    </div>
-                } else {
-                    <link itemprop="sameAs" href="http://www.theguardian.com">
-                }
+                <link itemprop="sameAs" href="http://www.theguardian.com">
             </div>
 
             @fragments.headImmersive(article)
@@ -58,11 +51,5 @@
                 </div>
             </div>
         </article>
-
-        @* Currently AMP documents don't support most of what we do in the footer *@
-        @if(!amp) {
-            @fragments.contentFooter(article, model.related)
-        }
-
     </div>
 }

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -8,7 +8,7 @@
 @defining(model.article) { article =>
     <div class="l-side-margins">
         <article id="article" data-test-id="article-root"
-            class="content content--article tonal tonal--@articleToneClass(article) section-@article.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
+            class="content content--article content--immersive tonal tonal--@articleToneClass(article) section-@article.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
             @if(article.isAdvertisementFeature){content--advertisement-feature}
             @if(article.isFeature && article.hasShowcaseMainElement){has-feature-showcase-element}"
             itemscope itemtype="@article.schemaType" role="main">
@@ -25,7 +25,7 @@
                 }
             </div>
 
-            @fragments.headTonal(article)
+            @fragments.headImmersive(article)
 
             @if(article.isFeature && article.hasShowcaseMainElement) {
                 @fragments.mainMedia(article, amp)

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -1,0 +1,80 @@
+
+@(model: ArticlePage, amp: Boolean = false)(implicit request: RequestHeader)
+
+@import common.LinkTo
+@import views.BodyCleaner
+@import views.support.TrailCssClasses.articleToneClass
+
+@defining(model.article) { article =>
+    <div class="l-side-margins">
+        <article id="article" data-test-id="article-root"
+            class="content content--article tonal tonal--@articleToneClass(article) section-@article.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
+            @if(article.isAdvertisementFeature){content--advertisement-feature}
+            @if(article.isFeature && article.hasShowcaseMainElement){has-feature-showcase-element}"
+            itemscope itemtype="@article.schemaType" role="main">
+            <meta itemprop="mainEntityOfPage" content="@LinkTo(article.url)">
+            <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
+                <meta itemprop="name" content="The Guardian">
+                @if(amp) {
+                    @* AMP doesn't support sameAs *@
+                    <div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">
+                        <meta itemprop="url" content="https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/10/1/1443713974413/Guardiantitlepiecedigitalon.png">
+                    </div>
+                } else {
+                    <link itemprop="sameAs" href="http://www.theguardian.com">
+                }
+            </div>
+
+            @fragments.headTonal(article)
+
+            @if(article.isFeature && article.hasShowcaseMainElement) {
+                @fragments.mainMedia(article, amp)
+            }
+
+            <div class="content__main tonal__main tonal__main--@articleToneClass(article)">
+                <div class="gs-container">
+                    <div class="content__main-column content__main-column--article js-content-main-column @if(article.isSudoku) {sudoku}">
+
+                        <div class="js-sport-tabs football-tabs content__mobile-full-width"></div>
+
+                        @if(!(article.isFeature && article.hasShowcaseMainElement)) {
+                            @fragments.mainMedia(article, amp)
+                        }
+
+                        @fragments.witnessCallToAction(article)
+
+                        @fragments.contentMeta(article)
+
+                        @if(article.isNews && !article.hasMainEmbed && article.elements("main").isEmpty) {
+                            <hr class="content__hr hide-until-leftcol" />
+                        }
+
+                        @fragments.chapterHeadings(article)
+
+                        <div class="content__article-body from-content-api js-article__body" itemprop="@if(article.isReview){reviewBody} else {articleBody}"
+                            data-test-id="article-review-body">
+                            @BodyCleaner(article, article.body, amp = amp)
+                        </div>
+
+                        @fragments.witnessCallToAction(article)
+
+                        @fragments.submeta(article)
+
+                        <div class="after-article js-after-article"></div>
+                    </div>
+
+                    <div class="content__secondary-column js-secondary-column" aria-hidden="true">
+                        <div class="ad-slot-container js-ad-slot-container"></div>
+                        <div class="js-components-container"></div>
+                    </div>
+                </div>
+            </div>
+        </article>
+
+        @* Currently AMP documents don't support most of what we do in the footer *@
+        @if(!amp) {
+            @fragments.contentFooter(article, model.related)
+        }
+
+    </div>
+}

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -339,6 +339,7 @@ class Article(delegate: contentapi.Content) extends Content(delegate) with Light
   lazy val main: String = delegate.safeFields.getOrElse("main","")
   lazy val body: String = delegate.safeFields.getOrElse("body","")
   override lazy val contentType = GuardianContentTypes.Article
+  override lazy val isImmersive: Boolean = displayHint.contains("immersive")
 
   override lazy val analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}"
   override def schemaType = Some(ArticleSchemas(this))

--- a/common/app/views/fragments/headImmersive.scala.html
+++ b/common/app/views/fragments/headImmersive.scala.html
@@ -2,16 +2,20 @@
 
 @import views.support.TrailCssClasses.articleToneClass
 @import views.support.ContributorLinks
+@import views.support.ImgSrc
+
 
 <header class="content__head content__head--desktop tonal__head tonal__head--@articleToneClass(content)
-    @if(content.hasTonalHeaderByline && content.hasLargeContributorImage) { content__head--byline-pic}">
+    @if(content.hasTonalHeaderByline && content.hasLargeContributorImage) { content__head--byline-pic}"
+        style="background-image: url('@content.mainPicture.map { picture => @ImgSrc.findNearestSrc(picture, Profile(width = Some(1300)))}');">
 
     <div class="gs-container content__logo-container">
         @fragments.inlineSvg("guardian-logo-160", "logo", Seq("content__logo"))
     </div>
 
     <div class="content__header">
-        <div class="content__head--mobile">
+        <div class="content__head--mobile"
+            style="background-image: url('@content.mainPicture.map { picture => @ImgSrc.findNearestSrc(picture, Profile(width = Some(1300)))}');">
             <div class="content__wrapper content__wrapper--headline">
                 <div class="gs-container">
                     <h1 class="content__headline">@Html(content.headline)</h1>

--- a/common/app/views/fragments/headImmersive.scala.html
+++ b/common/app/views/fragments/headImmersive.scala.html
@@ -6,8 +6,8 @@
 <header class="content__head content__head--desktop tonal__head tonal__head--@articleToneClass(content)
     @if(content.hasTonalHeaderByline && content.hasLargeContributorImage) { content__head--byline-pic}">
 
-    <div class="gs-container">
-        Logo
+    <div class="gs-container content__logo-container">
+        @fragments.inlineSvg("guardian-logo-160", "logo", Seq("content__logo"))
     </div>
 
     <div class="content__header">
@@ -22,7 +22,7 @@
         <div class="content__wrapper">
             <div class="gs-container">
                 @if(content.standfirst.isDefined) {
-                    <div class="content__standfirst">@fragments.standfirst(content)</div>
+                    @fragments.standfirst(content)
                 }
             </div>
         </div>

--- a/common/app/views/fragments/headImmersive.scala.html
+++ b/common/app/views/fragments/headImmersive.scala.html
@@ -1,0 +1,30 @@
+@(content: model.Content, showBadge: Boolean = false)(implicit request: RequestHeader)
+
+@import views.support.TrailCssClasses.articleToneClass
+@import views.support.ContributorLinks
+
+<header class="content__head content__head--desktop tonal__head tonal__head--@articleToneClass(content)
+    @if(content.hasTonalHeaderByline && content.hasLargeContributorImage) { content__head--byline-pic}">
+
+    <div class="gs-container">
+        Logo
+    </div>
+
+    <div class="content__header">
+        <div class="content__head--mobile">
+            <div class="content__wrapper content__wrapper--headline">
+                <div class="gs-container">
+                    <h1 class="content__headline">@Html(content.headline)</h1>
+                </div>
+            </div>
+        </div>
+
+        <div class="content__wrapper">
+            <div class="gs-container">
+                @if(content.standfirst.isDefined) {
+                    <div class="content__standfirst">@fragments.standfirst(content)</div>
+                }
+            </div>
+        </div>
+    </div>
+</header>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -43,18 +43,20 @@ http://developers.theguardian.com/join-the-team.html
 
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
-        @if(showAdverts) {
-            @fragments.commercial.topBanner(metaData, edition)
-        }
-
-        @fragments.header(metaData)
-
-        @if(adBelowNav) {
-            @fragments.commercial.topBannerBelowNav()
-        }
-
-        @if(showAdverts) {
-            @fragments.commercial.topBannerMobile(metaData, edition)
+        @if(!(metaData.isImmersive && metaData.isArticle)) {
+            @if(showAdverts) {
+                @fragments.commercial.topBanner(metaData, edition)
+            }
+    
+            @fragments.header(metaData)
+    
+            @if(adBelowNav) {
+                @fragments.commercial.topBannerBelowNav()
+            }
+    
+            @if(showAdverts) {
+                @fragments.commercial.topBannerMobile(metaData, edition)
+            }
         }
 
         <div id="maincontent" class="js-maincontent" tabindex="0"></div>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -57,9 +57,9 @@ http://developers.theguardian.com/join-the-team.html
             @if(showAdverts) {
                 @fragments.commercial.topBannerMobile(metaData, edition)
             }
-        }
 
-        <div id="maincontent" class="js-maincontent" tabindex="0"></div>
+            <div id="maincontent" class="js-maincontent" tabindex="0"></div>
+        }
 
         @if(BreakingNewsSwitch.isSwitchedOn) {
             <div class="js-breaking-news-placeholder breaking-news breaking-news--hidden breaking-news--fade-in"

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -122,7 +122,7 @@ object ImgSrc extends Logging {
     }
   }
 
-  private def findNearestSrc(imageContainer: ImageContainer, profile: Profile): Option[String] = {
+  def findNearestSrc(imageContainer: ImageContainer, profile: Profile): Option[String] = {
     profile.elementFor(imageContainer).flatMap(_.url).map{ largestImage =>
       ImgSrc(largestImage, profile)
     }

--- a/static/src/stylesheets/head.content.scss
+++ b/static/src/stylesheets/head.content.scss
@@ -14,6 +14,7 @@
 @import 'module/_layout-hints';
 @import 'module/_live-pulse';
 @import 'module/_chapters';
+@import 'module/content/_article-immersive';
 
 
 /* ==========================================================================

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -32,14 +32,13 @@
     }
 
     .content__logo {
-        fill: white;
         float: right;
         width: 160px;
         height: auto;
         margin-top: $gs-baseline / 2;
 
-        @include mq(tablet) {
-            fill: #333;
+        svg path {
+            fill: white;
         }
     }
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -31,12 +31,17 @@
 
     .content__logo {
         float: right;
-        width: gs-span(3) + $gs-gutter;
+        width: gs-span(2) + $gs-gutter;
         height: auto;
         margin-top: $gs-baseline / 2;
 
-        svg path {
-            fill: #ffffff;
+        svg {
+            width: 100%;
+            height: auto;
+
+            path {
+                fill: #ffffff;
+            }
         }
     }
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -1,0 +1,134 @@
+.content--immersive {
+
+    &.content {
+        border-top: 0;
+    }
+
+    .content__main {
+        padding: 0;
+    }
+
+    .content__article-body {
+        clear: both;
+    }
+    
+    .js-components-container {
+        display: none;
+    }
+
+// HEADER
+
+    .content__head {
+        position: relative;
+        color: white;
+    }
+
+    .content__wrapper {
+        background-color: rgba(0, 0, 0, .5);
+    }
+
+    .content__logo-container {
+        z-index: 2;
+    }
+
+    .content__logo {
+        fill: white;
+        float: right;
+        width: 160px;
+        height: auto;
+        margin-top: $gs-baseline / 2;
+
+        @include mq(tablet) {
+            fill: #333;
+        }
+    }
+
+    .content__headline,
+    .content__standfirst {
+        max-width: 620px;
+
+        @include mq(leftCol) {
+            margin-left: 160px;
+        }
+
+        @include mq(wide) {
+            margin-left: 240px;
+        }
+    }
+
+    .content__headline {
+        font-size: 2.2rem;
+        font-weight: 200;
+        line-height: 1;
+        padding-top: $gs-baseline / 2;
+        padding-bottom: 1em;
+
+        @include mq(desktop) {
+            font-size: 3.25rem;
+        }
+    }
+
+    .content__standfirst {
+        position: relative;
+        padding-top: 0.33em;
+        padding-bottom: 1em;
+        margin-bottom: 0;
+        color: white;
+
+        @include mq(desktop) {
+            &:before {
+                content: "";
+                position: absolute;
+                top: 0;
+                height: 2px;
+                width: 140px;
+                background-color: rgba(255, 255, 255, 0.2);
+            }
+        }
+
+        a {
+            color: #f7acbb;
+            border-bottom: 1px solid rgba(#f7acbb, 0.4);
+
+            &:hover {
+                text-decoration: none;
+                border-bottom-color: rgba(#f7acbb, 0.8);
+            }
+        }
+    }
+
+    @include mq($until: desktop) {
+        .content__head--mobile {
+            position: relative;
+            height: 100vh;
+            max-height: 800px; // Temp fix for old iOS devices that don't support 100vh
+            background-image: url('https://i.guim.co.uk/img/media/50ec0d0052fb79b576f607fd46fe4a748728366f/0_0_1400_840/master/1400.jpg?w=1920&q=85&auto=format&sharp=10&s=330c4580dd085312c02c0dc905b5b202');
+            background-position: center center;
+            background-size: cover;
+        }
+
+        .content__wrapper--headline {
+            position: absolute;
+            left: 0;
+            bottom: 0;
+            right: 0;
+        }
+    }
+
+    @include mq(desktop) {
+        .content__head--desktop {
+            position: relative;
+            height: 100vh;
+            background-image: url('https://i.guim.co.uk/img/media/50ec0d0052fb79b576f607fd46fe4a748728366f/0_0_1400_840/master/1400.jpg?w=1920&q=85&auto=format&sharp=10&s=330c4580dd085312c02c0dc905b5b202');
+            background-position: center center;
+            background-size: cover;
+        }
+
+        .content__header {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+        }
+    }
+}

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -1,5 +1,4 @@
 .content--immersive {
-
     &.content {
         border-top: 0;
     }
@@ -16,11 +15,10 @@
         display: none;
     }
 
-// HEADER
-
+    // HEADER
     .content__head {
         position: relative;
-        color: white;
+        color: #ffffff;
     }
 
     .content__wrapper {
@@ -33,25 +31,25 @@
 
     .content__logo {
         float: right;
-        width: 160px;
+        width: gs-span(3) + $gs-gutter;
         height: auto;
         margin-top: $gs-baseline / 2;
 
         svg path {
-            fill: white;
+            fill: #ffffff;
         }
     }
 
     .content__headline,
     .content__standfirst {
-        max-width: 620px;
+        max-width: gs-span(8);
 
         @include mq(leftCol) {
-            margin-left: 160px;
+            margin-left: gs-span(2) + $gs-gutter;
         }
 
         @include mq(wide) {
-            margin-left: 240px;
+            margin-left: gs-span(3) + $gs-gutter;
         }
     }
 
@@ -69,29 +67,29 @@
 
     .content__standfirst {
         position: relative;
-        padding-top: 0.33em;
+        padding-top: .33em;
         padding-bottom: 1em;
         margin-bottom: 0;
-        color: white;
+        color: #ffffff;
 
         @include mq(desktop) {
             &:before {
-                content: "";
+                content: '';
                 position: absolute;
                 top: 0;
                 height: 2px;
-                width: 140px;
-                background-color: rgba(255, 255, 255, 0.2);
+                width: gs-span(2);
+                background-color: rgba(255, 255, 255, .2);
             }
         }
 
         a {
-            color: #f7acbb;
-            border-bottom: 1px solid rgba(#f7acbb, 0.4);
+            color: colour(feature-mute);
+            border-bottom: 1px solid rgba(colour(feature-mute), .4);
 
             &:hover {
                 text-decoration: none;
-                border-bottom-color: rgba(#f7acbb, 0.8);
+                border-bottom-color: rgba(colour(feature-mute), .8);
             }
         }
     }
@@ -100,7 +98,7 @@
         .content__head--mobile {
             position: relative;
             height: 100vh;
-            max-height: 800px; // Temp fix for old iOS devices that don't support 100vh
+            max-height: 800px;
             background-image: url('https://i.guim.co.uk/img/media/50ec0d0052fb79b576f607fd46fe4a748728366f/0_0_1400_840/master/1400.jpg?w=1920&q=85&auto=format&sharp=10&s=330c4580dd085312c02c0dc905b5b202');
             background-position: center center;
             background-size: cover;

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -3,16 +3,14 @@
         border-top: 0;
     }
 
-    .content__main {
-        padding: 0;
+    .content__meta-container {
+        @include mq(leftCol) {
+            position: absolute !important;
+        }
     }
 
     .content__article-body {
         clear: both;
-    }
-    
-    .js-components-container {
-        display: none;
     }
 
     // HEADER
@@ -104,9 +102,12 @@
             position: relative;
             height: 100vh;
             max-height: 800px;
-            background-image: url('https://i.guim.co.uk/img/media/50ec0d0052fb79b576f607fd46fe4a748728366f/0_0_1400_840/master/1400.jpg?w=1920&q=85&auto=format&sharp=10&s=330c4580dd085312c02c0dc905b5b202');
             background-position: center center;
             background-size: cover;
+        }
+
+        .content__head--desktop {
+            background-image: none !important;
         }
 
         .content__wrapper--headline {
@@ -121,9 +122,12 @@
         .content__head--desktop {
             position: relative;
             height: 100vh;
-            background-image: url('https://i.guim.co.uk/img/media/50ec0d0052fb79b576f607fd46fe4a748728366f/0_0_1400_840/master/1400.jpg?w=1920&q=85&auto=format&sharp=10&s=330c4580dd085312c02c0dc905b5b202');
             background-position: center center;
             background-size: cover;
+        }
+
+        .content__head--mobile {
+            background-image: none !important;
         }
 
         .content__header {

--- a/static/src/stylesheets/module/content/_article.scss
+++ b/static/src/stylesheets/module/content/_article.scss
@@ -57,8 +57,3 @@
         display: none;
     }
 }
-
-.js-on.is-modern .is-immersive .l-side-margins {
-    display: none;
-}
-

--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -169,6 +169,11 @@
     }
 }
 
+.js-on.is-modern .is-immersive .content--interactive,
+.js-on.is-modern .is-immersive .content--interactive ~ * {
+    display: none;
+}
+
 .is-immersive {
     figure.element {
         margin: 0;


### PR DESCRIPTION
# ARE YOU READY TO BE IMMERSED!?!¡?

This takes advantage of the new `immersive` switch added to composer for all articles – it previously was only available for `interactives`. This new immersive article is designed for our longer reads and [long reads](http://www.theguardian.com/news/series/the-long-read) to have the nicer presentation we want and they deserve, but also to maintain some consistency. This is just the initial PR, there will be more to come, mainly styling.

I've created a new a new article template as we'll be deviating from the basic one quite a bit and it avoids death by a hundred if statements. The rest should be fairly self-explanatory.

Here's the screenshot bit...

Mobile:
![screen shot 2015-10-08 at 16 36 11](https://cloud.githubusercontent.com/assets/1607666/10371432/4c6fcb0c-6ddb-11e5-8700-e9a03e938030.png)

Desktop:
![screen shot 2015-10-08 at 16 40 49](https://cloud.githubusercontent.com/assets/1607666/10371438/5bb40a74-6ddb-11e5-8a82-a18ce2964753.png)
