### PR TITLE
Drive Ad Feature Expiry Emails Directly from DFP

### DIFF
--- a/admin/app/dfp/DfpDataHydrator.scala
+++ b/admin/app/dfp/DfpDataHydrator.scala
@@ -21,7 +21,10 @@ class DfpDataHydrator extends Logging {
   private def loadLineItems(statementBuilder: StatementBuilder): Seq[GuLineItem] = {
     dfpServiceRegistry.fold(Seq[GuLineItem]()) { serviceRegistry =>
       try {
-        val dfpLineItems = DfpApiWrapper.fetchLineItems(serviceRegistry, statementBuilder)
+        val dfpLineItems =
+          DfpApiWrapper.fetchLineItems(serviceRegistry, statementBuilder) filterNot {
+            _.getIsArchived
+          }
 
         val optSponsorFieldId = CustomFieldAgent.get.data.get("Sponsor")
         val allAdUnits = AdUnitAgent.get.data
@@ -148,6 +151,26 @@ class DfpDataHydrator extends Logging {
       .withBindVariableValue("draftStatus", ComputedStatus.DRAFT.toString)
 
     loadLineItems(allSponsored) filter { lineItem =>
+      lineItem.targeting.customTargetSets exists { targetSet =>
+        targetSet.targets exists (_.isAdvertisementFeatureSlot)
+      }
+    }
+  }
+
+  def loadAdFeatures(expiredSince: JodaDateTime, expiringBefore: JodaDateTime): Seq[GuLineItem] = {
+    val statement = new StatementBuilder()
+      .where(
+        "LineItemType = :sponsored AND " +
+          "Status != :draft AND " +
+          "EndDateTime > :startTime AND " +
+          "EndDateTime < :endTime"
+      )
+      .withBindVariableValue("sponsored", LineItemType.SPONSORSHIP.toString)
+      .withBindVariableValue("draft", ComputedStatus.DRAFT.toString)
+      .withBindVariableValue("startTime", expiredSince.getMillis)
+      .withBindVariableValue("endTime", expiringBefore.getMillis)
+
+    loadLineItems(statement) filter { lineItem =>
       lineItem.targeting.customTargetSets exists { targetSet =>
         targetSet.targets exists (_.isAdvertisementFeatureSlot)
       }

--- a/admin/app/views/commercial/email/expiringAdFeatures.scala.html
+++ b/admin/app/views/commercial/email/expiringAdFeatures.scala.html
@@ -9,14 +9,22 @@
 
 @if(expired.nonEmpty) {
     <div>
-        <p>These ad feature logos have expired recently:</p>
+        @if(expired.size == 1) {
+            <p>This ad feature logo has expired recently:</p>
+        } else {
+            <p>These ad feature logos have expired recently:</p>
+        }
         <ul>@for(lineItem <- expired) {@showLineItem(lineItem)}</ul>
     </div>
 }
 
 @if(expiring.nonEmpty) {
     <div>
-        <p>These ad feature logos will be expiring soon:</p>
+        @if(expired.size == 1) {
+            <p>This ad feature logo will be expiring soon:</p> \
+        } else {
+            <p>These ad feature logos will be expiring soon:</p>
+        }
         <ul>@for(lineItem <- expiring) {@showLineItem(lineItem)}</ul>
         <p>See https://frontend.gutools.co.uk/analytics/commercial/sponsorships#advertisement-feature-series</p>
     </div>

--- a/admin/conf/application-logger.xml
+++ b/admin/conf/application-logger.xml
@@ -16,7 +16,7 @@
     </appender>
 
     <!-- DFP API logging -->
-    <logger name="com.google.api.ads.dfp.lib.client.DfpServiceClient.soapXmlLogger" level="OFF"/>
+    <logger name="com.google.api.ads.dfp.lib.client.DfpServiceClient.soapXmlLogger" level="WARN"/>
     <logger name="com.google.api.client.http.HttpTransport" level="OFF"/>
 
     <root level="INFO">


### PR DESCRIPTION
Ad-feature expiry emails are the last feature dependent on the all-ad-features json file.

This change removes that dependency by looking up the data for the email directly in DFP.  Doing this means that we can stop generating the json file and remove a lot of redundant code.
