### PR TITLE
add linter rule for no focussed tests

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1020,6 +1020,11 @@
       "from": "btoa@1.1.2",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.2.tgz"
     },
+    "eslint-plugin-jasmine": {
+      "version": "1.5.0",
+      "from": "eslint-plugin-jasmine@*",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jasmine/-/eslint-plugin-jasmine-1.5.0.tgz"
+    },
     "eslint-plugin-react": {
       "version": "3.5.0",
       "from": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.5.0.tgz",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,9 +8,9 @@
       "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.21.tgz",
       "dependencies": {
         "babel-core": {
-          "version": "5.8.22",
-          "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.22.tgz",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.22.tgz",
+          "version": "5.8.21",
+          "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.21.tgz",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.21.tgz",
           "dependencies": {
             "babel-plugin-constant-folding": {
               "version": "1.0.1",
@@ -95,9 +95,9 @@
               "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
             },
             "babylon": {
-              "version": "5.8.22",
-              "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.22.tgz",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.22.tgz"
+              "version": "5.8.21",
+              "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.21.tgz",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.21.tgz"
             },
             "bluebird": {
               "version": "2.9.34",
@@ -178,9 +178,9 @@
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "minimist": {
-                  "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
                 }
               }
             },
@@ -484,19 +484,14 @@
               "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
               "dependencies": {
                 "recast": {
-                  "version": "0.10.28",
-                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.28.tgz",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.28.tgz",
+                  "version": "0.10.26",
+                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.26.tgz",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.26.tgz",
                   "dependencies": {
-                    "esprima-fb": {
-                      "version": "15001.1001.0-dev-harmony-fb",
-                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                    },
                     "ast-types": {
-                      "version": "0.8.8",
-                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.8.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.8.tgz"
+                      "version": "0.8.7",
+                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.7.tgz",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.7.tgz"
                     }
                   }
                 },
@@ -877,18 +872,6 @@
                   }
                 }
               }
-            },
-            "fsevents": {
-              "version": "0.3.8",
-              "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
-              "dependencies": {
-                "nan": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
-                }
-              }
             }
           }
         },
@@ -1034,64 +1017,64 @@
     },
     "btoa": {
       "version": "1.1.2",
-      "from": "https://registry.npmjs.org/btoa/-/btoa-1.1.2.tgz",
+      "from": "btoa@1.1.2",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.2.tgz"
     },
     "eslint-plugin-react": {
       "version": "3.5.0",
-      "from": "eslint-plugin-react@3.5.0",
+      "from": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.5.0.tgz"
     },
     "esprima": {
       "version": "1.2.2",
-      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+      "from": "esprima@1.2.2",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
     },
     "esprima-fb": {
       "version": "15001.1.0-dev-harmony-fb",
-      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+      "from": "esprima-fb@>=15001.1.0-dev-harmony-fb <15002.0.0",
       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
     },
     "glob": {
       "version": "4.0.6",
-      "from": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+      "from": "glob@4.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+          "from": "graceful-fs@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "from": "inherits@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+          "from": "minimatch@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.5",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "once": {
           "version": "1.3.2",
-          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+          "from": "once@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+              "from": "wrappy@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
@@ -1100,62 +1083,62 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "from": "grunt@0.4.5",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "from": "async@>=0.1.22 <0.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "from": "dateformat@1.0.2-1.2.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "from": "glob@>=3.2.9 <3.3.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -1164,149 +1147,149 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+              "from": "inherits@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "from": "minimatch@>=0.2.12 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.5",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "from": "nopt@>=1.0.10 <1.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "from": "abbrev@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@>=2.2.8 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "from": "lodash@>=0.9.2 <0.10.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "which": {
           "version": "1.0.9",
-          "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "from": "exit@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "from": "getobject@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "dependencies": {
             "grunt-legacy-log-utils": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "from": "lodash@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
             }
           }
@@ -1315,95 +1298,95 @@
     },
     "grunt-asset-hash": {
       "version": "0.1.6",
-      "from": "https://registry.npmjs.org/grunt-asset-hash/-/grunt-asset-hash-0.1.6.tgz",
+      "from": "grunt-asset-hash@0.1.6",
       "resolved": "https://registry.npmjs.org/grunt-asset-hash/-/grunt-asset-hash-0.1.6.tgz"
     },
     "grunt-asset-monitor": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/grunt-asset-monitor/-/grunt-asset-monitor-0.2.0.tgz",
+      "from": "grunt-asset-monitor@0.2.0",
       "resolved": "https://registry.npmjs.org/grunt-asset-monitor/-/grunt-asset-monitor-0.2.0.tgz",
       "dependencies": {
         "prettysize": {
           "version": "0.0.3",
-          "from": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz",
+          "from": "prettysize@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz"
         },
         "aws-sdk": {
           "version": "2.0.31",
-          "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
+          "from": "aws-sdk@>=2.0.0-rc4 <2.1.0",
           "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
           "dependencies": {
             "xml2js": {
               "version": "0.2.6",
-              "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
+              "from": "xml2js@0.2.6",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
               "dependencies": {
                 "sax": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
+                  "from": "sax@0.4.2",
                   "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
                 }
               }
             },
             "xmlbuilder": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+              "from": "xmlbuilder@0.4.2",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
             }
           }
         },
         "css-parse": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
+          "from": "css-parse@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
           "dependencies": {
             "css": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+              "from": "css@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.38 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 },
                 "source-map-resolve": {
                   "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+                  "from": "source-map-resolve@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
                   "dependencies": {
                     "source-map-url": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+                      "from": "source-map-url@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
                     },
                     "atob": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/atob/-/atob-1.1.2.tgz",
+                      "from": "atob@>=1.1.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.2.tgz"
                     },
                     "resolve-url": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+                      "from": "resolve-url@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
                     }
                   }
                 },
                 "urix": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+                  "from": "urix@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -1412,120 +1395,120 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "from": "lodash@>=2.4.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "grunt-autoprefixer": {
       "version": "3.0.3",
-      "from": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.3.tgz",
+      "from": "grunt-autoprefixer@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.3.tgz",
       "dependencies": {
         "autoprefixer-core": {
           "version": "5.2.1",
-          "from": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
+          "from": "autoprefixer-core@>=5.1.7 <6.0.0",
           "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
           "dependencies": {
             "browserslist": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
+              "from": "browserslist@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
             },
             "num2fraction": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz",
+              "from": "num2fraction@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000265",
-              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000265.tgz",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000265.tgz"
+              "version": "1.0.30000214",
+              "from": "caniuse-db@>=1.0.30000214 <2.0.0",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000214.tgz"
             }
           }
         },
         "chalk": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "from": "chalk@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+              "from": "supports-color@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
         },
         "diff": {
           "version": "1.3.2",
-          "from": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz",
+          "from": "diff@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz"
         },
         "postcss": {
-          "version": "4.1.16",
-          "from": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+          "version": "4.1.12",
+          "from": "postcss@>=4.1.11 <5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.12.tgz",
           "dependencies": {
             "es6-promise": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+              "from": "es6-promise@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
             },
             "source-map": {
-              "version": "0.4.4",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "version": "0.4.2",
+              "from": "source-map@>=0.4.2 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                 }
               }
             },
             "js-base64": {
-              "version": "2.1.9",
-              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+              "version": "2.1.8",
+              "from": "js-base64@>=2.1.8 <2.2.0",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz"
             }
           }
         }
@@ -1533,17 +1516,17 @@
     },
     "grunt-bytesize": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/grunt-bytesize/-/grunt-bytesize-0.1.1.tgz",
+      "from": "grunt-bytesize@0.1.1",
       "resolved": "https://registry.npmjs.org/grunt-bytesize/-/grunt-bytesize-0.1.1.tgz",
       "dependencies": {
         "bytesize": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/bytesize/-/bytesize-0.2.0.tgz",
+          "from": "bytesize@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/bytesize/-/bytesize-0.2.0.tgz",
           "dependencies": {
             "humanize": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/humanize/-/humanize-0.0.7.tgz",
+              "from": "humanize@0.0.7",
               "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.7.tgz"
             }
           }
@@ -1552,22 +1535,22 @@
     },
     "grunt-concurrent": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-1.0.0.tgz",
+      "from": "grunt-concurrent@1.0.0",
       "resolved": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-1.0.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "from": "async@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "pad-stdio": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/pad-stdio/-/pad-stdio-1.0.0.tgz",
+          "from": "pad-stdio@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/pad-stdio/-/pad-stdio-1.0.0.tgz",
           "dependencies": {
             "lpad": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/lpad/-/lpad-1.0.0.tgz",
+              "from": "lpad@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/lpad/-/lpad-1.0.0.tgz"
             }
           }
@@ -1576,63 +1559,63 @@
     },
     "grunt-contrib-clean": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
+      "from": "grunt-contrib-clean@0.6.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
     },
     "grunt-contrib-copy": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.6.0.tgz",
