### PR TITLE
always send omniture pixels over https

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -2,6 +2,7 @@ package common
 
 import common.editions.{Au, Us, Uk}
 import conf.Configuration
+import conf.switches.Switches
 import implicits.Requests
 import layout.ContentCard
 import model.Trail
@@ -127,7 +128,12 @@ object CanonicalLink extends CanonicalLink
 
 object AnalyticsHost extends implicits.Requests {
   def apply()(implicit request: RequestHeader): String =
-    "https://hits-secure.theguardian.com"
+    if (Switches.SecureOmniture.isSwitchedOn ||
+      request.headers.get("X-Forwarded-Proto").exists(_.equalsIgnoreCase("https"))) {
+      "https://hits-secure.theguardian.com"
+    } else {
+      "http://hits.theguardian.com"
+    }
 }
 
 object SubscribeLink {

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -127,7 +127,7 @@ object CanonicalLink extends CanonicalLink
 
 object AnalyticsHost extends implicits.Requests {
   def apply()(implicit request: RequestHeader): String =
-    if (request.isSecure) "https://hits-secure.theguardian.com" else "http://hits.theguardian.com"
+    "https://hits-secure.theguardian.com"
 }
 
 object SubscribeLink {

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -1,6 +1,7 @@
 package conf.switches
 
 import conf.switches.Expiry.never
+import org.joda.time.LocalDate
 
 trait MonitoringSwitches {
   // Monitoring
@@ -57,6 +58,15 @@ trait MonitoringSwitches {
     safeState = Off,
     never,
     exposeClientSide = true
+  )
+
+  val SecureOmniture = Switch(
+    "Monitoring",
+    "secure-omniture",
+    "Send omniture tracking to the https url for all pages",
+    safeState = Off,
+    new LocalDate(2015, 11, 16),
+    exposeClientSide = false
   )
 
 }

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -34,9 +34,6 @@ trait Requests {
 
     private val networkFronts = Edition.all.map(_.id).map(id => s"/$id")
 
-    // see http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html#x-forwarded-proto
-    lazy val isSecure: Boolean = r.headers.get("X-Forwarded-Proto").exists(_.equalsIgnoreCase("https"))
-
     //This is a header reliably set by jQuery for AJAX requests used in facia-tool
     lazy val isXmlHttpRequest: Boolean = r.headers.get("X-Requested-With").contains("XMLHttpRequest")
 

--- a/standalone/app/controllers/OAuthLoginController.scala
+++ b/standalone/app/controllers/OAuthLoginController.scala
@@ -51,7 +51,7 @@ object OAuthLoginController extends Controller with ExecutionContexts with impli
   // TODO - this is only while in transition from http to https for preview
   // no copy and paste for use elsewhere, simply go full https
   private def checkIsSecure(config: GoogleAuthConfig)(implicit request: RequestHeader) = {
-    if (request.isSecure){
+    if (request.headers.get("X-Forwarded-Proto").exists(_.equalsIgnoreCase("https"))){
       val oldRedirect = config.redirectUrl
       config.copy(redirectUrl = oldRedirect.replace("http://", "https://"))
     } else {


### PR DESCRIPTION
we used to check a header to decide whether to send an https or http omniture pixel (for no-js)
However this header is set by the ELB and the router sends all requests over http.   So in amp (https) the pixel tracking wasn't working.

I considered making things https after the router, but it seemed overkill - we are not advertising end to end encryption, and most of the https benefits are service worker and ability to access our site where things are blocked or random ISPs inject stuff into the page.
I also considered putting in a new header at fastly to say if it's secure but it turned out there's only one bit of code that uses it anyway.

Another option suggested by @rich-nguyen was to put everything in a VPC, but maybe this is a job for the future.

@mkopka would that cause any issues at your end?
