### PR TITLE
Don't display the supporter banner to paid members

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -5,7 +5,8 @@ define([
     'common/modules/ui/message',
     'text!common/views/membership-message.html',
     'common/views/svgs',
-    'common/modules/commercial/commercial-features'
+    'common/modules/commercial/commercial-features',
+    'common/modules/commercial/user-features'
 ], function (
     config,
     storage,
@@ -13,7 +14,8 @@ define([
     Message,
     messageTemplate,
     svgs,
-    commercialFeatures
+    commercialFeatures,
+    userFeatures
 ) {
 
     function canShowUkMessage() {
@@ -21,7 +23,8 @@ define([
         return (
             commercialFeatures.membershipMessages &&
             config.page.edition === 'UK' &&
-            alreadyVisited > 10
+            alreadyVisited > 10 &&
+            !userFeatures.isPayingMember()
         );
     }
 


### PR DESCRIPTION
The supporter banner is this one:

![picture 37](https://cloud.githubusercontent.com/assets/5122968/10944237/2610aaea-8310-11e5-9bf0-7a9bc45ae6de.png)

We don't want to display it to people who are already paid members. This work has [already been done for the ad blocker banner](https://github.com/guardian/frontend/pull/10945) so I'm using the `userFeatures.isPayingMember()` function added in that PR.

@Calanthe @jbreckmckye 
