### PR TITLE
Get's rid of path pattern matcher for redirects

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -12,7 +12,6 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
 
   private val R1ArtifactUrl = """www.theguardian.com/(.*)/[0|1]?,[\d]*,(-?\d+),[\d]*(.*)""".r
   private val ShortUrl = """^(www\.theguardian\.com/p/[\w\d]+).*$""".r
-  private val PathPattern = """www.theguardian.com/(.*)""".r
   private val R1Redirect = """www\.theguardian\.com/[\w\d-]+(.*/[0|1]?,[\d]*,-?\d+,[\d]*.*)""".r
   private val GoogleBot = """.*(Googlebot).*""".r
   private val CombinerSection = """^(www.theguardian.com/[\w\d-]+)[\w\d-/]*\+[\w\d-/]+$""".r
@@ -66,7 +65,6 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
 
   def linksToItself(path: String, destination: String): Boolean = path match {
     case R1Redirect(r1path) => destination.endsWith(r1path)
-    case PathPattern(relativepath) => destination.endsWith(relativepath)
     case _ => false
   }
 

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -5,7 +5,7 @@ import play.api.test.Helpers._
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import scala.concurrent.Future
 
-@DoNotDiscover class ArchiveControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+class ArchiveControllerTest extends FlatSpec with Matchers with SingleServerSuite {
 
   it should "return a normalised r1 path" in {
     val tests = List(
@@ -196,13 +196,6 @@ import scala.concurrent.Future
     val shortRedirectWithCMP = services.Redirect("http://www.theguardian.com/p/new?CMP=existing-cmp")
     val result = controllers.ArchiveController.retainShortUrlCampaign("http://www.theguardian.com/p/old/stw", "http://www.theguardian.com/p/new?CMP=existing-cmp")
     result should be ("http://www.theguardian.com/p/new?CMP=existing-cmp")
-  }
-
-  it should "check that a lookup which specifies a Redirect doesn't match the original path" in {
-    // This check needs to be in place to ensure we don't create redirect loops.
-    val databaseSaysRedirect = services.Redirect("http://www.theguardian.com/redirect/path-to-content")
-    val result = controllers.ArchiveController.processLookupDestination("www.theguardian.com/redirect/path-to-content").lift(databaseSaysRedirect)
-    result should be (None)
   }
 
   it should "not perform a redirect loop check on Archive objects" in {

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -5,7 +5,7 @@ import play.api.test.Helpers._
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import scala.concurrent.Future
 
-class ArchiveControllerTest extends FlatSpec with Matchers with SingleServerSuite {
+@DoNotDiscover class ArchiveControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
   it should "return a normalised r1 path" in {
     val tests = List(


### PR DESCRIPTION
The path pattern matcher has stopped /masterclasses redirects /guardian-masterclasses.

cc @rich-nguyen 
