### PR TITLE
Don't show adfree mode until we have an unambiguous cookie value

### DIFF
--- a/common/app/templates/headerInlineJS/applyAdfreeRenderCondition.scala.js
+++ b/common/app/templates/headerInlineJS/applyAdfreeRenderCondition.scala.js
@@ -9,7 +9,6 @@
         } else {
             var adfreeUser = readCookie('gu_adfree_user');
             // If the user doesn't have the cookie yet, we keep displaying ads until we know their status
-            console.log(adfreeUser, typeof adfreeUser);
             return adfreeUser === 'true';
         }
     }

--- a/common/app/templates/headerInlineJS/applyAdfreeRenderCondition.scala.js
+++ b/common/app/templates/headerInlineJS/applyAdfreeRenderCondition.scala.js
@@ -8,8 +8,9 @@
             return false;
         } else {
             var adfreeUser = readCookie('gu_adfree_user');
-            // If the cookie is ambiguous or null, err on the side of caution and hold off showing ads
-            return adfreeUser !== 'false';
+            // If the user doesn't have the cookie yet, we keep displaying ads until we know their status
+            console.log(adfreeUser, typeof adfreeUser);
+            return adfreeUser === 'true';
         }
     }
 


### PR DESCRIPTION
This is a change on the request of the business. It means that when a user first logs in, they always have at least one pageview with adverts, even if they are an adfree user.

This prevents ad impressions being lost when logged-in users without adfree first sign in.
