### PR TITLE
Fix image sizes for `ImageContent` type pages

### DIFF
--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -1,6 +1,7 @@
 @(page: ImageContentPage)(implicit request: RequestHeader)
 @import conf.switches.Switches._
 @import views.support.TrailCssClasses.articleToneClass
+@import layout.ContentWidths.PictureMedia
 
 @defining(page.image) { image =>
 
@@ -16,7 +17,8 @@
                     @image.mainPicture.map { picture =>
                         @fragments.img(
                             picture,
-                            lightboxIndex = if(image.isMainMediaLightboxable) Some(1) else None
+                            lightboxIndex = if(image.isMainMediaLightboxable) Some(1) else None,
+                            widthsByBreakpoint = PictureMedia.Inline
                         )
                     }
 

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -1,7 +1,7 @@
 @(page: ImageContentPage)(implicit request: RequestHeader)
 @import conf.switches.Switches._
 @import views.support.TrailCssClasses.articleToneClass
-@import layout.ContentWidths.PictureMedia
+@import layout.ContentWidths.ImageContentMedia
 
 @defining(page.image) { image =>
 
@@ -18,7 +18,7 @@
                         @fragments.img(
                             picture,
                             lightboxIndex = if(image.isMainMediaLightboxable) Some(1) else None,
-                            widthsByBreakpoint = PictureMedia.Inline
+                            widthsByBreakpoint = ImageContentMedia.Inline
                         )
                     }
 

--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -154,6 +154,10 @@ object ContentWidths {
       leftCol =         Some(780.px),
       wide =            Some(860.px))
 
+    /**
+     * main image is showcase on a feature article, e.g.
+     * http://www.theguardian.com/politics/2015/may/02/nicola-sturgeon-im-the-boss-now
+     */
     val FeatureShowcase = WidthsByBreakpoint(
       mobile =          Some(465.px),
       mobileLandscape = Some(645.px),

--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -164,8 +164,8 @@ object ContentWidths {
       wide =            Some(1300.px))
   }
 
-  object PictureMedia {
-    // PictureMedia does not support hinting/weighting, so does not extend ContentRelation.
+  object ImageContentMedia {
+    // ImageContentMedia does not support hinting/weighting, so does not extend ContentRelation.
     val Inline = WidthsByBreakpoint(
       mobile =          Some(465.px),
       mobileLandscape = Some(645.px),

--- a/common/app/model/GuardianContentTypes.scala
+++ b/common/app/model/GuardianContentTypes.scala
@@ -17,6 +17,7 @@ object GuardianContentTypes {
   val Article = "Article"
   val NetworkFront = "Network Front"
   val Section = "Section"
+  // i.e. Pictures
   val ImageContent = "ImageContent"
   val Interactive = "Interactive"
   val Gallery = "Gallery"

--- a/common/app/model/GuardianContentTypes.scala
+++ b/common/app/model/GuardianContentTypes.scala
@@ -17,7 +17,10 @@ object GuardianContentTypes {
   val Article = "Article"
   val NetworkFront = "Network Front"
   val Section = "Section"
-  // i.e. Pictures
+  /**
+   * ImageContent example:
+   * http://www.theguardian.com/commentisfree/picture/2015/oct/12/steve-bell-david-cameron-tom-watson-cartoon
+   */
   val ImageContent = "ImageContent"
   val Interactive = "Interactive"
   val Gallery = "Gallery"


### PR DESCRIPTION
Fixes #10467

This was broken by #10266. /cc @johnduffell
