### PR TITLE
Show the EU cookies message to UK and INT edition readers.

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -6,6 +6,15 @@ import org.joda.time.LocalDate
 trait FeatureSwitches {
 
   // Features
+  val EuCookieMessageSwitch = Switch(
+    "Feature",
+    "eu-cookie-msg",
+    "Show the EU cookies message footer? On: yes, Off: no.",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 11, 11),
+    exposeClientSide = true
+  )
+
   val OfflinePageSwitch = Switch(
     "Feature",
     "offline-page",

--- a/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
@@ -20,24 +20,27 @@ define([
     /**
      * Rules:
      *
-     * EU visitors only
+     * UK / INT edition readers only
      * Never seen the cookie message before
      * Show once only
      * Show only on FIRST page view
      * Persist close state
      */
     function init() {
-        var EU_COOKIE_MSG = 'GU_EU_MSG',
-            euMessageCookie = cookies.get(EU_COOKIE_MSG);
-
-        if (euMessageCookie && euMessageCookie === 'unseen') {
-            var link = 'https://www.theguardian.com/info/cookies',
-                txt = 'Welcome to the Guardian. This site uses cookies, read our policy <a href="' + link + '" class="cookie-message__link">here</a>',
-                opts = {important: true},
-                cookieLifeDays = 365,
-                msg = new Message('cookies');
-            msg.show(txt, opts);
-            cookies.add(EU_COOKIE_MSG, 'seen', cookieLifeDays);
+        if (config.switches.euCookieMsg) {
+            if (config.page.edition === 'UK' || config.page.edition === 'INT') {
+                var EU_COOKIE_MSG = 'GU_EU_MSG',
+                    euMessageCookie = cookies.get(EU_COOKIE_MSG);
+                if (!euMessageCookie || euMessageCookie != 'seen') {
+                    var link = 'https://www.theguardian.com/info/cookies',
+                        txt = 'Welcome to the Guardian. This site uses cookies, read our policy <a href="' + link + '" class="cookie-message__link">here</a>',
+                        opts = {important: true},
+                        cookieLifeDays = 365,
+                        msg = new Message('cookies');
+                    msg.show(txt, opts);
+                    cookies.add(EU_COOKIE_MSG, 'seen', cookieLifeDays);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This variant doesn't depend on Fastly and is behind a switch.
