### PR TITLE
Multiple videos preroll disabled

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -367,6 +367,13 @@ class Article(delegate: contentapi.Content) extends Content(delegate) with Light
   lazy val hasVideoAtTop: Boolean = Jsoup.parseBodyFragment(body).body().children().headOption
     .exists(e => e.hasClass("gu-video") && e.tagName() == "video")
 
+  lazy val numberOfVideosInTheBody: Int = Jsoup.parseBodyFragment(body).body().children().select("video[class=gu-video]").size()
+
+  lazy val hasMultipleVideosInPage: Boolean = mainVideoCanonicalPath match {
+    case Some(_) => numberOfVideosInTheBody > 0
+    case None => numberOfVideosInTheBody > 1
+  }
+
   lazy val mainVideoCanonicalPath: Option[String] = Jsoup.parseBodyFragment(main).body.getElementsByClass("element-video").headOption.map { v =>
     new URL(v.attr("data-canonical-url")).getPath.stripPrefix("/")
   }
@@ -382,7 +389,6 @@ class Article(delegate: contentapi.Content) extends Content(delegate) with Light
   override def metaData: Map[String, JsValue] = {
     val bookReviewIsbn = isbn.map { i: String => Map("isbn" -> JsString(i)) }.getOrElse(Map())
 
-
     super.metaData ++ Map(
       ("contentType", JsString(contentType)),
       ("isLiveBlog", JsBoolean(isLiveBlog)),
@@ -390,7 +396,8 @@ class Article(delegate: contentapi.Content) extends Content(delegate) with Light
       ("inBodyExternalLinkCount", JsNumber(linkCounts.external)),
       ("shouldHideAdverts", JsBoolean(shouldHideAdverts)),
       ("hasInlineMerchandise", JsBoolean(hasInlineMerchandise)),
-      ("lightboxImages", lightbox)
+      ("lightboxImages", lightbox),
+      ("hasMultipleVideosInPage", JsBoolean(hasMultipleVideosInPage))
     ) ++ bookReviewIsbn
   }
 

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -230,6 +230,8 @@ define([
 
             player.persistvolume({namespace: 'gu.vjs'});
 
+            console.log('player');
+
             deferToAnalytics(function () {
 
                 events.initOmnitureTracking(player);
@@ -239,8 +241,10 @@ define([
                 if (mediaType === 'video') {
 
                     player.fullscreener();
+                    console.log(commercialFeatures.videoPreRolls, !blockVideoAds, !config.page.hasMultipleVideosInPage);
 
-                    if (commercialFeatures.videoPreRolls && !blockVideoAds) {
+                    if (commercialFeatures.videoPreRolls && !blockVideoAds && !config.page.hasMultipleVideosInPage) {
+                        console.log('inside');
                         raven.wrap(
                             { tags: { feature: 'media' } },
                             function () {

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -230,8 +230,6 @@ define([
 
             player.persistvolume({namespace: 'gu.vjs'});
 
-            console.log('player');
-
             deferToAnalytics(function () {
 
                 events.initOmnitureTracking(player);
@@ -241,10 +239,8 @@ define([
                 if (mediaType === 'video') {
 
                     player.fullscreener();
-                    console.log(commercialFeatures.videoPreRolls, !blockVideoAds, !config.page.hasMultipleVideosInPage);
 
                     if (commercialFeatures.videoPreRolls && !blockVideoAds && !config.page.hasMultipleVideosInPage) {
-                        console.log('inside');
                         raven.wrap(
                             { tags: { feature: 'media' } },
                             function () {

--- a/static/src/javascripts/bootstraps/media.js
+++ b/static/src/javascripts/bootstraps/media.js
@@ -240,6 +240,7 @@ define([
 
                     player.fullscreener();
 
+                    //The `hasMultipleVideosInPage` flag is temporary until the #10034 will be fixed
                     if (commercialFeatures.videoPreRolls && !blockVideoAds && !config.page.hasMultipleVideosInPage) {
                         raven.wrap(
                             { tags: { feature: 'media' } },


### PR DESCRIPTION
In order to temporary obey the bug with multiple pre-rolls (https://github.com/guardian/frontend/issues/10034) we disabled video pre-rolls at all everywhere, where there is more than one video.

This needs to be tested especially on fronts and article pages.

CC @kenlim @rich-nguyen 
