### PR TITLE
AB test for related content naming

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -31,4 +31,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABOnwardNames = Switch(
+    "A/B Tests",
+    "ab-onward-names",
+    "Switch to enable alternative name for related content",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 11, 20),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardHeaderMeta.scala.html
@@ -18,7 +18,7 @@
                         @Localisation(title)
                     </a>
                     }.getOrElse {
-                        <span tabindex="0">@Localisation(title)</span>
+                        <span tabindex="0" @if(title == "related content") {class="js-ab-onward-names-related@* delete after ab test *@"}>@Localisation(title)</span>
                     }
 
                     @if(containerDefinition.showDateHeader) {

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -9,7 +9,8 @@ define([
     'common/modules/experiments/tests/high-commercial-component',
     'common/modules/experiments/tests/membership-message-usa',
     'common/modules/experiments/tests/adfree-survey',
-    'common/modules/experiments/tests/switch-most-pop-related-content'
+    'common/modules/experiments/tests/switch-most-pop-related-content',
+    'common/modules/experiments/tests/onward-container-names'
 ], function (
     reportError,
     _,
@@ -21,14 +22,16 @@ define([
     HighCommercialComponent,
     MembershipMessageUSA,
     AddfreeSurvey,
-    SwitchMostPopAndRelatedContent
+    SwitchMostPopAndRelatedContent,
+    OnwardContainerNames
 ) {
 
     var TESTS = _.flatten([
         new HighCommercialComponent(),
         new MembershipMessageUSA(),
         new AddfreeSurvey(),
-        new SwitchMostPopAndRelatedContent()
+        new SwitchMostPopAndRelatedContent(),
+        new OnwardContainerNames()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
@@ -7,11 +7,11 @@ define([
         this.expiry = '2015-11-20';
         this.author = 'John Duffell';
         this.description = 'renames the related content container';
-        this.audience = 0.025;
+        this.audience = 0.6;
         this.audienceOffset = 0.4;
         this.successMeasure = 'The number of onward journeys';
         this.audienceCriteria = 'All users';
-        this.dataLinkNames = '';//TODO
+        this.dataLinkNames = '';
         this.idealOutcome = 'the clicks should be significantly higher for one of the buckets';
 
         this.canRun = function () {
@@ -24,31 +24,11 @@ define([
                 test: function () {}
             },
             {
-                id: 'You might like ...',
+                id: 'test:You might like ...',
                 test: function () {}
             },
             {
-                id: 'Related stories',
-                test: function () {}
-            },
-            {
-                id: 'More like this',
-                test: function () {}
-            },
-            {
-                id: 'Connected stories',
-                test: function () {}
-            },
-            {
-                id: 'Explore further',
-                test: function () {}
-            },
-            {
-                id: 'Read further',
-                test: function () {}
-            },
-            {
-                id: 'Join the dots',
+                id: 'test:',
                 test: function () {}
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
@@ -24,7 +24,7 @@ define([
                 test: function () {}
             },
             {
-                id: 'test:You might like ...',
+                id: 'test:You might like &hellip;',
                 test: function () {}
             },
             {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
@@ -1,0 +1,58 @@
+define([
+    'common/utils/$'
+], function (
+    $
+) {
+    return function () {
+        this.id = 'OnwardNames';
+        this.start = '2015-10-20';
+        this.expiry = '2015-11-20';
+        this.author = 'John Duffell';
+        this.description = 'renames the related content container';
+        this.audience = 0.025;
+        this.audienceOffset = 0.4;
+        this.successMeasure = 'The number of onward journeys';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';//TODO
+        this.idealOutcome = 'the clicks should be significantly higher for one of the buckets';
+
+        this.canRun = function () {
+            return window.guardian.config.page.contentType === 'Article';
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {}
+            },
+            {
+                id: 'You might like ...',
+                test: function () {}
+            },
+            {
+                id: 'Related stories',
+                test: function () {}
+            },
+            {
+                id: 'More like this',
+                test: function () {}
+            },
+            {
+                id: 'Connected stories',
+                test: function () {}
+            },
+            {
+                id: 'Explore further',
+                test: function () {}
+            },
+            {
+                id: 'Read further',
+                test: function () {}
+            },
+            {
+                id: 'Join the dots',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
@@ -7,8 +7,8 @@ define([
         this.expiry = '2015-11-20';
         this.author = 'John Duffell';
         this.description = 'renames the related content container';
-        this.audience = 0.6;
-        this.audienceOffset = 0.4;
+        this.audience = 0.8;
+        this.audienceOffset = 0.2;
         this.successMeasure = 'The number of onward journeys';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';
@@ -28,7 +28,11 @@ define([
                 test: function () {}
             },
             {
-                id: 'test:',
+                id: 'test:Suggested articles',
+                test: function () {}
+            },
+            {
+                id: 'test:Keep reading',
                 test: function () {}
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
@@ -1,7 +1,5 @@
 define([
-    'common/utils/$'
 ], function (
-    $
 ) {
     return function () {
         this.id = 'OnwardNames';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/onward-container-names.js
@@ -24,7 +24,7 @@ define([
                 test: function () {}
             },
             {
-                id: 'test:You might like &hellip;',
+                id: 'test:You might like...',
                 test: function () {}
             },
             {

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -97,12 +97,16 @@ define([
                         register.end(componentName);
 
                         /* TODO remove after ab test*/
-                        if (ab.getTestVariantId('OnwardNames') !== 'control') {(function () {
-                            var heading = $('.js-ab-onward-names-related');
-                            if (heading) {
-                                heading.text(ab.getTestVariantId('OnwardNames'));
-                            }
-                        })();}
+                        if (ab.getTestVariantId('OnwardNames') &&
+                            ab.testCanBeRun('OnwardNames') &&
+                            ab.getTestVariantId('OnwardNames').indexOf('test:') === 0) {
+                            (function () {
+                                var heading = $('.js-ab-onward-names-related');
+                                if (heading) {
+                                    heading.text(ab.getTestVariantId('OnwardNames').substr(5));
+                                }
+                            })();
+                        }
 
                     },
                     error: function () {

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -6,6 +6,7 @@ define([
     'common/utils/config',
     'common/utils/mediator',
     'common/modules/analytics/register',
+    'common/modules/experiments/ab',
     'common/modules/lazyload',
     'common/modules/ui/expandable'
 ], function (
@@ -16,6 +17,7 @@ define([
     config,
     mediator,
     register,
+    ab,
     LazyLoad,
     Expandable
 ) {
@@ -93,6 +95,15 @@ define([
                         mediator.emit('page:new-content', container);
                         mediator.emit('ui:images:upgradePictures', container);
                         register.end(componentName);
+
+                        /* TODO remove after ab test*/
+                        if (ab.getTestVariantId('OnwardNames') !== 'control') (function () {
+                            var heading = $('.js-ab-onward-names-related');
+                            if (heading) {
+                                heading.text(ab.getTestVariantId('OnwardNames'));
+                            }
+                        })();
+
                     },
                     error: function () {
                         bonzo(container).remove();

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -97,12 +97,12 @@ define([
                         register.end(componentName);
 
                         /* TODO remove after ab test*/
-                        if (ab.getTestVariantId('OnwardNames') !== 'control') (function () {
+                        if (ab.getTestVariantId('OnwardNames') !== 'control') {(function () {
                             var heading = $('.js-ab-onward-names-related');
                             if (heading) {
                                 heading.text(ab.getTestVariantId('OnwardNames'));
                             }
-                        })();
+                        })();}
 
                     },
                     error: function () {


### PR DESCRIPTION
I've added an ab test to try different names for related content.
normal:
![image](https://cloud.githubusercontent.com/assets/7304387/10606373/536a288c-772a-11e5-9e51-ebbc8ce47496.png)
variant:
![image](https://cloud.githubusercontent.com/assets/7304387/10606384/66cdbd4e-772a-11e5-8bd5-74ac20238b48.png)

I'm not sure about the proportions in the test, also the exact phrases to be used in the tests may be updated once I spoke to a copy writer.  Any other comments would be appreciated!
