### PR TITLE
Halloween's over - let's stamp out these ZOMBIE merchandising components

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -31,12 +31,11 @@ define([
         };
     }
 
-    function getLenientRules() {
-        var lenientRules = _.cloneDeep(getRules());
-        // more lenient rules, closer to the top start of the article
-        lenientRules.minAbove = 300;
-        lenientRules.selectors[' > h2'].minAbove = 20;
-        return lenientRules;
+    function getInlineMerchRules() {
+        var newRules = _.cloneDeep(getRules());
+        newRules.minAbove = 300;
+        newRules.selectors[' > h2'].minAbove = 20;
+        return newRules;
     }
 
     function getLongArticleRules() {
@@ -85,19 +84,18 @@ define([
             }
         },
         init = function () {
-            var rules, lenientRules, inlineMercPromise;
+            var rules, inlineMercPromise;
 
             if (!commercialFeatures.articleBodyAdverts) {
                 return false;
             }
 
             rules = getRules();
-            lenientRules = getLenientRules();
 
             if (config.page.hasInlineMerchandise) {
                 adNames.unshift(['im', 'im']);
 
-                inlineMercPromise = spacefinder.getParaWithSpace(lenientRules).then(function (space) {
+                inlineMercPromise = spacefinder.getParaWithSpace(getInlineMerchRules()).then(function (space) {
                     return insertAdAtP(space);
                 });
             } else {
@@ -137,7 +135,7 @@ define([
         init: init,
         // rules exposed for spacefinder debugging
         getRules: getRules,
-        getLenientRules: getLenientRules,
+        getLenientRules: getInlineMerchRules,
 
         reset: function () {
             ads = [];

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -93,9 +93,10 @@ define([
             rules = getRules();
 
             if (config.page.hasInlineMerchandise) {
-                adNames.unshift(['im', 'im']);
-
                 inlineMercPromise = spacefinder.getParaWithSpace(getInlineMerchRules()).then(function (space) {
+                    if (space) {
+                        adNames.unshift(['im', 'im']);
+                    }
                     return insertAdAtP(space);
                 });
             } else {


### PR DESCRIPTION
This is a fix to a slightly obscure spacefinder bug.

Sometimes, inline merchandising components are added in [spaces they really don't belong](http://www.theguardian.com/higher-education-network/2015/oct/05/female-scientists-prettycurious-about-campaign-aimed-at-young-women):

![image](https://cloud.githubusercontent.com/assets/3148617/10942199/e2ce31fc-8306-11e5-9d85-00174dcbd065.png)

What's happening here? Aren't these things supposed to give headings clearance, because they're left aligned?

The rules they use certainly say so...

```
lenientRules.selectors[' > h2'].minAbove = 20;
```

So is this just spacefinder on the fritz? Let's take a look at the comparison it does between the elements for the purposes of the `inlineMercPromise`...

![image](https://cloud.githubusercontent.com/assets/3148617/10943228/6e2c2dd6-830b-11e5-9815-2fb0a2a8c050.png)

Both `isMinAbove` and `isMinBelow` are false for this check. So spacefinder considers the paragraph in question ineligible for the inline merchandising component. Yet it displays there all the same. What gives?

A look at `article-body-adverts.js` gives the answer...

```
if (config.page.hasInlineMerchandise) {
    adNames.unshift(['im', 'im']);

    inlineMercPromise = spacefinder.getParaWithSpace(lenientRules).then(function (space) {
        return insertAdAtP(space);
    });
} else {
   inlineMercPromise = Promise.resolve(null);
}
```

We're adding the inline merchandising ad names - `['im', 'im']` - regardless of whether the spacefinder actually finds a space for the IM component. So the next time we _do_ add an advert, it'll be an IM component instead, even though there's no space for such a thing. Thus I have termed it a _zombie_ merchandising component.

Originally, this wouldn't have been a problem, because the IM element was added with `lenientRules` - how would we later find ad spaces with stricter rules? But the `lenientRules` have been subtly changed at some point - they now have a `h2` clearance that wouldn't otherwise be in place on desktop - and are now not quite as `lenient` after all.

The fix is to -
- only add the 'im' adnames when we're actually able to inject an adslot, and
- rename `lenientRules` because their name is misleading

And now the zombie is gone, with the proper inline MPU in its place -

![image](https://cloud.githubusercontent.com/assets/3148617/10943641/1605daba-830d-11e5-8d88-965720a6530f.png)
