### PR TITLE
Remove adfree cookies on signout

### DIFF
--- a/identity/app/controllers/SignoutController.scala
+++ b/identity/app/controllers/SignoutController.scala
@@ -37,9 +37,16 @@ class SignoutController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
   }
 
   private def performSignout(request: RequestHeader) = {
+    val adfreeCookies = List(
+      DiscardingCookie("gu_adfree_user", "/", Some(conf.id.domain), secure = false),
+      DiscardingCookie("gu_user_features_expiry", "/", Some(conf.id.domain), secure = false),
+      DiscardingCookie("gu_paying_member", "/", Some(conf.id.domain), secure = false)
+      )
 
-    val cookiesToDiscard = DiscardingCookie("GU_U", "/", Some(conf.id.domain), secure = false) ::
-      DiscardingCookie("SC_GU_U", "/", Some(conf.id.domain), secure = true) :: Nil
+    val cookiesToDiscard = 
+      DiscardingCookie("GU_U", "/", Some(conf.id.domain), secure = false) ::
+      DiscardingCookie("SC_GU_U", "/", Some(conf.id.domain), secure = true) ::
+      adfreeCookies
 
     NoCache(Found(
       returnUrlVerifier.getVerifiedReturnUrl(request).getOrElse(returnUrlVerifier.defaultReturnUrl)


### PR DESCRIPTION
As part of the work for ad-free web, we're storing the user's membership features in the form of cookies. These values only make sense attached to a particular user, and we scrub them with JavaScript when the user is signed out. However, because that script runs later on in the page, it's not really something we should probably rely on.

This pull request makes us nix the cookies when the user hits the signout controller.
