### PR TITLE
Only attempt ServiceWorker install on HTTPS pages

### DIFF
--- a/static/src/javascripts/bootstraps/app.js
+++ b/static/src/javascripts/bootstraps/app.js
@@ -117,10 +117,11 @@ define([
             }
 
             if (config.switches.offlinePage) {
-                // Will fail on non-{HTTPS,localhost} pages
-                var navigator = window.navigator;
-                if (navigator && navigator.serviceWorker) {
-                    navigator.serviceWorker.register('/service-worker.js');
+                if (window.location.protocol === 'https:') {
+                    var navigator = window.navigator;
+                    if (navigator && navigator.serviceWorker) {
+                        navigator.serviceWorker.register('/service-worker.js');
+                    }
                 }
 
                 if (config.page.pageId === 'offline-page') {


### PR DESCRIPTION
This will prevent us from seeing `Uncaught (in promise) DOMException: Only secure origins are allowed` in the console on non-HTTP pages.
