### PR TITLE
Fix hiding adblock message to paying users

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -96,7 +96,7 @@ define([
         expiryDate.setDate(expiryDate.getDate() + 1);
         cookies.add(PERSISTENCE_KEYS.ADFREE_COOKIE, JsonResponse.adFree);
         cookies.add(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE, expiryDate.getTime().toString());
-        cookies.add(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, JsonResponse.adblockMessage);
+        cookies.add(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, !JsonResponse.adblockMessage);
     }
 
     return {


### PR DESCRIPTION
The original code recorded an 'adblockMessage' field on the server response as the user's 'isPayingMember' status - but it is actually negated. This is an issue in production.

I have added a negation to fix the live issue.
