### PR TITLE
Restore live blog aside adverts

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-aside-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-aside-adverts.js
@@ -32,7 +32,7 @@ define([
             $adSlotContainer;
 
         // are article aside ads disabled, or secondary column hidden?
-        if (!commercialFeatures.articleMPUs || colIsHidden) {
+        if (!commercialFeatures.articleAsideAdverts || colIsHidden) {
             return false;
         }
 

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -87,7 +87,7 @@ define([
         init = function () {
             var rules, lenientRules, inlineMercPromise;
 
-            if (!commercialFeatures.articleMPUs) {
+            if (!commercialFeatures.articleBodyAdverts) {
                 return false;
             }
 

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
@@ -83,11 +83,11 @@ define([
             return {
                 articleBodyAdverts : false,
                 articleAsideAdverts : false
-            }
+            };
         } else if (isLiveBlog) {
             return {
                 articleBodyAdverts : false
-            }
+            };
         }
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
@@ -47,7 +47,8 @@ define([
     policies.adfreeExperience = function () {
         if (userAdPreference.hideAds) {
             return {
-                articleMPUs : false,
+                articleBodyAdverts : false,
+                articleAsideAdverts : false,
                 sliceAdverts : false,
                 popularContentMPU : false,
                 videoPreRolls : false
@@ -75,8 +76,18 @@ define([
     };
 
     policies.nonArticlePages = function () {
-        if (config.page.contentType !== 'Article' || config.page.isLiveBlog) {
-            return {articleMPUs : false};
+        var isArticle = config.page.contentType === 'Article',
+            isLiveBlog = config.page.isLiveBlog;
+
+        if (!isArticle && !isLiveBlog) {
+            return {
+                articleBodyAdverts : false,
+                articleAsideAdverts : false
+            }
+        } else if (isLiveBlog) {
+            return {
+                articleBodyAdverts : false
+            }
         }
     };
 
@@ -93,7 +104,8 @@ define([
             switches.videoPreRolls = false;
         }
         if (!config.switches.standardAdverts) {
-            switches.articleMPUs = false;
+            switches.articleBodyAdverts = false;
+            switches.articleAsideAdverts = false;
             switches.sliceAdverts = false;
         }
         if (!config.switches.commercialComponents) {
@@ -111,7 +123,8 @@ define([
 
     function CommercialFeatureSwitches(enabled) {
         this.dfpAdvertising = enabled;
-        this.articleMPUs = enabled;
+        this.articleBodyAdverts = enabled;
+        this.articleAsideAdverts = enabled;
         this.sliceAdverts = enabled;
         this.popularContentMPU = enabled;
         this.videoPreRolls = enabled;

--- a/static/src/javascripts/test/spec/common/commercial/article-aside-adverts.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/article-aside-adverts.spec.js
@@ -31,7 +31,7 @@ describe('Article Aside Adverts', function () {
             commercialFeatures = arguments[1];
 
             // Reset dependencies
-            commercialFeatures.articleMPUs = true;
+            commercialFeatures.articleAsideAdverts = true;
 
             done();
         });
@@ -82,7 +82,7 @@ describe('Article Aside Adverts', function () {
     });
 
     it('should not display ad slot if disabled in commercial-feature-switches', function () {
-        commercialFeatures.articleMPUs = false;
+        commercialFeatures.articleAsideAdverts = false;
 
         expect(articleAsideAdverts.init()).toBe(false);
         expect(qwery('.ad-slot', $fixturesContainer).length).toBe(0);

--- a/static/src/javascripts/test/spec/common/commercial/article-body-adverts.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/article-body-adverts.spec.js
@@ -69,7 +69,7 @@ describe('Article Body Adverts', function () {
             getParaWithSpaceStub.onCall(11).returns(Promise.resolve(undefined));
             spacefinder.getParaWithSpace = getParaWithSpaceStub;
 
-            commercialFeatures.articleMPUs = true;
+            commercialFeatures.articleBodyAdverts = true;
 
             done();
         });
@@ -194,7 +194,7 @@ describe('Article Body Adverts', function () {
     });
 
     it('should not not display ad slot if turned off in commercial features', function () {
-        commercialFeatures.articleMPUs = false;
+        commercialFeatures.articleBodyAdverts = false;
         expect(articleBodyAdverts.init()).toBe(false);
     });
 

--- a/static/src/javascripts/test/spec/common/commercial/commercial-feature-policies.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/commercial-feature-policies.spec.js
@@ -161,7 +161,7 @@ describe('Commercial features', ()=> {
             userAdPreference.hideAds = true;
             const switches = commercialFeaturePolicies.getPolicySwitches().adfreeExperience;
 
-            expect(switches.articleMPUs).toBe(false);
+            expect(switches.articleBodyAdverts).toBe(false);
             expect(switches.sliceAdverts).toBe(false);
             expect(switches.popularContentMPU).toBe(false);
             expect(switches.videoPreRolls).toBe(false);
@@ -211,17 +211,30 @@ describe('Commercial features', ()=> {
             config.page.isLiveBlog = false;
         });
 
-        it('hides article MPUs on non-article pages', ()=> {
+        it('hides body MPUs on non-article pages', ()=> {
             config.page.contentType = 'Gallery';
             const switches = commercialFeaturePolicies.getPolicySwitches().nonArticlePages;
-            expect(switches.articleMPUs).toBe(false);
+            expect(switches.articleBodyAdverts).toBe(false);
         });
 
-        it('hides article MPUs on live blog articles', ()=> {
+        it('hides body MPUs on live blog articles', ()=> {
             config.page.contentType = 'Article';
             config.page.isLiveBlog = true;
             const switches = commercialFeaturePolicies.getPolicySwitches().nonArticlePages;
-            expect(switches.articleMPUs).toBe(false);
+            expect(switches.articleBodyAdverts).toBe(false);
+        });
+
+        it('hides aside MPUs on non-article pages', ()=> {
+            config.page.contentType = 'Gallery';
+            const switches = commercialFeaturePolicies.getPolicySwitches().nonArticlePages;
+            expect(switches.articleAsideAdverts).toBe(false);
+        });
+
+        it('does not hide aside MPUs on live blog articles', ()=> {
+            config.page.contentType = 'Article';
+            config.page.isLiveBlog = true;
+            const switches = commercialFeaturePolicies.getPolicySwitches().nonArticlePages;
+            expect(switches.articleAsideAdverts).toBeUndefined();
         });
 
         it('applies no changes otherwise', ()=> {
@@ -260,7 +273,7 @@ describe('Commercial features', ()=> {
         it('disables article adverts if standard-adverts switch is off', ()=> {
             config.switches.standardAdverts = false;
             const switches = commercialFeaturePolicies.getPolicySwitches().switchboard;
-            expect(switches.articleMPUs).toBe(false);
+            expect(switches.articleBodyAdverts).toBe(false);
         });
 
         it('disables slice adverts if standard-adverts switch is off', ()=> {


### PR DESCRIPTION
This is to fix a live issue - the commercial feature policies assumed _all_ article MPUs were disabled on live blog pages. They aren't supposed to be, however.

@uplne @Calanthe 
