### PR TITLE
Series container to have only four items

### DIFF
--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -69,7 +69,7 @@ object SeriesController extends Controller with Logging with Paging with Executi
         1,
         Fixed(visuallyPleasingContainerForStories(series.trails.length)),
         CollectionConfigWithId(dataId, config),
-        CollectionEssentials(series.trails map FaciaContentConvert.frontendContentToFaciaContent take 7, Nil, displayName, None, None, None),
+        CollectionEssentials(series.trails map FaciaContentConvert.frontendContentToFaciaContent take 4, Nil, displayName, None, None, None),
         componentId
       ).withTimeStamps
        .copy(customHeader = header),

--- a/onward/app/controllers/package.scala
+++ b/onward/app/controllers/package.scala
@@ -8,6 +8,6 @@ package object controllers {
     case 4 => FixedContainers.fixedSmallSlowIV
     case 5 => FixedContainers.slowSeriesV
     case 6 => FixedContainers.fixedMediumSlowVI
-    case _ => FixedContainers.fixedMediumSlowVII
+    case _ => FixedContainers.fixedSmallSlowIV
   }
 }


### PR DESCRIPTION
Agreed change to get Outbrain closer to the article body. We will AB test different containers in the future but this is a quick change to hit the monthly targets.

Before:
![screen shot 2015-10-15 at 16 38 24](https://cloud.githubusercontent.com/assets/2579465/10520505/496b3702-7362-11e5-9fa3-dd7bd84cf9bb.png)

After:
![screen shot 2015-10-15 at 16 58 33](https://cloud.githubusercontent.com/assets/2579465/10520512/53e14708-7362-11e5-8b72-fb5206aaf83a.png)
