### PR TITLE
Smaller header for immersive template on Safari mobile

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -102,10 +102,14 @@
         .content__head--mobile {
             position: relative;
             height: 100vh;
-            height: -webkit-calc(100vh - 48px); // To compensate for mobile Safari viewport height issue.
             max-height: 800px;
             background-position: center center;
             background-size: cover;
+
+            // Query is to target Safari only
+            @media screen and (min-color-index:0) and (-webkit-min-device-pixel-ratio:0) {
+                height: -webkit-calc(100vh - 48px); // To compensate for mobile Safari viewport height issue.
+            }
         }
 
         .content__head--desktop {

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -102,6 +102,7 @@
         .content__head--mobile {
             position: relative;
             height: 100vh;
+            height: -webkit-calc(100vh - 48px); // To compensate for mobile Safari viewport height issue.
             max-height: 800px;
             background-position: center center;
             background-size: cover;


### PR DESCRIPTION
My terrible solution to a problem with Safari's implementation of `vh`. [Read More](http://nicolas-hoizey.com/2015/02/viewport-height-is-taller-than-the-visible-part-of-the-document-in-some-mobile-browsers.html) about the issue. Basically I'm having to shave some pixels off just for webkit on mobile, hence the `-webkit-calc`.

Before:
![img_1620](https://cloud.githubusercontent.com/assets/1607666/10608747/43519cb0-7738-11e5-9352-5eeac2db5591.PNG)

After:
![img_1619](https://cloud.githubusercontent.com/assets/1607666/10608746/434ede94-7738-11e5-8e0b-407ad92eff2a.PNG)
