### PR TITLE
A/B test utilising Krux segment to test loyalty curve engagement

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -31,4 +31,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABRtrtEmailMessage = Switch(
+    "A/B Tests",
+    "ab-rtrt-email-message",
+    "Switch to show the Right Place Right Time email message with segmentation",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 11, 15),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -9,7 +9,8 @@ define([
     'common/modules/experiments/tests/high-commercial-component',
     'common/modules/experiments/tests/membership-message-usa',
     'common/modules/experiments/tests/adfree-survey',
-    'common/modules/experiments/tests/switch-most-pop-related-content'
+    'common/modules/experiments/tests/switch-most-pop-related-content',
+    'common/modules/experiments/tests/rtrt-email-message'
 ], function (
     reportError,
     _,
@@ -21,14 +22,16 @@ define([
     HighCommercialComponent,
     MembershipMessageUSA,
     AddfreeSurvey,
-    SwitchMostPopAndRelatedContent
+    SwitchMostPopAndRelatedContent,
+    RtrtEmailMessage
 ) {
 
     var TESTS = _.flatten([
         new HighCommercialComponent(),
         new MembershipMessageUSA(),
         new AddfreeSurvey(),
-        new SwitchMostPopAndRelatedContent()
+        new SwitchMostPopAndRelatedContent(),
+        new RtrtEmailMessage()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
@@ -32,6 +32,18 @@ define([
                 linkText: 'Sign up',
                 linkName: 'rtrt : message : email sign-up button',
                 arrowWhiteRight: svgs('arrowWhiteRight')
+            },
+            createMessage = function (kruxSegmentId) {
+                // If a segment Id is passed and the user is in the segment, show the message
+                // and fire off an omniture tracking call
+                if (kruxSegmentId && _.contains(krux.getSegments(), kruxSegmentId)) {
+                    new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
+                    // Omniture is a global var
+                    window.s.trackLink(this, 'Email sign-up message for segment ' + kruxSegmentId + ' shown');
+                } else if (!kruxSegmentId) {
+                    new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
+                }
+
             };
 
         this.id = 'RtrtEmailMessage';
@@ -50,28 +62,24 @@ define([
             return true;
         };
 
-        this.variants = [{
-            id: 'targeted',
-            test: function () {
-                var kruxSegmentId = 'o901c5kja',
-                    userIsInSegment = _.contains(krux.getSegments(), kruxSegmentId);
-
-                // If user is in our segment
-                if (userIsInSegment) {
-                    new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
-
-                    // Omniture is a global var
-                    s.trackLink(this, 'Email sign-up message for segment ' + kruxSegmentId + ' shown');
-
+        this.variants = [
+            {
+                id: 'targeted-loyal-A',
+                test: function () {
+                    createMessage('XXXXXXXX');
                 }
+            },
+            {
+                id: 'targeted-loyal-B',
+                test: function () {
+                    createMessage('XXXXXXXX');
+                }
+            },
+            {
+                id: 'all',
+                test: createMessage
             }
-        },
-        {
-            id: 'all',
-            test: function () {
-                new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
-            }
-        }];
+        ];
 
     };
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
@@ -5,7 +5,8 @@ define([
     'text!common/views/general-message.html',
     'common/views/svgs',
     'common/utils/_',
-    'common/modules/commercial/third-party-tags/krux'
+    'common/modules/commercial/third-party-tags/krux',
+    'common/modules/identity/api'
 ], function (
     config,
     template,
@@ -13,7 +14,8 @@ define([
     messageTemplate,
     svgs,
     _,
-    krux
+    krux,
+    Id
 ) {
 
     var messageId = 'rtrt-email-message';
@@ -50,34 +52,34 @@ define([
         this.start = '2015-10-15';
         this.expiry = '2015-11-15';
         this.author = 'Gareth Trufitt';
-        this.description = 'Test likelihood of email sign-up with 3 visits to the home page vs showing to all visitors on all pages';
+        this.description = 'Test likelihood of email sign-up with 10 visits to the Guardian vs any network front visitor vs showing to all visitors on all pages';
         this.audience = 0.01;
         this.audienceOffset = 0;
         this.successMeasure = 'Loyal users shown the email sign-up message higher on the loyalty curve are more likely to sign up';
-        this.audienceCriteria = 'Users who match the segment defined in Krux';
+        this.audienceCriteria = 'Users who match the segments defined in Krux';
         this.dataLinkNames = '';
-        this.idealOutcome = 'Users will sign up to email';
+        this.idealOutcome = 'Users who are more loyal will sign up to email';
 
         this.canRun = function () {
-            return true;
+            return !Id.isUserLoggedIn(); // Only show to non-logged-in users, as testing email sign-up
         };
 
         this.variants = [
             {
                 id: 'targeted-loyal-A',
                 test: function () {
-                    createMessage('XXXXXXXX');
+                    createMessage('p2lq8cs6r'); // 10 visits or more to the Guardian
                 }
             },
             {
                 id: 'targeted-loyal-B',
                 test: function () {
-                    createMessage('XXXXXXXX');
+                    createMessage('p2lryefg7'); // A visitor currently on the network front
                 }
             },
             {
                 id: 'all',
-                test: createMessage
+                test: createMessage // Any visitor, any page
             }
         ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
@@ -1,0 +1,80 @@
+define([
+    'common/utils/config',
+    'common/utils/template',
+    'common/modules/ui/message',
+    'text!common/views/general-message.html',
+    'common/views/svgs',
+    'common/utils/_',
+    'common/modules/commercial/third-party-tags/krux'
+], function (
+    config,
+    template,
+    Message,
+    messageTemplate,
+    svgs,
+    _,
+    krux
+) {
+
+    var messageId = 'rtrt-email-message';
+
+    return function () {
+
+        var messageOptions = {
+                siteMessageLinkName: 'rtrt : message : email sign-up',
+                siteMessageCloseBtn: 'hide',
+                widthBasedMessage: true
+            },
+            messageTemplateOptions = {
+                linkHref: 'http://www.theguardian.com/world/2013/oct/04/1',
+                messageTextWide: 'Get the day\'s top news and commentary delivered to your inbox each morning in our Guardian Today email',
+                messageTextNarrow: 'Get the day\'s top news and commentary delivered to your inbox each morning',
+                linkText: 'Sign up',
+                linkName: 'rtrt : message : email sign-up button',
+                arrowWhiteRight: svgs('arrowWhiteRight')
+            };
+
+        this.id = 'RtrtEmailMessage';
+        this.start = '2015-10-15';
+        this.expiry = '2015-11-15';
+        this.author = 'Gareth Trufitt';
+        this.description = 'Test likelihood of email sign-up with 3 visits to the home page vs showing to all visitors on article pages';
+        this.audience = 0.01;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Loyal users shown the email sign-up message are more likely to sign up';
+        this.audienceCriteria = 'Users on article pages';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'Users will sign up to email';
+
+        this.canRun = function () {
+            return true;
+        };
+
+        this.variants = [{
+            id: 'targeted',
+            test: function () {
+                var kruxSegmentId = 'o901c5kja',
+                    userIsInSegment = _.contains(krux.getSegments(), kruxSegmentId);
+
+                // If user is in our segment
+                if (userIsInSegment) {
+                    new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
+
+                    // Require omniture inline to avoid circular dependency
+                    // (ab requires this file, this file requires omniture, omniture requires ab)
+                    require(['common/modules/analytics/omniture'], function(omniture){
+                        omniture.trackLink(this, 'Email sign-up message for segment ' + kruxSegmentId + ' shown');
+                    });
+                }
+            }
+        },
+        {
+            id: 'all',
+            test: function () {
+                new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
+            }
+        }];
+
+    };
+
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
@@ -38,11 +38,11 @@ define([
         this.start = '2015-10-15';
         this.expiry = '2015-11-15';
         this.author = 'Gareth Trufitt';
-        this.description = 'Test likelihood of email sign-up with 3 visits to the home page vs showing to all visitors on article pages';
+        this.description = 'Test likelihood of email sign-up with 3 visits to the home page vs showing to all visitors on all pages';
         this.audience = 0.01;
         this.audienceOffset = 0;
-        this.successMeasure = 'Loyal users shown the email sign-up message are more likely to sign up';
-        this.audienceCriteria = 'Users on article pages';
+        this.successMeasure = 'Loyal users shown the email sign-up message higher on the loyalty curve are more likely to sign up';
+        this.audienceCriteria = 'Users who match the segment defined in Krux';
         this.dataLinkNames = '';
         this.idealOutcome = 'Users will sign up to email';
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
@@ -62,7 +62,7 @@ define([
 
                     // Require omniture inline to avoid circular dependency
                     // (ab requires this file, this file requires omniture, omniture requires ab)
-                    require(['common/modules/analytics/omniture'], function(omniture){
+                    require(['common/modules/analytics/omniture'], function (omniture) {
                         omniture.trackLink(this, 'Email sign-up message for segment ' + kruxSegmentId + ' shown');
                     });
                 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
@@ -60,11 +60,9 @@ define([
                 if (userIsInSegment) {
                     new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
 
-                    // Require omniture inline to avoid circular dependency
-                    // (ab requires this file, this file requires omniture, omniture requires ab)
-                    require(['common/modules/analytics/omniture'], function (omniture) {
-                        omniture.trackLink(this, 'Email sign-up message for segment ' + kruxSegmentId + ' shown');
-                    });
+                    // Omniture is a global var
+                    s.trackLink(this, 'Email sign-up message for segment ' + kruxSegmentId + ' shown');
+
                 }
             }
         },

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -3,13 +3,17 @@ define([
     'bean',
     'common/utils/storage',
     'common/modules/user-prefs',
-    'common/utils/_'
+    'common/utils/_',
+    'common/utils/mediator',
+    'common/utils/detect'
 ], function (
     $,
     bean,
     storage,
     userPrefs,
-    _
+    _,
+    mediator,
+    detect
 ) {
 
     /**
@@ -29,6 +33,7 @@ define([
         this.siteMessageLinkName = opts.siteMessageLinkName || '';
         this.siteMessageCloseBtn = opts.siteMessageCloseBtn || '';
         this.prefs = 'messages';
+        this.widthBasedMessage = opts.widthBasedMessage || false;
 
         this.$footerMessage = $('.js-footer-message');
     };
@@ -49,6 +54,13 @@ define([
             return false;
         }
         $('.js-site-message-copy').html(message);
+
+        this.$siteMessageNarrow = $('.js-site-message__narrow');
+        this.$siteMessageWide = $('.js-site-message__wide');
+
+        // Check and show the width based message
+        this.updateMessageOnWidth();
+        mediator.on('window:resize', _.debounce(this.updateMessageOnWidth, 200).bind(this));
 
         if (this.siteMessageLinkName) {
             siteMessage.attr('data-link-name', this.siteMessageLinkName);
@@ -100,6 +112,22 @@ define([
     Message.prototype.acknowledge = function () {
         this.remember();
         this.hide();
+    };
+
+    Message.prototype.updateMessageOnWidth = function () {
+        if (this.widthBasedMessage && this.$siteMessageNarrow.length && this.$siteMessageWide.length) {
+            (detect.isBreakpoint({ max: 'tablet' })) ? this.showNarrowMessage() : this.showWideMessage();
+        }
+    };
+
+    Message.prototype.showNarrowMessage = function () {
+        this.$siteMessageWide.addClass('is-hidden');
+        this.$siteMessageNarrow.removeClass('is-hidden');
+    };
+
+    Message.prototype.showWideMessage = function () {
+        this.$siteMessageNarrow.addClass('is-hidden');
+        this.$siteMessageWide.removeClass('is-hidden');
     };
 
     return Message;

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -55,8 +55,7 @@ define([
         }
         $('.js-site-message-copy').html(message);
 
-        this.$siteMessageNarrow = $('.js-site-message__narrow');
-        this.$siteMessageWide = $('.js-site-message__wide');
+        this.$siteMessage = $('.js-site-message__message');
 
         // Check and show the width based message
         this.updateMessageOnWidth();
@@ -115,19 +114,19 @@ define([
     };
 
     Message.prototype.updateMessageOnWidth = function () {
-        if (this.widthBasedMessage && this.$siteMessageNarrow.length && this.$siteMessageWide.length) {
-            (detect.isBreakpoint({ max: 'tablet' })) ? this.showNarrowMessage() : this.showWideMessage();
+        var narrowDataAttr = 'site-message-narrow',
+            wideDataAttr = 'site-message-wide';
+
+        if (this.widthBasedMessage && this.$siteMessage.length) {
+            this.updateMessageFromData((detect.isBreakpoint({ max: 'tablet' })) ? narrowDataAttr : wideDataAttr);
         }
     };
 
-    Message.prototype.showNarrowMessage = function () {
-        this.$siteMessageWide.addClass('is-hidden');
-        this.$siteMessageNarrow.removeClass('is-hidden');
-    };
-
-    Message.prototype.showWideMessage = function () {
-        this.$siteMessageNarrow.addClass('is-hidden');
-        this.$siteMessageWide.removeClass('is-hidden');
+    Message.prototype.updateMessageFromData = function (dataAttr) {
+        var message = this.$siteMessage.data(dataAttr);
+        if (message) {
+            this.$siteMessage.text(message);
+        }
     };
 
     return Message;

--- a/static/src/javascripts/projects/common/views/general-message.html
+++ b/static/src/javascripts/projects/common/views/general-message.html
@@ -1,0 +1,10 @@
+<p class="site-message__message" id="site-message__message">
+    <span class="js-site-message__narrow"><%=messageTextNarrow%></span>
+    <span class="js-site-message__wide is-hidden"><%=messageTextWide%></span>
+</p>
+<ul class="site-message__actions u-unstyled">
+    <li class="site-message__actions__item">
+        <%=arrowWhiteRight%>
+        <a href="<%=linkHref%>" target="_blank" data-link-name="<%=linkName%>"><%=linkText%></a>
+    </li>
+</ul>

--- a/static/src/javascripts/projects/common/views/general-message.html
+++ b/static/src/javascripts/projects/common/views/general-message.html
@@ -1,6 +1,7 @@
-<p class="site-message__message" id="site-message__message">
-    <span class="js-site-message__narrow"><%=messageTextNarrow%></span>
-    <span class="js-site-message__wide is-hidden"><%=messageTextWide%></span>
+<p class="site-message__message js-site-message__message" id="site-message__message"
+   data-site-message-wide="<%=messageTextWide%>"
+   data-site-message-narrow="<%=messageTextNarrow%>">
+    <%=messageTextNarrow%>
 </p>
 <ul class="site-message__actions u-unstyled">
     <li class="site-message__actions__item">


### PR DESCRIPTION
Following the Right Thing, Right Time concept, we believe that users further up the loyalty curve will be more receptive and more likely to click through to an email sign-up as an audience vs a control group of everyone.

The targeted group is a segment created in Krux that we believe is a group of user's displaying loyal tendencies just before before email sign-up. We are using the messages framework on 1% of the audience to test this hypothesis.

**Note**: Krux segment needs creating before merging.

This PR also contains an update to the message.js to allow different messages on wide and narrow screens.

<img width="1297" alt="screen shot 2015-10-19 at 11 44 12" src="https://cloud.githubusercontent.com/assets/638051/10577467/6d3b6f0e-7663-11e5-8bb5-600a13f7f326.png">
<img width="384" alt="screen shot 2015-10-19 at 11 44 18" src="https://cloud.githubusercontent.com/assets/638051/10577468/6d3c676a-7663-11e5-8e45-43ea45d9012f.png">
