### PR TITLE
Extend retina ipad fronts switch 

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -238,7 +238,7 @@ trait PerformanceSwitches {
     "ipad-core-fronts",
     "Serve core fronts to a random percentage of crash-prone ipad users",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 10, 31),
+    sellByDate = new LocalDate(2015, 11, 11),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
While waiting for all-clear to make this a permanent thing (see https://github.com/guardian/frontend/pull/11003) we shouldn't let the current switch expire.
