### PR TITLE
Get adfree status from remote server

### DIFF
--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -63,6 +63,7 @@ guardian.page.weatherapiurl=/weatherapi/city
 guardian.page.locationapiurl=/weatherapi/locations?query=
 guardian.page.forecastsapiurl=/weatherapi/forecast
 guardian.page.avatarApiUrl=https://avatar.code.dev-guardianapis.com
+guardian.page.userAttributesApiUrl=https://members-data-api.theguardian.com/user-attributes
 
 # Beacon
 beacon.url=//beacon.www.code.dev-theguardian.com

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -56,6 +56,7 @@ guardian.page.weatherapiurl=/weatherapi/city
 guardian.page.locationapiurl=/weatherapi/locations?query=
 guardian.page.forecastsapiurl=/weatherapi/forecast
 guardian.page.avatarApiUrl=https://avatar.code.dev-guardianapis.com
+guardian.page.userAttributesApiUrl=https://members-data-api.theguardian.com/user-attributes
 
 memcached.host=127.0.0.1:11211
 

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -60,6 +60,7 @@ guardian.page.weatherapiurl=/weatherapi/city
 guardian.page.locationapiurl=/weatherapi/locations?query=
 guardian.page.forecastsapiurl=/weatherapi/forecast
 guardian.page.avatarApiUrl=https://avatar.guardianapis.com
+guardian.page.userAttributesApiUrl=https://members-data-api.theguardian.com/user-attributes
 
 # Beacon
 beacon.url=//beacon.guim.co.uk

