### PR TITLE
Add shrinkwrap cleaner and npm install docs

### DIFF
--- a/dev/clean-shrinkwrap.js
+++ b/dev/clean-shrinkwrap.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+// Copied from https://github.com/angular/angular.js/blob/master/scripts/npm/clean-shrinkwrap.js
+
+/**
+ * this script is just a temporary solution to deal with the issue of npm outputting the npm
+ * shrinkwrap file in an unstable manner.
+ *
+ * See: https://github.com/npm/npm/issues/3581
+ */
+
+var _ = require('lodash');
+var sorted = require('sorted-object');
+var fs = require('fs');
+var path = require('path');
+
+
+function cleanModule(module, name) {
+
+  // keep `resolve` properties for git dependencies, delete otherwise
+  delete module.from;
+  if (!(module.resolved && module.resolved.match(/^git(\+[a-z]+)?:\/\//))) {
+    delete module.resolved;
+  }
+
+  _.forEach(module.dependencies, function(mod, name) {
+    cleanModule(mod, name);
+  });
+}
+
+
+console.log('Reading npm-shrinkwrap.json');
+var shrinkwrapPath = path.join(__dirname, '..', 'npm-shrinkwrap.json');
+var shrinkwrap = require(shrinkwrapPath);
+
+console.log('Cleaning shrinkwrap object');
+cleanModule(shrinkwrap, shrinkwrap.name);
+
+console.log('Writing cleaned to', shrinkwrapPath);
+fs.writeFileSync(shrinkwrapPath, JSON.stringify(sorted(shrinkwrap), null, 2) + "\n");

--- a/docs/libraries.md
+++ b/docs/libraries.md
@@ -16,3 +16,14 @@ https://github.com/ded/reqwest
 ## back end
 Play - the application server
 https://playframework.com/
+
+### Node dependencies
+We also have a set of Node dependencies, used mostly by our static asset pipeline. We use npm to manage these.
+
+When you want to add or update a dependency:
+
+```
+npm install <package>@<version> --save
+npm shrinkwrap
+node dev/clean-shrinkwrap.js
+```

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,252 +1,158 @@
 {
-  "name": "frontend",
-  "version": "0.1.0",
   "dependencies": {
     "babel": {
       "version": "5.8.21",
-      "from": "https://registry.npmjs.org/babel/-/babel-5.8.21.tgz",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.21.tgz",
       "dependencies": {
         "babel-core": {
-          "version": "5.8.21",
-          "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.21.tgz",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.21.tgz",
+          "version": "5.8.22",
           "dependencies": {
             "babel-plugin-constant-folding": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-dead-code-elimination": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+              "version": "1.0.2"
             },
             "babel-plugin-eval": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-inline-environment-variables": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-jscript": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+              "version": "1.0.4"
             },
             "babel-plugin-member-expression-literals": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-property-literals": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-proto-to-assign": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+              "version": "1.0.4"
             },
             "babel-plugin-react-constant-elements": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "babel-plugin-react-display-name": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "babel-plugin-remove-console": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-remove-debugger": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-runtime": {
-              "version": "1.0.7",
-              "from": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+              "version": "1.0.7"
             },
             "babel-plugin-undeclared-variables-check": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
               "dependencies": {
                 "leven": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                  "version": "1.0.2"
                 }
               }
             },
             "babel-plugin-undefined-to-void": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+              "version": "1.1.6"
             },
             "babylon": {
-              "version": "5.8.21",
-              "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.21.tgz",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.21.tgz"
+              "version": "5.8.22"
             },
             "bluebird": {
-              "version": "2.9.34",
-              "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
+              "version": "2.9.34"
             },
             "chalk": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                  "version": "2.1.0"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                  "version": "1.0.3"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "version": "2.0.0"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "version": "2.0.0"
                     }
                   }
                 },
                 "supports-color": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "core-js": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-js/-/core-js-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
-                  "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                  "version": "0.7.1"
                 }
               }
             },
             "detect-indent": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
               "dependencies": {
                 "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "4.0.1"
                 },
                 "minimist": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.2.tgz"
+                  "version": "1.1.3"
                 }
               }
             },
             "esutils": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+              "version": "2.0.2"
             },
             "globals": {
-              "version": "6.4.1",
-              "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+              "version": "6.4.1"
             },
             "home-or-tmp": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
               "dependencies": {
                 "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "user-home": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                  "version": "1.1.1"
                 }
               }
             },
             "is-integer": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "is-nan": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/is-nan/-/is-nan-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.1.0.tgz",
                   "dependencies": {
                     "define-properties": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.1.tgz",
                       "dependencies": {
                         "foreach": {
-                          "version": "2.0.5",
-                          "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                          "version": "2.0.5"
                         },
                         "object-keys": {
-                          "version": "1.0.7",
-                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.7.tgz",
-                          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.7.tgz"
+                          "version": "1.0.7"
                         }
                       }
                     }
@@ -255,265 +161,174 @@
               }
             },
             "js-tokens": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "version": "0.4.0"
             },
             "line-numbers": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
               "dependencies": {
                 "left-pad": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                  "version": "0.0.3"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                      "version": "0.2.0"
                     },
                     "concat-map": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      "version": "0.0.1"
                     }
                   }
                 }
               }
             },
             "private": {
-              "version": "0.1.6",
-              "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+              "version": "0.1.6"
             },
             "regenerator": {
               "version": "0.8.35",
-              "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.35.tgz",
-              "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.35.tgz",
               "dependencies": {
                 "commoner": {
                   "version": "0.10.3",
-                  "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
-                  "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
                   "dependencies": {
                     "q": {
-                      "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
+                      "version": "1.1.2"
                     },
                     "commander": {
-                      "version": "2.5.1",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+                      "version": "2.5.1"
                     },
                     "graceful-fs": {
-                      "version": "3.0.8",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                      "version": "3.0.8"
                     },
                     "glob": {
                       "version": "4.2.2",
-                      "from": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.1"
                             }
                           }
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.1"
                         },
                         "minimatch": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                           "dependencies": {
                             "lru-cache": {
-                              "version": "2.6.5",
-                              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                              "version": "2.6.5"
                             },
                             "sigmund": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                              "version": "1.0.1"
                             }
                           }
                         },
                         "once": {
                           "version": "1.3.2",
-                          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.1"
                             }
                           }
                         }
                       }
                     },
                     "install": {
-                      "version": "0.1.8",
-                      "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
-                      "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+                      "version": "0.1.8"
                     },
                     "iconv-lite": {
-                      "version": "0.4.11",
-                      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+                      "version": "0.4.11"
                     }
                   }
                 },
                 "defs": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/defs/-/defs-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.0.tgz",
                   "dependencies": {
                     "alter": {
                       "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                       "dependencies": {
                         "stable": {
-                          "version": "0.1.5",
-                          "from": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
-                          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                          "version": "0.1.5"
                         }
                       }
                     },
                     "ast-traverse": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                      "version": "0.1.1"
                     },
                     "breakable": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "esprima-fb": {
-                      "version": "8001.1001.0-dev-harmony-fb",
-                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
+                      "version": "8001.1001.0-dev-harmony-fb"
                     },
                     "simple-fmt": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                      "version": "0.1.0"
                     },
                     "simple-is": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                      "version": "0.2.0"
                     },
                     "stringmap": {
-                      "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                      "version": "0.2.2"
                     },
                     "stringset": {
-                      "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                      "version": "0.2.1"
                     },
                     "tryor": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                      "version": "0.1.2"
                     },
                     "yargs": {
-                      "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+                      "version": "1.3.3"
                     }
                   }
                 },
                 "recast": {
                   "version": "0.10.24",
-                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.24.tgz",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.24.tgz",
                   "dependencies": {
                     "ast-types": {
-                      "version": "0.8.5",
-                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.5.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.5.tgz"
+                      "version": "0.8.5"
                     }
                   }
                 },
                 "through": {
-                  "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                  "version": "2.3.8"
                 }
               }
             },
             "regexpu": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
               "dependencies": {
                 "recast": {
-                  "version": "0.10.26",
-                  "from": "https://registry.npmjs.org/recast/-/recast-0.10.26.tgz",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.26.tgz",
+                  "version": "0.10.28",
                   "dependencies": {
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb"
+                    },
                     "ast-types": {
-                      "version": "0.8.7",
-                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.7.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.7.tgz"
+                      "version": "0.8.8"
                     }
                   }
                 },
                 "regenerate": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                  "version": "1.2.1"
                 },
                 "regjsgen": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                  "version": "0.2.0"
                 },
                 "regjsparser": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.4.tgz",
                   "dependencies": {
                     "jsesc": {
-                      "version": "0.5.0",
-                      "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                      "version": "0.5.0"
                     }
                   }
                 }
@@ -521,263 +336,171 @@
             },
             "repeating": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
               }
             },
             "resolve": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+              "version": "1.1.6"
             },
             "shebang-regex": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.32",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
               }
             },
             "to-fast-properties": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "trim-right": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "try-resolve": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         },
         "chokidar": {
           "version": "1.0.5",
-          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.2.0.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
-                          "version": "0.2.3",
-                          "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                          "version": "0.2.3"
                         }
                       }
                     },
                     "array-unique": {
-                      "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                      "version": "0.2.1"
                     },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
-                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.2",
-                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
-                                  "version": "1.1.2",
-                                  "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                  "version": "1.1.2"
                                 },
                                 "isobject": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+                                  "version": "1.0.2"
                                 },
                                 "randomatic": {
-                                  "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                                  "version": "1.1.0"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "version": "1.5.2"
                                 }
                               }
                             }
                           }
                         },
                         "preserve": {
-                          "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                          "version": "0.2.0"
                         },
                         "repeat-element": {
-                          "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                          "version": "1.1.2"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.3.tgz",
                       "dependencies": {
                         "is-posix-bracket": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.0.tgz"
+                          "version": "0.1.0"
                         }
                       }
                     },
                     "extglob": {
                       "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
                       "dependencies": {
                         "ansi-green": {
                           "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
                           "dependencies": {
                             "ansi-wrap": {
-                              "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+                              "version": "0.1.0"
                             }
                           }
                         },
                         "is-extglob": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                          "version": "1.0.0"
                         },
                         "success-symbol": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
+                          "version": "0.1.0"
                         }
                       }
                     },
                     "filename-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "kind-of": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                      "version": "1.1.0"
                     },
                     "object.omit": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
-                              "version": "0.1.4",
-                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
-                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                              "version": "0.1.4"
                             }
                           }
                         },
                         "isobject": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+                          "version": "1.0.2"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
-                          "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                          "version": "0.2.0"
                         },
                         "is-dotfile": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "is-extglob": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                          "version": "0.1.3"
                         },
                         "is-primitive": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                          "version": "2.0.0"
                         }
                       }
                     }
@@ -786,90 +509,66 @@
               }
             },
             "arrify": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "async-each": {
-              "version": "0.1.6",
-              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+              "version": "0.1.6"
             },
             "glob-parent": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+              "version": "1.2.0"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
-                  "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
+                  "version": "1.3.1"
                 }
               }
             },
             "is-glob": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+              "version": "1.1.3"
             },
             "readdirp": {
               "version": "1.4.0",
-              "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                  "version": "4.1.2"
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.5",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                      "version": "2.6.5"
                     },
                     "sigmund": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "version": "1.0.1"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "version": "0.10.31"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     }
                   }
+                }
+              }
+            },
+            "fsevents": {
+              "version": "0.3.8",
+              "dependencies": {
+                "nan": {
+                  "version": "2.0.5"
                 }
               }
             }
@@ -877,67 +576,43 @@
         },
         "commander": {
           "version": "2.8.1",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "dependencies": {
             "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         },
         "convert-source-map": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+          "version": "1.1.1"
         },
         "fs-readdir-recursive": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+          "version": "0.1.2"
         },
         "glob": {
           "version": "5.0.14",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.1"
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                      "version": "0.2.0"
                     },
                     "concat-map": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      "version": "0.0.1"
                     }
                   }
                 }
@@ -945,142 +620,89 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             }
           }
         },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
         "output-file-sync": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "version": "0.0.8"
                 }
               }
             },
             "xtend": {
-              "version": "4.0.0",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+              "version": "4.0.0"
             }
           }
         },
         "path-exists": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "slash": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+          "version": "1.0.0"
         }
       }
     },
     "btoa": {
-      "version": "1.1.2",
-      "from": "btoa@1.1.2",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "eslint-plugin-jasmine": {
-      "version": "1.5.0",
-      "from": "eslint-plugin-jasmine@*",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jasmine/-/eslint-plugin-jasmine-1.5.0.tgz"
+      "version": "1.5.0"
     },
     "eslint-plugin-react": {
-      "version": "3.5.0",
-      "from": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.5.0.tgz"
+      "version": "3.5.0"
     },
     "esprima": {
-      "version": "1.2.2",
-      "from": "esprima@1.2.2",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
+      "version": "1.2.2"
     },
     "esprima-fb": {
-      "version": "15001.1.0-dev-harmony-fb",
-      "from": "esprima-fb@>=15001.1.0-dev-harmony-fb <15002.0.0",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
+      "version": "15001.1.0-dev-harmony-fb"
     },
     "glob": {
       "version": "4.0.6",
-      "from": "glob@4.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
       "dependencies": {
         "graceful-fs": {
-          "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+          "version": "3.0.8"
         },
         "inherits": {
-          "version": "2.0.1",
-          "from": "inherits@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+          "version": "2.0.1"
         },
         "minimatch": {
           "version": "1.0.0",
-          "from": "minimatch@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.4",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+              "version": "2.6.5"
             },
             "sigmund": {
-              "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         },
         "once": {
           "version": "1.3.2",
-          "from": "once@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
           "dependencies": {
             "wrappy": {
-              "version": "1.0.1",
-              "from": "wrappy@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         }
@@ -1088,432 +710,278 @@
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@0.4.5",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
-          "version": "0.1.22",
-          "from": "async@>=0.1.22 <0.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+          "version": "0.1.22"
         },
         "coffee-script": {
-          "version": "1.3.3",
-          "from": "coffee-script@>=1.3.3 <1.4.0",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+          "version": "1.3.3"
         },
         "colors": {
-          "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+          "version": "0.6.2"
         },
         "dateformat": {
-          "version": "1.0.2-1.2.3",
-          "from": "dateformat@1.0.2-1.2.3",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+          "version": "1.0.2-1.2.3"
         },
         "eventemitter2": {
-          "version": "0.4.14",
-          "from": "eventemitter2@>=0.4.13 <0.5.0",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+          "version": "0.4.14"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.4",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                      "version": "2.6.5"
                     },
                     "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
               }
             },
             "lodash": {
-              "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <2.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+              "version": "2.4.2"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
-              "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+              "version": "1.2.3"
             },
             "inherits": {
-              "version": "1.0.0",
-              "from": "inherits@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+          "version": "0.2.3"
         },
         "iconv-lite": {
-          "version": "0.2.11",
-          "from": "iconv-lite@>=0.2.11 <0.3.0",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+          "version": "0.2.11"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.12 <0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.4",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+              "version": "2.6.5"
             },
             "sigmund": {
-              "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.7",
-              "from": "abbrev@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+              "version": "1.0.7"
             }
           }
         },
         "rimraf": {
-          "version": "2.2.8",
-          "from": "rimraf@>=2.2.8 <2.3.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+          "version": "2.2.8"
         },
         "lodash": {
-          "version": "0.9.2",
-          "from": "lodash@>=0.9.2 <0.10.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+          "version": "0.9.2"
         },
         "underscore.string": {
-          "version": "2.2.1",
-          "from": "underscore.string@>=2.2.1 <2.3.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+          "version": "2.2.1"
         },
         "which": {
-          "version": "1.0.9",
-          "from": "which@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+          "version": "1.0.9"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@>=2.0.5 <2.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
-                  "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                  "version": "1.7.0"
                 },
                 "underscore.string": {
-                  "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                  "version": "2.4.0"
                 }
               }
             },
             "esprima": {
-              "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+              "version": "1.0.4"
             }
           }
         },
         "exit": {
-          "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+          "version": "0.1.2"
         },
         "getobject": {
-          "version": "0.1.0",
-          "from": "getobject@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+          "version": "0.1.0"
         },
         "grunt-legacy-util": {
-          "version": "0.2.0",
-          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+          "version": "0.2.0"
         },
         "grunt-legacy-log": {
           "version": "0.1.2",
-          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "dependencies": {
             "grunt-legacy-log-utils": {
-              "version": "0.1.1",
-              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
+              "version": "0.1.1"
             },
             "lodash": {
-              "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <2.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+              "version": "2.4.2"
             },
             "underscore.string": {
-              "version": "2.3.3",
-              "from": "underscore.string@>=2.3.3 <2.4.0",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+              "version": "2.3.3"
             }
           }
         }
       }
     },
     "grunt-asset-hash": {
-      "version": "0.1.6",
-      "from": "grunt-asset-hash@0.1.6",
-      "resolved": "https://registry.npmjs.org/grunt-asset-hash/-/grunt-asset-hash-0.1.6.tgz"
+      "version": "0.1.6"
     },
     "grunt-asset-monitor": {
       "version": "0.2.0",
-      "from": "grunt-asset-monitor@0.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-asset-monitor/-/grunt-asset-monitor-0.2.0.tgz",
       "dependencies": {
         "prettysize": {
-          "version": "0.0.3",
-          "from": "prettysize@>=0.0.2 <0.1.0",
-          "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz"
+          "version": "0.0.3"
         },
         "aws-sdk": {
           "version": "2.0.31",
-          "from": "aws-sdk@>=2.0.0-rc4 <2.1.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.31.tgz",
           "dependencies": {
             "xml2js": {
               "version": "0.2.6",
-              "from": "xml2js@0.2.6",
-              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.6.tgz",
               "dependencies": {
                 "sax": {
-                  "version": "0.4.2",
-                  "from": "sax@0.4.2",
-                  "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz"
+                  "version": "0.4.2"
                 }
               }
             },
             "xmlbuilder": {
-              "version": "0.4.2",
-              "from": "xmlbuilder@0.4.2",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+              "version": "0.4.2"
             }
           }
         },
         "css-parse": {
           "version": "2.0.0",
-          "from": "css-parse@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
           "dependencies": {
             "css": {
               "version": "2.2.1",
-              "from": "css@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.38 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.1",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "source-map-resolve": {
                   "version": "0.3.1",
-                  "from": "source-map-resolve@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
                   "dependencies": {
                     "source-map-url": {
-                      "version": "0.3.0",
-                      "from": "source-map-url@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+                      "version": "0.3.0"
                     },
                     "atob": {
-                      "version": "1.1.2",
-                      "from": "atob@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.2.tgz"
+                      "version": "1.1.2"
                     },
                     "resolve-url": {
-                      "version": "0.2.1",
-                      "from": "resolve-url@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
+                      "version": "0.2.1"
                     }
                   }
                 },
                 "urix": {
-                  "version": "0.1.0",
-                  "from": "urix@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+                  "version": "0.1.0"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 }
               }
             }
           }
         },
         "lodash": {
-          "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+          "version": "2.4.2"
         }
       }
     },
     "grunt-autoprefixer": {
       "version": "3.0.3",
-      "from": "grunt-autoprefixer@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.3.tgz",
       "dependencies": {
         "autoprefixer-core": {
           "version": "5.2.1",
-          "from": "autoprefixer-core@>=5.1.7 <6.0.0",
-          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
           "dependencies": {
             "browserslist": {
-              "version": "0.4.0",
-              "from": "browserslist@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
+              "version": "0.4.0"
             },
             "num2fraction": {
-              "version": "1.1.0",
-              "from": "num2fraction@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz"
+              "version": "1.1.0"
             },
             "caniuse-db": {
-              "version": "1.0.30000214",
-              "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000214.tgz"
+              "version": "1.0.30000265"
             }
           }
         },
         "chalk": {
           "version": "1.0.0",
-          "from": "chalk@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.0.1",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+              "version": "2.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "1.1.1"
                 },
                 "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "4.0.1"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "1.1.1"
                 }
               }
             },
             "supports-color": {
-              "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+              "version": "1.3.1"
             }
           }
         },
         "diff": {
-          "version": "1.3.2",
-          "from": "diff@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz"
+          "version": "1.3.2"
         },
         "postcss": {
-          "version": "4.1.12",
-          "from": "postcss@>=4.1.11 <5.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.12.tgz",
+          "version": "4.1.16",
           "dependencies": {
             "es6-promise": {
-              "version": "2.3.0",
-              "from": "es6-promise@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
+              "version": "2.3.0"
             },
             "source-map": {
-              "version": "0.4.2",
-              "from": "source-map@>=0.4.2 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+              "version": "0.4.4",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.1",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "js-base64": {
-              "version": "2.1.8",
-              "from": "js-base64@>=2.1.8 <2.2.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz"
+              "version": "2.1.9"
             }
           }
         }
@@ -1521,18 +989,12 @@
     },
     "grunt-bytesize": {
       "version": "0.1.1",
-      "from": "grunt-bytesize@0.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-bytesize/-/grunt-bytesize-0.1.1.tgz",
       "dependencies": {
         "bytesize": {
           "version": "0.2.0",
-          "from": "bytesize@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/bytesize/-/bytesize-0.2.0.tgz",
           "dependencies": {
             "humanize": {
-              "version": "0.0.7",
-              "from": "humanize@0.0.7",
-              "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.7.tgz"
+              "version": "0.0.7"
             }
           }
         }
@@ -1540,23 +1002,15 @@
     },
     "grunt-concurrent": {
       "version": "1.0.0",
-      "from": "grunt-concurrent@1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-1.0.0.tgz",
       "dependencies": {
         "async": {
-          "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+          "version": "0.9.2"
         },
         "pad-stdio": {
           "version": "1.0.0",
-          "from": "pad-stdio@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pad-stdio/-/pad-stdio-1.0.0.tgz",
           "dependencies": {
             "lpad": {
-              "version": "1.0.0",
-              "from": "lpad@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/lpad/-/lpad-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         }
@@ -1564,201 +1018,118 @@
     },
     "grunt-contrib-clean": {
       "version": "0.6.0",
-      "from": "grunt-contrib-clean@0.6.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
       "dependencies": {
         "rimraf": {
-          "version": "2.2.8",
-          "from": "rimraf@>=2.2.1 <2.3.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+          "version": "2.2.8"
         }
       }
     },
     "grunt-contrib-copy": {
       "version": "0.6.0",
-      "from": "grunt-contrib-copy@0.6.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.6.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+              "version": "1.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  "version": "0.2.1"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  "version": "0.2.1"
                 }
               }
             },
             "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+              "version": "0.2.0"
             }
           }
         }
       }
     },
     "grunt-contrib-requirejs": {
-      "version": "0.4.4",
-      "from": "grunt-contrib-requirejs@0.4.4",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz",
-      "dependencies": {
-        "requirejs": {
-          "version": "2.1.20",
-          "from": "requirejs@>=2.1.0 <2.2.0",
-          "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz"
-        }
-      }
+      "version": "0.4.4"
     },
     "grunt-contrib-uglify": {
       "version": "0.9.1",
-      "from": "grunt-contrib-uglify@0.9.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.9.1.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.0.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "version": "1.1.0",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.0.1",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+              "version": "2.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
-              "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "version": "2.0.0",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                },
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "strip-ansi": {
-              "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "version": "3.0.0",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "supports-color": {
-              "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+              "version": "2.0.0"
             }
           }
         },
-        "lodash": {
-          "version": "3.9.3",
-          "from": "lodash@>=3.2.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
-        },
         "maxmin": {
           "version": "1.1.0",
-          "from": "maxmin@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
           "dependencies": {
             "figures": {
-              "version": "1.3.5",
-              "from": "figures@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+              "version": "1.3.5"
             },
             "gzip-size": {
               "version": "1.0.0",
-              "from": "gzip-size@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.0",
-                  "from": "concat-stream@>=1.4.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                   "dependencies": {
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     },
                     "typedarray": {
-                      "version": "0.0.6",
-                      "from": "typedarray@>=0.0.5 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                      "version": "0.0.6"
                     },
                     "readable-stream": {
-                      "version": "2.0.1",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+                      "version": "2.0.2",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.1",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                          "version": "1.0.2"
                         },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "0.10.31"
                         },
                         "util-deprecate": {
-                          "version": "1.0.1",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
@@ -1766,13 +1137,9 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
-                      "version": "0.2.7",
-                      "from": "pako@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+                      "version": "0.2.7"
                     }
                   }
                 }
@@ -1780,55 +1147,35 @@
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "pretty-bytes@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "4.0.1"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "meow@>=3.1.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.1.0",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                          "version": "1.2.1"
                         },
                         "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "indent-string": {
-                      "version": "1.2.1",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "version": "1.2.2",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                  "version": "1.0.0"
                                 }
                               }
                             }
@@ -1837,14 +1184,10 @@
                       }
                     },
                     "minimist": {
-                      "version": "1.1.1",
-                      "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                      "version": "1.1.3"
                     },
                     "object-assign": {
-                      "version": "3.0.0",
-                      "from": "object-assign@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                      "version": "3.0.0"
                     }
                   }
                 }
