### PR TITLE
Rename X-GU-ID-REMOTE-IP to X-Forwarded-For

### DIFF
--- a/identity/app/idapiclient/IdApi.scala
+++ b/identity/app/idapiclient/IdApi.scala
@@ -103,7 +103,7 @@ abstract class IdApi(val apiRootUrl: String, http: Http, jsonBodyParser: JsonBod
   def register(user: User, trackingParameters: TrackingData, returnUrl: Option[String] = None): Future[Response[User]] = {
     val userData = write(user)
     val params = buildParams(tracking = Some(trackingParameters), extra = returnUrl.map(url => Iterable("returnUrl" -> url)))
-    val headers = buildHeaders(extra = trackingParameters.ipAddress.map(ip => Iterable("X-GU-ID-REMOTE-IP" -> ip)))
+    val headers = buildHeaders(extra = trackingParameters.ipAddress.map(ip => Iterable("X-Forwarded-For" -> ip)))
     val response = http.POST(apiUrl("user"), Some(userData), params, headers)
     response map extractUser
   }

--- a/identity/test/idapiclient/IdApiTest.scala
+++ b/identity/test/idapiclient/IdApiTest.scala
@@ -570,7 +570,7 @@ class IdApiTest extends path.FreeSpec with ShouldMatchers with MockitoSugar {
       "passes the user's IP details as provided" in {
         when(trackingParameters.ipAddress).thenReturn(Some("127.0.0.1"))
         api.register(user, trackingParameters)
-        verify(http).POST(Matchers.any[String], Matchers.eq(Some(expectedPostData)), Matchers.any[Parameters], argThat(new ParamsIncludes(Iterable("X-GU-ID-REMOTE-IP" -> "127.0.0.1"))))
+        verify(http).POST(Matchers.any[String], Matchers.eq(Some(expectedPostData)), Matchers.any[Parameters], argThat(new ParamsIncludes(Iterable("X-Forwarded-For" -> "127.0.0.1"))))
       }
     }
 


### PR DESCRIPTION
We don't check `X-GU-ID-REMOTE-IP` on our side, but having `X-Forwarded-For`[1] would mean it gets automatically picked up on our side. Right now this information is not processed.
1. http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/x-forwarded-headers.html#x-forwarded-for