+      "from": "grunt-contrib-copy@0.6.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.6.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -1641,18 +1624,1039 @@
     },
     "grunt-contrib-requirejs": {
       "version": "0.4.4",
-      "from": "https://registry.npmjs.org/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz"
+      "from": "grunt-contrib-requirejs@0.4.4",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz",
+      "dependencies": {
+        "requirejs": {
+          "version": "2.1.20",
+          "from": "requirejs@>=2.1.0 <2.2.0",
+          "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz"
+        }
+      }
     },
     "grunt-contrib-uglify": {
       "version": "0.9.1",
-      "from": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.9.1.tgz",
+      "from": "grunt-contrib-uglify@0.9.1",
       "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.9.1.tgz",
       "dependencies": {
         "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.9.3",
+          "from": "lodash@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+        },
+        "maxmin": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+          "from": "maxmin@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
+          "dependencies": {
+            "figures": {
+              "version": "1.3.5",
+              "from": "figures@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+            },
+            "gzip-size": {
+              "version": "1.0.0",
+              "from": "gzip-size@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.5.0",
+                  "from": "concat-stream@>=1.4.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.1",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.1",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.1",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "browserify-zlib": {
+                  "version": "0.1.4",
+                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                  "dependencies": {
+                    "pako": {
+                      "version": "0.2.7",
+                      "from": "pako@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "pretty-bytes": {
+              "version": "1.0.4",
+              "from": "pretty-bytes@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.3.0",
+                  "from": "meow@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.1.0",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    },
+                    "object-assign": {
+                      "version": "3.0.0",
+                      "from": "object-assign@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.4.23",
+          "from": "uglify-js@>=2.4.19 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.34",
+              "from": "source-map@0.1.34",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.5.4",
+              "from": "yargs@>=3.5.4 <3.6.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.1.0",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                },
+                "decamelize": {
+                  "version": "1.0.0",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "window-size@0.1.0",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "uri-path": {
+          "version": "0.0.2",
+          "from": "uri-path@0.0.2",
+          "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-0.0.2.tgz"
+        }
+      }
+    },
+    "grunt-contrib-watch": {
+      "version": "0.6.1",
+      "from": "grunt-contrib-watch@0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "dependencies": {
+        "gaze": {
+          "version": "0.5.1",
+          "from": "gaze@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+          "dependencies": {
+            "globule": {
+              "version": "0.1.0",
+              "from": "globule@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "1.0.2",
+                  "from": "lodash@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                },
+                "glob": {
+                  "version": "3.1.21",
+                  "from": "glob@>=3.1.21 <3.2.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@>=1.2.0 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                    },
+                    "inherits": {
+                      "version": "1.0.0",
+                      "from": "inherits@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tiny-lr-fork": {
+          "version": "0.0.5",
+          "from": "tiny-lr-fork@0.0.5",
+          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "0.5.6",
+              "from": "qs@>=0.5.2 <0.6.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+            },
+            "faye-websocket": {
+              "version": "0.4.4",
+              "from": "faye-websocket@>=0.4.3 <0.5.0",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
+            },
+            "noptify": {
+              "version": "0.0.3",
+              "from": "noptify@>=0.0.3 <0.1.0",
+              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "2.0.0",
+                  "from": "nopt@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@>=0.7.0 <0.8.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.9 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        }
+      }
+    },
+    "grunt-csdevmode": {
+      "version": "0.1.2",
+      "from": "grunt-csdevmode@0.1.2",
+      "resolved": "https://registry.npmjs.org/grunt-csdevmode/-/grunt-csdevmode-0.1.2.tgz",
+      "dependencies": {
+        "socket.io": {
+          "version": "1.0.6",
+          "from": "socket.io@>=1.0.4 <1.1.0",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.0.6.tgz",
+          "dependencies": {
+            "engine.io": {
+              "version": "1.3.1",
+              "from": "engine.io@1.3.1",
+              "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.3.1.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.6.0",
+                  "from": "debug@0.6.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.6.0.tgz"
+                },
+                "ws": {
+                  "version": "0.4.31",
+                  "from": "ws@0.4.31",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "0.6.1",
+                      "from": "commander@>=0.6.1 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                    },
+                    "nan": {
+                      "version": "0.3.2",
+                      "from": "nan@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                    },
+                    "tinycolor": {
+                      "version": "0.0.1",
+                      "from": "tinycolor@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                    },
+                    "options": {
+                      "version": "0.0.6",
+                      "from": "options@>=0.0.5",
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                    }
+                  }
+                },
+                "engine.io-parser": {
+                  "version": "1.0.6",
+                  "from": "engine.io-parser@1.0.6",
+                  "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
+                  "dependencies": {
+                    "base64-arraybuffer": {
+                      "version": "0.1.2",
+                      "from": "base64-arraybuffer@0.1.2",
+                      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                    },
+                    "after": {
+                      "version": "0.8.1",
+                      "from": "after@0.8.1",
+                      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                    },
+                    "arraybuffer.slice": {
+                      "version": "0.0.6",
+                      "from": "arraybuffer.slice@0.0.6",
+                      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                    },
+                    "blob": {
+                      "version": "0.0.2",
+                      "from": "blob@0.0.2",
+                      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                    },
+                    "utf8": {
+                      "version": "2.0.0",
+                      "from": "utf8@2.0.0",
+                      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                    }
+                  }
+                },
+                "base64id": {
+                  "version": "0.1.0",
+                  "from": "base64id@0.1.0",
+                  "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+                }
+              }
+            },
+            "socket.io-parser": {
+              "version": "2.2.0",
+              "from": "socket.io-parser@2.2.0",
+              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.0.tgz",
+              "dependencies": {
+                "json3": {
+                  "version": "3.2.6",
+                  "from": "json3@3.2.6",
+                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                },
+                "emitter": {
+                  "version": "1.0.1",
+                  "from": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+                  "resolved": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+                  "dependencies": {
+                    "indexof": {
+                      "version": "0.0.1",
+                      "from": "indexof@0.0.1",
+                      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                    }
+                  }
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "socket.io-client": {
+              "version": "1.0.6",
+              "from": "socket.io-client@1.0.6",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.0.6.tgz",
+              "dependencies": {
+                "engine.io-client": {
+                  "version": "1.3.1",
+                  "from": "engine.io-client@1.3.1",
+                  "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.3.1.tgz",
+                  "dependencies": {
+                    "has-cors": {
+                      "version": "1.0.3",
+                      "from": "has-cors@1.0.3",
+                      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
+                      "dependencies": {
+                        "global": {
+                          "version": "2.0.1",
+                          "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+                          "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+                        }
+                      }
+                    },
+                    "ws": {
+                      "version": "0.4.31",
+                      "from": "ws@0.4.31",
+                      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+                      "dependencies": {
+                        "commander": {
+                          "version": "0.6.1",
+                          "from": "commander@>=0.6.1 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                        },
+                        "nan": {
+                          "version": "0.3.2",
+                          "from": "nan@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                        },
+                        "tinycolor": {
+                          "version": "0.0.1",
+                          "from": "tinycolor@>=0.0.0 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                        },
+                        "options": {
+                          "version": "0.0.6",
+                          "from": "options@>=0.0.5",
+                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                        }
+                      }
+                    },
+                    "xmlhttprequest": {
+                      "version": "1.5.0",
+                      "from": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz",
+                      "resolved": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz"
+                    },
+                    "engine.io-parser": {
+                      "version": "1.0.6",
+                      "from": "engine.io-parser@1.0.6",
+                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
+                      "dependencies": {
+                        "base64-arraybuffer": {
+                          "version": "0.1.2",
+                          "from": "base64-arraybuffer@0.1.2",
+                          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                        },
+                        "after": {
+                          "version": "0.8.1",
+                          "from": "after@0.8.1",
+                          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                        },
+                        "arraybuffer.slice": {
+                          "version": "0.0.6",
+                          "from": "arraybuffer.slice@0.0.6",
+                          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                        },
+                        "blob": {
+                          "version": "0.0.2",
+                          "from": "blob@0.0.2",
+                          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                        },
+                        "utf8": {
+                          "version": "2.0.0",
+                          "from": "utf8@2.0.0",
+                          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "parsejson": {
+                      "version": "0.0.1",
+                      "from": "parsejson@0.0.1",
+                      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "parseqs": {
+                      "version": "0.0.2",
+                      "from": "parseqs@0.0.2",
+                      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "component-inherit": {
+                      "version": "0.0.3",
+                      "from": "component-inherit@0.0.3",
+                      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
+                    }
+                  }
+                },
+                "component-bind": {
+                  "version": "1.0.0",
+                  "from": "component-bind@1.0.0",
+                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "object-component": {
+                  "version": "0.0.3",
+                  "from": "object-component@0.0.3",
+                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+                },
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                },
+                "parseuri": {
+                  "version": "0.0.2",
+                  "from": "parseuri@0.0.2",
+                  "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
+                  "dependencies": {
+                    "better-assert": {
+                      "version": "1.0.2",
+                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                      "dependencies": {
+                        "callsite": {
+                          "version": "1.0.0",
+                          "from": "callsite@1.0.0",
+                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-array": {
+                  "version": "0.1.3",
+                  "from": "to-array@0.1.3",
+                  "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
+                }
+              }
+            },
+            "socket.io-adapter": {
+              "version": "0.2.0",
+              "from": "socket.io-adapter@0.2.0",
+              "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.2.0.tgz",
+              "dependencies": {
+                "socket.io-parser": {
+                  "version": "2.1.2",
+                  "from": "socket.io-parser@2.1.2",
+                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.1.2.tgz",
+                  "dependencies": {
+                    "json3": {
+                      "version": "3.2.6",
+                      "from": "json3@3.2.6",
+                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                    },
+                    "emitter": {
+                      "version": "1.0.1",
+                      "from": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+                      "resolved": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+                      "dependencies": {
+                        "indexof": {
+                          "version": "0.0.1",
+                          "from": "indexof@0.0.1",
+                          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                        }
+                      }
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "has-binary-data": {
+              "version": "0.1.1",
+              "from": "has-binary-data@0.1.1",
+              "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.1.tgz",
+              "dependencies": {
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            }
+          }
+        },
+        "win-spawn": {
+          "version": "2.0.0",
+          "from": "win-spawn@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
+        },
+        "ua-parser-js": {
+          "version": "0.7.7",
+          "from": "ua-parser-js@>=0.7.0 <0.8.0",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.7.tgz"
+        },
+        "express": {
+          "version": "4.4.5",
+          "from": "express@>=4.4.4 <4.5.0",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.4.5.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.0.7",
+              "from": "accepts@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "negotiator": {
+                  "version": "0.4.7",
+                  "from": "negotiator@0.4.7",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
+                }
+              }
+            },
+            "buffer-crc32": {
+              "version": "0.2.3",
+              "from": "buffer-crc32@0.2.3",
+              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
+            },
+            "debug": {
+              "version": "1.0.2",
+              "from": "debug@1.0.2",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "escape-html": {
+              "version": "1.0.1",
+              "from": "escape-html@1.0.1",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+            },
+            "methods": {
+              "version": "1.0.1",
+              "from": "methods@1.0.1",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+            },
+            "parseurl": {
+              "version": "1.0.1",
+              "from": "parseurl@1.0.1",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
+            },
+            "proxy-addr": {
+              "version": "1.0.1",
+              "from": "proxy-addr@1.0.1",
+              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
+              "dependencies": {
+                "ipaddr.js": {
+                  "version": "0.1.2",
+                  "from": "ipaddr.js@0.1.2",
+                  "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
+                }
+              }
+            },
+            "range-parser": {
+              "version": "1.0.0",
+              "from": "range-parser@1.0.0",
+              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
+            },
+            "send": {
+              "version": "0.4.3",
+              "from": "send@0.4.3",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.4.3.tgz",
+              "dependencies": {
+                "finished": {
+                  "version": "1.2.2",
+                  "from": "finished@1.2.2",
+                  "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.0.3",
+                      "from": "ee-first@1.0.3",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@1.2.11",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.2.3",
+              "from": "serve-static@1.2.3",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.3.tgz"
+            },
+            "type-is": {
+              "version": "1.2.1",
+              "from": "type-is@1.2.1",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.2.1.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "1.0.0",
+                  "from": "mime-types@1.0.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.0.tgz"
+                }
+              }
+            },
+            "vary": {
+              "version": "0.1.0",
+              "from": "vary@0.1.0",
+              "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz"
+            },
+            "cookie": {
+              "version": "0.1.2",
+              "from": "cookie@0.1.2",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+            },
+            "fresh": {
+              "version": "0.2.2",
+              "from": "fresh@0.2.2",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.4",
+              "from": "cookie-signature@1.0.4",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
+            },
+            "merge-descriptors": {
+              "version": "0.0.2",
+              "from": "merge-descriptors@0.0.2",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            },
+            "qs": {
+              "version": "0.6.6",
+              "from": "qs@0.6.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            },
+            "path-to-regexp": {
+              "version": "0.1.2",
+              "from": "path-to-regexp@0.1.2",
+              "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz"
+            }
+          }
+        },
+        "weinre": {
+          "version": "2.0.0-pre-I0Z7U9OV",
+          "from": "weinre@>=2.0.0-pre-HH0SN197 <2.1.0",
+          "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
+          "dependencies": {
+            "express": {
+              "version": "2.5.11",
+              "from": "express@>=2.5.0 <2.6.0",
+              "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+              "dependencies": {
+                "connect": {
+                  "version": "1.9.2",
+                  "from": "connect@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+                  "dependencies": {
+                    "formidable": {
+                      "version": "1.0.17",
+                      "from": "formidable@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.4",
+                  "from": "mime@1.2.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
+                },
+                "qs": {
+                  "version": "0.4.2",
+                  "from": "qs@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.0",
+                  "from": "mkdirp@0.3.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.2",
+              "from": "nopt@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                }
+              }
+            },
+            "underscore": {
+              "version": "1.7.0",
+              "from": "underscore@>=1.7.0 <1.8.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+            }
+          }
+        },
+        "array.prototype.findindex": {
+          "version": "0.1.1",
+          "from": "array.prototype.findindex@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-0.1.1.tgz"
+        }
+      }
+    },
+    "grunt-css-metrics": {
+      "version": "0.1.2",
+      "from": "grunt-css-metrics@0.1.2",
+      "resolved": "https://registry.npmjs.org/grunt-css-metrics/-/grunt-css-metrics-0.1.2.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "3.2.1",
+          "from": "glob@3.2.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.1.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@>=0.2.11 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "from": "inherits@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+            }
+          }
+        },
+        "css-parse": {
+          "version": "1.4.0",
+          "from": "css-parse@>=1.4.0 <1.5.0",
+          "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.4.0.tgz"
+        },
+        "humanize": {
+          "version": "0.0.9",
+          "from": "humanize@>=0.0.7 <0.1.0",
+          "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz"
+        }
+      }
+    },
+    "grunt-eslint": {
+      "version": "17.2.0",
+      "from": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.2.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
@@ -1695,98 +2699,980 @@
             }
           }
         },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
-        "maxmin": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
+        "eslint": {
+          "version": "1.5.1",
+          "from": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
           "dependencies": {
-            "figures": {
-              "version": "1.3.5",
-              "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
-            },
-            "gzip-size": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+            "concat-stream": {
+              "version": "1.5.0",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
               "dependencies": {
-                "concat-stream": {
-                  "version": "1.5.0",
-                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                    },
-                    "readable-stream": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
-                "browserify-zlib": {
-                  "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.0.2",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
-                    "pako": {
-                      "version": "0.2.7",
-                      "from": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz",
-                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
-            "pretty-bytes": {
+            "debug": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "doctrine": {
+              "version": "0.7.0",
+              "from": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "1.1.6",
+                  "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "escope": {
+              "version": "3.2.0",
+              "from": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
+              "dependencies": {
+                "es6-map": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.7",
+                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                      "dependencies": {
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                      "dependencies": {
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "es6-set": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    }
+                  }
+                },
+                "es6-weak-map": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.7",
+                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
+                    },
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "esrecurse": {
+                  "version": "3.1.1",
+                  "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
+                },
+                "estraverse": {
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                }
+              }
+            },
+            "espree": {
+              "version": "2.2.5",
+              "from": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+            },
+            "estraverse": {
+              "version": "4.1.0",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
+            },
+            "estraverse-fb": {
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "globals": {
+              "version": "8.10.0",
+              "from": "https://registry.npmjs.org/globals/-/globals-8.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.10.0.tgz"
+            },
+            "handlebars": {
+              "version": "4.0.3",
+              "from": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.3.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "1.4.2",
+                  "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.4.24",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.34",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "uglify-to-browserify": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                    },
+                    "yargs": {
+                      "version": "3.5.4",
+                      "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                        },
+                        "decamelize": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                        },
+                        "window-size": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "inquirer": {
+              "version": "0.9.0",
+              "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                },
+                "cli-width": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
+                },
+                "figures": {
+                  "version": "1.4.0",
+                  "from": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+                },
+                "readline2": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                  "dependencies": {
+                    "mute-stream": {
+                      "version": "0.0.4",
+                      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "run-async": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rx-lite": {
+                  "version": "2.5.2",
+                  "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz"
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                }
+              }
+            },
+            "file-entry-cache": {
+              "version": "1.2.4",
+              "from": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
+              "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
+              "dependencies": {
+                "flat-cache": {
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.9.tgz",
+                  "dependencies": {
+                    "del": {
+                      "version": "2.0.2",
+                      "from": "https://registry.npmjs.org/del/-/del-2.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/del/-/del-2.0.2.tgz",
+                      "dependencies": {
+                        "globby": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
+                          "dependencies": {
+                            "array-union": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                              "dependencies": {
+                                "array-uniq": {
+                                  "version": "1.0.2",
+                                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "arrify": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "is-path-cwd": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+                        },
+                        "is-path-in-cwd": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                          "dependencies": {
+                            "is-path-inside": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "pify": {
+                          "version": "2.2.0",
+                          "from": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
+                        },
+                        "pinkie-promise": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.4.3",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    },
+                    "read-json-sync": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "3.0.8",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                        }
+                      }
+                    },
+                    "write": {
+                      "version": "0.2.1",
+                      "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+                      "dependencies": {
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "4.0.1",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                }
+              }
+            },
+            "is-my-json-valid": {
+              "version": "2.12.2",
+              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+              "dependencies": {
+                "generate-function": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "dependencies": {
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    }
+                  }
+                },
+                "jsonpointer": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "is-resolvable": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+              "dependencies": {
+                "tryit": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.1.tgz"
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.4.2",
+              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.2.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                }
+              }
+            },
+            "lodash.clonedeep": {
+              "version": "3.0.2",
+              "from": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+              "dependencies": {
+                "lodash._baseclone": {
+                  "version": "3.3.0",
+                  "from": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+                  "dependencies": {
+                    "lodash._arraycopy": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                    },
+                    "lodash._arrayeach": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                    },
+                    "lodash._baseassign": {
+                      "version": "3.2.0",
+                      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._basefor": {
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                        },
+                        "lodash.isarguments": {
+                          "version": "3.0.4",
+                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                }
+              }
+            },
+            "lodash.merge": {
+              "version": "3.3.2",
+              "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                },
+                "lodash._createassigner": {
+                  "version": "3.1.1",
+                  "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "dependencies": {
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash._isiterateecall": {
+                      "version": "3.0.9",
+                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                    },
+                    "lodash.restparam": {
+                      "version": "3.6.1",
+                      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                    }
+                  }
+                },
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                },
+                "lodash.isplainobject": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basefor": {
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                    }
+                  }
+                },
+                "lodash.istypedarray": {
+                  "version": "3.0.2",
+                  "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+                },
+                "lodash.keysin": {
+                  "version": "3.0.8",
+                  "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
+                },
+                "lodash.toplainobject": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.omit": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+              "dependencies": {
+                "lodash._arraymap": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
+                },
+                "lodash._basedifference": {
+                  "version": "3.0.3",
+                  "from": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+                  "dependencies": {
+                    "lodash._baseindexof": {
+                      "version": "3.1.0",
+                      "from": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
+                    },
+                    "lodash._cacheindexof": {
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
+                    },
+                    "lodash._createcache": {
+                      "version": "3.1.2",
+                      "from": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._baseflatten": {
+                  "version": "3.1.4",
+                  "from": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                },
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                },
+                "lodash._pickbyarray": {
+                  "version": "3.0.2",
+                  "from": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+                },
+                "lodash._pickbycallback": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+                  "dependencies": {
+                    "lodash._basefor": {
+                      "version": "3.0.2",
+                      "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                    }
+                  }
+                },
+                "lodash.keysin": {
+                  "version": "3.0.8",
+                  "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "type-check": {
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "path-is-inside": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+            },
+            "shelljs": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+            },
+            "strip-json-comments": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+            },
+            "to-double-quotes": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.1.tgz",
               "dependencies": {
                 "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "3.0.2",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
                 },
                 "meow": {
                   "version": "3.3.0",
@@ -1815,6 +3701,11 @@
                       "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        },
                         "repeating": {
                           "version": "1.1.3",
                           "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
@@ -1837,9 +3728,9 @@
                       }
                     },
                     "minimist": {
-                      "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "object-assign": {
                       "version": "3.0.0",
@@ -1849,1063 +3740,129 @@
                   }
                 }
               }
+            },
+            "to-single-quotes": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.3.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "3.0.2",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+                },
+                "meow": {
+                  "version": "3.3.0",
+                  "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.2",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                      "dependencies": {
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    },
+                    "object-assign": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "user-home": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+            },
+            "xml-escape": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
             }
           }
-        },
-        "uglify-js": {
-          "version": "2.4.24",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+        }
+      }
+    },
+    "grunt-frequency-graph": {
+      "version": "0.1.6",
+      "from": "grunt-frequency-graph@>=0.1.6 <0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-frequency-graph/-/grunt-frequency-graph-0.1.6.tgz",
+      "dependencies": {
+        "asset-frequency-graph": {
+          "version": "0.3.1",
+          "from": "asset-frequency-graph@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/asset-frequency-graph/-/asset-frequency-graph-0.3.1.tgz",
           "dependencies": {
             "async": {
-              "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "version": "0.9.0",
+              "from": "async@0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
             },
-            "source-map": {
-              "version": "0.1.34",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-            },
-            "yargs": {
-              "version": "3.5.4",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                },
-                "decamelize": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
-                },
-                "window-size": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                },
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "uri-path": {
-          "version": "0.0.2",
-          "from": "https://registry.npmjs.org/uri-path/-/uri-path-0.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-0.0.2.tgz"
-        }
-      }
-    },
-    "grunt-contrib-watch": {
-      "version": "0.6.1",
-      "from": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
-      "dependencies": {
-        "gaze": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
-          "dependencies": {
-            "globule": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                },
-                "glob": {
-                  "version": "3.1.21",
-                  "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "1.2.3",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                    },
-                    "inherits": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "tiny-lr-fork": {
-          "version": "0.0.5",
-          "from": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
-          "dependencies": {
-            "qs": {
-              "version": "0.5.6",
-              "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
-            },
-            "faye-websocket": {
-              "version": "0.4.4",
-              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
-            },
-            "noptify": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            }
-          }
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
-        },
-        "async": {
-          "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        }
-      }
-    },
-    "grunt-csdevmode": {
-      "version": "0.1.2",
-      "from": "https://registry.npmjs.org/grunt-csdevmode/-/grunt-csdevmode-0.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-csdevmode/-/grunt-csdevmode-0.1.2.tgz",
-      "dependencies": {
-        "socket.io": {
-          "version": "1.0.6",
-          "from": "https://registry.npmjs.org/socket.io/-/socket.io-1.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.0.6.tgz",
-          "dependencies": {
-            "engine.io": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.3.1.tgz",
-              "dependencies": {
-                "debug": {
-                  "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/debug/-/debug-0.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.6.0.tgz"
-                },
-                "ws": {
-                  "version": "0.4.31",
-                  "from": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
-                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
-                  "dependencies": {
-                    "commander": {
-                      "version": "0.6.1",
-                      "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-                    },
-                    "nan": {
-                      "version": "0.3.2",
-                      "from": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
-                    },
-                    "tinycolor": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
-                    },
-                    "options": {
-                      "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-                    }
-                  }
-                },
-                "engine.io-parser": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
-                  "dependencies": {
-                    "base64-arraybuffer": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
-                    },
-                    "after": {
-                      "version": "0.8.1",
-                      "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-                      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
-                    },
-                    "arraybuffer.slice": {
-                      "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
-                    },
-                    "blob": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
-                    },
-                    "utf8": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
-                    }
-                  }
-                },
-                "base64id": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
-                }
-              }
-            },
-            "socket.io-parser": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.0.tgz",
-              "dependencies": {
-                "json3": {
-                  "version": "3.2.6",
-                  "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-                },
-                "emitter": {
-                  "version": "1.0.1",
-                  "from": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-                  "resolved": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-                  "dependencies": {
-                    "indexof": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-                    }
-                  }
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                }
-              }
-            },
-            "socket.io-client": {
-              "version": "1.0.6",
-              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.0.6.tgz",
-              "dependencies": {
-                "engine.io-client": {
-                  "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.3.1.tgz",
-                  "dependencies": {
-                    "has-cors": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
-                      "dependencies": {
-                        "global": {
-                          "version": "2.0.1",
-                          "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
-                          "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
-                        }
-                      }
-                    },
-                    "ws": {
-                      "version": "0.4.31",
-                      "from": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
-                      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
-                      "dependencies": {
-                        "commander": {
-                          "version": "0.6.1",
-                          "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-                          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-                        },
-                        "nan": {
-                          "version": "0.3.2",
-                          "from": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz",
-                          "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
-                        },
-                        "tinycolor": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
-                        },
-                        "options": {
-                          "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-                        }
-                      }
-                    },
-                    "xmlhttprequest": {
-                      "version": "1.5.0",
-                      "from": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz",
-                      "resolved": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz"
-                    },
-                    "engine.io-parser": {
-                      "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
-                      "dependencies": {
-                        "base64-arraybuffer": {
-                          "version": "0.1.2",
-                          "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
-                        },
-                        "after": {
-                          "version": "0.8.1",
-                          "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-                          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
-                        },
-                        "arraybuffer.slice": {
-                          "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
-                        },
-                        "blob": {
-                          "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
-                        },
-                        "utf8": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "parsejson": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "parseqs": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
-                      "dependencies": {
-                        "better-assert": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                          "dependencies": {
-                            "callsite": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "component-inherit": {
-                      "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
-                    }
-                  }
-                },
-                "component-bind": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
-                },
-                "component-emitter": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                },
-                "object-component": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
-                },
-                "indexof": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-                },
-                "parseuri": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
-                  "dependencies": {
-                    "better-assert": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-                      "dependencies": {
-                        "callsite": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "to-array": {
-                  "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
-                }
-              }
-            },
-            "socket.io-adapter": {
+            "git-promise": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.2.0.tgz",
+              "from": "git-promise@0.2.0",
+              "resolved": "https://registry.npmjs.org/git-promise/-/git-promise-0.2.0.tgz",
               "dependencies": {
-                "socket.io-parser": {
-                  "version": "2.1.2",
-                  "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.1.2.tgz",
-                  "dependencies": {
-                    "json3": {
-                      "version": "3.2.6",
-                      "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
-                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-                    },
-                    "emitter": {
-                      "version": "1.0.1",
-                      "from": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-                      "resolved": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-                      "dependencies": {
-                        "indexof": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-                        }
-                      }
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "has-binary-data": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.1.tgz",
-              "dependencies": {
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            }
-          }
-        },
-        "win-spawn": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
-        },
-        "ua-parser-js": {
-          "version": "0.7.9",
-          "from": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.9.tgz",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.9.tgz"
-        },
-        "express": {
-          "version": "4.4.5",
-          "from": "https://registry.npmjs.org/express/-/express-4.4.5.tgz",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.4.5.tgz",
-          "dependencies": {
-            "accepts": {
-              "version": "1.0.7",
-              "from": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
-              "dependencies": {
-                "mime-types": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                },
-                "negotiator": {
-                  "version": "0.4.7",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
-                }
-              }
-            },
-            "buffer-crc32": {
-              "version": "0.2.3",
-              "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
-            },
-            "debug": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.6.2",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                }
-              }
-            },
-            "escape-html": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
-            },
-            "methods": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
-            },
-            "parseurl": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
-            },
-            "proxy-addr": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
-              "dependencies": {
-                "ipaddr.js": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
-                }
-              }
-            },
-            "range-parser": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
-            },
-            "send": {
-              "version": "0.4.3",
-              "from": "https://registry.npmjs.org/send/-/send-0.4.3.tgz",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.4.3.tgz",
-              "dependencies": {
-                "finished": {
-                  "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
-                    }
-                  }
-                },
-                "mime": {
-                  "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                }
-              }
-            },
-            "serve-static": {
-              "version": "1.2.3",
-              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.3.tgz"
-            },
-            "type-is": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/type-is/-/type-is-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.2.1.tgz",
-              "dependencies": {
-                "mime-types": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.0.tgz"
-                }
-              }
-            },
-            "vary": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz"
-            },
-            "cookie": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
-            },
-            "fresh": {
-              "version": "0.2.2",
-              "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
-            },
-            "cookie-signature": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
-            },
-            "merge-descriptors": {
-              "version": "0.0.2",
-              "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
-            },
-            "utils-merge": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-            },
-            "qs": {
-              "version": "0.6.6",
-              "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
-            },
-            "path-to-regexp": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz"
-            }
-          }
-        },
-        "weinre": {
-          "version": "2.0.0-pre-I0Z7U9OV",
-          "from": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
-          "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
-          "dependencies": {
-            "express": {
-              "version": "2.5.11",
-              "from": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
-              "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
-              "dependencies": {
-                "connect": {
-                  "version": "1.9.2",
-                  "from": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
-                  "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
-                  "dependencies": {
-                    "formidable": {
-                      "version": "1.0.17",
-                      "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
-                      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
-                    }
-                  }
-                },
-                "mime": {
-                  "version": "1.2.4",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
-                },
-                "qs": {
-                  "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
-                },
-                "mkdirp": {
+                "shelljs": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                  "from": "shelljs@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
                 }
               }
-            },
-            "nopt": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                }
-              }
-            },
-            "underscore": {
-              "version": "1.7.0",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
-            }
-          }
-        },
-        "array.prototype.findindex": {
-          "version": "0.1.1",
-          "from": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-0.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-0.1.1.tgz"
-        }
-      }
-    },
-    "grunt-css-metrics": {
-      "version": "0.1.2",
-      "from": "https://registry.npmjs.org/grunt-css-metrics/-/grunt-css-metrics-0.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-css-metrics/-/grunt-css-metrics-0.1.2.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "3.2.1",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.1.tgz",
-          "dependencies": {
-            "minimatch": {
-              "version": "0.2.14",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-            },
-            "inherits": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-            }
-          }
-        },
-        "css-parse": {
-          "version": "1.4.0",
-          "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.4.0.tgz"
-        },
-        "humanize": {
-          "version": "0.0.9",
-          "from": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
-          "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz"
-        }
-      }
-    },
-    "grunt-eslint": {
-      "version": "17.2.0",
-      "from": "grunt-eslint@17.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.2.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "eslint": {
-          "version": "1.5.1",
-          "from": "eslint@>=1.5.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.5.0",
-              "from": "concat-stream@>=1.4.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                },
-                "readable-stream": {
-                  "version": "2.0.2",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.3",
-                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.1",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                }
-              }
-            },
-            "doctrine": {
-              "version": "0.7.0",
-              "from": "doctrine@>=0.7.0 <0.8.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "1.1.6",
-                  "from": "esutils@>=1.1.6 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                }
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "escope": {
-              "version": "3.2.0",
-              "from": "escope@>=3.2.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
-              "dependencies": {
-                "es6-map": {
-                  "version": "0.1.1",
-                  "from": "es6-map@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                    },
-                    "es5-ext": {
-                      "version": "0.10.7",
-                      "from": "es5-ext@>=0.10.4 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
-                      "dependencies": {
-                        "es6-symbol": {
-                          "version": "2.0.1",
-                          "from": "es6-symbol@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                        }
-                      }
-                    },
-                    "es6-iterator": {
-                      "version": "0.1.3",
-                      "from": "es6-iterator@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                      "dependencies": {
-                        "es6-symbol": {
-                          "version": "2.0.1",
-                          "from": "es6-symbol@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                        }
-                      }
-                    },
-                    "es6-set": {
-                      "version": "0.1.1",
-                      "from": "es6-set@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
-                    },
-                    "es6-symbol": {
-                      "version": "0.1.1",
-                      "from": "es6-symbol@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
-                    },
-                    "event-emitter": {
-                      "version": "0.3.3",
-                      "from": "event-emitter@>=0.3.1 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
-                    }
-                  }
-                },
-                "es6-weak-map": {
-                  "version": "0.1.4",
-                  "from": "es6-weak-map@>=0.1.2 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                    },
-                    "es5-ext": {
-                      "version": "0.10.7",
-                      "from": "es5-ext@>=0.10.6 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
-                    },
-                    "es6-iterator": {
-                      "version": "0.1.3",
-                      "from": "es6-iterator@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
-                    },
-                    "es6-symbol": {
-                      "version": "2.0.1",
-                      "from": "es6-symbol@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
-                    }
-                  }
-                },
-                "esrecurse": {
-                  "version": "3.1.1",
-                  "from": "esrecurse@>=3.1.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
-                },
-                "estraverse": {
-                  "version": "3.1.0",
-                  "from": "estraverse@>=3.1.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
-                }
-              }
-            },
-            "espree": {
-              "version": "2.2.5",
-              "from": "espree@>=2.2.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
-            },
-            "estraverse": {
-              "version": "4.1.0",
-              "from": "estraverse@>=4.1.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
-            },
-            "estraverse-fb": {
-              "version": "1.3.1",
-              "from": "estraverse-fb@>=1.3.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
             },
             "glob": {
-              "version": "5.0.15",
-              "from": "glob@>=5.0.14 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "version": "4.3.4",
+              "from": "glob@4.3.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.4.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
@@ -2924,6 +3881,30 @@
                   "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
                 "once": {
                   "version": "1.3.2",
                   "from": "once@>=1.3.0 <2.0.0",
@@ -2938,1040 +3919,54 @@
                 }
               }
             },
