### PR TITLE
Migrate admin+rich link embeds+video embeds back to using curl with RequireJS bundles

### DIFF
--- a/admin/app/views/admin_main.scala.html
+++ b/admin/app/views/admin_main.scala.html
@@ -76,22 +76,20 @@
         <link href='//fonts.googleapis.com/css?family=Merriweather' rel='stylesheet' type='text/css'>
         <link href='//fonts.googleapis.com/css?family=Open+Sans:800' rel='stylesheet' type='text/css'>
 
-        <script>
-            @Html(Static.systemJs.setupFragment)
-
-            // Our app assumes a normal env
-            window.guardian = {
-                config: {
-                    switches: { },
-                    page: { }
+        <script type="text/javascript">
+            var curl = {
+                baseUrl: 'assets/javascripts',
+                apiName: 'require',
+                paths:   {
+                    text: 'text', // noop
+                    inlineSvg: 'inlineSvg' // noop
                 }
             };
 
-            System.import('core').then(function () {
-                System.import('bootstraps/admin');
-            })
+            @Html(Static.js.curl)
         </script>
         <script src="//code.jquery.com/jquery.js"></script>
         <script type="text/javascript" src="@UncachedWebAssets.at("lib/bootstrap/js/bootstrap.min.js")"></script>
+        <script type="text/javascript" src="@Static("javascripts/bootstraps/admin.js")" async></script>
     </body>
 </html>

--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -5,41 +5,6 @@
 @import conf.Static
 @import conf.Configuration
 
-@bootCurl() = {
-    <script>
-        var curl = {
-            baseUrl: '@{Configuration.assets.path}javascripts',
-            apiName: 'require',
-            paths: {
-                core: '@Static("javascripts/core.js")',
-                text: 'text', // noop
-                inlineSvg: 'inlineSvg', // noop
-                'bootstraps/video-embed': '@Static("javascripts/bootstraps/video-embed.js")',
-                'ophan/embed':  '@{Configuration.javascript.config("ophanEmbedJsUrl")}'
-            }
-        };
-
-        @Html(Static.js.curl)
-
-        require(['bootstraps/video-embed'], function(bootstrap) {
-            bootstrap.init();
-        });
-    </script>
-}
-
-@bootSystemJs() = {
-    <script>
-        @Html(Static.systemJs.setupFragment)
-
-        // Bracket notation for IE8 (import is reserved)
-        System['import']('core').then(function () {
-            System['import']('bootstraps/video-embed').then(function (bootstrap) {
-                bootstrap.init();
-            });
-        });
-    </script>
-}
-
 <!DOCTYPE html>
 <html lang="en-GB" class="gu-video-embed-html ">
     <head>
@@ -139,11 +104,25 @@
 
                 @fragments.omnitureScript(None)
 
-                @if(mvt.JspmTest.isParticipating) {
-                    @bootSystemJs()
-                } else {
-                    @bootCurl()
-                }
+                <script>
+                    var curl = {
+                        baseUrl: '@{Configuration.assets.path}javascripts',
+                        apiName: 'require',
+                        paths: {
+                            core: '@Static("javascripts/core.js")',
+                            text: 'text', // noop
+                            inlineSvg: 'inlineSvg', // noop
+                            'bootstraps/video-embed': '@Static("javascripts/bootstraps/video-embed.js")',
+                            'ophan/embed':  '@{Configuration.javascript.config("ophanEmbedJsUrl")}'
+                        }
+                    };
+
+                    @Html(Static.js.curl)
+
+                    require(['bootstraps/video-embed'], function(bootstrap) {
+                        bootstrap.init();
+                    });
+                </script>
             }
         }
     </body>