@@ -1853,119 +1196,77 @@
           }
         },
         "uglify-js": {
-          "version": "2.4.23",
-          "from": "uglify-js@>=2.4.19 <3.0.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+          "version": "2.4.24",
           "dependencies": {
             "async": {
-              "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "version": "0.2.10"
             },
             "source-map": {
               "version": "0.1.34",
-              "from": "source-map@0.1.34",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.1",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "uglify-to-browserify": {
-              "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+              "version": "1.0.2"
             },
             "yargs": {
               "version": "3.5.4",
-              "from": "yargs@>=3.5.4 <3.6.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "dependencies": {
                 "camelcase": {
-                  "version": "1.1.0",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                  "version": "1.2.1"
                 },
                 "decamelize": {
-                  "version": "1.0.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "window-size": {
-                  "version": "0.1.0",
-                  "from": "window-size@0.1.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                  "version": "0.1.0"
                 },
                 "wordwrap": {
-                  "version": "0.0.2",
-                  "from": "wordwrap@0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                  "version": "0.0.2"
                 }
               }
             }
           }
         },
         "uri-path": {
-          "version": "0.0.2",
-          "from": "uri-path@0.0.2",
-          "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-0.0.2.tgz"
+          "version": "0.0.2"
         }
       }
     },
     "grunt-contrib-watch": {
       "version": "0.6.1",
-      "from": "grunt-contrib-watch@0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
       "dependencies": {
         "gaze": {
           "version": "0.5.1",
-          "from": "gaze@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "globule@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
-                  "version": "1.0.2",
-                  "from": "lodash@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                  "version": "1.0.2"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "glob@>=3.1.21 <3.2.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
-                      "version": "1.2.3",
-                      "from": "graceful-fs@>=1.2.0 <1.3.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                      "version": "1.2.3"
                     },
                     "inherits": {
-                      "version": "1.0.0",
-                      "from": "inherits@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.4",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                      "version": "2.6.5"
                     },
                     "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
@@ -1975,272 +1276,174 @@
         },
         "tiny-lr-fork": {
           "version": "0.0.5",
-          "from": "tiny-lr-fork@0.0.5",
-          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
           "dependencies": {
             "qs": {
-              "version": "0.5.6",
-              "from": "qs@>=0.5.2 <0.6.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+              "version": "0.5.6"
             },
             "faye-websocket": {
-              "version": "0.4.4",
-              "from": "faye-websocket@>=0.4.3 <0.5.0",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
+              "version": "0.4.4"
             },
             "noptify": {
               "version": "0.0.3",
-              "from": "noptify@>=0.0.3 <0.1.0",
-              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
               "dependencies": {
                 "nopt": {
                   "version": "2.0.0",
-                  "from": "nopt@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
                   "dependencies": {
                     "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                      "version": "1.0.7"
                     }
                   }
                 }
               }
             },
             "debug": {
-              "version": "0.7.4",
-              "from": "debug@>=0.7.0 <0.8.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+              "version": "0.7.4"
             }
           }
         },
         "lodash": {
-          "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+          "version": "2.4.2"
         },
         "async": {
-          "version": "0.2.10",
-          "from": "async@>=0.2.9 <0.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+          "version": "0.2.10"
         }
       }
     },
     "grunt-csdevmode": {
       "version": "0.1.2",
-      "from": "grunt-csdevmode@0.1.2",
-      "resolved": "https://registry.npmjs.org/grunt-csdevmode/-/grunt-csdevmode-0.1.2.tgz",
       "dependencies": {
         "socket.io": {
           "version": "1.0.6",
-          "from": "socket.io@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.0.6.tgz",
           "dependencies": {
             "engine.io": {
               "version": "1.3.1",
-              "from": "engine.io@1.3.1",
-              "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.3.1.tgz",
               "dependencies": {
                 "debug": {
-                  "version": "0.6.0",
-                  "from": "debug@0.6.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.6.0.tgz"
+                  "version": "0.6.0"
                 },
                 "ws": {
                   "version": "0.4.31",
-                  "from": "ws@0.4.31",
-                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
                   "dependencies": {
                     "commander": {
-                      "version": "0.6.1",
-                      "from": "commander@>=0.6.1 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                      "version": "0.6.1"
                     },
                     "nan": {
-                      "version": "0.3.2",
-                      "from": "nan@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                      "version": "0.3.2"
                     },
                     "tinycolor": {
-                      "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "options": {
-                      "version": "0.0.6",
-                      "from": "options@>=0.0.5",
-                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                      "version": "0.0.6"
                     }
                   }
                 },
                 "engine.io-parser": {
                   "version": "1.0.6",
-                  "from": "engine.io-parser@1.0.6",
-                  "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
                   "dependencies": {
                     "base64-arraybuffer": {
-                      "version": "0.1.2",
-                      "from": "base64-arraybuffer@0.1.2",
-                      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                      "version": "0.1.2"
                     },
                     "after": {
-                      "version": "0.8.1",
-                      "from": "after@0.8.1",
-                      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                      "version": "0.8.1"
                     },
                     "arraybuffer.slice": {
-                      "version": "0.0.6",
-                      "from": "arraybuffer.slice@0.0.6",
-                      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                      "version": "0.0.6"
                     },
                     "blob": {
-                      "version": "0.0.2",
-                      "from": "blob@0.0.2",
-                      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                      "version": "0.0.2"
                     },
                     "utf8": {
-                      "version": "2.0.0",
-                      "from": "utf8@2.0.0",
-                      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                      "version": "2.0.0"
                     }
                   }
                 },
                 "base64id": {
-                  "version": "0.1.0",
-                  "from": "base64id@0.1.0",
-                  "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+                  "version": "0.1.0"
                 }
               }
             },
             "socket.io-parser": {
               "version": "2.2.0",
-              "from": "socket.io-parser@2.2.0",
-              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.0.tgz",
               "dependencies": {
                 "json3": {
-                  "version": "3.2.6",
-                  "from": "json3@3.2.6",
-                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                  "version": "3.2.6"
                 },
                 "emitter": {
                   "version": "1.0.1",
-                  "from": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-                  "resolved": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
                   "dependencies": {
                     "indexof": {
-                      "version": "0.0.1",
-                      "from": "indexof@0.0.1",
-                      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                      "version": "0.0.1"
                     }
                   }
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "0.0.1"
                 }
               }
             },
             "socket.io-client": {
               "version": "1.0.6",
-              "from": "socket.io-client@1.0.6",
-              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.0.6.tgz",
               "dependencies": {
                 "engine.io-client": {
                   "version": "1.3.1",
-                  "from": "engine.io-client@1.3.1",
-                  "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.3.1.tgz",
                   "dependencies": {
                     "has-cors": {
                       "version": "1.0.3",
-                      "from": "has-cors@1.0.3",
-                      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
                       "dependencies": {
                         "global": {
-                          "version": "2.0.1",
-                          "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
-                          "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+                          "version": "2.0.1"
                         }
                       }
                     },
                     "ws": {
                       "version": "0.4.31",
-                      "from": "ws@0.4.31",
-                      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
                       "dependencies": {
                         "commander": {
-                          "version": "0.6.1",
-                          "from": "commander@>=0.6.1 <0.7.0",
-                          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                          "version": "0.6.1"
                         },
                         "nan": {
-                          "version": "0.3.2",
-                          "from": "nan@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                          "version": "0.3.2"
                         },
                         "tinycolor": {
-                          "version": "0.0.1",
-                          "from": "tinycolor@>=0.0.0 <1.0.0",
-                          "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "options": {
-                          "version": "0.0.6",
-                          "from": "options@>=0.0.5",
-                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                          "version": "0.0.6"
                         }
                       }
                     },
                     "xmlhttprequest": {
-                      "version": "1.5.0",
-                      "from": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz",
-                      "resolved": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz"
+                      "version": "1.5.0"
                     },
                     "engine.io-parser": {
                       "version": "1.0.6",
-                      "from": "engine.io-parser@1.0.6",
-                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
                       "dependencies": {
                         "base64-arraybuffer": {
-                          "version": "0.1.2",
-                          "from": "base64-arraybuffer@0.1.2",
-                          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                          "version": "0.1.2"
                         },
                         "after": {
-                          "version": "0.8.1",
-                          "from": "after@0.8.1",
-                          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                          "version": "0.8.1"
                         },
                         "arraybuffer.slice": {
-                          "version": "0.0.6",
-                          "from": "arraybuffer.slice@0.0.6",
-                          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                          "version": "0.0.6"
                         },
                         "blob": {
-                          "version": "0.0.2",
-                          "from": "blob@0.0.2",
-                          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                          "version": "0.0.2"
                         },
                         "utf8": {
-                          "version": "2.0.0",
-                          "from": "utf8@2.0.0",
-                          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                          "version": "2.0.0"
                         }
                       }
                     },
                     "parsejson": {
                       "version": "0.0.1",
-                      "from": "parsejson@0.0.1",
-                      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
-                              "version": "1.0.0",
-                              "from": "callsite@1.0.0",
-                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                              "version": "1.0.0"
                             }
                           }
                         }
@@ -2248,107 +1451,71 @@
                     },
                     "parseqs": {
                       "version": "0.0.2",
-                      "from": "parseqs@0.0.2",
-                      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
-                              "version": "1.0.0",
-                              "from": "callsite@1.0.0",
-                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                              "version": "1.0.0"
                             }
                           }
                         }
                       }
                     },
                     "component-inherit": {
-                      "version": "0.0.3",
-                      "from": "component-inherit@0.0.3",
-                      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
+                      "version": "0.0.3"
                     }
                   }
                 },
                 "component-bind": {
-                  "version": "1.0.0",
-                  "from": "component-bind@1.0.0",
-                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "component-emitter": {
-                  "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "object-component": {
-                  "version": "0.0.3",
-                  "from": "object-component@0.0.3",
-                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+                  "version": "0.0.3"
                 },
                 "indexof": {
-                  "version": "0.0.1",
-                  "from": "indexof@0.0.1",
-                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                  "version": "0.0.1"
                 },
                 "parseuri": {
                   "version": "0.0.2",
-                  "from": "parseuri@0.0.2",
-                  "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
                   "dependencies": {
                     "better-assert": {
                       "version": "1.0.2",
-                      "from": "better-assert@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "dependencies": {
                         "callsite": {
-                          "version": "1.0.0",
-                          "from": "callsite@1.0.0",
-                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     }
                   }
                 },
                 "to-array": {
-                  "version": "0.1.3",
-                  "from": "to-array@0.1.3",
-                  "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
+                  "version": "0.1.3"
                 }
               }
             },
             "socket.io-adapter": {
               "version": "0.2.0",
-              "from": "socket.io-adapter@0.2.0",
-              "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.2.0.tgz",
               "dependencies": {
                 "socket.io-parser": {
                   "version": "2.1.2",
-                  "from": "socket.io-parser@2.1.2",
-                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.1.2.tgz",
                   "dependencies": {
                     "json3": {
-                      "version": "3.2.6",
-                      "from": "json3@3.2.6",
-                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                      "version": "3.2.6"
                     },
                     "emitter": {
                       "version": "1.0.1",
-                      "from": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-                      "resolved": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
                       "dependencies": {
                         "indexof": {
-                          "version": "0.0.1",
-                          "from": "indexof@0.0.1",
-                          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                          "version": "0.0.1"
                         }
                       }
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     }
                   }
                 }
@@ -2356,403 +1523,259 @@
             },
             "has-binary-data": {
               "version": "0.1.1",
-              "from": "has-binary-data@0.1.1",
-              "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.1.tgz",
               "dependencies": {
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "0.0.1"
                 }
               }
             },
             "debug": {
-              "version": "0.7.4",
-              "from": "debug@0.7.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+              "version": "0.7.4"
             }
           }
         },
         "win-spawn": {
-          "version": "2.0.0",
-          "from": "win-spawn@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
+          "version": "2.0.0"
         },
         "ua-parser-js": {
-          "version": "0.7.7",
-          "from": "ua-parser-js@>=0.7.0 <0.8.0",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.7.tgz"
+          "version": "0.7.9"
         },
         "express": {
           "version": "4.4.5",
-          "from": "express@>=4.4.4 <4.5.0",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.4.5.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.0.7",
-              "from": "accepts@>=1.0.5 <1.1.0",
-              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
               "dependencies": {
                 "mime-types": {
-                  "version": "1.0.2",
-                  "from": "mime-types@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                  "version": "1.0.2"
                 },
                 "negotiator": {
-                  "version": "0.4.7",
-                  "from": "negotiator@0.4.7",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
+                  "version": "0.4.7"
                 }
               }
             },
             "buffer-crc32": {
-              "version": "0.2.3",
-              "from": "buffer-crc32@0.2.3",
-              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
+              "version": "0.2.3"
             },
             "debug": {
               "version": "1.0.2",
-              "from": "debug@1.0.2",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
               "dependencies": {
                 "ms": {
-                  "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                  "version": "0.6.2"
                 }
               }
             },
             "escape-html": {
-              "version": "1.0.1",
-              "from": "escape-html@1.0.1",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "methods": {
-              "version": "1.0.1",
-              "from": "methods@1.0.1",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "parseurl": {
-              "version": "1.0.1",
-              "from": "parseurl@1.0.1",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "proxy-addr": {
               "version": "1.0.1",
-              "from": "proxy-addr@1.0.1",
-              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
               "dependencies": {
                 "ipaddr.js": {
-                  "version": "0.1.2",
-                  "from": "ipaddr.js@0.1.2",
-                  "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
+                  "version": "0.1.2"
                 }
               }
             },
             "range-parser": {
-              "version": "1.0.0",
-              "from": "range-parser@1.0.0",
-              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "send": {
               "version": "0.4.3",
-              "from": "send@0.4.3",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.4.3.tgz",
               "dependencies": {
                 "finished": {
                   "version": "1.2.2",
-                  "from": "finished@1.2.2",
-                  "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
                   "dependencies": {
                     "ee-first": {
-                      "version": "1.0.3",
-                      "from": "ee-first@1.0.3",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
+                      "version": "1.0.3"
                     }
                   }
                 },
                 "mime": {
-                  "version": "1.2.11",
-                  "from": "mime@1.2.11",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                  "version": "1.2.11"
                 }
               }
             },
             "serve-static": {
-              "version": "1.2.3",
-              "from": "serve-static@1.2.3",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.3.tgz"
+              "version": "1.2.3"
             },
             "type-is": {
               "version": "1.2.1",
-              "from": "type-is@1.2.1",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.2.1.tgz",
               "dependencies": {
                 "mime-types": {
-                  "version": "1.0.0",
-                  "from": "mime-types@1.0.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "vary": {
-              "version": "0.1.0",
-              "from": "vary@0.1.0",
-              "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz"
+              "version": "0.1.0"
             },
             "cookie": {
-              "version": "0.1.2",
-              "from": "cookie@0.1.2",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+              "version": "0.1.2"
             },
             "fresh": {
-              "version": "0.2.2",
-              "from": "fresh@0.2.2",
-              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
+              "version": "0.2.2"
             },
             "cookie-signature": {
-              "version": "1.0.4",
-              "from": "cookie-signature@1.0.4",
-              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
+              "version": "1.0.4"
             },
             "merge-descriptors": {
-              "version": "0.0.2",
-              "from": "merge-descriptors@0.0.2",
-              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+              "version": "0.0.2"
             },
             "utils-merge": {
-              "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
-              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "qs": {
-              "version": "0.6.6",
-              "from": "qs@0.6.6",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+              "version": "0.6.6"
             },
             "path-to-regexp": {
-              "version": "0.1.2",
-              "from": "path-to-regexp@0.1.2",
-              "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz"
+              "version": "0.1.2"
             }
           }
         },
         "weinre": {
           "version": "2.0.0-pre-I0Z7U9OV",
-          "from": "weinre@>=2.0.0-pre-HH0SN197 <2.1.0",
-          "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
           "dependencies": {
             "express": {
               "version": "2.5.11",
-              "from": "express@>=2.5.0 <2.6.0",
-              "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
               "dependencies": {
                 "connect": {
                   "version": "1.9.2",
-                  "from": "connect@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
                   "dependencies": {
                     "formidable": {
-                      "version": "1.0.17",
-                      "from": "formidable@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
+                      "version": "1.0.17"
                     }
                   }
                 },
                 "mime": {
-                  "version": "1.2.4",
-                  "from": "mime@1.2.4",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
+                  "version": "1.2.4"
                 },
                 "qs": {
-                  "version": "0.4.2",
-                  "from": "qs@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+                  "version": "0.4.2"
                 },
                 "mkdirp": {
-                  "version": "0.3.0",
-                  "from": "mkdirp@0.3.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                  "version": "0.3.0"
                 }
               }
             },
             "nopt": {
-              "version": "3.0.2",
-              "from": "nopt@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+              "version": "3.0.3",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                  "version": "1.0.7"
                 }
               }
             },
             "underscore": {
-              "version": "1.7.0",
-              "from": "underscore@>=1.7.0 <1.8.0",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+              "version": "1.7.0"
             }
           }
         },
         "array.prototype.findindex": {
-          "version": "0.1.1",
-          "from": "array.prototype.findindex@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-0.1.1.tgz"
+          "version": "0.1.1"
         }
       }
     },
     "grunt-css-metrics": {
       "version": "0.1.2",
-      "from": "grunt-css-metrics@0.1.2",
-      "resolved": "https://registry.npmjs.org/grunt-css-metrics/-/grunt-css-metrics-0.1.2.tgz",
       "dependencies": {
         "glob": {
           "version": "3.2.1",
-          "from": "glob@3.2.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.1.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.4",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                  "version": "2.6.5"
                 },
                 "sigmund": {
-                  "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "graceful-fs": {
-              "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+              "version": "1.2.3"
             },
             "inherits": {
-              "version": "1.0.0",
-              "from": "inherits@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "css-parse": {
-          "version": "1.4.0",
-          "from": "css-parse@>=1.4.0 <1.5.0",
-          "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.4.0.tgz"
+          "version": "1.4.0"
         },
         "humanize": {
-          "version": "0.0.9",
-          "from": "humanize@>=0.0.7 <0.1.0",
-          "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz"
+          "version": "0.0.9"
         }
       }
     },
     "grunt-eslint": {
       "version": "17.2.0",
-      "from": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.2.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "version": "2.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "version": "2.0.0"
             }
           }
         },
         "eslint": {
           "version": "1.5.1",
-          "from": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
           "dependencies": {
             "concat-stream": {
               "version": "1.5.0",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "typedarray": {
-                  "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                  "version": "0.0.6"
                 },
                 "readable-stream": {
                   "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "version": "1.0.1"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                      "version": "1.0.3"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "version": "0.10.31"
                     },
                     "util-deprecate": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
@@ -2760,279 +1783,179 @@
             },
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
-                  "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                  "version": "0.7.1"
                 }
               }
             },
             "doctrine": {
               "version": "0.7.0",
-              "from": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.0.tgz",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.0.tgz",
               "dependencies": {
                 "esutils": {
-                  "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                  "version": "1.1.6"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "0.0.1"
                 }
               }
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "escope": {
               "version": "3.2.0",
-              "from": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
               "dependencies": {
                 "es6-map": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.1.tgz",
                   "dependencies": {
                     "d": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                      "version": "0.1.1"
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                       "dependencies": {
                         "es6-symbol": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                          "version": "2.0.1"
                         }
                       }
                     },
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                       "dependencies": {
                         "es6-symbol": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                          "version": "2.0.1"
                         }
                       }
                     },
                     "es6-set": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz"
+                      "version": "0.1.1"
                     },
                     "es6-symbol": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                      "version": "0.1.1"
                     },
                     "event-emitter": {
-                      "version": "0.3.3",
-                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                      "version": "0.3.3"
                     }
                   }
                 },
                 "es6-weak-map": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                   "dependencies": {
                     "d": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                      "version": "0.1.1"
                     },
                     "es5-ext": {
-                      "version": "0.10.7",
-                      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz"
+                      "version": "0.10.7"
                     },
                     "es6-iterator": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                      "version": "0.1.3"
                     },
                     "es6-symbol": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                      "version": "2.0.1"
                     }
                   }
                 },
                 "esrecurse": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz"
+                  "version": "3.1.1"
                 },
                 "estraverse": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                  "version": "3.1.0"
                 }
               }
             },
             "espree": {
-              "version": "2.2.5",
-              "from": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+              "version": "2.2.5"
             },
             "estraverse": {
-              "version": "4.1.0",
-              "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.0.tgz"
+              "version": "4.1.0"
             },
             "estraverse-fb": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+              "version": "1.3.1"
             },
             "glob": {
               "version": "5.0.15",
-              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
               }
             },
             "globals": {
-              "version": "8.10.0",
-              "from": "https://registry.npmjs.org/globals/-/globals-8.10.0.tgz",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-8.10.0.tgz"
+              "version": "8.10.0"
             },
             "handlebars": {
               "version": "4.0.3",
-              "from": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.3.tgz",
               "dependencies": {
                 "async": {
-                  "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                  "version": "1.4.2"
                 },
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                      "version": "0.0.3"
                     },
                     "minimist": {
-                      "version": "0.0.10",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                      "version": "0.0.10"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "uglify-js": {
                   "version": "2.4.24",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "0.2.10",
-                      "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                      "version": "0.2.10"
                     },
                     "source-map": {
                       "version": "0.1.34",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                       "dependencies": {
                         "amdefine": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     },
                     "uglify-to-browserify": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "yargs": {
                       "version": "3.5.4",
-                      "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.2.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                          "version": "1.2.1"
                         },
                         "decamelize": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                          "version": "1.0.0"
                         },
                         "window-size": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                          "version": "0.1.0"
                         },
                         "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "version": "0.0.2"
                         }
                       }
                     }
@@ -3042,43 +1965,27 @@
             },
             "inquirer": {
               "version": "0.9.0",
-              "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "2.0.0"
                 },
                 "cli-width": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "figures": {
-                  "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+                  "version": "1.4.0"
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "mute-stream": {
-                      "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                      "version": "0.0.4"
                     },
                     "strip-ansi": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                          "version": "1.1.1"
                         }
                       }
                     }
@@ -3086,151 +1993,99 @@
                 },
                 "run-async": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
                   "dependencies": {
                     "once": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
                   }
                 },
                 "rx-lite": {
-                  "version": "2.5.2",
-                  "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz",
-                  "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz"
+                  "version": "2.5.2"
                 },
                 "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                  "version": "3.0.0"
                 },
                 "through": {
-                  "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                  "version": "2.3.8"
                 }
               }
             },
             "file-entry-cache": {
               "version": "1.2.4",
-              "from": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
-              "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
               "dependencies": {
                 "flat-cache": {
                   "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.9.tgz",
                   "dependencies": {
                     "del": {
                       "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/del/-/del-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/del/-/del-2.0.2.tgz",
                       "dependencies": {
                         "globby": {
                           "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
                           "dependencies": {
                             "array-union": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
                               "dependencies": {
                                 "array-uniq": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                  "version": "1.0.2"
                                 }
                               }
                             },
                             "arrify": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+                              "version": "1.0.0"
                             }
                           }
                         },
                         "is-path-cwd": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+                          "version": "1.0.0"
                         },
                         "is-path-in-cwd": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
                           "dependencies": {
                             "is-path-inside": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                              "version": "1.0.0"
                             }
                           }
                         },
                         "pify": {
-                          "version": "2.2.0",
-                          "from": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.2.0.tgz"
+                          "version": "2.2.0"
                         },
                         "pinkie-promise": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                              "version": "1.0.0"
                             }
                           }
                         },
                         "rimraf": {
-                          "version": "2.4.3",
-                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
+                          "version": "2.4.3"
                         }
                       }
                     },
                     "graceful-fs": {
-                      "version": "4.1.2",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                      "version": "4.1.2"
                     },
                     "read-json-sync": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
-                          "version": "3.0.8",
-                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                          "version": "3.0.8"
                         }
                       }
                     },
                     "write": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
                       "dependencies": {
                         "mkdirp": {
                           "version": "0.5.1",
-                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                           "dependencies": {
                             "minimist": {
-                              "version": "0.0.8",
-                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                              "version": "0.0.8"
                             }
                           }
                         }
@@ -3239,238 +2094,154 @@
                   }
                 },
                 "object-assign": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                  "version": "4.0.1"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.12.2",
-              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
               "dependencies": {
                 "generate-function": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                  "version": "2.0.0"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                      "version": "1.0.2"
                     }
                   }
                 },
                 "jsonpointer": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                  "version": "2.0.0"
                 },
                 "xtend": {
-                  "version": "4.0.0",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                  "version": "4.0.0"
                 }
               }
             },
             "is-resolvable": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
               "dependencies": {
                 "tryit": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "js-yaml": {
               "version": "3.4.2",
-              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.2.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
                     "sprintf-js": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                      "version": "1.0.3"
                     }
                   }
                 },
                 "esprima": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                  "version": "2.2.0"
                 }
               }
             },
             "lodash.clonedeep": {
               "version": "3.0.2",
-              "from": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
               "dependencies": {
                 "lodash._baseclone": {
                   "version": "3.3.0",
-                  "from": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
                   "dependencies": {
                     "lodash._arraycopy": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                      "version": "3.0.0"
                     },
                     "lodash._arrayeach": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                      "version": "3.0.0"
                     },
                     "lodash._baseassign": {
                       "version": "3.2.0",
-                      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                       "dependencies": {
                         "lodash._basecopy": {
-                          "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                          "version": "3.0.1"
                         }
                       }
                     },
                     "lodash._basefor": {
-                      "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                      "version": "3.0.2"
                     },
                     "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                      "version": "3.0.4"
                     },
                     "lodash.keys": {
                       "version": "3.1.2",
-                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "dependencies": {
                         "lodash._getnative": {
-                          "version": "3.9.1",
-                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                          "version": "3.9.1"
                         },
                         "lodash.isarguments": {
-                          "version": "3.0.4",
-                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                          "version": "3.0.4"
                         }
                       }
                     }
                   }
                 },
                 "lodash._bindcallback": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                  "version": "3.0.1"
                 }
               }
             },
             "lodash.merge": {
               "version": "3.3.2",
-              "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                  "version": "3.0.0"
                 },
                 "lodash._arrayeach": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                  "version": "3.0.0"
                 },
                 "lodash._createassigner": {
                   "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
-                      "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                      "version": "3.0.1"
                     },
                     "lodash._isiterateecall": {
-                      "version": "3.0.9",
-                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                      "version": "3.0.9"
                     },
                     "lodash.restparam": {
-                      "version": "3.6.1",
-                      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                      "version": "3.6.1"
                     }
                   }
                 },
                 "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                  "version": "3.9.1"
                 },
                 "lodash.isarguments": {
-                  "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                  "version": "3.0.4"
                 },
                 "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                  "version": "3.0.4"
                 },
                 "lodash.isplainobject": {
                   "version": "3.2.0",
-                  "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basefor": {
-                      "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                      "version": "3.0.2"
                     }
                   }
                 },
                 "lodash.istypedarray": {
-                  "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
+                  "version": "3.0.2"
                 },
                 "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+                  "version": "3.1.2"
                 },
                 "lodash.keysin": {
-                  "version": "3.0.8",
-                  "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
+                  "version": "3.0.8"
                 },
                 "lodash.toplainobject": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
-                      "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                      "version": "3.0.1"
                     }
                   }
                 }
