### PR TITLE
Layout news/most-popular Container Without MPU

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -106,7 +106,8 @@ object ContainerCommercialOptions {
     DfpAgent.isAdvertisementFeature(config),
     DfpAgent.isFoundationSupported(config),
     DfpAgent.sponsorshipTag(config),
-    DfpAgent.sponsorshipType(config)
+    DfpAgent.sponsorshipType(config),
+    omitMPU = false
   )
 
   val empty = ContainerCommercialOptions(
@@ -114,7 +115,8 @@ object ContainerCommercialOptions {
     isAdvertisementFeature = false,
     isFoundationSupported = false,
     sponsorshipTag = None,
-    sponsorshipType = None
+    sponsorshipType = None,
+    omitMPU = false
   )
 
   def mostPopular(omitMPU: Boolean) = empty.copy(omitMPU = omitMPU)
@@ -126,7 +128,7 @@ case class ContainerCommercialOptions(
   isFoundationSupported: Boolean,
   sponsorshipTag: Option[SponsorshipTag],
   sponsorshipType: Option[String],
-  omitMPU: Boolean = false
+  omitMPU: Boolean
 ) {
   val isPaidFor = isSponsored || isAdvertisementFeature || isFoundationSupported
 }

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -115,6 +115,8 @@ object ContainerCommercialOptions {
     sponsorshipTag = None,
     sponsorshipType = None
   )
+
+  def mostPopular(omitMPU: Boolean) = empty.copy(omitMPU = omitMPU)
 }
 
 case class ContainerCommercialOptions(
@@ -122,7 +124,8 @@ case class ContainerCommercialOptions(
   isAdvertisementFeature: Boolean,
   isFoundationSupported: Boolean,
   sponsorshipTag: Option[SponsorshipTag],
-  sponsorshipType: Option[String]
+  sponsorshipType: Option[String],
+  omitMPU: Boolean = false
 ) {
   val isPaidFor = isSponsored || isAdvertisementFeature || isFoundationSupported
 }
@@ -170,7 +173,8 @@ object FaciaContainer {
     config: CollectionConfigWithId,
     collectionEssentials: CollectionEssentials,
     containerLayout: Option[ContainerLayout],
-    componentId: Option[String]
+    componentId: Option[String],
+    omitMPU: Boolean = false
   ): FaciaContainer = FaciaContainer(
     index,
     config.id,
@@ -184,7 +188,7 @@ object FaciaContainer {
     config.config.showLatestUpdate,
     // popular containers should never be sponsored
     container match {
-      case MostPopular => ContainerCommercialOptions.empty
+      case MostPopular => ContainerCommercialOptions.mostPopular(omitMPU)
       case _ => ContainerCommercialOptions.fromConfig(config.config)
     },
     config.config.description.map(DescriptionMetaHeader.apply(_)),
@@ -464,7 +468,8 @@ object Front extends implicits.Collections {
             pressedCollection.collectionConfigWithId,
             collectionEssentials.copy(items = newItems),
             None,
-            None
+            None,
+            omitMPU
           ))
         }
     }

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -34,7 +34,7 @@
                     @section.trails.zipWithRowInfo.map{ case (trail, info) =>
                         <li class="headline-list__item headline-column__item headline-column--tablet__item headline-column--desktop__item @articleToneClass(trail)--most-popular">
                             <div class="headline-list__link" data-link-name="@info.rowNum | text">
-                                <span class="headline-list__count">@info.rowNum</span>
+                                <p class="headline-list__count">@info.rowNum</p>
                                 @title(FaciaCardHeader.fromTrail(trail, None), 2, 2, "headline-list__body")
                             </div>
                         </li>

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -1,10 +1,10 @@
-@(popular: Seq[model.MostPopular])(implicit request: RequestHeader)
-
+@(popular: Seq[model.MostPopular], containerDefinition: Option[layout.FaciaContainer] = None)(implicit request: RequestHeader)
 @import common.Localisation
-@import views.support._
-@import views.html.fragments.items.elements.facia_cards.title
 @import layout.FaciaCardHeader
+@import views.html.fragments.items.elements.facia_cards.title
+@import views.support._
 @import TrailCssClasses.articleToneClass
+@import views.support.MostPopular.{showMPU, tabsPaneCssClass}
 
 @defining(popular.size > 1){ isTabbed =>
     <div id="popular-trails" class="fc-slice fc-slice--popular" data-link-name="most popular" data-test-id="popular-in">
@@ -22,8 +22,8 @@
 
         @popular.zipWithRowInfo.map{ case (section, info) =>
             <div id="tabs-popular-@info.rowNum"
-                 class="@if(isTabbed){js-tab-@info.rowNum @if(!info.isFirst){modern-hidden}} tabs__pane u-cf"
-                 @if(isTabbed){
+                 class="@if(isTabbed){js-tab-@info.rowNum @if(!info.isFirst){modern-hidden}} @tabsPaneCssClass(containerDefinition) u-cf"
+                @if(isTabbed){
                      role="tabpanel"
                      aria-labelledby="tabs-popular-@info.rowNum-tab"
                  }
@@ -43,7 +43,9 @@
             </div>
         }
 
+        @if(showMPU(containerDefinition)) {
             <div class="fc-slice__popular-mpu js-fc-slice-mpu-candidate fc-slice__item--mpu-candidate fc-slice__item--no-mpu"></div>
+        }
 
         @if(isTabbed) {
                 </div>

--- a/common/app/views/fragments/containers/facia_cards/mostPopularContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/mostPopularContainer.scala.html
@@ -1,7 +1,7 @@
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
-
 @import common.LinkTo
 @import model.MostPopular
+@import views.support.MostPopular.numItemsToShow
 
 <div class="fc-container__header js-container__header">
     @containerDefinition.displayName.map { title =>
@@ -22,7 +22,7 @@
     MostPopular(
         containerDefinition.displayName.getOrElse("popular"),
         "popular",
-        containerDefinition.contentItems.slice(0, 10)
+        containerDefinition.contentItems.take(numItemsToShow(containerDefinition))
     ),
     MostPopular(
         "across the guardian",
@@ -30,6 +30,6 @@
         Nil
     )
 )){ popular =>
-    @fragments.collections.popular(popular)
+    @fragments.collections.popular(popular, Some(containerDefinition))
 }
 </div>

--- a/common/app/views/fragments/containers/facia_cards/mostPopularContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/mostPopularContainer.scala.html
@@ -1,7 +1,6 @@
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit requestHeader: RequestHeader)
 @import common.LinkTo
 @import model.MostPopular
-@import views.support.MostPopular.numItemsToShow
 
 <div class="fc-container__header js-container__header">
     @containerDefinition.displayName.map { title =>
@@ -22,7 +21,7 @@
     MostPopular(
         containerDefinition.displayName.getOrElse("popular"),
         "popular",
-        containerDefinition.contentItems.take(numItemsToShow(containerDefinition))
+        containerDefinition.contentItems.take(10)
     ),
     MostPopular(
         "across the guardian",

--- a/common/app/views/support/MostPopular.scala
+++ b/common/app/views/support/MostPopular.scala
@@ -1,14 +1,8 @@
 package views.support
 
 import layout.FaciaContainer
-import play.api.mvc.RequestHeader
 
 object MostPopular extends implicits.Requests {
-
-  def numItemsToShow(container: FaciaContainer)(implicit request: RequestHeader): Int = {
-    if (container.commercialOptions.omitMPU) 9
-    else 10
-  }
 
   def showMPU(maybeContainer: Option[FaciaContainer]): Boolean = {
     !maybeContainer.exists(_.commercialOptions.omitMPU)

--- a/common/app/views/support/MostPopular.scala
+++ b/common/app/views/support/MostPopular.scala
@@ -1,0 +1,21 @@
+package views.support
+
+import layout.FaciaContainer
+import play.api.mvc.RequestHeader
+
+object MostPopular extends implicits.Requests {
+
+  def numItemsToShow(container: FaciaContainer)(implicit request: RequestHeader): Int = {
+    if (container.commercialOptions.omitMPU) 9
+    else 10
+  }
+
+  def showMPU(maybeContainer: Option[FaciaContainer]): Boolean = {
+    !maybeContainer.exists(_.commercialOptions.omitMPU)
+  }
+
+  def tabsPaneCssClass(maybeContainer: Option[FaciaContainer]): String = {
+    if (showMPU(maybeContainer)) "tabs__pane"
+    else "tabs__pane--without-mpu"
+  }
+}

--- a/static/src/stylesheets/module/_headline-list.scss
+++ b/static/src/stylesheets/module/_headline-list.scss
@@ -1,7 +1,6 @@
 .headline-list__item {
     position: relative;
     box-sizing: border-box;
-    padding-left: gs-span(1) - $gs-gutter/2;
     padding-top: $gs-baseline / 3;
     padding-bottom: $gs-baseline * 2;
 
@@ -35,14 +34,13 @@
 }
 
 .headline-list__count {
-    position: absolute;
-    top: $gs-baseline / 6;
-    left: 0;
+    float: left;
+    width: gs-span(1);
     color: colour(neutral-4);
     @include font($f-serif-headline, 200, 44px);
 
-    @include mq(desktop) {
-        top: $gs-baseline / 4;
+    @include mq(mobile) {
+        width: gs-span(1) - $gs-gutter / 2;
     }
 }
 

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -231,6 +231,11 @@ Hence why a greater depth of selector specificity is needed.
             width: (100% / 3) * 2;
             min-height: 300px;
         }
+
+        .tabs__pane--without-mpu {
+            width: (100% / 3) * 3;
+            min-height: 300px;
+        }
     }
 }
 


### PR DESCRIPTION
This is a slightly different solution to #10908 because it's not a fixed container type.
Others to come should all be slight variations of #10908.

Popular container with MPU:
![image](https://cloud.githubusercontent.com/assets/1722550/10611817/c7b50c14-7745-11e5-83e6-65d600b62f48.png)

Popular container without MPU:
![image](https://cloud.githubusercontent.com/assets/1722550/10611825/d35ccbd8-7745-11e5-976b-6974e1778b05.png)

/cc @kenlim @janua @sammorrisdesign 
