### PR TITLE
footer share buttons

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -39,145 +39,195 @@
     </div>
 
     <div class="l-footer__secondary gs-container" role="contentinfo">
-        <ul class="colophon u-cf">
-        @defining(Edition(request)) { currentEdition =>
-            @if(currentEdition == Uk) {
-                @if(mvt.EmailTextTestControl.isParticipating) {
-                    @* MVT - Test email text - Control *@
-                    <li class="colophon__item"><a data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
-                        daily email sign up</a></li>
-                } else {
-                    @if(mvt.EmailTextTestV1.isParticipating) {
-                        @* MVT - Test email text - Variant 1 *@
-                        <li class="colophon__item"><a data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
-                            Guardian Today email</a></li>
-                    } else {
-                        <li class="colophon__item"><a data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
-                            daily email sign up</a></li>
+        <div class="colophon u-cf">
+            @defining(Edition(request)) { currentEdition =>
+            <div class="footer__follow-us">
+                <h3 class="footer__follow-us__title">Follow theguardian</h3>
+                @currentEdition match {
+                    case Uk => {
+                        <a class="button button--tertiary" data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
+                            @fragments.inlineSvg("share-facebook", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Facebook</span></a>
+                        <a class="button button--tertiary" data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
+                            @fragments.inlineSvg("share-twitter", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Twitter</span></a>
+
+                        @if(mvt.EmailTextTestV1.isParticipating) {
+                            <a class="button button--tertiary" data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                                @fragments.inlineSvg("share-email", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Guardian Today email</span></a>
+                        } else {
+                            <a class="button button--tertiary" data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                                @fragments.inlineSvg("share-email", "icon", Seq("i","i-left")) <span class="footer__follow-us__item">daily email sign up</span></a>
+                        }
+                    }
+
+                    case Us => {
+                        <a class="button button--tertiary" data-link-name="us : footer : facebook" href="https://www.facebook.com/GuardianUs">
+                            @fragments.inlineSvg("share-facebook", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Facebook</span></a>
+                        <a class="button button--tertiary" data-link-name="us : footer : twitter" href="https://twitter.com/GuardianUs">
+                            @fragments.inlineSvg("share-twitter", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Twitter</span></a>
+                        <a class="button button--tertiary" data-link-name="us : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                            @fragments.inlineSvg("share-email", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">daily email sign up</span></a>
+                    }
+
+                    case Au => {
+                        <a class="button button--tertiary" data-link-name="au : footer : facebook" href="https://www.facebook.com/theguardianaustralia">
+                            @fragments.inlineSvg("share-facebook", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Facebook</span></a>
+                        <a class="button button--tertiary" data-link-name="au : footer : twitter" href="https://twitter.com/GuardianAus">
+                            @fragments.inlineSvg("share-twitter", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Twitter</span></a>
+                        <a class="button button--tertiary" data-link-name="au : footer : email sign-up" href="@LinkTo {/info/2015/jan/30/guardian-australia-emails-delivered-to-your-inbox-subscribe-now}">
+                            @fragments.inlineSvg("share-email", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">email sign up</span></a>
+                    }
+
+                    case International => {
+                        <a class="button button--tertiary" data-link-name="int : footer : facebook" href="https://www.facebook.com/theguardian">
+                            @fragments.inlineSvg("share-facebook", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Facebook</span></a>
+                        <a class="button button--tertiary" data-link-name="int : footer : twitter" href="https://twitter.com/guardian">
+                            @fragments.inlineSvg("share-twitter", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Twitter</span></a>
+                        <a class="button button--tertiary" data-link-name="int : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                            @fragments.inlineSvg("share-email", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">daily email sign up</span></a>
                     }
                 }
-                <li class="colophon__item"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
-                    Facebook</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
-                    Twitter</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
-                    membership</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
-                    jobs</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
-                    dating</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="@LinkTo {/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES}">
-                    masterclasses</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : guardian labs" href="@LinkTo {/guardian-labs}">
-                    Guardian labs</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="http://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">
-                    subscribe</a></li>
-                <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
-                    all topics</a></li>
-                <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
-                    all contributors</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : about us" href="@LinkTo {/info}">
-                    about us</a></li>
-                <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="@LinkTo {/help/contact-us}">
-                    contact us</a></li>
-                <li class="colophon__item">
-                    <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                        solve technical issue
-                    </a>
-                </li>
+            </div>
+
+            <ul class="colophon__list">
+                @currentEdition match {
+                    case Uk => {
+                        <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
+                            membership</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
+                            jobs</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
+                            dating</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="@LinkTo {/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES}">
+                            masterclasses</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : guardian labs" href="@LinkTo {/guardian-labs}">
+                            Guardian labs</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="http://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">
+                            subscribe</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                            all topics</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                            all contributors</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : about us" href="@LinkTo {/info}">
+                            about us</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="@LinkTo {/help/contact-us}">
+                            contact us</a>
+                        </li>
+                        <li class="colophon__item">
+                            <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                                solve technical issue
+                            </a>
+                        </li>
+                    }
+
+                    case Us => {
+                        <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
+                            jobs</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs}">
+                            guardian labs</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="http://subscribe.theguardian.com/us?INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE">
+                            subscribe</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                            all topics</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                            all contributors</a>
+                        </li>
+                        <li class="colophon__item">
+                            <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                                solve technical issue
+                            </a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="us : footer : about us" href="@LinkTo {/info/about-guardian-us}">
+                            about us</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="us : footer : contact us" href="@LinkTo {/info/about-guardian-us/contact}">
+                            contact us</a>
+                        </li>
+                    }
+
+                    case Au => {
+                        <li class="colophon__item"><a data-link-name="au : footer : advertising" href="@LinkTo {/advertising/guardian-australia-advertising}">
+                            advertising</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="@LinkTo {/guardian-masterclasses/guardian-masterclasses-australia}">
+                            masterclasses</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="au : footer : guardian labs" href="@LinkTo {/guardian-labs}">
+                            Guardian labs</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="http://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
+                            subscribe</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
+                            UK jobs</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                            all topics</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                            all contributors</a>
+                        </li>
+                        <li class="colophon__item">
+                            <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                                solve technical issue
+                            </a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="au : footer : about us" href="@LinkTo {/info/about-guardian-australia}">
+                            about us</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="@LinkTo {/info/2014/aug/11/guardian-australia-vacancies}">
+                            vacancies</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="au : footer : information" href="@LinkTo {/info}">
+                            information</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="au : footer : contact us" href="@LinkTo {/info/2013/may/26/contact-guardian-australia}">
+                            contact us</a>
+                        </li>
+                    }
+
+                    case International => {
+                        <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                            all topics</a>
+                        </li>
+                        <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                            all contributors</a>
+                        </li>
+                        <li class="colophon__item">
+                            <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                                solve technical issue
+                            </a>
+                        </li>
+                    }
+                }
+
+                @if(currentEdition != Au) {
+                    <li class="colophon__item"><a data-link-name="complaints" href="@LinkTo {/info/complaints-and-corrections}">
+                        complaints &amp; corrections</a></li>
+                }
+
+                <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
+                    terms &amp; conditions</a></li>
+                <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo {/info/privacy}">
+                    privacy policy</a></li>
+                <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">cookie policy</a></li>
+                <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">
+                    securedrop</a></li>
             }
-            @if(currentEdition == Us) {
-                <li class="colophon__item"><a data-link-name="us : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
-                    daily email sign up</a></li>
-                <li class="colophon__item"><a data-link-name="us : footer : facebook" href="https://www.facebook.com/GuardianUs">
-                    Facebook</a></li>
-                <li class="colophon__item"><a data-link-name="us : footer : twitter" href="https://twitter.com/GuardianUs">
-                    Twitter</a></li>
-                <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
-                    jobs</a></li>
-                <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs}">
-                    guardian labs</a></li>
-                <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="http://subscribe.theguardian.com/us?INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE">
-                    subscribe</a></li>
-                <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
-                    all topics</a></li>
-                <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
-                    all contributors</a></li>
-                <li class="colophon__item">
-                    <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                        solve technical issue
-                    </a>
-                </li>
-                <li class="colophon__item"><a data-link-name="us : footer : about us" href="@LinkTo {/info/about-guardian-us}">
-                    about us</a></li>
-                <li class="colophon__item"><a data-link-name="us : footer : contact us" href="@LinkTo {/info/about-guardian-us/contact}">
-                    contact us</a></li>
-            }
-            @if(currentEdition == Au) {
-                <li class="colophon__item"><a data-link-name="au : footer : email sign-up" href="@LinkTo {/info/2015/jan/30/guardian-australia-emails-delivered-to-your-inbox-subscribe-now}">
-                    email sign-up</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : facebook" href="https://www.facebook.com/theguardianaustralia">
-                    Facebook</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : twitter" href="https://twitter.com/GuardianAus">
-                    Twitter</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : advertising" href="@LinkTo {/advertising/guardian-australia-advertising}">
-                    advertising</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="@LinkTo {/guardian-masterclasses/guardian-masterclasses-australia}">
-                    masterclasses</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : guardian labs" href="@LinkTo {/guardian-labs}">
-                    Guardian labs</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="http://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
-                    subscribe</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
-                    UK jobs</a></li>
-                <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
-                    all topics</a></li>
-                <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
-                    all contributors</a></li>
-                <li class="colophon__item">
-                    <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                        solve technical issue
-                    </a>
-                </li>
-                <li class="colophon__item"><a data-link-name="au : footer : about us" href="@LinkTo {/info/about-guardian-australia}">
-                    about us</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="@LinkTo {/info/2014/aug/11/guardian-australia-vacancies}">
-                    vacancies</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : information" href="@LinkTo {/info}">
-                    information</a></li>
-                <li class="colophon__item"><a data-link-name="au : footer : contact us" href="@LinkTo {/info/2013/may/26/contact-guardian-australia}">
-                    contact us</a></li>
-            }
-            @if(currentEdition == International) {
-                <li class="colophon__item"><a data-link-name="int : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
-                    daily email sign up</a></li>
-                <li class="colophon__item"><a data-link-name="int : footer : facebook" href="https://www.facebook.com/theguardian">
-                    Facebook</a></li>
-                <li class="colophon__item"><a data-link-name="int : footer : twitter" href="https://twitter.com/guardian">
-                    Twitter</a></li>
-                <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
-                    all topics</a></li>
-                <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
-                    all contributors</a></li>
-                <li class="colophon__item">
-                    <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                        solve technical issue
-                    </a>
-                </li>
-            }
-            @if(currentEdition != Au) {
-                <li class="colophon__item"><a data-link-name="complaints" href="@LinkTo {/info/complaints-and-corrections}">
-                    complaints &amp; corrections</a></li>
-            }
-            <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
-                terms &amp; conditions</a></li>
-            <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo {/info/privacy}">
-                privacy policy</a></li>
-            <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">cookie policy</a></li>
-            <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">
-                securedrop</a></li>
-        }
-        </ul>
+            </ul>
+        </div>
         <div class="l-footer__misc">
             <div class="really-serious-copyright">© @{new DateTime().year.getAsText} Guardian News and Media Limited or its affiliated companies. All rights reserved.</div>
         </div>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -1,6 +1,5 @@
-@(page: model.MetaData, showNav: Boolean = true, amp: Boolean = false)(implicit request: RequestHeader)
+@(page: model.MetaData, showNav: Boolean = true)(implicit request: RequestHeader)
 
-@import conf.Configuration
 @import org.joda.time.DateTime
 @import common.Edition
 @import common.LinkTo
@@ -10,12 +9,11 @@
     <div class="l-footer__primary">
         <div id="footer-nav" class="gs-container">
             <div class="brand-bar modern-visible u-cf">
-                @if(!amp) {
-                    <a href="@LinkTo {/}" data-link-name="site logo" class="guardian-logo-footer hide-on-mobile">
-                        <span class="u-h">The Guardian</span>
-                        <i class="i i-guardian-logo-160"></i>
-                    </a>
-                }
+                <a href="@LinkTo {/}" data-link-name="site logo" class="guardian-logo-footer hide-on-mobile">
+                    <span class="u-h">The Guardian</span>
+                    <i class="i i-guardian-logo-160"></i>
+                </a>
+
                 <a class="brand-bar__item brand-bar__item--action" data-link-name="back to top" href="#top">
                     <span class="rounded-icon control__icon-wrapper">
                         @fragments.inlineSvg("arrow-up", "icon")
@@ -23,7 +21,8 @@
                     <span class="control__info">back to top</span>
                 </a>
             </div>
-            @if(showNav && !amp) {
+
+            @if(showNav) {
                 <div class="l-footer__navigation-wrapper u-cf">
                     @fragments.nav.navigationFooter(page)
                 </div>
@@ -42,168 +41,141 @@
     <div class="l-footer__secondary gs-container" role="contentinfo">
         <ul class="colophon u-cf">
         @defining(Edition(request)) { currentEdition =>
-            @if(amp) {
-                @if(currentEdition == Uk) {
-                    <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
-                        jobs</a></li>
-                    <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="@LinkTo {/help/contact-us}">
-                        contact us</a></li>
-                }
-                @if(currentEdition == Us) {
-                    <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
-                        jobs</a></li>
-                    <li class="colophon__item"><a data-link-name="us : footer : contact us" href="@LinkTo {/info/about-guardian-us/contact}">
-                        contact us</a></li>
-                }
-                @if(currentEdition == Au) {
-                    <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="@LinkTo {/info/2014/aug/11/guardian-australia-vacancies}">
-                        vacancies</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : contact us" href="@LinkTo {/info/2013/may/26/contact-guardian-australia}">
-                        contact us</a></li>
-                }
-                @if(currentEdition != Au) {
-                    <li class="colophon__item"><a data-link-name="complaints" href="@LinkTo {/info/complaints-and-corrections}">
-                        complaints &amp; corrections</a></li>
-                }
-                <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
-                    terms &amp; conditions</a></li>
-            } else {
-                @if(currentEdition == Uk) {
-                    @if(mvt.EmailTextTestControl.isParticipating) {
-                        @* MVT - Test email text - Control *@
+            @if(currentEdition == Uk) {
+                @if(mvt.EmailTextTestControl.isParticipating) {
+                    @* MVT - Test email text - Control *@
+                    <li class="colophon__item"><a data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                        daily email sign up</a></li>
+                } else {
+                    @if(mvt.EmailTextTestV1.isParticipating) {
+                        @* MVT - Test email text - Variant 1 *@
+                        <li class="colophon__item"><a data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                            Guardian Today email</a></li>
+                    } else {
                         <li class="colophon__item"><a data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
                             daily email sign up</a></li>
-                    } else {
-                        @if(mvt.EmailTextTestV1.isParticipating) {
-                            @* MVT - Test email text - Variant 1 *@
-                            <li class="colophon__item"><a data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
-                                Guardian Today email</a></li>
-                        } else {
-                            <li class="colophon__item"><a data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
-                                daily email sign up</a></li>
-                        }
                     }
-                    <li class="colophon__item"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
-                        Facebook</a></li>
-                    <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
-                        Twitter</a></li>
-                    <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
-                        membership</a></li>
-                    <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
-                        jobs</a></li>
-                    <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
-                        dating</a></li>
-                    <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="@LinkTo {/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES}">
-                        masterclasses</a></li>
-                    <li class="colophon__item"><a data-link-name="uk : footer : guardian labs" href="@LinkTo {/guardian-labs}">
-                        Guardian labs</a></li>
-                    <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="http://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">
-                        subscribe</a></li>
-                    <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
-                        all topics</a></li>
-                    <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
-                        all contributors</a></li>
-                    <li class="colophon__item"><a data-link-name="uk : footer : about us" href="@LinkTo {/info}">
-                        about us</a></li>
-                    <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="@LinkTo {/help/contact-us}">
-                        contact us</a></li>
-                    <li class="colophon__item">
-                        <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                            solve technical issue
-                        </a>
-                    </li>
                 }
-                @if(currentEdition == Us) {
-                    <li class="colophon__item"><a data-link-name="us : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
-                        daily email sign up</a></li>
-                    <li class="colophon__item"><a data-link-name="us : footer : facebook" href="https://www.facebook.com/GuardianUs">
-                        Facebook</a></li>
-                    <li class="colophon__item"><a data-link-name="us : footer : twitter" href="https://twitter.com/GuardianUs">
-                        Twitter</a></li>
-                    <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
-                        jobs</a></li>
-                    <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs}">
-                        guardian labs</a></li>
-                    <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="http://subscribe.theguardian.com/us?INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE">
-                        subscribe</a></li>
-                    <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
-                        all topics</a></li>
-                    <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
-                        all contributors</a></li>
-                    <li class="colophon__item">
-                        <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                            solve technical issue
-                        </a>
-                    </li>
-                    <li class="colophon__item"><a data-link-name="us : footer : about us" href="@LinkTo {/info/about-guardian-us}">
-                        about us</a></li>
-                    <li class="colophon__item"><a data-link-name="us : footer : contact us" href="@LinkTo {/info/about-guardian-us/contact}">
-                        contact us</a></li>
-                }
-                @if(currentEdition == Au) {
-                    <li class="colophon__item"><a data-link-name="au : footer : email sign-up" href="@LinkTo {/info/2015/jan/30/guardian-australia-emails-delivered-to-your-inbox-subscribe-now}">
-                        email sign-up</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : facebook" href="https://www.facebook.com/theguardianaustralia">
-                        Facebook</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : twitter" href="https://twitter.com/GuardianAus">
-                        Twitter</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : advertising" href="@LinkTo {/advertising/guardian-australia-advertising}">
-                        advertising</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="@LinkTo {/guardian-masterclasses/guardian-masterclasses-australia}">
-                        masterclasses</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : guardian labs" href="@LinkTo {/guardian-labs}">
-                        Guardian labs</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="http://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
-                        subscribe</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
-                        UK jobs</a></li>
-                    <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
-                        all topics</a></li>
-                    <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
-                        all contributors</a></li>
-                    <li class="colophon__item">
-                        <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                            solve technical issue
-                        </a>
-                    </li>
-                    <li class="colophon__item"><a data-link-name="au : footer : about us" href="@LinkTo {/info/about-guardian-australia}">
-                        about us</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="@LinkTo {/info/2014/aug/11/guardian-australia-vacancies}">
-                        vacancies</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : information" href="@LinkTo {/info}">
-                        information</a></li>
-                    <li class="colophon__item"><a data-link-name="au : footer : contact us" href="@LinkTo {/info/2013/may/26/contact-guardian-australia}">
-                        contact us</a></li>
-                }
-                @if(currentEdition == International) {
-                    <li class="colophon__item"><a data-link-name="int : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
-                        daily email sign up</a></li>
-                    <li class="colophon__item"><a data-link-name="int : footer : facebook" href="https://www.facebook.com/theguardian">
-                        Facebook</a></li>
-                    <li class="colophon__item"><a data-link-name="int : footer : twitter" href="https://twitter.com/guardian">
-                        Twitter</a></li>
-                    <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
-                        all topics</a></li>
-                    <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
-                        all contributors</a></li>
-                    <li class="colophon__item">
-                        <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                            solve technical issue
-                        </a>
-                    </li>
-                }
-                @if(currentEdition != Au) {
-                    <li class="colophon__item"><a data-link-name="complaints" href="@LinkTo {/info/complaints-and-corrections}">
-                        complaints &amp; corrections</a></li>
-                }
-                <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
-                    terms &amp; conditions</a></li>
-                <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo {/info/privacy}">
-                    privacy policy</a></li>
-                <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">cookie policy</a></li>
-                <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">
-                    securedrop</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
+                    Facebook</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
+                    Twitter</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
+                    membership</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
+                    jobs</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : soulmates" href="https://soulmates.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES">
+                    dating</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : masterclasses" href="@LinkTo {/guardian-masterclasses?INTCMP=NGW_FOOTER_UK_GU_MASTERCLASSES}">
+                    masterclasses</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : guardian labs" href="@LinkTo {/guardian-labs}">
+                    Guardian labs</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : subscribe" href="http://subscribe.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_SUBSCRIBE">
+                    subscribe</a></li>
+                <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                    all topics</a></li>
+                <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                    all contributors</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : about us" href="@LinkTo {/info}">
+                    about us</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="@LinkTo {/help/contact-us}">
+                    contact us</a></li>
+                <li class="colophon__item">
+                    <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                        solve technical issue
+                    </a>
+                </li>
             }
+            @if(currentEdition == Us) {
+                <li class="colophon__item"><a data-link-name="us : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                    daily email sign up</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : facebook" href="https://www.facebook.com/GuardianUs">
+                    Facebook</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : twitter" href="https://twitter.com/GuardianUs">
+                    Twitter</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
+                    jobs</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : guardian labs" href="@LinkTo {/guardian-labs}">
+                    guardian labs</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : subscribe" href="http://subscribe.theguardian.com/us?INTCMP=NGW_FOOTER_US_GU_SUBSCRIBE">
+                    subscribe</a></li>
+                <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                    all topics</a></li>
+                <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                    all contributors</a></li>
+                <li class="colophon__item">
+                    <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                        solve technical issue
+                    </a>
+                </li>
+                <li class="colophon__item"><a data-link-name="us : footer : about us" href="@LinkTo {/info/about-guardian-us}">
+                    about us</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : contact us" href="@LinkTo {/info/about-guardian-us/contact}">
+                    contact us</a></li>
+            }
+            @if(currentEdition == Au) {
+                <li class="colophon__item"><a data-link-name="au : footer : email sign-up" href="@LinkTo {/info/2015/jan/30/guardian-australia-emails-delivered-to-your-inbox-subscribe-now}">
+                    email sign-up</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : facebook" href="https://www.facebook.com/theguardianaustralia">
+                    Facebook</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : twitter" href="https://twitter.com/GuardianAus">
+                    Twitter</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : advertising" href="@LinkTo {/advertising/guardian-australia-advertising}">
+                    advertising</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="@LinkTo {/guardian-masterclasses/guardian-masterclasses-australia}">
+                    masterclasses</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : guardian labs" href="@LinkTo {/guardian-labs}">
+                    Guardian labs</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="http://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">
+                    subscribe</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : uk-jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_AU_GU_JOBS">
+                    UK jobs</a></li>
+                <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                    all topics</a></li>
+                <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                    all contributors</a></li>
+                <li class="colophon__item">
+                    <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                        solve technical issue
+                    </a>
+                </li>
+                <li class="colophon__item"><a data-link-name="au : footer : about us" href="@LinkTo {/info/about-guardian-australia}">
+                    about us</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="@LinkTo {/info/2014/aug/11/guardian-australia-vacancies}">
+                    vacancies</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : information" href="@LinkTo {/info}">
+                    information</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : contact us" href="@LinkTo {/info/2013/may/26/contact-guardian-australia}">
+                    contact us</a></li>
+            }
+            @if(currentEdition == International) {
+                <li class="colophon__item"><a data-link-name="int : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                    daily email sign up</a></li>
+                <li class="colophon__item"><a data-link-name="int : footer : facebook" href="https://www.facebook.com/theguardian">
+                    Facebook</a></li>
+                <li class="colophon__item"><a data-link-name="int : footer : twitter" href="https://twitter.com/guardian">
+                    Twitter</a></li>
+                <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
+                    all topics</a></li>
+                <li class="colophon__item"><a data-link-name="all contributors" href="@LinkTo {/index/contributors}">
+                    all contributors</a></li>
+                <li class="colophon__item">
+                    <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
+                        solve technical issue
+                    </a>
+                </li>
+            }
+            @if(currentEdition != Au) {
+                <li class="colophon__item"><a data-link-name="complaints" href="@LinkTo {/info/complaints-and-corrections}">
+                    complaints &amp; corrections</a></li>
+            }
+            <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
+                terms &amp; conditions</a></li>
+            <li class="colophon__item"><a data-link-name="privacy" href="@LinkTo {/info/privacy}">
+                privacy policy</a></li>
+            <li class="colophon__item"><a data-link-name="cookie" href="@LinkTo {/info/cookies}">cookie policy</a></li>
+            <li class="colophon__item"><a data-link-name="securedrop" href="https://securedrop.theguardian.com/">
+                securedrop</a></li>
         }
         </ul>
         <div class="l-footer__misc">

--- a/common/app/views/fragments/footerAMP.scala.html
+++ b/common/app/views/fragments/footerAMP.scala.html
@@ -1,0 +1,63 @@
+@(page: model.MetaData, showNav: Boolean = true)(implicit request: RequestHeader)
+
+@import org.joda.time.DateTime
+@import common.Edition
+@import common.LinkTo
+@import common.editions.{Au, Uk, Us}
+
+<footer class="l-footer u-cf" data-link-name="footer" data-component="footer">
+    <div class="l-footer__primary">
+        <div id="footer-nav" class="gs-container">
+            <div class="brand-bar modern-visible u-cf">
+                <a class="brand-bar__item brand-bar__item--action" data-link-name="back to top" href="#top">
+                    <span class="rounded-icon control__icon-wrapper">
+                        @fragments.inlineSvg("arrow-up", "icon")
+                    </span>
+                    <span class="control__info">back to top</span>
+                </a>
+            </div>
+
+            @page match {
+                case content: model.Content => {
+                    @fragments.breadcrumb(content)
+                }
+
+                case _ => {}
+            }
+        </div>
+    </div>
+
+    <div class="l-footer__secondary gs-container" role="contentinfo">
+        <ul class="colophon u-cf">
+        @defining(Edition(request)) { currentEdition =>
+            @if(currentEdition == Uk) {
+                <li class="colophon__item"><a data-link-name="uk : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_JOBS">
+                    jobs</a></li>
+                <li class="colophon__item"><a data-link-name="uk : footer : contact us" href="@LinkTo {/help/contact-us}">
+                    contact us</a></li>
+            }
+            @if(currentEdition == Us) {
+                <li class="colophon__item"><a data-link-name="us : footer : jobs" href="http://jobs.theguardian.com/?INTCMP=NGW_FOOTER_US_GU_JOBS">
+                    jobs</a></li>
+                <li class="colophon__item"><a data-link-name="us : footer : contact us" href="@LinkTo {/info/about-guardian-us/contact}">
+                    contact us</a></li>
+            }
+            @if(currentEdition == Au) {
+                <li class="colophon__item"><a data-link-name="au : footer : vacancies" href="@LinkTo {/info/2014/aug/11/guardian-australia-vacancies}">
+                    vacancies</a></li>
+                <li class="colophon__item"><a data-link-name="au : footer : contact us" href="@LinkTo {/info/2013/may/26/contact-guardian-australia}">
+                    contact us</a></li>
+            }
+            @if(currentEdition != Au) {
+                <li class="colophon__item"><a data-link-name="complaints" href="@LinkTo {/info/complaints-and-corrections}">
+                    complaints &amp; corrections</a></li>
+            }
+            <li class="colophon__item"><a data-link-name="terms" href="@LinkTo {/help/terms-of-service}">
+                terms &amp; conditions</a></li>
+        }
+        </ul>
+        <div class="l-footer__misc">
+            <div class="really-serious-copyright">© @{new DateTime().year.getAsText} Guardian News and Media Limited or its affiliated companies. All rights reserved.</div>
+        </div>
+    </div>
+</footer>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -38,7 +38,7 @@
 
             @body
 
-            @fragments.footer(metaData, amp = true)
+            @fragments.footerAMP(metaData)
         </div>
     </body>
 </html>

--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -78,7 +78,6 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
     &,
     a {
         color: colour(neutral-4);
-        text-transform: lowercase;
     }
 }
 
@@ -107,6 +106,7 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
     a {
         display: inline-block;
         padding-bottom: $gs-baseline;
+        text-transform: lowercase;
     }
 }
 
@@ -153,6 +153,7 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
 
 .footer__follow-us__item {
     display: none;
+    text-transform: lowercase;
 
     @include mq(tablet) {
         display: inline;
@@ -162,7 +163,6 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
 .footer__follow-us__title {
     @include fs-header(3);
     color: colour(neutral-7);
-    text-transform: initial;
 }
 
 .l-footer__misc {

--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -81,12 +81,17 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
         text-transform: lowercase;
     }
 }
+
 .colophon {
+    padding-top: $gs-baseline * 2;
+    padding-bottom: $gs-baseline * .5;
+}
+
+.colophon__list {
     @include fs-bodyHeading(1);
     list-style: none;
     margin: 0;
-    padding-top: $gs-baseline * 2;
-    padding-bottom: $gs-baseline * .5;
+
     @include mq($until: tablet) {
         @include columns(2);
     }
@@ -103,10 +108,61 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
         display: inline-block;
         padding-bottom: $gs-baseline;
     }
-
 }
+
 .colophon__item {
     box-sizing: border-box;
+}
+
+.footer__follow-us {
+    margin-bottom: $gs-baseline;
+    padding-bottom: $gs-baseline;
+    border-bottom: 1px solid colour(neutral-2);
+
+    @include mq(tablet) {
+        float: left;
+        border: 0;
+        margin: 0;
+        padding: 0;
+    }
+
+    @include mq(tablet, desktop) {
+        width: 33%;
+    }
+
+    @include mq(desktop, wide) {
+        width: 25%;
+    }
+
+    @include mq(wide) {
+        width: 20%;
+    }
+
+    .button {
+        font-size: .875rem;
+        width: 32px;
+
+        @include mq(tablet) {
+            display: block;
+            margin-bottom: $gs-baseline;
+            width: 80%;
+            max-width: $gs-gutter * 10;
+        }
+    }
+}
+
+.footer__follow-us__item {
+    display: none;
+
+    @include mq(tablet) {
+        display: inline;
+    }
+}
+
+.footer__follow-us__title {
+    @include fs-header(3);
+    color: colour(neutral-7);
+    text-transform: initial;
 }
 
 .l-footer__misc {

--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -145,8 +145,8 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
         @include mq(tablet) {
             display: block;
             margin-bottom: $gs-baseline;
-            width: 80%;
-            max-width: $gs-gutter * 10;
+            width: 70%;
+            max-width: $gs-gutter * 9;
         }
     }
 }


### PR DESCRIPTION
As well as promoting the sharing links to buttons, this splits out the AMP/non-amp footer templates. 

I'm also working on refactoring the footer to make it much easier to work with, once that's done we'll be able to simplify it and maybe bring the AMP one back in.

![screen shot 2015-10-22 at 19 28 05](https://cloud.githubusercontent.com/assets/1064734/10674566/8b948d36-78f3-11e5-8536-65322a35f5e8.png)

![screen shot 2015-10-22 at 19 41 16](https://cloud.githubusercontent.com/assets/1064734/10674827/eca0f41a-78f4-11e5-9469-66463f393be3.png)

![screen shot 2015-10-22 at 19 41 28](https://cloud.githubusercontent.com/assets/1064734/10674832/f06e2270-78f4-11e5-8a1a-126b3a8ebae5.png)
