### PR TITLE
Force hide the fullscreen image icon AMP

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -58,7 +58,6 @@
         text-decoration: none;
         font-size: 1rem;
         line-height: 1.25rem;
-        font-weight: 900;
     }
 
     .content__labels {
@@ -146,7 +145,7 @@
 
     @* temporarily hiding these for demo *@
     .inline-expand-image, .content__dateline-lm , .block-share, .witness-cta-wrapper {
-        display: none;
+        display: none !important;
     }
 
     .caption {


### PR DESCRIPTION
Temporary fix until the feature is added. Also bumped down the weight of the section label for good measure. 
