### PR TITLE
Layout dynamic/slow-mpu Container Without MPU

### DIFF
--- a/common/app/slices/Container.scala
+++ b/common/app/slices/Container.scala
@@ -10,7 +10,7 @@ object Container extends Logging {
     ("dynamic/fast", Dynamic(DynamicFast)),
     ("dynamic/slow", Dynamic(DynamicSlow)),
     ("dynamic/package", Dynamic(DynamicPackage)),
-    ("dynamic/slow-mpu", Dynamic(DynamicSlowMPU)),
+    ("dynamic/slow-mpu", Dynamic(DynamicSlowMPU(omitMPU = false))),
     ("nav/list", NavList),
     ("nav/media-list", NavMediaList),
     ("news/most-popular", MostPopular)
@@ -32,6 +32,8 @@ object Container extends Logging {
     container match {
       case Fixed(definition) if omitMPU =>
         Fixed(definition.copy(slices = definition.slicesWithoutMPU))
+      case Dynamic(DynamicSlowMPU(_)) if omitMPU =>
+        Dynamic(DynamicSlowMPU(omitMPU = true))
       case _ => container
     }
   }

--- a/common/app/slices/DynamicSlowMpu.scala
+++ b/common/app/slices/DynamicSlowMpu.scala
@@ -1,6 +1,6 @@
 package slices
 
-object DynamicSlowMPU extends DynamicContainer {
+case class DynamicSlowMPU(omitMPU: Boolean) extends DynamicContainer {
   override protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
     val BigsAndStandards(bigs, _) = bigsAndStandards(stories)
     val isFirstBoosted = stories.headOption.exists(_.isBoosted)
@@ -20,7 +20,9 @@ object DynamicSlowMPU extends DynamicContainer {
 
   override protected def standardSlices(stories: Seq[Story], firstSlice: Option[Slice]): Seq[Slice] =
     firstSlice match {
+      case Some(_) if omitMPU => Seq(Hl3QuarterQuarter)
       case Some(_) => Seq(Hl3Mpu)
+      case None if omitMPU => Seq(QuarterQuarterQuarterQuarter)
       case None    => Seq(TTlMpu)
     }
 }

--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -109,7 +109,7 @@ object DynamicContainers {
     ("dynamic/fast", DynamicFast),
     ("dynamic/slow", DynamicSlow),
     ("dynamic/package", DynamicPackage),
-    ("dynamic/slow-mpu", DynamicSlowMPU)
+    ("dynamic/slow-mpu", DynamicSlowMPU(omitMPU = false))
   )
 
   def apply(collectionType: Option[String], items: Seq[Content]): Option[ContainerDefinition] = {

--- a/common/app/slices/Slice.scala
+++ b/common/app/slices/Slice.scala
@@ -360,6 +360,43 @@ case object QuarterQuarterHl3 extends Slice {
   )
 }
 
+/* .________.________._________________.
+ * |                 |########|########|
+ * |_________________|########|########|
+ * |_________________|        |        |
+ * |_________________|________|________|
+ */
+case object Hl3QuarterQuarter extends Slice {
+  val layout = SliceLayout(
+    cssClassName = "hl3-q-q",
+    columns = Seq(
+      Rows(
+        colSpan = 2,
+        columns = 1,
+        rows = 3,
+        ItemClasses(
+          mobile = ListItem,
+          tablet = MediaList
+        )
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = MediaList,
+          tablet = Standard
+        )
+      ),
+      SingleItem(
+        colSpan = 1,
+        ItemClasses(
+          mobile = MediaList,
+          tablet = Standard
+        )
+      )
+    )
+  )
+}
+
 /* ._________________.________.________.
  * |_________________|########|########|
  * |_________________|########|########|

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -1,9 +1,9 @@
 package views.support
 
-import com.gu.facia.api.utils.{Audio, Video, Gallery}
-import layout._
+import com.gu.facia.api.utils.{Audio, Gallery, Video}
 import conf.switches.Switches.SaveForLaterSwitch
-import slices.{DynamicSlowMPU, Dynamic}
+import layout._
+import slices.{Dynamic, DynamicSlowMPU}
 
 object GetClasses {
   def forHtmlBlob(item: HtmlBlob) = {
@@ -58,7 +58,7 @@ object GetClasses {
       containerDefinition.showLatestUpdate,
       containerDefinition.index == 0 && containerDefinition.customHeader.isEmpty,
       containerDefinition.displayName.isDefined,
-      containerDefinition.displayName == Some("headlines"),
+      containerDefinition.displayName.contains("headlines"),
       containerDefinition.commercialOptions,
       containerDefinition.hasDesktopShowMore,
       Some(containerDefinition.container),
@@ -66,7 +66,7 @@ object GetClasses {
         slices.Container.customClasses(containerDefinition.container),
       disableHide = containerDefinition.hideToggle,
       lazyLoad = containerDefinition.shouldLazyLoad,
-      dynamicSlowMpu = containerDefinition.container == Dynamic(DynamicSlowMPU)
+      dynamicSlowMpu = containerDefinition.container == Dynamic(DynamicSlowMPU(omitMPU = false))
     )
 
   /** TODO get rid of this when we consolidate 'all' logic with index logic */


### PR DESCRIPTION
Now this container has different layouts according to whether or not it should show an MPU.

Single slice with MPU:
![image](https://cloud.githubusercontent.com/assets/1722550/10690703/6c7c1a80-797b-11e5-99dd-b90ffe78068c.png)

Single slice without MPU:
![image](https://cloud.githubusercontent.com/assets/1722550/10690712/7d3c79b4-797b-11e5-82d1-59cc3180d302.png)

Multiple slice with MPU:
![image](https://cloud.githubusercontent.com/assets/1722550/10690749/cbe5cb92-797b-11e5-8f70-8ae27f06daab.png)

Multiple slice without MPU:
![image](https://cloud.githubusercontent.com/assets/1722550/10690764/f0ae7da2-797b-11e5-99b0-6fe4b98db2de.png)

/cc @Pearson82 @janua
