### PR TITLE
Only remove margin on is-immersive for interactives

### DIFF
--- a/static/src/stylesheets/module/content/_interactive.scss
+++ b/static/src/stylesheets/module/content/_interactive.scss
@@ -174,7 +174,7 @@
     display: none;
 }
 
-.is-immersive {
+.is-immersive .content--interactive {
     figure.element {
         margin: 0;
     }


### PR DESCRIPTION
Because the interactives partial should be used for stuff that affects interactives...

Before:
![screen shot 2015-10-09 at 15 33 51](https://cloud.githubusercontent.com/assets/1607666/10396583/445c7738-6e9b-11e5-958a-f8feec98c040.png)

After:
![screen shot 2015-10-09 at 15 33 43](https://cloud.githubusercontent.com/assets/1607666/10396585/49c31b00-6e9b-11e5-9243-0fa73541bfeb.png)
