### PR TITLE
Encode RSS image uri's safely

### DIFF
--- a/common/app/implicits/Strings.scala
+++ b/common/app/implicits/Strings.scala
@@ -24,6 +24,9 @@ trait Strings {
     lazy val urlEncoded = URLEncoder.encode(s, "utf-8")
     lazy val javascriptEscaped = StringEscapeUtils.escapeJavaScript(s)
     lazy val encodeURIComponent = {
+      // This can be used to encode parts of a URI, eg. "example-component/uk?parameter=unsafe-chars-such-as ://+ must-be-encoded#fragment"
+      // The fragment part is optional.
+      // Use encodeURI below for full URI strings like "http://theguardian.com/path with spaces".
       URLEncoder.encode(s, "UTF-8")
         .replaceAll("\\+", "%20")
         .replaceAll("\\%21", "!")
@@ -31,6 +34,15 @@ trait Strings {
         .replaceAll("\\%28", "(")
         .replaceAll("\\%29", ")")
         .replaceAll("\\%7E", "~")
+    }
+    lazy val encodeURI = {
+      // For a URI like this, [scheme:][//authority][path][?query][#fragment]
+      // The URI syntax rfc2396 does not permit encoding the [scheme:] and [//authority] components of the URI with % escape characters.
+
+      // This helper uses Jersey's implementation of UriBuilder to encode the path, query and fragment legally.
+      // We can't use java.net.URLEncoder here, it does not encode rfc2396 compliant urls (it actually encodes to application/x-www-form-urlencoded).
+      val uri = javax.ws.rs.core.UriBuilder.fromPath(s).build()
+      uri.toString
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,6 +69,8 @@ object Dependencies {
   val uaDetectorResources = "net.sf.uadetector" % "uadetector-resources" % "2013.04"
   val scalaTestPlus = "org.scalatestplus" %% "play" % "1.4.0-M3" % "test"
   val anormModule = "com.typesafe.play" %% "anorm" % "2.4.0"
+  val jerseyCore = "com.sun.jersey" % "jersey-core" % "1.19"
+  val jerseyClient = "com.sun.jersey" % "jersey-client" % "1.19"
 
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "3.3.5"

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -48,7 +48,9 @@ object Frontend extends Build with Prototypes {
       ws,
       faciaFapiScalaClient,
       dispatchTest,
-      closureCompiler
+      closureCompiler,
+      jerseyCore,
+      jerseyClient
     )
   ).settings(
       mappings in TestAssets ~= filterAssets


### PR DESCRIPTION
This fixes an issue where image paths with spaces were not encoded into legal URI's, which would cause an exception, and a 500 page, to be delivered to rss clients.
