### PR TITLE
Cleanup International edition.

### DIFF
--- a/article/test/ArticleControllerTest.scala
+++ b/article/test/ArticleControllerTest.scala
@@ -106,7 +106,7 @@ import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
   "International users" should "be in the International edition" in {
     val request = TestRequest("/world/2014/sep/24/radical-cleric-islamic-state-release-british-hostage-alan-henning")
       .withHeaders(
-        "X-GU-Edition" -> "intl"
+        "X-GU-Edition" -> "int"
       )
     val result = route(app, request).head
     contentAsString(result) should include ("\"edition\":\"INT\"")

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -2,11 +2,9 @@ package common
 
 import java.util.Locale
 
-import conf.switches.Switches.InternationalEditionBetaSwitch
 import org.joda.time.DateTimeZone
 import play.api.libs.json._
 import play.api.mvc.RequestHeader
-import Function.const
 
 // describes the ways in which editions differ from each other
 abstract class Edition(
@@ -32,8 +30,6 @@ abstract class Edition(
 
   def navigation: Seq[NavItem]
   def briefNav: Seq[NavItem]
-
-  def isBeta: Boolean = false
 
   def isEditionalised(id: String) = editionalisedSections.contains(id)
 
@@ -69,15 +65,9 @@ object Edition {
     // in production no cookies make it this far
     val editionFromCookie = request.cookies.get("GU_EDITION").map(_.value)
 
-    // TODO - temporary measure between coming out of Testing and going fully live
-    // Keeps the "control" group of the international edition in the UK edition
-    val isInternationalControlGroup = InternationalEdition(request).contains("control") &&
-      InternationalEditionBetaSwitch.isSwitchedOn
-
     editionFromParameter
      .orElse(editionFromHeader)
      .orElse(editionFromCookie)
-     .filter(const(!isInternationalControlGroup))
      .getOrElse(defaultEdition.id)
   }
 

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -4,7 +4,6 @@ import java.util.Locale
 
 import common._
 import conf.switches.Switches
-import conf.switches.Switches.InternationalEditionBetaSwitch
 import org.joda.time.DateTimeZone
 
 object International extends Edition(
@@ -17,13 +16,6 @@ object International extends Edition(
 ){
 
   implicit val INT = International
-
-  override def isBeta: Boolean = InternationalEditionBetaSwitch.isSwitchedOn
-
-  // TODO temporary to let us migrate cookies to proper value (i.e. INT)
-  // it is currently INTL
-  override def matchesCookie(cookieValue: String): Boolean = super.matchesCookie(cookieValue) ||
-    "INTL".equalsIgnoreCase(cookieValue)
 
   import Switches.RugbyWorldCupswitch
   val sportLocalNav: Seq[SectionLink] = Seq(

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -367,15 +367,4 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
-  val InternationalEditionBetaSwitch = Switch(
-    "Feature",
-    "international-edition-beta",
-    "International edition A/B test on",
-    safeState = On,
-    sellByDate = new LocalDate(2015, 10, 31),
-
-    exposeClientSide = true
-  )
-
-
 }

--- a/common/app/views/fragments/topNav/editionMenu.scala.html
+++ b/common/app/views/fragments/topNav/editionMenu.scala.html
@@ -10,20 +10,12 @@
             @Edition.others(request).map { edition =>
                 <a class="@RenderClasses(Map(
                     "brand-bar__item--action" -> true,
-                    "brand-bar__item--inline-action" -> true,
-                    "brand-bar__item--action-beta" -> edition.isBeta
+                    "brand-bar__item--inline-action" -> true
                 ))" data-edition="@edition.id"
                 data-link-name="switch to @edition.id edition"
                 href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")"
                 title="Switch to the @edition.id edition">
-                    @if(edition.isBeta) {
-                        <span class="u-h">switch to the </span>
-                        <span class="brand-bar__edition-name">@edition.id</span>
-                        <small class="brand-bar__beta">beta</small>
-                        <span class="u-h"> edition</span>
-                    }else{
-                        <span class="u-h">switch to the </span> @edition.id <span class="u-h"> edition</span>
-                    }
+                    <span class="u-h">switch to the </span> @edition.id <span class="u-h"> edition</span>
                 </a>
             }
         </li>

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -3,9 +3,22 @@
 @import common.LinkTo
 @import common.Edition
 @import common.editions._
-@import common.editions.Uk
 @import views.support.RenderClasses
 @import views.html.fragments.topNav.editionMenu
+
+@ellipsis() = {
+    <a class="brand-bar__item--action popup__toggle"
+    data-toggle="top-bar__popup--more" data-link-name="topNav : more"
+    aria-haspopup="true" aria-controls="guardian-services-top-menu">
+        <span class="rounded-icon control__icon-wrapper">
+            @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
+                <!--[if (gt IE 8)&(IEMobile)]><!-->
+            @fragments.inlineSvg("ellipsis-36", "icon")
+                <!--<![endif]-->
+        </span>
+        <span class="control__info" data-test-id="sign-in-name">more</span>
+    </a>
+}
 
 <div class="brand-bar__item--right brand-bar__item--right--@Edition(request).id.toLowerCase-edition"
      data-component="guardian-services">
@@ -19,17 +32,7 @@
                href="https://soulmates.theguardian.com/?INTCMP=NGW_TOPNAV_UK_GU_SOULMATES">dating</a>
         </div>
         <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--more">
-            <a class="brand-bar__item--action popup__toggle"
-               data-toggle="top-bar__popup--more" data-link-name="uk : topNav : more"
-               aria-haspopup="true" aria-controls="guardian-services-top-menu">
-                <span class="rounded-icon control__icon-wrapper">
-                    @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
-                    <!--[if (gt IE 8)&(IEMobile)]><!-->
-                    @fragments.inlineSvg("ellipsis-36", "icon")
-                    <!--<![endif]-->
-                </span>
-                <span class="control__info" data-test-id="sign-in-name">more</span>
-            </a>
+            @ellipsis()
             <div class="popup is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
@@ -69,17 +72,7 @@
                href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_US_GU_JOBS">jobs</a>
         </div>
         <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--more">
-            <a class="brand-bar__item--action popup__toggle"
-               data-toggle="top-bar__popup--more" data-link-name="topNav : more"
-               aria-haspopup="true" aria-controls="guardian-services-top-menu">
-                <span class="rounded-icon control__icon-wrapper">
-                    @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
-                    <!--[if (gt IE 8)&(IEMobile)]><!-->
-                    @fragments.inlineSvg("ellipsis-36", "icon")
-                    <!--<![endif]-->
-                </span>
-                <span class="control__info" data-test-id="sign-in-name">more</span>
-            </a>
+            @ellipsis()
             <div class="popup is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
@@ -98,17 +91,7 @@
                 href="http://www.theguardian.com/guardian-masterclasses/guardian-masterclasses-australia">masterclasses</a>
         </div>
         <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--more">
-            <a class="brand-bar__item--action popup__toggle"
-               data-toggle="top-bar__popup--more" data-link-name="topNav : more"
-               aria-haspopup="true" aria-controls="guardian-services-top-menu">
-                <span class="rounded-icon control__icon-wrapper">
-                    @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
-                    <!--[if (gt IE 8)&(IEMobile)]><!-->
-                    @fragments.inlineSvg("ellipsis-36", "icon")
-                    <!--<![endif]-->
-                </span>
-                <span class="control__info" data-test-id="sign-in-name">more</span>
-            </a>
+            @ellipsis()
             <div class="popup is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
@@ -125,34 +108,45 @@
             </div>
         </div>
     }
+    @if(Edition(request) == International){
+        <div class="brand-bar__item brand-bar__item--jobs">
+            <a class="brand-bar__item--action" data-link-name="us : topNav : jobs"
+            href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_INT_GU_JOBS">jobs</a>
+        </div>
+        <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--more">
+            @ellipsis()
+            <div class="popup is-off top-bar__popup--more" id="guardian-services-top-menu">
+                <h3 class="popup__group-header">from the guardian:</h3>
+                <ul class="popup__group">
+                    <li class="popup__item brand-bar__popup--jobs">
+                        <a class="brand-bar__item--action" data-link-name="us: topNav : jobs"
+                        href="http://jobs.theguardian.com/?INTCMP=NGW_TOPNAV_US_GU_JOBS">jobs</a>
+                    </li>
+                </ul>
+                @editionMenu()
+            </div>
+        </div>
+    }
     <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--edition" data-component="edition">
         <a class="@RenderClasses(Map(
             "brand-bar__item--action" -> true,
-            "popup__toggle" -> true,
-            "brand-bar__item--action-beta" -> Edition(request).isBeta
+            "popup__toggle" -> true
         ))"
            data-link-name="topNav : edition" data-toggle="top-bar__popup--edition"
            aria-haspopup="true" aria-controls="guardian-edition-menu">
