### PR TITLE
Hide badges on smaller football front snaps

### DIFF
--- a/static/src/stylesheets/module/facia/snaps/_football.scss
+++ b/static/src/stylesheets/module/facia/snaps/_football.scss
@@ -78,6 +78,7 @@
         }
     }
 
+    .football-match__crest,
     .football-team__form {
         display: none;
     }
@@ -139,6 +140,9 @@
         }
         .team__info {
             @include fs-headline(6, true)
+        }
+        .football-match__crest {
+            display: block;
         }
     }
 


### PR DESCRIPTION
A quick revert for most of the fixture embeds on football.

Before:
![screen shot 2015-10-14 at 12 18 27](https://cloud.githubusercontent.com/assets/1607666/10482164/f15ff772-726d-11e5-8ee4-8dec6691550a.png)

After:
![screen shot 2015-10-14 at 12 19 11](https://cloud.githubusercontent.com/assets/1607666/10482163/f15b9ad8-726d-11e5-9b89-cb7ebbd0e516.png)
