### PR TITLE
Layout fixed/medium/slow-VIII Container Without MPU

### DIFF
--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -53,7 +53,7 @@ object FixedContainers {
   val fixedSmallSlowVI = slices(TTTL4)
   val fixedMediumSlowVI = slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter)
   val fixedMediumSlowVII = slices(HalfQQ, QuarterQuarterQuarterQuarter)
-  val fixedMediumSlowVIII = slices(TTMpu, TlTlTl)
+  val fixedMediumSlowVIII = slices(Seq(TTMpu, TlTlTl), slicesWithoutMpu = Seq(TTT, TlTlTl))
   val fixedMediumSlowXIIMpu = slices(TTT, TlTlMpu)
   val fixedMediumFastXI = slices(HalfQQ, Ql2Ql2Ql2Ql2)
   val fixedMediumFastXII = slices(QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)


### PR DESCRIPTION
Another fixed container with different layouts according to whether or not it should show an MPU.

With MPU:
![image](https://cloud.githubusercontent.com/assets/1722550/10636990/efd2a5f2-77fa-11e5-8906-6abf0d0e4984.png)

Without MPU:
![image](https://cloud.githubusercontent.com/assets/1722550/10637017/0727127e-77fb-11e5-9798-0053aaa24e6b.png)

/cc @janua 
