### PR TITLE
 removing development attr for amp validator

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -13,7 +13,7 @@
         <title>@views.support.Title(metaData)</title>
         <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
         @fragments.amp.stylesheets.main(metaData)
-        <script src="https://cdn.ampproject.org/v0.js" @if(Play.isDev) { development } async></script>
+        <script src="https://cdn.ampproject.org/v0.js" async></script>
         <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>


### PR DESCRIPTION
AMP is no longer advising people to use the development attribute, instead us `#development=1`.

https://github.com/ampproject/amphtml/issues/408
