### PR TITLE
Remove minify more switch

### DIFF
--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -99,7 +99,7 @@ object InlineJs {
       } else {
         val md5 = new String(MessageDigest.getInstance("MD5").digest(codeToCompile.getBytes))
 
-        lazy val compiledCode = if (Switches.MinifyInlineJsSwitch.isSwitchedOn) {
+        lazy val compiledCode = if (Switches.ClosureCompilerStandardOptimisation.isSwitchedOn) {
           JsMinifier.unsafeCompileWithStandardOptimisation(codeToCompile, fileName)
         } else {
           JsMinifier.unsafeCompileWithWhitespaceOptimisation(codeToCompile, fileName)

--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -99,7 +99,7 @@ object InlineJs {
       } else {
         val md5 = new String(MessageDigest.getInstance("MD5").digest(codeToCompile.getBytes))
 
-        lazy val compiledCode = if (Switches.ClosureCompilerStandardOptimisation.isSwitchedOn) {
+        lazy val compiledCode = if (Switches.InlineJSStandardOptimisation.isSwitchedOn) {
           JsMinifier.unsafeCompileWithStandardOptimisation(codeToCompile, fileName)
         } else {
           JsMinifier.unsafeCompileWithWhitespaceOptimisation(codeToCompile, fileName)

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -5,10 +5,10 @@ import org.joda.time.LocalDate
 
 trait PerformanceSwitches {
 
-  val ClosureCompilerStandardOptimisation = Switch(
+  val InlineJSStandardOptimisation = Switch(
     "Performance",
-    "closure-compiler-standard",
-    "If this switch is on, the closure compiler will use standard optimisation instead of whitespace only",
+    "inline-standard-optimisation",
+    "If this switch is on, the inline JS will be compressed using closure compiler's standard optimisation instead of whitespace only",
     safeState = On,
     sellByDate = never,
     exposeClientSide = false

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -14,15 +14,6 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
-  val MoreInlineHead = Switch(
-    "Performance",
-    "minify-more-inline-js",
-    "If this switch is on, applyRenderConditions.js, cloudwatchBeacons.js and shouldEnhance.js will be minified by closure",
-    safeState = Off,
-    sellByDate = new LocalDate(2015, 10, 30),
-    exposeClientSide = false
-  )
-
   // Performance
   val LazyLoadContainersSwitch = Switch(
     "Performance",

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -5,11 +5,11 @@ import org.joda.time.LocalDate
 
 trait PerformanceSwitches {
 
-  val MinifyInlineJsSwitch = Switch(
+  val ClosureCompilerStandardOptimisation = Switch(
     "Performance",
-    "minify-inline-js",
-    "If this switch is on, InlineJs output will be minified by closure compiler",
-    safeState = Off,
+    "closure-compiler-standard",
+    "If this switch is on, the closure compiler will use standard optimisation instead of whitespace only",
+    safeState = On,
     sellByDate = never,
     exposeClientSide = false
   )

--- a/common/app/views/fragments/javaScriptPreFlight.scala.html
+++ b/common/app/views/fragments/javaScriptPreFlight.scala.html
@@ -15,28 +15,18 @@
 
     @* NOTE the order of these is important  *@
     @Html(templates.headerInlineJS.js.polyfills().body)
-    @if(Switches.MoreInlineHead.isSwitchedOn) {
-        @InlineJs.withFileNameHint(templates.headerInlineJS.js.shouldEnhance(item).body, "shouldEnhance.js")
-    } else {
-        @Html(templates.headerInlineJS.js.shouldEnhance(item).body)
-    }
+
+    @InlineJs.withFileNameHint(templates.headerInlineJS.js.shouldEnhance(item).body, "shouldEnhance.js")
+
     @Html(templates.headerInlineJS.js.config(item).body)
 
     @Html(templates.headerInlineJS.js.analytics().body)
 
-    @if(Switches.MoreInlineHead.isSwitchedOn) {
-        @InlineJs.withFileNameHint(templates.headerInlineJS.js.applyRenderConditions().body, "applyRenderConditions.js")
-    } else {
-        @Html(templates.headerInlineJS.js.applyRenderConditions().body)
-    }
+    @InlineJs.withFileNameHint(templates.headerInlineJS.js.applyRenderConditions().body, "applyRenderConditions.js")
 
     @* Not the usual type of thing we do, but I want this separate to our "normal" javascript. *@
     @* also delete iPhoneConfidenceCheck inside of facia.js *@
-    @if(Switches.MoreInlineHead.isSwitchedOn) {
-        @InlineJs.withFileNameHint(templates.headerInlineJS.js.cloudwatchBeacons(item).body, "cloudwatchBeacons.js")
-    } else {
-        @Html(templates.headerInlineJS.js.cloudwatchBeacons(item).body)
-    }
+    @InlineJs.withFileNameHint(templates.headerInlineJS.js.cloudwatchBeacons(item).body, "cloudwatchBeacons.js")
 
 </script>
 


### PR DESCRIPTION
This removes the `MoreMinify` switch which was used to switch off the closure compiler on sensitive parts of the `head`.

Everything seems to be fine, and this expires this friday.
