### PR TITLE
Check for crossword asset to ensure image is shown

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -268,6 +268,7 @@ case class ContentCard(
     case Some(InlineVideo(_, _, _, Some(_))) => true
     case Some(InlineImage(_)) => true
     case Some(InlineSlideshow(_)) => true
+    case Some(svg@CrosswordSvg(_)) => true
     case _ => false
   }
 

--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -268,7 +268,7 @@ case class ContentCard(
     case Some(InlineVideo(_, _, _, Some(_))) => true
     case Some(InlineImage(_)) => true
     case Some(InlineSlideshow(_)) => true
-    case Some(svg@CrosswordSvg(_)) => true
+    case Some(CrosswordSvg(_)) => true
     case _ => false
   }
 


### PR DESCRIPTION
Update ContentCard class method `hasImage` to also check for crossword SVG
## Before

![image](https://cloud.githubusercontent.com/assets/638051/10428718/45a5f6ee-70eb-11e5-8f7e-aaa6800e4026.png)
## After

![image](https://cloud.githubusercontent.com/assets/638051/10428756/95af17e2-70eb-11e5-88a4-bbefe20ec928.png)
