### PR TITLE
Extend Fixed Top-Above-Nav Switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -226,7 +226,7 @@ trait CommercialSwitches {
     "fixed-top-above-nav",
     "Fixes size of top-above-nav ad slot on fronts.",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 11, 11),
+    sellByDate = new LocalDate(2015, 12, 16),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
This switch is either going to be expanded to be used on all fronts or it will be removed altogether, depending on future of top slot.  But need more time to test and decide.
