### PR TITLE
Use the geoip.continent_code from fastly to determine EU readers

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
@@ -28,7 +28,8 @@ define([
      */
     function init() {
         if (config.switches.euCookieMsg) {
-            if (config.page.edition === 'UK' || config.page.edition === 'INT') {
+            var geoContinentCookie = cookies.get('GU_geo_continent');
+            if (geoContinentCookie && geoContinentCookie.toUpperCase() === 'EU') {
                 var EU_COOKIE_MSG = 'GU_EU_MSG',
                     euMessageCookie = cookies.get(EU_COOKIE_MSG);
                 if (!euMessageCookie || euMessageCookie != 'seen') {


### PR DESCRIPTION
This is instead of showing to anyone reading the uk or int editions.
