### PR TITLE
Fix syncing issues between service worker and offline page

### DIFF
--- a/applications/app/controllers/WebAppController.scala
+++ b/applications/app/controllers/WebAppController.scala
@@ -1,11 +1,12 @@
 package controllers
 
 import com.gu.contentapi.client.model.Crossword
-import common.{Edition, ExecutionContexts, Logging}
-import conf.LiveContentApi
+import common.{JsonComponent, Edition, ExecutionContexts, Logging}
+import conf.{StaticJspm, Static, LiveContentApi}
 import crosswords.CrosswordData
 import model.{Cached, MetaData}
 import play.api.mvc.{Action, Controller, RequestHeader, Result}
+import play.api.libs.json.{JsArray, JsString, JsObject}
 
 import scala.concurrent.Future
 
@@ -49,8 +50,18 @@ object WebAppController extends Controller with ExecutionContexts with Logging {
   def offlinePage() = Action.async { implicit request =>
     if (conf.switches.Switches.OfflinePageSwitch.isSwitchedOn) {
       withCrossword("quick", 14127) { crossword =>
-        Cached(60)(Ok(views.html.offlinePage(
-          new OfflinePage(CrosswordData.fromCrossword(crossword)))))
+        val crosswordHtml = views.html.offlinePage(new OfflinePage(CrosswordData.fromCrossword(crossword)))
+        Cached(60)(JsonComponent(JsObject(Map(
+          "html" -> JsString(crosswordHtml.body),
+          "assets" -> JsArray(Seq(
+            Static("stylesheets/head.content.css"),
+            Static("stylesheets/content.css"),
+            Static("stylesheets/print.css"),
+            StaticJspm("javascripts/core.js"),
+            StaticJspm("javascripts/bootstraps/app.js"),
+            StaticJspm("javascripts/es6/bootstraps/crosswords.js")
+          ).map(asset => JsString(asset.toString)))
+        ))))
       }
     } else {
       Future(NotFound)

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -19,18 +19,44 @@
         return new Date().toISOString().split('T')[0];
     };
 
+    var fetchAll = function (inputs) {
+        return Promise.all(inputs.map(function (input) {
+            return fetch(input);
+        }));
+    };
+
+    var cachePageAndAssetResponses = function (jsonResponse, assetResponses) {
+        var cacheName = [getISODate(), staticCacheName].join('-');
+        return caches.open(cacheName).then(function (cache) {
+            return jsonResponse.clone().json().then(function (jsonResponseJson) {
+                var pageRequest = new Request('/offline-page');
+                var pageResponse = new Response(jsonResponseJson.html, { headers: { 'Content-Type': 'text/html' } });
+                return Promise.all([
+                    cache.put(pageRequest, pageResponse)
+                ].concat(
+                    assetResponses.map(function (assetResponse) {
+                        var assetRequest = new Request(assetResponse.url);
+                        return cache.put(assetRequest, assetResponse);
+                    })
+                ));
+            });
+        });
+    };
+
     var updateCache = function () {
-        return caches.open([getISODate(), staticCacheName].join('-')).then(function (cache) {
-            return cache.addAll([
-                '/offline-page',
-                '@Static("stylesheets/head.content.css")',
-                '@Static("stylesheets/content.css")',
-                '@Static("stylesheets/print.css")',
-                // Crossword pages use jspm
-                '@StaticJspm("javascripts/core.js")',
-                '@StaticJspm("javascripts/bootstraps/app.js")',
-                '@StaticJspm("javascripts/es6/bootstraps/crosswords.js")'
-            ]);
+        // Fetch page and all assets. Iff all responses are OK then cache all assets and page.
+        return fetch('/offline-page.json').then(function (jsonResponse) {
+            if (jsonResponse.ok) {
+                return jsonResponse.clone().json().then(function (json) {
+                    return fetchAll(json.assets).then(function (assetResponses) {
+                        var allAssetResponsesOk = assetResponses.every(function (response) { return response.ok; });
+
+                        if (allAssetResponsesOk) {
+                            return cachePageAndAssetResponses(jsonResponse, assetResponses);
+                        }
+                    });
+                });
+            }
         });
     };
 

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -43,6 +43,8 @@
         });
     };
 
+    // The JSON contains the HTML and asset versions. We cache the assets at
+    // their specified URLs and the page HTML as '/offline-page'.
     var updateCache = function () {
         // Fetch page and all assets. Iff all responses are OK then cache all assets and page.
         return fetch('/offline-page.json').then(function (jsonResponse) {

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -307,7 +307,7 @@ GET            /commercial/magento/books                                        
 GET            /series/*path.json                                                                                                controllers.SeriesController.renderSeriesStories(path)
 
 # Applications (must come before wildcard)
-GET            /offline-page                                                                                                     controllers.WebAppController.offlinePage()
+GET            /offline-page.json                                                                                                controllers.WebAppController.offlinePage()
 GET            /service-worker.js                                                                                                controllers.WebAppController.serviceWorker()
 GET            /2015-06-24-manifest.json                                                                                         controllers.WebAppController.manifest()
 GET            /preferences                                                                                                      controllers.PreferencesController.indexPrefs()


### PR DESCRIPTION
Fixes #10667

To do:
- [ ] Update nginx config to route `/offline-page.json` instead of `/offline-page`: https://github.com/guardian/platform/pull/844
- [ ] Update fastly SSL config to force HTTPS for `/offline-page.json` instead of `/offline-page`: https://github.com/guardian/fastly-edge-cache/pull/493
