### PR TITLE
Add new Immersive figure weighting

### DIFF
--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -114,6 +114,7 @@ object ContentWidths {
     def supporting: WidthsByBreakpoint = unused
     def showcase: WidthsByBreakpoint = unused
     def thumbnail: WidthsByBreakpoint = unused
+    def immersive: WidthsByBreakpoint = unused
   }
 
   object BodyMedia extends ContentRelation {
@@ -135,6 +136,15 @@ object ContentWidths {
       phablet =         Some(620.px), // tablet and desktop are also 620px
       leftCol =         Some(780.px),
       wide =            Some(860.px))
+
+    override val immersive = WidthsByBreakpoint(
+      mobile =          Some(465.px),
+      mobileLandscape = Some(645.px),
+      phablet =         Some(725.px),
+      tablet =          Some(965.px),
+      desktop =         Some(1125.px),
+      leftCol =         Some(1140.px),
+      wide =            Some(1300.px))
 
     override val thumbnail = WidthsByBreakpoint(
       mobile =          Some(120.px), // mobileLandscape and tablet are also 120px
@@ -217,6 +227,7 @@ object ContentWidths {
       case Supporting => relation.supporting
       case Showcase => relation.showcase
       case Thumbnail => relation.thumbnail
+      case Immersive => relation.immersive
       case _ => unused
     }
   }

--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -137,15 +137,6 @@ object ContentWidths {
       leftCol =         Some(780.px),
       wide =            Some(860.px))
 
-    override val immersive = WidthsByBreakpoint(
-      mobile =          Some(465.px),
-      mobileLandscape = Some(645.px),
-      phablet =         Some(725.px),
-      tablet =          Some(965.px),
-      desktop =         Some(1125.px),
-      leftCol =         Some(1140.px),
-      wide =            Some(1300.px))
-
     override val thumbnail = WidthsByBreakpoint(
       mobile =          Some(120.px), // mobileLandscape and tablet are also 120px
       tablet =          Some(140.px)) // desktop, leftCol and wide are also 140px
@@ -180,6 +171,29 @@ object ContentWidths {
       desktop =         Some(1125.px),
       leftCol =         Some(1140.px),
       wide =            Some(1300.px))
+  }
+
+  object ImmersiveMedia extends ContentRelation {
+    override val inline = BodyMedia.inline
+    override val supporting = BodyMedia.supporting
+    override val thumbnail = BodyMedia.thumbnail
+
+    override val immersive = WidthsByBreakpoint(
+      mobile =          Some(465.px),
+      mobileLandscape = Some(645.px),
+      phablet =         Some(725.px),
+      tablet =          Some(965.px),
+      desktop =         Some(1125.px),
+      leftCol =         Some(1140.px),
+      wide =            Some(1300.px))
+
+    override val showcase = WidthsByBreakpoint(
+      mobile =          Some(445.px),
+      mobileLandscape = Some(605.px),
+      phablet =         Some(620.px), // tablet is also 620px
+      desktop =         Some(640.px),
+      leftCol =         Some(800.px),
+      wide =            Some(880.px))
   }
 
   object LiveBlogMedia extends ContentRelation {

--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -107,6 +107,7 @@ object ContentWidths {
   object Supporting extends ContentHinting (Some("element--supporting"))
   object Showcase   extends ContentHinting (Some("element--showcase"))
   object Thumbnail  extends ContentHinting (Some("element--thumbnail"))
+  object Immersive  extends ContentHinting (Some("element--immersive"))
 
   sealed trait ContentRelation {
     def inline: WidthsByBreakpoint

--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -140,6 +140,8 @@ object ContentWidths {
     override val thumbnail = WidthsByBreakpoint(
       mobile =          Some(120.px), // mobileLandscape and tablet are also 120px
       tablet =          Some(140.px)) // desktop, leftCol and wide are also 140px
+
+    override val immersive = BodyMedia.inline
   }
 
   object MainMedia extends ContentRelation {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -103,7 +103,7 @@ case class PictureCleaner(article: Article, amp: Boolean)(implicit request: Requ
       container <- findContainerFromId(figure.attr("data-media-id"), image.attr("src"))
       image <- container.largestImage
     }{
-      val hinting = findBreakpointWidths(figure)
+      val hinting = findBreakpointWidths(figure, article.isImmersive)
       val relation = if (article.isLiveBlog) { LiveBlogMedia } else { BodyMedia }
       val widths = ContentWidths.getWidthsFromContentElement(hinting, relation)
 
@@ -160,12 +160,13 @@ case class PictureCleaner(article: Article, amp: Boolean)(implicit request: Requ
     fullyMatchedImage.orElse(imageContainers.headOption)
   }
 
-  def findBreakpointWidths(figure: Element): ContentHinting = {
+  def findBreakpointWidths(figure: Element, isImmersive: Boolean): ContentHinting = {
 
     figure.classNames().map(Some(_)) match {
       case classes if classes.contains(Supporting.className) => Supporting
       case classes if classes.contains(Showcase.className) => Showcase
       case classes if classes.contains(Thumbnail.className) => Thumbnail
+      case classes if classes.contains(Immersive.className) && isImmersive => Immersive
       case _ => Inline
     }
   }

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -104,7 +104,7 @@ case class PictureCleaner(article: Article, amp: Boolean)(implicit request: Requ
       image <- container.largestImage
     }{
       val hinting = findBreakpointWidths(figure, article.isImmersive)
-      val relation = if (article.isLiveBlog) { LiveBlogMedia } else { BodyMedia }
+      val relation = if (article.isLiveBlog) { LiveBlogMedia } else if (article.isImmersive) { ImmersiveMedia } else { BodyMedia }
       val widths = ContentWidths.getWidthsFromContentElement(hinting, relation)
 
       val orientationClass = image.orientation match {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -103,8 +103,15 @@ case class PictureCleaner(article: Article, amp: Boolean)(implicit request: Requ
       container <- findContainerFromId(figure.attr("data-media-id"), image.attr("src"))
       image <- container.largestImage
     }{
-      val hinting = findBreakpointWidths(figure, article.isImmersive)
-      val relation = if (article.isLiveBlog) { LiveBlogMedia } else if (article.isImmersive) { ImmersiveMedia } else { BodyMedia }
+      val hinting = findBreakpointWidths(figure)
+      val relation = if (article.isLiveBlog) {
+        LiveBlogMedia
+      } else if (article.isImmersive) {
+        ImmersiveMedia
+      } else {
+        BodyMedia
+      }
+
       val widths = ContentWidths.getWidthsFromContentElement(hinting, relation)
 
       val orientationClass = image.orientation match {
@@ -160,13 +167,13 @@ case class PictureCleaner(article: Article, amp: Boolean)(implicit request: Requ
     fullyMatchedImage.orElse(imageContainers.headOption)
   }
 
-  def findBreakpointWidths(figure: Element, isImmersive: Boolean): ContentHinting = {
+  def findBreakpointWidths(figure: Element): ContentHinting = {
 
     figure.classNames().map(Some(_)) match {
       case classes if classes.contains(Supporting.className) => Supporting
       case classes if classes.contains(Showcase.className) => Showcase
       case classes if classes.contains(Thumbnail.className) => Thumbnail
-      case classes if classes.contains(Immersive.className) && isImmersive => Immersive
+      case classes if classes.contains(Immersive.className) => Immersive
       case _ => Inline
     }
   }
@@ -484,7 +491,7 @@ case class Summary(amount: Int) extends HtmlCleaner {
 case class ImmersiveLinks(isImmersive: Boolean) extends HtmlCleaner {
   override def clean(document: Document): Document = {
     if(isImmersive) {
-      document.getElementsByTag("a").foreach{ a => 
+      document.getElementsByTag("a").foreach{ a =>
         a.addClass("in-body-link--immersive")
       }
     }
@@ -521,7 +528,7 @@ case class DropCaps(isFeature: Boolean, isImmersive: Boolean) extends HtmlCleane
             val next = h2.nextElementSibling()
             if (next.nodeName() == "p") {
                 next.html(setDropCap(next))
-            } 
+            }
         }
     }
     document

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -459,6 +459,54 @@
         }
     }
 
+    figure.element--immersive {
+        margin-left: -$gs-gutter / 2;
+        margin-right: -$gs-gutter / 2;
+
+        @include mq(mobileLandscape) {
+            margin-left: -$gs-gutter;
+            margin-right: -$gs-gutter;
+        }
+
+        @include mq(tablet) {
+            margin-right: -(gs-span(1) + $gs-gutter * 2);
+        }
+
+        @include mq(desktop) {
+            margin-right: -(gs-span(4) + $gs-gutter * 2);
+        }
+
+        @include mq(leftCol) {
+            margin-left: -(gs-span(2) + $gs-gutter * 2);
+        }
+
+        @include mq(wide) {
+            margin-left: -(gs-span(3) + $gs-gutter * 2);
+            margin-right: -(gs-span(5) + $gs-gutter *2);
+        }
+
+        .caption {
+            margin-left: $gs-gutter / 2;
+            margin-right: $gs-gutter / 2;
+
+            @include mq(mobileLandscape) {
+                margin-left: $gs-gutter;
+                margin-right: $gs-gutter;
+            }
+
+            @include mq(desktop) {
+                margin-left: 0;
+                margin-right: 0;
+            }
+        }
+
+        .block-share {
+            @include mq(tablet) {
+                margin-right: $gs-gutter;
+            }
+        }
+    }
+
     figure.element--showcase {
         @include mq(desktop) {
             margin-left: -($gs-gutter);
@@ -466,11 +514,17 @@
 
         @include mq(leftCol) {
             margin-left: -(gs-span(2) + $gs-gutter * 2);
-            margin-bottom: $gs-baseline - 2px; // 2px is to compensate for x-height of type
         }
 
         @include mq(wide) {
             margin-left: -(gs-span(3) + $gs-gutter * 2);
+        }
+    }
+
+    figure.element--showcase,
+    figure.element--immersive {
+        @include mq(leftCol) {
+            margin-bottom: $gs-baseline - 2px; // 2px is to compensate for x-height of type
         }
 
         .caption {


### PR DESCRIPTION
It's time to go BIG with a new image weighting. This is scoped to the new `immersive` template. The name suggests this and going bigger than `showcase` on regular articles would be strange and break stuff.

Mobile (flush to edge of device)
![screen shot 2015-11-02 at 17 45 47](https://cloud.githubusercontent.com/assets/1607666/10889409/cbc3493a-8189-11e5-90d9-91d0f3e9aeb5.png)

Desktop (expands into RHC)
![screen shot 2015-11-02 at 17 45 09](https://cloud.githubusercontent.com/assets/1607666/10889408/cbbed288-8189-11e5-9bde-1fae854f0392.png)
