### PR TITLE
Fix sticky nav conflicting with app banners

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/sticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/sticky.js
@@ -70,7 +70,7 @@ define([
         this.$els.window           = $(window);
 
         fastdom.read(function () {
-            this.headerBigHeight     = this.$els.navHeader.dim().height;
+            this.headerBigHeight     = this.$els.navHeader.height();
             this.navigationClassList = this.$els.navigation.attr('class');
         }.bind(this));
 
@@ -223,7 +223,7 @@ define([
             scrollY = window.pageYOffset;
 
         if (!this.isSensitivePage) {
-            bannerHeight = this.$els.bannerDesktop.dim().height || 128;
+            bannerHeight = this.$els.bannerDesktop.height() || 128;
         }
 
         this.setScrollDirection(scrollY);
@@ -375,7 +375,7 @@ define([
     };
 
     StickyHeader.prototype.updatePositionProfile = function () {
-        var headerHeight = this.$els.header.dim().height;
+        var headerHeight = this.$els.header.height();
         fastdom.write(function () {
             this.$els.header.css({
                 position:  'fixed',
@@ -390,7 +390,7 @@ define([
     };
 
     StickyHeader.prototype.updatePositionAdblock = function () {
-        var headerHeight = this.$els.header.dim().height,
+        var headerHeight = this.$els.header.height(),
             scrollY      = window.pageYOffset;
 
         this.setScrollDirection(scrollY);
@@ -440,7 +440,7 @@ define([
     };
 
     StickyHeader.prototype.updatePositionApple = function () {
-        var bannerHeight = this.$els.bannerBelowNav.dim().height || 336,
+        var bannerHeight = this.$els.bannerBelowNav.height() || 336,
             scrollY      = window.pageYOffset;
 
         this.setScrollDirection(scrollY);
@@ -517,7 +517,7 @@ define([
     };
 
     StickyHeader.prototype.updatePositionMobile = function () {
-        var bannerHeight      = this.$els.bannerMobile.dim().height,
+        var bannerHeight      = this.$els.bannerMobile.height(),
             scrollY           = window.pageYOffset,
             smartBannerHeight = smartAppBanner.getMessageHeight();
 

--- a/static/src/javascripts/projects/common/modules/navigation/sticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/sticky.js
@@ -228,9 +228,13 @@ define([
 
         this.setScrollDirection(scrollY);
 
+        var $appBanner = $('.site-message--ios, .site-message--android');
+        var appBannerHeight = $appBanner.height();
+
         // Header is slim and navigation is shown on the scroll up
         // Unless meganav is opened
-        if (scrollY >= this.headerBigHeight + (bannerHeight * this.config.showHeaderDepth) && !this.config.isNavigationLocked) {
+        if ((scrollY >= this.headerBigHeight + (bannerHeight * this.config.showHeaderDepth) + appBannerHeight)
+            && !this.config.isNavigationLocked) {
             fastdom.write(function () {
                 this.$els.header.css({
                     position:  'fixed',
@@ -245,7 +249,7 @@ define([
                 this.$els.bannerDesktop.css({
                     position: 'absolute',
                     width: '100%',
-                    top: this.headerBigHeight
+                    top: this.headerBigHeight + appBannerHeight
                 });
 
                 this.$els.main.css('margin-top', this.headerBigHeight + bannerHeight);
@@ -261,13 +265,13 @@ define([
             if (!this.config.isNavigationLocked && config.page.contentType !== 'Interactive') {
                 this.showNavigation(scrollY);
             }
-        } else if (scrollY >= this.headerBigHeight) {
+        } else if (scrollY >= this.headerBigHeight + appBannerHeight) {
             fastdom.write(function () {
                 // Add is not sticky anymore
                 this.$els.bannerDesktop.css({
                     position: 'absolute',
                     width: '100%',
-                    top: this.headerBigHeight,
+                    top: this.headerBigHeight + appBannerHeight,
                     'z-index': '1019' // Sticky z-index +1 so banner is over sticky header
                 });
 
@@ -302,32 +306,60 @@ define([
             }
         } else {
             fastdom.write(function () {
-                // Make sure that we show slim nav when page loaded with anchor
-                this.$els.bannerDesktop.css({
-                    position:  'fixed',
-                    top:       0,
-                    width:     '100%',
-                    'z-index': '1019',
-                    'backface-visibility': 'hidden'
-                });
-                //Header is slim only on interactives page
-                if (config.page.contentType !== 'Interactive') {
-                    this.$els.header.removeClass('l-header--is-slim');
-                }
+                // Only apply sticky when scrolled past the site message, if there is one
+                if (window.scrollY > appBannerHeight) {
+                    // Make sure that we show slim nav when page loaded with anchor
+                    this.$els.bannerDesktop.css({
+                        position:  'fixed',
+                        top:       0,
+                        width:     '100%',
+                        'z-index': '1019',
+                        'backface-visibility': 'hidden'
+                    });
+                    //Header is slim only on interactives page
+                    if (config.page.contentType !== 'Interactive') {
+                        this.$els.header.removeClass('l-header--is-slim');
+                    }
 
-                this.$els.header.css({
-                    position:  'relative',
-                    width:     '100%',
-                    'margin-top': bannerHeight,
-                    '-webkit-transform': 'translateY(0%)',
-                    '-ms-transform': 'translateY(0%)',
-                    'transform': 'translateY(0%)',
-                    'z-index': '1018'
-                });
+                    this.$els.header.css({
+                        position:  'relative',
+                        width:     '100%',
+                        'margin-top': bannerHeight,
+                        '-webkit-transform': 'translateY(0%)',
+                        '-ms-transform': 'translateY(0%)',
+                        'transform': 'translateY(0%)',
+                        'z-index': '1018'
+                    });
 
-                this.$els.main.css('margin-top', 0);
-                if (this.isSensitivePage) {
-                    this.$els.navigation.css('display', 'block');
+                    this.$els.main.css('margin-top', 0);
+                    if (this.isSensitivePage) {
+                        this.$els.navigation.css('display', 'block');
+                    }
+                } else {
+                    // Reset
+                    this.$els.bannerDesktop.css({
+                        position: '',
+                        top: '',
+                        width: '',
+                        'z-index': '',
+                        'backface-visibility': ''
+                    });
+
+                    this.$els.header.css({
+                        position: '',
+                        width: '',
+                        'margin-top': '',
+                        '-webkit-transform': '',
+                        '-ms-transform': '',
+                        'transform': '',
+                        'z-index': ''
+                    });
+
+                    this.$els.main.css('margin-top', '');
+
+                    if (this.isSensitivePage) {
+                        this.$els.navigation.css('display', '');
+                    }
                 }
             }.bind(this));
 

--- a/static/src/javascripts/projects/common/utils/$.js
+++ b/static/src/javascripts/projects/common/utils/$.js
@@ -8,6 +8,13 @@ define([
     _
 ) {
 
+    // Warning: side effect. This patches the bonzo module for use everywhere
+    bonzo.aug({
+        height: function () {
+            return this.dim().height;
+        }
+    });
+
     function $(selector, context) {
         return bonzo(qwery(selector, context));
     }


### PR DESCRIPTION
I think we need to improve the quality of our experience for first time users, as this is crucial to their impression of our site.

There is a bug whereby the sticky nav conflicts with the app install banner. This results in a poor user experience for all our first time users who are using an iOS or Android device (tablet only, because the sticky nav is disabled on mobile). Not only that, we continue to show the app banner until after the fourth impression, plus many users who browse in incognito mode will get this experience for every page view. :cry: 

I recommend viewing the diff in no whitespace mode: https://github.com/guardian/frontend/pull/10914/files?w=1

Fixes #10881 
## Before

![1](https://cloud.githubusercontent.com/assets/921609/10605959/5a74d904-7727-11e5-9d25-b4b483e43939.gif)
## After

![2](https://cloud.githubusercontent.com/assets/921609/10605969/6804cef8-7727-11e5-966c-41e3ce33520e.gif)
