### PR TITLE
Prevent app banners from jumping the page

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -1,4 +1,5 @@
 define([
+    'fastdom',
     'common/utils/$',
     'common/utils/cookies',
     'common/utils/detect',
@@ -7,6 +8,7 @@ define([
     'common/modules/user-prefs',
     'common/modules/ui/message'
 ], function (
+    fastdom,
     $,
     cookies,
     detect,
@@ -58,7 +60,16 @@ define([
             fullTemplate = tmp + (detect.getBreakpoint() === 'mobile' ? '' : tablet);
 
         msg.show(template(fullTemplate, DATA[platform.toUpperCase()]));
+
         cookies.add(COOKIE_IMPRESSION_KEY, impressions + 1);
+
+        fastdom.read(function () {
+            var $banner = $('.site-message--ios, .site-message--android');
+            var bannerHeight = $banner.dim().height;
+            if (window.scrollY !== 0) {
+                window.scrollTo(window.scrollX, window.scrollY + bannerHeight);
+            }
+        });
     }
 
     function init() {

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -21,7 +21,7 @@ define([
      * Rules:
      *
      * 4 visits within the last month
-     * 3 impressions
+     * Less than 4 impressions
      * Persist close state
      */
     var COOKIE_IMPRESSION_KEY = 'GU_SMARTAPPBANNER',


### PR DESCRIPTION
I think we need to improve the quality of our experience for first time users, as this is crucial to their impression of our site.

The app banners cause the whole page to jump when they load, causing the user to lose their reading position. This results in a poor user experience for all our first time users who are using an iOS or Android device (tablet only, because the sticky nav is disabled on mobile). Not only that, we continue to show the app banner until after the fourth impression, plus many users who browse in incognito mode will get this experience for every page view. 

The demos below demonstrate the following: load the page, scroll down to content, app banner loads, scroll up to down of page

Fixes #10882

To do:
- [x] Fix https://github.com/guardian/frontend/issues/10910 first to avoid double jump

/cc @johnduffell 
## Before

When the app banner loads, the page jumps.
![1](https://cloud.githubusercontent.com/assets/921609/10608516/3ab2ebc8-7737-11e5-93e0-3aff6e27beaf.gif)
## After

There is no longer any page jump when the app banner loads.
![2](https://cloud.githubusercontent.com/assets/921609/10608524/47b31820-7737-11e5-9472-25590a4c2eb2.gif)

To allow the user a chance of seeing the app banner, we let the page jump if the user has not scrolled:
![3](https://cloud.githubusercontent.com/assets/921609/10608600/a7c647fa-7737-11e5-8224-c2cc477bdd22.gif)