-            "globals": {
-              "version": "8.10.0",
-              "from": "globals@>=8.6.0 <9.0.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.10.0.tgz"
-            },
-            "handlebars": {
-              "version": "4.0.3",
-              "from": "handlebars@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.3.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "1.4.2",
-                  "from": "async@>=1.4.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
-                },
-                "optimist": {
-                  "version": "0.6.1",
-                  "from": "optimist@>=0.6.1 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                  "dependencies": {
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                    },
-                    "minimist": {
-                      "version": "0.0.10",
-                      "from": "minimist@>=0.0.1 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.4.4",
-                  "from": "source-map@>=0.4.4 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                    }
-                  }
-                },
-                "uglify-js": {
-                  "version": "2.4.24",
-                  "from": "uglify-js@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.2.10",
-                      "from": "async@>=0.2.6 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                    },
-                    "source-map": {
-                      "version": "0.1.34",
-                      "from": "source-map@0.1.34",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "uglify-to-browserify": {
-                      "version": "1.0.2",
-                      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-                    },
-                    "yargs": {
-                      "version": "3.5.4",
-                      "from": "yargs@>=3.5.4 <3.6.0",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.2.1",
-                          "from": "camelcase@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                        },
-                        "decamelize": {
-                          "version": "1.0.0",
-                          "from": "decamelize@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
-                        },
-                        "window-size": {
-                          "version": "0.1.0",
-                          "from": "window-size@0.1.0",
-                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "inquirer": {
-              "version": "0.9.0",
-              "from": "inquirer@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                },
-                "cli-width": {
-                  "version": "1.0.1",
-                  "from": "cli-width@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
-                },
-                "figures": {
-                  "version": "1.4.0",
-                  "from": "figures@>=1.3.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
-                },
-                "readline2": {
-                  "version": "0.1.1",
-                  "from": "readline2@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-                  "dependencies": {
-                    "mute-stream": {
-                      "version": "0.0.4",
-                      "from": "mute-stream@0.0.4",
-                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
-                    },
-                    "strip-ansi": {
-                      "version": "2.0.1",
-                      "from": "strip-ansi@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "1.1.1",
-                          "from": "ansi-regex@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "run-async": {
-                  "version": "0.1.0",
-                  "from": "run-async@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "rx-lite": {
-                  "version": "2.5.2",
-                  "from": "rx-lite@>=2.5.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz"
-                },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "from": "through@>=2.3.6 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                }
-              }
-            },
-            "file-entry-cache": {
-              "version": "1.2.4",
-              "from": "file-entry-cache@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
-              "dependencies": {
-                "flat-cache": {
-                  "version": "1.0.9",
-                  "from": "flat-cache@>=1.0.9 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.9.tgz",
-                  "dependencies": {
-                    "del": {
-                      "version": "2.0.2",
-                      "from": "del@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/del/-/del-2.0.2.tgz",
-                      "dependencies": {
-                        "globby": {
-                          "version": "3.0.1",
-                          "from": "globby@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
-                          "dependencies": {
-                            "array-union": {
-                              "version": "1.0.1",
-                              "from": "array-union@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-                              "dependencies": {
-                                "array-uniq": {
-                                  "version": "1.0.2",
-                                  "from": "array-uniq@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                                }
-                              }
-                            },
-                            "arrify": {
-                              "version": "1.0.0",
-                              "from": "arrify@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "is-path-cwd": {
-                          "version": "1.0.0",
-                          "from": "is-path-cwd@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
-                        },
-                        "is-path-in-cwd": {
-                          "version": "1.0.0",
-                          "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                          "dependencies": {
-                            "is-path-inside": {
-                              "version": "1.0.0",
-                              "from": "is-path-inside@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.2.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "1.0.0",
-                          "from": "pinkie-promise@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "1.0.0",
-                              "from": "pinkie@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "rimraf": {
-                          "version": "2.4.3",
-                          "from": "rimraf@>=2.2.8 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.2",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                    },
-                    "read-json-sync": {
-                      "version": "1.1.0",
-                      "from": "read-json-sync@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "3.0.8",
-                          "from": "graceful-fs@>=3.0.5 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-                        }
-                      }
-                    },
-                    "write": {
-                      "version": "0.2.1",
-                      "from": "write@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                      "dependencies": {
-                        "mkdirp": {
-                          "version": "0.5.1",
-                          "from": "mkdirp@>=0.5.1 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                          "dependencies": {
-                            "minimist": {
-                              "version": "0.0.8",
-                              "from": "minimist@0.0.8",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                }
-              }
-            },
-            "is-my-json-valid": {
-              "version": "2.12.2",
-              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
-              "dependencies": {
-                "generate-function": {
-                  "version": "2.0.0",
-                  "from": "generate-function@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "from": "generate-object-property@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                  "dependencies": {
-                    "is-property": {
-                      "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                    }
-                  }
-                },
-                "jsonpointer": {
-                  "version": "2.0.0",
-                  "from": "jsonpointer@2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                },
-                "xtend": {
-                  "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-                }
-              }
-            },
-            "is-resolvable": {
-              "version": "1.0.0",
-              "from": "is-resolvable@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-              "dependencies": {
-                "tryit": {
-                  "version": "1.0.1",
-                  "from": "tryit@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.1.tgz"
-                }
-              }
-            },
-            "js-yaml": {
-              "version": "3.4.2",
-              "from": "js-yaml@>=3.2.5 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.2.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.2",
-                  "from": "argparse@>=1.0.2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
-                  "dependencies": {
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.2.0",
-                  "from": "esprima@>=2.2.0 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
-                }
-              }
-            },
-            "lodash.clonedeep": {
-              "version": "3.0.2",
-              "from": "lodash.clonedeep@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-              "dependencies": {
-                "lodash._baseclone": {
-                  "version": "3.3.0",
-                  "from": "lodash._baseclone@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-                  "dependencies": {
-                    "lodash._arraycopy": {
-                      "version": "3.0.0",
-                      "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
-                    },
-                    "lodash._arrayeach": {
-                      "version": "3.0.0",
-                      "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
-                    },
-                    "lodash._baseassign": {
-                      "version": "3.2.0",
-                      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                      "dependencies": {
-                        "lodash._basecopy": {
-                          "version": "3.0.1",
-                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                        }
-                      }
-                    },
-                    "lodash._basefor": {
-                      "version": "3.0.2",
-                      "from": "lodash._basefor@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                    },
-                    "lodash.keys": {
-                      "version": "3.1.2",
-                      "from": "lodash.keys@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                      "dependencies": {
-                        "lodash._getnative": {
-                          "version": "3.9.1",
-                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                        },
-                        "lodash.isarguments": {
-                          "version": "3.0.4",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash._bindcallback": {
-                  "version": "3.0.1",
-                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-                }
-              }
-            },
-            "lodash.merge": {
-              "version": "3.3.2",
-              "from": "lodash.merge@>=3.3.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
-              "dependencies": {
-                "lodash._arraycopy": {
-                  "version": "3.0.0",
-                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
-                },
-                "lodash._arrayeach": {
-                  "version": "3.0.0",
-                  "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
-                },
-                "lodash._createassigner": {
-                  "version": "3.1.1",
-                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-                  "dependencies": {
-                    "lodash._bindcallback": {
-                      "version": "3.0.1",
-                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-                    },
-                    "lodash._isiterateecall": {
-                      "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-                    },
-                    "lodash.restparam": {
-                      "version": "3.6.1",
-                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-                    }
-                  }
-                },
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                },
-                "lodash.isplainobject": {
-                  "version": "3.2.0",
-                  "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-                  "dependencies": {
-                    "lodash._basefor": {
-                      "version": "3.0.2",
-                      "from": "lodash._basefor@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
-                    }
-                  }
-                },
-                "lodash.istypedarray": {
-                  "version": "3.0.2",
-                  "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "lodash.keys@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-                },
-                "lodash.keysin": {
-                  "version": "3.0.8",
-                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
-                },
-                "lodash.toplainobject": {
-                  "version": "3.0.0",
-                  "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash.omit": {
-              "version": "3.1.0",
-              "from": "lodash.omit@>=3.1.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
-              "dependencies": {
-                "lodash._arraymap": {
-                  "version": "3.0.0",
-                  "from": "lodash._arraymap@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
-                },
-                "lodash._basedifference": {
-                  "version": "3.0.3",
-                  "from": "lodash._basedifference@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
-                  "dependencies": {
-                    "lodash._baseindexof": {
-                      "version": "3.1.0",
-                      "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
-                    },
-                    "lodash._cacheindexof": {
-                      "version": "3.0.2",
-                      "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
-                    },
-                    "lodash._createcache": {
-                      "version": "3.1.2",
-                      "from": "lodash._createcache@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-                      "dependencies": {
-                        "lodash._getnative": {
-                          "version": "3.9.1",
-                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash._baseflatten": {
-                  "version": "3.1.4",
-                  "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
-                  "dependencies": {
-                    "lodash.isarguments": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                    }
-                  }
-                },
-                "lodash._bindcallback": {
-                  "version": "3.0.1",
-                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-                },
-                "lodash._pickbyarray": {
-                  "version": "3.0.2",
-                  "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
-                },
-                "lodash._pickbycallback": {
-                  "version": "3.0.0",
-                  "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
-                  "dependencies": {
-                    "lodash._basefor": {
-                      "version": "3.0.2",
-                      "from": "lodash._basefor@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
-                    }
-                  }
-                },
-                "lodash.keysin": {
-                  "version": "3.0.8",
-                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-                  "dependencies": {
-                    "lodash.isarguments": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                    }
-                  }
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1",
-                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.1.1",
-              "from": "object-assign@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-            },
-            "optionator": {
-              "version": "0.5.0",
-              "from": "optionator@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "from": "prelude-ls@>=1.1.1 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                },
-                "deep-is": {
-                  "version": "0.1.3",
-                  "from": "deep-is@>=0.1.2 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                },
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                },
-                "type-check": {
-                  "version": "0.3.1",
-                  "from": "type-check@>=0.3.1 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
-                },
-                "levn": {
-                  "version": "0.2.5",
-                  "from": "levn@>=0.2.5 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
-                },
-                "fast-levenshtein": {
-                  "version": "1.0.7",
-                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-            },
-            "path-is-inside": {
-              "version": "1.0.1",
-              "from": "path-is-inside@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
-            },
-            "shelljs": {
-              "version": "0.3.0",
-              "from": "shelljs@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "from": "strip-json-comments@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "from": "text-table@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-            },
-            "to-double-quotes": {
-              "version": "1.0.1",
-              "from": "to-double-quotes@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.1.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "3.0.2",
-                  "from": "get-stdin@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
-                },
-                "meow": {
-                  "version": "3.3.0",
-                  "from": "meow@>=3.1.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.2.1",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                        },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "indent-string": {
-                      "version": "1.2.2",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                      "dependencies": {
-                        "get-stdin": {
-                          "version": "4.0.1",
-                          "from": "get-stdin@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                        },
-                        "repeating": {
-                          "version": "1.1.3",
-                          "from": "repeating@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "minimist": {
-                      "version": "1.2.0",
-                      "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                    },
-                    "object-assign": {
-                      "version": "3.0.0",
-                      "from": "object-assign@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "to-single-quotes": {
-              "version": "1.0.3",
-              "from": "to-single-quotes@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.3.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "3.0.2",
-                  "from": "get-stdin@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
-                },
-                "meow": {
-                  "version": "3.3.0",
-                  "from": "meow@>=3.1.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.2.1",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                        },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "indent-string": {
-                      "version": "1.2.2",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                      "dependencies": {
-                        "get-stdin": {
-                          "version": "4.0.1",
-                          "from": "get-stdin@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                        },
-                        "repeating": {
-                          "version": "1.1.3",
-                          "from": "repeating@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "minimist": {
-                      "version": "1.2.0",
-                      "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                    },
-                    "object-assign": {
-                      "version": "3.0.0",
-                      "from": "object-assign@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "user-home": {
-              "version": "1.1.1",
-              "from": "user-home@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-            },
-            "xml-escape": {
-              "version": "1.0.0",
-              "from": "xml-escape@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "grunt-frequency-graph": {
-      "version": "0.1.6",
-      "from": "https://registry.npmjs.org/grunt-frequency-graph/-/grunt-frequency-graph-0.1.6.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-frequency-graph/-/grunt-frequency-graph-0.1.6.tgz",
-      "dependencies": {
-        "asset-frequency-graph": {
-          "version": "0.3.1",
-          "from": "https://registry.npmjs.org/asset-frequency-graph/-/asset-frequency-graph-0.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/asset-frequency-graph/-/asset-frequency-graph-0.3.1.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-            },
-            "git-promise": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/git-promise/-/git-promise-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/git-promise/-/git-promise-0.2.0.tgz",
-              "dependencies": {
-                "shelljs": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-                }
-              }
-            },
-            "glob": {
-              "version": "4.3.4",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.3.4.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.4.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "gzip-size": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+              "from": "gzip-size@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.0",
-                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                  "from": "concat-stream@>=1.4.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                      "version": "2.0.1",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                          "version": "1.0.1",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
@@ -3980,12 +3975,12 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
                       "version": "0.2.7",
-                      "from": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz",
+                      "from": "pako@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
                     }
                   }
@@ -3994,7 +3989,7 @@
             },
             "madge": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/madge/-/madge-0.4.1.tgz",
+              "from": "madge@0.4.1",
               "resolved": "https://registry.npmjs.org/madge/-/madge-0.4.1.tgz",
               "dependencies": {
                 "amdetective": {
@@ -4212,60 +4207,60 @@
               }
             },
             "moment": {
-              "version": "2.10.6",
-              "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+              "version": "2.10.3",
+              "from": "moment@>=2.9.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+              "from": "pretty-bytes@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+                  "from": "meow@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.2.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                          "version": "1.1.0",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "indent-string": {
-                      "version": "1.2.2",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                      "version": "1.2.1",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "from": "repeating@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -4275,13 +4270,13 @@
                       }
                     },
                     "minimist": {
-                      "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+                      "version": "1.1.1",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                     },
                     "object-assign": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                      "from": "object-assign@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                     }
                   }
@@ -4290,59 +4285,59 @@
             },
             "progress": {
               "version": "1.1.8",
-              "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+              "from": "progress@1.1.8",
               "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
             },
             "uglify-js": {
-              "version": "2.4.24",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+              "version": "2.4.23",
+              "from": "uglify-js@>=2.4.16 <3.0.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "from": "async@>=0.2.6 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.34",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "from": "source-map@0.1.34",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.5.4",
-                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "from": "yargs@>=3.5.4 <3.6.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                     },
                     "decamelize": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "from": "window-size@0.1.0",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "from": "wordwrap@0.0.2",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
@@ -4352,229 +4347,229 @@
           }
         },
         "aws-sdk": {
-          "version": "2.1.45",
-          "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.45.tgz",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.45.tgz",
+          "version": "2.1.35",
+          "from": "aws-sdk@>=2.1.8 <3.0.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.35.tgz",
           "dependencies": {
             "sax": {
               "version": "0.5.3",
-              "from": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz",
+              "from": "sax@0.5.3",
               "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz"
             },
             "xml2js": {
               "version": "0.2.8",
-              "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+              "from": "xml2js@0.2.8",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz"
             },
             "xmlbuilder": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+              "from": "xmlbuilder@0.4.2",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
             }
           }
         },
         "es6-promise": {
           "version": "2.3.0",
-          "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+          "from": "es6-promise@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
         }
       }
     },
     "grunt-hologram": {
       "version": "0.0.4",
-      "from": "https://registry.npmjs.org/grunt-hologram/-/grunt-hologram-0.0.4.tgz",
+      "from": "grunt-hologram@0.0.4",
       "resolved": "https://registry.npmjs.org/grunt-hologram/-/grunt-hologram-0.0.4.tgz",
       "dependencies": {
         "which": {
           "version": "1.0.9",
-          "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "from": "which@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
         },
         "win-spawn": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz",
+          "from": "win-spawn@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
         }
       }
     },
     "grunt-jscs": {
       "version": "1.8.0",
-      "from": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.8.0.tgz",
+      "from": "grunt-jscs@1.8.0",
       "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.8.0.tgz",
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jscs": {
           "version": "1.13.1",
-          "from": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
+          "from": "jscs@>=1.13.0 <1.14.0",
           "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "from": "chalk@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                  "version": "2.0.1",
+                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "from": "has-ansi@>=1.0.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     },
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+                  "from": "supports-color@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                 }
               }
             },
             "cli-table": {
               "version": "0.3.1",
-              "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+              "from": "cli-table@>=0.3.1 <0.4.0",
               "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
               "dependencies": {
                 "colors": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                  "from": "colors@1.0.3",
                   "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.6.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+              "from": "commander@>=2.6.0 <2.7.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "esprima": {
               "version": "1.2.5",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+              "from": "esprima@>=1.2.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
             },
             "esprima-harmony-jscs": {
               "version": "1.1.0-bin",
-              "from": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz",
+              "from": "esprima-harmony-jscs@1.1.0-bin",
               "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz"
             },
             "estraverse": {
               "version": "1.9.3",
-              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "from": "estraverse@>=1.9.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "exit": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "from": "exit@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
             },
             "glob": {
-              "version": "5.0.14",
-              "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+              "version": "5.0.10",
+              "from": "glob@>=5.0.1 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "lodash.assign": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
+              "from": "lodash.assign@>=3.0.0 <3.1.0",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     },
                     "lodash.keys": {
-                      "version": "3.1.2",
-                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "version": "3.1.1",
+                      "from": "lodash.keys@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
                       "dependencies": {
                         "lodash._getnative": {
-                          "version": "3.9.1",
-                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                          "version": "3.9.0",
+                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
                         },
                         "lodash.isarguments": {
-                          "version": "3.0.4",
-                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                          "version": "3.0.3",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
                         },
                         "lodash.isarray": {
-                          "version": "3.0.4",
-                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                          "version": "3.0.3",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
                         }
                       }
                     }
@@ -4582,22 +4577,22 @@
                 },
                 "lodash._createassigner": {
                   "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
                       "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     },
                     "lodash.restparam": {
                       "version": "3.6.1",
-                      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                     }
                   }
@@ -4605,23 +4600,23 @@
               }
             },
             "minimatch": {
-              "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "from": "concat-map@0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -4630,101 +4625,139 @@
             },
             "pathval": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
+              "from": "pathval@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
             },
             "prompt": {
               "version": "0.2.14",
-              "from": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+              "from": "prompt@>=0.2.14 <0.3.0",
               "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "dependencies": {
                 "pkginfo": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
+                  "from": "pkginfo@>=0.0.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
                 },
                 "read": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
+                  "from": "read@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                      "from": "mute-stream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "revalidator": {
                   "version": "0.1.8",
-                  "from": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+                  "from": "revalidator@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
                 },
                 "utile": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+                  "from": "utile@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "from": "async@>=0.2.9 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "deep-equal": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
+                      "from": "deep-equal@*",
                       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
                     },
                     "i": {
                       "version": "0.3.3",
-                      "from": "https://registry.npmjs.org/i/-/i-0.3.3.tgz",
+                      "from": "i@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                     },
                     "ncp": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+                      "from": "ncp@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                     },
                     "rimraf": {
-                      "version": "2.4.2",
-                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz"
+                      "version": "2.4.0",
+                      "from": "rimraf@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.0.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "4.5.3",
+                          "from": "glob@>=4.4.2 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "once": {
+                              "version": "1.3.2",
+                              "from": "once@>=1.3.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 },
                 "winston": {
                   "version": "0.8.3",
-                  "from": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+                  "from": "winston@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "from": "async@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "colors": {
                       "version": "0.6.2",
-                      "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+                      "from": "colors@>=0.6.0 <0.7.0",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
                     },
                     "cycle": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+                      "from": "cycle@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                     },
                     "eyes": {
                       "version": "0.1.8",
-                      "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+                      "from": "eyes@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                     },
                     "isstream": {
                       "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                      "from": "isstream@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
                     "stack-trace": {
                       "version": "0.0.9",
-                      "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+                      "from": "stack-trace@>=0.0.0 <0.1.0",
                       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                     }
                   }
@@ -4732,55 +4765,55 @@
               }
             },
             "strip-json-comments": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+              "version": "1.0.2",
+              "from": "strip-json-comments@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
             },
             "vow-fs": {
               "version": "0.3.4",
-              "from": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
+              "from": "vow-fs@>=0.3.4 <0.4.0",
               "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "from": "node-uuid@>=1.4.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "vow-queue": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz",
+                  "from": "vow-queue@>=0.4.1 <0.5.0",
                   "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "from": "glob@>=4.3.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -4791,13 +4824,13 @@
             },
             "xmlbuilder": {
               "version": "2.6.4",
-              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz",
+              "from": "xmlbuilder@>=2.6.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz",
               "dependencies": {
                 "lodash": {
-                  "version": "3.10.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                  "version": "3.9.3",
+                  "from": "lodash@>=3.5.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
                 }
               }
             }
@@ -4805,570 +4838,530 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "vow": {
           "version": "0.4.10",
-          "from": "https://registry.npmjs.org/vow/-/vow-0.4.10.tgz",
+          "from": "vow@>=0.4.1 <0.5.0",
           "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.10.tgz"
         }
       }
     },
     "grunt-karma": {
       "version": "0.10.1",
-      "from": "https://registry.npmjs.org/grunt-karma/-/grunt-karma-0.10.1.tgz",
+      "from": "grunt-karma@0.10.1",
       "resolved": "https://registry.npmjs.org/grunt-karma/-/grunt-karma-0.10.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "grunt-mkdir": {
       "version": "0.1.2",
-      "from": "https://registry.npmjs.org/grunt-mkdir/-/grunt-mkdir-0.1.2.tgz",
+      "from": "grunt-mkdir@0.1.2",
       "resolved": "https://registry.npmjs.org/grunt-mkdir/-/grunt-mkdir-0.1.2.tgz"
     },
     "grunt-pagespeed": {
       "version": "0.3.0",
-      "from": "https://registry.npmjs.org/grunt-pagespeed/-/grunt-pagespeed-0.3.0.tgz",
+      "from": "grunt-pagespeed@0.3.0",
       "resolved": "https://registry.npmjs.org/grunt-pagespeed/-/grunt-pagespeed-0.3.0.tgz",
       "dependencies": {
         "psi": {
           "version": "0.1.6",
-          "from": "https://registry.npmjs.org/psi/-/psi-0.1.6.tgz",
+          "from": "psi@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/psi/-/psi-0.1.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "from": "chalk@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "gpagespeed": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/gpagespeed/-/gpagespeed-0.0.8.tgz",
+              "from": "gpagespeed@0.0.8",
               "resolved": "https://registry.npmjs.org/gpagespeed/-/gpagespeed-0.0.8.tgz",
               "dependencies": {
                 "googleapis": {
                   "version": "1.1.5",
-                  "from": "https://registry.npmjs.org/googleapis/-/googleapis-1.1.5.tgz",
+                  "from": "googleapis@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-1.1.5.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     },
                     "gapitoken": {
-                      "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/gapitoken/-/gapitoken-0.1.5.tgz",
-                      "resolved": "https://registry.npmjs.org/gapitoken/-/gapitoken-0.1.5.tgz",
+                      "version": "0.1.4",
+                      "from": "gapitoken@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/gapitoken/-/gapitoken-0.1.4.tgz",
                       "dependencies": {
                         "jws": {
-                          "version": "3.0.0",
-                          "from": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
+                          "version": "0.0.2",
+                          "from": "jws@0.0.2",
+                          "resolved": "https://registry.npmjs.org/jws/-/jws-0.0.2.tgz",
                           "dependencies": {
-                            "jwa": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
+                            "tap": {
+                              "version": "0.3.3",
+                              "from": "tap@>=0.3.3 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/tap/-/tap-0.3.3.tgz",
                               "dependencies": {
-                                "base64url": {
-                                  "version": "0.0.6",
-                                  "from": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
-                                  "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
+                                "inherits": {
+                                  "version": "1.0.0"
                                 },
-                                "buffer-equal-constant-time": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+                                "yamlish": {
+                                  "version": "0.0.5"
                                 },
-                                "ecdsa-sig-formatter": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
+                                "slide": {
+                                  "version": "1.1.6",
+                                  "from": "slide@*",
+                                  "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+                                },
+                                "runforcover": {
+                                  "version": "0.0.2",
+                                  "from": "runforcover@>=0.0.2 <0.1.0",
+                                  "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
                                   "dependencies": {
-                                    "asn1.js": {
-                                      "version": "2.2.0",
-                                      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz",
+                                    "bunker": {
+                                      "version": "0.1.2",
+                                      "from": "bunker@>=0.1.0 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
                                       "dependencies": {
-                                        "bn.js": {
-                                          "version": "2.2.0",
-                                          "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
-                                        },
-                                        "inherits": {
-                                          "version": "2.0.1",
-                                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                        },
-                                        "minimalistic-assert": {
-                                          "version": "1.0.0",
-                                          "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                        "burrito": {
+                                          "version": "0.2.12",
+                                          "from": "burrito@>=0.2.5 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+                                          "dependencies": {
+                                            "traverse": {
+                                              "version": "0.5.2",
+                                              "from": "traverse@>=0.5.1 <0.6.0",
+                                              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
+                                            },
+                                            "uglify-js": {
+                                              "version": "1.1.1",
+                                              "from": "uglify-js@>=1.1.1 <1.2.0",
+                                              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
+                                            }
+                                          }
                                         }
                                       }
+                                    }
+                                  }
+                                },
+                                "nopt": {
+                                  "version": "2.2.1",
+                                  "from": "nopt@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                                  "dependencies": {
+                                    "abbrev": {
+                                      "version": "1.0.7",
+                                      "from": "abbrev@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                                    }
+                                  }
+                                },
+                                "mkdirp": {
+                                  "version": "0.3.5",
+                                  "from": "mkdirp@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                                },
+                                "difflet": {
+                                  "version": "0.2.6",
+                                  "from": "difflet@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+                                  "dependencies": {
+                                    "traverse": {
+                                      "version": "0.6.6",
+                                      "from": "traverse@>=0.6.0 <0.7.0",
+                                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
                                     },
-                                    "base64-url": {
-                                      "version": "1.2.1",
-                                      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                                    "charm": {
+                                      "version": "0.1.2",
+                                      "from": "charm@>=0.1.0 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
+                                    },
+                                    "deep-is": {
+                                      "version": "0.1.3",
+                                      "from": "deep-is@>=0.1.0 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                                    }
+                                  }
+                                },
+                                "deep-equal": {
+                                  "version": "0.0.0",
+                                  "from": "deep-equal@>=0.0.0 <0.1.0",
+                                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
+                                },
+                                "buffer-equal": {
+                                  "version": "0.0.1",
+                                  "from": "buffer-equal@>=0.0.0 <0.1.0",
+                                  "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
+                                },
+                                "tap-consumer": {
+                                  "version": "0.0.1",
+                                  "from": "tap-consumer@*",
+                                  "resolved": "https://registry.npmjs.org/tap-consumer/-/tap-consumer-0.0.1.tgz",
+                                  "dependencies": {
+                                    "tap-results": {
+                                      "version": "0.0.2",
+                                      "from": "tap-results@>=0.0.0 <1.0.0",
+                                      "resolved": "https://registry.npmjs.org/tap-results/-/tap-results-0.0.2.tgz"
                                     }
                                   }
                                 }
                               }
                             },
                             "base64url": {
-                              "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
-                              "dependencies": {
-                                "concat-stream": {
-                                  "version": "1.4.10",
-                                  "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-                                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-                                  "dependencies": {
-                                    "inherits": {
-                                      "version": "2.0.1",
-                                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                    },
-                                    "typedarray": {
-                                      "version": "0.0.6",
-                                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                                    },
-                                    "readable-stream": {
-                                      "version": "1.1.13",
-                                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                                      "dependencies": {
-                                        "core-util-is": {
-                                          "version": "1.0.1",
-                                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                                        },
-                                        "isarray": {
-                                          "version": "0.0.1",
-                                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                        },
-                                        "string_decoder": {
-                                          "version": "0.10.31",
-                                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "meow": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-                                  "dependencies": {
-                                    "camelcase-keys": {
-                                      "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                                      "dependencies": {
-                                        "camelcase": {
-                                          "version": "1.2.1",
-                                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                                        },
-                                        "map-obj": {
-                                          "version": "1.0.1",
-                                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                                        }
-                                      }
-                                    },
-                                    "indent-string": {
-                                      "version": "1.2.2",
-                                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                                      "dependencies": {
-                                        "get-stdin": {
-                                          "version": "4.0.1",
-                                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                                        },
-                                        "repeating": {
-                                          "version": "1.1.3",
-                                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                                          "dependencies": {
-                                            "is-finite": {
-                                              "version": "1.0.1",
-                                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                              "dependencies": {
-                                                "number-is-nan": {
-                                                  "version": "1.0.0",
-                                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                                }
-                                              }
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "minimist": {
-                                      "version": "1.1.3",
-                                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
-                                    },
-                                    "object-assign": {
-                                      "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
+                              "version": "0.0.3",
+                              "from": "base64url@0.0.3",
+                              "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.3.tgz"
                             }
                           }
                         },
                         "request": {
-                          "version": "2.60.0",
-                          "from": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
-                          "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
+                          "version": "2.58.0",
+                          "from": "request@>=2.54.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
                           "dependencies": {
                             "bl": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                              "version": "0.9.4",
+                              "from": "bl@>=0.9.0 <0.10.0",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                               "dependencies": {
                                 "readable-stream": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "version": "1.0.33",
+                                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                                    },
-                                    "inherits": {
-                                      "version": "2.0.1",
-                                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                      "from": "isarray@0.0.1",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                    },
-                                    "process-nextick-args": {
-                                      "version": "1.0.2",
-                                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
-                                    "util-deprecate": {
-                                      "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     }
                                   }
                                 }
                               }
                             },
                             "caseless": {
-                              "version": "0.11.0",
-                              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                              "version": "0.10.0",
+                              "from": "caseless@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
                             },
                             "extend": {
-                              "version": "3.0.0",
-                              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                              "version": "2.0.1",
+                              "from": "extend@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
                             },
                             "forever-agent": {
                               "version": "0.6.1",
-                              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                              "from": "forever-agent@>=0.6.0 <0.7.0",
                               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                             },
                             "form-data": {
-                              "version": "1.0.0-rc3",
-                              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                              "version": "1.0.0-rc1",
+                              "from": "form-data@>=1.0.0-rc1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
                               "dependencies": {
                                 "async": {
-                                  "version": "1.4.2",
-                                  "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                                  "version": "1.2.1",
+                                  "from": "async@>=1.2.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
+                                },
+                                "mime-types": {
+                                  "version": "2.1.1",
+                                  "from": "mime-types@>=2.1.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
+                                  "dependencies": {
+                                    "mime-db": {
+                                      "version": "1.13.0",
+                                      "from": "mime-db@>=1.13.0 <1.14.0",
+                                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
+                                    }
+                                  }
                                 }
                               }
                             },
                             "json-stringify-safe": {
                               "version": "5.0.1",
-                              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                             },
                             "mime-types": {
-                              "version": "2.1.4",
-                              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
-                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
+                              "version": "2.0.14",
+                              "from": "mime-types@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                               "dependencies": {
                                 "mime-db": {
-                                  "version": "1.16.0",
-                                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
+                                  "version": "1.12.0",
+                                  "from": "mime-db@>=1.12.0 <1.13.0",
+                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                                 }
                               }
                             },
                             "node-uuid": {
                               "version": "1.4.3",
-                              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                              "from": "node-uuid@>=1.4.0 <1.5.0",
                               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                             },
                             "qs": {
-                              "version": "4.0.0",
-                              "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+                              "version": "3.1.0",
+                              "from": "qs@>=3.1.0 <3.2.0",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
                             },
                             "tunnel-agent": {
-                              "version": "0.4.1",
-                              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                              "version": "0.4.0",
+                              "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                             },
                             "tough-cookie": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+                              "from": "tough-cookie@>=0.12.0",
                               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                             },
                             "http-signature": {
                               "version": "0.11.0",
-                              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                              "from": "http-signature@>=0.11.0 <0.12.0",
                               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                               "dependencies": {
                                 "assert-plus": {
                                   "version": "0.1.5",
-                                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                                  "from": "assert-plus@>=0.1.5 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                                 },
                                 "asn1": {
                                   "version": "0.1.11",
-                                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                                  "from": "asn1@0.1.11",
                                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                                 },
                                 "ctype": {
                                   "version": "0.5.3",
-                                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                                  "from": "ctype@0.5.3",
                                   "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                                 }
                               }
                             },
                             "oauth-sign": {
                               "version": "0.8.0",
-                              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+                              "from": "oauth-sign@>=0.8.0 <0.9.0",
                               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                             },
                             "hawk": {
-                              "version": "3.1.0",
-                              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                              "version": "2.3.1",
+                              "from": "hawk@>=2.3.0 <2.4.0",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                               "dependencies": {
                                 "hoek": {
                                   "version": "2.14.0",
-                                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
+                                  "from": "hoek@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                                 },
                                 "boom": {
                                   "version": "2.8.0",
-                                  "from": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz",
+                                  "from": "boom@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                                 },
                                 "cryptiles": {
                                   "version": "2.0.4",
-                                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+                                  "from": "cryptiles@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                                 },
                                 "sntp": {
                                   "version": "1.0.9",
-                                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                                  "from": "sntp@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                                 }
                               }
                             },
                             "aws-sign2": {
                               "version": "0.5.0",
-                              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                              "from": "aws-sign2@>=0.5.0 <0.6.0",
                               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                             },
                             "stringstream": {
                               "version": "0.0.4",
-                              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                              "from": "stringstream@>=0.0.4 <0.1.0",
                               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                             },
                             "combined-stream": {
                               "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                              "from": "combined-stream@>=1.0.1 <1.1.0",
                               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                               "dependencies": {
                                 "delayed-stream": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                                  "from": "delayed-stream@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                                 }
                               }
                             },
                             "isstream": {
                               "version": "0.1.2",
-                              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                              "from": "isstream@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                             },
                             "har-validator": {
                               "version": "1.8.0",
-                              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+                              "from": "har-validator@>=1.6.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                               "dependencies": {
                                 "bluebird": {
-                                  "version": "2.9.34",
-                                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
-                                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
+                                  "version": "2.9.30",
+                                  "from": "bluebird@>=2.9.30 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.30.tgz"
                                 },
                                 "chalk": {
-                                  "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+                                  "version": "1.0.0",
+                                  "from": "chalk@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
                                   "dependencies": {
                                     "ansi-styles": {
-                                      "version": "2.1.0",
-                                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                      "version": "2.0.1",
+                                      "from": "ansi-styles@>=2.0.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                                     },
                                     "escape-string-regexp": {
                                       "version": "1.0.3",
-                                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                                     },
                                     "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "version": "1.0.3",
+                                      "from": "has-ansi@>=1.0.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                                       "dependencies": {
                                         "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                          "version": "1.1.1",
+                                          "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                        },
+                                        "get-stdin": {
+                                          "version": "4.0.1",
+                                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                                         }
                                       }
                                     },
                                     "strip-ansi": {
-                                      "version": "3.0.0",
-                                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                      "version": "2.0.1",
+                                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                                       "dependencies": {
                                         "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                          "version": "1.1.1",
+                                          "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                                         }
                                       }
                                     },
                                     "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                      "version": "1.3.1",
+                                      "from": "supports-color@>=1.3.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                                     }
                                   }
                                 },
                                 "commander": {
                                   "version": "2.8.1",
-                                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                                  "from": "commander@>=2.8.1 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                                   "dependencies": {
                                     "graceful-readlink": {
                                       "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                                      "from": "graceful-readlink@>=1.0.0",
                                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                                     }
                                   }
                                 },
                                 "is-my-json-valid": {
-                                  "version": "2.12.1",
-                                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
+                                  "version": "2.12.0",
+                                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                                   "dependencies": {
                                     "generate-function": {
                                       "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                                      "from": "generate-function@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                                     },
                                     "generate-object-property": {
                                       "version": "1.2.0",
-                                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                                       "dependencies": {
                                         "is-property": {
                                           "version": "1.0.2",
-                                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                                          "from": "is-property@>=1.0.0 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                                         }
                                       }
                                     },
                                     "jsonpointer": {
                                       "version": "1.1.0",
-                                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
+                                      "from": "jsonpointer@>=1.1.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                                     },
                                     "xtend": {
                                       "version": "4.0.0",
-                                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                                      "from": "xtend@>=4.0.0 <5.0.0",
                                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                                     }
                                   }
@@ -5381,37 +5374,37 @@
                     },
                     "request": {
                       "version": "2.51.0",
-                      "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                      "from": "request@>=2.51.0 <2.52.0",
                       "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                       "dependencies": {
                         "bl": {
                           "version": "0.9.4",
-                          "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                          "from": "bl@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.33",
-                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "from": "readable-stream@>=1.0.26 <1.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "from": "isarray@0.0.1",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 }
                               }
@@ -5420,27 +5413,27 @@
                         },
                         "caseless": {
                           "version": "0.8.0",
-                          "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                          "from": "caseless@>=0.8.0 <0.9.0",
                           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                         },
                         "forever-agent": {
                           "version": "0.5.2",
-                          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                          "from": "forever-agent@>=0.5.0 <0.6.0",
                           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                         },
                         "form-data": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                          "from": "form-data@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                           "dependencies": {
                             "mime-types": {
                               "version": "2.0.14",
-                              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                              "from": "mime-types@>=2.0.3 <2.1.0",
                               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                               "dependencies": {
                                 "mime-db": {
                                   "version": "1.12.0",
-                                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                                  "from": "mime-db@>=1.12.0 <1.13.0",
                                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                                 }
                               }
@@ -5449,106 +5442,106 @@
                         },
                         "json-stringify-safe": {
                           "version": "5.0.1",
-                          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                         },
                         "mime-types": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                          "from": "mime-types@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                         },
                         "node-uuid": {
                           "version": "1.4.3",
-                          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                          "from": "node-uuid@>=1.4.0 <1.5.0",
                           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                         },
                         "qs": {
                           "version": "2.3.3",
-                          "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                          "from": "qs@>=2.3.1 <2.4.0",
                           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                         },
                         "tunnel-agent": {
-                          "version": "0.4.1",
-                          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                          "version": "0.4.0",
+                          "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                         },
                         "tough-cookie": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+                          "from": "tough-cookie@>=0.12.0",
                           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                         },
                         "http-signature": {
                           "version": "0.10.1",
-                          "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                          "from": "http-signature@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                           "dependencies": {
                             "assert-plus": {
                               "version": "0.1.5",
-                              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                              "from": "assert-plus@>=0.1.5 <0.2.0",
                               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                             },
                             "asn1": {
                               "version": "0.1.11",
-                              "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                              "from": "asn1@0.1.11",
                               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                             },
                             "ctype": {
                               "version": "0.5.3",
-                              "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                              "from": "ctype@0.5.3",
                               "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                             }
                           }
                         },
                         "oauth-sign": {
                           "version": "0.5.0",
-                          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                          "from": "oauth-sign@>=0.5.0 <0.6.0",
                           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                         },
                         "hawk": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                          "from": "hawk@1.1.1",
                           "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                           "dependencies": {
                             "hoek": {
                               "version": "0.9.1",
-                              "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                              "from": "hoek@>=0.9.0 <0.10.0",
                               "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                             },
                             "boom": {
                               "version": "0.4.2",
-                              "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                              "from": "boom@>=0.4.0 <0.5.0",
                               "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                             },
                             "cryptiles": {
                               "version": "0.2.2",
-                              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                              "from": "cryptiles@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                             },
                             "sntp": {
                               "version": "0.2.4",
-                              "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                              "from": "sntp@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                             }
                           }
                         },
                         "aws-sign2": {
                           "version": "0.5.0",
-                          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                          "from": "aws-sign2@>=0.5.0 <0.6.0",
                           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                         },
                         "stringstream": {
                           "version": "0.0.4",
-                          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                          "from": "stringstream@>=0.0.4 <0.1.0",
                           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                         },
                         "combined-stream": {
                           "version": "0.0.7",
-                          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                          "from": "combined-stream@>=0.0.5 <0.1.0",
                           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                           "dependencies": {
                             "delayed-stream": {
                               "version": "0.0.5",
-                              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                              "from": "delayed-stream@0.0.5",
                               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                             }
                           }
@@ -5557,83 +5550,83 @@
                     },
                     "string-template": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+                      "from": "string-template@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
                     }
                   }
                 },
                 "minimist": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+                  "from": "minimist@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
                 },
                 "valid-url": {
                   "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+                  "from": "valid-url@>=1.0.9 <2.0.0",
                   "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz"
                 }
               }
             },
             "minimist": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+              "version": "1.1.1",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
             },
             "prepend-http": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
+              "version": "1.0.1",
+              "from": "prepend-http@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+              "from": "pretty-bytes@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+                  "from": "meow@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.2.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                          "version": "1.1.0",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "indent-string": {
-                      "version": "1.2.2",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                      "version": "1.2.1",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "from": "repeating@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -5644,7 +5637,7 @@
                     },
                     "object-assign": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                      "from": "object-assign@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                     }
                   }
@@ -5657,80 +5650,80 @@
     },
     "grunt-px-to-rem": {
       "version": "0.4.0",
-      "from": "https://registry.npmjs.org/grunt-px-to-rem/-/grunt-px-to-rem-0.4.0.tgz",
+      "from": "grunt-px-to-rem@0.4.0",
       "resolved": "https://registry.npmjs.org/grunt-px-to-rem/-/grunt-px-to-rem-0.4.0.tgz",
       "dependencies": {
         "postcss": {
           "version": "4.0.6",
-          "from": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
+          "from": "postcss@>=4.0.6 <4.1.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "from": "source-map@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                 }
               }
             },
             "js-base64": {
-              "version": "2.1.9",
-              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+              "version": "2.1.8",
+              "from": "js-base64@>=2.1.7 <2.2.0",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz"
             }
           }
         },
         "chalk": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "from": "chalk@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+              "from": "supports-color@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
@@ -5739,127 +5732,127 @@
     },
     "grunt-sass": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-1.0.0.tgz",
+      "from": "grunt-sass@1.0.0",
       "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-1.0.0.tgz",
       "dependencies": {
         "each-async": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+          "from": "each-async@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
+              "from": "onetime@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
             "set-immediate-shim": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
             }
           }
         },
         "node-sass": {
           "version": "3.2.0",
-          "from": "https://registry.npmjs.org/node-sass/-/node-sass-3.2.0.tgz",
+          "from": "node-sass@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.2.0.tgz",
           "dependencies": {
             "async-foreach": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+              "from": "async-foreach@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
             },
             "chalk": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+              "version": "1.0.0",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                  "version": "2.0.1",
+                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "version": "1.0.3",
+                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                  "version": "1.3.1",
+                  "from": "supports-color@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                 }
               }
             },
             "gaze": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+              "from": "gaze@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
               "dependencies": {
                 "globule": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                  "from": "globule@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                      "from": "lodash@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                     },
                     "glob": {
                       "version": "3.1.21",
-                      "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "from": "glob@>=3.1.21 <3.2.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "1.2.3",
-                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                          "from": "graceful-fs@>=1.2.0 <1.3.0",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                         },
                         "inherits": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+                          "from": "inherits@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.6.5",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
@@ -5870,49 +5863,49 @@
             },
             "get-stdin": {
               "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "glob": {
-              "version": "5.0.14",
-              "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+              "version": "5.0.10",
+              "from": "glob@>=5.0.3 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -5921,63 +5914,63 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "meow": {
               "version": "3.3.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+              "from": "meow@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
-                  "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "from": "repeating@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -5987,149 +5980,144 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+                  "version": "1.1.1",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
             },
             "nan": {
-              "version": "1.9.0",
-              "from": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
+              "version": "1.8.4",
+              "from": "nan@>=1.8.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
             },
             "npmconf": {
               "version": "2.1.2",
-              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+              "from": "npmconf@>=2.1.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.9",
-                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
                   "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
                   "dependencies": {
                     "proto-list": {
                       "version": "1.2.4",
-                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                      "from": "proto-list@>=1.2.1 <1.3.0",
                       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                  "from": "ini@>=1.2.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "nopt": {
-                  "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+                  "version": "3.0.2",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "osenv": {
-                  "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "version": "0.1.2",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
                   "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "semver": {
                   "version": "4.3.6",
-                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 },
                 "uid-number": {
                   "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+                  "from": "uid-number@0.0.5",
                   "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
                 }
               }
             },
             "pangyp": {
-              "version": "2.3.0",
-              "from": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.3.0.tgz",
+              "version": "2.2.1",
+              "from": "pangyp@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.1.tgz",
               "dependencies": {
                 "fstream": {
                   "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
+                  "from": "fstream@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "glob": {
                   "version": "4.3.5",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+                  "from": "glob@>=4.3.5 <4.4.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -6138,27 +6126,27 @@
                 },
                 "graceful-fs": {
                   "version": "3.0.8",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+                  "from": "graceful-fs@>=3.0.5 <3.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 },
                 "minimatch": {
-                  "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -6166,60 +6154,60 @@
                   }
                 },
                 "nopt": {
-                  "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+                  "version": "3.0.2",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "npmlog": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
+                  "from": "npmlog@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
                   "dependencies": {
                     "ansi": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz",
+                      "from": "ansi@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
                     },
                     "are-we-there-yet": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                       "dependencies": {
                         "delegates": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+                          "from": "delegates@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
                         },
                         "readable-stream": {
                           "version": "1.1.13",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "from": "readable-stream@>=1.1.13 <2.0.0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "isarray@0.0.1",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "inherits@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -6228,12 +6216,12 @@
                     },
                     "gauge": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
+                      "from": "gauge@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                       "dependencies": {
                         "has-unicode": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz",
+                          "from": "has-unicode@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
                         }
                       }
@@ -6241,55 +6229,50 @@
                   }
                 },
                 "osenv": {
-                  "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "version": "0.1.2",
+                  "from": "osenv@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
                   "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "request": {
                   "version": "2.51.0",
-                  "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                  "from": "request@>=2.51.0 <2.52.0",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "0.9.4",
-                      "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                      "from": "bl@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "from": "readable-stream@>=1.0.26 <1.1.0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "isarray@0.0.1",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "inherits@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -6298,32 +6281,32 @@
                     },
                     "caseless": {
                       "version": "0.8.0",
-                      "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                      "from": "caseless@>=0.8.0 <0.9.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                     },
                     "forever-agent": {
                       "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                      "from": "forever-agent@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                     },
                     "form-data": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                      "from": "form-data@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.9.2",
-                          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                          "from": "async@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                         },
                         "mime-types": {
                           "version": "2.0.14",
-                          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                          "from": "mime-types@>=2.0.3 <2.1.0",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                           "dependencies": {
                             "mime-db": {
                               "version": "1.12.0",
-                              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                              "from": "mime-db@>=1.12.0 <1.13.0",
                               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                             }
                           }
@@ -6332,106 +6315,106 @@
                     },
                     "json-stringify-safe": {
                       "version": "5.0.1",
-                      "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "mime-types": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                      "from": "mime-types@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                     },
                     "node-uuid": {
                       "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                      "from": "node-uuid@>=1.4.0 <1.5.0",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                     },
                     "qs": {
                       "version": "2.3.3",
-                      "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                      "from": "qs@>=2.3.1 <2.4.0",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                     },
                     "tunnel-agent": {
-                      "version": "0.4.1",
-                      "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                      "version": "0.4.0",
+                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                     },
                     "tough-cookie": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+                      "from": "tough-cookie@>=0.12.0",
                       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                     },
                     "http-signature": {
                       "version": "0.10.1",
-                      "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                      "from": "http-signature@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.5",
-                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                         },
                         "asn1": {
                           "version": "0.1.11",
-                          "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                          "from": "asn1@0.1.11",
                           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                         },
                         "ctype": {
                           "version": "0.5.3",
-                          "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                          "from": "ctype@0.5.3",
                           "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                         }
                       }
                     },
                     "oauth-sign": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                      "from": "oauth-sign@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                     },
                     "hawk": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "from": "hawk@1.1.1",
                       "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                       "dependencies": {
                         "hoek": {
                           "version": "0.9.1",
-                          "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                          "from": "hoek@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                         },
                         "boom": {
                           "version": "0.4.2",
-                          "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                          "from": "boom@>=0.4.0 <0.5.0",
                           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                         },
                         "cryptiles": {
                           "version": "0.2.2",
-                          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                          "from": "cryptiles@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                         },
                         "sntp": {
                           "version": "0.2.4",
-                          "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                          "from": "sntp@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                         }
                       }
                     },
                     "aws-sign2": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                      "from": "aws-sign2@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                     },
                     "stringstream": {
                       "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                      "from": "stringstream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "from": "combined-stream@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                          "from": "delayed-stream@0.0.5",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
@@ -6440,284 +6423,286 @@
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "from": "rimraf@>=2.2.8 <2.3.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "semver": {
                   "version": "4.3.6",
-                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+                  "from": "semver@>=4.3.6 <4.4.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                 },
                 "tar": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+                  "from": "tar@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
                   "dependencies": {
                     "block-stream": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
+                      "from": "block-stream@*",
                       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "which": {
                   "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+                  "from": "which@>=1.0.8 <1.1.0",
                   "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
                 }
               }
             },
             "request": {
-              "version": "2.60.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",
+              "version": "2.58.0",
+              "from": "request@>=2.55.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
               "dependencies": {
                 "bl": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
-                        "util-deprecate": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
                   }
                 },
                 "caseless": {
-                  "version": "0.11.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                  "version": "0.10.0",
+                  "from": "caseless@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
                 },
                 "extend": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                  "version": "2.0.1",
+                  "from": "extend@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
                 },
                 "forever-agent": {
                   "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "from": "forever-agent@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
-                  "version": "1.0.0-rc3",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                  "version": "1.0.0-rc1",
+                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "1.4.2",
-                      "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                      "version": "1.2.1",
+                      "from": "async@>=1.2.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.1",
+                      "from": "mime-types@>=2.1.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.13.0",
+                          "from": "mime-db@>=1.13.0 <1.14.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
+                        }
+                      }
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.4",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
+                  "version": "2.0.14",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.16.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
+                      "version": "1.12.0",
+                      "from": "mime-db@>=1.12.0 <1.13.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
-                  "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+                  "version": "3.1.0",
+                  "from": "qs@>=3.1.0 <3.2.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+                  "from": "tough-cookie@>=0.12.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.11.0",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                  "from": "http-signature@>=0.11.0 <0.12.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.8.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+                  "from": "oauth-sign@>=0.8.0 <0.9.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                 },
                 "hawk": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                  "version": "2.3.1",
+                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.14.0",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
+                      "from": "hoek@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
                       "version": "2.8.0",
-                      "from": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz",
+                      "from": "boom@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "from": "sntp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "from": "combined-stream@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "from": "isstream@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "1.8.0",
-                  "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+                  "from": "har-validator@>=1.6.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "dependencies": {
                     "bluebird": {
-                      "version": "2.9.34",
-                      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
+                      "version": "2.9.30",
+                      "from": "bluebird@>=2.9.30 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.30.tgz"
                     },
                     "commander": {
                       "version": "2.8.1",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                      "from": "commander@>=2.8.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "from": "graceful-readlink@>=1.0.0",
                           "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                         }
                       }
                     },
                     "is-my-json-valid": {
-                      "version": "2.12.1",
-                      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.1.tgz",
+                      "version": "2.12.0",
+                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "from": "generate-function@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "from": "is-property@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
+                          "from": "jsonpointer@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
                         },
                         "xtend": {
                           "version": "4.0.0",
-                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                          "from": "xtend@>=4.0.0 <5.0.0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                         }
                       }
@@ -6727,53 +6712,53 @@
               }
             },
             "sass-graph": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.1.tgz",
+              "version": "2.0.0",
+              "from": "sass-graph@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
               "dependencies": {
                 "lodash": {
-                  "version": "3.10.1",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                  "version": "3.9.3",
+                  "from": "lodash@>=3.8.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
                 },
                 "yargs": {
-                  "version": "3.19.0",
-                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.19.0.tgz",
+                  "version": "3.12.0",
+                  "from": "yargs@>=3.8.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.12.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "from": "cliui@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
+                          "from": "center-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz",
+                                  "from": "kind-of@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "from": "longest@>=1.0.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -6782,27 +6767,27 @@
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "from": "right-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz",
+                                  "from": "kind-of@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "from": "longest@>=1.0.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -6811,25 +6796,20 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "from": "wordwrap@0.0.2",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                     },
                     "window-size": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
-                    },
-                    "y18n": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/y18n/-/y18n-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.0.0.tgz"
+                      "version": "0.1.1",
+                      "from": "window-size@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.1.tgz"
                     }
                   }
                 }
@@ -6839,75 +6819,75 @@
         },
         "object-assign": {
           "version": "2.1.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "from": "object-assign@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         }
       }
     },
     "grunt-scss-lint": {
       "version": "0.3.3",
-      "from": "https://registry.npmjs.org/grunt-scss-lint/-/grunt-scss-lint-0.3.3.tgz",
+      "from": "grunt-scss-lint@0.3.3",
       "resolved": "https://registry.npmjs.org/grunt-scss-lint/-/grunt-scss-lint-0.3.3.tgz",
       "dependencies": {
         "lodash": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "from": "lodash@2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "xmlbuilder": {
           "version": "2.4.3",
-          "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.3.tgz",
+          "from": "xmlbuilder@2.4.3",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.3.tgz",
           "dependencies": {
             "lodash-node": {
               "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+              "from": "lodash-node@>=2.4.1 <2.5.0",
               "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
             }
           }
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "from": "chalk@0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -6916,51 +6896,51 @@
     },
     "grunt-shell": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.1.1.tgz",
+      "from": "grunt-shell@1.1.1",
       "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.1.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "from": "chalk@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+              "from": "supports-color@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
             }
           }
@@ -6969,127 +6949,132 @@
     },
     "grunt-svgmin": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/grunt-svgmin/-/grunt-svgmin-2.0.1.tgz",
+      "from": "grunt-svgmin@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/grunt-svgmin/-/grunt-svgmin-2.0.1.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
         },
         "each-async": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+          "from": "each-async@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
+              "from": "onetime@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
             },
             "set-immediate-shim": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
             }
           }
         },
         "log-symbols": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "from": "log-symbols@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
         },
         "pretty-bytes": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+          "from": "pretty-bytes@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.3.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+              "from": "meow@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
-                  "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "from": "repeating@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -7099,13 +7084,13 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+                  "version": "1.1.1",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
@@ -7113,74 +7098,74 @@
           }
         },
         "svgo": {
-          "version": "0.5.6",
-          "from": "https://registry.npmjs.org/svgo/-/svgo-0.5.6.tgz",
-          "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.5.6.tgz",
+          "version": "0.5.3",
+          "from": "svgo@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.5.3.tgz",
           "dependencies": {
             "sax": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/sax/-/sax-1.1.1.tgz",
+              "from": "sax@>=1.1.1 <1.2.0",
               "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.1.tgz"
             },
             "coa": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
+              "from": "coa@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
               "dependencies": {
                 "q": {
                   "version": "1.4.1",
-                  "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                  "from": "q@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                 }
               }
             },
             "js-yaml": {
               "version": "3.3.1",
-              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+              "from": "js-yaml@>=3.3.1 <3.4.0",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "from": "argparse@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
-                      "version": "3.10.1",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                      "version": "3.9.3",
+                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
                     },
                     "sprintf-js": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                      "version": "1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+                  "from": "esprima@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                 }
               }
             },
             "colors": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+              "from": "colors@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
             },
             "whet.extend": {
               "version": "0.9.9",
-              "from": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+              "from": "whet.extend@>=0.9.9 <0.10.0",
               "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "from": "mkdirp@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
@@ -7191,27 +7176,27 @@
     },
     "grunt-text-replace": {
       "version": "0.3.12",
-      "from": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.3.12.tgz",
+      "from": "grunt-text-replace@0.3.12",
       "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.3.12.tgz"
     },
     "grunt-webfontjson": {
       "version": "0.0.4",
-      "from": "https://registry.npmjs.org/grunt-webfontjson/-/grunt-webfontjson-0.0.4.tgz",
+      "from": "grunt-webfontjson@0.0.4",
       "resolved": "https://registry.npmjs.org/grunt-webfontjson/-/grunt-webfontjson-0.0.4.tgz",
       "dependencies": {
         "webfontjson": {
           "version": "0.0.4",
-          "from": "https://registry.npmjs.org/webfontjson/-/webfontjson-0.0.4.tgz",
+          "from": "webfontjson@0.0.4",
           "resolved": "https://registry.npmjs.org/webfontjson/-/webfontjson-0.0.4.tgz",
           "dependencies": {
             "commander": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+              "from": "commander@>=1.1.1 <1.2.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
               "dependencies": {
                 "keypress": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+                  "from": "keypress@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
                 }
               }
@@ -7222,40 +7207,40 @@
     },
     "handlebars": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+      "from": "handlebars@2.0.0",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
       "dependencies": {
         "optimist": {
           "version": "0.3.7",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "from": "optimist@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.3.6",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+          "from": "uglify-js@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "from": "source-map@>=0.1.7 <0.2.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "version": "0.1.1",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                 }
               }
             }
@@ -7265,17 +7250,17 @@
     },
     "jasmine-core": {
       "version": "2.3.4",
-      "from": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz",
+      "from": "jasmine-core@>=2.3.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
     },
     "jit-grunt": {
       "version": "0.9.1",
-      "from": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.9.1.tgz",
+      "from": "jit-grunt@0.9.1",
       "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.9.1.tgz"
     },
     "jsonfile": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz",
+      "from": "jsonfile@2.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz"
     },
     "jspm": {
@@ -8605,172 +8590,172 @@
     },
     "jspm-bower-endpoint": {
       "version": "0.3.2",
-      "from": "https://registry.npmjs.org/jspm-bower-endpoint/-/jspm-bower-endpoint-0.3.2.tgz",
+      "from": "jspm-bower-endpoint@>=0.3.2 <0.4.0",
       "resolved": "https://registry.npmjs.org/jspm-bower-endpoint/-/jspm-bower-endpoint-0.3.2.tgz",
       "dependencies": {
         "bower": {
           "version": "1.4.0",
-          "from": "https://registry.npmjs.org/bower/-/bower-1.4.0.tgz",
+          "from": "bower@1.4.0",
           "resolved": "https://registry.npmjs.org/bower/-/bower-1.4.0.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "from": "abbrev@>=1.0.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             },
             "archy": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+              "from": "archy@1.0.0",
               "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
             },
             "bower-config": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
+              "from": "bower-config@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "mout": {
                   "version": "0.9.1",
-                  "from": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz",
+                  "from": "mout@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
                 },
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "from": "optimist@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     },
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "from": "minimist@>=0.0.1 <0.1.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
                 },
                 "osenv": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
+                  "from": "osenv@0.0.3",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
                 }
               }
             },
             "bower-json": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+              "from": "bower-json@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
               "dependencies": {
                 "deep-extend": {
                   "version": "0.2.11",
-                  "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+                  "from": "deep-extend@>=0.2.5 <0.3.0",
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "intersect": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz",
+                  "from": "intersect@>=0.0.3 <0.1.0",
                   "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
                 }
               }
             },
             "bower-registry-client": {
               "version": "0.2.4",
-              "from": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.4.tgz",
+              "from": "bower-registry-client@>=0.2.1 <0.3.0",
               "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.4.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "from": "async@>=0.2.8 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "bower-config": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
+                  "from": "bower-config@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
                   "dependencies": {
                     "mout": {
                       "version": "0.9.1",
-                      "from": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz",
+                      "from": "mout@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
                     },
                     "optimist": {
                       "version": "0.6.1",
-                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                      "from": "optimist@>=0.6.0 <0.7.0",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.3",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "from": "wordwrap@>=0.0.2 <0.1.0",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         },
                         "minimist": {
                           "version": "0.0.10",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                          "from": "minimist@>=0.0.1 <0.1.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                         }
                       }
                     },
                     "osenv": {
                       "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
+                      "from": "osenv@0.0.3",
                       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "lru-cache": {
                   "version": "2.3.1",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
+                  "from": "lru-cache@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
                 },
                 "request": {
                   "version": "2.51.0",
-                  "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                  "from": "request@>=2.51.0 <2.52.0",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "0.9.4",
-                      "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                      "from": "bl@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "from": "readable-stream@>=1.0.26 <1.1.0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "isarray@0.0.1",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "inherits@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -8779,32 +8764,32 @@
                     },
                     "caseless": {
                       "version": "0.8.0",
-                      "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                      "from": "caseless@>=0.8.0 <0.9.0",
                       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
                     },
                     "forever-agent": {
                       "version": "0.5.2",
-                      "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                      "from": "forever-agent@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                     },
                     "form-data": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                      "from": "form-data@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.9.2",
-                          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                          "from": "async@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                         },
                         "mime-types": {
                           "version": "2.0.14",
-                          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                          "from": "mime-types@>=2.0.3 <2.1.0",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                           "dependencies": {
                             "mime-db": {
                               "version": "1.12.0",
-                              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                              "from": "mime-db@>=1.12.0 <1.13.0",
                               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                             }
                           }
@@ -8813,106 +8798,106 @@
                     },
                     "json-stringify-safe": {
                       "version": "5.0.1",
-                      "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "mime-types": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                      "from": "mime-types@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                     },
                     "node-uuid": {
                       "version": "1.4.3",
-                      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                      "from": "node-uuid@>=1.4.0 <1.5.0",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                     },
                     "qs": {
                       "version": "2.3.3",
-                      "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                      "from": "qs@>=2.3.1 <2.4.0",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                     },
                     "tunnel-agent": {
-                      "version": "0.4.1",
-                      "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                      "version": "0.4.0",
+                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                     },
                     "tough-cookie": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+                      "from": "tough-cookie@>=0.12.0",
                       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                     },
                     "http-signature": {
                       "version": "0.10.1",
-                      "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                      "from": "http-signature@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.5",
-                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                         },
                         "asn1": {
                           "version": "0.1.11",
-                          "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                          "from": "asn1@0.1.11",
                           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                         },
                         "ctype": {
                           "version": "0.5.3",
-                          "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                          "from": "ctype@0.5.3",
                           "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                         }
                       }
                     },
                     "oauth-sign": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                      "from": "oauth-sign@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
                     },
                     "hawk": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "from": "hawk@1.1.1",
                       "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                       "dependencies": {
                         "hoek": {
                           "version": "0.9.1",
-                          "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                          "from": "hoek@>=0.9.0 <0.10.0",
                           "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                         },
                         "boom": {
                           "version": "0.4.2",
-                          "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                          "from": "boom@>=0.4.0 <0.5.0",
                           "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                         },
                         "cryptiles": {
                           "version": "0.2.2",
-                          "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                          "from": "cryptiles@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                         },
                         "sntp": {
                           "version": "0.2.4",
-                          "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                          "from": "sntp@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                         }
                       }
                     },
                     "aws-sign2": {
                       "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                      "from": "aws-sign2@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                     },
                     "stringstream": {
                       "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                      "from": "stringstream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "from": "combined-stream@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
                           "version": "0.0.5",
-                          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                          "from": "delayed-stream@0.0.5",
                           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
@@ -8921,233 +8906,233 @@
                 },
                 "request-replay": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
+                  "from": "request-replay@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.2.8",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "from": "rimraf@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 }
               }
             },
             "cardinal": {
               "version": "0.4.4",
-              "from": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+              "from": "cardinal@0.4.4",
               "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
               "dependencies": {
                 "redeyed": {
                   "version": "0.4.4",
-                  "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+                  "from": "redeyed@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
                   "dependencies": {
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                      "from": "esprima@>=1.0.4 <1.1.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     }
                   }
                 },
                 "ansicolors": {
                   "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+                  "from": "ansicolors@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
                 }
               }
             },
             "chalk": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+              "version": "1.0.0",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                  "version": "2.0.1",
