### PR TITLE
Only consider paths as matching if the destination ends with the r1 path

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -64,7 +64,7 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   }
 
   def linksToItself(path: String, destination: String): Boolean = path match {
-    case PathPattern(_, r1path) => destination contains r1path
+    case PathPattern(_, r1path) => destination.endsWith(r1path)
     case _ => false
   }
 


### PR DESCRIPTION
This strengthens the conditions needed to consider a path as one which 'links to itself'. This should only be true if the candidate redirect path string ends with the input string (rather than contains).
