### PR TITLE
Allow slow mpu to boost 2nd item 

### DIFF
--- a/common/app/slices/DynamicSlowMpu.scala
+++ b/common/app/slices/DynamicSlowMpu.scala
@@ -4,7 +4,7 @@ case class DynamicSlowMPU(omitMPU: Boolean) extends DynamicContainer {
   override protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
     val BigsAndStandards(bigs, _) = bigsAndStandards(stories)
     val isFirstBoosted = stories.headOption.exists(_.isBoosted)
-    val isSecondBoosted = stories.tail.headOption.exists(_.isBoosted)
+    val isSecondBoosted = stories.lift(1).exists(_.isBoosted)
 
     if (bigs.length == 3) {
       Some((HalfQQ, stories.drop(3)))

--- a/common/app/slices/DynamicSlowMpu.scala
+++ b/common/app/slices/DynamicSlowMpu.scala
@@ -4,11 +4,12 @@ case class DynamicSlowMPU(omitMPU: Boolean) extends DynamicContainer {
   override protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {
     val BigsAndStandards(bigs, _) = bigsAndStandards(stories)
     val isFirstBoosted = stories.headOption.exists(_.isBoosted)
+    val isSecondBoosted = stories.tail.headOption.exists(_.isBoosted)
 
     if (bigs.length == 3) {
       Some((HalfQQ, stories.drop(3)))
     } else if (bigs.length == 2) {
-      Some((if (isFirstBoosted) ThreeQuarterQuarter else HalfHalf, stories.drop(2)))
+      Some(if (isFirstBoosted) ThreeQuarterQuarter else if (isSecondBoosted) QuarterThreeQuarter else HalfHalf, stories.drop(2))
     } else if (bigs.length == 1) {
       Some(if (isFirstBoosted) ThreeQuarterQuarter else HalfHalf, stories.drop(2))
     } else if (bigs.isEmpty) {


### PR DESCRIPTION
before:

![screen shot 2015-11-02 at 15 52 00](https://cloud.githubusercontent.com/assets/867233/10886383/bea4a286-8179-11e5-87e8-cdd8c16d0574.png)

after:

![screen shot 2015-11-02 at 15 51 04](https://cloud.githubusercontent.com/assets/867233/10886387/c3aeec82-8179-11e5-927a-f14ec609fda4.png)

@jennysivapalan `lift(2)` didn't work, but `tail.headOption` does. you think it's ok?