+                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "version": "1.0.3",
+                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                  "version": "1.3.1",
+                  "from": "supports-color@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
                 }
               }
             },
             "chmodr": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz",
+              "from": "chmodr@0.1.0",
               "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
             },
             "configstore": {
               "version": "0.3.2",
-              "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+              "from": "configstore@>=0.3.2 <0.4.0",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
               "dependencies": {
                 "js-yaml": {
                   "version": "3.3.1",
-                  "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+                  "from": "js-yaml@>=3.1.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                      "from": "argparse@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                       "dependencies": {
                         "lodash": {
-                          "version": "3.10.1",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                          "version": "3.9.3",
+                          "from": "lodash@>=3.2.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
                         },
                         "sprintf-js": {
-                          "version": "1.0.3",
-                          "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                          "version": "1.0.2",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                         }
                       }
                     },
                     "esprima": {
                       "version": "2.2.0",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+                      "from": "esprima@>=2.2.0 <2.3.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "2.1.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                 },
                 "osenv": {
-                  "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "version": "0.1.2",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
                   "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    },
                     "os-tmpdir": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                     }
                   }
                 },
                 "uuid": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+                  "from": "uuid@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                 },
                 "xdg-basedir": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
+                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
                 }
               }
             },
             "decompress-zip": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+              "from": "decompress-zip@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
               "dependencies": {
                 "binary": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+                  "from": "binary@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                   "dependencies": {
                     "chainsaw": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                      "from": "chainsaw@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                       "dependencies": {
                         "traverse": {
                           "version": "0.3.9",
-                          "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+                          "from": "traverse@>=0.3.0 <0.4.0",
                           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                         }
                       }
                     },
                     "buffers": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+                      "from": "buffers@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                     }
                   }
                 },
                 "mkpath": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+                  "from": "mkpath@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@>=1.1.8 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "touch": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+                  "from": "touch@0.0.3",
                   "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
                   "dependencies": {
                     "nopt": {
                       "version": "1.0.10",
-                      "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+                      "from": "nopt@>=1.0.10 <1.1.0",
                       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
                     }
                   }
