### PR TITLE
Limit request handling to developer blog to circumvent redirect issue

### DIFF
--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -108,11 +108,12 @@
         var url = new URL(request.url);
         var isRootRequest = url.host === self.location.host;
         // To workaround a bug in Chrome which results in broken HTTPS->HTTP
-        // redirects, we only handle root requests if they match a HTTPS
-        // endpoint
+        // redirects, we only handle root requests if they match the developer
+        // blog. The info section often hosts holding pages which will could
+        // eventually redirect to a HTTP page.
         // https://github.com/guardian/frontend/issues/10936
-        var isRequestToHttpsSection = url.pathname.match(/^\/info($|\/.*$)/);
-        if (isRootRequest && isRequestToHttpsSection && doesRequestAcceptHtml(request)) {
+        var isRequestToDeveloperBlog = url.pathname.match(/^\/info\/developer-blog($|\/.*$)/);
+        if (isRootRequest && isRequestToDeveloperBlog && doesRequestAcceptHtml(request)) {
             // HTML pages fallback to offline page
             event.respondWith(
                 fetch(request)


### PR DESCRIPTION
Issue https://github.com/guardian/frontend/issues/10936 came up again, this time because of a holding page which now redirects to a HTTP page:

https://www.theguardian.com/info/2015/nov/03/removed-gallery

We can circumvent the browser bug by limiting the offline page to the developer blog, until the bug is fixed.
