### PR TITLE
Don't call the API for Members data if user isn't signed in

### DIFF
--- a/common/app/templates/headerInlineJS/membershipAccess.scala.js
+++ b/common/app/templates/headerInlineJS/membershipAccess.scala.js
@@ -16,7 +16,7 @@
             'common/utils/$',
             'common/utils/ajax',
             'common/modules/identity/api'
-        ], function($, ajax, id) {
+        ], function($, ajax, identity) {
 
             var membershipUrl = "@Configuration.id.membershipUrl",
                 membershipAccess = "@membershipAccess",
@@ -27,26 +27,26 @@
                 window.location.href = membershipAuthUrl;
             }
 
-            if (id.isUserLoggedIn()) {
-		    ajax({
-		        url: membershipUrl + '/user/me',
-		        type: 'json',
-		        crossOrigin: true,
-		        withCredentials: true
-		    }).then(function (resp) {
-		        // Check the users access matches the content
-		        var canViewContent = (requiresPaidTier) ? !!resp.tier && resp.isPaidTier : !!resp.tier;
-		        if (canViewContent) {
-		            $('body').removeClass('has-membership-access-requirement');
-		        } else {
-		            redirect();
-		        }
-		    }).fail(function() {
-		        // If the request fails assume non-member
-		        redirect();
-		    });
-            } else { 
+            if (identity.isUserLoggedIn()) {
+                ajax({
+                    url: membershipUrl + '/user/me',
+                    type: 'json',
+                    crossOrigin: true,
+                    withCredentials: true
+                }).then(function (resp) {
+                    // Check the users access matches the content
+                    var canViewContent = (requiresPaidTier) ? !!resp.tier && resp.isPaidTier : !!resp.tier;
+                    if (canViewContent) {
+                        $('body').removeClass('has-membership-access-requirement');
+                    } else {
+                        redirect();
+                    }
+                }).fail(function() {
+                    // If the request fails assume non-member
                     redirect();
+                });
+            } else {
+                redirect();
             }
 
         });

--- a/common/app/templates/headerInlineJS/membershipAccess.scala.js
+++ b/common/app/templates/headerInlineJS/membershipAccess.scala.js
@@ -14,8 +14,9 @@
 
         require([
             'common/utils/$',
-            'common/utils/ajax'
-        ], function($, ajax) {
+            'common/utils/ajax',
+            'common/modules/identity/api'
+        ], function($, ajax, id) {
 
             var membershipUrl = "@Configuration.id.membershipUrl",
                 membershipAccess = "@membershipAccess",
@@ -26,23 +27,28 @@
                 window.location.href = membershipAuthUrl;
             }
 
-            ajax({
-                url: membershipUrl + '/user/me',
-                type: 'json',
-                crossOrigin: true,
-                withCredentials: true
-            }).then(function (resp) {
-                // Check the users access matches the content
-                var canViewContent = (requiresPaidTier) ? !!resp.tier && resp.isPaidTier : !!resp.tier;
-                if (canViewContent) {
-                    $('body').removeClass('has-membership-access-requirement');
-                } else {
+            if (id.isUserLoggedIn()) {
+		    ajax({
+		        url: membershipUrl + '/user/me',
+		        type: 'json',
+		        crossOrigin: true,
+		        withCredentials: true
+		    }).then(function (resp) {
+		        // Check the users access matches the content
+		        var canViewContent = (requiresPaidTier) ? !!resp.tier && resp.isPaidTier : !!resp.tier;
+		        if (canViewContent) {
+		            $('body').removeClass('has-membership-access-requirement');
+		        } else {
+		            redirect();
+		        }
+		    }).fail(function() {
+		        // If the request fails assume non-member
+		        redirect();
+		    });
+            } else { 
                     redirect();
-                }
-            }).fail(function() {
-                // If the request fails assume non-member
-                redirect();
-            });
+            }
+
         });
     }(window));
 }


### PR DESCRIPTION
We don't need to make an AJAX call checking the user's tier if the user isn't signed-in, so avoid the overhead :sparkles: 

cc @jbreckmckye @ostapneko 
