### PR TITLE
Add versions of '#core' and '#nocore' that dont use the c-word so we can surface the options to the public.

### DIFF
--- a/common/app/templates/headerInlineJS/shouldEnhance.scala.js
+++ b/common/app/templates/headerInlineJS/shouldEnhance.scala.js
@@ -4,8 +4,8 @@
 (function (navigator, window) {
     // Enable manual optin to core functionality/optout of enhancement
     var personPrefersCore = function () {
-        if (window.location.hash === '#core' || window.location.hash === '#gu.prefs.force-core=on') return true;
-        if (window.location.hash === '#nocore' || window.location.hash === '#gu.prefs.force-core=off') return false;
+        if (window.location.hash === '#featuresoff' || window.location.hash === '#core' || window.location.hash === '#gu.prefs.force-core=on') return true;
+        if (window.location.hash === '#featureson' || window.location.hash === '#nocore' || window.location.hash === '#gu.prefs.force-core=off') return false;
         try {
             var preference = window.localStorage.getItem('gu.prefs.force-core') || 'off';
             return /"value":"on"/.test(preference);

--- a/common/app/templates/headerInlineJS/shouldEnhance.scala.js
+++ b/common/app/templates/headerInlineJS/shouldEnhance.scala.js
@@ -4,7 +4,7 @@
 (function (navigator, window) {
     // Enable manual optin to core functionality/optout of enhancement
     var personPrefersCore = function () {
-        var locationHash = window.location.hash
+        var locationHash = window.location.hash;
         if (locationHash === '#featuresoff' || locationHash === '#core' || locationHash === '#gu.prefs.force-core=on') return true;
         if (locationHash === '#featureson' || locationHash === '#nocore' || locationHash === '#gu.prefs.force-core=off') return false;
         try {

--- a/common/app/templates/headerInlineJS/shouldEnhance.scala.js
+++ b/common/app/templates/headerInlineJS/shouldEnhance.scala.js
@@ -4,8 +4,9 @@
 (function (navigator, window) {
     // Enable manual optin to core functionality/optout of enhancement
     var personPrefersCore = function () {
-        if (window.location.hash === '#featuresoff' || window.location.hash === '#core' || window.location.hash === '#gu.prefs.force-core=on') return true;
-        if (window.location.hash === '#featureson' || window.location.hash === '#nocore' || window.location.hash === '#gu.prefs.force-core=off') return false;
+        var locationHash = window.location.hash
+        if (locationHash === '#featuresoff' || locationHash === '#core' || locationHash === '#gu.prefs.force-core=on') return true;
+        if (locationHash === '#featureson' || locationHash === '#nocore' || locationHash === '#gu.prefs.force-core=off') return false;
         try {
             var preference = window.localStorage.getItem('gu.prefs.force-core') || 'off';
             return /"value":"on"/.test(preference);


### PR DESCRIPTION
At the moment, users who have opted out of the enhanced pages are unable to comment without opting back in to all pages.
We have the ability to display a particular page as fully enhanced even though the default setting for our browser is set to show the non-enhanced (core pages). This is currently done by appending '#nocore' to the url.

Users running the core opt in have asked if comments will be added to the non-enhanced pages. While we wrestle with this, I would like to add information about the '#nocore' option to our user help page - https://www.theguardian.com/info/2015/sep/22/making-theguardiancom-work-best-for-you
- so that if a user feels particularly moved to comment on a page, or if they would like to see an interactive running properly, they have an easy way to do so. 

The problem at the moment is the naming of this option still uses the old 'core' / 'nocore' terminology, which we have been asked to steer clear of.

This change adds two extra # options '#featuresoff' and '#featureson' which do the same job as '#core' and '#nocore' but will make more sense to users (and avoid using the dreaded "core").