@@ -3478,38 +2249,24 @@
             },
             "lodash.omit": {
               "version": "3.1.0",
-              "from": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
               "dependencies": {
                 "lodash._arraymap": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
+                  "version": "3.0.0"
                 },
                 "lodash._basedifference": {
                   "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
                   "dependencies": {
                     "lodash._baseindexof": {
-                      "version": "3.1.0",
-                      "from": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
+                      "version": "3.1.0"
                     },
                     "lodash._cacheindexof": {
-                      "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
+                      "version": "3.0.2"
                     },
                     "lodash._createcache": {
                       "version": "3.1.2",
-                      "from": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
                       "dependencies": {
                         "lodash._getnative": {
-                          "version": "3.9.1",
-                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                          "version": "3.9.1"
                         }
                       }
                     }
@@ -3517,214 +2274,136 @@
                 },
                 "lodash._baseflatten": {
                   "version": "3.1.4",
-                  "from": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
                   "dependencies": {
                     "lodash.isarguments": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                      "version": "3.0.4"
                     },
                     "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                      "version": "3.0.4"
                     }
                   }
                 },
                 "lodash._bindcallback": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                  "version": "3.0.1"
                 },
                 "lodash._pickbyarray": {
-                  "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+                  "version": "3.0.2"
                 },
                 "lodash._pickbycallback": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
                   "dependencies": {
                     "lodash._basefor": {
-                      "version": "3.0.2",
-                      "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                      "version": "3.0.2"
                     }
                   }
                 },
                 "lodash.keysin": {
                   "version": "3.0.8",
-                  "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
                   "dependencies": {
                     "lodash.isarguments": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                      "version": "3.0.4"
                     },
                     "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                      "version": "3.0.4"
                     }
                   }
                 },
                 "lodash.restparam": {
-                  "version": "3.6.1",
-                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                  "version": "3.6.1"
                 }
               }
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                      "version": "0.2.0"
                     },
                     "concat-map": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      "version": "0.0.1"
                     }
                   }
                 }
               }
             },
             "object-assign": {
-              "version": "2.1.1",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+              "version": "2.1.1"
             },
             "optionator": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
               "dependencies": {
                 "prelude-ls": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "deep-is": {
-                  "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                  "version": "0.1.3"
                 },
                 "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                  "version": "0.0.3"
                 },
                 "type-check": {
-                  "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                  "version": "0.3.1"
                 },
                 "levn": {
-                  "version": "0.2.5",
-                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                  "version": "0.2.5"
                 },
                 "fast-levenshtein": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                  "version": "1.0.7"
                 }
               }
             },
             "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "path-is-inside": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "shelljs": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+              "version": "0.3.0"
             },
             "strip-json-comments": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+              "version": "1.0.4"
             },
             "text-table": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+              "version": "0.2.0"
             },
             "to-double-quotes": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.1.tgz",
               "dependencies": {
                 "get-stdin": {
-                  "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+                  "version": "3.0.2"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.2.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                          "version": "1.2.1"
                         },
                         "map-obj": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.2",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "get-stdin": {
-                          "version": "4.0.1",
-                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                          "version": "4.0.1"
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                  "version": "1.0.0"
                                 }
                               }
                             }
@@ -3733,14 +2412,10 @@
                       }
                     },
                     "minimist": {
-                      "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                      "version": "1.2.0"
                     },
                     "object-assign": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                      "version": "3.0.0"
                     }
                   }
                 }
@@ -3748,60 +2423,38 @@
             },
             "to-single-quotes": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.3.tgz",
               "dependencies": {
                 "get-stdin": {
-                  "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+                  "version": "3.0.2"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.2.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                          "version": "1.2.1"
                         },
                         "map-obj": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.2",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "get-stdin": {
-                          "version": "4.0.1",
-                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                          "version": "4.0.1"
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                  "version": "1.0.0"
                                 }
                               }
                             }
@@ -3810,28 +2463,20 @@
                       }
                     },
                     "minimist": {
-                      "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                      "version": "1.2.0"
                     },
                     "object-assign": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                      "version": "3.0.0"
                     }
                   }
                 }
               }
             },
             "user-home": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+              "version": "1.1.1"
             },
             "xml-escape": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         }
@@ -3839,72 +2484,46 @@
     },
     "grunt-frequency-graph": {
       "version": "0.1.6",
-      "from": "grunt-frequency-graph@>=0.1.6 <0.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-frequency-graph/-/grunt-frequency-graph-0.1.6.tgz",
       "dependencies": {
         "asset-frequency-graph": {
           "version": "0.3.1",
-          "from": "asset-frequency-graph@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/asset-frequency-graph/-/asset-frequency-graph-0.3.1.tgz",
           "dependencies": {
             "async": {
-              "version": "0.9.0",
-              "from": "async@0.9.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+              "version": "0.9.0"
             },
             "git-promise": {
               "version": "0.2.0",
-              "from": "git-promise@0.2.0",
-              "resolved": "https://registry.npmjs.org/git-promise/-/git-promise-0.2.0.tgz",
               "dependencies": {
                 "shelljs": {
-                  "version": "0.3.0",
-                  "from": "shelljs@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+                  "version": "0.3.0"
                 }
               }
             },
             "glob": {
               "version": "4.3.4",
-              "from": "glob@4.3.4",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.4.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "minimatch": {
-                  "version": "2.0.8",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "version": "2.0.10",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                          "version": "0.2.0"
                         },
                         "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "version": "0.0.1"
                         }
                       }
                     }
@@ -3912,13 +2531,9 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
@@ -3926,53 +2541,33 @@
             },
             "gzip-size": {
               "version": "1.0.0",
-              "from": "gzip-size@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.0",
-                  "from": "concat-stream@>=1.4.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                   "dependencies": {
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     },
                     "typedarray": {
-                      "version": "0.0.6",
-                      "from": "typedarray@>=0.0.5 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                      "version": "0.0.6"
                     },
                     "readable-stream": {
-                      "version": "2.0.1",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+                      "version": "2.0.2",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.1",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                          "version": "1.0.2"
                         },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "0.10.31"
                         },
                         "util-deprecate": {
-                          "version": "1.0.1",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
@@ -3980,13 +2575,9 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
-                      "version": "0.2.7",
-                      "from": "pako@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+                      "version": "0.2.7"
                     }
                   }
                 }
@@ -3994,199 +2585,127 @@
             },
             "madge": {
               "version": "0.4.1",
-              "from": "madge@0.4.1",
-              "resolved": "https://registry.npmjs.org/madge/-/madge-0.4.1.tgz",
               "dependencies": {
                 "amdetective": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/amdetective/-/amdetective-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/amdetective/-/amdetective-0.0.2.tgz"
+                  "version": "0.0.2"
                 },
                 "coffee-script": {
-                  "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+                  "version": "1.3.3"
                 },
                 "colors": {
-                  "version": "0.6.0-1",
-                  "from": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz",
-                  "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz"
+                  "version": "0.6.0-1"
                 },
                 "commander": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "commondir": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
+                  "version": "0.0.1"
                 },
                 "detective": {
-                  "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/detective/-/detective-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/detective/-/detective-0.1.1.tgz"
+                  "version": "0.1.1"
                 },
                 "graphviz": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.7.tgz",
                   "dependencies": {
                     "temp": {
-                      "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
-                      "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz"
+                      "version": "0.4.0"
                     }
                   }
                 },
                 "react-tools": {
                   "version": "0.12.1",
-                  "from": "https://registry.npmjs.org/react-tools/-/react-tools-0.12.1.tgz",
-                  "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.12.1.tgz",
                   "dependencies": {
                     "commoner": {
                       "version": "0.10.1",
-                      "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
                       "dependencies": {
                         "q": {
-                          "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
+                          "version": "1.1.2"
                         },
                         "recast": {
                           "version": "0.9.11",
-                          "from": "https://registry.npmjs.org/recast/-/recast-0.9.11.tgz",
-                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.11.tgz",
                           "dependencies": {
                             "esprima-fb": {
-                              "version": "8001.1001.0-dev-harmony-fb",
-                              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
+                              "version": "8001.1001.0-dev-harmony-fb"
                             },
                             "source-map": {
                               "version": "0.1.41",
-                              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
-                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
                               "dependencies": {
                                 "amdefine": {
-                                  "version": "0.1.0",
-                                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                  "version": "0.1.0"
                                 }
                               }
                             },
                             "ast-types": {
-                              "version": "0.6.7",
-                              "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz",
-                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz"
+                              "version": "0.6.7"
                             }
                           }
                         },
                         "commander": {
-                          "version": "2.5.1",
-                          "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
-                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+                          "version": "2.5.1"
                         },
                         "graceful-fs": {
-                          "version": "3.0.5",
-                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                          "version": "3.0.5"
                         },
                         "glob": {
                           "version": "4.2.2",
-                          "from": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                               "dependencies": {
                                 "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                  "version": "1.0.1"
                                 }
                               }
                             },
                             "inherits": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "version": "2.0.1"
                             },
                             "minimatch": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                               "dependencies": {
                                 "lru-cache": {
-                                  "version": "2.5.0",
-                                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                  "version": "2.5.0"
                                 },
                                 "sigmund": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                  "version": "1.0.0"
                                 }
                               }
                             },
                             "once": {
                               "version": "1.3.1",
-                              "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                               "dependencies": {
                                 "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                  "version": "1.0.1"
                                 }
                               }
                             }
                           }
                         },
                         "private": {
-                          "version": "0.1.6",
-                          "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-                          "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                          "version": "0.1.6"
                         },
                         "install": {
-                          "version": "0.1.8",
-                          "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
-                          "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+                          "version": "0.1.8"
                         },
                         "iconv-lite": {
-                          "version": "0.4.5",
-                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
-                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
+                          "version": "0.4.5"
                         }
                       }
                     },
                     "jstransform": {
                       "version": "8.2.0",
-                      "from": "https://registry.npmjs.org/jstransform/-/jstransform-8.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-8.2.0.tgz",
                       "dependencies": {
                         "base62": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
+                          "version": "0.1.1"
                         },
                         "esprima-fb": {
-                          "version": "8001.1001.0-dev-harmony-fb",
-                          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
+                          "version": "8001.1001.0-dev-harmony-fb"
                         },
                         "source-map": {
                           "version": "0.1.31",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                           "dependencies": {
                             "amdefine": {
-                              "version": "0.1.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                              "version": "0.1.0"
                             }
                           }
                         }
@@ -4195,78 +2714,50 @@
                   }
                 },
                 "resolve": {
-                  "version": "0.2.3",
-                  "from": "https://registry.npmjs.org/resolve/-/resolve-0.2.3.tgz",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.2.3.tgz"
+                  "version": "0.2.3"
                 },
                 "uglify-js": {
-                  "version": "1.2.6",
-                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz"
+                  "version": "1.2.6"
                 },
                 "walkdir": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.5.tgz"
+                  "version": "0.0.5"
                 }
               }
             },
             "moment": {
-              "version": "2.10.3",
-              "from": "moment@>=2.9.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.3.tgz"
+              "version": "2.10.6"
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "pretty-bytes@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "4.0.1"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "meow@>=3.1.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.1.0",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                          "version": "1.2.1"
                         },
                         "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "indent-string": {
-                      "version": "1.2.1",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "version": "1.2.2",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                  "version": "1.0.0"
                                 }
                               }
                             }
@@ -4275,75 +2766,49 @@
                       }
                     },
                     "minimist": {
-                      "version": "1.1.1",
-                      "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                      "version": "1.1.3"
                     },
                     "object-assign": {
-                      "version": "3.0.0",
-                      "from": "object-assign@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                      "version": "3.0.0"
                     }
                   }
                 }
               }
             },
             "progress": {
-              "version": "1.1.8",
-              "from": "progress@1.1.8",
-              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+              "version": "1.1.8"
             },
             "uglify-js": {
-              "version": "2.4.23",
-              "from": "uglify-js@>=2.4.16 <3.0.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+              "version": "2.4.24",
               "dependencies": {
                 "async": {
-                  "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                  "version": "0.2.10"
                 },
                 "source-map": {
                   "version": "0.1.34",
-                  "from": "source-map@0.1.34",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.1",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                  "version": "1.0.2"
                 },
                 "yargs": {
                   "version": "3.5.4",
-                  "from": "yargs@>=3.5.4 <3.6.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.1.0",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                      "version": "1.2.1"
                     },
                     "decamelize": {
-                      "version": "1.0.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "window-size": {
-                      "version": "0.1.0",
-                      "from": "window-size@0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                      "version": "0.1.0"
                     },
                     "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                      "version": "0.0.2"
                     }
                   }
                 }