@@ -9156,44 +9141,44 @@
             },
             "fstream": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
+              "from": "fstream@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "fstream-ignore": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+              "from": "fstream-ignore@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -9204,56 +9189,56 @@
             },
             "github": {
               "version": "0.2.4",
-              "from": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+              "from": "github@>=0.2.3 <0.3.0",
               "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
               "dependencies": {
                 "mime": {
                   "version": "1.3.4",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                  "from": "mime@>=1.2.11 <2.0.0",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 }
               }
             },
             "glob": {
               "version": "4.5.3",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "from": "glob@>=4.3.2 <5.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -9262,12 +9247,12 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -9276,139 +9261,139 @@
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "from": "graceful-fs@>=3.0.5 <4.0.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "inquirer": {
               "version": "0.8.0",
-              "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.0.tgz",
+              "from": "inquirer@0.8.0",
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "chalk": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "from": "chalk@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                      "from": "ansi-styles@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "from": "has-ansi@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "from": "strip-ansi@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                     }
                   }
                 },
                 "cli-color": {
                   "version": "0.3.3",
-                  "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+                  "from": "cli-color@>=0.3.2 <0.4.0",
                   "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
                   "dependencies": {
                     "d": {
                       "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                      "from": "d@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                      "from": "es5-ext@>=0.10.6 <0.11.0",
                       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                       "dependencies": {
                         "es6-iterator": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                          "from": "es6-iterator@>=0.1.3 <0.2.0",
                           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                         },
                         "es6-symbol": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                         }
                       }
                     },
                     "memoizee": {
-                      "version": "0.3.9",
-                      "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
-                      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
+                      "version": "0.3.8",
+                      "from": "memoizee@>=0.3.8 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
                       "dependencies": {
                         "es6-weak-map": {
                           "version": "0.1.4",
-                          "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                          "from": "es6-weak-map@>=0.1.2 <0.2.0",
                           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                           "dependencies": {
                             "es6-iterator": {
                               "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                              "from": "es6-iterator@>=0.1.3 <0.2.0",
                               "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                             },
                             "es6-symbol": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                              "from": "es6-symbol@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                             }
                           }
                         },
                         "event-emitter": {
                           "version": "0.3.3",
-                          "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
+                          "from": "event-emitter@>=0.3.1 <0.4.0",
                           "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                         },
                         "lru-queue": {
                           "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+                          "from": "lru-queue@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                         },
                         "next-tick": {
                           "version": "0.2.2",
-                          "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+                          "from": "next-tick@>=0.2.2 <0.3.0",
                           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                         }
                       }
                     },
                     "timers-ext": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                      "from": "timers-ext@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                       "dependencies": {
                         "next-tick": {
                           "version": "0.2.2",
-                          "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+                          "from": "next-tick@>=0.2.2 <0.3.0",
                           "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                         }
                       }
@@ -9417,102 +9402,102 @@
                 },
                 "figures": {
                   "version": "1.3.5",
-                  "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
+                  "from": "figures@>=1.3.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
                 },
                 "lodash": {
                   "version": "2.4.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                  "from": "lodash@>=2.4.1 <2.5.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
                 },
                 "mute-stream": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+                  "from": "mute-stream@0.0.4",
                   "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+                  "from": "readline2@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
                     }
                   }
                 },
                 "rx": {
                   "version": "2.5.3",
-                  "from": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
+                  "from": "rx@>=2.2.27 <3.0.0",
                   "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
                 },
                 "through": {
-                  "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                  "version": "2.3.7",
+                  "from": "through@>=2.3.4 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
                 }
               }
             },
             "insight": {
               "version": "0.5.3",
-              "from": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
+              "from": "insight@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.9.2",
-                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                  "from": "async@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 },
                 "lodash.debounce": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
+                  "version": "3.1.0",
+                  "from": "lodash.debounce@>=3.0.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.0.tgz",
                   "dependencies": {
                     "lodash._getnative": {
-                      "version": "3.9.1",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                      "version": "3.9.0",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "2.1.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                 },
                 "os-name": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+                  "from": "os-name@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
                   "dependencies": {
                     "osx-release": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
+                      "from": "osx-release@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
                       "dependencies": {
                         "minimist": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+                          "version": "1.1.1",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                         }
                       }
                     },
                     "win-release": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz",
+                      "from": "win-release@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
                     }
                   }
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "from": "tough-cookie@>=0.12.1 <0.13.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                      "from": "punycode@>=0.2.0",
                       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                     }
                   }
