### PR TITLE
Bust local (browser) caches when switching editions

### DIFF
--- a/data/database/d492274aba9074f4686af37d20a3afcf613339da3bd9ae54784d5ab6750ca7bc
+++ b/data/database/d492274aba9074f4686af37d20a3afcf613339da3bd9ae54784d5ab6750ca7bc
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/fb741604f3ca2a1d8a7a3ff8ffa125ca2a833573d6e4613b28c144dfe511a594
+++ b/data/database/fb741604f3ca2a1d8a7a3ff8ffa125ca2a833573d6e4613b28c144dfe511a594
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/onward/app/controllers/ChangeEditionController.scala
+++ b/onward/app/controllers/ChangeEditionController.scala
@@ -7,7 +7,6 @@ import play.api.mvc._
 object ChangeEditionController extends Controller with PreferenceController {
   def render(editionId: String) = Action { implicit request =>
     NoCache(Edition.byId(editionId).map{ edition =>
-      val index = Edition.all.indexOf(edition)
       val home = edition.homePagePath
       // This INTCMP parameter is simply to cachebust the local cache of browsers
       // For people who switch a lot of editions (mixing going to the page directly and using the edition switcher)

--- a/onward/app/controllers/ChangeEditionController.scala
+++ b/onward/app/controllers/ChangeEditionController.scala
@@ -5,12 +5,16 @@ import model.NoCache
 import play.api.mvc._
 
 object ChangeEditionController extends Controller with PreferenceController {
-
   def render(editionId: String) = Action { implicit request =>
     NoCache(Edition.byId(editionId).map{ edition =>
-      switchTo("GU_EDITION" -> edition.id, edition.homePagePath)
+      val index = Edition.all.indexOf(edition)
+      val home = edition.homePagePath
+      // This INTCMP parameter is simply to cachebust the local cache of browsers
+      // For people who switch a lot of editions (mixing going to the page directly and using the edition switcher)
+      // the local cache is too long.
+      // Using an INTCMP as it follows a familiar pattern & gives extra tracking
+      val path = s"$home?INTCMP=CE_${edition.id}"
+      switchTo("GU_EDITION" -> edition.id, path)
     }.getOrElse(NotFound))
   }
-
-
 }

--- a/onward/test/controllers/ChangeEditionControllerTest.scala
+++ b/onward/test/controllers/ChangeEditionControllerTest.scala
@@ -13,7 +13,7 @@ import test.{ConfiguredTestSuite, TestRequest}
   "ChangeEditionController" should "redirect to correct page" in {
     val result = controllers.ChangeEditionController.render("uk")(TestRequest())
     status(result) should be(302)
-    header("Location", result) should be (Some("/uk"))
+    header("Location", result) should be (Some("/uk?INTCMP=CE_UK"))
   }
 
   it should "set a preference cookie" in {
@@ -32,7 +32,7 @@ import test.{ConfiguredTestSuite, TestRequest}
     GU_EDITION.maxAge.getOrElse(0) should be (5184000 +- 1)  // 60 days, this is seconds
     GU_EDITION.value should be ("INT")
 
-    header("Location", result).head should endWith ("/international")
+    header("Location", result).head should endWith ("/international?INTCMP=CE_INT")
   }
 
   it should "not cache" in {


### PR DESCRIPTION
For people who switch a lot of editions (mixing going to the page directly and using the edition switcher) the local cache is too long and results in them seeing unexpected pages. 

Using an `INTCMP=XX` as it follows a familiar pattern for users & gives us extra tracking.

`INTCMP` only busts the browser cache, it does not bust the CDN cache.
