### PR TITLE
Fail grunt early if dependencies are invalid

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,13 @@
 'use strict';
 /* global module: false, process: false */
+
+var dependencyTest = require('check-dependencies').sync();
+
+if (dependencyTest.status !== 0) {
+    console.error(dependencyTest.error.join('\n')); // eslint-disable-line no-console
+    process.exit(dependencyTest.status);
+}
+
 var megalog = require('megalog');
 
 module.exports = function (grunt) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1251,6 +1251,123 @@
     "btoa": {
       "version": "1.1.2"
     },
+    "check-dependencies": {
+      "version": "0.11.0",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.10.2"
+        },
+        "bower-config": {
+          "version": "0.6.1",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3"
+            },
+            "mout": {
+              "version": "0.9.1"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3"
+                },
+                "minimist": {
+                  "version": "0.0.10"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3"
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0"
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "0.3.0",
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1"
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.1",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.1"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0"
+        },
+        "semver": {
+          "version": "5.0.3"
+        }
+      }
+    },
     "eslint-plugin-jasmine": {
       "version": "1.5.0"
     },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "babel": "5.8.21",
     "btoa": "1.1.2",
+    "check-dependencies": "^0.11.0",
     "eslint-plugin-jasmine": "^1.5.0",
     "eslint-plugin-react": "^3.5.0",
     "esprima": "1.2.2",


### PR DESCRIPTION
When we change update dependencies, we notify users on merge:

![image](https://cloud.githubusercontent.com/assets/921609/10789500/b1111ca6-7d75-11e5-9b75-d5cb64fd2d7f.png)

But it's still possible to run Grunt, and eventually Grunt will probably fail because it is expecting a different version of a certain dependency. It's easy to get confused when this happens, because there's no obvious cause, e.g. this happened to @jbreckmckye and others when I updated the jscs package yesterday.

We can catch these problems early by checking that our dependencies are in sync with the package manifest and shrinkwrap, using this tool: https://github.com/mzgol/check-dependencies
