### PR TITLE
`make watch` bug fix

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ default: help
 
 watch: compile-dev
 	@./node_modules/grunt-sass/node_modules/node-sass/bin/node-sass -w ./static/src/stylesheets -o ./static/target/stylesheets --source-map=true & \
-		gulp --cwd ./dev watch:css & \
+		./node_modules/.bin/gulp --cwd ./dev watch:css & \
 		./node_modules/browser-sync/bin/browser-sync.js start --config ./dev/bs-config.js
 
 compile:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1281,6 +1281,487 @@
         }
       }
     },
+    "babel-core": {
+      "version": "5.8.33",
+      "dependencies": {
+        "babel-plugin-constant-folding": {
+          "version": "1.0.1"
+        },
+        "babel-plugin-dead-code-elimination": {
+          "version": "1.0.2"
+        },
+        "babel-plugin-eval": {
+          "version": "1.0.1"
+        },
+        "babel-plugin-inline-environment-variables": {
+          "version": "1.0.1"
+        },
+        "babel-plugin-jscript": {
+          "version": "1.0.4"
+        },
+        "babel-plugin-member-expression-literals": {
+          "version": "1.0.1"
+        },
+        "babel-plugin-property-literals": {
+          "version": "1.0.1"
+        },
+        "babel-plugin-proto-to-assign": {
+          "version": "1.0.4"
+        },
+        "babel-plugin-react-constant-elements": {
+          "version": "1.0.3"
+        },
+        "babel-plugin-react-display-name": {
+          "version": "1.0.3"
+        },
+        "babel-plugin-remove-console": {
+          "version": "1.0.1"
+        },
+        "babel-plugin-remove-debugger": {
+          "version": "1.0.1"
+        },
+        "babel-plugin-runtime": {
+          "version": "1.0.7"
+        },
+        "babel-plugin-undeclared-variables-check": {
+          "version": "1.0.2",
+          "dependencies": {
+            "leven": {
+              "version": "1.0.2"
+            }
+          }
+        },
+        "babel-plugin-undefined-to-void": {
+          "version": "1.1.6"
+        },
+        "babylon": {
+          "version": "5.8.29"
+        },
+        "bluebird": {
+          "version": "2.10.2"
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0"
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "1.1.1"
+        },
+        "core-js": {
+          "version": "1.2.5"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1"
+            }
+          }
+        },
+        "detect-indent": {
+          "version": "3.0.1",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1"
+            },
+            "minimist": {
+              "version": "1.2.0"
+            }
+          }
+        },
+        "esutils": {
+          "version": "2.0.2"
+        },
+        "fs-readdir-recursive": {
+          "version": "0.1.2"
+        },
+        "globals": {
+          "version": "6.4.1"
+        },
+        "home-or-tmp": {
+          "version": "1.0.0",
+          "dependencies": {
+            "os-tmpdir": {
+              "version": "1.0.1"
+            },
+            "user-home": {
+              "version": "1.1.1"
+            }
+          }
+        },
+        "is-integer": {
+          "version": "1.0.6",
+          "dependencies": {
+            "is-finite": {
+              "version": "1.0.1",
+              "dependencies": {
+                "number-is-nan": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "js-tokens": {
+          "version": "1.0.1"
+        },
+        "json5": {
+          "version": "0.4.0"
+        },
+        "line-numbers": {
+          "version": "0.2.0",
+          "dependencies": {
+            "left-pad": {
+              "version": "0.0.3"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.1",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.1"
+                },
+                "concat-map": {
+                  "version": "0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "output-file-sync": {
+          "version": "1.1.1",
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0"
+            }
+          }
+        },
+        "path-exists": {
+          "version": "1.0.0"
+        },
+        "path-is-absolute": {
+          "version": "1.0.0"
+        },
+        "private": {
+          "version": "0.1.6"
+        },
+        "regenerator": {
+          "version": "0.8.40",
+          "dependencies": {
+            "commoner": {
+              "version": "0.10.3",
+              "dependencies": {
+                "q": {
+                  "version": "1.1.2"
+                },
+                "commander": {
+                  "version": "2.5.1"
+                },
+                "graceful-fs": {
+                  "version": "3.0.8"
+                },
+                "glob": {
+                  "version": "4.2.2",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
+                    "minimatch": {
+                      "version": "1.0.0",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.7.0"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "install": {
+                  "version": "0.1.8"
+                },
+                "iconv-lite": {
+                  "version": "0.4.13"
+                }
+              }
+            },
+            "defs": {
+              "version": "1.1.1",
+              "dependencies": {
+                "alter": {
+                  "version": "0.2.0",
+                  "dependencies": {
+                    "stable": {
+                      "version": "0.1.5"
+                    }
+                  }
+                },
+                "ast-traverse": {
+                  "version": "0.1.1"
+                },
+                "breakable": {
+                  "version": "1.0.0"
+                },
+                "simple-fmt": {
+                  "version": "0.1.0"
+                },
+                "simple-is": {
+                  "version": "0.2.0"
+                },
+                "stringmap": {
+                  "version": "0.2.2"
+                },
+                "stringset": {
+                  "version": "0.2.1"
+                },
+                "tryor": {
+                  "version": "0.1.2"
+                },
+                "yargs": {
+                  "version": "3.27.0",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1"
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.2",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.3",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "2.0.1",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.0"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2"
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "0.2.4"
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.3",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "2.0.1",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.0"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.1.1"
+                    },
+                    "os-locale": {
+                      "version": "1.4.0",
+                      "dependencies": {
+                        "lcid": {
+                          "version": "1.0.0",
+                          "dependencies": {
+                            "invert-kv": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "window-size": {
+                      "version": "0.1.2"
+                    },
+                    "y18n": {
+                      "version": "3.2.0"
+                    }
+                  }
+                }
+              }
+            },
+            "esprima-fb": {
+              "version": "15001.1001.0-dev-harmony-fb"
+            },
+            "recast": {
+              "version": "0.10.33",
+              "dependencies": {
+                "ast-types": {
+                  "version": "0.8.12"
+                }
+              }
+            },
+            "through": {
+              "version": "2.3.8"
+            }
+          }
+        },
+        "regexpu": {
+          "version": "1.3.0",
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.0"
+            },
+            "recast": {
+              "version": "0.10.35",
+              "dependencies": {
+                "esprima-fb": {
+                  "version": "15001.1001.0-dev-harmony-fb"
+                },
+                "ast-types": {
+                  "version": "0.8.12"
+                }
+              }
+            },
+            "regenerate": {
+              "version": "1.2.1"
+            },
+            "regjsgen": {
+              "version": "0.2.0"
+            },
+            "regjsparser": {
+              "version": "0.1.5",
+              "dependencies": {
+                "jsesc": {
+                  "version": "0.5.0"
+                }
+              }
+            }
+          }
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "dependencies": {
+            "is-finite": {
+              "version": "1.0.1",
+              "dependencies": {
+                "number-is-nan": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.6"
+        },
+        "shebang-regex": {
+          "version": "1.0.0"
+        },
+        "slash": {
+          "version": "1.0.0"
+        },
+        "source-map": {
+          "version": "0.5.3"
+        },
+        "source-map-support": {
+          "version": "0.2.10",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.1"
+        },
+        "trim-right": {
+          "version": "1.0.1"
+        },
+        "try-resolve": {
+          "version": "1.0.1"
+        }
+      }
+    },
     "browser-sync": {
       "version": "2.9.11",
       "dependencies": {
@@ -3299,20 +3780,6 @@
     "grunt-autoprefixer": {
       "version": "3.0.3",
       "dependencies": {
-        "autoprefixer-core": {
-          "version": "5.2.1",
-          "dependencies": {
-            "browserslist": {
-              "version": "0.4.0"
-            },
-            "num2fraction": {
-              "version": "1.2.2"
-            },
-            "caniuse-db": {
-              "version": "1.0.30000350"
-            }
-          }
-        },
         "chalk": {
           "version": "1.0.0",
           "dependencies": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "devDependencies": {
     "autoprefixer-core": "^5.2.1",
+    "babel-core": "^5.0.0",
     "browser-sync": "^2.8.2",
     "gulp": "^3.9.0",
     "gulp-load-tasks": "^0.8.3",


### PR DESCRIPTION
expected gulp and babel-core to be global, so failed if they weren't. now uses local versions regardless.
