### PR TITLE
Use 'the Guardian', not  'The Guardian'

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -32,7 +32,7 @@ define([
             siteMessageCloseBtn: 'hide'
         }).show(template(messageTemplate, {
             messageText: [
-                'Thank you for reading The Guardian.',
+                'Thank you for reading the Guardian.',
                 'Help keep our journalism free and independent by becoming a Supporter for just £5 a month.'
             ].join(' '),
             linkHref: 'https://membership.theguardian.com/supporter?INTCMP=MEMBERSHIP_SUPPORTER_BANNER_UK',


### PR DESCRIPTION
Jenny Heeley & Lauren Babcock pointed out this should be lower case.

The [Guardian Style Guide](http://www.theguardian.com/guardian-observer-style-guide-t) says of 'the' : `lc for newspapers (the Guardian)`

cc @chrisjowen 

```
---------- Forwarded message ----------
From: Lauren Babcock
Date: 29 October 2015 at 16:52
Subject: Fwd: Screengrab
To: Nick M Miller

Hello there - do you know who builds these? Should be a lower case t. Thanks so much
```
