### PR TITLE
Allow the letter I to be used as a drop cap

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -484,7 +484,7 @@ case class DropCaps(isFeature: Boolean) extends HtmlCleaner {
 
   private def setDropCap(p: Element): String = {
     val html = p.html
-    if ( html.length > 200 && html.matches("^[\"a-hj-zA-HJ-Z].*") && html.split("\\s+").head.length >= 3 ) {
+    if ( html.length > 200 && html.matches("^[\"a-zA-Z].*") && html.split("\\s+").head.length >= 3 ) {
       val classes = if (html.length > 325) "drop-cap drop-cap--wide" else "drop-cap"
       s"""<span class="${classes}"><span class="drop-cap__inner">${html.head}</span></span>${html.tail}"""
     } else {


### PR DESCRIPTION
We make sure the word that the cap is applied to is 3 or more characters long, so there's no need to remove `I` from the drop-cappable characters list.

Before:
![screen shot 2015-10-20 at 14 54 13](https://cloud.githubusercontent.com/assets/1607666/10609306/f3b4fdde-773a-11e5-980c-1acb1d75954c.png)

After:
![screen shot 2015-10-20 at 14 54 20](https://cloud.githubusercontent.com/assets/1607666/10609307/f3b5a3e2-773a-11e5-8745-2193d7224866.png)
