### PR TITLE
Save for later alignment 

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -671,10 +671,11 @@ $block-height: 71px;
     }
 }
 
-.facia-page .fc-save-for-later:only-child {
+.fc-container .fc-save-for-later:only-child {
     @include mq(tablet) {
         border: 0;
         padding: 0;
+        margin-left: -$gs-gutter / 4;
     }
 }
 

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -636,17 +636,6 @@ $block-height: 71px;
         content: 'saved';
     }
 
-    @include mq(tablet) {
-        &:only-child {
-            border: 0;
-            padding: 0;
-        
-            .inline-icon {
-                margin-left: 0;
-            }
-        }
-    }
-
     @include mq($until: tablet) {
         border-left: 0;
         float: right;
@@ -678,6 +667,17 @@ $block-height: 71px;
         @include mq(tablet) {
             float: left;
             margin-right: $gs-gutter / 4;
+        }
+    }
+}
+
+.fc-save-for-later:only-child {
+    @include mq(tablet) {
+        border: 0;
+        padding: 0;
+        
+        .inline-icon {
+            margin-left: 0;
         }
     }
 }

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -636,6 +636,17 @@ $block-height: 71px;
         content: 'saved';
     }
 
+    @include mq(tablet) {
+        &:only-child {
+            border: 0;
+            padding: 0;
+        
+            .inline-icon {
+                margin-left: 0;
+            }
+        }
+    }
+
     @include mq($until: tablet) {
         border-left: 0;
         float: right;
@@ -668,14 +679,6 @@ $block-height: 71px;
             float: left;
             margin-right: $gs-gutter / 4;
         }
-    }
-}
-
-.fc-container .fc-save-for-later:only-child {
-    @include mq(tablet) {
-        border: 0;
-        padding: 0;
-        margin-left: -$gs-gutter / 4;
     }
 }
 


### PR DESCRIPTION
Ensured that all individual instances of the save for later button don't have a seperator and excess spacing (At the bottom of articles).  

Also neatened the margin of individual instances 

From
![screen shot 2015-10-12 at 17 01 01](https://cloud.githubusercontent.com/assets/14570016/10450933/3ae5ff38-7195-11e5-9f10-6a6155ef9646.png)
To
![screen shot 2015-10-13 at 10 26 45](https://cloud.githubusercontent.com/assets/14570016/10450934/3af5a078-7195-11e5-9617-bb6dbdc15763.png)

From
![screen shot 2015-10-13 at 10 28 11](https://cloud.githubusercontent.com/assets/14570016/10450936/3b02b4e8-7195-11e5-91f1-88b8bbd2c778.png)
To
![screen shot 2015-10-13 at 10 27 41](https://cloud.githubusercontent.com/assets/14570016/10450935/3b01b2e6-7195-11e5-855b-4e15920975a0.png)
