### PR TITLE
Defer running of adBlockInUse

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -135,7 +135,7 @@ define([
         this.s.prop31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
         this.s.eVar31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
 
-        this.s.prop40    = detect.adblockInUse || detect.getFirefoxAdblockPlusInstalled();
+        this.s.prop40    = detect.adblockInUse() || detect.getFirefoxAdblockPlusInstalled();
 
         this.s.prop51  = config.page.allowUserGeneratedContent ? 'witness-contribution-cta-shown' : null;
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp.js
@@ -174,7 +174,7 @@ define([
         showSponsorshipPlaceholder = function () {
             var sponsorshipIdsFound = isSponsorshipContainerTest();
 
-            if (detect.adblockInUse && sponsorshipIdsFound.length) {
+            if (detect.adblockInUse() && sponsorshipIdsFound.length) {
                 fastdom.write(function () {
                     _.forEach(sponsorshipIdsFound, function (value) {
                         var sponsorshipIdFoundEl = $(value),

--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -47,7 +47,7 @@ define([
                 }
             ]);
 
-        if (detect.getBreakpoint() !== 'mobile' && detect.adblockInUse && config.switches.adblock && alreadyVisted > 1) {
+        if (detect.getBreakpoint() !== 'mobile' && detect.adblockInUse() && config.switches.adblock && alreadyVisted > 1) {
             new Message('adblock-message', {
                 pinOnHide: false,
                 siteMessageLinkName: 'adblock message variant ' + message.id,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-uk.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-uk.js
@@ -43,7 +43,7 @@ define([
              * - Only show to visitors who have viewed more than 10 pages.
              */
             var alreadyVisited = storage.local.get('alreadyVisited') || 0;
-            return !detect.adblockInUse &&
+            return !detect.adblockInUse() &&
                 detect.getBreakpoint() !== 'mobile' &&
                 config.page.edition === 'UK' &&
                 config.page.contentType === 'Article' &&

--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-usa.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership-message-usa.js
@@ -43,7 +43,7 @@ define([
              * - Only show to visitors who have viewed at least 10 pages.
              */
             var alreadyVisited = storage.local.get('alreadyVisited') || 0;
-            return !detect.adblockInUse &&
+            return !detect.adblockInUse() &&
                 detect.getBreakpoint() !== 'mobile' &&
                 config.page.edition === 'US' &&
                 config.page.contentType === 'Article' &&

--- a/static/src/javascripts/projects/common/modules/navigation/sticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/sticky.js
@@ -46,7 +46,7 @@ define([
         this.isAppleCampaign = config.page.hasBelowTopNavSlot;
         this.isSensitivePage = config.page.section === 'childrens-books-site' || config.page.shouldHideAdverts;
         this.isProfilePage = config.page.section === 'identity';
-        this.isAdblockInUse = detect.adblockInUse;
+        this.isAdblockInUse = detect.adblockInUse();
 
         _.bindAll(this, 'updatePositionMobile', 'updatePositionAdblock', 'updatePositionApple', 'updatePosition');
     }

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -387,8 +387,8 @@ define([
 
     function adblockInUse() {
         if (!detect.cachedAdblockInUse) {
-            var sacrificialAd = createSacrificialAd();
-            var contentBlocked = isHidden(sacrificialAd);
+            var sacrificialAd = createSacrificialAd(),
+                contentBlocked = isHidden(sacrificialAd);
             sacrificialAd.remove();
             detect.cachedAdblockInUse = contentBlocked;
             return contentBlocked;

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -386,10 +386,15 @@ define([
     }
 
     function adblockInUse() {
-        var sacrificialAd = createSacrificialAd();
-        var contentBlocked = isHidden(sacrificialAd);
-        sacrificialAd.remove();
-        return contentBlocked;
+        if(!detect.cachedAdblockInUse) {
+            var sacrificialAd = createSacrificialAd();
+            var contentBlocked = isHidden(sacrificialAd);
+            sacrificialAd.remove();
+            detect.cachedAdblockInUse = contentBlocked;
+            return contentBlocked;
+        }
+
+        return detect.cachedAdblockInUse;
 
         function isHidden(bonzoElement) {
             return bonzoElement.css('display') === 'none';
@@ -440,7 +445,7 @@ define([
         getPageSpeed: getPageSpeed,
         breakpoints: breakpoints,
         isModernBrowser: isModernBrowser,
-        adblockInUse: adblockInUse(),
+        adblockInUse: adblockInUse,
         getFirefoxAdblockPlusInstalled: getFirefoxAdblockPlusInstalled
     };
     return detect;

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -386,7 +386,7 @@ define([
     }
 
     function adblockInUse() {
-        if(!detect.cachedAdblockInUse) {
+        if (!detect.cachedAdblockInUse) {
             var sacrificialAd = createSacrificialAd();
             var contentBlocked = isHidden(sacrificialAd);
             sacrificialAd.remove();


### PR DESCRIPTION
Fix for a longstanding bug: https://github.com/guardian/frontend/issues/9927

On slower browsers or when opening multiple tabs in Firefox, adBlockInUse would try to modify the dom before the dom was ready. This defers the running of adBlockInUse and stores its value.

@rich-nguyen 

This affects commercial components & tracking, can you take a look @Calanthe @uplne?