@@ -4352,229 +2817,147 @@
           }
         },
         "aws-sdk": {
-          "version": "2.1.35",
-          "from": "aws-sdk@>=2.1.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.35.tgz",
+          "version": "2.1.45",
           "dependencies": {
             "sax": {
-              "version": "0.5.3",
-              "from": "sax@0.5.3",
-              "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz"
+              "version": "0.5.3"
             },
             "xml2js": {
-              "version": "0.2.8",
-              "from": "xml2js@0.2.8",
-              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz"
+              "version": "0.2.8"
             },
             "xmlbuilder": {
-              "version": "0.4.2",
-              "from": "xmlbuilder@0.4.2",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+              "version": "0.4.2"
             }
           }
         },
         "es6-promise": {
-          "version": "2.3.0",
-          "from": "es6-promise@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
+          "version": "2.3.0"
         }
       }
     },
     "grunt-hologram": {
       "version": "0.0.4",
-      "from": "grunt-hologram@0.0.4",
-      "resolved": "https://registry.npmjs.org/grunt-hologram/-/grunt-hologram-0.0.4.tgz",
       "dependencies": {
         "which": {
-          "version": "1.0.9",
-          "from": "which@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+          "version": "1.0.9"
         },
         "win-spawn": {
-          "version": "2.0.0",
-          "from": "win-spawn@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
+          "version": "2.0.0"
         }
       }
     },
     "grunt-jscs": {
       "version": "1.8.0",
-      "from": "grunt-jscs@1.8.0",
-      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-1.8.0.tgz",
       "dependencies": {
         "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+          "version": "0.2.3"
         },
         "jscs": {
           "version": "1.13.1",
-          "from": "jscs@>=1.13.0 <1.14.0",
-          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.0.0",
-              "from": "chalk@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.0.1",
-                  "from": "ansi-styles@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                  "version": "2.1.0"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                  "version": "1.0.3"
                 },
                 "has-ansi": {
                   "version": "1.0.3",
-                  "from": "has-ansi@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                      "version": "1.1.1"
                     },
                     "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                      "version": "4.0.1"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "2.0.1",
-                  "from": "strip-ansi@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                      "version": "1.1.1"
                     }
                   }
                 },
                 "supports-color": {
-                  "version": "1.3.1",
-                  "from": "supports-color@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                  "version": "1.3.1"
                 }
               }
             },
             "cli-table": {
               "version": "0.3.1",
-              "from": "cli-table@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
               "dependencies": {
                 "colors": {
-                  "version": "1.0.3",
-                  "from": "colors@1.0.3",
-                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+                  "version": "1.0.3"
                 }
               }
             },
             "commander": {
-              "version": "2.6.0",
-              "from": "commander@>=2.6.0 <2.7.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+              "version": "2.6.0"
             },
             "esprima": {
-              "version": "1.2.5",
-              "from": "esprima@>=1.2.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+              "version": "1.2.5"
             },
             "esprima-harmony-jscs": {
-              "version": "1.1.0-bin",
-              "from": "esprima-harmony-jscs@1.1.0-bin",
-              "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz"
+              "version": "1.1.0-bin"
             },
             "estraverse": {
-              "version": "1.9.3",
-              "from": "estraverse@>=1.9.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+              "version": "1.9.3"
             },
             "exit": {
-              "version": "0.1.2",
-              "from": "exit@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+              "version": "0.1.2"
             },
             "glob": {
-              "version": "5.0.10",
-              "from": "glob@>=5.0.1 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
+              "version": "5.0.14",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "lodash.assign": {
               "version": "3.0.0",
-              "from": "lodash.assign@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
-                      "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                      "version": "3.0.1"
                     },
                     "lodash.keys": {
-                      "version": "3.1.1",
-                      "from": "lodash.keys@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+                      "version": "3.1.2",
                       "dependencies": {
                         "lodash._getnative": {
-                          "version": "3.9.0",
-                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                          "version": "3.9.1"
                         },
                         "lodash.isarguments": {
-                          "version": "3.0.3",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                          "version": "3.0.4"
                         },
                         "lodash.isarray": {
-                          "version": "3.0.3",
-                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                          "version": "3.0.4"
                         }
                       }
                     }
@@ -4582,244 +2965,132 @@
                 },
                 "lodash._createassigner": {
                   "version": "3.1.1",
-                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
-                      "version": "3.0.1",
-                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                      "version": "3.0.1"
                     },
                     "lodash._isiterateecall": {
-                      "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                      "version": "3.0.9"
                     },
                     "lodash.restparam": {
-                      "version": "3.6.1",
-                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                      "version": "3.6.1"
                     }
                   }
                 }
               }
             },
             "minimatch": {
-              "version": "2.0.8",
-              "from": "minimatch@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "version": "2.0.10",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                      "version": "0.2.0"
                     },
                     "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      "version": "0.0.1"
                     }
                   }
                 }
               }
             },
             "pathval": {
-              "version": "0.1.1",
-              "from": "pathval@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
+              "version": "0.1.1"
             },
             "prompt": {
               "version": "0.2.14",
-              "from": "prompt@>=0.2.14 <0.3.0",
-              "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
               "dependencies": {
                 "pkginfo": {
-                  "version": "0.3.0",
-                  "from": "pkginfo@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+                  "version": "0.3.0"
                 },
                 "read": {
                   "version": "1.0.6",
-                  "from": "read@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
                   "dependencies": {
                     "mute-stream": {
-                      "version": "0.0.5",
-                      "from": "mute-stream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                      "version": "0.0.5"
                     }
                   }
                 },
                 "revalidator": {
-                  "version": "0.1.8",
-                  "from": "revalidator@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
+                  "version": "0.1.8"
                 },
                 "utile": {
                   "version": "0.2.1",
-                  "from": "utile@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "0.2.10",
-                      "from": "async@>=0.2.9 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                      "version": "0.2.10"
                     },
                     "deep-equal": {
-                      "version": "1.0.0",
-                      "from": "deep-equal@*",
-                      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "i": {
-                      "version": "0.3.3",
-                      "from": "i@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
+                      "version": "0.3.3"
                     },
                     "ncp": {
-                      "version": "0.4.2",
-                      "from": "ncp@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+                      "version": "0.4.2"
                     },
                     "rimraf": {
-                      "version": "2.4.0",
-                      "from": "rimraf@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.0.tgz",
-                      "dependencies": {
-                        "glob": {
-                          "version": "4.5.3",
-                          "from": "glob@>=4.4.2 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "from": "inflight@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "once": {
-                              "version": "1.3.2",
-                              "from": "once@>=1.3.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
+                      "version": "2.4.2"
                     }
                   }
                 },
                 "winston": {
                   "version": "0.8.3",
-                  "from": "winston@>=0.8.0 <0.9.0",
-                  "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "0.2.10",
-                      "from": "async@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                      "version": "0.2.10"
                     },
                     "colors": {
-                      "version": "0.6.2",
-                      "from": "colors@>=0.6.0 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+                      "version": "0.6.2"
                     },
                     "cycle": {
-                      "version": "1.0.3",
-                      "from": "cycle@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+                      "version": "1.0.3"
                     },
                     "eyes": {
-                      "version": "0.1.8",
-                      "from": "eyes@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+                      "version": "0.1.8"
                     },
                     "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                      "version": "0.1.2"
                     },
                     "stack-trace": {
-                      "version": "0.0.9",
-                      "from": "stack-trace@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+                      "version": "0.0.9"
                     }
                   }
                 }
               }
             },
             "strip-json-comments": {
-              "version": "1.0.2",
-              "from": "strip-json-comments@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+              "version": "1.0.4"
             },
             "vow-fs": {
               "version": "0.3.4",
-              "from": "vow-fs@>=0.3.4 <0.4.0",
-              "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
               "dependencies": {
                 "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                  "version": "1.4.3"
                 },
                 "vow-queue": {
-                  "version": "0.4.2",
-                  "from": "vow-queue@>=0.4.1 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
+                  "version": "0.4.2"
                 },
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@>=4.3.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
@@ -4829,545 +3100,377 @@
             },
             "xmlbuilder": {
               "version": "2.6.4",
-              "from": "xmlbuilder@>=2.6.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz",
               "dependencies": {
                 "lodash": {
-                  "version": "3.9.3",
-                  "from": "lodash@>=3.5.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+                  "version": "3.10.1"
                 }
               }
             }
           }
         },
         "lodash": {
-          "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+          "version": "2.4.2"
         },
         "vow": {
-          "version": "0.4.10",
-          "from": "vow@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.10.tgz"
+          "version": "0.4.10"
         }
       }
     },
     "grunt-karma": {
       "version": "0.10.1",
-      "from": "grunt-karma@0.10.1",
-      "resolved": "https://registry.npmjs.org/grunt-karma/-/grunt-karma-0.10.1.tgz",
       "dependencies": {
         "lodash": {
-          "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+          "version": "2.4.2"
         }
       }
     },
     "grunt-mkdir": {
-      "version": "0.1.2",
-      "from": "grunt-mkdir@0.1.2",
-      "resolved": "https://registry.npmjs.org/grunt-mkdir/-/grunt-mkdir-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "grunt-pagespeed": {
       "version": "0.3.0",
-      "from": "grunt-pagespeed@0.3.0",
-      "resolved": "https://registry.npmjs.org/grunt-pagespeed/-/grunt-pagespeed-0.3.0.tgz",
       "dependencies": {
         "psi": {
           "version": "0.1.6",
-          "from": "psi@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/psi/-/psi-0.1.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                  "version": "1.1.0"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                  "version": "1.0.3"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                      "version": "0.2.1"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                      "version": "0.2.1"
                     }
                   }
                 },
                 "supports-color": {
-                  "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                  "version": "0.2.0"
                 }
               }
             },
             "gpagespeed": {
               "version": "0.0.8",
-              "from": "gpagespeed@0.0.8",
-              "resolved": "https://registry.npmjs.org/gpagespeed/-/gpagespeed-0.0.8.tgz",
               "dependencies": {
                 "googleapis": {
                   "version": "1.1.5",
-                  "from": "googleapis@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-1.1.5.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                      "version": "0.9.2"
                     },
                     "gapitoken": {
-                      "version": "0.1.4",
-                      "from": "gapitoken@>=0.1.2 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/gapitoken/-/gapitoken-0.1.4.tgz",
+                      "version": "0.1.5",
                       "dependencies": {
                         "jws": {
-                          "version": "0.0.2",
-                          "from": "jws@0.0.2",
-                          "resolved": "https://registry.npmjs.org/jws/-/jws-0.0.2.tgz",
+                          "version": "3.0.0",
                           "dependencies": {
-                            "tap": {
-                              "version": "0.3.3",
-                              "from": "tap@>=0.3.3 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/tap/-/tap-0.3.3.tgz",
+                            "jwa": {
+                              "version": "1.0.2",
                               "dependencies": {
-                                "inherits": {
-                                  "version": "1.0.0"
+                                "base64url": {
+                                  "version": "0.0.6"
                                 },
-                                "yamlish": {
-                                  "version": "0.0.5"
+                                "buffer-equal-constant-time": {
+                                  "version": "1.0.1"
                                 },
-                                "slide": {
-                                  "version": "1.1.6",
-                                  "from": "slide@*",
-                                  "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-                                },
-                                "runforcover": {
-                                  "version": "0.0.2",
-                                  "from": "runforcover@>=0.0.2 <0.1.0",
-                                  "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+                                "ecdsa-sig-formatter": {
+                                  "version": "1.0.2",
                                   "dependencies": {
-                                    "bunker": {
-                                      "version": "0.1.2",
-                                      "from": "bunker@>=0.1.0 <0.2.0",
-                                      "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+                                    "asn1.js": {
+                                      "version": "2.2.0",
                                       "dependencies": {
-                                        "burrito": {
-                                          "version": "0.2.12",
-                                          "from": "burrito@>=0.2.5 <0.3.0",
-                                          "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
-                                          "dependencies": {
-                                            "traverse": {
-                                              "version": "0.5.2",
-                                              "from": "traverse@>=0.5.1 <0.6.0",
-                                              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
-                                            },
-                                            "uglify-js": {
-                                              "version": "1.1.1",
-                                              "from": "uglify-js@>=1.1.1 <1.2.0",
-                                              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
-                                            }
-                                          }
+                                        "bn.js": {
+                                          "version": "2.2.0"
+                                        },
+                                        "inherits": {
+                                          "version": "2.0.1"
+                                        },
+                                        "minimalistic-assert": {
+                                          "version": "1.0.0"
                                         }
                                       }
-                                    }
-                                  }
-                                },
-                                "nopt": {
-                                  "version": "2.2.1",
-                                  "from": "nopt@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
-                                  "dependencies": {
-                                    "abbrev": {
-                                      "version": "1.0.7",
-                                      "from": "abbrev@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                                    }
-                                  }
-                                },
-                                "mkdirp": {
-                                  "version": "0.3.5",
-                                  "from": "mkdirp@>=0.3.0 <0.4.0",
-                                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
-                                },
-                                "difflet": {
-                                  "version": "0.2.6",
-                                  "from": "difflet@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
-                                  "dependencies": {
-                                    "traverse": {
-                                      "version": "0.6.6",
-                                      "from": "traverse@>=0.6.0 <0.7.0",
-                                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
                                     },
-                                    "charm": {
-                                      "version": "0.1.2",
-                                      "from": "charm@>=0.1.0 <0.2.0",
-                                      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
-                                    },
-                                    "deep-is": {
-                                      "version": "0.1.3",
-                                      "from": "deep-is@>=0.1.0 <0.2.0",
-                                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                                    }
-                                  }
-                                },
-                                "deep-equal": {
-                                  "version": "0.0.0",
-                                  "from": "deep-equal@>=0.0.0 <0.1.0",
-                                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
-                                },
-                                "buffer-equal": {
-                                  "version": "0.0.1",
-                                  "from": "buffer-equal@>=0.0.0 <0.1.0",
-                                  "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
-                                },
-                                "tap-consumer": {
-                                  "version": "0.0.1",
-                                  "from": "tap-consumer@*",
-                                  "resolved": "https://registry.npmjs.org/tap-consumer/-/tap-consumer-0.0.1.tgz",
-                                  "dependencies": {
-                                    "tap-results": {
-                                      "version": "0.0.2",
-                                      "from": "tap-results@>=0.0.0 <1.0.0",
-                                      "resolved": "https://registry.npmjs.org/tap-results/-/tap-results-0.0.2.tgz"
+                                    "base64-url": {
+                                      "version": "1.2.1"
                                     }
                                   }
                                 }
                               }
                             },
                             "base64url": {
-                              "version": "0.0.3",
-                              "from": "base64url@0.0.3",
-                              "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.3.tgz"
+                              "version": "1.0.4",
+                              "dependencies": {
+                                "concat-stream": {
+                                  "version": "1.4.10",
+                                  "dependencies": {
+                                    "inherits": {
+                                      "version": "2.0.1"
+                                    },
+                                    "typedarray": {
+                                      "version": "0.0.6"
+                                    },
+                                    "readable-stream": {
+                                      "version": "1.1.13",
+                                      "dependencies": {
+                                        "core-util-is": {
+                                          "version": "1.0.1"
+                                        },
+                                        "isarray": {
+                                          "version": "0.0.1"
+                                        },
+                                        "string_decoder": {
+                                          "version": "0.10.31"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "meow": {
+                                  "version": "2.0.0",
+                                  "dependencies": {
+                                    "camelcase-keys": {
+                                      "version": "1.0.0",
+                                      "dependencies": {
+                                        "camelcase": {
+                                          "version": "1.2.1"
+                                        },
+                                        "map-obj": {
+                                          "version": "1.0.1"
+                                        }
+                                      }
+                                    },
+                                    "indent-string": {
+                                      "version": "1.2.2",
+                                      "dependencies": {
+                                        "get-stdin": {
+                                          "version": "4.0.1"
+                                        },
+                                        "repeating": {
+                                          "version": "1.1.3",
+                                          "dependencies": {
+                                            "is-finite": {
+                                              "version": "1.0.1",
+                                              "dependencies": {
+                                                "number-is-nan": {
+                                                  "version": "1.0.0"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "minimist": {
+                                      "version": "1.1.3"
+                                    },
+                                    "object-assign": {
+                                      "version": "1.0.0"
+                                    }
+                                  }
+                                }
+                              }
                             }
                           }
                         },
                         "request": {
-                          "version": "2.58.0",
-                          "from": "request@>=2.54.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
+                          "version": "2.60.0",
                           "dependencies": {
                             "bl": {
-                              "version": "0.9.4",
-                              "from": "bl@>=0.9.0 <0.10.0",
-                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                              "version": "1.0.0",
                               "dependencies": {
                                 "readable-stream": {
-                                  "version": "1.0.33",
-                                  "from": "readable-stream@>=1.0.26 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                  "version": "2.0.2",
                                   "dependencies": {
                                     "core-util-is": {
-                                      "version": "1.0.1",
-                                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                                    },
-                                    "isarray": {
-                                      "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                    },
-                                    "string_decoder": {
-                                      "version": "0.10.31",
-                                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                      "version": "1.0.1"
                                     },
                                     "inherits": {
-                                      "version": "2.0.1",
-                                      "from": "inherits@>=2.0.1 <2.1.0",
-                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                      "version": "2.0.1"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.2"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.1"
                                     }
                                   }
                                 }
                               }
                             },
                             "caseless": {
-                              "version": "0.10.0",
-                              "from": "caseless@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
+                              "version": "0.11.0"
                             },
                             "extend": {
-                              "version": "2.0.1",
-                              "from": "extend@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+                              "version": "3.0.0"
                             },
                             "forever-agent": {
-                              "version": "0.6.1",
-                              "from": "forever-agent@>=0.6.0 <0.7.0",
-                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                              "version": "0.6.1"
                             },
                             "form-data": {
-                              "version": "1.0.0-rc1",
-                              "from": "form-data@>=1.0.0-rc1 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
+                              "version": "1.0.0-rc3",
                               "dependencies": {
                                 "async": {
-                                  "version": "1.2.1",
-                                  "from": "async@>=1.2.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
-                                },
-                                "mime-types": {
-                                  "version": "2.1.1",
-                                  "from": "mime-types@>=2.1.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
-                                  "dependencies": {
-                                    "mime-db": {
-                                      "version": "1.13.0",
-                                      "from": "mime-db@>=1.13.0 <1.14.0",
-                                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
-                                    }
-                                  }
+                                  "version": "1.4.2"
                                 }
                               }
                             },
                             "json-stringify-safe": {
-                              "version": "5.0.1",
-                              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                              "version": "5.0.1"
                             },
                             "mime-types": {
-                              "version": "2.0.14",
-                              "from": "mime-types@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                              "version": "2.1.4",
                               "dependencies": {
                                 "mime-db": {
-                                  "version": "1.12.0",
-                                  "from": "mime-db@>=1.12.0 <1.13.0",
-                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                                  "version": "1.16.0"
                                 }
                               }
                             },
                             "node-uuid": {
-                              "version": "1.4.3",
-                              "from": "node-uuid@>=1.4.0 <1.5.0",
-                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                              "version": "1.4.3"
                             },
                             "qs": {
-                              "version": "3.1.0",
-                              "from": "qs@>=3.1.0 <3.2.0",
-                              "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
+                              "version": "4.0.0"
                             },
                             "tunnel-agent": {
-                              "version": "0.4.0",
-                              "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                              "version": "0.4.1"
                             },
                             "tough-cookie": {
-                              "version": "2.0.0",
-                              "from": "tough-cookie@>=0.12.0",
-                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                              "version": "2.0.0"
                             },
                             "http-signature": {
                               "version": "0.11.0",
-                              "from": "http-signature@>=0.11.0 <0.12.0",
-                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                               "dependencies": {
                                 "assert-plus": {
-                                  "version": "0.1.5",
-                                  "from": "assert-plus@>=0.1.5 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                                  "version": "0.1.5"
                                 },
                                 "asn1": {
-                                  "version": "0.1.11",
-                                  "from": "asn1@0.1.11",
-                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                                  "version": "0.1.11"
                                 },
                                 "ctype": {
-                                  "version": "0.5.3",
-                                  "from": "ctype@0.5.3",
-                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                                  "version": "0.5.3"
                                 }
                               }
                             },
                             "oauth-sign": {
-                              "version": "0.8.0",
-                              "from": "oauth-sign@>=0.8.0 <0.9.0",
-                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                              "version": "0.8.0"
                             },
                             "hawk": {
-                              "version": "2.3.1",
-                              "from": "hawk@>=2.3.0 <2.4.0",
-                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                              "version": "3.1.0",
                               "dependencies": {
                                 "hoek": {
-                                  "version": "2.14.0",
-                                  "from": "hoek@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
+                                  "version": "2.14.0"
                                 },
                                 "boom": {
-                                  "version": "2.8.0",
-                                  "from": "boom@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
+                                  "version": "2.8.0"
                                 },
                                 "cryptiles": {
-                                  "version": "2.0.4",
-                                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                                  "version": "2.0.4"
                                 },
                                 "sntp": {
-                                  "version": "1.0.9",
-                                  "from": "sntp@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                                  "version": "1.0.9"
                                 }
                               }
                             },
                             "aws-sign2": {
-                              "version": "0.5.0",
-                              "from": "aws-sign2@>=0.5.0 <0.6.0",
-                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                              "version": "0.5.0"
                             },
                             "stringstream": {
-                              "version": "0.0.4",
-                              "from": "stringstream@>=0.0.4 <0.1.0",
-                              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                              "version": "0.0.4"
                             },
                             "combined-stream": {
                               "version": "1.0.5",
-                              "from": "combined-stream@>=1.0.1 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                               "dependencies": {
                                 "delayed-stream": {
-                                  "version": "1.0.0",
-                                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                                  "version": "1.0.0"
                                 }
                               }
                             },
                             "isstream": {
-                              "version": "0.1.2",
-                              "from": "isstream@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                              "version": "0.1.2"
                             },
                             "har-validator": {
                               "version": "1.8.0",
-                              "from": "har-validator@>=1.6.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                               "dependencies": {
                                 "bluebird": {
-                                  "version": "2.9.30",
-                                  "from": "bluebird@>=2.9.30 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.30.tgz"
+                                  "version": "2.9.34"
                                 },
                                 "chalk": {
-                                  "version": "1.0.0",
-                                  "from": "chalk@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                                  "version": "1.1.0",
                                   "dependencies": {
                                     "ansi-styles": {
-                                      "version": "2.0.1",
-                                      "from": "ansi-styles@>=2.0.1 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                                      "version": "2.1.0"
                                     },
                                     "escape-string-regexp": {
-                                      "version": "1.0.3",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                      "version": "1.0.3"
                                     },
                                     "has-ansi": {
-                                      "version": "1.0.3",
-                                      "from": "has-ansi@>=1.0.3 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                                      "version": "2.0.0",
                                       "dependencies": {
                                         "ansi-regex": {
-                                          "version": "1.1.1",
-                                          "from": "ansi-regex@>=1.1.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                                        },
-                                        "get-stdin": {
-                                          "version": "4.0.1",
-                                          "from": "get-stdin@>=4.0.1 <5.0.0",
-                                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                          "version": "2.0.0"
                                         }
                                       }
                                     },
                                     "strip-ansi": {
-                                      "version": "2.0.1",
-                                      "from": "strip-ansi@>=2.0.1 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                                      "version": "3.0.0",
                                       "dependencies": {
                                         "ansi-regex": {
-                                          "version": "1.1.1",
-                                          "from": "ansi-regex@>=1.1.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                          "version": "2.0.0"
                                         }
                                       }
                                     },
                                     "supports-color": {
-                                      "version": "1.3.1",
-                                      "from": "supports-color@>=1.3.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                                      "version": "2.0.0"
                                     }
                                   }
                                 },
                                 "commander": {
                                   "version": "2.8.1",
-                                  "from": "commander@>=2.8.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                                   "dependencies": {
                                     "graceful-readlink": {
-                                      "version": "1.0.1",
-                                      "from": "graceful-readlink@>=1.0.0",
-                                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                      "version": "1.0.1"
                                     }
                                   }
                                 },
                                 "is-my-json-valid": {
-                                  "version": "2.12.0",
-                                  "from": "is-my-json-valid@>=2.12.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                                  "version": "2.12.1",
                                   "dependencies": {
                                     "generate-function": {
-                                      "version": "2.0.0",
-                                      "from": "generate-function@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                                      "version": "2.0.0"
                                     },
                                     "generate-object-property": {
                                       "version": "1.2.0",
-                                      "from": "generate-object-property@>=1.1.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                                       "dependencies": {
                                         "is-property": {
-                                          "version": "1.0.2",
-                                          "from": "is-property@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                                          "version": "1.0.2"
                                         }
                                       }
                                     },
                                     "jsonpointer": {
-                                      "version": "1.1.0",
-                                      "from": "jsonpointer@>=1.1.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                                      "version": "1.1.0"
                                     },
                                     "xtend": {
-                                      "version": "4.0.0",
-                                      "from": "xtend@>=4.0.0 <5.0.0",
-                                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                                      "version": "4.0.0"
                                     }
                                   }
                                 }
@@ -5379,260 +3482,166 @@
                     },
                     "request": {
                       "version": "2.51.0",
-                      "from": "request@>=2.51.0 <2.52.0",
-                      "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                       "dependencies": {
                         "bl": {
                           "version": "0.9.4",
-                          "from": "bl@>=0.9.0 <0.10.0",
-                          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "1.0.33",
-                              "from": "readable-stream@>=1.0.26 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                               "dependencies": {
                                 "core-util-is": {
-                                  "version": "1.0.1",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                  "version": "1.0.1"
                                 },
                                 "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                  "version": "0.0.1"
                                 },
                                 "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                  "version": "0.10.31"
                                 },
                                 "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                  "version": "2.0.1"
                                 }
                               }
                             }
                           }
                         },
                         "caseless": {
-                          "version": "0.8.0",
-                          "from": "caseless@>=0.8.0 <0.9.0",
-                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                          "version": "0.8.0"
                         },
                         "forever-agent": {
-                          "version": "0.5.2",
-                          "from": "forever-agent@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                          "version": "0.5.2"
                         },
                         "form-data": {
                           "version": "0.2.0",
-                          "from": "form-data@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                           "dependencies": {
                             "mime-types": {
                               "version": "2.0.14",
-                              "from": "mime-types@>=2.0.3 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                               "dependencies": {
                                 "mime-db": {
-                                  "version": "1.12.0",
-                                  "from": "mime-db@>=1.12.0 <1.13.0",
-                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                                  "version": "1.12.0"
                                 }
                               }
                             }
                           }
                         },
                         "json-stringify-safe": {
-                          "version": "5.0.1",
-                          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                          "version": "5.0.1"
                         },
                         "mime-types": {
-                          "version": "1.0.2",
-                          "from": "mime-types@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                          "version": "1.0.2"
                         },
                         "node-uuid": {
-                          "version": "1.4.3",
-                          "from": "node-uuid@>=1.4.0 <1.5.0",
-                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                          "version": "1.4.3"
                         },
                         "qs": {
-                          "version": "2.3.3",
-                          "from": "qs@>=2.3.1 <2.4.0",
-                          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                          "version": "2.3.3"
                         },
                         "tunnel-agent": {
-                          "version": "0.4.0",
-                          "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                          "version": "0.4.1"
                         },
                         "tough-cookie": {
-                          "version": "2.0.0",
-                          "from": "tough-cookie@>=0.12.0",
-                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                          "version": "2.0.0"
                         },
                         "http-signature": {
                           "version": "0.10.1",
-                          "from": "http-signature@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                           "dependencies": {
                             "assert-plus": {
-                              "version": "0.1.5",
-                              "from": "assert-plus@>=0.1.5 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                              "version": "0.1.5"
                             },
                             "asn1": {
-                              "version": "0.1.11",
-                              "from": "asn1@0.1.11",
-                              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                              "version": "0.1.11"
                             },
                             "ctype": {
-                              "version": "0.5.3",
-                              "from": "ctype@0.5.3",
-                              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                              "version": "0.5.3"
                             }
                           }
                         },
                         "oauth-sign": {
-                          "version": "0.5.0",
-                          "from": "oauth-sign@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                          "version": "0.5.0"
                         },
                         "hawk": {
                           "version": "1.1.1",
-                          "from": "hawk@1.1.1",
-                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                           "dependencies": {
                             "hoek": {
-                              "version": "0.9.1",
-                              "from": "hoek@>=0.9.0 <0.10.0",
-                              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                              "version": "0.9.1"
                             },
                             "boom": {
-                              "version": "0.4.2",
-                              "from": "boom@>=0.4.0 <0.5.0",
-                              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                              "version": "0.4.2"
                             },
                             "cryptiles": {
-                              "version": "0.2.2",
-                              "from": "cryptiles@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                              "version": "0.2.2"
                             },
                             "sntp": {
-                              "version": "0.2.4",
-                              "from": "sntp@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                              "version": "0.2.4"
                             }
                           }
                         },
                         "aws-sign2": {
-                          "version": "0.5.0",
-                          "from": "aws-sign2@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                          "version": "0.5.0"
                         },
                         "stringstream": {
-                          "version": "0.0.4",
-                          "from": "stringstream@>=0.0.4 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                          "version": "0.0.4"
                         },
                         "combined-stream": {
                           "version": "0.0.7",
-                          "from": "combined-stream@>=0.0.5 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                           "dependencies": {
                             "delayed-stream": {
-                              "version": "0.0.5",
-                              "from": "delayed-stream@0.0.5",
-                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                              "version": "0.0.5"
                             }
                           }
                         }
                       }
                     },
                     "string-template": {
-                      "version": "0.2.1",
-                      "from": "string-template@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
+                      "version": "0.2.1"
                     }
                   }
                 },
                 "minimist": {
-                  "version": "0.2.0",
-                  "from": "minimist@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+                  "version": "0.2.0"
                 },
                 "valid-url": {
-                  "version": "1.0.9",
-                  "from": "valid-url@>=1.0.9 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz"
+                  "version": "1.0.9"
                 }
               }
             },
             "minimist": {
-              "version": "1.1.1",
-              "from": "minimist@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+              "version": "1.1.3"
             },
             "prepend-http": {
-              "version": "1.0.1",
-              "from": "prepend-http@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+              "version": "1.0.2"
             },
             "pretty-bytes": {
               "version": "1.0.4",
-              "from": "pretty-bytes@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
               "dependencies": {
                 "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "4.0.1"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "meow@>=3.1.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.1.0",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                          "version": "1.2.1"
                         },
                         "map-obj": {
-                          "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "indent-string": {
-                      "version": "1.2.1",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "version": "1.2.2",
                       "dependencies": {
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                  "version": "1.0.0"
                                 }
                               }
                             }
@@ -5641,9 +3650,7 @@
                       }
                     },
                     "object-assign": {
-                      "version": "3.0.0",
-                      "from": "object-assign@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                      "version": "3.0.0"
                     }
                   }
                 }
@@ -5655,81 +3662,53 @@
     },
     "grunt-px-to-rem": {
       "version": "0.4.0",
-      "from": "grunt-px-to-rem@0.4.0",
-      "resolved": "https://registry.npmjs.org/grunt-px-to-rem/-/grunt-px-to-rem-0.4.0.tgz",
       "dependencies": {
         "postcss": {
           "version": "4.0.6",
-          "from": "postcss@>=4.0.6 <4.1.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.2.0",
-              "from": "source-map@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.1",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "js-base64": {
-              "version": "2.1.8",
-              "from": "js-base64@>=2.1.7 <2.2.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz"
+              "version": "2.1.9"
             }
           }
         },
         "chalk": {
           "version": "1.0.0",
-          "from": "chalk@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.0.1",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+              "version": "2.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "1.1.1"
                 },
                 "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "4.0.1"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "1.1.1"
                 }
               }
             },
             "supports-color": {
-              "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+              "version": "1.3.1"
             }
           }
         }
@@ -5737,128 +3716,82 @@
     },
     "grunt-sass": {
       "version": "1.0.0",
-      "from": "grunt-sass@1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-1.0.0.tgz",
       "dependencies": {
         "each-async": {
           "version": "1.1.1",
-          "from": "each-async@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
-              "version": "1.0.0",
-              "from": "onetime@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "set-immediate-shim": {
-              "version": "1.0.1",
-              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         },
         "node-sass": {
           "version": "3.2.0",
-          "from": "node-sass@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.2.0.tgz",
           "dependencies": {
             "async-foreach": {
-              "version": "0.1.3",
-              "from": "async-foreach@>=0.1.3 <0.2.0",
-              "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
+              "version": "0.1.3"
             },
             "chalk": {
-              "version": "1.0.0",
-              "from": "chalk@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "version": "1.1.0",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.0.1",
-                  "from": "ansi-styles@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                  "version": "2.1.0"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                  "version": "1.0.3"
                 },
                 "has-ansi": {
-                  "version": "1.0.3",
-                  "from": "has-ansi@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "version": "2.0.0",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                      "version": "2.0.0"
                     }
                   }
                 },
                 "strip-ansi": {
-                  "version": "2.0.1",
-                  "from": "strip-ansi@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "version": "3.0.0",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                      "version": "2.0.0"
                     }
                   }
                 },
                 "supports-color": {
-                  "version": "1.3.1",
-                  "from": "supports-color@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "gaze": {
               "version": "0.5.1",
-              "from": "gaze@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
               "dependencies": {
                 "globule": {
                   "version": "0.1.0",
-                  "from": "globule@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                   "dependencies": {
                     "lodash": {
-                      "version": "1.0.2",
-                      "from": "lodash@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "glob": {
                       "version": "3.1.21",
-                      "from": "glob@>=3.1.21 <3.2.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                       "dependencies": {
                         "graceful-fs": {
-                          "version": "1.2.3",
-                          "from": "graceful-fs@>=1.2.0 <1.3.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                          "version": "1.2.3"
                         },
                         "inherits": {
-                          "version": "1.0.0",
-                          "from": "inherits@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@>=0.2.11 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.6.4",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                          "version": "2.6.5"
                         },
                         "sigmund": {
-                          "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
@@ -5867,51 +3800,33 @@
               }
             },
             "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "version": "4.0.1"
             },
             "glob": {
-              "version": "5.0.10",
-              "from": "glob@>=5.0.3 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
+              "version": "5.0.14",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "minimatch": {
-                  "version": "2.0.8",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "version": "2.0.10",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                          "version": "0.2.0"
                         },
                         "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "version": "0.0.1"
                         }
                       }
                     }
@@ -5919,64 +3834,42 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@>=3.1.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.1.0",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                      "version": "1.2.1"
                     },
                     "map-obj": {
-                      "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "indent-string": {
-                  "version": "1.2.1",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "version": "1.2.2",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
-                              "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                              "version": "1.0.0"
                             }
                           }
                         }
@@ -5985,235 +3878,156 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.1.1",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                  "version": "1.1.3"
                 },
                 "object-assign": {
-                  "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                  "version": "3.0.0"
                 }
               }
             },
             "nan": {
-              "version": "1.8.4",
-              "from": "nan@>=1.8.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+              "version": "1.9.0"
             },
             "npmconf": {
               "version": "2.1.2",
-              "from": "npmconf@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
               "dependencies": {
                 "config-chain": {
                   "version": "1.1.9",
-                  "from": "config-chain@>=1.1.8 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
                   "dependencies": {
                     "proto-list": {
-                      "version": "1.2.4",
-                      "from": "proto-list@>=1.2.1 <1.3.0",
-                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                      "version": "1.2.4"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@>=1.2.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                  "version": "1.3.4"
                 },
                 "nopt": {
-                  "version": "3.0.2",
-                  "from": "nopt@>=3.0.1 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+                  "version": "3.0.3",
                   "dependencies": {
                     "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                      "version": "1.0.7"
                     }
                   }
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "osenv": {
-                  "version": "0.1.2",
-                  "from": "osenv@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
+                  "version": "0.1.3",
                   "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1"
+                    },
                     "os-tmpdir": {
-                      "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "semver": {
-                  "version": "4.3.6",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                  "version": "4.3.6"
                 },
                 "uid-number": {
-                  "version": "0.0.5",
-                  "from": "uid-number@0.0.5",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                  "version": "0.0.5"
                 }
               }
             },
             "pangyp": {
-              "version": "2.2.1",
-              "from": "pangyp@>=2.2.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.1.tgz",
+              "version": "2.3.0",
               "dependencies": {
                 "fstream": {
                   "version": "1.0.7",
-                  "from": "fstream@>=1.0.3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
                   "dependencies": {
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     }
                   }
                 },
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@>=4.3.5 <4.4.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
                   }
                 },
                 "graceful-fs": {
-                  "version": "3.0.8",
-                  "from": "graceful-fs@>=3.0.5 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                  "version": "3.0.8"
                 },
                 "minimatch": {
-                  "version": "2.0.8",
-                  "from": "minimatch@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "version": "2.0.10",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                          "version": "0.2.0"
                         },
                         "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "version": "0.0.1"
                         }
                       }
                     }
                   }
                 },
                 "nopt": {
-                  "version": "3.0.2",
-                  "from": "nopt@>=3.0.1 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+                  "version": "3.0.3",
                   "dependencies": {
                     "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                      "version": "1.0.7"
                     }
                   }
                 },
                 "npmlog": {
                   "version": "1.0.0",
-                  "from": "npmlog@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
                   "dependencies": {
                     "ansi": {
-                      "version": "0.3.0",
-                      "from": "ansi@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                      "version": "0.3.0"
                     },
                     "are-we-there-yet": {
                       "version": "1.0.4",
-                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
                       "dependencies": {
                         "delegates": {
-                          "version": "0.1.0",
-                          "from": "delegates@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                          "version": "0.1.0"
                         },
                         "readable-stream": {
                           "version": "1.1.13",
-                          "from": "readable-stream@>=1.1.13 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                              "version": "1.0.1"
                             },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "0.0.1"
                             },
                             "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                              "version": "0.10.31"
                             },
                             "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "version": "2.0.1"
                             }
                           }
                         }
