### PR TITLE
add the referrer to amp tracking

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -21,7 +21,7 @@
     <body>
         @defining(s"${request.host}${request.path}") { path =>
             @defining({
-                val params = OmnitureAnalyticsData(metaData, "No Javascript", path, "GoogleAMP", Map(("r", "$DOCUMENT_REFERRER")))
+                val params = OmnitureAnalyticsData(metaData, "No Javascript", path, "GoogleAMP", Map(("r", "DOCUMENT_REFERRER")))
                 val omnitureAccount = Configuration.javascript.pageData("guardian.page.omnitureAccount")
                 s"${AnalyticsHost()}/b/ss/$omnitureAccount/1/H.25.3/?$params"
             }) { omnitureCall =>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -20,9 +20,11 @@
     </head>
     <body>
         @defining(s"${request.host}${request.path}") { path =>
-            @defining(
-                s"${AnalyticsHost()}/b/ss/${Configuration.javascript.pageData("guardian.page.omnitureAccount")}/1/H.25.3/?${OmnitureAnalyticsData(metaData, "No Javascript", path, "GoogleAMP")}"
-            ) { omnitureCall =>
+            @defining({
+                val params = OmnitureAnalyticsData(metaData, "No Javascript", path, "GoogleAMP", Map(("r", "$DOCUMENT_REFERRER")))
+                val omnitureAccount = Configuration.javascript.pageData("guardian.page.omnitureAccount")
+                s"${AnalyticsHost()}/b/ss/$omnitureAccount/1/H.25.3/?$params"
+            }) { omnitureCall =>
                 <amp-pixel src="@Html(omnitureCall)"></amp-pixel>
                 <amp-pixel src="//beacon.guim.co.uk/count/pva.gif"></amp-pixel>
             }

--- a/common/app/views/support/OmnitureAnalyticsData.scala
+++ b/common/app/views/support/OmnitureAnalyticsData.scala
@@ -22,7 +22,7 @@ object OmnitureAnalyticsAccount {
 
 object OmnitureAnalyticsData {
 
-  def apply(page: MetaData, jsSupport: String, path: String, platform: String = "frontend")(implicit request: RequestHeader): Html = {
+  def apply(page: MetaData, jsSupport: String, path: String, platform: String = "frontend", extras: Map[String, String] = Map.empty)(implicit request: RequestHeader): Html = {
     val data = page.metaData map {
       case (key, JsString(s)) => key -> s
       case (key, jValue: JsValue) => key -> Json.stringify(jValue)
@@ -68,7 +68,7 @@ object OmnitureAnalyticsData {
       ("event", omnitureEvent),
       ("v23", registrationType),
       ("e27", omnitureErrorMessage)
-    )
+    ) ++ extras
 
     Html(analyticsData map { case (key, value) => s"$key=${encode(value, "UTF-8")}" } mkString "&")
   }


### PR DESCRIPTION
This doesn't actually work yet because google haven't shipped the referrer feature, but once they do we should get the referrer in omniture for amp.  We will ship once it's released by google.

The feature is this: https://github.com/ampproject/amphtml/blob/master/builtins/amp-pixel.md
and scroll down to $DOCUMENT_REFERRER
@stephanfowler 
