### PR TITLE
Sort the image crops to find the largest Image

### DIFF
--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -39,7 +39,7 @@ trait ImageContainer extends Element {
   lazy val masterImage: Option[ImageAsset] = allImages.find(_.isMaster)
 
   // The image crop with the largest width.
-  lazy val largestImage: Option[ImageAsset] = masterImage.orElse(imageCrops.headOption)
+  lazy val largestImage: Option[ImageAsset] = masterImage.orElse(imageCrops.sortBy(-_.width).headOption)
 
   // all landscape images get 4:3 aspect autocrops generated at widths of 1024 and 2048. portrait images are never
   // auto-cropped.. this is a temporary solution until the new media service is in use and we can properly

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -17,9 +17,9 @@ sealed trait ElementProfile {
   def compression: Int
 
   def elementFor(image: ImageContainer): Option[ImageAsset] = {
-    val sortedCorps = image.imageCrops.sortBy(_.width)
+    val sortedCrops = image.imageCrops.sortBy(-_.width)
     width.flatMap{ desiredWidth =>
-      sortedCorps.find(_.width >= desiredWidth)
+      sortedCrops.find(_.width >= desiredWidth)
     }.orElse(image.largestImage)
   }
 


### PR DESCRIPTION
There's an issue when we are finding poster images for a video. If the desired image width is not found, we should use the largest image available. This fixes a bug that meant we chose the wrong image.

Before:
![screen shot 2015-10-16 at 16 15 35](https://cloud.githubusercontent.com/assets/4549425/10545531/0ef6a506-7421-11e5-864e-234abb6a4f2c.png)
After:
![screen shot 2015-10-16 at 16 15 44](https://cloud.githubusercontent.com/assets/4549425/10545535/12074a0c-7421-11e5-82e8-4deaf018bba5.png)
