### PR TITLE
Style the immersive article body

### DIFF
--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -46,7 +46,6 @@
 
                     <div class="content__secondary-column js-secondary-column" aria-hidden="true">
                         <div class="ad-slot-container js-ad-slot-container"></div>
-                        <div class="js-components-container"></div>
                     </div>
                 </div>
             </div>

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -70,6 +70,8 @@ object PullquoteCleaner extends HtmlCleaner {
     pullquotes.foreach { element: Element =>
       element.prepend(openingQuoteSvg)
       element.append(closingQuoteSvg)
+      element.getElementsByTag("p").addClass("pullquote-paragraph")
+      element.getElementsByTag("cite").addClass("pullquote-cite")
     }
 
     document

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -500,6 +500,16 @@ case class DropCaps(isFeature: Boolean) extends HtmlCleaner {
         case _ =>
       }
     }
+
+    document.getElementsByTag("h2").foreach{ h2 =>
+        if (h2.text() == "* * *") {
+            h2.tagName("div").addClass("section-rule").html("")
+            val next = h2.nextElementSibling()
+            if (next.nodeName() == "p") {
+                next.html(setDropCap(next))
+            } 
+        }
+    }
     document
   }
 }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -503,7 +503,7 @@ case class DropCaps(isFeature: Boolean) extends HtmlCleaner {
 
     document.getElementsByTag("h2").foreach{ h2 =>
         if (h2.text() == "* * *") {
-            h2.tagName("div").addClass("section-rule").html("")
+            h2.tagName("hr").addClass("section-rule").html("")
             val next = h2.nextElementSibling()
             if (next.nodeName() == "p") {
                 next.html(setDropCap(next))

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -145,8 +145,8 @@
         height: 7.25em;
 
         .drop-cap__inner {
-            font-size: 9.5rem;
-            line-height: 8rem;
+            font-size: 9.5em;
+            line-height: .83;
         }
     }
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -12,7 +12,7 @@
     .content__article-body {
         clear: both;
 
-        a {
+        > p a {
             color: colour(feature-default);
 
             &:hover {
@@ -162,6 +162,8 @@
         display: block;
         width: gs-span(2);
         height: 2px;
+        margin: 0;
+        border: 0;
         margin-top: $gs-baseline * 4;
         margin-bottom: $gs-baseline / 4;
         background-color: colour(neutral-7);

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -11,6 +11,14 @@
 
     .content__article-body {
         clear: both;
+
+        a {
+            color: colour(feature-default);
+
+            &:hover {
+                border-bottom-color: rgba(colour(feature-default), .4);
+            }
+        }
     }
 
 /* Header
@@ -217,6 +225,7 @@
 
         @include mq(leftCol) {
             margin-left: -(gs-span(2) + $gs-gutter * 2);
+            margin-bottom: $gs-baseline - 2px; // 2px is to compensate for x-height of type
         }
 
         @include mq(wide) {
@@ -225,6 +234,20 @@
 
         .caption {
             padding-left: $gs-gutter;
+
+            @include mq(leftCol) {
+                position: absolute;
+                width: gs-span(2);
+                padding-top: $gs-baseline;
+            }
+
+            @include mq(wide) {
+                width: gs-span(3);
+            }
+        }
+
+        .block-share {
+            display: none !important; // To override hide on mobile
         }
     }
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -203,7 +203,16 @@
 
         .caption {
             padding-left: $gs-gutter;
+        }
+    }
 
+    .ad-slot--inline {
+        @include mq(desktop) {
+            margin-right: -320px;
+        }
+
+        @include mq(wide) {
+            margin-right: -400px;
         }
     }
 }

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -11,14 +11,6 @@
 
     .content__article-body {
         clear: both;
-
-        > p a {
-            color: colour(feature-default);
-
-            &:hover {
-                border-bottom-color: rgba(colour(feature-default), .4);
-            }
-        }
     }
 
 /* Header

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -208,11 +208,11 @@
 
     .ad-slot--inline {
         @include mq(desktop) {
-            margin-right: -320px;
+            margin-right: -(gs-span(4) + $gs-gutter);
         }
 
         @include mq(wide) {
-            margin-right: -400px;
+            margin-right: -(gs-span(5) + $gs-gutter);
         }
     }
 }

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -146,11 +146,11 @@
         width: auto;
         margin-left: 0;
         padding: 0;
-        padding-top: 0.33em;
+        padding-top: .33em;
         margin-bottom: 2rem;
 
         &:before {
-            content: "";
+            content: '';
             position: absolute;
             top: 0;
             height: 2px;
@@ -185,6 +185,25 @@
 
         .inline-quote.closing {
             display: none;
+        }
+    }
+
+    figure.element--showcase {
+        @include mq(desktop) {
+            margin-left: -($gs-gutter);
+        }
+
+        @include mq(leftCol) {
+            margin-left: -(gs-span(2) + $gs-gutter * 2);
+        }
+
+        @include mq(wide) {
+            margin-left: -(gs-span(3) + $gs-gutter * 2);
+        }
+
+        .caption {
+            padding-left: $gs-gutter;
+
         }
     }
 }

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -150,6 +150,19 @@
         }
     }
 
+    .section-rule {
+        display: block;
+        width: gs-span(2);
+        height: 2px;
+        margin-top: $gs-baseline * 4;
+        margin-bottom: $gs-baseline / 4;
+        background-color: colour(neutral-7);
+    }
+
+    .element + .section-rule {
+        margin-top: 0;
+    }
+
     .element-pullquote {
         position: relative;
         width: auto;
@@ -163,7 +176,7 @@
             position: absolute;
             top: 0;
             height: 2px;
-            width: 140px;
+            width: gs-span(2);
             background-color: colour(neutral-7);
         }
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -146,7 +146,7 @@
 
         .drop-cap__inner {
             font-size: 9.5em;
-            line-height: .83;
+            line-height: .83; // To optically align to top of five lines of text
         }
     }
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -233,7 +233,9 @@
         }
 
         .caption {
-            padding-left: $gs-gutter;
+            @include mq(desktop) {
+                padding-left: $gs-gutter;
+            }
 
             @include mq(leftCol) {
                 position: absolute;

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -191,19 +191,19 @@
             width: 2.425rem;
         }
 
-        blockquote p,
-        cite {
+        .pullquote-paragraph,
+        .pullquote-cite {
             font-family: $f-serif-headline;
             font-weight: 200;
             font-size: 1.75rem;
             line-height: 1.1;
         }
 
-        blockquote p {
+        .pullquote-paragraph {
             color: colour(feature-default);
         }
 
-        cite {
+        .pullquote-cite {
             color: colour(neutral-1) !important; // important to override super specific tonal classes
         }
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -13,7 +13,8 @@
         clear: both;
     }
 
-    // HEADER
+/* Header
+   ========================================================================== */
     .content__head {
         position: relative;
         color: #ffffff;
@@ -135,6 +136,55 @@
             bottom: 0;
             left: 0;
             right: 0;
+        }
+    }
+
+/* Body
+   ========================================================================== */
+    .element-pullquote {
+        position: relative;
+        width: auto;
+        margin-left: 0;
+        padding: 0;
+        padding-top: 0.33em;
+        margin-bottom: 2rem;
+
+        &:before {
+            content: "";
+            position: absolute;
+            top: 0;
+            height: 2px;
+            width: 140px;
+            background-color: colour(neutral-7);
+        }
+
+        .inline-quote {
+            margin-bottom: $gs-baseline / 4;
+        }
+
+        .inline-quote svg {
+            fill: colour(neutral-3);
+            width: 2.425rem;
+        }
+
+        blockquote p,
+        cite {
+            font-family: $f-serif-headline;
+            font-weight: 200;
+            font-size: 1.75rem;
+            line-height: 1.1;
+        }
+
+        blockquote p {
+            color: colour(feature-default);
+        }
+
+        cite {
+            color: colour(neutral-1) !important; // important to override super specific tonal classes
+        }
+
+        .inline-quote.closing {
+            display: none;
         }
     }
 }

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -141,6 +141,15 @@
 
 /* Body
    ========================================================================== */
+    .drop-cap {
+        height: 7.25em;
+
+        .drop-cap__inner {
+            font-size: 9.5rem;
+            line-height: 8rem;
+        }
+    }
+
     .element-pullquote {
         position: relative;
         width: auto;


### PR DESCRIPTION
A bunch of changes to make so the immersive article not only has a good header on it's shoulders, but it now has a hot bod too. Here's what's happening...
## THE MOST PULLED PULL QUOTES

![screen shot 2015-10-19 at 14 29 52](https://cloud.githubusercontent.com/assets/1607666/10579299/35c81ad4-766f-11e5-8695-dc179b7caf09.png)
## E.2.R.H.C.E.S.D. (EDGE TO RHC ELEMENT SHOWCASE DISPLAYS)

![screen shot 2015-10-19 at 14 32 12](https://cloud.githubusercontent.com/assets/1607666/10579319/52850448-766f-11e5-8857-be949c3d0816.png)
## DROP CAPS AFTER SECTION BREAKS

![image 2015-10-19 at 2 36 23 pm](https://cloud.githubusercontent.com/assets/1607666/10579367/8944dac6-766f-11e5-9b51-f8db557c07b8.png)

There are also a few other bits, like moving the ads into the right hand column to allow the art director to have full control over an area on the page. Adding the feature colour to in body links. Nice.
