### PR TITLE
Prevent app banners from appearing unstyled and FOUC

### DIFF
--- a/common/app/templates/headerInlineJS/config.scala.js
+++ b/common/app/templates/headerInlineJS/config.scala.js
@@ -18,7 +18,8 @@ window.guardian = {
             )
     ),
     css: {
-        loaded: false
+        loaded: false,
+        loadedListeners: []
     },
     config: @defining(Edition(request)) { edition => {
         "page": @JavaScript(StringEncodings.jsonToJS(Json.stringify(JavaScriptPage(item).get))),

--- a/common/app/templates/headerInlineJS/config.scala.js
+++ b/common/app/templates/headerInlineJS/config.scala.js
@@ -19,7 +19,7 @@ window.guardian = {
     ),
     css: {
         loaded: false,
-        loadedListeners: []
+        onLoadQueue: []
     },
     config: @defining(Edition(request)) { edition => {
         "page": @JavaScript(StringEncodings.jsonToJS(Json.stringify(JavaScriptPage(item).get))),

--- a/common/app/templates/headerInlineJS/config.scala.js
+++ b/common/app/templates/headerInlineJS/config.scala.js
@@ -18,8 +18,7 @@ window.guardian = {
             )
     ),
     css: {
-        loaded: false,
-        onLoadQueue: []
+        loaded: false
     },
     config: @defining(Edition(request)) { edition => {
         "page": @JavaScript(StringEncodings.jsonToJS(Json.stringify(JavaScriptPage(item).get))),

--- a/common/app/templates/headerInlineJS/enableStylesheets.scala.js
+++ b/common/app/templates/headerInlineJS/enableStylesheets.scala.js
@@ -12,10 +12,10 @@
                 styleSheet.media = "screen";
                 // Set flag for when the CSS loads before the JS
                 window.guardian.css.loaded = true;
-                // Execute listeners for when the JS loads before the CSS
-                var onLoadQueue = window.guardian.css.onLoadQueue;
-                for (var i = onLoadQueue.length - 1; i >= 0; i--) {
-                    onLoadQueue[i]();
+                // Execute callback for when the JS loads before the CSS
+                var onLoad = window.guardian.css.onLoad;
+                if (onLoad) {
+                    onLoad();
                 }
                 return true;
             }

--- a/common/app/templates/headerInlineJS/enableStylesheets.scala.js
+++ b/common/app/templates/headerInlineJS/enableStylesheets.scala.js
@@ -13,10 +13,7 @@
                 // Set flag for when the CSS loads before the JS
                 window.guardian.css.loaded = true;
                 // Execute callback for when the JS loads before the CSS
-                var onLoad = window.guardian.css.onLoad;
-                if (onLoad) {
-                    onLoad();
-                }
+                try { window.guardian.css.onLoad(); } catch(e) {};
                 return true;
             }
         }

--- a/common/app/templates/headerInlineJS/enableStylesheets.scala.js
+++ b/common/app/templates/headerInlineJS/enableStylesheets.scala.js
@@ -13,9 +13,9 @@
                 // Set flag for when the CSS loads before the JS
                 window.guardian.css.loaded = true;
                 // Execute listeners for when the JS loads before the CSS
-                var loadedListeners = window.guardian.css.loadedListeners;
-                for (var i = loadedListeners.length - 1; i >= 0; i--) {
-                    loadedListeners[i]();
+                var onLoadQueue = window.guardian.css.onLoadQueue;
+                for (var i = onLoadQueue.length - 1; i >= 0; i--) {
+                    onLoadQueue[i]();
                 }
                 return true;
             }

--- a/common/app/templates/headerInlineJS/enableStylesheets.scala.js
+++ b/common/app/templates/headerInlineJS/enableStylesheets.scala.js
@@ -10,6 +10,13 @@
             var sheet = documentStyleSheets[i];
             if (sheet.href && sheet.href.indexOf(styleSheet.href) > -1) {
                 styleSheet.media = "screen";
+                // Set flag for when the CSS loads before the JS
+                window.guardian.css.loaded = true;
+                // Execute listeners for when the JS loads before the CSS
+                var loadedListeners = window.guardian.css.loadedListeners;
+                for (var i = loadedListeners.length - 1; i >= 0; i--) {
+                    loadedListeners[i]();
+                }
                 return true;
             }
         }

--- a/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/smartAppBanner.js
@@ -4,6 +4,7 @@ define([
     'common/utils/detect',
     'common/utils/storage',
     'common/utils/template',
+    'common/utils/load-css-promise',
     'common/modules/user-prefs',
     'common/modules/ui/message'
 ], function (
@@ -12,6 +13,7 @@ define([
     detect,
     storage,
     template,
+    loadCssPromise,
     userPrefs,
     Message
 ) {
@@ -53,12 +55,14 @@ define([
     }
 
     function showMessage() {
-        var platform = (detect.isIOS()) ? 'ios' : 'android',
-            msg = new Message(platform),
-            fullTemplate = tmp + (detect.getBreakpoint() === 'mobile' ? '' : tablet);
+        loadCssPromise.then(function () {
+            var platform = (detect.isIOS()) ? 'ios' : 'android',
+                msg = new Message(platform),
+                fullTemplate = tmp + (detect.getBreakpoint() === 'mobile' ? '' : tablet);
 
-        msg.show(template(fullTemplate, DATA[platform.toUpperCase()]));
-        cookies.add(COOKIE_IMPRESSION_KEY, impressions + 1);
+            msg.show(template(fullTemplate, DATA[platform.toUpperCase()]));
+            cookies.add(COOKIE_IMPRESSION_KEY, impressions + 1);
+        });
     }
 
     function init() {

--- a/static/src/javascripts/projects/common/utils/load-css-promise.js
+++ b/static/src/javascripts/projects/common/utils/load-css-promise.js
@@ -1,15 +1,11 @@
 define(['Promise'], function (Promise) {
-    var loadCssThen = function (fn) {
+    return new Promise(function (resolve) {
         if (window.guardian.css.loaded) {
             // CSS has loaded, go
-            fn();
+            resolve();
         } else {
             // Push a listener for when the JS loads
-            window.guardian.css.loadedListeners.push(fn);
+            window.guardian.css.loadedListeners.push(resolve);
         }
-    };
-
-    return new Promise(function (resolve) {
-        loadCssThen(resolve);
     });
 })

--- a/static/src/javascripts/projects/common/utils/load-css-promise.js
+++ b/static/src/javascripts/projects/common/utils/load-css-promise.js
@@ -5,7 +5,7 @@ define(['Promise'], function (Promise) {
             resolve();
         } else {
             // Push a listener for when the JS loads
-            window.guardian.css.loadedListeners.push(resolve);
+            window.guardian.css.onLoadQueue.push(resolve);
         }
     });
-})
+});

--- a/static/src/javascripts/projects/common/utils/load-css-promise.js
+++ b/static/src/javascripts/projects/common/utils/load-css-promise.js
@@ -1,0 +1,15 @@
+define(['Promise'], function (Promise) {
+    var loadCssThen = function (fn) {
+        if (window.guardian.css.loaded) {
+            // CSS has loaded, go
+            fn();
+        } else {
+            // Push a listener for when the JS loads
+            window.guardian.css.loadedListeners.push(fn);
+        }
+    };
+
+    return new Promise(function (resolve) {
+        loadCssThen(resolve);
+    });
+})

--- a/static/src/javascripts/projects/common/utils/load-css-promise.js
+++ b/static/src/javascripts/projects/common/utils/load-css-promise.js
@@ -5,7 +5,7 @@ define(['Promise'], function (Promise) {
             resolve();
         } else {
             // Push a listener for when the JS loads
-            window.guardian.css.onLoadQueue.push(resolve);
+            window.guardian.css.onLoad = resolve;
         }
     });
 });


### PR DESCRIPTION
Fixes #10910

This is a race condition: if the CSS loads before the JS executes, you don't get a flash, otherwise you do.

One solution would be to add this CSS to the inline CSS, but that would increase the inefficiency and bloat of our inline CSS, as we hardly ever show these banners.

This solution will force the JS to wait until the CSS has loaded before injecting the DOM element.

I wonder if we could move more CSS out of inline and towards this model of waiting to execute JS.

/cc @sndrs 