@@ -6221,494 +4035,317 @@
                     },
                     "gauge": {
                       "version": "1.0.2",
-                      "from": "gauge@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
                       "dependencies": {
                         "has-unicode": {
-                          "version": "1.0.0",
-                          "from": "has-unicode@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     }
                   }
                 },
                 "osenv": {
-                  "version": "0.1.2",
-                  "from": "osenv@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
+                  "version": "0.1.3",
                   "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1"
+                    },
                     "os-tmpdir": {
-                      "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "request": {
                   "version": "2.51.0",
-                  "from": "request@>=2.51.0 <2.52.0",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "0.9.4",
-                      "from": "bl@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.26 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                              "version": "1.0.1"
                             },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "0.0.1"
                             },
                             "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                              "version": "0.10.31"
                             },
                             "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "version": "2.0.1"
                             }
                           }
                         }
                       }
                     },
                     "caseless": {
-                      "version": "0.8.0",
-                      "from": "caseless@>=0.8.0 <0.9.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                      "version": "0.8.0"
                     },
                     "forever-agent": {
-                      "version": "0.5.2",
-                      "from": "forever-agent@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                      "version": "0.5.2"
                     },
                     "form-data": {
                       "version": "0.2.0",
-                      "from": "form-data@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                       "dependencies": {
                         "async": {
-                          "version": "0.9.2",
-                          "from": "async@>=0.9.0 <0.10.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                          "version": "0.9.2"
                         },
                         "mime-types": {
                           "version": "2.0.14",
-                          "from": "mime-types@>=2.0.3 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                           "dependencies": {
                             "mime-db": {
-                              "version": "1.12.0",
-                              "from": "mime-db@>=1.12.0 <1.13.0",
-                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                              "version": "1.12.0"
                             }
                           }
                         }
                       }
                     },
                     "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                      "version": "5.0.1"
                     },
                     "mime-types": {
-                      "version": "1.0.2",
-                      "from": "mime-types@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "node-uuid": {
-                      "version": "1.4.3",
-                      "from": "node-uuid@>=1.4.0 <1.5.0",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                      "version": "1.4.3"
                     },
                     "qs": {
-                      "version": "2.3.3",
-                      "from": "qs@>=2.3.1 <2.4.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                      "version": "2.3.3"
                     },
                     "tunnel-agent": {
-                      "version": "0.4.0",
-                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                      "version": "0.4.1"
                     },
                     "tough-cookie": {
-                      "version": "2.0.0",
-                      "from": "tough-cookie@>=0.12.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "http-signature": {
                       "version": "0.10.1",
-                      "from": "http-signature@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                       "dependencies": {
                         "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "assert-plus@>=0.1.5 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                          "version": "0.1.5"
                         },
                         "asn1": {
-                          "version": "0.1.11",
-                          "from": "asn1@0.1.11",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                          "version": "0.1.11"
                         },
                         "ctype": {
-                          "version": "0.5.3",
-                          "from": "ctype@0.5.3",
-                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                          "version": "0.5.3"
                         }
                       }
                     },
                     "oauth-sign": {
-                      "version": "0.5.0",
-                      "from": "oauth-sign@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                      "version": "0.5.0"
                     },
                     "hawk": {
                       "version": "1.1.1",
-                      "from": "hawk@1.1.1",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                       "dependencies": {
                         "hoek": {
-                          "version": "0.9.1",
-                          "from": "hoek@>=0.9.0 <0.10.0",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                          "version": "0.9.1"
                         },
                         "boom": {
-                          "version": "0.4.2",
-                          "from": "boom@>=0.4.0 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                          "version": "0.4.2"
                         },
                         "cryptiles": {
-                          "version": "0.2.2",
-                          "from": "cryptiles@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                          "version": "0.2.2"
                         },
                         "sntp": {
-                          "version": "0.2.4",
-                          "from": "sntp@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                          "version": "0.2.4"
                         }
                       }
                     },
                     "aws-sign2": {
-                      "version": "0.5.0",
-                      "from": "aws-sign2@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                      "version": "0.5.0"
                     },
                     "stringstream": {
-                      "version": "0.0.4",
-                      "from": "stringstream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                      "version": "0.0.4"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.5 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                          "version": "0.0.5"
                         }
                       }
                     }
                   }
                 },
                 "rimraf": {
-                  "version": "2.2.8",
-                  "from": "rimraf@>=2.2.8 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                  "version": "2.2.8"
                 },
                 "semver": {
-                  "version": "4.3.6",
-                  "from": "semver@>=4.3.6 <4.4.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                  "version": "4.3.6"
                 },
                 "tar": {
                   "version": "1.0.3",
-                  "from": "tar@>=1.0.3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
                   "dependencies": {
                     "block-stream": {
-                      "version": "0.0.8",
-                      "from": "block-stream@*",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                      "version": "0.0.8"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     }
                   }
                 },
                 "which": {
-                  "version": "1.0.9",
-                  "from": "which@>=1.0.8 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+                  "version": "1.0.9"
                 }
               }
             },
             "request": {
-              "version": "2.58.0",
-              "from": "request@>=2.55.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
+              "version": "2.60.0",
               "dependencies": {
                 "bl": {
-                  "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "version": "1.0.0",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "version": "2.0.2",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "1.0.1"
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.1"
+                        },
+                        "isarray": {
+                          "version": "0.0.1"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.2"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.1"
                         }
                       }
                     }
                   }
                 },
                 "caseless": {
-                  "version": "0.10.0",
-                  "from": "caseless@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
+                  "version": "0.11.0"
                 },
                 "extend": {
-                  "version": "2.0.1",
-                  "from": "extend@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+                  "version": "3.0.0"
                 },
                 "forever-agent": {
-                  "version": "0.6.1",
-                  "from": "forever-agent@>=0.6.0 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                  "version": "0.6.1"
                 },
                 "form-data": {
-                  "version": "1.0.0-rc1",
-                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
+                  "version": "1.0.0-rc3",
                   "dependencies": {
                     "async": {
-                      "version": "1.2.1",
-                      "from": "async@>=1.2.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.1.1",
-                      "from": "mime-types@>=2.1.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.13.0",
-                          "from": "mime-db@>=1.13.0 <1.14.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
-                        }
-                      }
+                      "version": "1.4.2"
                     }
                   }
                 },
                 "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                  "version": "5.0.1"
                 },
                 "mime-types": {
-                  "version": "2.0.14",
-                  "from": "mime-types@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                  "version": "2.1.4",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.12.0",
-                      "from": "mime-db@>=1.12.0 <1.13.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                      "version": "1.16.0"
                     }
                   }
                 },
                 "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                  "version": "1.4.3"
                 },
                 "qs": {
-                  "version": "3.1.0",
-                  "from": "qs@>=3.1.0 <3.2.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
+                  "version": "4.0.0"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.0",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                  "version": "0.4.1"
                 },
                 "tough-cookie": {
-                  "version": "2.0.0",
-                  "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                  "version": "2.0.0"
                 },
                 "http-signature": {
                   "version": "0.11.0",
-                  "from": "http-signature@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                   "dependencies": {
                     "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                      "version": "0.1.5"
                     },
                     "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                      "version": "0.1.11"
                     },
                     "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                      "version": "0.5.3"
                     }
                   }
                 },
                 "oauth-sign": {
-                  "version": "0.8.0",
-                  "from": "oauth-sign@>=0.8.0 <0.9.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                  "version": "0.8.0"
                 },
                 "hawk": {
-                  "version": "2.3.1",
-                  "from": "hawk@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "version": "3.1.0",
                   "dependencies": {
                     "hoek": {
-                      "version": "2.14.0",
-                      "from": "hoek@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
+                      "version": "2.14.0"
                     },
                     "boom": {
-                      "version": "2.8.0",
-                      "from": "boom@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
+                      "version": "2.8.0"
                     },
                     "cryptiles": {
-                      "version": "2.0.4",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                      "version": "2.0.4"
                     },
                     "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                      "version": "1.0.9"
                     }
                   }
                 },
                 "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                  "version": "0.5.0"
                 },
                 "stringstream": {
-                  "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                  "version": "0.0.4"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "combined-stream@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "isstream": {
-                  "version": "0.1.2",
-                  "from": "isstream@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                  "version": "0.1.2"
                 },
                 "har-validator": {
                   "version": "1.8.0",
-                  "from": "har-validator@>=1.6.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "dependencies": {
                     "bluebird": {
-                      "version": "2.9.30",
-                      "from": "bluebird@>=2.9.30 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.30.tgz"
+                      "version": "2.9.34"
                     },
                     "commander": {
                       "version": "2.8.1",
-                      "from": "commander@>=2.8.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                       "dependencies": {
                         "graceful-readlink": {
-                          "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "is-my-json-valid": {
-                      "version": "2.12.0",
-                      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                      "version": "2.12.1",
                       "dependencies": {
                         "generate-function": {
-                          "version": "2.0.0",
-                          "from": "generate-function@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                          "version": "2.0.0"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "generate-object-property@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
-                              "version": "1.0.2",
-                              "from": "is-property@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                              "version": "1.0.2"
                             }
                           }
                         },
                         "jsonpointer": {
-                          "version": "1.1.0",
-                          "from": "jsonpointer@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                          "version": "1.1.0"
                         },
                         "xtend": {
-                          "version": "4.0.0",
-                          "from": "xtend@>=4.0.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                          "version": "4.0.0"
                         }
                       }
                     }
@@ -6717,54 +4354,31 @@
               }
             },
             "sass-graph": {
-              "version": "2.0.0",
-              "from": "sass-graph@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
+              "version": "2.0.1",
               "dependencies": {
-                "lodash": {
-                  "version": "3.9.3",
-                  "from": "lodash@>=3.8.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
-                },
                 "yargs": {
-                  "version": "3.12.0",
-                  "from": "yargs@>=3.8.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.12.0.tgz",
+                  "version": "3.19.0",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.1.0",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                      "version": "1.2.1"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.1",
-                          "from": "center-align@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
-                                  "version": "2.0.0",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
+                                  "version": "2.0.0"
                                 },
                                 "longest": {
-                                  "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                  "version": "1.0.1"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "version": "1.5.2"
                                 }
                               }
                             }
@@ -6772,49 +4386,36 @@
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
-                                  "version": "2.0.0",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.0.tgz"
+                                  "version": "2.0.0"
                                 },
                                 "longest": {
-                                  "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                  "version": "1.0.1"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "version": "1.5.2"
                                 }
                               }
                             }
                           }
                         },
                         "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "version": "0.0.2"
                         }
                       }
                     },
                     "decamelize": {
-                      "version": "1.0.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "window-size": {
-                      "version": "0.1.1",
-                      "from": "window-size@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.1.tgz"
+                      "version": "0.1.2"
+                    },
+                    "y18n": {
+                      "version": "3.0.0"
                     }
                   }
                 }
@@ -6823,77 +4424,51 @@
           }
         },
         "object-assign": {
-          "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+          "version": "2.1.1"
         }
       }
     },
     "grunt-scss-lint": {
       "version": "0.3.3",
-      "from": "grunt-scss-lint@0.3.3",
-      "resolved": "https://registry.npmjs.org/grunt-scss-lint/-/grunt-scss-lint-0.3.3.tgz",
       "dependencies": {
         "lodash": {
-          "version": "2.4.1",
-          "from": "lodash@2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+          "version": "2.4.1"
         },
         "xmlbuilder": {
           "version": "2.4.3",
-          "from": "xmlbuilder@2.4.3",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.3.tgz",
           "dependencies": {
             "lodash-node": {
-              "version": "2.4.1",
-              "from": "lodash-node@>=2.4.1 <2.5.0",
-              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+              "version": "2.4.1"
             }
           }
         },
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+              "version": "1.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  "version": "0.2.1"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  "version": "0.2.1"
                 }
               }
             },
             "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+              "version": "0.2.0"
             }
           }
         }
@@ -6901,52 +4476,34 @@
     },
     "grunt-shell": {
       "version": "1.1.1",
-      "from": "grunt-shell@1.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.1.1.tgz",
       "dependencies": {
         "chalk": {
           "version": "0.5.1",
-          "from": "chalk@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "1.1.0",
-              "from": "ansi-styles@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+              "version": "1.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
               "version": "0.1.0",
-              "from": "has-ansi@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  "version": "0.2.1"
                 }
               }
             },
             "strip-ansi": {
               "version": "0.3.0",
-              "from": "strip-ansi@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                  "version": "0.2.1"
                 }
               }
             },
             "supports-color": {
-              "version": "0.2.0",
-              "from": "supports-color@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+              "version": "0.2.0"
             }
           }
         }
@@ -6954,133 +4511,82 @@
     },
     "grunt-svgmin": {
       "version": "2.0.1",
-      "from": "grunt-svgmin@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-svgmin/-/grunt-svgmin-2.0.1.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.0.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "version": "1.1.0",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.0.1",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+              "version": "2.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
-              "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "version": "2.0.0",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                },
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "strip-ansi": {
-              "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "version": "3.0.0",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "supports-color": {
-              "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+              "version": "2.0.0"
             }
           }
         },
         "each-async": {
           "version": "1.1.1",
-          "from": "each-async@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "dependencies": {
             "onetime": {
-              "version": "1.0.0",
-              "from": "onetime@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "set-immediate-shim": {
-              "version": "1.0.1",
-              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         },
         "log-symbols": {
-          "version": "1.0.2",
-          "from": "log-symbols@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
+          "version": "1.0.2"
         },
         "pretty-bytes": {
           "version": "1.0.4",
-          "from": "pretty-bytes@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
           "dependencies": {
             "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "version": "4.0.1"
             },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@>=3.1.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.1.0",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                      "version": "1.2.1"
                     },
                     "map-obj": {
-                      "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "indent-string": {
-                  "version": "1.2.1",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "version": "1.2.2",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
-                              "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                              "version": "1.0.0"
                             }
                           }
                         }
@@ -7089,89 +4595,56 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.1.1",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                  "version": "1.1.3"
                 },
                 "object-assign": {
-                  "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                  "version": "3.0.0"
                 }
               }
             }
           }
         },
         "svgo": {
-          "version": "0.5.3",
-          "from": "svgo@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.5.3.tgz",
+          "version": "0.5.6",
           "dependencies": {
             "sax": {
-              "version": "1.1.1",
-              "from": "sax@>=1.1.1 <1.2.0",
-              "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.1.tgz"
+              "version": "1.1.1"
             },
             "coa": {
               "version": "1.0.1",
-              "from": "coa@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
               "dependencies": {
                 "q": {
-                  "version": "1.4.1",
-                  "from": "q@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                  "version": "1.4.1"
                 }
               }
             },
             "js-yaml": {
               "version": "3.3.1",
-              "from": "js-yaml@>=3.3.1 <3.4.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "argparse@>=1.0.2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
-                    "lodash": {
-                      "version": "3.9.3",
-                      "from": "lodash@>=3.2.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
-                    },
                     "sprintf-js": {
-                      "version": "1.0.2",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                      "version": "1.0.3"
                     }
                   }
                 },
                 "esprima": {
-                  "version": "2.2.0",
-                  "from": "esprima@>=2.2.0 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                  "version": "2.2.0"
                 }
               }
             },
             "colors": {
-              "version": "1.1.2",
-              "from": "colors@>=1.1.2 <1.2.0",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+              "version": "1.1.2"
             },
             "whet.extend": {
-              "version": "0.9.9",
-              "from": "whet.extend@>=0.9.9 <0.10.0",
-              "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+              "version": "0.9.9"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "version": "0.0.8"
                 }
               }
             }
@@ -7180,29 +4653,19 @@
       }
     },
     "grunt-text-replace": {
-      "version": "0.3.12",
-      "from": "grunt-text-replace@0.3.12",
-      "resolved": "https://registry.npmjs.org/grunt-text-replace/-/grunt-text-replace-0.3.12.tgz"
+      "version": "0.3.12"
     },
     "grunt-webfontjson": {
       "version": "0.0.4",
-      "from": "grunt-webfontjson@0.0.4",
-      "resolved": "https://registry.npmjs.org/grunt-webfontjson/-/grunt-webfontjson-0.0.4.tgz",
       "dependencies": {
         "webfontjson": {
           "version": "0.0.4",
-          "from": "webfontjson@0.0.4",
-          "resolved": "https://registry.npmjs.org/webfontjson/-/webfontjson-0.0.4.tgz",
           "dependencies": {
             "commander": {
               "version": "1.1.1",
-              "from": "commander@>=1.1.1 <1.2.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
               "dependencies": {
                 "keypress": {
-                  "version": "0.1.0",
-                  "from": "keypress@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
+                  "version": "0.1.0"
                 }
               }
             }
@@ -7212,40 +4675,26 @@
     },
     "handlebars": {
       "version": "2.0.0",
-      "from": "handlebars@2.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
       "dependencies": {
         "optimist": {
           "version": "0.3.7",
-          "from": "optimist@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+              "version": "0.0.3"
             }
           }
         },
         "uglify-js": {
           "version": "2.3.6",
-          "from": "uglify-js@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
           "dependencies": {
             "async": {
-              "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "version": "0.2.10"
             },
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@>=0.1.7 <0.2.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.1",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                  "version": "1.0.0"
                 }
               }
             }
@@ -7254,349 +4703,223 @@
       }
     },
     "jasmine-core": {
-      "version": "2.3.4",
-      "from": "jasmine-core@>=2.3.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
+      "version": "2.3.4"
     },
     "jit-grunt": {
-      "version": "0.9.1",
-      "from": "jit-grunt@0.9.1",
-      "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.9.1.tgz"
+      "version": "0.9.1"
     },
     "jsonfile": {
-      "version": "2.0.0",
-      "from": "jsonfile@2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz"
+      "version": "2.0.0"
     },
     "jspm": {
       "version": "0.16.10",
-      "from": "https://registry.npmjs.org/jspm/-/jspm-0.16.10.tgz",
-      "resolved": "https://registry.npmjs.org/jspm/-/jspm-0.16.10.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "version": "2.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "version": "2.0.0"
             }
           }
         },
         "core-js": {
-          "version": "0.9.18",
-          "from": "https://registry.npmjs.org/core-js/-/core-js-0.9.18.tgz",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.9.18.tgz"
+          "version": "0.9.18"
         },
         "glob": {
           "version": "5.0.15",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.1"
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "graceful-fs": {
-          "version": "3.0.8",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+          "version": "3.0.8"
         },
         "jspm-github": {
           "version": "0.13.5",
-          "from": "https://registry.npmjs.org/jspm-github/-/jspm-github-0.13.5.tgz",
-          "resolved": "https://registry.npmjs.org/jspm-github/-/jspm-github-0.13.5.tgz",
           "dependencies": {
             "netrc": {
-              "version": "0.1.4",
-              "from": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz"
+              "version": "0.1.4"
             },
             "request": {
               "version": "2.53.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "0.10.31"
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.1"
                         }
                       }
                     }
                   }
                 },
                 "caseless": {
-                  "version": "0.9.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                  "version": "0.9.0"
                 },
                 "forever-agent": {
-                  "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                  "version": "0.5.2"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "0.9.2",
-                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                      "version": "0.9.2"
                     }
                   }
                 },
                 "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                  "version": "5.0.1"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.12.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                      "version": "1.12.0"
                     }
                   }
                 },
                 "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                  "version": "1.4.3"
                 },
                 "qs": {
-                  "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                  "version": "2.3.3"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                  "version": "0.4.1"
                 },
                 "tough-cookie": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                  "version": "2.0.0"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                      "version": "0.1.5"
                     },
                     "asn1": {
-                      "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                      "version": "0.1.11"
                     },
                     "ctype": {
-                      "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                      "version": "0.5.3"
                     }
                   }
                 },
                 "oauth-sign": {
-                  "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                  "version": "0.6.0"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
-                      "version": "2.16.3",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                      "version": "2.16.3"
                     },
                     "boom": {
-                      "version": "2.9.0",
-                      "from": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
+                      "version": "2.9.0"
                     },
                     "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                      "version": "2.0.5"
                     },
                     "sntp": {
-                      "version": "1.0.9",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                      "version": "1.0.9"
                     }
                   }
                 },
                 "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                  "version": "0.5.0"
                 },
                 "stringstream": {
-                  "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                  "version": "0.0.4"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                      "version": "0.0.5"
                     }
                   }
                 },
                 "isstream": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                  "version": "0.1.2"
                 }
               }
             },
             "rimraf": {
               "version": "2.3.4",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
@@ -7606,47 +4929,31 @@
             },
             "tar": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
               "dependencies": {
                 "block-stream": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                  "version": "0.0.8"
                 },
                 "fstream": {
                   "version": "1.0.8",
-                  "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
                   "dependencies": {
                     "graceful-fs": {
-                      "version": "4.1.2",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                      "version": "4.1.2"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 }
               }
             },
             "which": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/which/-/which-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.1.2.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                      "version": "0.1.3"
                     }
                   }
                 }
@@ -7654,18 +4961,12 @@
             },
             "yauzl": {
               "version": "2.3.1",
-              "from": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
               "dependencies": {
                 "fd-slicer": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "pend": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+                  "version": "1.2.0"
                 }
               }
             }
@@ -7673,258 +4974,164 @@
         },
         "jspm-npm": {
           "version": "0.25.1",
-          "from": "https://registry.npmjs.org/jspm-npm/-/jspm-npm-0.25.1.tgz",
-          "resolved": "https://registry.npmjs.org/jspm-npm/-/jspm-npm-0.25.1.tgz",
           "dependencies": {
             "request": {
               "version": "2.58.0",
-              "from": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "0.10.31"
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.1"
                         }
                       }
                     }
                   }
                 },
                 "caseless": {
-                  "version": "0.10.0",
-                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
+                  "version": "0.10.0"
                 },
                 "extend": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "forever-agent": {
-                  "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                  "version": "0.6.1"
                 },
                 "form-data": {
                   "version": "1.0.0-rc3",
-                  "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "1.4.2",
-                      "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                      "version": "1.4.2"
                     },
                     "mime-types": {
                       "version": "2.1.7",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.19.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                          "version": "1.19.0"
                         }
                       }
                     }
                   }
                 },
                 "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                  "version": "5.0.1"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.12.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                      "version": "1.12.0"
                     }
                   }
                 },
                 "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                  "version": "1.4.3"
                 },
                 "qs": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
+                  "version": "3.1.0"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                  "version": "0.4.1"
                 },
                 "tough-cookie": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                  "version": "2.0.0"
                 },
                 "http-signature": {
                   "version": "0.11.0",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                   "dependencies": {
                     "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                      "version": "0.1.5"
                     },
                     "asn1": {
-                      "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                      "version": "0.1.11"
                     },
                     "ctype": {
-                      "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                      "version": "0.5.3"
                     }
                   }
                 },
                 "oauth-sign": {
-                  "version": "0.8.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                  "version": "0.8.0"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
-                      "version": "2.16.3",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                      "version": "2.16.3"
                     },
                     "boom": {
-                      "version": "2.9.0",
-                      "from": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
+                      "version": "2.9.0"
                     },
                     "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                      "version": "2.0.5"
                     },
                     "sntp": {
-                      "version": "1.0.9",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                      "version": "1.0.9"
                     }
                   }
                 },
                 "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                  "version": "0.5.0"
                 },
                 "stringstream": {
-                  "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                  "version": "0.0.4"
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "isstream": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                  "version": "0.1.2"
                 },
                 "har-validator": {
                   "version": "1.8.0",
-                  "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
                   "dependencies": {
                     "bluebird": {
-                      "version": "2.10.1",
-                      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.1.tgz"
+                      "version": "2.10.1"
                     },
                     "commander": {
                       "version": "2.8.1",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                       "dependencies": {
                         "graceful-readlink": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.12.2",
-                      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
                       "dependencies": {
                         "generate-function": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                          "version": "2.0.0"
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                           "dependencies": {
                             "is-property": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                              "version": "1.0.2"
                             }
                           }
                         },
                         "jsonpointer": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                          "version": "2.0.0"
                         },
                         "xtend": {
-                          "version": "4.0.0",
-                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                          "version": "4.0.0"
                         }
                       }
                     }
@@ -7933,34 +5140,22 @@
               }
             },
             "resolve": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+              "version": "1.1.6"
             },
             "rmdir": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/rmdir/-/rmdir-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/rmdir/-/rmdir-1.1.0.tgz",
               "dependencies": {
                 "node.flow": {
                   "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/node.flow/-/node.flow-1.2.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node.flow/-/node.flow-1.2.3.tgz",
                   "dependencies": {
                     "node.extend": {
                       "version": "1.0.8",
-                      "from": "https://registry.npmjs.org/node.extend/-/node.extend-1.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.0.8.tgz",
                       "dependencies": {
                         "is": {
-                          "version": "0.2.7",
-                          "from": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
-                          "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz"
+                          "version": "0.2.7"
                         },
                         "object-keys": {
-                          "version": "0.4.0",
-                          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-                          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                          "version": "0.4.0"
                         }
                       }
                     }
@@ -7970,47 +5165,31 @@
             },
             "tar": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
               "dependencies": {
                 "block-stream": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                  "version": "0.0.8"
                 },
                 "fstream": {
                   "version": "1.0.8",
-                  "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
                   "dependencies": {
                     "graceful-fs": {
-                      "version": "4.1.2",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                      "version": "4.1.2"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 }
               }
             },
             "which": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/which/-/which-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.1.2.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                      "version": "0.1.3"
                     }
                   }
                 }
@@ -8020,67 +5199,43 @@
         },
         "jspm-registry": {
           "version": "0.4.0",
-          "from": "https://registry.npmjs.org/jspm-registry/-/jspm-registry-0.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/jspm-registry/-/jspm-registry-0.4.0.tgz",
           "dependencies": {
             "semver": {
-              "version": "4.3.6",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+              "version": "4.3.6"
             }
           }
         },
         "liftoff": {
           "version": "2.2.0",
-          "from": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
           "dependencies": {
             "extend": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+              "version": "2.0.1"
             },
             "findup-sync": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
+              "version": "0.3.0"
             },
             "flagged-respawn": {
-              "version": "0.3.1",
-              "from": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+              "version": "0.3.1"
             },
             "rechoir": {
-              "version": "0.6.2",
-              "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+              "version": "0.6.2"
             },
             "resolve": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+              "version": "1.1.6"
             }
           }
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
               "dependencies": {
                 "balanced-match": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                  "version": "0.2.0"
                 },
                 "concat-map": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                  "version": "0.0.1"
                 }
               }
             }
@@ -8088,268 +5243,170 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "version": "0.0.8"
             }
           }
         },
         "ncp": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
+          "version": "2.0.0"
         },
         "request": {
           "version": "2.64.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.64.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.64.0.tgz",
           "dependencies": {
             "bl": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "version": "1.0.1"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                      "version": "1.0.3"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "version": "0.10.31"
                     },
                     "util-deprecate": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
               }
             },
             "caseless": {
-              "version": "0.11.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+              "version": "0.11.0"
             },
             "extend": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+              "version": "3.0.0"
             },
             "forever-agent": {
-              "version": "0.6.1",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+              "version": "0.6.1"
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
-                  "version": "1.4.2",
-                  "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                  "version": "1.4.2"
                 }
               }
             },
             "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+              "version": "5.0.1"
             },
             "mime-types": {
               "version": "2.1.7",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.19.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                  "version": "1.19.0"
                 }
               }
             },
             "node-uuid": {
-              "version": "1.4.3",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+              "version": "1.4.3"
             },
             "qs": {
-              "version": "5.1.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
+              "version": "5.1.0"
             },
             "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+              "version": "0.4.1"
             },
             "tough-cookie": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+              "version": "2.0.0"
             },
             "http-signature": {
               "version": "0.11.0",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
               "dependencies": {
                 "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                  "version": "0.1.5"
                 },
                 "asn1": {
-                  "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                  "version": "0.1.11"
                 },
                 "ctype": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                  "version": "0.5.3"
                 }
               }
             },
             "oauth-sign": {
-              "version": "0.8.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+              "version": "0.8.0"
             },
             "hawk": {
               "version": "3.1.0",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                  "version": "2.16.3"
                 },
                 "boom": {
-                  "version": "2.9.0",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
+                  "version": "2.9.0"
                 },
                 "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                  "version": "2.0.5"
                 },
                 "sntp": {
-                  "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                  "version": "1.0.9"
                 }
               }
             },
             "aws-sign2": {
-              "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+              "version": "0.5.0"
             },
             "stringstream": {
-              "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+              "version": "0.0.4"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "isstream": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+              "version": "0.1.2"
             },
             "har-validator": {
               "version": "1.8.0",
-              "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
               "dependencies": {
                 "bluebird": {
-                  "version": "2.10.1",
-                  "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.1.tgz"
+                  "version": "2.10.1"
                 },
                 "commander": {
                   "version": "2.8.1",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.2",
-                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
                   "dependencies": {
                     "generate-function": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                          "version": "1.0.2"
                         }
                       }
                     },
                     "jsonpointer": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "xtend": {
-                      "version": "4.0.0",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                      "version": "4.0.0"
                     }
                   }
                 }
@@ -8358,78 +5415,50 @@
           }
         },
         "rimraf": {
-          "version": "2.4.3",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
+          "version": "2.4.3"
         },
         "rsvp": {
-          "version": "3.1.0",
-          "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.1.0.tgz"
+          "version": "3.1.0"
         },
         "semver": {
-          "version": "5.0.3",
-          "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+          "version": "5.0.3"
         },
         "systemjs": {
           "version": "0.19.3",
-          "from": "https://registry.npmjs.org/systemjs/-/systemjs-0.19.3.tgz",
-          "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.19.3.tgz",
           "dependencies": {
             "es6-module-loader": {
-              "version": "0.17.8",
-              "from": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.8.tgz",
-              "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.8.tgz"
+              "version": "0.17.8"
             },
             "when": {
-              "version": "3.7.3",
-              "from": "https://registry.npmjs.org/when/-/when-3.7.3.tgz",
-              "resolved": "https://registry.npmjs.org/when/-/when-3.7.3.tgz"
+              "version": "3.7.3"
             }
           }
         },
         "systemjs-builder": {
           "version": "0.14.6",
-          "from": "https://registry.npmjs.org/systemjs-builder/-/systemjs-builder-0.14.6.tgz",
-          "resolved": "https://registry.npmjs.org/systemjs-builder/-/systemjs-builder-0.14.6.tgz",
           "dependencies": {
             "algorithms": {
-              "version": "0.9.1",
-              "from": "https://registry.npmjs.org/algorithms/-/algorithms-0.9.1.tgz",
-              "resolved": "https://registry.npmjs.org/algorithms/-/algorithms-0.9.1.tgz"
+              "version": "0.9.1"
             },
             "es6-template-strings": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/es6-template-strings/-/es6-template-strings-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/es6-template-strings/-/es6-template-strings-2.0.0.tgz",
               "dependencies": {
                 "es5-ext": {
                   "version": "0.10.7",
-                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                   "dependencies": {
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                       "dependencies": {
                         "d": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                          "version": "0.1.1"
                         }
                       }
                     },
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                       "dependencies": {
                         "d": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                          "version": "0.1.1"
                         }
                       }
                     }
@@ -8437,13 +5466,9 @@
                 },
                 "esniff": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/esniff/-/esniff-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/esniff/-/esniff-1.0.0.tgz",
                   "dependencies": {
                     "d": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                      "version": "0.1.1"
                     }
                   }
                 }
