### PR TITLE
Add byline to Immersive Header

### DIFF
--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -15,7 +15,17 @@
     }
     @content.standfirst.map { s =>
         @defining(Edition(request)) { edition =>
-            @withJsoup(BulletCleaner(s))(
+            @withJsoup(BulletCleaner(
+                if(content.isImmersive && content.isArticle) {
+                    if (s.indexOf(content.byline.get) != -1) {
+                        ContributorLinks(s, content.contributors).toString()
+                    } else {
+                        s + "<p>Words by" + ContributorLinks(content.byline.get, content.contributors) + "</p>"
+                    }
+                } else {
+                    s
+                }
+            ))(
                 InBodyLinkCleaner("in standfirst link")
             )
         }

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -62,7 +62,7 @@
         font-weight: 200;
         line-height: 1;
         padding-top: $gs-baseline / 2;
-        padding-bottom: 1em;
+        padding-bottom: 1.5rem;
 
         @include mq(desktop) {
             font-size: 3.25rem;
@@ -72,7 +72,7 @@
     .content__standfirst {
         position: relative;
         padding-top: .33em;
-        padding-bottom: 1em;
+        padding-bottom: 1rem;
         margin-bottom: 0;
         color: #ffffff;
 


### PR DESCRIPTION
This PR adjusts spacing for the headline and standfirst and adds some new logic for standfirsts in the immersive template.

So, if the standfirst includes the contributor:
![screen shot 2015-10-20 at 17 33 26](https://cloud.githubusercontent.com/assets/1607666/10614176/bb3150d2-7750-11e5-9a5e-3a4c60a2498c.png)

If the standfirst doesn't include the contributor:
![screen shot 2015-10-20 at 17 33 30](https://cloud.githubusercontent.com/assets/1607666/10614182/c2382d10-7750-11e5-889b-3c0c72a54839.png)

Normal standfirsts on non-immersive pages get left alone.

This was the solution I've arrived but there might be a nicer way of getting there.
