### PR TITLE
Use different image sizes for immersive header

### DIFF
--- a/common/app/layout/Breakpoint.scala
+++ b/common/app/layout/Breakpoint.scala
@@ -2,7 +2,7 @@ package layout
 
 import scalaz.syntax.std.option._
 
-sealed trait Breakpoint {
+trait Breakpoint {
   val minWidth: Option[Int]
 }
 

--- a/common/app/layout/Breakpoint.scala
+++ b/common/app/layout/Breakpoint.scala
@@ -2,7 +2,7 @@ package layout
 
 import scalaz.syntax.std.option._
 
-trait Breakpoint {
+sealed trait Breakpoint {
   val minWidth: Option[Int]
 }
 

--- a/common/app/views/fragments/headImmersive.scala.html
+++ b/common/app/views/fragments/headImmersive.scala.html
@@ -3,11 +3,32 @@
 @import views.support.TrailCssClasses.articleToneClass
 @import views.support.ContributorLinks
 @import views.support.ImgSrc
-
+@import layout._
 
 <header class="content__head content__head--desktop tonal__head tonal__head--@articleToneClass(content)
-    @if(content.hasTonalHeaderByline && content.hasLargeContributorImage) { content__head--byline-pic}"
-        style="background-image: url('@content.mainPicture.map { picture => @ImgSrc.findNearestSrc(picture, Profile(width = Some(1300)))}');">
+    @if(content.hasTonalHeaderByline && content.hasLargeContributorImage) { content__head--byline-pic}">
+
+        <style>
+            @content.mainPicture.map { picture => 
+                .content__head--mobile {
+                    background-image: url('@ImgSrc.findNearestSrc(picture, Profile(width = Some(500)))');
+                }
+                @@media (min-width: @{layout.Phablet.minWidth}px) {
+                    .content__head--mobile {
+                        background-image: url('@ImgSrc.findNearestSrc(picture, Profile(width = Some(700)))');
+                    }
+                }
+                .content__head--desktop {
+                    background-image: url('@ImgSrc.findNearestSrc(picture, Profile(width = Some(1200)))');
+                }
+                @@media (min-width: @{layout.Wide.minWidth}px) {
+                    .content__head--desktop {
+                        background-image: url('@ImgSrc.findNearestSrc(picture, Profile(width = Some(2000)))');
+                    }
+                }
+                
+            }
+        </style>
 
     <div class="gs-container content__logo-container">
         <a href="@LinkTo{/}">
@@ -16,8 +37,7 @@
     </div>
 
     <div class="content__header">
-        <div class="content__head--mobile"
-            style="background-image: url('@content.mainPicture.map { picture => @ImgSrc.findNearestSrc(picture, Profile(width = Some(1300)))}');">
+        <div class="content__head--mobile">
             <div class="content__wrapper content__wrapper--headline">
                 <div class="gs-container">
                     <h1 class="content__headline">@Html(content.headline)</h1>


### PR DESCRIPTION
Use appropriately sized images on the immersive header. Had to break the seal on the `Breakpoint` trait, not sure if there's a better way to do it.
