### PR TITLE
Rename admin link to give more context

### DIFF
--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -71,7 +71,7 @@
                 <div class="panel-heading">Diagnose problems with features.</div>
                 <div class="panel-body">
                     <ul>
-                        <li><a href="@controllers.admin.routes.TroubleshooterController.index()">Site outages</a></li>
+                        <li><a href="@controllers.admin.routes.TroubleshooterController.index()">Check a path</a></li>
                         <li><a href="@controllers.admin.routes.SportTroubleshooterController.renderFootballTroubleshooter()">Football feeds</a></li>
                         <li><a href="@controllers.admin.routes.SportTroubleshooterController.renderCricketTroubleshooter()">Cricket feeds</a></li>
                     </ul>


### PR DESCRIPTION
I recently learnt about the trouble shooter page on Admin. It's pretty useful for checking the existence of a path. I think renaming the link on the index page might help others find and use it too.