-        @if(Edition(request).isBeta) {
-            <span class="brand-bar__edition-name">@Edition(request).displayName</span>
-            <small class="brand-bar__beta">beta</small>
-        } else {
             @Edition(request).displayName
-        }
         </a>
         <ul class="popup popup__group is-off top-bar__popup--edition" id="guardian-edition-menu">
             @Edition.others(request).map{ edition =>
                 <li class="popup__item">
                     <a class="@RenderClasses(Map(
-                        "brand-bar__item--action" -> true,
-                        "brand-bar__item--action-beta" -> edition.isBeta
+                        "brand-bar__item--action" -> true
                     ))" data-edition="@edition.id"
                         data-link-name="switch to @edition.id edition"
                         href="@LinkTo(s"/preference/edition/${edition.id.toLowerCase}")"
                         title="Switch to the @edition.id edition">
                         <span class="u-h">switch to the </span>
                         <span class="brand-bar__edition-name">@edition.displayName</span>
-                        @if(edition.isBeta) {<small class="brand-bar__beta">beta</small>}
                     </a>
                 </li>
             }

--- a/data/database/4068c0dd723a578d8ec1395ecfe95ef2c1a4121ab4c1acc06901ddd0b977e987
+++ b/data/database/4068c0dd723a578d8ec1395ecfe95ef2c1a4121ab4c1acc06901ddd0b977e987
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/6027421ecee4c9fc501159bc5bb1e6f1ea76390179ad49ca20b8a61276d20c55
+++ b/data/database/6027421ecee4c9fc501159bc5bb1e6f1ea76390179ad49ca20b8a61276d20c55
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/a8efc454bd1ffe06e9f0bef8488d55e23a237a266615b23156e0ee524df4a31f
+++ b/data/database/a8efc454bd1ffe06e9f0bef8488d55e23a237a266615b23156e0ee524df4a31f
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/d095d65d6d3d2de57ac3ec4e934a0a9fa5ded8d21307276877ea6d75574bec07
+++ b/data/database/d095d65d6d3d2de57ac3ec4e934a0a9fa5ded8d21307276877ea6d75574bec07
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/ecd0d2858c1dc6ff6adf645a2c5abd7d626a7972742b3c9c71c9d5412994bb33
+++ b/data/database/ecd0d2858c1dc6ff6adf645a2c5abd7d626a7972742b3c9c71c9d5412994bb33
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -101,35 +101,19 @@ import services.ConfigAgent
   it should "understand the international edition" in {
 
 
-    val international = FakeRequest("GET", "/").withHeaders("X-GU-Edition" -> "INTL", "X-GU-International" -> "international")
+    val international = FakeRequest("GET", "/").withHeaders("X-GU-Edition" -> "INT")
     val redirectToInternational = FaciaController.renderFront("")(international)
     header("Location", redirectToInternational).head should endWith ("/international")
-
-    val ukOptInRequest = FakeRequest("GET", "/").withHeaders("X-GU-Edition" -> "UK", "X-GU-International" -> "international")
-    val redirect = FaciaController.renderFront("")(ukOptInRequest)
-    header("Location", redirect).head should endWith ("/uk")
-
   }
 
   it should "obey when the international edition is set by cookie" in {
 
     val control = FakeRequest("GET", "/").withHeaders(
-      "X-GU-Edition" -> "INTL",
-      "X-GU-International" -> "control",
+      "X-GU-Edition" -> "INT",
       "X-GU-Edition-From-Cookie" -> "true"
     )
     val redirectToUk = FaciaController.renderFront("")(control)
     header("Location", redirectToUk).head should endWith ("/international")
-  }
-
-   // TODO - last piece of the puzzle
-  it should "obey the control group when the international edition is not set by cookie" in {
-    val control = FakeRequest("GET", "/").withHeaders(
-      "X-GU-Edition" -> "INTL",
-      "X-GU-International" -> "control"
-    )
-    val redirectToUk = FaciaController.renderFront("")(control)
-    header("Location", redirectToUk).head should endWith ("/uk")
   }
 
   it should "send international traffic ot the UK version of editionalised sections" in {

--- a/static/src/stylesheets/module/nav/_brand-bar.scss
+++ b/static/src/stylesheets/module/nav/_brand-bar.scss
@@ -297,39 +297,3 @@
         }
     }
 }
-
-// see .brand-bar__item--action above. This should be removed when we remove the 'beta' bit for International, as it's
-// ugly.
-.brand-bar__item--action-beta {
-    &:focus,
-    &:active {
-        &,
-        .control__info {
-            text-decoration: none;
-
-            .brand-bar__edition-name {
-                text-decoration: underline;
-            }
-        }
-    }
-
-    &:hover {
-        &,
-        .control__info {
-            text-decoration: none;
-
-            .brand-bar__edition-name {
-                text-decoration: underline;
-            }
-        }
-    }
-}
-
-.brand-bar__beta {
-    position: relative;
-    top: -6px;
-    font-weight: bold;
-    color: colour(news-main-2);
-    font-size: 12px;
-    text-decoration: none;
-}


### PR DESCRIPTION
Post launch this gets rid of some "temporary" code.

Also add the popup edition switcher to mobile for the International edition.

![int](https://cloud.githubusercontent.com/assets/76709/10428247/f42874ac-70e7-11e5-92f5-670ea90686f0.png)
