### PR TITLE
Knocking back the colour of breadcrumb chevrons

### DIFF
--- a/static/src/stylesheets/module/nav/_navigation.scss
+++ b/static/src/stylesheets/module/nav/_navigation.scss
@@ -237,7 +237,7 @@ $c-navigation-expandable-background: colour(neutral-1);
 }
 .signposting__separator__inner {
     font-weight: 200;
-    color: $c-signposting-action;
+    color: colour(neutral-2);
     font-size: 27px;
     line-height: $navigation-height;
 }


### PR DESCRIPTION
Tiny change but something I that I've questioned for a while.

The current breadcrumb chevrons are an active link colour, feel like it would make sense to knock them back to neutral-2 grey.

From:
![screen shot 2015-10-09 at 14 38 33](https://cloud.githubusercontent.com/assets/14570016/10395311/27059fea-6e94-11e5-9980-d9376982f2ab.png)

To:
![screen shot 2015-10-09 at 14 38 15](https://cloud.githubusercontent.com/assets/14570016/10395310/26f4feb0-6e94-11e5-86b7-76ee1eefcead.png)
