### PR TITLE
Change link colours for immersive articles

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -57,7 +57,8 @@ object BodyCleaner {
       BlockquoteCleaner,
       ChaptersLinksCleaner,
       PullquoteCleaner,
-      CmpParamCleaner
+      CmpParamCleaner,
+      ImmersiveLinks(article.isImmersive)
     )
     val nonAmpCleaners = List(
       VideoEmbedCleaner(article)

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -480,6 +480,17 @@ case class Summary(amount: Int) extends HtmlCleaner {
   }
 }
 
+case class ImmersiveLinks(isImmersive: Boolean) extends HtmlCleaner {
+  override def clean(document: Document): Document = {
+    if(isImmersive) {
+      document.getElementsByTag("a").foreach{ a => 
+        a.addClass("in-body-link--immersive")
+      }
+    }
+    document
+  }
+}
+
 case class DropCaps(isFeature: Boolean) extends HtmlCleaner {
 
   private def setDropCap(p: Element): String = {

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -161,6 +161,14 @@
         background-color: colour(neutral-7);
     }
 
+    .in-body-link--immersive {
+        color: colour(feature-default);
+
+        &:hover {
+            border-bottom-color: rgba(colour(feature-default), .4);
+        }
+    }
+
     .element + .section-rule {
         margin-top: 0;
     }


### PR DESCRIPTION
Reinstating a [previously removed commit](https://github.com/guardian/frontend/commit/5a24530d9a405d8662b10cd96a9fc03a348725a0) and doing it properly now I know what I'm doing in `htmlCleaner`

Before: 
![screen shot 2015-10-28 at 15 17 12](https://cloud.githubusercontent.com/assets/1607666/10793006/fd7d9d42-7d86-11e5-9610-a594452ac9af.png)

After:
![screen shot 2015-10-28 at 15 16 43](https://cloud.githubusercontent.com/assets/1607666/10793005/fd6b0b1e-7d86-11e5-8836-595c757f431c.png)
