### PR TITLE
Video icon alignment issue on video end state

### DIFF
--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -158,6 +158,7 @@
                 height: .75em;
                 width: 1.1em;
                 margin-right: .3em;
+                position: relative;
             }
         }
     }


### PR DESCRIPTION
In response to https://github.com/guardian/frontend/issues/10823.

Before:
![screen shot 2015-10-09 at 11 24 04](https://cloud.githubusercontent.com/assets/14570016/10391731/cfb7b590-6e78-11e5-8645-e6e436ad4ed4.png)

After:
![screen shot 2015-10-09 at 11 24 23](https://cloud.githubusercontent.com/assets/14570016/10391730/cfb4f88c-6e78-11e5-9a68-2ab9a7891e57.png)
