### PR TITLE
Update email message and cookie banner to prevent double shown message

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
@@ -6,7 +6,8 @@ define([
     'common/views/svgs',
     'common/utils/_',
     'common/modules/commercial/third-party-tags/krux',
-    'common/modules/identity/api'
+    'common/modules/identity/api',
+    'common/utils/mediator'
 ], function (
     config,
     template,
@@ -15,7 +16,8 @@ define([
     svgs,
     _,
     krux,
-    Id
+    Id,
+    mediator
 ) {
 
     var messageId = 'rtrt-email-message';
@@ -35,7 +37,8 @@ define([
                 linkName: 'email sign-up button',
                 arrowWhiteRight: svgs('arrowWhiteRight')
             },
-            createMessage = function (kruxSegmentId) {
+            kruxSegmentId = null,
+            createMessage = function () {
                 var messageShown = false,
                     omnitureEvent = '';
 
@@ -76,18 +79,22 @@ define([
             {
                 id: 'targeted-loyal-A',
                 test: function () {
-                    createMessage('p2lq8cs6r'); // 10 visits or more to the Guardian
+                    kruxSegmentId = 'p2lq8cs6r';
+                    mediator.once('modules:ui:cookiesBanner:notShown', createMessage); // 10 visits or more to the Guardian
                 }
             },
             {
                 id: 'targeted-loyal-B',
                 test: function () {
-                    createMessage('p2lryefg7'); // A visitor currently on the network front
+                    kruxSegmentId = 'p2lryefg7';
+                    mediator.once('modules:ui:cookiesBanner:notShown', createMessage); // A visitor currently on the network front
                 }
             },
             {
                 id: 'all',
-                test: createMessage // Any visitor, any page
+                test: function () {
+                    mediator.once('modules:ui:cookiesBanner:notShown', createMessage); // Any visitor, any page
+                }
             }
         ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-message.js
@@ -37,25 +37,26 @@ define([
                 linkName: 'email sign-up button',
                 arrowWhiteRight: svgs('arrowWhiteRight')
             },
-            kruxSegmentId = null,
-            createMessage = function () {
+            createMessage = function (kruxSegmentId) {
                 var messageShown = false,
                     omnitureEvent = '';
 
-                // If a segment Id is passed and the user is in the segment
-                // or there is no kruxSegmentId passed in
-                // show the message
-                if ((kruxSegmentId && _.contains(krux.getSegments(), kruxSegmentId)) || !kruxSegmentId) {
-                    messageShown = new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
-                    omnitureEvent = !kruxSegmentId ? 'message for all users shown' : 'message for segment ' + kruxSegmentId + ' shown' ;
-                }
+                return function () {
+                    // If a segment Id is passed and the user is in the segment
+                    // or there is no kruxSegmentId passed in
+                    // show the message
+                    if ((kruxSegmentId && _.contains(krux.getSegments(), kruxSegmentId)) || !kruxSegmentId) {
+                        messageShown = new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
+                        omnitureEvent = !kruxSegmentId ? 'message for all users shown' : 'message for segment ' + kruxSegmentId + ' shown' ;
+                    }
 
-                // If the message was shown then pull in omniture and fire off an event
-                if (messageShown) {
-                    require('common/modules/analytics/omniture', function (omniture) {
-                        omniture.trackLinkImmediate('rtrt | message | email sign-up | ' + omnitureEvent);
-                    });
-                }
+                    // If the message was shown then pull in omniture and fire off an event
+                    if (messageShown) {
+                        require('common/modules/analytics/omniture', function (omniture) {
+                            omniture.trackLinkImmediate('rtrt | message | email sign-up | ' + omnitureEvent);
+                        });
+                    }
+                };
             };
 
         this.id = 'RtrtEmailMessage';
@@ -79,21 +80,19 @@ define([
             {
                 id: 'targeted-loyal-A',
                 test: function () {
-                    kruxSegmentId = 'p2lq8cs6r';
-                    mediator.once('modules:ui:cookiesBanner:notShown', createMessage); // 10 visits or more to the Guardian
+                    mediator.once('modules:ui:cookiesBanner:notShown', createMessage('p2lq8cs6r')); // 10 visits or more to the Guardian
                 }
             },
             {
                 id: 'targeted-loyal-B',
                 test: function () {
-                    kruxSegmentId = 'p2lryefg7';
-                    mediator.once('modules:ui:cookiesBanner:notShown', createMessage); // A visitor currently on the network front
+                    mediator.once('modules:ui:cookiesBanner:notShown', createMessage('p2lryefg7')); // A visitor currently on the network front
                 }
             },
             {
                 id: 'all',
                 test: function () {
-                    mediator.once('modules:ui:cookiesBanner:notShown', createMessage); // Any visitor, any page
+                    mediator.once('modules:ui:cookiesBanner:notShown', createMessage()); // Any visitor, any page
                 }
             }
         ];

--- a/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/cookiesBanner.js
@@ -6,7 +6,8 @@ define([
     'common/utils/storage',
     'common/utils/template',
     'common/modules/user-prefs',
-    'common/modules/ui/message'
+    'common/modules/ui/message',
+    'common/utils/mediator'
 ], function (
     config,
     $,
@@ -15,7 +16,8 @@ define([
     storage,
     template,
     userPrefs,
-    Message
+    Message,
+    mediator
 ) {
     /**
      * Rules:
@@ -36,12 +38,15 @@ define([
                         txt = 'Welcome to the Guardian. This site uses cookies, read our policy <a href="' + link + '" class="cookie-message__link">here</a>',
                         opts = {important: true},
                         cookieLifeDays = 365,
-                        msg = new Message('cookies');
-                    msg.show(txt, opts);
+                        msg = new Message('cookies', opts);
+                    msg.show(txt);
                     cookies.add(EU_COOKIE_MSG, 'seen', cookieLifeDays);
+                    return true;
                 }
             }
         }
+
+        mediator.emit('modules:ui:cookiesBanner:notShown');
     }
 
     return {


### PR DESCRIPTION
This PR updates the cookie message with the important var, so that it always shows (overriding currently shown messages), however this meant that you were shown the email banner briefly  before cookie kicked in, so have added a listener to ensure that we only shown the email banner once the cookie banner fails any of its 'show' `if` statements.
