### PR TITLE
Redirects for short urls should pass through campaign code

### DIFF
--- a/applications/app/controllers/ShortUrlsCampaignController.scala
+++ b/applications/app/controllers/ShortUrlsCampaignController.scala
@@ -1,33 +1,13 @@
 package controllers
 
-import common.{LinkTo, Logging}
+import common.{ExecutionContexts, LinkTo, Logging}
 import common.`package`._
+import campaigns.ShortCampaignCodes
 import conf.LiveContentApi
 import model.Cached
 import play.api.mvc.{RequestHeader, Action, Controller}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
-object ShortUrlsCampaignController extends Controller with Logging {
-
-  val campaigns = Map (
-    "iw" -> "twt_ipd",
-    "wc" -> "twt_wc",
-    "tf" -> "twt_fd",
-    "fb" -> "fb_gu",
-    "fo" -> "fb_ot",
-    "us" -> "fb_us",
-    "au" -> "soc_567",
-    "tw" -> "twt_gu",
-    "at" -> "twt_atn",
-    "sfb"-> "share_btn_fb",
-    "ip" -> "twt_iph",
-    "stw" -> "share_btn_tw",
-    "swa" -> "share_btn_wa",
-    "em" -> "email",
-    "sgp" -> "share_btn_gp",
-    "sbl" -> "share_btn_link"
-  )
+object ShortUrlsCampaignController extends Controller with Logging with ExecutionContexts {
 
   def redirectShortUrl(shortUrl: String) = Action.async { implicit request =>
     log.info(s"Redirecting short url $shortUrl")
@@ -42,10 +22,9 @@ object ShortUrlsCampaignController extends Controller with Logging {
     }.recover(convertApiExceptionsWithoutEither).map(Cached(60))
   }
 
-
   def fetchCampaignAndRedirectShortCode(shortUrl: String, campaignCode: String) = Action.async { implicit request =>
     log.info(s"Fetching campaign for $campaignCode and redirect short url")
-    val queryString = request.queryString ++ campaigns.get(campaignCode).map(code => ("CMP", Seq(code)))
+    val queryString = request.queryString ++ ShortCampaignCodes.makeQueryParameter(campaignCode)
     redirectUrl(shortUrl, queryString)
   }
 }

--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -7,7 +7,7 @@ import conf.LiveContentApi
 import model.Cached
 import play.api.mvc.{RequestHeader, Action, Controller}
 
-object ShortUrlsCampaignController extends Controller with Logging with ExecutionContexts {
+object ShortUrlsController extends Controller with Logging with ExecutionContexts {
 
   def redirectShortUrl(shortUrl: String) = Action.async { implicit request =>
     log.info(s"Redirecting short url $shortUrl")

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -64,8 +64,8 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json    
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>         controllers.InteractiveController.renderInteractive(path)
 
 # Short urls with campaign codes
-GET        /$shortCode<p/[\w]+>                                                 controllers.ShortUrlsCampaignController.redirectShortUrl(shortCode)
-GET        /$shortCode<p/[\w]+>/:campaignCode                                   controllers.ShortUrlsCampaignController.fetchCampaignAndRedirectShortCode(shortCode, campaignCode)
+GET        /$shortCode<p/[\w]+>                                                 controllers.ShortUrlsController.redirectShortUrl(shortCode)
+GET        /$shortCode<p/[\w]+>/:campaignCode                                   controllers.ShortUrlsController.fetchCampaignAndRedirectShortCode(shortCode, campaignCode)
 
 # Index pages for tags
 GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>/trails.json                 controllers.IndexController.renderTrailsJson(path)

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -51,7 +51,7 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   }
 
   // Our redirects are 'normalised' Vignette URLs, Ie. path/to/0,<n>,123,<n>.html -> path/to/0,,123,.html
-  private def normalise(path: String, zeros: String = ""): String = {
+  def normalise(path: String, zeros: String = ""): String = {
     val normalised = path match {
       case R1ArtifactUrl(path, artifactOrContextId, extension) =>
         val normalisedUrl = s"www.theguardian.com/$path/0,,$artifactOrContextId,$zeros.html"
@@ -63,12 +63,12 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
     s"http://${normalised.getOrElse(path)}"
   }
 
-  private def linksToItself(path: String, destination: String): Boolean = path match {
+  def linksToItself(path: String, destination: String): Boolean = path match {
     case PathPattern(_, r1path) => destination contains r1path
     case _ => false
   }
 
-  private def retainShortUrlCampaign(path: String)(destination: Destination): Destination = {
+  def retainShortUrlCampaign(path: String)(destination: Destination): Destination = {
     // if the path is a short url with a campaign, and the destination doesn't have a campaign, pass it through the redirect.
     val shortUrlWithCampaign = """.*www\.theguardian\.com/p/[\w\d]+/([\w\d]+)$""".r
     val urlWithCampaignParam = """.*www\.theguardian\.com.*?.*CMP=.*$""".r

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -1,11 +1,12 @@
 package controllers
 
+import campaigns.ShortCampaignCodes
 import common._
 import play.api.mvc._
-import services.{Archive, DynamoDB, Googlebot404Count}
-import java.net.URLDecoder
+import services.{Archive, DynamoDB, Googlebot404Count, Destination}
+import java.net.{URI, URLDecoder}
 import model.Cached
-
+import scala.concurrent.Future
 
 object ArchiveController extends Controller with Logging with ExecutionContexts {
 
@@ -50,8 +51,8 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   }
 
   // Our redirects are 'normalised' Vignette URLs, Ie. path/to/0,<n>,123,<n>.html -> path/to/0,,123,.html
-  def normalise(path: String, zeros: String = ""): Option[String] = {
-    path match {
+  private def normalise(path: String, zeros: String = ""): String = {
+    val normalised = path match {
       case R1ArtifactUrl(path, artifactOrContextId, extension) =>
         val normalisedUrl = s"www.theguardian.com/$path/0,,$artifactOrContextId,$zeros.html"
         Some(normalisedUrl)
@@ -59,16 +60,39 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
         Some(path)
       case _ => None
     }
+    s"http://${normalised.getOrElse(path)}"
   }
 
-  def linksToItself(path: String, destination: String): Boolean = path match {
+  private def linksToItself(path: String, destination: String): Boolean = path match {
     case PathPattern(_, r1path) => destination contains r1path
     case _ => false
   }
 
-  private def destinationFor(path: String) = DynamoDB.destinationFor(path).map(_.filterNot { destination =>
-      linksToItself(path, destination.location)
-  })
+  private def retainShortUrlCampaign(path: String)(destination: Destination): Destination = {
+    // if the path is a short url with a campaign, and the destination doesn't have a campaign, pass it through the redirect.
+    val shortUrlWithCampaign = """.*www\.theguardian\.com/p/[\w\d]+/([\w\d]+)$""".r
+    val urlWithCampaignParam = """.*www\.theguardian\.com.*?.*CMP=.*$""".r
+
+    val destinationHasCampaign = destination.location match {
+      case shortUrlWithCampaign(_) => true
+      case urlWithCampaignParam() => true
+      case _ => false
+    }
+
+    path match {
+      case shortUrlWithCampaign(campaign) if !destinationHasCampaign => {
+        val uri = javax.ws.rs.core.UriBuilder.fromPath(destination.location)
+        ShortCampaignCodes.getFullCampaign(campaign).foreach(uri.replaceQueryParam("CMP", _))
+        services.Redirect(uri.build().toString)
+      }
+      case _ => destination
+    }
+  }
+
+  private def destinationFor(path: String): Future[Option[Destination]] = DynamoDB.destinationFor(normalise(path)).map(
+    _.filterNot { destination => linksToItself(path, destination.location) }
+     .map { retainShortUrlCampaign(path) }
+  )
 
   private object Combiner {
     def unapply(path: String): Option[String] = {
@@ -125,7 +149,7 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
         log.info(s"404,${RequestLog(request)}")
     }
 
-  private def lookupPath(path: String) = destinationFor(s"http://${normalise(path).getOrElse(path)}").map { _.map {
+  private def lookupPath(path: String) = destinationFor(path).map { _.map {
     case services.Redirect(url) =>
       logDestination(path, "redirect", url)
       Cached(300)(Redirect(url, 301))

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -1,7 +1,6 @@
 package test
 
-import play.api.mvc.{AnyContentAsEmpty, Result}
-import play.api.test.FakeRequest
+import play.api.mvc.Result
 import play.api.test.Helpers._
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import scala.concurrent.Future
@@ -9,11 +8,11 @@ import scala.concurrent.Future
 @DoNotDiscover class ArchiveControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
   it should "return a normalised r1 path" in {
-    val tests = Map[String, Option[String]](
-      "www.theguardian.com/books/reviews/travel/0,,343395,00.html" -> Some("www.theguardian.com/books/reviews/travel/0,,343395,.html"),
-      "www.theguardian.com/books/reviews/travel/0,,343395,.html" -> Some("www.theguardian.com/books/reviews/travel/0,,343395,.html"),
-      "www.theguardian.com/books/review/story/0,034,908973,00.html" -> Some("www.theguardian.com/books/review/story/0,,908973,.html"),
-      "www.theguardian.com/books/reviews/travel/foo" -> None
+    val tests = List(
+      "www.theguardian.com/books/reviews/travel/0,,343395,00.html" -> "http://www.theguardian.com/books/reviews/travel/0,,343395,.html",
+      "www.theguardian.com/books/reviews/travel/0,,343395,.html" -> "http://www.theguardian.com/books/reviews/travel/0,,343395,.html",
+      "www.theguardian.com/books/review/story/0,034,908973,00.html" -> "http://www.theguardian.com/books/review/story/0,,908973,.html",
+      "www.theguardian.com/books/reviews/travel/foo" -> "http://www.theguardian.com/books/reviews/travel/foo"
     )
     tests foreach {
       case (key, value) => controllers.ArchiveController.normalise(key) should be (value)
@@ -23,8 +22,18 @@ import scala.concurrent.Future
   // r1 curio (all the redirects have their 00's removed, all the s3 archived files don't)
   it should "return a normalised r1 path with suffixed zeros" in {
     val path = "www.theguardian.com/books/reviews/travel/0,,343395,.html"
-    val expectedPath = Some("www.theguardian.com/books/reviews/travel/0,,343395,00.html")
+    val expectedPath = "http://www.theguardian.com/books/reviews/travel/0,,343395,00.html"
     controllers.ArchiveController.normalise(path , zeros = "00") should be (expectedPath)
+  }
+
+  it should "return a normalised short url path" in {
+    val tests = List(
+      "www.theguardian.com/p/dfas/stw" -> "http://www.theguardian.com/p/dfas",
+      "www.theguardian.com/p/dfas" -> "http://www.theguardian.com/p/dfas"
+    )
+    tests foreach {
+      case (key, value) => controllers.ArchiveController.normalise(key) should be (value)
+    }
   }
 
   it should "not decode encoded urls" in {
@@ -175,6 +184,18 @@ import scala.concurrent.Future
     val result3 = controllers.ArchiveController.lookup("www.theguardian.com/theobserver/2015/jun/14/news")(TestRequest())
     status(result3) should be (301)
     location(result3) should be ("/theobserver/news/2015/jun/14/all")
+  }
+
+  it should "redirect short urls with campaign codes" in {
+    val shortRedirect = services.Redirect("http://www.theguardian.com/p/new")
+    val result = controllers.ArchiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw")(shortRedirect)
+    result.location should be("http://www.theguardian.com/p/new?CMP=share_btn_tw")
+  }
+
+  it should "redirect short urls with campaign codes and allow for overrides" in {
+    val shortRedirectWithCMP = services.Redirect("http://www.theguardian.com/p/new?CMP=existing-cmp")
+    val result = controllers.ArchiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw")(shortRedirectWithCMP)
+    result.location should be ("http://www.theguardian.com/p/new?CMP=existing-cmp")
   }
 
   private def location(result: Future[Result]): String = header("Location", result).head

--- a/common/app/campaigns/ShortCampaignCodes.scala
+++ b/common/app/campaigns/ShortCampaignCodes.scala
@@ -1,0 +1,32 @@
+package campaigns
+
+object ShortCampaignCodes {
+
+  private val campaigns = Map (
+    "iw" -> "twt_ipd",
+    "wc" -> "twt_wc",
+    "tf" -> "twt_fd",
+    "fb" -> "fb_gu",
+    "fo" -> "fb_ot",
+    "us" -> "fb_us",
+    "au" -> "soc_567",
+    "tw" -> "twt_gu",
+    "at" -> "twt_atn",
+    "sfb"-> "share_btn_fb",
+    "ip" -> "twt_iph",
+    "stw" -> "share_btn_tw",
+    "swa" -> "share_btn_wa",
+    "em"  -> "email",
+    "sgp" -> "share_btn_gp",
+    "sbl" -> "share_btn_link"
+  )
+
+  // Resolves "stw" to query param: CMP->share_btn_tw
+  def makeQueryParameter(shortCode: String): Map[String, Seq[String]] = {
+    campaigns.get(shortCode).map { fullCampaign =>
+      Map(("CMP", Seq(fullCampaign)))
+    } getOrElse Map.empty
+  }
+
+  def getFullCampaign(shortCode: String): Option[String] = campaigns.get(shortCode)
+}

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -312,8 +312,8 @@ GET            /2015-06-24-manifest.json                                        
 GET            /preferences                                                                                                      controllers.PreferencesController.indexPrefs()
 GET            /embed/video/*path                                                                                                controllers.EmbedController.render(path)
 
-GET            /$shortCode<p/[\w]+>                                                                                              controllers.ShortUrlsCampaignController.redirectShortUrl(shortCode)
-GET            /$shortCode<p/[\w]+>/:campaignCode                                                                                controllers.ShortUrlsCampaignController.fetchCampaignAndRedirectShortCode(shortCode, campaignCode)
+GET            /$shortCode<p/[\w]+>                                                                                              controllers.ShortUrlsController.redirectShortUrl(shortCode)
+GET            /$shortCode<p/[\w]+>/:campaignCode                                                                                controllers.ShortUrlsController.fetchCampaignAndRedirectShortCode(shortCode, campaignCode)
 
 GET            /$path<.+/\d\d\d\d/\w\w\w/\d\d>                                                                                   controllers.AllIndexController.on(path)
 GET            /$path<.+>/latest                                                                                                 controllers.LatestIndexController.latest(path)


### PR DESCRIPTION
our archive redirect system needs to pass through the campaign code from the original request 