--- a/static/src/javascripts/bootstraps/common.js
+++ b/static/src/javascripts/bootstraps/common.js
@@ -25,6 +25,7 @@ define([
     'common/modules/analytics/simple-metrics',
     'common/modules/commercial/user-ad-targeting',
     'common/modules/commercial/donot-use-adblock',
+    'common/modules/commercial/adfree/maintain-adfree-freshness',
     'common/modules/discussion/comment-count',
     'common/modules/experiments/ab',
     'common/modules/identity/autosignin',
@@ -76,6 +77,7 @@ define([
     simpleMetrics,
     userAdTargeting,
     donotUseAdblock,
+    maintainAdfreeFreshness,
     CommentCount,
     ab,
     AutoSignin,
@@ -348,7 +350,6 @@ define([
                 }
             },
 
-
             saveForLater: function () {
                 if (config.switches.saveForLater) {
                     var saveForLater = new SaveForLater();
@@ -401,7 +402,8 @@ define([
                 ['c-accessibility-prefs', accessibilityPrefs],
                 ['c-international-signposting', modules.internationalSignposting],
                 ['c-pinterest', modules.initPinterest],
-                ['c-save-for-later', modules.saveForLater]
+                ['c-save-for-later', modules.saveForLater],
+                ['c-maintain-adfree-freshness', maintainAdfreeFreshness]
             ]), function (fn) {
                 fn();
             });

--- a/static/src/javascripts/projects/common/modules/commercial/adfree/maintain-adfree-freshness.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adfree/maintain-adfree-freshness.js
@@ -1,0 +1,36 @@
+define([
+    'common/utils/cookies',
+    'common/utils/config',
+    'common/utils/storage',
+    'common/modules/identity/api',
+    'common/modules/commercial/adfree/renew-adfree-status'
+], function (
+    cookies,
+    config,
+    storage,
+    identity,
+    renewAdfreeStatus
+) {
+    return maintainAdfreeFreshness;
+
+    function maintainAdfreeFreshness() {
+        if (featureEnabled() && identity.isUserLoggedIn() && userNeedsNewAdfreeCookie()) {
+            renewAdfreeStatus.renew();
+        }
+    }
+
+    function userNeedsNewAdfreeCookie() {
+        var adfreeCookie = cookies.get('gu_adfree_user');
+        return (adfreeCookie === null) || adfreeCookieStale();
+    }
+
+    function adfreeCookieStale() {
+        var adfreeCookieExpiry = storage.local.get('gu_adfree_user_expiry'),
+            currentTime = new Date().getTime();
+        return (adfreeCookieExpiry === null) || (currentTime > adfreeCookieExpiry);
+    }
+
+    function featureEnabled() {
+        return config.switches.advertOptOut;
+    }
+});

--- a/static/src/javascripts/projects/common/modules/commercial/adfree/maintain-adfree-freshness.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adfree/maintain-adfree-freshness.js
@@ -25,7 +25,7 @@ define([
     }
 
     function adfreeCookieStale() {
-        var adfreeCookieExpiry = storage.local.get('gu_adfree_user_expiry'),
+        var adfreeCookieExpiry = storage.local.get('gu.adfree.user.expiry'),
             currentTime = new Date().getTime();
         return (adfreeCookieExpiry === null) || (currentTime > adfreeCookieExpiry);
     }

--- a/static/src/javascripts/projects/common/modules/commercial/adfree/renew-adfree-status.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adfree/renew-adfree-status.js
@@ -1,0 +1,39 @@
+define([
+    'common/utils/ajax-promise',
+    'common/utils/storage'
+], function (
+    ajaxPromise,
+    storage
+) {
+    return {
+        /* jscs:disable disallowDanglingUnderscores */
+        renew : renew,
+        _handleResponse : handleResponse // expose for testing
+        /* jscs:enable */
+    };
+
+    function renew() {
+        ajaxPromise({
+            url : 'https://members-data-api.theguardian.com/user-attributes/me/adfree',
+            crossOrigin : true,
+            success : handleResponse,
+            error : function () {}
+        });
+    }
+
+    function handleResponse(response) {
+        var responseData = JSON.parse(response),
+            nextCookieExpiry = getNextCookieExpiry(responseData.issuedAt);
+        storage.local.set('gu_adfree_user_expiry', nextCookieExpiry);
+    }
+
+    function getNextCookieExpiry(cookieIssueTime) {
+        var issueDate = new Date(cookieIssueTime || new Date()),
+            issueDay = issueDate.getDate(),
+            expiryDate = new Date(cookieIssueTime);
+
+        expiryDate.setDate(issueDay + 1);
+        return expiryDate.getTime();
+    }
+
+});

--- a/static/src/javascripts/projects/common/modules/commercial/adfree/renew-adfree-status.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adfree/renew-adfree-status.js
@@ -1,8 +1,10 @@
 define([
     'common/utils/ajax-promise',
+    'common/utils/config',
     'common/utils/storage'
 ], function (
     ajaxPromise,
+    config,
     storage
 ) {
     return {
@@ -13,9 +15,9 @@ define([
     };
 
     function renew() {
+        var endpoint = config.page.userAttributesApiUrl + '/me/adfree';
         ajaxPromise({
-            // Endpoint returns cookie, 'gu_adfree_user'
-            url : 'https://members-data-api.theguardian.com/user-attributes/me/adfree',
+            url : endpoint, // returns cookie 'gu_adfree_user'
             crossOrigin : true,
             success : handleResponse,
             error : function () {}

--- a/static/src/javascripts/projects/common/modules/commercial/adfree/renew-adfree-status.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adfree/renew-adfree-status.js
@@ -14,6 +14,7 @@ define([
 
     function renew() {
         ajaxPromise({
+            // Endpoint returns cookie, 'gu_adfree_user'
             url : 'https://members-data-api.theguardian.com/user-attributes/me/adfree',
             crossOrigin : true,
             success : handleResponse,
@@ -24,7 +25,7 @@ define([
     function handleResponse(response) {
         var responseData = JSON.parse(response),
             nextCookieExpiry = getNextCookieExpiry(responseData.issuedAt);
-        storage.local.set('gu_adfree_user_expiry', nextCookieExpiry);
+        storage.local.set('gu.adfree.user.expiry', nextCookieExpiry);
     }
 
     function getNextCookieExpiry(cookieIssueTime) {

--- a/static/src/javascripts/test/spec/common/commercial/adfree/maintain-adfree-freshness.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/adfree/maintain-adfree-freshness.spec.js
@@ -3,6 +3,8 @@ import Injector from 'helpers/injector';
 const injector = new Injector();
 
 fdescribe('Maintaining the freshness of a user`s adfree status', ()=> {
+    const adfreeExpiryStorageKey = 'gu.adfree.user.expiry';
+
     let cookies, config, storage, identity, maintainAdfreeFreshness, renewAdfreeStatus;
 
     beforeEach(function (done) {
@@ -45,7 +47,7 @@ fdescribe('Maintaining the freshness of a user`s adfree status', ()=> {
             it('Makes no requests if the user has an up-to-date adfree cookie', ()=> {
                 cookies.add('gu_adfree_user', 'true');
                 const futureTime = new Date().getTime() + 99999;
-                storage.local.set('gu_adfree_user_expiry', futureTime);
+                storage.local.set(adfreeExpiryStorageKey, futureTime);
 
                 maintainAdfreeFreshness();
                 expect(renewAdfreeStatus.renew).not.toHaveBeenCalled();
@@ -54,7 +56,7 @@ fdescribe('Maintaining the freshness of a user`s adfree status', ()=> {
             it('Makes a request if user has out-of-date adfree cookie', ()=> {
                 cookies.add('gu_adfree_user', 'true');
                 const pastTime = new Date().getTime() - 99999;
-                storage.local.set('gu_adfree_user_expiry', pastTime);
+                storage.local.set(adfreeExpiryStorageKey, pastTime);
 
                 maintainAdfreeFreshness();
                 expect(renewAdfreeStatus.renew).toHaveBeenCalled();
@@ -68,7 +70,7 @@ fdescribe('Maintaining the freshness of a user`s adfree status', ()=> {
 
             it('Makes a request if user has valid expiry time but no cookie', ()=> {
                 const futureTime = new Date().getTime() + 99999;
-                storage.local.set('gu_adfree_user_expiry', futureTime);
+                storage.local.set(adfreeExpiryStorageKey, futureTime);
 
                 maintainAdfreeFreshness();
                 expect(renewAdfreeStatus.renew).toHaveBeenCalled();

--- a/static/src/javascripts/test/spec/common/commercial/adfree/maintain-adfree-freshness.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/adfree/maintain-adfree-freshness.spec.js
@@ -2,7 +2,7 @@ import Injector from 'helpers/injector';
 
 const injector = new Injector();
 
-fdescribe('Maintaining the freshness of a user`s adfree status', ()=> {
+describe('Maintaining the freshness of a user`s adfree status', ()=> {
     const adfreeExpiryStorageKey = 'gu.adfree.user.expiry';
 
     let cookies, config, storage, identity, maintainAdfreeFreshness, renewAdfreeStatus;
@@ -36,6 +36,11 @@ fdescribe('Maintaining the freshness of a user`s adfree status', ()=> {
     });
 
     describe('If the featue is enabled', ()=> {
+        beforeEach(()=> {
+            config.switches = {
+                advertOptOut : true
+            };
+        });
 
         describe('If the user is logged in', ()=> {
             beforeEach(()=> {

--- a/static/src/javascripts/test/spec/common/commercial/adfree/maintain-adfree-freshness.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/adfree/maintain-adfree-freshness.spec.js
@@ -1,0 +1,90 @@
+import Injector from 'helpers/injector';
+
+const injector = new Injector();
+
+fdescribe('Maintaining the freshness of a user`s adfree status', ()=> {
+    let cookies, config, storage, identity, maintainAdfreeFreshness, renewAdfreeStatus;
+
+    beforeEach(function (done) {
+        injector.test([
+            'common/utils/cookies',
+            'common/utils/config',
+            'common/utils/storage',
+            'common/modules/identity/api',
+            'common/modules/commercial/adfree/maintain-adfree-freshness',
+            'common/modules/commercial/adfree/renew-adfree-status'
+        ], function () {
+            [cookies, config, storage, identity, maintainAdfreeFreshness, renewAdfreeStatus] = arguments;
+            spyOn(renewAdfreeStatus, 'renew');
+            done();
+        });
+    });
+
+    describe('If the feature is disabled', ()=> {
+        beforeEach(()=> {
+            config.switches = {
+                advertOptOut : false
+            };
+        });
+
+        it('Makes no requests', ()=> {
+            maintainAdfreeFreshness();
+            expect(renewAdfreeStatus.renew).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('If the featue is enabled', ()=> {
+
+        describe('If the user is logged in', ()=> {
+            beforeEach(()=> {
+                identity.isUserLoggedIn = ()=> true;
+                cookies.remove('gu_adfree_user');
+                storage.local.remove('gu_adfree_user_expiry');
+            });
+
+            it('Makes no requests if the user has an up-to-date adfree cookie', ()=> {
+                cookies.add('gu_adfree_user', 'true');
+                const futureTime = new Date().getTime() + 99999;
+                storage.local.set('gu_adfree_user_expiry', futureTime);
+
+                maintainAdfreeFreshness();
+                expect(renewAdfreeStatus.renew).not.toHaveBeenCalled();
+            });
+
+            it('Makes a request if user has out-of-date adfree cookie', ()=> {
+                cookies.add('gu_adfree_user', 'true');
+                const pastTime = new Date().getTime() - 99999;
+                storage.local.set('gu_adfree_user_expiry', pastTime);
+
+                maintainAdfreeFreshness();
+                expect(renewAdfreeStatus.renew).toHaveBeenCalled();
+            });
+
+            it('Makes a request if user has a cookie but no expiry time', ()=> {
+                cookies.add('gu_adfree_user', 'true');
+                maintainAdfreeFreshness();
+                expect(renewAdfreeStatus.renew).toHaveBeenCalled();
+            });
+
+            it('Makes a request if user has valid expiry time but no cookie', ()=> {
+                const futureTime = new Date().getTime() + 99999;
+                storage.local.set('gu_adfree_user_expiry', futureTime);
+
+                maintainAdfreeFreshness();
+                expect(renewAdfreeStatus.renew).toHaveBeenCalled();
+            });
+        });
+
+        describe('If the user is logged out', ()=> {
+            beforeEach(()=> {
+                identity.isUserLoggedIn = ()=> false;
+            });
+
+            it('Makes no requests, because users must log in to see adfree', ()=> {
+                maintainAdfreeFreshness();
+                expect(renewAdfreeStatus.renew).not.toHaveBeenCalled();
+            });
+        });
+    });
+});
+

--- a/static/src/javascripts/test/spec/common/commercial/adfree/maintain-adfree-freshness.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/adfree/maintain-adfree-freshness.spec.js
@@ -35,7 +35,7 @@ describe('Maintaining the freshness of a user`s adfree status', ()=> {
         });
     });
 
-    describe('If the featue is enabled', ()=> {
+    describe('If the feature is enabled', ()=> {
         beforeEach(()=> {
             config.switches = {
                 advertOptOut : true

--- a/static/src/javascripts/test/spec/common/commercial/adfree/renew-adfree-status.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/adfree/renew-adfree-status.spec.js
@@ -4,7 +4,7 @@ import sinon from 'sinonjs';
 
 const injector = new Injector();
 
-describe('User ad preference service', ()=> {
+describe('Requesting the user`s adfree status', ()=> {
     const adfreeExpiryStorageKey = 'gu.adfree.user.expiry';
     let renewAdfreeStatus, config, storage, adfreeRequest, environmentXHR;
 

--- a/static/src/javascripts/test/spec/common/commercial/adfree/renew-adfree-status.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/adfree/renew-adfree-status.spec.js
@@ -5,7 +5,7 @@ import sinon from 'sinonjs';
 const injector = new Injector();
 
 describe('User ad preference service', ()=> {
-    const adfreeExpiryStorageKey = 'gu_adfree_user_expiry';
+    const adfreeExpiryStorageKey = 'gu.adfree.user.expiry';
 
     let renewAdfreeStatus, storage, adfreeRequest, environmentXHR;
 

--- a/static/src/javascripts/test/spec/common/commercial/adfree/renew-adfree-status.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/adfree/renew-adfree-status.spec.js
@@ -6,15 +6,15 @@ const injector = new Injector();
 
 describe('User ad preference service', ()=> {
     const adfreeExpiryStorageKey = 'gu.adfree.user.expiry';
-
-    let renewAdfreeStatus, storage, adfreeRequest, environmentXHR;
+    let renewAdfreeStatus, config, storage, adfreeRequest, environmentXHR;
 
     beforeEach(done => {
         injector.test([
             'common/modules/commercial/adfree/renew-adfree-status',
+            'common/utils/config',
             'common/utils/storage'
         ], function () {
-            [renewAdfreeStatus, storage] = arguments;
+            [renewAdfreeStatus, config, storage] = arguments;
             done();
         });
     });
@@ -31,10 +31,11 @@ describe('User ad preference service', ()=> {
             environmentXHR.restore();
         });
 
-        it('Makes a GET request to the members data API', ()=> {
+        it('Makes a GET request to the configured endpoint URI', ()=> {
+            config.page = {userAttributesApiUrl : 'https://test-domain.com/test'};
             renewAdfreeStatus.renew();
             expect(adfreeRequest.method).toBe('GET');
-            expect(adfreeRequest.url).toBe('https://members-data-api.theguardian.com/user-attributes/me/adfree');
+            expect(adfreeRequest.url).toBe(config.page.userAttributesApiUrl + '/me/adfree');
         });
 
         it('Makes asynchronous requests', ()=> {

--- a/static/src/javascripts/test/spec/common/commercial/adfree/renew-adfree-status.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/adfree/renew-adfree-status.spec.js
@@ -1,0 +1,71 @@
+/* jscs:disable disallowDanglingUnderscores */
+import Injector from 'helpers/injector';
+import sinon from 'sinonjs';
+
+const injector = new Injector();
+
+describe('User ad preference service', ()=> {
+    const adfreeExpiryStorageKey = 'gu_adfree_user_expiry';
+
+    let renewAdfreeStatus, storage, adfreeRequest, environmentXHR;
+
+    beforeEach(done => {
+        injector.test([
+            'common/modules/commercial/adfree/renew-adfree-status',
+            'common/utils/storage'
+        ], function () {
+            [renewAdfreeStatus, storage] = arguments;
+            done();
+        });
+    });
+
+    describe('Making the request', ()=> {
+        beforeEach(()=> {
+            environmentXHR = sinon.useFakeXMLHttpRequest();
+            environmentXHR.onCreate = xhr => {
+                adfreeRequest = xhr;
+            };
+        });
+
+        afterEach(()=> {
+            environmentXHR.restore();
+        });
+
+        it('Makes a GET request to the members data API', ()=> {
+            renewAdfreeStatus.renew();
+            expect(adfreeRequest.method).toBe('GET');
+            expect(adfreeRequest.url).toBe('https://members-data-api.theguardian.com/user-attributes/me/adfree');
+        });
+
+        it('Makes asynchronous requests', ()=> {
+            renewAdfreeStatus.renew();
+            expect(adfreeRequest.async).toBe(true);
+        });
+    });
+
+    describe('Handling the response', ()=> {
+        const now = new Date().getTime();
+        const response = {
+            adfree : true,
+            issuedAt : now
+        };
+        const serializedResponse = JSON.stringify(response);
+
+        beforeEach(()=> {
+            storage.local.remove(adfreeExpiryStorageKey);
+        });
+
+        it('Adds an adfree status expiry time to localstorage', ()=> {
+            renewAdfreeStatus._handleResponse(serializedResponse);
+            const storedExpiryDate = storage.local.get(adfreeExpiryStorageKey);
+            expect(storedExpiryDate).toEqual(jasmine.any(Number));
+        });
+
+        it('That expiry time is in the future', ()=> {
+            renewAdfreeStatus._handleResponse(serializedResponse);
+            const storedExpiryDate = storage.local.get(adfreeExpiryStorageKey);
+            expect(storedExpiryDate > now).toBeTruthy();
+        });
+    });
+
+});


### PR DESCRIPTION
This pull request is for the adfree experience product.

We use an adfree cookie to tell us whether a signed in user is able to see adfree or not. We need to hit a remote endpoint to gather that cookie. We also need that cookie to have a concept of being 'stale' without it expiring - so that we can respect its value temporarily whilst we quietly verify it.

This pull request does _not_ include the work to remove the cookies on signout.

The 'maintain-adfree-freshness' script is separate to the user-ad-preference.js file; the latter may be removed soon as we will need to reason about the user's adfree status in the pre-render head scripts.

One question I had was whether the endpoint URI should be hardcoded in the script. At the moment, there are no pre-production or dev endpoints to use. Should this URI be inserted into the various dev/prod config files regardless?

@calanthe - I know you were waiting on this.
