### PR TITLE
Change order of loading indicator and embed in immersive templates

### DIFF
--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -13,14 +13,14 @@
     </div>
 
     @if(article.hasMainEmbed || article.elements("main").isEmpty) {
-        @MainCleaner(article, article.main, false)
         <div class="content__loading">
             <span class="content__loading-animation is-updating"></span>
             <span class="u-h">Loading header</span>
         </div>
+        @MainCleaner(article, article.main, false)
     } else {
         <style>
-            @article.mainPicture.map { picture => 
+            @article.mainPicture.map { picture =>
                 .content__head--mobile {
                     background-image: url('@Html(ImgSrc.findNearestSrc(picture, Profile(width = Some(1000))).getOrElse(""))');
                 }

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -154,7 +154,6 @@
         bottom: 0;
         background-color: colour(neutral-5);
         color: colour(neutral-1);
-        z-index: -1;
     }
 
     .content__loading-animation {


### PR DESCRIPTION
For some reason `z-index: -1` was doing what I wanted too locally but `PROD` decided it didn't fancy any of it. So I'm just doing this instead. Good old natural z-index. 
