### PR TITLE
Revert "Log Bad Soap Messages from DFP"

### DIFF
--- a/admin/conf/application-logger.xml
+++ b/admin/conf/application-logger.xml
@@ -16,7 +16,7 @@
     </appender>
 
     <!-- DFP API logging -->
-    <logger name="com.google.api.ads.dfp.lib.client.DfpServiceClient.soapXmlLogger" level="WARN"/>
+    <logger name="com.google.api.ads.dfp.lib.client.DfpServiceClient.soapXmlLogger" level="OFF"/>
     <logger name="com.google.api.client.http.HttpTransport" level="OFF"/>
 
     <root level="INFO">


### PR DESCRIPTION
Reverts guardian/frontend#10862

Admin keeps dying every 20 minutes. This was the only change made on the day it started so we are going to revert it and see if this is the cause. cc @kelvin-chappell 
