### PR TITLE
Only check linksToItself for redirects

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -68,12 +68,12 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
     case _ => false
   }
 
-  def retainShortUrlCampaign(path: String)(destination: Destination): Destination = {
+  def retainShortUrlCampaign(path: String, redirectLocation: String ): String = {
     // if the path is a short url with a campaign, and the destination doesn't have a campaign, pass it through the redirect.
     val shortUrlWithCampaign = """.*www\.theguardian\.com/p/[\w\d]+/([\w\d]+)$""".r
     val urlWithCampaignParam = """.*www\.theguardian\.com.*?.*CMP=.*$""".r
 
-    val destinationHasCampaign = destination.location match {
+    val destinationHasCampaign = redirectLocation match {
       case shortUrlWithCampaign(_) => true
       case urlWithCampaignParam() => true
       case _ => false
@@ -81,18 +81,15 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
 
     path match {
       case shortUrlWithCampaign(campaign) if !destinationHasCampaign => {
-        val uri = javax.ws.rs.core.UriBuilder.fromPath(destination.location)
+        val uri = javax.ws.rs.core.UriBuilder.fromPath(redirectLocation)
         ShortCampaignCodes.getFullCampaign(campaign).foreach(uri.replaceQueryParam("CMP", _))
-        services.Redirect(uri.build().toString)
+        uri.build().toString
       }
-      case _ => destination
+      case _ => redirectLocation
     }
   }
 
-  private def destinationFor(path: String): Future[Option[Destination]] = DynamoDB.destinationFor(normalise(path)).map(
-    _.filterNot { destination => linksToItself(path, destination.location) }
-     .map { retainShortUrlCampaign(path) }
-  )
+  private def destinationFor(path: String): Future[Option[Destination]] = DynamoDB.destinationFor(normalise(path))
 
   private object Combiner {
     def unapply(path: String): Option[String] = {
@@ -149,14 +146,16 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
         log.info(s"404,${RequestLog(request)}")
     }
 
-  private def lookupPath(path: String) = destinationFor(path).map { _.map {
-    case services.Redirect(url) =>
-      logDestination(path, "redirect", url)
-      Cached(300)(Redirect(url, 301))
+  private def lookupPath(path: String) = destinationFor(path).map { _.flatMap {
+    case services.Redirect(location) if !linksToItself(path, location) =>
+      val locationWithCampaign = retainShortUrlCampaign(path, location)
+      logDestination(path, "redirect", locationWithCampaign)
+      Some(Cached(300)(Redirect(locationWithCampaign, 301)))
     case Archive(archivePath) =>
       // http://wiki.nginx.org/X-accel
       logDestination(path, "archive", archivePath)
-      Cached(300)(Ok.withHeaders("X-Accel-Redirect" -> s"/s3-archive/$archivePath"))
+      Some(Cached(300)(Ok.withHeaders("X-Accel-Redirect" -> s"/s3-archive/$archivePath")))
+    case _ => None
   }}
 
 }

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -188,14 +188,14 @@ import scala.concurrent.Future
 
   it should "redirect short urls with campaign codes" in {
     val shortRedirect = services.Redirect("http://www.theguardian.com/p/new")
-    val result = controllers.ArchiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw")(shortRedirect)
-    result.location should be("http://www.theguardian.com/p/new?CMP=share_btn_tw")
+    val result = controllers.ArchiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw", shortRedirect)
+    result should be("http://www.theguardian.com/p/new?CMP=share_btn_tw")
   }
 
   it should "redirect short urls with campaign codes and allow for overrides" in {
     val shortRedirectWithCMP = services.Redirect("http://www.theguardian.com/p/new?CMP=existing-cmp")
-    val result = controllers.ArchiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw")(shortRedirectWithCMP)
-    result.location should be ("http://www.theguardian.com/p/new?CMP=existing-cmp")
+    val result = controllers.ArchiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw", shortRedirectWithCMP)
+    result should be ("http://www.theguardian.com/p/new?CMP=existing-cmp")
   }
 
   private def location(result: Future[Result]): String = header("Location", result).head


### PR DESCRIPTION
A bug was introduced by https://github.com/guardian/frontend/pull/11000 which meant pressed page lookups were 404-ing. 

This is due to `linksToItself`, a function that is intended to stop redirect loops. But `linksToItself` is also checked for pressed page lookups, and used to be benign because normalised r1 paths do not look the same as the final s3 path. The most rational fix is to avoid using `linksToItself` at all for pressed pages path queries.