--- a/bundle.js
+++ b/bundle.js
@@ -35,13 +35,7 @@ var bundleConfigs = [
     ['bootstraps/trail - core - bootstraps/app', 'trail'],
     ['bootstraps/profile - core - bootstraps/app', 'profile'],
     ['bootstraps/ophan - core', 'ophan'],
-    ['bootstraps/admin - core', 'admin'],
-    // Odd issue when bundling admin with core: https://github.com/jspm/jspm-cli/issues/806
-    // ['bootstraps/admin', 'admin'],
     ['bootstraps/media - core', 'media'],
-    ['bootstraps/video-embed - core', 'video-embed'],
-    // Odd issue when bundling admin with core: https://github.com/jspm/jspm-cli/issues/806
-    // ['bootstraps/video-embed', 'video-embed'],
     ['bootstraps/dev - core - bootstraps/app', 'dev'],
     ['bootstraps/creatives - core - bootstraps/app', 'creatives'],
     ['zxcvbn', 'zxcvbn']

--- a/cluster-bundle.js
+++ b/cluster-bundle.js
@@ -40,13 +40,7 @@ var bundleConfigs = [
     ['bootstraps/trail - core - bootstraps/app', 'trail'],
     ['bootstraps/profile - core - bootstraps/app', 'profile'],
     ['bootstraps/ophan - core', 'ophan'],
-    ['bootstraps/admin - core', 'admin'],
-    // Odd issue when bundling admin with core: https://github.com/jspm/jspm-cli/issues/806
-    // ['bootstraps/admin', 'admin'],
     ['bootstraps/media - core', 'media'],
-    ['bootstraps/video-embed - core', 'video-embed'],
-    // Odd issue when bundling admin with core: https://github.com/jspm/jspm-cli/issues/806
-    // ['bootstraps/video-embed', 'video-embed'],
     ['bootstraps/dev - core - bootstraps/app', 'dev'],
     ['bootstraps/creatives - core - bootstraps/app', 'creatives'],
     ['zxcvbn', 'zxcvbn']

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -311,6 +311,7 @@ GET            /offline-page.json                                               
 GET            /service-worker.js                                                                                                controllers.WebAppController.serviceWorker()
 GET            /2015-06-24-manifest.json                                                                                         controllers.WebAppController.manifest()
 GET            /preferences                                                                                                      controllers.PreferencesController.indexPrefs()
+GET            /embed/video/*path                                                                                                controllers.EmbedController.render(path)
 
 GET            /$shortCode<p/[\w]+>                                                                                              controllers.ShortUrlsCampaignController.redirectShortUrl(shortCode)
 GET            /$shortCode<p/[\w]+>/:campaignCode                                                                                controllers.ShortUrlsCampaignController.fetchCampaignAndRedirectShortCode(shortCode, campaignCode)
@@ -359,7 +360,6 @@ GET            /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/trails                  
 GET            /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                                                                     controllers.IndexController.renderJson(path)
 GET            /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                                                                          controllers.IndexController.render(path)
 GET            /$leftSide<[^+]+>+*rightSide                                                                                      controllers.IndexController.renderCombiner(leftSide, rightSide)
-GET            /embed/video/*path                                                                                                controllers.EmbedController.render(path)
 
 # Articles
 GET            /*path.json                                                                                                       controllers.ArticleController.renderArticle(path, lastUpdate: Option[String], rendered: Option[Boolean])

--- a/grunt-configs/requirejs.js
+++ b/grunt-configs/requirejs.js
@@ -212,6 +212,17 @@ module.exports = function(grunt, options) {
                 out: options.staticTargetDir + 'javascripts/bootstraps/ophan.js'
             }
         },
+        admin: {
+            options: {
+                name: 'bootstraps/admin',
+                out: options.staticTargetDir + 'javascripts/bootstraps/admin.js',
+                shim: {
+                    omniture: {
+                        exports: 's'
+                    }
+                }
+            }
+        },
         media: {
             options: {
                 name: 'bootstraps/media',

--- a/onward/app/views/richLink.scala.html
+++ b/onward/app/views/richLink.scala.html
@@ -19,24 +19,25 @@
             </style>
         }
 
-        @if(play.Play.isDev()) {
-            <script>
-                @Html(Static.systemJs.setupFragment)
+        <script type="text/javascript">
+            var curl = {
+                baseUrl: '@{Configuration.assets.path}javascripts',
+                apiName: 'require',
+                paths: {
+                    core:                      '@Static("javascripts/core.js")',
+                    'bootstraps/dev':          '@Static("javascripts/bootstraps/dev.js")'
+                }
+            };
 
-                // Our app assumes a normal env
-                window.guardian = {
-                    config: {
-                        switches: { },
-                        page: { }
-                    }
-                };
+            @Html(Static.js.curl)
 
-                // Bracket notation for IE8 (import is reserved)
-                System['import']('core').then(function () {
-                    System['import']('bootstraps/dev').then(function (devmode) { devmode.init(); });
-                });
-            </script>
-        }
+            require([
+                'core',
+                'domReady!'
+            ], function() {
+                require(['bootstraps/dev'], function (devmode) { devmode.init(); });
+            });
+        </script>
 
    </head>
    <body width="30%">

--- a/static/src/javascripts/bootstraps/admin.js
+++ b/static/src/javascripts/bootstraps/admin.js
@@ -5,8 +5,7 @@ define([
     'admin/bootstraps/browserstats',
     'admin/bootstraps/radiator',
     'admin/bootstraps/commercial',
-    'admin/bootstraps/commercial/adTests',
-    'domready'
+    'admin/bootstraps/commercial/adTests'
 ], function (
     ajax,
     abTests,
@@ -14,11 +13,10 @@ define([
     browserstats,
     radiator,
     commercial,
-    adTests,
-    domready
+    adTests
 ) {
 
-    domready(function () {
+    require(['domReady!'], function () {
         ajax.setHost('');
 
         switch (window.location.pathname) {


### PR DESCRIPTION
Mostly a revert of https://github.com/guardian/frontend/pull/9385

Test URLs:
- Admin: https://frontend.gutools.co.uk/analytics/abtests
- Rich link embed: https://embed.theguardian.com/embed/card/world/2015/oct/22/pupils-wounded-in-sword-attack-at-swedish-school
- Video embed: https://embed.theguardian.com/embed/video/commentisfree/video/2015/oct/21/in-defence-of-lad-culture-camaraderie-fun-and-friendships-video