@@ -8451,13 +5476,9 @@
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             }
@@ -8465,69 +5486,45 @@
         },
         "traceur": {
           "version": "0.0.91",
-          "from": "https://registry.npmjs.org/traceur/-/traceur-0.0.91.tgz",
-          "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.91.tgz",
           "dependencies": {
             "commander": {
-              "version": "2.6.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+              "version": "2.6.0"
             },
             "glob": {
               "version": "4.3.5",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
               }
             },
             "semver": {
-              "version": "2.3.2",
-              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+              "version": "2.3.2"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.32",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
@@ -8537,55 +5534,35 @@
         },
         "uglify-js": {
           "version": "2.4.24",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
           "dependencies": {
             "async": {
-              "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "version": "0.2.10"
             },
             "source-map": {
               "version": "0.1.34",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "uglify-to-browserify": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+              "version": "1.0.2"
             },
             "yargs": {
               "version": "3.5.4",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "dependencies": {
                 "camelcase": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                  "version": "1.2.1"
                 },
                 "decamelize": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "window-size": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                  "version": "0.1.0"
                 },
                 "wordwrap": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                  "version": "0.0.2"
                 }
               }
             }
@@ -8595,550 +5572,349 @@
     },
     "jspm-bower-endpoint": {
       "version": "0.3.2",
-      "from": "jspm-bower-endpoint@>=0.3.2 <0.4.0",
-      "resolved": "https://registry.npmjs.org/jspm-bower-endpoint/-/jspm-bower-endpoint-0.3.2.tgz",
       "dependencies": {
         "bower": {
           "version": "1.4.0",
-          "from": "bower@1.4.0",
-          "resolved": "https://registry.npmjs.org/bower/-/bower-1.4.0.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.7",
-              "from": "abbrev@>=1.0.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+              "version": "1.0.7"
             },
             "archy": {
-              "version": "1.0.0",
-              "from": "archy@1.0.0",
-              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "bower-config": {
               "version": "0.6.1",
-              "from": "bower-config@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                  "version": "2.0.3"
                 },
                 "mout": {
-                  "version": "0.9.1",
-                  "from": "mout@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+                  "version": "0.9.1"
                 },
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "optimist@>=0.6.0 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                      "version": "0.0.3"
                     },
                     "minimist": {
-                      "version": "0.0.10",
-                      "from": "minimist@>=0.0.1 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                      "version": "0.0.10"
                     }
                   }
                 },
                 "osenv": {
-                  "version": "0.0.3",
-                  "from": "osenv@0.0.3",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+                  "version": "0.0.3"
                 }
               }
             },
             "bower-json": {
               "version": "0.4.0",
-              "from": "bower-json@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
               "dependencies": {
                 "deep-extend": {
-                  "version": "0.2.11",
-                  "from": "deep-extend@>=0.2.5 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                  "version": "0.2.11"
                 },
                 "graceful-fs": {
-                  "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                  "version": "2.0.3"
                 },
                 "intersect": {
-                  "version": "0.0.3",
-                  "from": "intersect@>=0.0.3 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
+                  "version": "0.0.3"
                 }
               }
             },
             "bower-registry-client": {
               "version": "0.2.4",
-              "from": "bower-registry-client@>=0.2.1 <0.3.0",
-              "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.4.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.2.10",
-                  "from": "async@>=0.2.8 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                  "version": "0.2.10"
                 },
                 "bower-config": {
                   "version": "0.5.2",
-                  "from": "bower-config@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
                   "dependencies": {
                     "mout": {
-                      "version": "0.9.1",
-                      "from": "mout@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+                      "version": "0.9.1"
                     },
                     "optimist": {
                       "version": "0.6.1",
-                      "from": "optimist@>=0.6.0 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                       "dependencies": {
                         "wordwrap": {
-                          "version": "0.0.3",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                          "version": "0.0.3"
                         },
                         "minimist": {
-                          "version": "0.0.10",
-                          "from": "minimist@>=0.0.1 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                          "version": "0.0.10"
                         }
                       }
                     },
                     "osenv": {
-                      "version": "0.0.3",
-                      "from": "osenv@0.0.3",
-                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+                      "version": "0.0.3"
                     }
                   }
                 },
                 "graceful-fs": {
-                  "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                  "version": "2.0.3"
                 },
                 "lru-cache": {
-                  "version": "2.3.1",
-                  "from": "lru-cache@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+                  "version": "2.3.1"
                 },
                 "request": {
                   "version": "2.51.0",
-                  "from": "request@>=2.51.0 <2.52.0",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "0.9.4",
-                      "from": "bl@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.26 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                              "version": "1.0.1"
                             },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "0.0.1"
                             },
                             "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                              "version": "0.10.31"
                             },
                             "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "version": "2.0.1"
                             }
                           }
                         }
                       }
                     },
                     "caseless": {
-                      "version": "0.8.0",
-                      "from": "caseless@>=0.8.0 <0.9.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                      "version": "0.8.0"
                     },
                     "forever-agent": {
-                      "version": "0.5.2",
-                      "from": "forever-agent@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                      "version": "0.5.2"
                     },
                     "form-data": {
                       "version": "0.2.0",
-                      "from": "form-data@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                       "dependencies": {
                         "async": {
-                          "version": "0.9.2",
-                          "from": "async@>=0.9.0 <0.10.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                          "version": "0.9.2"
                         },
                         "mime-types": {
                           "version": "2.0.14",
-                          "from": "mime-types@>=2.0.3 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                           "dependencies": {
                             "mime-db": {
-                              "version": "1.12.0",
-                              "from": "mime-db@>=1.12.0 <1.13.0",
-                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                              "version": "1.12.0"
                             }
                           }
                         }
                       }
                     },
                     "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                      "version": "5.0.1"
                     },
                     "mime-types": {
-                      "version": "1.0.2",
-                      "from": "mime-types@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "node-uuid": {
-                      "version": "1.4.3",
-                      "from": "node-uuid@>=1.4.0 <1.5.0",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                      "version": "1.4.3"
                     },
                     "qs": {
-                      "version": "2.3.3",
-                      "from": "qs@>=2.3.1 <2.4.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                      "version": "2.3.3"
                     },
                     "tunnel-agent": {
-                      "version": "0.4.0",
-                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                      "version": "0.4.1"
                     },
                     "tough-cookie": {
-                      "version": "2.0.0",
-                      "from": "tough-cookie@>=0.12.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "http-signature": {
                       "version": "0.10.1",
-                      "from": "http-signature@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                       "dependencies": {
                         "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "assert-plus@>=0.1.5 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                          "version": "0.1.5"
                         },
                         "asn1": {
-                          "version": "0.1.11",
-                          "from": "asn1@0.1.11",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                          "version": "0.1.11"
                         },
                         "ctype": {
-                          "version": "0.5.3",
-                          "from": "ctype@0.5.3",
-                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                          "version": "0.5.3"
                         }
                       }
                     },
                     "oauth-sign": {
-                      "version": "0.5.0",
-                      "from": "oauth-sign@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                      "version": "0.5.0"
                     },
                     "hawk": {
                       "version": "1.1.1",
-                      "from": "hawk@1.1.1",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                       "dependencies": {
                         "hoek": {
-                          "version": "0.9.1",
-                          "from": "hoek@>=0.9.0 <0.10.0",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                          "version": "0.9.1"
                         },
                         "boom": {
-                          "version": "0.4.2",
-                          "from": "boom@>=0.4.0 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                          "version": "0.4.2"
                         },
                         "cryptiles": {
-                          "version": "0.2.2",
-                          "from": "cryptiles@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                          "version": "0.2.2"
                         },
                         "sntp": {
-                          "version": "0.2.4",
-                          "from": "sntp@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                          "version": "0.2.4"
                         }
                       }
                     },
                     "aws-sign2": {
-                      "version": "0.5.0",
-                      "from": "aws-sign2@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                      "version": "0.5.0"
                     },
                     "stringstream": {
-                      "version": "0.0.4",
-                      "from": "stringstream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                      "version": "0.0.4"
                     },
                     "combined-stream": {
                       "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.5 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                       "dependencies": {
                         "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                          "version": "0.0.5"
                         }
                       }
                     }
                   }
                 },
                 "request-replay": {
-                  "version": "0.2.0",
-                  "from": "request-replay@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
+                  "version": "0.2.0"
                 },
                 "rimraf": {
-                  "version": "2.2.8",
-                  "from": "rimraf@>=2.2.0 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                  "version": "2.2.8"
                 },
                 "mkdirp": {
-                  "version": "0.3.5",
-                  "from": "mkdirp@>=0.3.5 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                  "version": "0.3.5"
                 }
               }
             },
             "cardinal": {
               "version": "0.4.4",
-              "from": "cardinal@0.4.4",
-              "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
               "dependencies": {
                 "redeyed": {
                   "version": "0.4.4",
-                  "from": "redeyed@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
                   "dependencies": {
                     "esprima": {
-                      "version": "1.0.4",
-                      "from": "esprima@>=1.0.4 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                      "version": "1.0.4"
                     }
                   }
                 },
                 "ansicolors": {
-                  "version": "0.2.1",
-                  "from": "ansicolors@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+                  "version": "0.2.1"
                 }
               }
             },
             "chalk": {
-              "version": "1.0.0",
-              "from": "chalk@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "version": "1.1.0",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.0.1",
-                  "from": "ansi-styles@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                  "version": "2.1.0"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                  "version": "1.0.3"
                 },
                 "has-ansi": {
-                  "version": "1.0.3",
-                  "from": "has-ansi@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "version": "2.0.0",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                      "version": "2.0.0"
                     }
                   }
                 },
                 "strip-ansi": {
-                  "version": "2.0.1",
-                  "from": "strip-ansi@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "version": "3.0.0",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                      "version": "2.0.0"
                     }
                   }
                 },
                 "supports-color": {
-                  "version": "1.3.1",
-                  "from": "supports-color@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "chmodr": {
-              "version": "0.1.0",
-              "from": "chmodr@0.1.0",
-              "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
+              "version": "0.1.0"
             },
             "configstore": {
               "version": "0.3.2",
-              "from": "configstore@>=0.3.2 <0.4.0",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
               "dependencies": {
                 "js-yaml": {
                   "version": "3.3.1",
-                  "from": "js-yaml@>=3.1.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
                   "dependencies": {
                     "argparse": {
                       "version": "1.0.2",
-                      "from": "argparse@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                       "dependencies": {
-                        "lodash": {
-                          "version": "3.9.3",
-                          "from": "lodash@>=3.2.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
-                        },
                         "sprintf-js": {
-                          "version": "1.0.2",
-                          "from": "sprintf-js@>=1.0.2 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                          "version": "1.0.3"
                         }
                       }
                     },
                     "esprima": {
-                      "version": "2.2.0",
-                      "from": "esprima@>=2.2.0 <2.3.0",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                      "version": "2.2.0"
                     }
                   }
                 },
                 "object-assign": {
-                  "version": "2.1.1",
-                  "from": "object-assign@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                  "version": "2.1.1"
                 },
                 "osenv": {
-                  "version": "0.1.2",
-                  "from": "osenv@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
+                  "version": "0.1.3",
                   "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1"
+                    },
                     "os-tmpdir": {
-                      "version": "1.0.1",
-                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "uuid": {
-                  "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "xdg-basedir": {
-                  "version": "1.0.1",
-                  "from": "xdg-basedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "decompress-zip": {
               "version": "0.1.0",
-              "from": "decompress-zip@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
               "dependencies": {
                 "binary": {
                   "version": "0.3.0",
-                  "from": "binary@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
                   "dependencies": {
                     "chainsaw": {
                       "version": "0.1.0",
-                      "from": "chainsaw@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
                       "dependencies": {
                         "traverse": {
-                          "version": "0.3.9",
-                          "from": "traverse@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                          "version": "0.3.9"
                         }
                       }
                     },
                     "buffers": {
-                      "version": "0.1.1",
-                      "from": "buffers@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                      "version": "0.1.1"
                     }
                   }
                 },
                 "mkpath": {
-                  "version": "0.1.0",
-                  "from": "mkpath@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
+                  "version": "0.1.0"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.8 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "version": "1.0.1"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "version": "0.10.31"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     }
                   }
                 },
                 "touch": {
                   "version": "0.0.3",
-                  "from": "touch@0.0.3",
-                  "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
                   "dependencies": {
                     "nopt": {
-                      "version": "1.0.10",
-                      "from": "nopt@>=1.0.10 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+                      "version": "1.0.10"
                     }
                   }
                 }
@@ -9146,45 +5922,29 @@
             },
             "fstream": {
               "version": "1.0.7",
-              "from": "fstream@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.7.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 }
               }
             },
             "fstream-ignore": {
               "version": "1.0.2",
-              "from": "fstream-ignore@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "minimatch": {
-                  "version": "2.0.8",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "version": "2.0.10",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                          "version": "0.2.0"
                         },
                         "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "version": "0.0.1"
                         }
                       }
                     }
@@ -9194,57 +5954,37 @@
             },
             "github": {
               "version": "0.2.4",
-              "from": "github@>=0.2.3 <0.3.0",
-              "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
               "dependencies": {
                 "mime": {
-                  "version": "1.3.4",
-                  "from": "mime@>=1.2.11 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                  "version": "1.3.4"
                 }
               }
             },
             "glob": {
               "version": "4.5.3",
-              "from": "glob@>=4.3.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "minimatch": {
-                  "version": "2.0.8",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "version": "2.0.10",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                          "version": "0.2.0"
                         },
                         "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "version": "0.0.1"
                         }
                       }
                     }
@@ -9252,319 +5992,207 @@
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
               }
             },
             "graceful-fs": {
-              "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.5 <4.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+              "version": "3.0.8"
             },
             "inquirer": {
               "version": "0.8.0",
-              "from": "inquirer@0.8.0",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "1.1.1"
                 },
                 "chalk": {
                   "version": "0.5.1",
-                  "from": "chalk@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
-                      "version": "1.1.0",
-                      "from": "ansi-styles@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                      "version": "1.1.0"
                     },
                     "escape-string-regexp": {
-                      "version": "1.0.3",
-                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                      "version": "1.0.3"
                     },
                     "has-ansi": {
                       "version": "0.1.0",
-                      "from": "has-ansi@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                          "version": "0.2.1"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "0.3.0",
-                      "from": "strip-ansi@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.1 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                          "version": "0.2.1"
                         }
                       }
                     },
                     "supports-color": {
-                      "version": "0.2.0",
-                      "from": "supports-color@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                      "version": "0.2.0"
                     }
                   }
                 },
                 "cli-color": {
                   "version": "0.3.3",
-                  "from": "cli-color@>=0.3.2 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
                   "dependencies": {
                     "d": {
-                      "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                      "version": "0.1.1"
                     },
                     "es5-ext": {
                       "version": "0.10.7",
-                      "from": "es5-ext@>=0.10.6 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
                       "dependencies": {
                         "es6-iterator": {
-                          "version": "0.1.3",
-                          "from": "es6-iterator@>=0.1.3 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                          "version": "0.1.3"
                         },
                         "es6-symbol": {
-                          "version": "2.0.1",
-                          "from": "es6-symbol@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                          "version": "2.0.1"
                         }
                       }
                     },
                     "memoizee": {
-                      "version": "0.3.8",
-                      "from": "memoizee@>=0.3.8 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                      "version": "0.3.9",
                       "dependencies": {
                         "es6-weak-map": {
                           "version": "0.1.4",
-                          "from": "es6-weak-map@>=0.1.2 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                           "dependencies": {
                             "es6-iterator": {
-                              "version": "0.1.3",
-                              "from": "es6-iterator@>=0.1.3 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                              "version": "0.1.3"
                             },
                             "es6-symbol": {
-                              "version": "2.0.1",
-                              "from": "es6-symbol@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                              "version": "2.0.1"
                             }
                           }
                         },
                         "event-emitter": {
-                          "version": "0.3.3",
-                          "from": "event-emitter@>=0.3.1 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                          "version": "0.3.3"
                         },
                         "lru-queue": {
-                          "version": "0.1.0",
-                          "from": "lru-queue@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                          "version": "0.1.0"
                         },
                         "next-tick": {
-                          "version": "0.2.2",
-                          "from": "next-tick@>=0.2.2 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                          "version": "0.2.2"
                         }
                       }
                     },
                     "timers-ext": {
                       "version": "0.1.0",
-                      "from": "timers-ext@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                       "dependencies": {
                         "next-tick": {
-                          "version": "0.2.2",
-                          "from": "next-tick@>=0.2.2 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                          "version": "0.2.2"
                         }
                       }
                     }
                   }
                 },
                 "figures": {
-                  "version": "1.3.5",
-                  "from": "figures@>=1.3.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+                  "version": "1.3.5"
                 },
                 "lodash": {
-                  "version": "2.4.2",
-                  "from": "lodash@>=2.4.1 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+                  "version": "2.4.2"
                 },
                 "mute-stream": {
-                  "version": "0.0.4",
-                  "from": "mute-stream@0.0.4",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                  "version": "0.0.4"
                 },
                 "readline2": {
                   "version": "0.1.1",
-                  "from": "readline2@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
                   "dependencies": {
                     "strip-ansi": {
-                      "version": "2.0.1",
-                      "from": "strip-ansi@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                      "version": "2.0.1"
                     }
                   }
                 },
                 "rx": {
-                  "version": "2.5.3",
-                  "from": "rx@>=2.2.27 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
+                  "version": "2.5.3"
                 },
                 "through": {
-                  "version": "2.3.7",
-                  "from": "through@>=2.3.4 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+                  "version": "2.3.8"
                 }
               }
             },
             "insight": {
               "version": "0.5.3",
-              "from": "insight@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                  "version": "0.9.2"
                 },
                 "lodash.debounce": {
-                  "version": "3.1.0",
-                  "from": "lodash.debounce@>=3.0.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.0.tgz",
+                  "version": "3.1.1",
                   "dependencies": {
                     "lodash._getnative": {
-                      "version": "3.9.0",
-                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                      "version": "3.9.1"
                     }
                   }
                 },
                 "object-assign": {
-                  "version": "2.1.1",
-                  "from": "object-assign@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                  "version": "2.1.1"
                 },
                 "os-name": {
                   "version": "1.0.3",
-                  "from": "os-name@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
                   "dependencies": {
                     "osx-release": {
                       "version": "1.1.0",
-                      "from": "osx-release@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
                       "dependencies": {
                         "minimist": {
-                          "version": "1.1.1",
-                          "from": "minimist@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                          "version": "1.1.3"
                         }
                       }
                     },
                     "win-release": {
-                      "version": "1.0.0",
-                      "from": "win-release@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "tough-cookie": {
                   "version": "0.12.1",
-                  "from": "tough-cookie@>=0.12.1 <0.13.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
                   "dependencies": {
                     "punycode": {
-                      "version": "1.3.2",
-                      "from": "punycode@>=0.2.0",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                      "version": "1.3.2"
                     }
                   }
                 }
               }
             },
             "is-root": {
-              "version": "1.0.0",
-              "from": "is-root@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "junk": {
-              "version": "1.0.1",
-              "from": "junk@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz"
+              "version": "1.0.2"
             },
             "lockfile": {
-              "version": "1.0.1",
-              "from": "lockfile@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "lru-cache": {
-              "version": "2.6.4",
-              "from": "lru-cache@>=2.5.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+              "version": "2.6.5"
             },
             "nopt": {
-              "version": "3.0.2",
-              "from": "nopt@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz"
+              "version": "3.0.3"
             },
             "opn": {
-              "version": "1.0.2",
-              "from": "opn@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+              "version": "1.0.2"
             },
             "p-throttler": {
               "version": "0.1.1",
-              "from": "p-throttler@0.1.1",
-              "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
               "dependencies": {
                 "q": {
-                  "version": "0.9.7",
-                  "from": "q@>=0.9.2 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+                  "version": "0.9.7"
                 }
               }
             },
             "promptly": {
               "version": "0.2.0",
-              "from": "promptly@0.2.0",
-              "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
               "dependencies": {
                 "read": {
                   "version": "1.0.6",
-                  "from": "read@>=1.0.4 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
                   "dependencies": {
                     "mute-stream": {
-                      "version": "0.0.5",
-                      "from": "mute-stream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                      "version": "0.0.5"
                     }
                   }
                 }
@@ -9572,268 +6200,215 @@
             },
             "request": {
               "version": "2.53.0",
-              "from": "request@2.53.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.26 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "0.10.31"
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.1"
                         }
                       }
                     }
                   }
                 },
                 "caseless": {
-                  "version": "0.9.0",
-                  "from": "caseless@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                  "version": "0.9.0"
                 },
                 "forever-agent": {
-                  "version": "0.5.2",
-                  "from": "forever-agent@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                  "version": "0.5.2"
                 },
                 "form-data": {
                   "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                      "version": "0.9.2"
                     }
                   }
                 },
                 "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                  "version": "5.0.1"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.12.0",
