### PR TITLE
Specify port for archive test

### DIFF
--- a/archive/test/package.scala
+++ b/archive/test/package.scala
@@ -12,4 +12,7 @@ object `package` {
 }
 
 class ArchiveTestSuite extends Suites (
-  new ArchiveControllerTest ) with SingleServerSuite
+  new ArchiveControllerTest ) with SingleServerSuite {
+
+  override lazy val port: Int = conf.HealthCheck.testPort
+}


### PR DESCRIPTION
I think this will help the intermittent test error, `ChannelException: Failed to bind to: /0.0.0.0:19001`