@@ -9521,59 +9506,59 @@
             },
             "is-root": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+              "from": "is-root@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
             },
             "junk": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz"
+              "version": "1.0.1",
+              "from": "junk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz"
             },
             "lockfile": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
+              "from": "lockfile@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
             },
             "lru-cache": {
-              "version": "2.6.5",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "nopt": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz"
+              "version": "3.0.2",
+              "from": "nopt@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz"
             },
             "opn": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
+              "from": "opn@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
             },
             "p-throttler": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
+              "from": "p-throttler@0.1.1",
               "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
               "dependencies": {
                 "q": {
                   "version": "0.9.7",
-                  "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+                  "from": "q@>=0.9.2 <0.10.0",
                   "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
                 }
               }
             },
             "promptly": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+              "from": "promptly@0.2.0",
               "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
               "dependencies": {
                 "read": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
+                  "from": "read@>=1.0.4 <1.1.0",
                   "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
                   "dependencies": {
                     "mute-stream": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                      "from": "mute-stream@>=0.0.4 <0.1.0",
                       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                     }
                   }
@@ -9582,37 +9567,37 @@
             },
             "request": {
               "version": "2.53.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+              "from": "request@2.53.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "from": "bl@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -9621,295 +9606,228 @@
                 },
                 "caseless": {
                   "version": "0.9.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+                  "from": "caseless@>=0.9.0 <0.10.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "from": "form-data@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.9.2",
-                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                      "from": "async@>=0.9.0 <0.10.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     }
                   }
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                      "from": "mime-db@>=1.12.0 <1.13.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
                 },
                 "node-uuid": {
                   "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "qs": {
                   "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                  "from": "qs@>=2.3.1 <2.4.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
+                  "from": "tough-cookie@>=0.12.0",
                   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                     },
                     "asn1": {
                       "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "from": "asn1@0.1.11",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "from": "ctype@0.5.3",
                       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
                   "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "from": "hawk@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "2.14.0",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
+                      "from": "hoek@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
                       "version": "2.8.0",
-                      "from": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz",
+                      "from": "boom@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "from": "sntp@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
                 "aws-sign2": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
                 },
                 "stringstream": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "from": "delayed-stream@0.0.5",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "isstream": {
                   "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "from": "isstream@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 }
               }
             },
             "request-progress": {
               "version": "0.3.1",
-              "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+              "from": "request-progress@0.3.1",
               "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
               "dependencies": {
                 "throttleit": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+                  "from": "throttleit@>=0.0.2 <0.1.0",
                   "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
                 }
               }
             },
             "retry": {
               "version": "0.6.1",
-              "from": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
+              "from": "retry@0.6.1",
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
             },
             "rimraf": {
-              "version": "2.4.2",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.2.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.14",
-                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "2.0.10",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.0",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
+              "version": "2.4.0",
+              "from": "rimraf@>=2.2.8 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.0.tgz"
             },
             "semver": {
               "version": "2.3.2",
-              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+              "from": "semver@>=2.3.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "shell-quote": {
               "version": "1.4.3",
-              "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+              "from": "shell-quote@>=1.4.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 },
                 "array-filter": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+                  "from": "array-filter@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
                 },
                 "array-reduce": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+                  "from": "array-reduce@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
                 },
                 "array-map": {
                   "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+                  "from": "array-map@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
                 }
               }
             },
             "stringify-object": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz",
+              "from": "stringify-object@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
             },
             "tar-fs": {
-              "version": "1.8.1",
-              "from": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.8.1.tgz",
-              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.8.1.tgz",
+              "version": "1.6.0",
+              "from": "tar-fs@>=1.4.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.6.0.tgz",
               "dependencies": {
                 "pump": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
+                  "from": "pump@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                      "from": "end-of-stream@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "from": "once@>=1.3.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -9918,27 +9836,27 @@
                 },
                 "tar-stream": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
+                  "from": "tar-stream@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                      "from": "bl@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
                     },
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                      "from": "end-of-stream@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "dependencies": {
                         "once": {
                           "version": "1.3.2",
-                          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "from": "once@>=1.3.0 <1.4.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -9946,45 +9864,45 @@
                       }
                     },
                     "readable-stream": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                      "version": "2.0.1",
