### PR TITLE
Fix video layout behaviour when beside rich link

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -35,6 +35,8 @@ $ima-controls-height: 70px;
 
 .element-video {
     position: relative;
+    // Force this container to wrap around the floated rich link
+    overflow: hidden;
 }
 
 .gu-video-embed-html {


### PR DESCRIPTION
Fixes #10885

Test URL on preview: http://preview.gutools.co.uk/global/2015/oct/16/foo

Isolated test case: http://jsbin.com/hodari/9/edit?html,css,output
Demonstration of the fix applied: http://jsbin.com/hodari/10/edit?html,css,output
## Chrome
### Before

![image](https://cloud.githubusercontent.com/assets/921609/10545668/c56fb606-7421-11e5-9eea-2de25c9bc466.png)
### After

![image](https://cloud.githubusercontent.com/assets/921609/10545652/b027646a-7421-11e5-9d1d-0f923fb3ecc5.png)
## Firefox
### Before

![image](https://cloud.githubusercontent.com/assets/921609/10545813/784cfdf6-7422-11e5-81b9-1611e0cb58c7.png)
### After

![image](https://cloud.githubusercontent.com/assets/921609/10545807/6f230162-7422-11e5-9440-34481cfcf3d0.png)
