### PR TITLE
Fix Slices at Mobile Breakpoint

### DIFF
--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -35,6 +35,10 @@
         }
     }
 
+    @include mq(mobile) {
+        float: none;
+    }
+
     + .fc-slice__item {
         @include vertical-item-separator;
     }


### PR DESCRIPTION
This fixes a layout issue on mobile.
I don't think I've broken anything anywhere else with this fix.

Before:

![image](https://cloud.githubusercontent.com/assets/1722550/10888303/595558a8-8183-11e5-88f4-6e4576df34ec.png)

After:

![image](https://cloud.githubusercontent.com/assets/1722550/10888286/32f28636-8183-11e5-8cd2-850e2362f114.png)

/cc @jbreckmckye @stephanfowler 