+                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                          "version": "1.0.1",
+                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "4.0.0",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                      "from": "xtend@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                     }
                   }
@@ -9993,52 +9911,52 @@
             },
             "tmp": {
               "version": "0.0.24",
-              "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
+              "from": "tmp@0.0.24",
               "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
             },
             "update-notifier": {
               "version": "0.3.2",
-              "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
+              "from": "update-notifier@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
               "dependencies": {
                 "is-npm": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+                  "from": "is-npm@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
                 },
                 "latest-version": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
+                  "from": "latest-version@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
                   "dependencies": {
                     "package-json": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
+                      "from": "package-json@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
                       "dependencies": {
                         "got": {
-                          "version": "3.3.1",
-                          "from": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
-                          "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
+                          "version": "3.2.0",
+                          "from": "got@>=3.2.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/got/-/got-3.2.0.tgz",
                           "dependencies": {
                             "duplexify": {
                               "version": "3.4.2",
-                              "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                              "from": "duplexify@>=3.2.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                               "dependencies": {
                                 "end-of-stream": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                                  "from": "end-of-stream@1.0.0",
                                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                                   "dependencies": {
                                     "once": {
                                       "version": "1.3.2",
-                                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                      "from": "once@>=1.3.0 <1.4.0",
                                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                                       "dependencies": {
                                         "wrappy": {
                                           "version": "1.0.1",
-                                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                          "from": "wrappy@>=1.0.0 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                         }
                                       }
@@ -10046,38 +9964,38 @@
                                   }
                                 },
                                 "readable-stream": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "version": "2.0.1",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                      "from": "isarray@0.0.1",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     },
                                     "process-nextick-args": {
-                                      "version": "1.0.2",
-                                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                      "version": "1.0.1",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                                     }
                                   }
@@ -10086,137 +10004,118 @@
                             },
                             "infinity-agent": {
                               "version": "2.0.3",
-                              "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
+                              "from": "infinity-agent@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
-                            },
-                            "is-redirect": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
                             },
                             "is-stream": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
+                              "from": "is-stream@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
                             },
                             "lowercase-keys": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                              "from": "lowercase-keys@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                             },
                             "nested-error-stacks": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
-                              "dependencies": {
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                }
-                              }
+                              "version": "1.0.0",
+                              "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz"
                             },
                             "object-assign": {
-                              "version": "3.0.0",
-                              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                              "version": "2.1.1",
+                              "from": "object-assign@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                             },
                             "prepend-http": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.2.tgz"
+                              "version": "1.0.1",
+                              "from": "prepend-http@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
                             },
                             "read-all-stream": {
-                              "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                              "version": "2.2.0",
+                              "from": "read-all-stream@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.2.0.tgz",
                               "dependencies": {
-                                "pinkie-promise": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                                  "dependencies": {
-                                    "pinkie": {
-                                      "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-                                    }
-                                  }
-                                },
                                 "readable-stream": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                                  "version": "2.0.1",
+                                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
                                   "dependencies": {
                                     "core-util-is": {
                                       "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                      "from": "core-util-is@>=1.0.0 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                                     },
                                     "inherits": {
                                       "version": "2.0.1",
-                                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                      "from": "inherits@>=2.0.1 <2.1.0",
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                     },
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                      "from": "isarray@0.0.1",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     },
                                     "process-nextick-args": {
-                                      "version": "1.0.2",
-                                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.2.tgz"
+                                      "version": "1.0.1",
+                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
                                     },
                                     "string_decoder": {
                                       "version": "0.10.31",
-                                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                      "from": "string_decoder@>=0.10.0 <0.11.0",
                                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                     },
                                     "util-deprecate": {
                                       "version": "1.0.1",
-                                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
+                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                                     }
                                   }
                                 }
                               }
                             },
+                            "statuses": {
+                              "version": "1.2.1",
+                              "from": "statuses@>=1.2.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                            },
                             "timed-out": {
                               "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+                              "from": "timed-out@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                             }
                           }
                         },
                         "registry-url": {
                           "version": "3.0.3",
-                          "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+                          "from": "registry-url@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
                           "dependencies": {
                             "rc": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/rc/-/rc-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.0.tgz",
+                              "version": "1.0.3",
+                              "from": "rc@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/rc/-/rc-1.0.3.tgz",
                               "dependencies": {
                                 "minimist": {
-                                  "version": "1.1.3",
-                                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+                                  "version": "0.0.10",
+                                  "from": "minimist@>=0.0.7 <0.1.0",
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                                 },
                                 "deep-extend": {
                                   "version": "0.2.11",
-                                  "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+                                  "from": "deep-extend@>=0.2.5 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                                 },
                                 "strip-json-comments": {
                                   "version": "0.1.3",
-                                  "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+                                  "from": "strip-json-comments@>=0.1.0 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                                 },
                                 "ini": {
                                   "version": "1.3.4",
-                                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                                  "from": "ini@>=1.3.0 <1.4.0",
                                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                                 }
                               }
@@ -10229,30 +10128,30 @@
                 },
                 "semver-diff": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
+                  "from": "semver-diff@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
                   "dependencies": {
                     "semver": {
                       "version": "4.3.6",
-                      "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+                      "from": "semver@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
                     }
                   }
                 },
                 "string-length": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+                  "version": "1.0.0",
+                  "from": "string-length@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
                   "dependencies": {
                     "strip-ansi": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "version": "2.0.1",
+                      "from": "strip-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                          "version": "1.1.1",
+                          "from": "ansi-regex@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                         }
                       }
                     }
@@ -10262,22 +10161,22 @@
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "from": "user-home@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             },
             "which": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
+              "from": "which@>=1.0.8 <2.0.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                  "from": "is-absolute@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                      "from": "is-relative@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                     }
                   }
@@ -10288,96 +10187,96 @@
         },
         "bower-endpoint-parser": {
           "version": "0.2.2",
-          "from": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
+          "from": "bower-endpoint-parser@0.2.2",
           "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
         },
         "bower-logger": {
           "version": "0.2.2",
-          "from": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz",
+          "from": "bower-logger@0.2.2",
           "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
         },
         "mout": {
           "version": "0.11.0",
-          "from": "https://registry.npmjs.org/mout/-/mout-0.11.0.tgz",
+          "from": "mout@>=0.11.0 <0.12.0",
           "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.0.tgz"
         },
         "q": {
           "version": "1.4.1",
-          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+          "from": "q@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "from": "semver@>=4.3.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "karma": {
       "version": "0.12.31",
-      "from": "https://registry.npmjs.org/karma/-/karma-0.12.31.tgz",
+      "from": "karma@0.12.31",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.31.tgz",
       "dependencies": {
         "di": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+          "from": "di@>=0.0.1 <0.1.0",
           "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
         },
         "socket.io": {
           "version": "0.9.16",
-          "from": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
+          "from": "socket.io@0.9.16",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
-              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "from": "socket.io-client@0.9.16",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
                 "uglify-js": {
                   "version": "1.2.5",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
+                  "from": "uglify-js@1.2.5",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+                  "from": "ws@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+                      "from": "commander@>=2.1.0 <2.2.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
                     },
                     "nan": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
+                      "from": "nan@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
                     },
                     "tinycolor": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+                      "from": "tinycolor@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
                     },
                     "options": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                      "from": "options@>=0.0.5",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     }
                   }
                 },
                 "xmlhttprequest": {
                   "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
+                  "from": "xmlhttprequest@1.4.2",
                   "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
                 },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "from": "active-x-obfuscator@0.0.1",
                   "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
                       "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
+                      "from": "zeparser@0.0.5",
                       "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
@@ -10386,86 +10285,81 @@
             },
             "policyfile": {
               "version": "0.0.4",
-              "from": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
+              "from": "policyfile@0.0.4",
               "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
             },
             "base64id": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+              "from": "base64id@0.1.0",
               "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "redis": {
               "version": "0.7.3",
-              "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
+              "from": "redis@0.7.3",
               "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
         "chokidar": {
-          "version": "1.0.5",
-          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
+          "version": "1.0.3",
+          "from": "chokidar@>=0.8.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "from": "anymatch@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
+                  "version": "2.1.6",
+                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                      "from": "arr-diff@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
                           "version": "0.2.3",
-                          "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+                          "from": "array-slice@>=0.2.2 <0.3.0",
                           "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                         }
                       }
                     },
-                    "array-unique": {
-                      "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-                    },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                      "from": "braces@>=1.8.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "from": "expand-range@>=1.8.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.2",
-                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "from": "fill-range@>=2.1.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "1.1.2",
-                                  "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
+                                  "from": "is-number@>=1.1.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                                 },
                                 "isobject": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+                                  "version": "1.0.0",
+                                  "from": "isobject@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
+                                  "from": "randomatic@>=1.1.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -10474,126 +10368,109 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                          "from": "preserve@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                          "from": "repeat-element@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
-                    "expand-brackets": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.1.3 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
-                        "is-posix-bracket": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz"
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
-                    "extglob": {
-                      "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-                      "dependencies": {
-                        "ansi-green": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-                          "dependencies": {
-                            "ansi-wrap": {
-                              "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
-                            }
-                          }
-                        },
-                        "is-extglob": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                        },
-                        "success-symbol": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
-                        }
-                      }
+                    "expand-brackets": {
+                      "version": "0.1.1",
+                      "from": "expand-brackets@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+                      "from": "kind-of@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                     },
                     "object.omit": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
+                      "version": "0.2.1",
+                      "from": "object.omit@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "from": "for-own@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
+                              "from": "for-in@>=0.1.4 <0.2.0",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "isobject": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+                          "version": "0.2.0",
+                          "from": "isobject@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                      "from": "parse-glob@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
+                          "from": "glob-base@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz",
+                          "from": "is-dotfile@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "from": "regex-cache@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                          "version": "0.1.2",
+                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
+                          "dependencies": {
+                            "is-primitive": {
+                              "version": "1.0.0",
+                              "from": "is-primitive@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
+                            }
+                          }
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                          "from": "is-primitive@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -10604,74 +10481,69 @@
             },
             "arrify": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
+              "from": "arrify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
+              "from": "async-each@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
+              "from": "glob-parent@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "from": "is-binary-path@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
+                  "from": "binary-extensions@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
+              "from": "is-glob@>=1.1.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
-              "version": "1.4.0",
-              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
+              "version": "1.3.0",
+              "from": "readdirp@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
               "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -10679,14 +10551,14 @@
               }
             },
             "fsevents": {
-              "version": "0.3.8",
-              "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
+              "version": "0.3.6",
+              "from": "fsevents@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
               "dependencies": {
                 "nan": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
+                  "version": "1.8.4",
+                  "from": "nan@>=1.8.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                 }
               }
             }
@@ -10694,27 +10566,27 @@
         },
         "glob": {
           "version": "3.2.11",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "from": "glob@>=3.2.7 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -10723,54 +10595,54 @@
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "from": "minimatch@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.5",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "http-proxy": {
           "version": "0.10.4",
-          "from": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
+          "from": "http-proxy@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
           "dependencies": {
             "pkginfo": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
+              "from": "pkginfo@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "utile": {
               "version": "0.2.1",
-              "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+              "from": "utile@>=0.2.1 <0.3.0",
               "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "from": "async@>=0.2.9 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "deep-equal": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz",
+                  "from": "deep-equal@*",
                   "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
                 },
                 "i": {
                   "version": "0.3.3",
-                  "from": "https://registry.npmjs.org/i/-/i-0.3.3.tgz",
+                  "from": "i@>=0.3.0 <0.4.0",
                   "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
                 },
                 "ncp": {
                   "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+                  "from": "ncp@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                 }
               }
@@ -10779,276 +10651,276 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "from": "rimraf@>=2.2.5 <2.3.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
         },
         "q": {
           "version": "0.9.7",
-          "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+          "from": "q@>=0.9.7 <0.10.0",
           "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.2 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "from": "mime@>=1.2.11 <1.3.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "log4js": {
           "version": "0.6.26",
-          "from": "https://registry.npmjs.org/log4js/-/log4js-0.6.26.tgz",
+          "from": "log4js@>=0.6.3 <0.7.0",
           "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.26.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "from": "readable-stream@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "semver": {
               "version": "4.3.6",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "from": "semver@>=4.3.3 <4.4.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "underscore": {
               "version": "1.8.2",
-              "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.2.tgz",
+              "from": "underscore@1.8.2",
               "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.2.tgz"
             }
           }
         },
         "useragent": {
           "version": "2.0.10",
-          "from": "https://registry.npmjs.org/useragent/-/useragent-2.0.10.tgz",
+          "from": "useragent@>=2.0.4 <2.1.0",
           "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.10.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+              "from": "lru-cache@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
             }
           }
         },
         "graceful-fs": {
           "version": "2.0.3",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+          "from": "graceful-fs@>=2.0.1 <2.1.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
         },
         "connect": {
           "version": "2.26.6",
-          "from": "https://registry.npmjs.org/connect/-/connect-2.26.6.tgz",
+          "from": "connect@>=2.26.0 <2.27.0",
           "resolved": "https://registry.npmjs.org/connect/-/connect-2.26.6.tgz",
           "dependencies": {
             "basic-auth-connect": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+              "from": "basic-auth-connect@1.0.0",
               "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
             },
             "body-parser": {
               "version": "1.8.4",
-              "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
+              "from": "body-parser@>=1.8.4 <1.9.0",
               "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
               "dependencies": {
                 "iconv-lite": {
                   "version": "0.4.4",
-                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz",
+                  "from": "iconv-lite@0.4.4",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
                 },
                 "on-finished": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "from": "on-finished@2.1.0",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
+                      "from": "ee-first@1.0.5",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                     }
                   }
                 },
                 "raw-body": {
                   "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz",
+                  "from": "raw-body@1.3.0",
                   "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
                 }
               }
             },
             "bytes": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+              "from": "bytes@1.0.0",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
             },
             "cookie": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
+              "from": "cookie@0.1.2",
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
             },
             "cookie-parser": {
               "version": "1.3.5",
-              "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
+              "from": "cookie-parser@>=1.3.3 <1.4.0",
               "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
               "dependencies": {
                 "cookie": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+                  "from": "cookie@0.1.3",
                   "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
                 },
                 "cookie-signature": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+                  "from": "cookie-signature@1.0.6",
                   "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
                 }
               }
             },
             "cookie-signature": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz",
+              "from": "cookie-signature@1.0.5",
               "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
             },
             "compression": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
+              "from": "compression@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+                  "from": "accepts@>=1.1.2 <1.2.0",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+                      "from": "negotiator@0.4.9",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
                 },
                 "compressible": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.5.tgz",
+                  "version": "2.0.3",
+                  "from": "compressible@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.3.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.17.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.17.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.17.0.tgz"
+                      "version": "1.13.0",
+                      "from": "mime-db@>=1.13.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                     }
                   }
                 },
                 "vary": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "vary@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
                 }
               }
             },
             "connect-timeout": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
+              "from": "connect-timeout@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                  "from": "ms@0.6.2",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "csurf": {
               "version": "1.6.6",
-              "from": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
+              "from": "csurf@>=1.6.2 <1.7.0",
               "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
               "dependencies": {
                 "csrf": {
                   "version": "2.0.7",
-                  "from": "https://registry.npmjs.org/csrf/-/csrf-2.0.7.tgz",
+                  "from": "csrf@>=2.0.5 <2.1.0",
                   "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.7.tgz",
                   "dependencies": {
                     "base64-url": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+                      "from": "base64-url@1.2.1",
                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     },
                     "rndm": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz",
+                      "from": "rndm@>=1.1.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz"
                     },
                     "scmp": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz",
+                      "from": "scmp@1.0.0",
                       "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
                     },
                     "uid-safe": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
+                      "from": "uid-safe@>=1.1.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
+                          "from": "native-or-bluebird@>=1.1.2 <1.2.0",
                           "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
                         }
                       }
@@ -11057,17 +10929,17 @@
                 },
                 "http-errors": {
                   "version": "1.2.8",
-                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
+                  "from": "http-errors@>=1.2.8 <1.3.0",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "statuses": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+                      "from": "statuses@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                     }
                   }
@@ -11076,165 +10948,165 @@
             },
             "debug": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+              "from": "debug@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.6.2",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                  "from": "ms@0.6.2",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "depd": {
               "version": "0.4.5",
-              "from": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz",
+              "from": "depd@0.4.5",
               "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
             },
             "errorhandler": {
               "version": "1.2.4",
-              "from": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.4.tgz",
+              "from": "errorhandler@>=1.2.2 <1.3.0",
               "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.4.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+                  "from": "accepts@>=1.1.2 <1.2.0",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+                      "from": "negotiator@0.4.9",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
                 },
                 "escape-html": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+                  "from": "escape-html@1.0.1",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 }
               }
             },
             "express-session": {
               "version": "1.8.2",
-              "from": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
+              "from": "express-session@>=1.8.2 <1.9.0",
               "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
               "dependencies": {
                 "crc": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz",
+                  "from": "crc@3.0.0",
                   "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
                 },
                 "uid-safe": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
+                  "from": "uid-safe@1.0.1",
                   "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                   "dependencies": {
                     "mz": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
+                      "from": "mz@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz",
+                          "from": "native-or-bluebird@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
                         },
                         "thenify": {
                           "version": "3.1.0",
-                          "from": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz",
+                          "from": "thenify@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz"
                         },
                         "thenify-all": {
                           "version": "1.6.0",
-                          "from": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+                          "from": "thenify-all@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
                         }
                       }
                     },
                     "base64-url": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+                      "from": "base64-url@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     }
                   }
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+                  "from": "utils-merge@1.0.0",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 }
               }
             },
             "finalhandler": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
+              "from": "finalhandler@0.2.0",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+                  "from": "escape-html@1.0.1",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 }
               }
             },
             "fresh": {
               "version": "0.2.4",
-              "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz",
+              "from": "fresh@0.2.4",
               "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
             },
             "media-typer": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "from": "media-typer@0.3.0",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "method-override": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
+              "from": "method-override@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
               "dependencies": {
                 "methods": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz",
+                  "from": "methods@1.1.0",
                   "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
                 },
                 "vary": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "vary@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
                 }
               }
             },
             "morgan": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
+              "from": "morgan@>=1.3.2 <1.4.0",
               "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
               "dependencies": {
                 "basic-auth": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz",
+                  "from": "basic-auth@1.0.0",
                   "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
                 },
                 "on-finished": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "from": "on-finished@2.1.0",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
+                      "from": "ee-first@1.0.5",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                     }
                   }
@@ -11243,199 +11115,199 @@
             },
             "multiparty": {
               "version": "3.3.2",
-              "from": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+              "from": "multiparty@3.3.2",
               "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "stream-counter": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+                  "from": "stream-counter@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
                 }
               }
             },
             "on-headers": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz",
+              "from": "on-headers@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
             },
             "parseurl": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
+              "from": "parseurl@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
             },
             "qs": {
               "version": "2.2.4",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz",
+              "from": "qs@2.2.4",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz"
             },
             "response-time": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz",
