### PR TITLE
Adds travel/skiing to the travel nav bar

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -196,6 +196,7 @@ trait Navigation {
   val budget = SectionLink("travel", "budget travel", "Budget travel", "/travel/budget")
   val australasiaTravel = SectionLink("australasia", "australasia", "Australasia", "/travel/australasia")
   val asiaTravel = SectionLink("asia", "asia", "Asia", "/travel/asia")
+  val skiingTravel = SectionLink("travel", "skiing", "Skiing", "/travel/skiing")
 
   //Environment
   val climateChange = SectionLink("environment", "climate change", "Climate change", "/environment/climate-change")

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -54,7 +54,7 @@ object Au extends Edition(
       NavItem(lifeandstyle, Seq(foodanddrink, healthandwellbeing, loveAndSex, family, women)),
       NavItem(fashion),
       NavItem(economy, economyLocalNav),
-      NavItem(travel, Seq(australasiaTravel, asiaTravel, uktravel, europetravel, usTravel)),
+      NavItem(travel, Seq(australasiaTravel, asiaTravel, uktravel, europetravel, usTravel, skiingTravel)),
       NavItem(media),
       NavItem(environment, Seq(cities, globalDevelopment)),
       NavItem(science),

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -116,7 +116,7 @@ object International extends Edition(
       NavItem(fashion),
       NavItem(environment, environmentLocalNav),
       NavItem(technology),
-      NavItem(travel, Seq(uktravel, europetravel, usTravel)),
+      NavItem(travel, Seq(uktravel, europetravel, usTravel, skiingTravel)),
       NavItem(money, Seq(property, savings, pensions, borrowing, workAndCareers)),
       NavItem(science),
       NavItem(guardianProfessional),

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -108,7 +108,7 @@ object Uk extends Edition(
       NavItem(fashion),
       NavItem(environment, environmentLocalNav),
       NavItem(technology),
-      NavItem(travel, Seq(uktravel, europetravel, usTravel)),
+      NavItem(travel, Seq(uktravel, europetravel, usTravel, skiingTravel)),
       NavItem(money, Seq(property, savings, pensions, borrowing, workAndCareers)),
       NavItem(science),
       NavItem(guardianProfessional),

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -72,7 +72,7 @@ object Us extends Edition(
       NavItem(lifeandstyle, Seq(foodanddrink, healthandwellbeing, loveAndSex, family, women, homeAndGarden)),
       NavItem(fashion),
       NavItem(business, businessLocalNav),
-      NavItem(travel, Seq(usaTravel, europetravel, uktravel)),
+      NavItem(travel, Seq(usaTravel, europetravel, uktravel, skiingTravel)),
       NavItem(environment, environmentLocalNav),
       NavItem(science),
       NavItem(media),


### PR DESCRIPTION
A new skiing front has been built for the Travel section in the lead up to a special in tomorrow's paper. This adds skiing to the travel nav bar.
:ski: :snowboarder: :snowflake: 
