### PR TITLE
make force core work without a refresh

### DIFF
--- a/common/app/templates/headerInlineJS/shouldEnhance.scala.js
+++ b/common/app/templates/headerInlineJS/shouldEnhance.scala.js
@@ -4,8 +4,8 @@
 (function (navigator, window) {
     // Enable manual optin to core functionality/optout of enhancement
     var personPrefersCore = function () {
-        if (window.location.hash === '#core' || window.location.hash === 'gu.prefs.force-core=on') return true;
-        if (window.location.hash === '#nocore' || window.location.hash === 'gu.prefs.force-core=off') return false;
+        if (window.location.hash === '#core' || window.location.hash === '#gu.prefs.force-core=on') return true;
+        if (window.location.hash === '#nocore' || window.location.hash === '#gu.prefs.force-core=off') return false;
         try {
             var preference = window.localStorage.getItem('gu.prefs.force-core') || 'off';
             return /"value":"on"/.test(preference);


### PR DESCRIPTION
take account that window hash starts with a hash - probably a typo

@sndrs 
@ScottPainterGNM then we can update the article to say it doesn't actually need a refresh afterwards (and it will avoid the problem if /uk is crashing people's browser)
