### PR TITLE
Load outbrain instantly on international edition

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -110,7 +110,7 @@ define([
                 && !config.page.isPreview
                 && this.identityPolicy()
                 && config.page.section !== 'childrens-books-site') {
-                if (detect.adblockInUse()) {
+                if (detect.adblockInUse() || config.page.edition.toLowerCase() === 'int') {
                     this.load();
                 } else {
                     mediator.on('modules:commercial:dfp:rendered', function (event) {

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -104,13 +104,17 @@ define([
             return (!identity.isUserLoggedIn() || !(identity.isUserLoggedIn() && config.page.commentable));
         },
 
+        hasHighRelevanceComponent: function () {
+            return detect.adblockInUse() || config.page.edition.toLowerCase() === 'int';
+        },
+
         init: function () {
             if (config.switches.outbrain
                 && !config.page.isFront
                 && !config.page.isPreview
                 && this.identityPolicy()
                 && config.page.section !== 'childrens-books-site') {
-                if (detect.adblockInUse() || config.page.edition.toLowerCase() === 'int') {
+                if (this.hasHighRelevanceComponent()) {
                     this.load();
                 } else {
                     mediator.on('modules:commercial:dfp:rendered', function (event) {

--- a/static/src/javascripts/test/spec/common/commercial/third-party-tags/outbrain.spec.js
+++ b/static/src/javascripts/test/spec/common/commercial/third-party-tags/outbrain.spec.js
@@ -36,7 +36,8 @@ describe('Outbrain', function () {
                 section: 'uk-news',
                 isPreview: false,
                 isFront: false,
-                commentable: true
+                commentable: true,
+                edition: 'UK'
             };
             identity.isUserLoggedIn = function () {
                 return false;
@@ -152,10 +153,19 @@ describe('Outbrain', function () {
             not loading Outbrain. As Outbrain is being partially loaded behind the adblock we can
             make the call instantly when we detect adBlock in use.
          */
-        it('should load when ad block is in use', () => {
+        it('should load instantly when ad block is in use', () => {
             spyOn(sut, 'load');
 
             detect.adblockInUse = () => true;
+
+            sut.init();
+            expect(sut.load).toHaveBeenCalled();
+        });
+
+        it('should load instantly when international edition', () => {
+            spyOn(sut, 'load');
+
+            config.page.edition = 'INT';
 
             sut.init();
             expect(sut.load).toHaveBeenCalled();


### PR DESCRIPTION
There is no high relevance commercial component on international edition so we don't need to wait for DFP to return.
