### PR TITLE
Report Outbrain separately from ads

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -88,10 +88,9 @@ define([
             // Ophan
             require(['ophan/ng'], function (ophan) {
                 ophan.record({
-                    ads: [{
-                        slot: 'outbrain',
+                    outbrain: {
                         widgetId: widgetCode
-                    }]
+                    }
                 });
             });
         },


### PR DESCRIPTION
Outbrain isn't an ad, so we think it only confuses things to treat it as if it were. This treats it as a completely separate entity, which I'll add the processing into Ophan for if we're all happy with this.

cc @uplne @kenlim @guardian/ophan-developers 
