### PR TITLE
AB test: style most popular as cards

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -31,4 +31,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABMostPopAsFaciaCards = Switch(
+    "A/B Tests",
+    "ab-most-pop-as-facia-cards",
+    "Style the most popular container as facia cards",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 11, 30),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -205,6 +205,16 @@ object FaciaContainer {
       componentId = None
     ).withTimeStamps
   }
+
+  def forMostPopular(dataId: String, items: Seq[FaciaContent], title: String, href: Option[String] = None) = {
+    FaciaContainer(
+      index = 2,
+      container = Dynamic(DynamicSlowMPUABTest),
+      config = ContainerDisplayConfig.withDefaults(CollectionConfigWithId(dataId, CollectionConfig.empty)),
+      collectionEssentials = CollectionEssentials(items take 10, Nil, Some(title), href, None, None),
+      componentId = None
+    ).withTimeStamps
+  }
 }
 
 case class FaciaContainer(

--- a/common/app/slices/DynamicSlowMpu.scala
+++ b/common/app/slices/DynamicSlowMpu.scala
@@ -24,3 +24,12 @@ object DynamicSlowMPU extends DynamicContainer {
       case None    => Seq(TTlMpu)
     }
 }
+
+
+object DynamicSlowMPUABTest extends DynamicContainer {
+  override protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] =
+    Some(QuarterQuarterQuarterQuarter, stories.drop(4))
+
+  override protected def standardSlices(stories: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] =
+    Seq(TlTlMpu)
+}

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -22,13 +22,13 @@
 
         @popular.zipWithRowInfo.map{ case (section, info) =>
             <div id="tabs-popular-@info.rowNum"
-                class="@if(isTabbed){js-tab-@info.rowNum @if(!info.isFirst){modern-hidden}} tabs__pane u-cf"
-                @if(isTabbed){
-                    role="tabpanel"
-                    aria-labelledby="tabs-popular-@info.rowNum-tab"
-                }
-                data-link-name="@section.heading"
-                data-link-context="most-read/@section.section">
+                 class="@if(isTabbed){js-tab-@info.rowNum @if(!info.isFirst){modern-hidden}} tabs__pane u-cf"
+                 @if(isTabbed){
+                     role="tabpanel"
+                     aria-labelledby="tabs-popular-@info.rowNum-tab"
+                 }
+                 data-link-name="@section.heading"
+                 data-link-context="most-read/@section.section">
 
                 <ul class="u-unstyled headline-list headline-list--large headline-column headline-column--tablet headline-column--desktop">
                     @section.trails.zipWithRowInfo.map{ case (trail, info) =>

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -12,22 +12,23 @@
             <div class="tabs u-cf">
                 <ol class="tabs__container js-tabs" id="js-popular-tabs" role="tablist">
                     @popular.zipWithRowInfo.map{ case (section, info) =>
-                        <li class="tabs__tab@if(info.isFirst){ tabs__tab--selected tone-colour tone-accent-border}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum"><a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading"><span class="u-h">Popular </span>@Html(Localisation(section.heading.stripPrefix("popular ")))</a>
+                        <li class="tabs__tab@if(info.isFirst){ tabs__tab--selected tone-colour tone-accent-border}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum">
+                            <a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading"><span class="u-h">Popular </span>@Html(Localisation(section.heading.stripPrefix("popular ")))</a>
                         </li>
                     }
                 </ol>
                 <div class="tabs__content js-tabs-content">
-                }
+        }
 
         @popular.zipWithRowInfo.map{ case (section, info) =>
             <div id="tabs-popular-@info.rowNum"
                 class="@if(isTabbed){js-tab-@info.rowNum @if(!info.isFirst){modern-hidden}} tabs__pane u-cf"
-            @if(isTabbed){
-                role="tabpanel"
-                aria-labelledby="tabs-popular-@info.rowNum-tab"
-            }
-            data-link-name="@section.heading"
-            data-link-context="most-read/@section.section">
+                @if(isTabbed){
+                    role="tabpanel"
+                    aria-labelledby="tabs-popular-@info.rowNum-tab"
+                }
+                data-link-name="@section.heading"
+                data-link-context="most-read/@section.section">
 
                 <ul class="u-unstyled headline-list headline-list--large headline-column headline-column--tablet headline-column--desktop">
                     @section.trails.zipWithRowInfo.map{ case (trail, info) =>
@@ -42,11 +43,11 @@
             </div>
         }
 
-    <div class="fc-slice__popular-mpu js-fc-slice-mpu-candidate fc-slice__item--mpu-candidate fc-slice__item--no-mpu"></div>
+            <div class="fc-slice__popular-mpu js-fc-slice-mpu-candidate fc-slice__item--mpu-candidate fc-slice__item--no-mpu"></div>
 
         @if(isTabbed) {
-        </div>
-        </div>
+                </div>
+            </div>
         }
 
     </div>

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -11,36 +11,35 @@
         @if(isTabbed) {
             <div class="tabs u-cf">
                 <ol class="tabs__container js-tabs" id="js-popular-tabs" role="tablist">
-                @popular.zipWithRowInfo.map{ case (section, info) =>
-                <li class="tabs__tab@if(info.isFirst){ tabs__tab--selected tone-colour tone-accent-border}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum">
-                    <a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading"><span class="u-h">Popular </span>@Html(Localisation(section.heading.stripPrefix("popular ")))</a>
-                </li>
-                }
+                    @popular.zipWithRowInfo.map{ case (section, info) =>
+                        <li class="tabs__tab@if(info.isFirst){ tabs__tab--selected tone-colour tone-accent-border}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum"><a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading"><span class="u-h">Popular </span>@Html(Localisation(section.heading.stripPrefix("popular ")))</a>
+                        </li>
+                    }
                 </ol>
                 <div class="tabs__content js-tabs-content">
                 }
 
         @popular.zipWithRowInfo.map{ case (section, info) =>
-        <div id="tabs-popular-@info.rowNum"
-        class="@if(isTabbed){js-tab-@info.rowNum @if(!info.isFirst){modern-hidden}} tabs__pane u-cf"
+            <div id="tabs-popular-@info.rowNum"
+                class="@if(isTabbed){js-tab-@info.rowNum @if(!info.isFirst){modern-hidden}} tabs__pane u-cf"
             @if(isTabbed){
                 role="tabpanel"
                 aria-labelledby="tabs-popular-@info.rowNum-tab"
             }
-        data-link-name="@section.heading"
-        data-link-context="most-read/@section.section">
+            data-link-name="@section.heading"
+            data-link-context="most-read/@section.section">
 
-            <ul class="u-unstyled headline-list headline-list--large headline-column headline-column--tablet headline-column--desktop">
-            @section.trails.zipWithRowInfo.map{ case (trail, info) =>
-            <li class="headline-list__item headline-column__item headline-column--tablet__item headline-column--desktop__item @articleToneClass(trail)--most-popular">
-                <div class="headline-list__link" data-link-name="@info.rowNum | text">
-                    <span class="headline-list__count">@info.rowNum</span>
-                    @title(FaciaCardHeader.fromTrail(trail, None), 2, 2, "headline-list__body")
+                <ul class="u-unstyled headline-list headline-list--large headline-column headline-column--tablet headline-column--desktop">
+                    @section.trails.zipWithRowInfo.map{ case (trail, info) =>
+                        <li class="headline-list__item headline-column__item headline-column--tablet__item headline-column--desktop__item @articleToneClass(trail)--most-popular">
+                            <div class="headline-list__link" data-link-name="@info.rowNum | text">
+                                <span class="headline-list__count">@info.rowNum</span>
+                                @title(FaciaCardHeader.fromTrail(trail, None), 2, 2, "headline-list__body")
+                            </div>
+                        </li>
+                    }
+                </ul>
             </div>
-            </li>
-            }
-        </ul>
-        </div>
         }
 
     <div class="fc-slice__popular-mpu js-fc-slice-mpu-candidate fc-slice__item--mpu-candidate fc-slice__item--no-mpu"></div>

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -1,54 +1,15 @@
 @(popular: Seq[model.MostPopular])(implicit request: RequestHeader)
 
-@import common.Localisation
-@import views.support._
-@import views.html.fragments.items.elements.facia_cards.title
-@import layout.FaciaCardHeader
-@import TrailCssClasses.articleToneClass
+@import layout.FaciaContainer
+@import views.html.fragments.containers
+@import com.gu.facia.api.models.FaciaContent
 
-@defining(popular.size > 1){ isTabbed =>
-    <div id="popular-trails" class="fc-slice fc-slice--popular" data-link-name="most popular" data-test-id="popular-in">
-        @if(isTabbed) {
-            <div class="tabs u-cf">
-                <ol class="tabs__container js-tabs" id="js-popular-tabs" role="tablist">
-                    @popular.zipWithRowInfo.map{ case (section, info) =>
-                        <li class="tabs__tab@if(info.isFirst){ tabs__tab--selected tone-colour tone-accent-border}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum">
-                            <a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading"><span class="u-h">Popular </span>@Html(Localisation(section.heading.stripPrefix("popular ")))</a>
-                        </li>
-                    }
-                </ol>
-                <div class="tabs__content js-tabs-content">
-        }
+@container(stories: Seq[FaciaContent], title: String, dataId: String, href: Option[String]) = {
+    @containers.facia_cards.container(
+        FaciaContainer.forMostPopular(dataId, stories, title, href)
+    )(request)
+}
 
-        @popular.zipWithRowInfo.map{ case (section, info) =>
-            <div id="tabs-popular-@info.rowNum"
-                 class="@if(isTabbed){js-tab-@info.rowNum @if(!info.isFirst){modern-hidden}} tabs__pane u-cf"
-                 @if(isTabbed){
-                     role="tabpanel"
-                     aria-labelledby="tabs-popular-@info.rowNum-tab"
-                 }
-                 data-link-name="@section.heading"
-                 data-link-context="most-read/@section.section">
-
-                <ul class="u-unstyled headline-list headline-list--large headline-column headline-column--tablet headline-column--desktop">
-                    @section.trails.zipWithRowInfo.map{ case (trail, info) =>
-                        <li class="headline-list__item headline-column__item headline-column--tablet__item headline-column--desktop__item @articleToneClass(trail)--most-popular">
-                            <div class="headline-list__link" data-link-name="@info.rowNum | text">
-                                <span class="headline-list__count">@info.rowNum</span>
-                                @title(FaciaCardHeader.fromTrail(trail, None), 2, 2, "headline-list__body")
-                            </div>
-                        </li>
-                    }
-                </ul>
-            </div>
-        }
-
-            <div class="fc-slice__popular-mpu js-fc-slice-mpu-candidate fc-slice__item--mpu-candidate fc-slice__item--no-mpu"></div>
-
-        @if(isTabbed) {
-                </div>
-            </div>
-        }
-
-    </div>
+@popular.headOption.map{ content =>
+    @container(content.trails, "popular " + content.heading, "most-popular-as-rel-content", href = None)
 }

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -1,15 +1,54 @@
 @(popular: Seq[model.MostPopular])(implicit request: RequestHeader)
 
-@import layout.FaciaContainer
-@import views.html.fragments.containers
-@import com.gu.facia.api.models.FaciaContent
+@import common.Localisation
+@import views.support._
+@import views.html.fragments.items.elements.facia_cards.title
+@import layout.FaciaCardHeader
+@import TrailCssClasses.articleToneClass
 
-@container(stories: Seq[FaciaContent], title: String, dataId: String, href: Option[String]) = {
-    @containers.facia_cards.container(
-        FaciaContainer.forMostPopular(dataId, stories, title, href)
-    )(request)
-}
+@defining(popular.size > 1){ isTabbed =>
+    <div id="popular-trails" class="fc-slice fc-slice--popular" data-link-name="most popular" data-test-id="popular-in">
+        @if(isTabbed) {
+            <div class="tabs u-cf">
+                <ol class="tabs__container js-tabs" id="js-popular-tabs" role="tablist">
+                @popular.zipWithRowInfo.map{ case (section, info) =>
+                <li class="tabs__tab@if(info.isFirst){ tabs__tab--selected tone-colour tone-accent-border}" role="tab" id="tabs-popular-@info.rowNum-tab"@if(info.isFirst){ aria-selected="true"} aria-controls="tabs-popular-@info.rowNum">
+                    <a href="#tabs-popular-@info.rowNum" data-link-name="tab @info.rowNum @section.heading"><span class="u-h">Popular </span>@Html(Localisation(section.heading.stripPrefix("popular ")))</a>
+                </li>
+                }
+                </ol>
+                <div class="tabs__content js-tabs-content">
+                }
 
-@popular.headOption.map{ content =>
-    @container(content.trails, "popular " + content.heading, "most-popular-as-rel-content", href = None)
+        @popular.zipWithRowInfo.map{ case (section, info) =>
+        <div id="tabs-popular-@info.rowNum"
+        class="@if(isTabbed){js-tab-@info.rowNum @if(!info.isFirst){modern-hidden}} tabs__pane u-cf"
+            @if(isTabbed){
+                role="tabpanel"
+                aria-labelledby="tabs-popular-@info.rowNum-tab"
+            }
+        data-link-name="@section.heading"
+        data-link-context="most-read/@section.section">
+
+            <ul class="u-unstyled headline-list headline-list--large headline-column headline-column--tablet headline-column--desktop">
+            @section.trails.zipWithRowInfo.map{ case (trail, info) =>
+            <li class="headline-list__item headline-column__item headline-column--tablet__item headline-column--desktop__item @articleToneClass(trail)--most-popular">
+                <div class="headline-list__link" data-link-name="@info.rowNum | text">
+                    <span class="headline-list__count">@info.rowNum</span>
+                    @title(FaciaCardHeader.fromTrail(trail, None), 2, 2, "headline-list__body")
+            </div>
+            </li>
+            }
+        </ul>
+        </div>
+        }
+
+    <div class="fc-slice__popular-mpu js-fc-slice-mpu-candidate fc-slice__item--mpu-candidate fc-slice__item--no-mpu"></div>
+
+        @if(isTabbed) {
+        </div>
+        </div>
+        }
+
+    </div>
 }

--- a/common/app/views/fragments/collections/popularABTest.scala.html
+++ b/common/app/views/fragments/collections/popularABTest.scala.html
@@ -1,0 +1,15 @@
+@(popular: Seq[model.MostPopular])(implicit request: RequestHeader)
+
+@import layout.FaciaContainer
+@import views.html.fragments.containers
+@import com.gu.facia.api.models.FaciaContent
+
+@container(stories: Seq[FaciaContent], title: String, dataId: String, href: Option[String]) = {
+    @containers.facia_cards.container(
+        FaciaContainer.forMostPopular(dataId, stories, title, href)
+    )(request)
+}
+
+@popular.headOption.map { content =>
+    @container(content.trails, "popular " + content.heading, "most-popular-as-rel-content", href = None)
+}

--- a/common/app/views/fragments/collections/popularABTest.scala.html
+++ b/common/app/views/fragments/collections/popularABTest.scala.html
@@ -11,5 +11,5 @@
 }
 
 @popular.headOption.map { content =>
-    @container(content.trails, "popular " + content.heading, "most-popular-as-rel-content", href = None)
+    @container(content.trails, "popular " + content.heading, "most-popular-as-facia-cards", href = None)
 }

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -37,6 +37,7 @@ object MostPopularController extends Controller with Logging with ExecutionConte
         case popular => Cached(900) {
           JsonComponent(
             "html" -> views.html.fragments.collections.popular(popular),
+            "ABhtml" -> views.html.fragments.collections.popularABTest(popular),
             "rightHtml" -> views.html.fragments.rightMostPopular(globalPopular)
           )
         }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -9,7 +9,8 @@ define([
     'common/modules/experiments/tests/high-commercial-component',
     'common/modules/experiments/tests/membership-message-usa',
     'common/modules/experiments/tests/adfree-survey',
-    'common/modules/experiments/tests/switch-most-pop-related-content'
+    'common/modules/experiments/tests/switch-most-pop-related-content',
+    'common/modules/experiments/tests/most-pop-as-facia-cards'
 ], function (
     reportError,
     _,
@@ -21,14 +22,16 @@ define([
     HighCommercialComponent,
     MembershipMessageUSA,
     AddfreeSurvey,
-    SwitchMostPopAndRelatedContent
+    SwitchMostPopAndRelatedContent,
+    MostPopAsFaciaCards
 ) {
 
     var TESTS = _.flatten([
         new HighCommercialComponent(),
         new MembershipMessageUSA(),
         new AddfreeSurvey(),
-        new SwitchMostPopAndRelatedContent()
+        new SwitchMostPopAndRelatedContent(),
+        new MostPopAsFaciaCards()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/most-pop-as-facia-cards.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/most-pop-as-facia-cards.js
@@ -1,0 +1,36 @@
+define([
+], function (
+) {
+    return function () {
+        this.id = 'MostPopAsFaciaCards';
+        this.start = '2015-10-21';
+        this.expiry = '2015-11-21';
+        this.author = 'Josh Holder';
+        this.description = 'Styles the most popular container as facia cards';
+        this.audience = 0.1;
+        this.audienceOffset = 0.1;
+        this.successMeasure = 'The number of onward journeys increases';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = 'popular-container-as-facia-cards';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            return window.guardian.config.page.contentType === 'Article';
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+
+                }
+            },
+            {
+                id: 'variant',
+                test: function () {
+
+                }
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/onward/popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/popular.js
@@ -8,7 +8,8 @@ define([
     'common/utils/mediator',
     'common/modules/commercial/create-ad-slot',
     'common/modules/commercial/commercial-features',
-    'common/modules/commercial/dfp'
+    'common/modules/commercial/dfp',
+    'common/modules/experiments/ab'
 ], function (
     _,
     qwery,
@@ -19,7 +20,8 @@ define([
     mediator,
     createAdSlot,
     commercialFeatures,
-    dfp
+    dfp,
+    ab
 ) {
 
     function MostPopular() {
@@ -36,8 +38,12 @@ define([
     Component.define(MostPopular);
 
     MostPopular.prototype.init = function () {
-        $('.js-most-popular-footer').html('');
-        this.fetch(qwery('.js-most-popular-footer'), 'html');
+        if (ab.getParticipations().MostPopAsFaciaCards && ab.getParticipations().MostPopAsFaciaCards.variant === 'variant') {
+            $('.js-most-popular-footer').html('');
+            this.fetch(qwery('.js-most-popular-footer'), 'ABhtml');
+        } else {
+            this.fetch(qwery('.js-popular-trails'), 'html');
+        }
     };
 
     MostPopular.prototype.mobileMaximumSlotsReached = function () {

--- a/static/src/javascripts/projects/common/modules/onward/popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/popular.js
@@ -39,8 +39,10 @@ define([
 
     MostPopular.prototype.init = function () {
         if (ab.getParticipations().MostPopAsFaciaCards && ab.getParticipations().MostPopAsFaciaCards.variant === 'variant') {
-            $('.js-most-popular-footer').html('');
+            var $mostPopFooter = $('.js-most-popular-footer');
+            $mostPopFooter.html('');
             this.fetch(qwery('.js-most-popular-footer'), 'ABhtml');
+            $('.js-most-popular-footer').attr('data-link-name', $mostPopFooter.attr('data-link-name') + ' most-popular-as-facia-cards');
         } else {
             this.fetch(qwery('.js-popular-trails'), 'html');
         }

--- a/static/src/javascripts/projects/common/modules/onward/popular.js
+++ b/static/src/javascripts/projects/common/modules/onward/popular.js
@@ -36,7 +36,8 @@ define([
     Component.define(MostPopular);
 
     MostPopular.prototype.init = function () {
-        this.fetch(qwery('.js-popular-trails'), 'html');
+        $('.js-most-popular-footer').html('');
+        this.fetch(qwery('.js-most-popular-footer'), 'html');
     };
 
     MostPopular.prototype.mobileMaximumSlotsReached = function () {


### PR DESCRIPTION
This is an AB test to test the impact of styling the most popular container as a series of cards. This only shows the 'popular in section' content. 

This container layout was chosen to ensure we keep the MPU.

It's a client side test that just injects a different blob of html from the most popular JSON response.

![screen shot 2015-10-19 at 16 35 58](https://cloud.githubusercontent.com/assets/2236852/10605877/bce28600-7726-11e5-89aa-df93e536577e.png)