-                      "from": "mime-db@>=1.12.0 <1.13.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                      "version": "1.12.0"
                     }
                   }
                 },
                 "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.0 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                  "version": "1.4.3"
                 },
                 "qs": {
-                  "version": "2.3.3",
-                  "from": "qs@>=2.3.1 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                  "version": "2.3.3"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.0",
-                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                  "version": "0.4.1"
                 },
                 "tough-cookie": {
-                  "version": "2.0.0",
-                  "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                  "version": "2.0.0"
                 },
                 "http-signature": {
                   "version": "0.10.1",
-                  "from": "http-signature@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
                   "dependencies": {
                     "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                      "version": "0.1.5"
                     },
                     "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                      "version": "0.1.11"
                     },
                     "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                      "version": "0.5.3"
                     }
                   }
                 },
                 "oauth-sign": {
-                  "version": "0.6.0",
-                  "from": "oauth-sign@>=0.6.0 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                  "version": "0.6.0"
                 },
                 "hawk": {
                   "version": "2.3.1",
-                  "from": "hawk@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
                   "dependencies": {
                     "hoek": {
-                      "version": "2.14.0",
-                      "from": "hoek@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
+                      "version": "2.14.0"
                     },
                     "boom": {
-                      "version": "2.8.0",
-                      "from": "boom@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
+                      "version": "2.8.0"
                     },
                     "cryptiles": {
-                      "version": "2.0.4",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                      "version": "2.0.4"
                     },
                     "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                      "version": "1.0.9"
                     }
                   }
                 },
                 "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                  "version": "0.5.0"
                 },
                 "stringstream": {
-                  "version": "0.0.4",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                  "version": "0.0.4"
                 },
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.5 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                      "version": "0.0.5"
                     }
                   }
                 },
                 "isstream": {
-                  "version": "0.1.2",
-                  "from": "isstream@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                  "version": "0.1.2"
                 }
               }
             },
             "request-progress": {
               "version": "0.3.1",
-              "from": "request-progress@0.3.1",
-              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
               "dependencies": {
                 "throttleit": {
-                  "version": "0.0.2",
-                  "from": "throttleit@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+                  "version": "0.0.2"
                 }
               }
             },
             "retry": {
-              "version": "0.6.1",
-              "from": "retry@0.6.1",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
+              "version": "0.6.1"
             },
             "rimraf": {
-              "version": "2.4.0",
-              "from": "rimraf@>=2.2.8 <3.0.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.0.tgz"
+              "version": "2.4.2",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.14",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
             },
             "semver": {
-              "version": "2.3.2",
-              "from": "semver@>=2.3.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+              "version": "2.3.2"
             },
             "shell-quote": {
               "version": "1.4.3",
-              "from": "shell-quote@>=1.4.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
               "dependencies": {
                 "jsonify": {
-                  "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                  "version": "0.0.0"
                 },
                 "array-filter": {
-                  "version": "0.0.1",
-                  "from": "array-filter@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+                  "version": "0.0.1"
                 },
                 "array-reduce": {
-                  "version": "0.0.0",
-                  "from": "array-reduce@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+                  "version": "0.0.0"
                 },
                 "array-map": {
-                  "version": "0.0.0",
-                  "from": "array-map@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+                  "version": "0.0.0"
                 }
               }
             },
             "stringify-object": {
-              "version": "1.0.1",
-              "from": "stringify-object@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "tar-fs": {
-              "version": "1.6.0",
-              "from": "tar-fs@>=1.4.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.6.0.tgz",
+              "version": "1.8.1",
               "dependencies": {
                 "pump": {
                   "version": "1.0.0",
-                  "from": "pump@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
                   "dependencies": {
                     "end-of-stream": {
-                      "version": "1.1.0",
-                      "from": "end-of-stream@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
+                      "version": "1.1.0"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
@@ -9841,287 +6416,196 @@
                 },
                 "tar-stream": {
                   "version": "1.2.1",
-                  "from": "tar-stream@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.1.tgz",
                   "dependencies": {
                     "bl": {
-                      "version": "1.0.0",
-                      "from": "bl@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "end-of-stream@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "dependencies": {
                         "once": {
                           "version": "1.3.2",
-                          "from": "once@>=1.3.0 <1.4.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.1"
                             }
                           }
                         }
                       }
                     },
                     "readable-stream": {
-                      "version": "2.0.1",
-                      "from": "readable-stream@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+                      "version": "2.0.2",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.1"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.1",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                          "version": "1.0.2"
                         },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "0.10.31"
                         },
                         "util-deprecate": {
-                          "version": "1.0.1",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "xtend": {
-                      "version": "4.0.0",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                      "version": "4.0.0"
                     }
                   }
                 }
               }
             },
             "tmp": {
-              "version": "0.0.24",
-              "from": "tmp@0.0.24",
-              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
+              "version": "0.0.24"
             },
             "update-notifier": {
               "version": "0.3.2",
-              "from": "update-notifier@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
               "dependencies": {
                 "is-npm": {
-                  "version": "1.0.0",
-                  "from": "is-npm@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "latest-version": {
                   "version": "1.0.1",
-                  "from": "latest-version@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
                   "dependencies": {
                     "package-json": {
                       "version": "1.2.0",
-                      "from": "package-json@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
                       "dependencies": {
                         "got": {
-                          "version": "3.2.0",
-                          "from": "got@>=3.2.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/got/-/got-3.2.0.tgz",
+                          "version": "3.3.1",
                           "dependencies": {
                             "duplexify": {
                               "version": "3.4.2",
-                              "from": "duplexify@>=3.2.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                               "dependencies": {
                                 "end-of-stream": {
                                   "version": "1.0.0",
-                                  "from": "end-of-stream@1.0.0",
-                                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                                   "dependencies": {
                                     "once": {
                                       "version": "1.3.2",
-                                      "from": "once@>=1.3.0 <1.4.0",
-                                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                                       "dependencies": {
                                         "wrappy": {
-                                          "version": "1.0.1",
-                                          "from": "wrappy@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                          "version": "1.0.1"
                                         }
                                       }
                                     }
                                   }
                                 },
                                 "readable-stream": {
-                                  "version": "2.0.1",
-                                  "from": "readable-stream@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+                                  "version": "2.0.2",
                                   "dependencies": {
                                     "core-util-is": {
-                                      "version": "1.0.1",
-                                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                      "version": "1.0.1"
                                     },
                                     "inherits": {
-                                      "version": "2.0.1",
-                                      "from": "inherits@>=2.0.1 <2.1.0",
-                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                      "version": "2.0.1"
                                     },
                                     "isarray": {
-                                      "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                      "version": "0.0.1"
                                     },
                                     "process-nextick-args": {
-                                      "version": "1.0.1",
-                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                                      "version": "1.0.2"
                                     },
                                     "string_decoder": {
-                                      "version": "0.10.31",
-                                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                      "version": "0.10.31"
                                     },
                                     "util-deprecate": {
-                                      "version": "1.0.1",
-                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                      "version": "1.0.1"
                                     }
                                   }
                                 }
                               }
                             },
                             "infinity-agent": {
-                              "version": "2.0.3",
-                              "from": "infinity-agent@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                              "version": "2.0.3"
+                            },
+                            "is-redirect": {
+                              "version": "1.0.0"
                             },
                             "is-stream": {
-                              "version": "1.0.1",
-                              "from": "is-stream@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                              "version": "1.0.1"
                             },
                             "lowercase-keys": {
-                              "version": "1.0.0",
-                              "from": "lowercase-keys@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                              "version": "1.0.0"
                             },
                             "nested-error-stacks": {
-                              "version": "1.0.0",
-                              "from": "nested-error-stacks@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz"
+                              "version": "1.0.1",
+                              "dependencies": {
+                                "inherits": {
+                                  "version": "2.0.1"
+                                }
+                              }
                             },
                             "object-assign": {
-                              "version": "2.1.1",
-                              "from": "object-assign@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                              "version": "3.0.0"
                             },
                             "prepend-http": {
-                              "version": "1.0.1",
-                              "from": "prepend-http@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+                              "version": "1.0.2"
                             },
                             "read-all-stream": {
-                              "version": "2.2.0",
-                              "from": "read-all-stream@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.2.0.tgz",
+                              "version": "3.0.1",
                               "dependencies": {
+                                "pinkie-promise": {
+                                  "version": "1.0.0",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "1.0.0"
+                                    }
+                                  }
+                                },
                                 "readable-stream": {
-                                  "version": "2.0.1",
-                                  "from": "readable-stream@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.1.tgz",
+                                  "version": "2.0.2",
                                   "dependencies": {
                                     "core-util-is": {
-                                      "version": "1.0.1",
-                                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                      "version": "1.0.1"
                                     },
                                     "inherits": {
-                                      "version": "2.0.1",
-                                      "from": "inherits@>=2.0.1 <2.1.0",
-                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                      "version": "2.0.1"
                                     },
                                     "isarray": {
-                                      "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                      "version": "0.0.1"
                                     },
                                     "process-nextick-args": {
-                                      "version": "1.0.1",
-                                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                                      "version": "1.0.2"
                                     },
                                     "string_decoder": {
-                                      "version": "0.10.31",
-                                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                      "version": "0.10.31"
                                     },
                                     "util-deprecate": {
-                                      "version": "1.0.1",
-                                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                                      "version": "1.0.1"
                                     }
                                   }
                                 }
                               }
                             },
-                            "statuses": {
-                              "version": "1.2.1",
-                              "from": "statuses@>=1.2.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
-                            },
                             "timed-out": {
-                              "version": "2.0.0",
-                              "from": "timed-out@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                              "version": "2.0.0"
                             }
                           }
                         },
                         "registry-url": {
                           "version": "3.0.3",
-                          "from": "registry-url@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
                           "dependencies": {
                             "rc": {
-                              "version": "1.0.3",
-                              "from": "rc@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/rc/-/rc-1.0.3.tgz",
+                              "version": "1.1.0",
                               "dependencies": {
                                 "minimist": {
-                                  "version": "0.0.10",
-                                  "from": "minimist@>=0.0.7 <0.1.0",
-                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                                  "version": "1.1.3"
                                 },
                                 "deep-extend": {
-                                  "version": "0.2.11",
-                                  "from": "deep-extend@>=0.2.5 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                                  "version": "0.2.11"
                                 },
                                 "strip-json-comments": {
-                                  "version": "0.1.3",
-                                  "from": "strip-json-comments@>=0.1.0 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                                  "version": "0.1.3"
                                 },
                                 "ini": {
-                                  "version": "1.3.4",
-                                  "from": "ini@>=1.3.0 <1.4.0",
-                                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                                  "version": "1.3.4"
                                 }
                               }
                             }
@@ -10133,30 +6617,20 @@
                 },
                 "semver-diff": {
                   "version": "2.0.0",
-                  "from": "semver-diff@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
                   "dependencies": {
                     "semver": {
-                      "version": "4.3.6",
-                      "from": "semver@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                      "version": "4.3.6"
                     }
                   }
                 },
                 "string-length": {
-                  "version": "1.0.0",
-                  "from": "string-length@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
+                  "version": "1.0.1",
                   "dependencies": {
                     "strip-ansi": {
-                      "version": "2.0.1",
-                      "from": "strip-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "version": "3.0.0",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "1.1.1",
-                          "from": "ansi-regex@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                          "version": "2.0.0"
                         }
                       }
                     }
@@ -10165,24 +6639,16 @@
               }
             },
             "user-home": {
-              "version": "1.1.1",
-              "from": "user-home@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+              "version": "1.1.1"
             },
             "which": {
               "version": "1.1.1",
-              "from": "which@>=1.0.8 <2.0.0",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "is-absolute@>=0.1.7 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
-                      "version": "0.1.3",
-                      "from": "is-relative@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                      "version": "0.1.3"
                     }
                   }
                 }
@@ -10191,292 +6657,202 @@
           }
         },
         "bower-endpoint-parser": {
-          "version": "0.2.2",
-          "from": "bower-endpoint-parser@0.2.2",
-          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
+          "version": "0.2.2"
         },
         "bower-logger": {
-          "version": "0.2.2",
-          "from": "bower-logger@0.2.2",
-          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
+          "version": "0.2.2"
         },
         "mout": {
-          "version": "0.11.0",
-          "from": "mout@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.0.tgz"
+          "version": "0.11.0"
         },
         "q": {
-          "version": "1.4.1",
-          "from": "q@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+          "version": "1.4.1"
         },
         "semver": {
-          "version": "4.3.6",
-          "from": "semver@>=4.3.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+          "version": "4.3.6"
         }
       }
     },
     "karma": {
       "version": "0.12.31",
-      "from": "karma@0.12.31",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.31.tgz",
       "dependencies": {
         "di": {
-          "version": "0.0.1",
-          "from": "di@>=0.0.1 <0.1.0",
-          "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
+          "version": "0.0.1"
         },
         "socket.io": {
           "version": "0.9.16",
-          "from": "socket.io@0.9.16",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
-              "from": "socket.io-client@0.9.16",
-              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
                 "uglify-js": {
-                  "version": "1.2.5",
-                  "from": "uglify-js@1.2.5",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
+                  "version": "1.2.5"
                 },
                 "ws": {
                   "version": "0.4.32",
-                  "from": "ws@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
                   "dependencies": {
                     "commander": {
-                      "version": "2.1.0",
-                      "from": "commander@>=2.1.0 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+                      "version": "2.1.0"
                     },
                     "nan": {
-                      "version": "1.0.0",
-                      "from": "nan@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "tinycolor": {
-                      "version": "0.0.1",
-                      "from": "tinycolor@>=0.0.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "options": {
-                      "version": "0.0.6",
-                      "from": "options@>=0.0.5",
-                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                      "version": "0.0.6"
                     }
                   }
                 },
                 "xmlhttprequest": {
-                  "version": "1.4.2",
-                  "from": "xmlhttprequest@1.4.2",
-                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
+                  "version": "1.4.2"
                 },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
-                  "from": "active-x-obfuscator@0.0.1",
-                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
-                      "version": "0.0.5",
-                      "from": "zeparser@0.0.5",
-                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
+                      "version": "0.0.5"
                     }
                   }
                 }
               }
             },
             "policyfile": {
-              "version": "0.0.4",
-              "from": "policyfile@0.0.4",
-              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
+              "version": "0.0.4"
             },
             "base64id": {
-              "version": "0.1.0",
-              "from": "base64id@0.1.0",
-              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+              "version": "0.1.0"
             },
             "redis": {
-              "version": "0.7.3",
-              "from": "redis@0.7.3",
-              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
+              "version": "0.7.3"
             }
           }
         },
         "chokidar": {
-          "version": "1.0.3",
-          "from": "chokidar@>=0.8.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
+          "version": "1.0.5",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "micromatch": {
-                  "version": "2.1.6",
-                  "from": "micromatch@>=2.1.5 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+                  "version": "2.2.0",
                   "dependencies": {
                     "arr-diff": {
                       "version": "1.0.1",
-                      "from": "arr-diff@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                       "dependencies": {
                         "array-slice": {
-                          "version": "0.2.3",
-                          "from": "array-slice@>=0.2.2 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                          "version": "0.2.3"
                         }
                       }
                     },
+                    "array-unique": {
+                      "version": "0.2.1"
+                    },
                     "braces": {
                       "version": "1.8.0",
-                      "from": "braces@>=1.8.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.2",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                               "dependencies": {
                                 "is-number": {
-                                  "version": "1.1.2",
-                                  "from": "is-number@>=1.1.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                  "version": "1.1.2"
                                 },
                                 "isobject": {
-                                  "version": "1.0.0",
-                                  "from": "isobject@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
+                                  "version": "1.0.2"
                                 },
                                 "randomatic": {
-                                  "version": "1.1.0",
-                                  "from": "randomatic@>=1.1.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                                  "version": "1.1.0"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "version": "1.5.2"
                                 }
                               }
                             }
                           }
                         },
                         "preserve": {
-                          "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                          "version": "0.2.0"
                         },
                         "repeat-element": {
-                          "version": "1.1.2",
-                          "from": "repeat-element@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "from": "debug@>=2.1.3 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "from": "ms@0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                          "version": "1.1.2"
                         }
                       }
                     },
                     "expand-brackets": {
-                      "version": "0.1.1",
-                      "from": "expand-brackets@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
+                      "version": "0.1.3",
+                      "dependencies": {
+                        "is-posix-bracket": {
+                          "version": "0.1.0"
+                        }
+                      }
+                    },
+                    "extglob": {
+                      "version": "0.3.1",
+                      "dependencies": {
+                        "ansi-green": {
+                          "version": "0.1.1",
+                          "dependencies": {
+                            "ansi-wrap": {
+                              "version": "0.1.0"
+                            }
+                          }
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0"
+                        },
+                        "success-symbol": {
+                          "version": "0.1.0"
+                        }
+                      }
                     },
                     "filename-regex": {
-                      "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "kind-of": {
-                      "version": "1.1.0",
-                      "from": "kind-of@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                      "version": "1.1.0"
                     },
                     "object.omit": {
-                      "version": "0.2.1",
-                      "from": "object.omit@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+                      "version": "1.1.0",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
-                              "version": "0.1.4",
-                              "from": "for-in@>=0.1.4 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                              "version": "0.1.4"
                             }
                           }
                         },
                         "isobject": {
-                          "version": "0.2.0",
-                          "from": "isobject@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                          "version": "1.0.2"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.2",
-                      "from": "parse-glob@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                       "dependencies": {
                         "glob-base": {
-                          "version": "0.2.0",
-                          "from": "glob-base@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                          "version": "0.2.0"
                         },
                         "is-dotfile": {
-                          "version": "1.0.1",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "is-extglob": {
-                          "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "regex-cache@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
-                          "version": "0.1.2",
-                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
-                          "dependencies": {
-                            "is-primitive": {
-                              "version": "1.0.0",
-                              "from": "is-primitive@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
-                            }
-                          }
+                          "version": "0.1.3"
                         },
                         "is-primitive": {
-                          "version": "2.0.0",
-                          "from": "is-primitive@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                          "version": "2.0.0"
                         }
                       }
                     }
@@ -10485,85 +6861,58 @@
               }
             },
             "arrify": {
-              "version": "1.0.0",
-              "from": "arrify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "async-each": {
-              "version": "0.1.6",
-              "from": "async-each@>=0.1.5 <0.2.0",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+              "version": "0.1.6"
             },
             "glob-parent": {
-              "version": "1.2.0",
-              "from": "glob-parent@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+              "version": "1.2.0"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
-                  "version": "1.3.1",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
+                  "version": "1.3.1"
                 }
               }
             },
             "is-glob": {
-              "version": "1.1.3",
-              "from": "is-glob@>=1.1.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+              "version": "1.1.3"
             },
             "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "readdirp": {
-              "version": "1.3.0",
-              "from": "readdirp@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+              "version": "1.4.0",
               "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.2"
+                },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "version": "1.0.1"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "version": "0.10.31"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     }
                   }
                 }
               }
             },
             "fsevents": {
-              "version": "0.3.6",
-              "from": "fsevents@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
+              "version": "0.3.8",
               "dependencies": {
                 "nan": {
-                  "version": "1.8.4",
-                  "from": "nan@>=1.8.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                  "version": "2.0.5"
                 }
               }
             }
@@ -10571,28 +6920,18 @@
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.7 <3.3.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.1"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.4",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                  "version": "2.6.5"
                 },
                 "sigmund": {
-                  "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             }
@@ -10600,55 +6939,35 @@
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.4",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+              "version": "2.6.5"
             },
             "sigmund": {
-              "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         },
         "http-proxy": {
           "version": "0.10.4",
-          "from": "http-proxy@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
           "dependencies": {
             "pkginfo": {
-              "version": "0.3.0",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+              "version": "0.3.0"
             },
             "utile": {
               "version": "0.2.1",
-              "from": "utile@>=0.2.1 <0.3.0",
-              "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.2.10",
-                  "from": "async@>=0.2.9 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                  "version": "0.2.10"
                 },
                 "deep-equal": {
-                  "version": "1.0.0",
-                  "from": "deep-equal@*",
-                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "i": {
-                  "version": "0.3.3",
-                  "from": "i@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
+                  "version": "0.3.3"
                 },
                 "ncp": {
-                  "version": "0.4.2",
-                  "from": "ncp@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+                  "version": "0.4.2"
                 }
               }
             }
@@ -10656,277 +6975,177 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+              "version": "0.0.3"
             },
             "minimist": {
-              "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+              "version": "0.0.10"
             }
           }
         },
         "rimraf": {
-          "version": "2.2.8",
-          "from": "rimraf@>=2.2.5 <2.3.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+          "version": "2.2.8"
         },
         "q": {
-          "version": "0.9.7",
-          "from": "q@>=0.9.7 <0.10.0",
-          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+          "version": "0.9.7"
         },
         "colors": {
-          "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+          "version": "0.6.2"
         },
         "lodash": {
-          "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+          "version": "2.4.2"
         },
         "mime": {
-          "version": "1.2.11",
-          "from": "mime@>=1.2.11 <1.3.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+          "version": "1.2.11"
         },
         "log4js": {
           "version": "0.6.26",
-          "from": "log4js@>=0.6.3 <0.7.0",
-          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.26.tgz",
           "dependencies": {
             "async": {
-              "version": "0.2.10",
-              "from": "async@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "version": "0.2.10"
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "0.0.1"
                 },
                 "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "version": "0.10.31"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.1"
                 }
               }
             },
             "semver": {
-              "version": "4.3.6",
-              "from": "semver@>=4.3.3 <4.4.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+              "version": "4.3.6"
             },
             "underscore": {
-              "version": "1.8.2",
-              "from": "underscore@1.8.2",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.2.tgz"
+              "version": "1.8.2"
             }
           }
         },
         "useragent": {
           "version": "2.0.10",
-          "from": "useragent@>=2.0.4 <2.1.0",
-          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.10.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.2.4",
-              "from": "lru-cache@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
+              "version": "2.2.4"
             }
           }
         },
         "graceful-fs": {
-          "version": "2.0.3",
-          "from": "graceful-fs@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+          "version": "2.0.3"
         },
         "connect": {
           "version": "2.26.6",
-          "from": "connect@>=2.26.0 <2.27.0",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-2.26.6.tgz",
           "dependencies": {
             "basic-auth-connect": {
-              "version": "1.0.0",
-              "from": "basic-auth-connect@1.0.0",
-              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "body-parser": {
               "version": "1.8.4",
-              "from": "body-parser@>=1.8.4 <1.9.0",
-              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
               "dependencies": {
                 "iconv-lite": {
-                  "version": "0.4.4",
-                  "from": "iconv-lite@0.4.4",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+                  "version": "0.4.4"
                 },
                 "on-finished": {
                   "version": "2.1.0",
-                  "from": "on-finished@2.1.0",
-                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
-                      "version": "1.0.5",
-                      "from": "ee-first@1.0.5",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                      "version": "1.0.5"
                     }
                   }
                 },
                 "raw-body": {
-                  "version": "1.3.0",
-                  "from": "raw-body@1.3.0",
-                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
+                  "version": "1.3.0"
                 }
               }
             },
             "bytes": {
-              "version": "1.0.0",
-              "from": "bytes@1.0.0",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "cookie": {
-              "version": "0.1.2",
-              "from": "cookie@0.1.2",
-              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+              "version": "0.1.2"
             },
             "cookie-parser": {
               "version": "1.3.5",
-              "from": "cookie-parser@>=1.3.3 <1.4.0",
-              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
               "dependencies": {
                 "cookie": {
-                  "version": "0.1.3",
-                  "from": "cookie@0.1.3",
-                  "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+                  "version": "0.1.3"
                 },
                 "cookie-signature": {
-                  "version": "1.0.6",
-                  "from": "cookie-signature@1.0.6",
-                  "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+                  "version": "1.0.6"
                 }
               }
             },
             "cookie-signature": {
-              "version": "1.0.5",
-              "from": "cookie-signature@1.0.5",
-              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+              "version": "1.0.5"
             },
             "compression": {
               "version": "1.1.2",
-              "from": "compression@>=1.1.2 <1.2.0",
-              "resolved": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@>=1.1.2 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                          "version": "1.12.0"
                         }
                       }
                     },
                     "negotiator": {
-                      "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                      "version": "0.4.9"
                     }
                   }
                 },
                 "compressible": {
-                  "version": "2.0.3",
-                  "from": "compressible@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.3.tgz",
+                  "version": "2.0.5",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.13.0",
-                      "from": "mime-db@>=1.13.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
+                      "version": "1.17.0"
                     }
                   }
                 },
                 "vary": {
-                  "version": "1.0.0",
-                  "from": "vary@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "connect-timeout": {
               "version": "1.3.0",
-              "from": "connect-timeout@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
               "dependencies": {
                 "ms": {
-                  "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                  "version": "0.6.2"
                 }
               }
             },
             "csurf": {
               "version": "1.6.6",
-              "from": "csurf@>=1.6.2 <1.7.0",
-              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
               "dependencies": {
                 "csrf": {
                   "version": "2.0.7",
-                  "from": "csrf@>=2.0.5 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.7.tgz",
                   "dependencies": {
                     "base64-url": {
-                      "version": "1.2.1",
-                      "from": "base64-url@1.2.1",
-                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                      "version": "1.2.1"
                     },
                     "rndm": {
-                      "version": "1.1.0",
-                      "from": "rndm@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz"
+                      "version": "1.1.0"
                     },
                     "scmp": {
-                      "version": "1.0.0",
-                      "from": "scmp@1.0.0",
-                      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "uid-safe": {
                       "version": "1.1.0",
-                      "from": "uid-safe@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
-                          "version": "1.1.2",
-                          "from": "native-or-bluebird@>=1.1.2 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
+                          "version": "1.1.2"
                         }
                       }
                     }
@@ -10934,18 +7153,12 @@
                 },
                 "http-errors": {
                   "version": "1.2.8",
-                  "from": "http-errors@>=1.2.8 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
                   "dependencies": {
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     },
                     "statuses": {
-                      "version": "1.2.1",
-                      "from": "statuses@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                      "version": "1.2.1"
                     }
                   }
                 }
@@ -10953,166 +7166,108 @@
             },
             "debug": {
               "version": "2.0.0",
-              "from": "debug@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
               "dependencies": {
                 "ms": {
-                  "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                  "version": "0.6.2"
                 }
               }
             },
             "depd": {
-              "version": "0.4.5",
-              "from": "depd@0.4.5",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
+              "version": "0.4.5"
             },
             "errorhandler": {
               "version": "1.2.4",
-              "from": "errorhandler@>=1.2.2 <1.3.0",
-              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.4.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@>=1.1.2 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                          "version": "1.12.0"
                         }
                       }
                     },
                     "negotiator": {
-                      "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                      "version": "0.4.9"
                     }
                   }
                 },
                 "escape-html": {
-                  "version": "1.0.1",
-                  "from": "escape-html@1.0.1",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "express-session": {
               "version": "1.8.2",
-              "from": "express-session@>=1.8.2 <1.9.0",
-              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
               "dependencies": {
                 "crc": {
-                  "version": "3.0.0",
-                  "from": "crc@3.0.0",
-                  "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+                  "version": "3.0.0"
                 },
                 "uid-safe": {
                   "version": "1.0.1",
-                  "from": "uid-safe@1.0.1",
-                  "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                   "dependencies": {
                     "mz": {
                       "version": "1.3.0",
-                      "from": "mz@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
                       "dependencies": {
                         "native-or-bluebird": {
-                          "version": "1.2.0",
-                          "from": "native-or-bluebird@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
+                          "version": "1.2.0"
                         },
                         "thenify": {
-                          "version": "3.1.0",
-                          "from": "thenify@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz"
+                          "version": "3.1.0"
                         },
                         "thenify-all": {
-                          "version": "1.6.0",
-                          "from": "thenify-all@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
+                          "version": "1.6.0"
                         }
                       }
                     },
                     "base64-url": {
-                      "version": "1.2.1",
-                      "from": "base64-url@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                      "version": "1.2.1"
                     }
                   }
                 },
                 "utils-merge": {
-                  "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
-                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "finalhandler": {
               "version": "0.2.0",
-              "from": "finalhandler@0.2.0",
-              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
               "dependencies": {
                 "escape-html": {
-                  "version": "1.0.1",
-                  "from": "escape-html@1.0.1",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "fresh": {
-              "version": "0.2.4",
-              "from": "fresh@0.2.4",
-              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+              "version": "0.2.4"
             },
             "media-typer": {
-              "version": "0.3.0",
-              "from": "media-typer@0.3.0",
-              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+              "version": "0.3.0"
             },
             "method-override": {
               "version": "2.2.0",
-              "from": "method-override@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
               "dependencies": {
                 "methods": {
-                  "version": "1.1.0",
-                  "from": "methods@1.1.0",
-                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+                  "version": "1.1.0"
                 },
                 "vary": {
-                  "version": "1.0.0",
-                  "from": "vary@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "morgan": {
               "version": "1.3.2",
-              "from": "morgan@>=1.3.2 <1.4.0",
-              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
               "dependencies": {
                 "basic-auth": {
-                  "version": "1.0.0",
-                  "from": "basic-auth@1.0.0",
-                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "on-finished": {
                   "version": "2.1.0",
-                  "from": "on-finished@2.1.0",
-                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
-                      "version": "1.0.5",
-                      "from": "ee-first@1.0.5",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                      "version": "1.0.5"
                     }
                   }
                 }
@@ -11120,226 +7275,148 @@
             },
             "multiparty": {
               "version": "3.3.2",
-              "from": "multiparty@3.3.2",
-              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "version": "1.0.1"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "version": "0.10.31"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     }
                   }
                 },
                 "stream-counter": {
-                  "version": "0.2.0",
-                  "from": "stream-counter@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                  "version": "0.2.0"
                 }
               }
             },
             "on-headers": {
-              "version": "1.0.0",
-              "from": "on-headers@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+              "version": "1.3.0"
             },
             "qs": {
-              "version": "2.2.4",
-              "from": "qs@2.2.4",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz"
+              "version": "2.2.4"
             },
             "response-time": {
-              "version": "2.0.1",
-              "from": "response-time@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz"
+              "version": "2.0.1"
             },
             "serve-favicon": {
               "version": "2.1.7",
-              "from": "serve-favicon@>=2.1.5 <2.2.0",
-              "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
               "dependencies": {
                 "etag": {
                   "version": "1.5.1",
-                  "from": "etag@>=1.5.0 <1.6.0",
-                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
                   "dependencies": {
                     "crc": {
-                      "version": "3.2.1",
-                      "from": "crc@3.2.1",
-                      "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
+                      "version": "3.2.1"
                     }
                   }
                 },
                 "ms": {
-                  "version": "0.6.2",
-                  "from": "ms@0.6.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                  "version": "0.6.2"
                 }
               }
             },
             "serve-index": {
               "version": "1.2.1",
-              "from": "serve-index@>=1.2.1 <1.3.0",
-              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                          "version": "1.12.0"
                         }
                       }
                     },
                     "negotiator": {
-                      "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                      "version": "0.4.9"
                     }
                   }
                 },
                 "batch": {
-                  "version": "0.5.1",
-                  "from": "batch@0.5.1",
-                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz"
+                  "version": "0.5.1"
                 }
               }
             },
             "serve-static": {
               "version": "1.6.5",
-              "from": "serve-static@>=1.6.4 <1.7.0",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
               "dependencies": {
                 "escape-html": {
-                  "version": "1.0.1",
-                  "from": "escape-html@1.0.1",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "send": {
                   "version": "0.9.3",
-                  "from": "send@0.9.3",
-                  "resolved": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
                   "dependencies": {
                     "destroy": {
-                      "version": "1.0.3",
-                      "from": "destroy@1.0.3",
-                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                      "version": "1.0.3"
                     },
                     "etag": {
                       "version": "1.4.0",
-                      "from": "etag@>=1.4.0 <1.5.0",
-                      "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
                       "dependencies": {
                         "crc": {
-                          "version": "3.0.0",
-                          "from": "crc@3.0.0",
-                          "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+                          "version": "3.0.0"
                         }
                       }
                     },
                     "ms": {
-                      "version": "0.6.2",
-                      "from": "ms@0.6.2",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                      "version": "0.6.2"
                     },
                     "on-finished": {
                       "version": "2.1.0",
-                      "from": "on-finished@2.1.0",
-                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                       "dependencies": {
                         "ee-first": {
-                          "version": "1.0.5",
-                          "from": "ee-first@1.0.5",
-                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                          "version": "1.0.5"
                         }
                       }
                     },
                     "range-parser": {
-                      "version": "1.0.2",
-                      "from": "range-parser@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+                      "version": "1.0.2"
                     }
                   }
                 },
                 "utils-merge": {
-                  "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
-                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "type-is": {
               "version": "1.5.7",
-              "from": "type-is@>=1.5.2 <1.6.0",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "mime-types@>=2.0.9 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.12.0",
-                      "from": "mime-db@>=1.12.0 <1.13.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                      "version": "1.12.0"
                     }
                   }
                 }
               }
             },
             "vhost": {
-              "version": "3.0.0",
-              "from": "vhost@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz"
+              "version": "3.0.1"
             },
             "pause": {
-              "version": "0.0.1",
-              "from": "pause@0.0.1",
-              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+              "version": "0.0.1"
             }
           }
         },
         "source-map": {
           "version": "0.1.43",
-          "from": "source-map@>=0.1.31 <0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "0.1.1",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+              "version": "1.0.0"
             }
           }
         }
