### PR TITLE
Send GU_U and SC_GU_U cookies on the membership AJAX request

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -87,6 +87,7 @@ define([
         ajaxPromise({
             url : config.page.userAttributesApiUrl + '/me/features',
             crossOrigin : true,
+            withCredentials : true,
             error : function () {}
         }).then(persistResponse, _.noop);
     }


### PR DESCRIPTION
We're trying to call the membership service to know if a user is paying us money, and stop sending them anti-adblock messages if they are, but the request to the server doesn't actually send request cookies unless we explicitly demand that behaviour.

Needed to fix an issue in production related to #10945 
