### PR TITLE
If the call to Fastly API fails then fail gracefully and log the error.

### DIFF
--- a/admin/app/services/Fastly.scala
+++ b/admin/app/services/Fastly.scala
@@ -26,9 +26,21 @@ object Fastly extends ExecutionContexts with Logging {
 
   def apply(): Future[List[FastlyStatistic]] = {
 
-    val futureResponses: Future[List[String]] = Future.sequence( regions map { region =>
-        WS.url(s"https://api.fastly.com/stats?by=minute&from=45+minutes+ago&to=15+minutes+ago&region=${region}"
-        ).withHeaders("Fastly-Key" -> AdminConfiguration.fastly.key).get() map { _.body } })
+    val futureResponses: Future[List[String]] = Future.sequence{
+      regions map { region =>
+        val request = WS.url(s"https://api.fastly.com/stats?by=minute&from=45+minutes+ago&to=15+minutes+ago&region=${region}"
+        ).withHeaders("Fastly-Key" -> AdminConfiguration.fastly.key)
+
+        val response: Future[Option[String]] = request.get().map { resp => Some(resp.body) }.recover {
+          case e: Throwable => {
+            log.error(s"Error with request to api.fastly.com: ${e.getMessage}")
+            None
+          }
+        }
+        response
+      }
+
+    }.map(_.flatten)
 
     futureResponses map { responses =>
 


### PR DESCRIPTION
Admin instances keeps dying every 20 minutes. Looking into it the FastlyCloudwatchLoadJob is throwing an unhandled exception. The calls to Fastly might be failing so I paired with @rich-nguyen to add a recover on these calls. Maybe this will fix it!