@@ -11347,23 +7424,15 @@
     },
     "karma-chrome-launcher": {
       "version": "0.1.10",
-      "from": "karma-chrome-launcher@0.1.10",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.10.tgz",
       "dependencies": {
         "which": {
           "version": "1.1.1",
-          "from": "which@>=1.0.9 <2.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "from": "is-absolute@>=0.1.7 <0.2.0",
-              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
               "dependencies": {
                 "is-relative": {
-                  "version": "0.1.3",
-                  "from": "is-relative@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                  "version": "0.1.3"
                 }
               }
             }
@@ -11373,18 +7442,12 @@
     },
     "karma-coffee-preprocessor": {
       "version": "0.2.1",
-      "from": "karma-coffee-preprocessor@0.2.1",
-      "resolved": "https://registry.npmjs.org/karma-coffee-preprocessor/-/karma-coffee-preprocessor-0.2.1.tgz",
       "dependencies": {
         "coffee-script": {
           "version": "1.7.1",
-          "from": "coffee-script@>=1.7.0 <1.8.0",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
           "dependencies": {
             "mkdirp": {
-              "version": "0.3.5",
-              "from": "mkdirp@>=0.3.5 <0.4.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+              "version": "0.3.5"
             }
           }
         }
@@ -11392,80 +7455,50 @@
     },
     "karma-coverage": {
       "version": "0.3.1",
-      "from": "karma-coverage@0.3.1",
-      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-0.3.1.tgz",
       "dependencies": {
         "istanbul": {
-          "version": "0.3.15",
-          "from": "istanbul@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.15.tgz",
+          "version": "0.3.17",
           "dependencies": {
             "esprima": {
-              "version": "2.1.0",
-              "from": "esprima@>=2.1.0 <2.2.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.1.0.tgz"
+              "version": "2.4.1"
             },
             "escodegen": {
               "version": "1.6.1",
-              "from": "escodegen@>=1.6.0 <1.7.0",
-              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
               "dependencies": {
                 "estraverse": {
-                  "version": "1.9.3",
-                  "from": "estraverse@>=1.9.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                  "version": "1.9.3"
                 },
                 "esutils": {
-                  "version": "1.1.6",
-                  "from": "esutils@>=1.1.6 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                  "version": "1.1.6"
                 },
                 "esprima": {
-                  "version": "1.2.5",
-                  "from": "esprima@>=1.2.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                  "version": "1.2.5"
                 },
                 "optionator": {
                   "version": "0.5.0",
-                  "from": "optionator@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                   "dependencies": {
                     "prelude-ls": {
-                      "version": "1.1.2",
-                      "from": "prelude-ls@>=1.1.1 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                      "version": "1.1.2"
                     },
                     "deep-is": {
-                      "version": "0.1.3",
-                      "from": "deep-is@>=0.1.2 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                      "version": "0.1.3"
                     },
                     "type-check": {
-                      "version": "0.3.1",
-                      "from": "type-check@>=0.3.1 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                      "version": "0.3.1"
                     },
                     "levn": {
-                      "version": "0.2.5",
-                      "from": "levn@>=0.2.5 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                      "version": "0.2.5"
                     },
                     "fast-levenshtein": {
-                      "version": "1.0.6",
-                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                      "version": "1.0.7"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.40 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.1",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
@@ -11473,185 +7506,118 @@
             },
             "handlebars": {
               "version": "3.0.0",
-              "from": "handlebars@3.0.0",
-              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.0.tgz",
               "dependencies": {
                 "optimist": {
                   "version": "0.6.1",
-                  "from": "optimist@>=0.6.1 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
                     "minimist": {
-                      "version": "0.0.10",
-                      "from": "minimist@>=0.0.1 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                      "version": "0.0.10"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.40 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.1",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "uglify-js": {
                   "version": "2.3.6",
-                  "from": "uglify-js@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "0.2.10",
-                      "from": "async@>=0.2.6 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                      "version": "0.2.10"
                     },
                     "optimist": {
-                      "version": "0.3.7",
-                      "from": "optimist@>=0.3.5 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
+                      "version": "0.3.7"
                     }
                   }
                 }
               }
             },
             "nopt": {
-              "version": "3.0.2",
-              "from": "nopt@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz"
+              "version": "3.0.3"
             },
             "fileset": {
-              "version": "0.1.6",
-              "from": "fileset@0.1.6",
-              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.6.tgz",
+              "version": "0.2.1",
               "dependencies": {
+                "minimatch": {
+                  "version": "2.0.10",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
                 "glob": {
-                  "version": "5.0.10",
-                  "from": "glob@>=5.0.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
+                  "version": "5.0.14",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "2.0.8",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.0",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.0",
-                              "from": "balanced-match@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
+                      "version": "2.0.1"
                     },
                     "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
               }
             },
             "which": {
-              "version": "1.0.9",
-              "from": "which@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+              "version": "1.0.9"
             },
             "async": {
-              "version": "0.9.2",
-              "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+              "version": "1.4.2"
             },
             "supports-color": {
-              "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+              "version": "1.3.1"
             },
             "abbrev": {
-              "version": "1.0.7",
-              "from": "abbrev@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+              "version": "1.0.7"
             },
             "wordwrap": {
-              "version": "0.0.3",
-              "from": "wordwrap@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+              "version": "0.0.3"
             },
             "resolve": {
-              "version": "1.1.6",
-              "from": "resolve@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+              "version": "1.1.6"
             },
             "js-yaml": {
               "version": "3.3.1",
-              "from": "js-yaml@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
               "dependencies": {
                 "argparse": {
                   "version": "1.0.2",
-                  "from": "argparse@>=1.0.2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
                   "dependencies": {
-                    "lodash": {
-                      "version": "3.9.3",
-                      "from": "lodash@>=3.2.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
-                    },
                     "sprintf-js": {
-                      "version": "1.0.2",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                      "version": "1.0.3"
                     }
                   }
                 },
                 "esprima": {
-                  "version": "2.2.0",
-                  "from": "esprima@>=2.2.0 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                  "version": "2.2.0"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             }
@@ -11659,55 +7625,35 @@
         },
         "dateformat": {
           "version": "1.0.11",
-          "from": "dateformat@>=1.0.6 <1.1.0",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
           "dependencies": {
             "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "version": "4.0.1"
             },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@*",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.1.0",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                      "version": "1.2.1"
                     },
                     "map-obj": {
-                      "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "indent-string": {
-                  "version": "1.2.1",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "version": "1.2.2",
                   "dependencies": {
                     "repeating": {
                       "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
-                              "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                              "version": "1.0.0"
                             }
                           }
                         }
@@ -11716,14 +7662,10 @@
                   }
                 },
                 "minimist": {
-                  "version": "1.1.1",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                  "version": "1.1.3"
                 },
                 "object-assign": {
-                  "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                  "version": "3.0.0"
                 }
               }
             }
@@ -11731,67 +7673,44 @@
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.6.4",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+              "version": "2.6.5"
             },
             "sigmund": {
-              "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         }
       }
     },
     "karma-firefox-launcher": {
-      "version": "0.1.6",
-      "from": "karma-firefox-launcher@0.1.6",
-      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.6.tgz"
+      "version": "0.1.6"
     },
     "karma-html2js-preprocessor": {
-      "version": "0.1.0",
-      "from": "karma-html2js-preprocessor@0.1.0",
-      "resolved": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "karma-jasmine": {
-      "version": "0.3.5",
-      "from": "karma-jasmine@0.3.5",
-      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz"
+      "version": "0.3.5"
     },
     "karma-jspm": {
       "version": "1.1.6",
-      "from": "rich-nguyen/karma-jspm#1.1.6",
       "resolved": "git://github.com/rich-nguyen/karma-jspm.git#491f43be0891f1a0a598f3e5e7bdb27a6f5bf050",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.0 <3.3.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.1"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.4",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                  "version": "2.6.5"
                 },
                 "sigmund": {
-                  "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             }
@@ -11800,481 +7719,291 @@
       }
     },
     "karma-phantomjs-launcher": {
-      "version": "0.1.4",
-      "from": "karma-phantomjs-launcher@0.1.4",
-      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz"
+      "version": "0.1.4"
     },
     "karma-phantomjs-shim": {
-      "version": "1.0.0",
-      "from": "karma-phantomjs-shim@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/karma-phantomjs-shim/-/karma-phantomjs-shim-1.0.0.tgz"
+      "version": "1.0.0"
     },
     "karma-requirejs": {
-      "version": "0.2.2",
-      "from": "karma-requirejs@0.2.2",
-      "resolved": "https://registry.npmjs.org/karma-requirejs/-/karma-requirejs-0.2.2.tgz"
+      "version": "0.2.2"
     },
     "karma-script-launcher": {
-      "version": "0.1.0",
-      "from": "karma-script-launcher@0.1.0",
-      "resolved": "https://registry.npmjs.org/karma-script-launcher/-/karma-script-launcher-0.1.0.tgz"
+      "version": "0.1.0"
     },
     "karma-spec-reporter": {
       "version": "0.0.19",
-      "from": "karma-spec-reporter@0.0.19",
-      "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.19.tgz",
       "dependencies": {
         "colors": {
-          "version": "0.6.2",
-          "from": "colors@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+          "version": "0.6.2"
         }
       }
     },
     "load-grunt-config": {
       "version": "0.17.1",
-      "from": "load-grunt-config@0.17.1",
-      "resolved": "https://registry.npmjs.org/load-grunt-config/-/load-grunt-config-0.17.1.tgz",
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "from": "async@>=0.2.10 <0.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+          "version": "0.2.10"
         },
         "cson": {
           "version": "1.6.2",
-          "from": "cson@>=1.6.2 <1.7.0",
-          "resolved": "https://registry.npmjs.org/cson/-/cson-1.6.2.tgz",
           "dependencies": {
             "ambi": {
               "version": "2.2.0",
-              "from": "ambi@>=2.2.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.2.0.tgz",
               "dependencies": {
                 "typechecker": {
-                  "version": "2.0.8",
-                  "from": "typechecker@>=2.0.7 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz"
+                  "version": "2.0.8"
                 }
               }
             },
             "coffee-script": {
               "version": "1.8.0",
-              "from": "coffee-script@>=1.8.0 <1.9.0",
-              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
               "dependencies": {
                 "mkdirp": {
-                  "version": "0.3.5",
-                  "from": "mkdirp@>=0.3.5 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                  "version": "0.3.5"
                 }
               }
             },
             "extract-opts": {
               "version": "2.2.0",
-              "from": "extract-opts@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-2.2.0.tgz",
               "dependencies": {
                 "typechecker": {
-                  "version": "2.0.8",
-                  "from": "typechecker@>=2.0.7 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz"
+                  "version": "2.0.8"
                 }
               }
             },
             "js2coffee": {
               "version": "0.3.5",
-              "from": "js2coffee@>=0.3.5 <0.4.0",
-              "resolved": "https://registry.npmjs.org/js2coffee/-/js2coffee-0.3.5.tgz",
               "dependencies": {
                 "coffee-script": {
                   "version": "1.7.1",
-                  "from": "coffee-script@>=1.7.1 <1.8.0",
-                  "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
                   "dependencies": {
                     "mkdirp": {
-                      "version": "0.3.5",
-                      "from": "mkdirp@>=0.3.5 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                      "version": "0.3.5"
                     }
                   }
                 },
                 "file": {
-                  "version": "0.2.2",
-                  "from": "file@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/file/-/file-0.2.2.tgz"
+                  "version": "0.2.2"
                 },
                 "nopt": {
-                  "version": "3.0.2",
-                  "from": "nopt@>=3.0.1 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+                  "version": "3.0.3",
                   "dependencies": {
                     "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                      "version": "1.0.7"
                     }
                   }
                 },
                 "underscore": {
-                  "version": "1.6.0",
-                  "from": "underscore@>=1.6.0 <1.7.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                  "version": "1.6.0"
                 }
               }
             },
             "requirefresh": {
-              "version": "1.1.2",
-              "from": "requirefresh@>=1.1.2 <1.2.0",
-              "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-1.1.2.tgz"
+              "version": "1.1.2"
             }
           }
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.6 <3.3.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.1"
             },
             "minimatch": {
               "version": "0.3.0",
-              "from": "minimatch@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.6.4",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                  "version": "2.6.5"
                 },
                 "sigmund": {
-                  "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             }
           }
         },
         "jit-grunt": {
-          "version": "0.8.0",
-          "from": "jit-grunt@>=0.8.0 <0.9.0",
-          "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.8.0.tgz"
+          "version": "0.8.0"
         },
         "js-yaml": {
           "version": "3.0.2",
-          "from": "js-yaml@>=3.0.1 <3.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
-                  "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                  "version": "1.7.0"
                 },
                 "underscore.string": {
-                  "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                  "version": "2.4.0"
                 }
               }
             },
             "esprima": {
-              "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+              "version": "1.0.4"
             }
           }
         },
         "load-grunt-tasks": {
           "version": "0.3.0",
-          "from": "load-grunt-tasks@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.3.0.tgz",
           "dependencies": {
             "globule": {
               "version": "0.2.0",
-              "from": "globule@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.6.4",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                      "version": "2.6.5"
                     },
                     "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
               }
             },
             "findup-sync": {
-              "version": "0.1.3",
-              "from": "findup-sync@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz"
+              "version": "0.1.3"
             }
           }
         },
         "lodash": {
-          "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+          "version": "2.4.2"
         }
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+      "version": "3.10.1"
     },
     "megalog": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/megalog/-/megalog-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/megalog/-/megalog-0.1.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "version": "2.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "version": "2.0.0"
             }
           }
         },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        },
         "window-size": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
+          "version": "0.1.2"
         }
       }
     },
     "mkdirp": {
       "version": "0.5.0",
-      "from": "mkdirp@0.5.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          "version": "0.0.8"
         }
       }
     },
     "moment": {
-      "version": "2.8.3",
-      "from": "moment@2.8.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.3.tgz"
+      "version": "2.8.3"
     },
     "phantom": {
       "version": "0.6.5",
-      "from": "phantom@0.6.5",
-      "resolved": "https://registry.npmjs.org/phantom/-/phantom-0.6.5.tgz",
       "dependencies": {
         "dnode": {
           "version": "1.2.1",
-          "from": "dnode@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/dnode/-/dnode-1.2.1.tgz",
           "dependencies": {
             "dnode-protocol": {
-              "version": "0.2.2",
-              "from": "dnode-protocol@>=0.2.2 <0.3.0",
-              "resolved": "https://registry.npmjs.org/dnode-protocol/-/dnode-protocol-0.2.2.tgz"
+              "version": "0.2.2"
             },
             "jsonify": {
-              "version": "0.0.0",
-              "from": "jsonify@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+              "version": "0.0.0"
             },
             "weak": {
               "version": "0.4.1",
-              "from": "weak@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/weak/-/weak-0.4.1.tgz",
               "dependencies": {
                 "bindings": {
-                  "version": "1.2.1",
-                  "from": "bindings@*",
-                  "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+                  "version": "1.2.1"
                 },
                 "nan": {
-                  "version": "1.8.4",
-                  "from": "nan@>=1.8.4 <1.9.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                  "version": "1.8.4"
                 }
               }
-            }
-          }
-        },
-        "shoe": {
-          "version": "0.0.15",
-          "from": "shoe@>=0.0.10 <0.1.0",
-          "resolved": "https://registry.npmjs.org/shoe/-/shoe-0.0.15.tgz",
-          "dependencies": {
-            "sockjs": {
-              "version": "0.3.7",
-              "from": "sockjs@0.3.7",
-              "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.7.tgz",
-              "dependencies": {
-                "node-uuid": {
-                  "version": "1.3.3",
-                  "from": "node-uuid@1.3.3",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.3.3.tgz"
-                },
-                "faye-websocket": {
-                  "version": "0.4.4",
-                  "from": "faye-websocket@0.4.4",
-                  "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
-                }
-              }
-            },
-            "sockjs-client": {
-              "version": "0.0.0-unreleasable"
             }
           }
         },
         "win-spawn": {
-          "version": "2.0.0",
-          "from": "win-spawn@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
+          "version": "2.0.0"
         },
         "traverse": {
-          "version": "0.6.6",
-          "from": "traverse@>=0.6.3 <0.7.0",
-          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
+          "version": "0.6.6"
         }
       }
     },
     "phantomjs": {
       "version": "1.9.18",
-      "from": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.18.tgz",
-      "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.18.tgz",
       "dependencies": {
         "adm-zip": {
-          "version": "0.4.4",
-          "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
-          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+          "version": "0.4.4"
         },
         "fs-extra": {
           "version": "0.23.1",
-          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
           "dependencies": {
             "graceful-fs": {
-              "version": "4.1.2",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+              "version": "4.1.2"
             },
             "jsonfile": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.1.tgz"
+              "version": "2.2.1"
             },
             "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "rimraf": {
               "version": "2.4.3",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
               "dependencies": {
                 "glob": {
                   "version": "5.0.14",
-                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.14.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.2.0",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                              "version": "0.2.0"
                             },
                             "concat-map": {
-                              "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "version": "0.0.1"
                             }
                           }
                         }
@@ -12282,13 +8011,9 @@
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
@@ -12299,549 +8024,357 @@
           }
         },
         "kew": {
-          "version": "0.4.0",
-          "from": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
+          "version": "0.4.0"
         },
         "npmconf": {
           "version": "2.1.1",
-          "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
           "dependencies": {
             "config-chain": {
               "version": "1.1.9",
-              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
               "dependencies": {
                 "proto-list": {
-                  "version": "1.2.4",
-                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                  "version": "1.2.4"
                 }
               }
             },
             "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "version": "2.0.1"
             },
             "ini": {
-              "version": "1.3.4",
-              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+              "version": "1.3.4"
             },
             "nopt": {
               "version": "3.0.4",
-              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                  "version": "1.0.7"
                 }
               }
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "semver": {
-              "version": "4.3.6",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+              "version": "4.3.6"
             },
             "uid-number": {
-              "version": "0.0.5",
-              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+              "version": "0.0.5"
             }
           }
         },
         "progress": {
-          "version": "1.1.8",
-          "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+          "version": "1.1.8"
         },
         "request": {
           "version": "2.42.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
-              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "version": "1.0.1"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "version": "0.10.31"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     }
                   }
                 }
               }
             },
             "caseless": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+              "version": "0.6.0"
             },
             "forever-agent": {
-              "version": "0.5.2",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+              "version": "0.5.2"
             },
             "qs": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+              "version": "1.2.2"
             },
             "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+              "version": "5.0.1"
             },
             "mime-types": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+              "version": "1.0.2"
             },
             "node-uuid": {
-              "version": "1.4.3",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+              "version": "1.4.3"
             },
             "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+              "version": "0.4.1"
             },
             "tough-cookie": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+              "version": "2.0.0"
             },
             "form-data": {
               "version": "0.1.4",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
                   "dependencies": {
                     "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                      "version": "0.0.5"
                     }
                   }
                 },
                 "mime": {
-                  "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                  "version": "1.2.11"
                 },
                 "async": {
-                  "version": "0.9.2",
-                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                  "version": "0.9.2"
                 }
               }
             },
             "http-signature": {
               "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
               "dependencies": {
                 "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                  "version": "0.1.5"
                 },
                 "asn1": {
-                  "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                  "version": "0.1.11"
                 },
                 "ctype": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                  "version": "0.5.3"
                 }
               }
             },
             "oauth-sign": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+              "version": "0.4.0"
             },
             "hawk": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "0.9.1",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                  "version": "0.9.1"
                 },
                 "boom": {
-                  "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                  "version": "0.4.2"
                 },
                 "cryptiles": {
-                  "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                  "version": "0.2.2"
                 },
                 "sntp": {
-                  "version": "0.2.4",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                  "version": "0.2.4"
                 }
               }
             },
             "aws-sign2": {
-              "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+              "version": "0.5.0"
             },
             "stringstream": {
-              "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+              "version": "0.0.4"
             }
           }
         },
         "request-progress": {
           "version": "0.3.1",
-          "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
           "dependencies": {
             "throttleit": {
-              "version": "0.0.2",
-              "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+              "version": "0.0.2"
             }
           }
         },
         "which": {
-          "version": "1.0.9",
-          "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+          "version": "1.0.9"
         }
       }
     },
     "q": {
-      "version": "1.0.1",
-      "from": "q@1.0.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "requirejs": {
-      "version": "2.1.20",
-      "from": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz"
+      "version": "2.1.20"
     },
     "shoe": {
       "version": "0.0.11",
-      "from": "https://registry.npmjs.org/shoe/-/shoe-0.0.11.tgz",
-      "resolved": "https://registry.npmjs.org/shoe/-/shoe-0.0.11.tgz",
       "dependencies": {
         "sockjs": {
           "version": "0.3.1",
-          "from": "git://github.com/substack/sockjs-node.git#49090a1212ba2e7216c1cf36415de3c5c74e1901",
           "resolved": "git://github.com/substack/sockjs-node.git#49090a1212ba2e7216c1cf36415de3c5c74e1901",
           "dependencies": {
             "node-uuid": {
-              "version": "1.3.3",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.3.3.tgz"
+              "version": "1.3.3"
             },
             "faye-websocket": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.0.tgz"
+              "version": "0.4.0"
             }
           }
         },
         "sockjs-client": {
           "version": "0.0.0-unreleasable",
-          "from": "git://github.com/substack/sockjs-client.git#40d48d06b4dba884416bf88a051f76ca3c8ffcae",
           "resolved": "git://github.com/substack/sockjs-client.git#40d48d06b4dba884416bf88a051f76ca3c8ffcae"
         }
       }
     },
+    "sorted-object": {
+      "version": "1.0.0"
+    },
     "svgo": {
       "version": "0.4.5",
-      "from": "svgo@0.4.5",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.4.5.tgz",
       "dependencies": {
         "sax": {
-          "version": "0.6.1",
-          "from": "sax@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
+          "version": "0.6.1"
         },
         "coa": {
           "version": "0.4.1",
-          "from": "coa@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/coa/-/coa-0.4.1.tgz",
           "dependencies": {
             "q": {
-              "version": "0.9.7",
-              "from": "q@>=0.9.6 <0.10.0",
-              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+              "version": "0.9.7"
             }
           }
         },
         "js-yaml": {
           "version": "2.1.3",
-          "from": "js-yaml@>=2.1.0 <2.2.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
-                  "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                  "version": "1.7.0"
                 },
                 "underscore.string": {
-                  "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                  "version": "2.4.0"
                 }
               }
             },
             "esprima": {
-              "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+              "version": "1.0.4"
             }
           }
         },
         "colors": {
-          "version": "0.6.2",
-          "from": "colors@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+          "version": "0.6.2"
         },
         "whet.extend": {
-          "version": "0.9.9",
-          "from": "whet.extend@>=0.9.9 <0.10.0",
-          "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+          "version": "0.9.9"
         }
       }
     },
     "time-grunt": {
       "version": "1.2.0",
-      "from": "time-grunt@1.2.0",
-      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.2.0.tgz",
       "dependencies": {
         "chalk": {
-          "version": "1.0.0",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "version": "1.1.0",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.0.1",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+              "version": "2.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "has-ansi": {
-              "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "version": "2.0.0",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                },
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "strip-ansi": {
-              "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "version": "3.0.0",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "1.1.1",
-                  "from": "ansi-regex@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "supports-color": {
-              "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+              "version": "2.0.0"
             }
           }
         },
         "date-time": {
-          "version": "1.0.0",
-          "from": "date-time@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "figures": {
-          "version": "1.3.5",
-          "from": "figures@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+          "version": "1.3.5"
         },
         "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+          "version": "0.2.3"
         },
         "pretty-ms": {
-          "version": "1.2.0",
-          "from": "pretty-ms@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.2.0.tgz",
+          "version": "1.4.0",
           "dependencies": {
             "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "version": "4.0.1"
+            },
+            "is-finite": {
+              "version": "1.0.1",
+              "dependencies": {
+                "number-is-nan": {
+                  "version": "1.0.0"
+                }
+              }
             },
             "meow": {
               "version": "3.3.0",
-              "from": "meow@>=3.1.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.1.0",
-                      "from": "camelcase@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                      "version": "1.2.1"
                     },
                     "map-obj": {
-                      "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "indent-string": {
-                  "version": "1.2.1",
-                  "from": "indent-string@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "version": "1.2.2",
                   "dependencies": {
                     "repeating": {
-                      "version": "1.1.3",
-                      "from": "repeating@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
+                      "version": "1.1.3"
                     }
                   }
                 },
                 "minimist": {
-                  "version": "1.1.1",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                  "version": "1.1.3"
                 },
                 "object-assign": {
-                  "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                  "version": "3.0.0"
                 }
               }
             },
             "parse-ms": {
-              "version": "1.0.0",
-              "from": "parse-ms@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "plur": {
-              "version": "1.0.0",
-              "from": "plur@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+          "version": "0.2.0"
         }
       }
     }
-  }
+  },
+  "name": "frontend",
+  "version": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "phantomjs": "1.9.18",
     "q": "1.0.1",
     "shoe": "0.0.11",
+    "sorted-object": "^1.0.0",
     "svgo": "0.4.5",
     "time-grunt": "1.2.0"
   },


### PR DESCRIPTION
`npm shrinkwrap` spits out different metadata depending on the npm version, which makes our diffs much too difficult to read properly.

Browsing [the issue](https://github.com/npm/npm/issues/3581) I found [a little script](https://github.com/angular/angular.js/blob/master/scripts/npm/clean-shrinkwrap.js) we can use to tidy up the shrinkwrap and keep it consistent.

I've also tried to document the npm install process.