+              "from": "response-time@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz"
             },
             "serve-favicon": {
               "version": "2.1.7",
-              "from": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
+              "from": "serve-favicon@>=2.1.5 <2.2.0",
               "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
               "dependencies": {
                 "etag": {
                   "version": "1.5.1",
-                  "from": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+                  "from": "etag@>=1.5.0 <1.6.0",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
                   "dependencies": {
                     "crc": {
                       "version": "3.2.1",
-                      "from": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz",
+                      "from": "crc@3.2.1",
                       "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
                     }
                   }
                 },
                 "ms": {
                   "version": "0.6.2",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                  "from": "ms@0.6.2",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "serve-index": {
               "version": "1.2.1",
-              "from": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
+              "from": "serve-index@>=1.2.1 <1.3.0",
               "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+                  "from": "accepts@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+                      "from": "negotiator@0.4.9",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
                 },
                 "batch": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz",
+                  "from": "batch@0.5.1",
                   "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz"
                 }
               }
             },
             "serve-static": {
               "version": "1.6.5",
-              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
+              "from": "serve-static@>=1.6.4 <1.7.0",
               "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+                  "from": "escape-html@1.0.1",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 },
                 "send": {
                   "version": "0.9.3",
-                  "from": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
+                  "from": "send@0.9.3",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
+                      "from": "destroy@1.0.3",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
                     },
                     "etag": {
                       "version": "1.4.0",
-                      "from": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
+                      "from": "etag@>=1.4.0 <1.5.0",
                       "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
                       "dependencies": {
                         "crc": {
                           "version": "3.0.0",
-                          "from": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz",
+                          "from": "crc@3.0.0",
                           "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
                         }
                       }
                     },
                     "ms": {
                       "version": "0.6.2",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                      "from": "ms@0.6.2",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                     },
                     "on-finished": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                      "from": "on-finished@2.1.0",
                       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                       "dependencies": {
                         "ee-first": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
+                          "from": "ee-first@1.0.5",
                           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                         }
                       }
                     },
                     "range-parser": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz",
+                      "from": "range-parser@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
                     }
                   }
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+                  "from": "utils-merge@1.0.0",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 }
               }
             },
             "type-is": {
               "version": "1.5.7",
-              "from": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+              "from": "type-is@>=1.5.2 <1.6.0",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                  "from": "mime-types@>=2.0.9 <2.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                      "from": "mime-db@>=1.12.0 <1.13.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
@@ -11443,26 +11315,26 @@
               }
             },
             "vhost": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/vhost/-/vhost-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.1.tgz"
+              "version": "3.0.0",
+              "from": "vhost@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz"
             },
             "pause": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+              "from": "pause@0.0.1",
               "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
             }
           }
         },
         "source-map": {
           "version": "0.1.43",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "from": "source-map@>=0.1.31 <0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+              "version": "0.1.1",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
             }
           }
         }
@@ -11470,22 +11342,22 @@
     },
     "karma-chrome-launcher": {
       "version": "0.1.10",
-      "from": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.10.tgz",
+      "from": "karma-chrome-launcher@0.1.10",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.10.tgz",
       "dependencies": {
         "which": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
+          "from": "which@>=1.0.9 <2.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "from": "is-absolute@>=0.1.7 <0.2.0",
               "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                  "from": "is-relative@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                 }
               }
@@ -11496,17 +11368,17 @@
     },
     "karma-coffee-preprocessor": {
       "version": "0.2.1",
-      "from": "https://registry.npmjs.org/karma-coffee-preprocessor/-/karma-coffee-preprocessor-0.2.1.tgz",
+      "from": "karma-coffee-preprocessor@0.2.1",
       "resolved": "https://registry.npmjs.org/karma-coffee-preprocessor/-/karma-coffee-preprocessor-0.2.1.tgz",
       "dependencies": {
         "coffee-script": {
           "version": "1.7.1",
-          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+          "from": "coffee-script@>=1.7.0 <1.8.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.3.5",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             }
           }
@@ -11515,80 +11387,80 @@
     },
     "karma-coverage": {
       "version": "0.3.1",
-      "from": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.3.1.tgz",
+      "from": "karma-coverage@0.3.1",
       "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.3.1.tgz",
       "dependencies": {
         "istanbul": {
-          "version": "0.3.17",
-          "from": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.17.tgz",
-          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.17.tgz",
+          "version": "0.3.15",
+          "from": "istanbul@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.15.tgz",
           "dependencies": {
             "esprima": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.4.1.tgz"
+              "version": "2.1.0",
+              "from": "esprima@>=2.1.0 <2.2.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.1.0.tgz"
             },
             "escodegen": {
               "version": "1.6.1",
-              "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+              "from": "escodegen@>=1.6.0 <1.7.0",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
               "dependencies": {
                 "estraverse": {
                   "version": "1.9.3",
-                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                  "from": "estraverse@>=1.9.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                 },
                 "esutils": {
                   "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                  "from": "esutils@>=1.1.6 <2.0.0",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                 },
                 "esprima": {
                   "version": "1.2.5",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+                  "from": "esprima@>=1.2.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
                 },
                 "optionator": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                  "from": "optionator@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                   "dependencies": {
                     "prelude-ls": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0",
                       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                     },
                     "deep-is": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                      "from": "deep-is@>=0.1.2 <0.2.0",
                       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                     },
                     "type-check": {
                       "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                      "from": "type-check@>=0.3.1 <0.4.0",
                       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
                     },
                     "levn": {
                       "version": "0.2.5",
-                      "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                      "from": "levn@>=0.2.5 <0.3.0",
                       "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                     },
                     "fast-levenshtein": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                      "version": "1.0.6",
+                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.40 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 }
@@ -11596,46 +11468,46 @@
             },
             "handlebars": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.0.tgz",
+              "from": "handlebars@3.0.0",
               "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.0.tgz",
               "dependencies": {
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "from": "optimist@>=0.6.1 <0.7.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.10",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "from": "minimist@>=0.0.1 <0.1.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "from": "source-map@>=0.1.40 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "0.1.1",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                     }
                   }
                 },
                 "uglify-js": {
                   "version": "2.3.6",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "from": "uglify-js@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
-                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "from": "async@>=0.2.6 <0.3.0",
                       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                     },
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                      "from": "optimist@>=0.3.5 <0.4.0",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
                     }
                   }
@@ -11643,64 +11515,64 @@
               }
             },
             "nopt": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz"
+              "version": "3.0.2",
+              "from": "nopt@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz"
             },
             "fileset": {
-              "version": "0.2.1",
-              "from": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+              "version": "0.1.6",
+              "from": "fileset@0.1.6",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.6.tgz",
               "dependencies": {
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
                 "glob": {
-                  "version": "5.0.14",
-                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
+                  "version": "5.0.10",
+                  "from": "glob@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.8",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
@@ -11709,71 +11581,71 @@
             },
             "which": {
               "version": "1.0.9",
-              "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+              "from": "which@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
             },
             "async": {
-              "version": "1.4.2",
-              "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+              "from": "supports-color@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             },
             "abbrev": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+              "from": "abbrev@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
             },
             "wordwrap": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "from": "wordwrap@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+              "from": "resolve@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "js-yaml": {
               "version": "3.3.1",
-              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+              "from": "js-yaml@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "from": "argparse@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "lodash": {
-                      "version": "3.10.1",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                      "version": "3.9.3",
+                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
                     },
                     "sprintf-js": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                      "version": "1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+                  "from": "esprima@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "from": "once@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
@@ -11782,54 +11654,54 @@
         },
         "dateformat": {
           "version": "1.0.11",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+          "from": "dateformat@>=1.0.6 <1.1.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.3.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+              "from": "meow@*",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
-                  "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "from": "repeating@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                             }
                           }
@@ -11839,13 +11711,13 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+                  "version": "1.1.1",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
@@ -11854,17 +11726,17 @@
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "from": "minimatch@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.5",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "from": "sigmund@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
@@ -11873,47 +11745,47 @@
     },
     "karma-firefox-launcher": {
       "version": "0.1.6",
-      "from": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.6.tgz",
+      "from": "karma-firefox-launcher@0.1.6",
       "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.6.tgz"
     },
     "karma-html2js-preprocessor": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-0.1.0.tgz",
+      "from": "karma-html2js-preprocessor@0.1.0",
       "resolved": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-0.1.0.tgz"
     },
     "karma-jasmine": {
       "version": "0.3.5",
-      "from": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz",
+      "from": "karma-jasmine@0.3.5",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz"
     },
     "karma-jspm": {
       "version": "1.1.6",
-      "from": "git://github.com/rich-nguyen/karma-jspm.git#491f43be0891f1a0a598f3e5e7bdb27a6f5bf050",
+      "from": "rich-nguyen/karma-jspm#1.1.6",
       "resolved": "git://github.com/rich-nguyen/karma-jspm.git#491f43be0891f1a0a598f3e5e7bdb27a6f5bf050",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "from": "glob@>=3.2.0 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -11924,158 +11796,158 @@
     },
     "karma-phantomjs-launcher": {
       "version": "0.1.4",
-      "from": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz",
+      "from": "karma-phantomjs-launcher@0.1.4",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz"
     },
     "karma-phantomjs-shim": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/karma-phantomjs-shim/-/karma-phantomjs-shim-1.0.0.tgz",
+      "from": "karma-phantomjs-shim@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-shim/-/karma-phantomjs-shim-1.0.0.tgz"
     },
     "karma-requirejs": {
       "version": "0.2.2",
-      "from": "https://registry.npmjs.org/karma-requirejs/-/karma-requirejs-0.2.2.tgz",
+      "from": "karma-requirejs@0.2.2",
       "resolved": "https://registry.npmjs.org/karma-requirejs/-/karma-requirejs-0.2.2.tgz"
     },
     "karma-script-launcher": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/karma-script-launcher/-/karma-script-launcher-0.1.0.tgz",
+      "from": "karma-script-launcher@0.1.0",
       "resolved": "https://registry.npmjs.org/karma-script-launcher/-/karma-script-launcher-0.1.0.tgz"
     },
     "karma-spec-reporter": {
       "version": "0.0.19",
-      "from": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.19.tgz",
+      "from": "karma-spec-reporter@0.0.19",
       "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.19.tgz",
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         }
       }
     },
     "load-grunt-config": {
       "version": "0.17.1",
-      "from": "https://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.17.1.tgz",
+      "from": "load-grunt-config@0.17.1",
       "resolved": "https://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.17.1.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "from": "async@>=0.2.10 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "cson": {
           "version": "1.6.2",
-          "from": "https://registry.npmjs.org/cson/-/cson-1.6.2.tgz",
+          "from": "cson@>=1.6.2 <1.7.0",
           "resolved": "https://registry.npmjs.org/cson/-/cson-1.6.2.tgz",
           "dependencies": {
             "ambi": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/ambi/-/ambi-2.2.0.tgz",
+              "from": "ambi@>=2.2.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.2.0.tgz",
               "dependencies": {
                 "typechecker": {
                   "version": "2.0.8",
-                  "from": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
+                  "from": "typechecker@>=2.0.7 <2.1.0",
                   "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz"
                 }
               }
             },
             "coffee-script": {
               "version": "1.8.0",
-              "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
+              "from": "coffee-script@>=1.8.0 <1.9.0",
               "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.3.5",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                 }
               }
             },
             "extract-opts": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/extract-opts/-/extract-opts-2.2.0.tgz",
+              "from": "extract-opts@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-2.2.0.tgz",
               "dependencies": {
                 "typechecker": {
                   "version": "2.0.8",
-                  "from": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
+                  "from": "typechecker@>=2.0.7 <2.1.0",
                   "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz"
                 }
               }
             },
             "js2coffee": {
               "version": "0.3.5",
-              "from": "https://registry.npmjs.org/js2coffee/-/js2coffee-0.3.5.tgz",
+              "from": "js2coffee@>=0.3.5 <0.4.0",
               "resolved": "https://registry.npmjs.org/js2coffee/-/js2coffee-0.3.5.tgz",
               "dependencies": {
                 "coffee-script": {
                   "version": "1.7.1",
-                  "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+                  "from": "coffee-script@>=1.7.1 <1.8.0",
                   "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.3.5",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                      "from": "mkdirp@>=0.3.5 <0.4.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
                     }
                   }
                 },
                 "file": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/file/-/file-0.2.2.tgz",
+                  "from": "file@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/file/-/file-0.2.2.tgz"
                 },
                 "nopt": {
-                  "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+                  "version": "3.0.2",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
                   "dependencies": {
                     "abbrev": {
                       "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                     }
                   }
                 },
                 "underscore": {
                   "version": "1.6.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                  "from": "underscore@>=1.6.0 <1.7.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
                 }
               }
             },
             "requirefresh": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/requirefresh/-/requirefresh-1.1.2.tgz",
+              "from": "requirefresh@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-1.1.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "from": "glob@>=3.2.6 <3.3.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "from": "minimatch@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.5",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
@@ -12084,61 +11956,61 @@
         },
         "jit-grunt": {
           "version": "0.8.0",
-          "from": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz",
+          "from": "jit-grunt@>=0.8.0 <0.9.0",
           "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz"
         },
         "js-yaml": {
           "version": "3.0.2",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+          "from": "js-yaml@>=3.0.1 <3.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "load-grunt-tasks": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
+          "from": "load-grunt-tasks@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
           "dependencies": {
             "globule": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
+              "from": "globule@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -12147,21 +12019,21 @@
             },
             "findup-sync": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+              "from": "findup-sync@>=0.1.2 <0.2.0",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "lodash@*",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "megalog": {
@@ -12229,68 +12101,95 @@
     },
     "mkdirp": {
       "version": "0.5.0",
-      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+      "from": "mkdirp@0.5.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "moment": {
       "version": "2.8.3",
-      "from": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz",
+      "from": "moment@2.8.3",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz"
     },
     "phantom": {
       "version": "0.6.5",
-      "from": "https://registry.npmjs.org/phantom/-/phantom-0.6.5.tgz",
+      "from": "phantom@0.6.5",
       "resolved": "https://registry.npmjs.org/phantom/-/phantom-0.6.5.tgz",
       "dependencies": {
         "dnode": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/dnode/-/dnode-1.2.1.tgz",
+          "from": "dnode@>=1.2.0 <1.3.0",
           "resolved": "https://registry.npmjs.org/dnode/-/dnode-1.2.1.tgz",
           "dependencies": {
             "dnode-protocol": {
               "version": "0.2.2",
-              "from": "https://registry.npmjs.org/dnode-protocol/-/dnode-protocol-0.2.2.tgz",
+              "from": "dnode-protocol@>=0.2.2 <0.3.0",
               "resolved": "https://registry.npmjs.org/dnode-protocol/-/dnode-protocol-0.2.2.tgz"
             },
             "jsonify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "from": "jsonify@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             },
             "weak": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/weak/-/weak-0.4.1.tgz",
+              "from": "weak@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/weak/-/weak-0.4.1.tgz",
               "dependencies": {
                 "bindings": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+                  "from": "bindings@*",
                   "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
                 },
                 "nan": {
                   "version": "1.8.4",
-                  "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+                  "from": "nan@>=1.8.4 <1.9.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
                 }
               }
             }
           }
         },
+        "shoe": {
+          "version": "0.0.15",
+          "from": "shoe@>=0.0.10 <0.1.0",
+          "resolved": "https://registry.npmjs.org/shoe/-/shoe-0.0.15.tgz",
+          "dependencies": {
+            "sockjs": {
+              "version": "0.3.7",
+              "from": "sockjs@0.3.7",
+              "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.7.tgz",
+              "dependencies": {
+                "node-uuid": {
+                  "version": "1.3.3",
+                  "from": "node-uuid@1.3.3",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.3.3.tgz"
+                },
+                "faye-websocket": {
+                  "version": "0.4.4",
+                  "from": "faye-websocket@0.4.4",
+                  "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
+                }
+              }
+            },
+            "sockjs-client": {
+              "version": "0.0.0-unreleasable"
+            }
+          }
+        },
         "win-spawn": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz",
+          "from": "win-spawn@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
         },
         "traverse": {
           "version": "0.6.6",
-          "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+          "from": "traverse@>=0.6.3 <0.7.0",
           "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
         }
       }
@@ -12679,7 +12578,7 @@
     },
     "q": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/q/-/q-1.0.1.tgz",
+      "from": "q@1.0.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
     },
     "requirejs": {
@@ -12718,216 +12617,223 @@
     },
     "svgo": {
       "version": "0.4.5",
-      "from": "https://registry.npmjs.org/svgo/-/svgo-0.4.5.tgz",
+      "from": "svgo@0.4.5",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.4.5.tgz",
       "dependencies": {
         "sax": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
+          "from": "sax@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
         },
         "coa": {
           "version": "0.4.1",
-          "from": "https://registry.npmjs.org/coa/-/coa-0.4.1.tgz",
+          "from": "coa@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/coa/-/coa-0.4.1.tgz",
           "dependencies": {
             "q": {
               "version": "0.9.7",
-              "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+              "from": "q@>=0.9.6 <0.10.0",
               "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
             }
           }
         },
         "js-yaml": {
           "version": "2.1.3",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
+          "from": "js-yaml@>=2.1.0 <2.2.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "from": "argparse@>=0.1.11 <0.2.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "from": "underscore@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "from": "esprima@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
             }
           }
         },
         "colors": {
           "version": "0.6.2",
-          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "from": "colors@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "whet.extend": {
           "version": "0.9.9",
-          "from": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+          "from": "whet.extend@>=0.9.9 <0.10.0",
           "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
         }
       }
     },
     "time-grunt": {
       "version": "1.2.0",
-      "from": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.2.0.tgz",
+      "from": "time-grunt@1.2.0",
       "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.2.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
         },
         "date-time": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz",
+          "from": "date-time@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
         },
         "figures": {
           "version": "1.3.5",
-          "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
+          "from": "figures@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "from": "hooker@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "pretty-ms": {
-          "version": "1.4.0",
-          "from": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
+          "version": "1.2.0",
+          "from": "pretty-ms@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.2.0.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            },
-            "is-finite": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-              "dependencies": {
-                "number-is-nan": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                }
-              }
             },
             "meow": {
               "version": "3.3.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
+              "from": "meow@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "indent-string": {
-                  "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 },
                 "minimist": {
-                  "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+                  "version": "1.1.1",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                  "from": "object-assign@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 }
               }
             },
             "parse-ms": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz",
+              "from": "parse-ms@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz"
             },
             "plur": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+              "from": "plur@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "from": "text-table@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -109,5 +109,8 @@
       "babel-runtime": "npm:babel-runtime@5.8.20",
       "core-js": "npm:core-js@1.1.0"
     }
+  },
+  "devDependencies": {
+    "eslint-plugin-jasmine": "^1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "babel": "5.8.21",
     "btoa": "1.1.2",
+    "eslint-plugin-jasmine": "^1.5.0",
     "eslint-plugin-react": "^3.5.0",
     "esprima": "1.2.2",
     "esprima-fb": "15001.1.0-dev-harmony-fb",
@@ -109,8 +110,5 @@
       "babel-runtime": "npm:babel-runtime@5.8.20",
       "core-js": "npm:core-js@1.1.0"
     }
-  },
-  "devDependencies": {
-    "eslint-plugin-jasmine": "^1.5.0"
   }
 }

--- a/static/src/javascripts/test/.eslintrc
+++ b/static/src/javascripts/test/.eslintrc
@@ -1,4 +1,7 @@
 {
+    "plugins": [
+        "jasmine"
+    ],
     "env": {
         "jasmine": true
     },


### PR DESCRIPTION
Seems like just about everyone has left a test with fdescribe in at some stage.  This is really bad because it will basically stop running tests in the automation!  So I've added a linter with that rule in it https://www.npmjs.com/package/eslint-plugin-jasmine

not sure why so many changes to npm-shrinkwrap

Seems to work but I feel like I need a test for it...

@OliverJAsh @jbreckmckye 
