### PR TITLE
Remove switches from user-features.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/user-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/user-features.js
@@ -34,10 +34,10 @@ define([
     };
 
     function refresh() {
-        if (featuresEnabled() && identity.isUserLoggedIn() && needNewFeatureData()) {
+        if (identity.isUserLoggedIn() && needNewFeatureData()) {
             userFeatures._requestNewData();
         }
-        if (!featuresEnabled() || haveDataAfterSignout()) {
+        if (haveDataAfterSignout()) {
             userFeatures._deleteOldData();
         }
     }
@@ -55,12 +55,9 @@ define([
     }
 
     function isPayingMember() {
+        // Does NOT check if data has expired
         // If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
         return identity.isUserLoggedIn() && cookies.get(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE) !== 'false';
-    }
-
-    function featuresEnabled() {
-        return config.switches.advertOptOut || config.switches.adblock;
     }
 
     function needNewFeatureData() {

--- a/static/test/javascripts/spec/common/commercial/user-features.spec.js
+++ b/static/test/javascripts/spec/common/commercial/user-features.spec.js
@@ -34,79 +34,48 @@ define(['helpers/injector'], function (Injector) {
 
         describe('Refreshing the features data', function () {
 
-            describe('If a downstream feature is enabled', function () {
+            describe('If user signed in', function () {
                 beforeEach(function () {
-                    config.switches = {advertOptOut : true};
+                    identityApi.isUserLoggedIn = function () {return true;};
                 });
 
-                describe('If user signed in', function () {
-                    beforeEach(function () {
-                        identityApi.isUserLoggedIn = function () {return true;};
-                    });
-
-                    it('Performs an update if the user has missing data', function () {
-                        deleteAllFeaturesData();
-                        userFeatures.refresh();
-                        expect(userFeatures._requestNewData).toHaveBeenCalled();
-                    });
-
-                    it('Performs an update if the user has expired data', function () {
-                        setAllFeaturesData({isExpired: true});
-                        userFeatures.refresh();
-                        expect(userFeatures._requestNewData).toHaveBeenCalled();
-                    });
-
-                    it('Does not delete the data just because it has expired', function () {
-                        setAllFeaturesData({isExpired: true});
-                        userFeatures.refresh();
-                        expect(userFeatures._deleteOldData).not.toHaveBeenCalled();
-                    });
-
-                    it('Does not perform update if user has fresh feature data', function () {
-                        setAllFeaturesData({isExpired: false});
-                        userFeatures.refresh();
-                        expect(userFeatures._requestNewData).not.toHaveBeenCalled();
-                    });
+                it('Performs an update if the user has missing data', function () {
+                    deleteAllFeaturesData();
+                    userFeatures.refresh();
+                    expect(userFeatures._requestNewData).toHaveBeenCalled();
                 });
 
-                describe('If user signed out', function () {
-                    beforeEach(function () {
-                        identityApi.isUserLoggedIn = function () {return false;};
-                    });
+                it('Performs an update if the user has expired data', function () {
+                    setAllFeaturesData({isExpired: true});
+                    userFeatures.refresh();
+                    expect(userFeatures._requestNewData).toHaveBeenCalled();
+                });
 
-                    it('Does not perform update, even if feature data missing', function () {
-                        deleteAllFeaturesData();
-                        userFeatures.refresh();
-                        expect(userFeatures._requestNewData).not.toHaveBeenCalled();
-                    });
+                it('Does not delete the data just because it has expired', function () {
+                    setAllFeaturesData({isExpired: true});
+                    userFeatures.refresh();
+                    expect(userFeatures._deleteOldData).not.toHaveBeenCalled();
+                });
 
-                    it('Deletes leftover feature data', function () {
-                        setAllFeaturesData({isExpired: false});
-                        userFeatures.refresh();
-                        expect(userFeatures._deleteOldData).toHaveBeenCalled();
-                    });
+                it('Does not perform update if user has fresh feature data', function () {
+                    setAllFeaturesData({isExpired: false});
+                    userFeatures.refresh();
+                    expect(userFeatures._requestNewData).not.toHaveBeenCalled();
                 });
             });
 
-            describe('If no downstream features enabled', function () {
-                // We want to short-circuit the request if no features actually depend on the data
-
+            describe('If user signed out', function () {
                 beforeEach(function () {
-                    config.switches = {
-                        advertOptOut : false,
-                        adblock : false
-                    };
+                    identityApi.isUserLoggedIn = function () {return false;};
                 });
 
-                it('Does not perform update, even if a signed in user needs more feature data', function () {
-                    identityApi.isUserLoggedIn = function () {return true;};
+                it('Does not perform update, even if feature data missing', function () {
                     deleteAllFeaturesData();
                     userFeatures.refresh();
                     expect(userFeatures._requestNewData).not.toHaveBeenCalled();
                 });
 
-                it('Cleans up any outstanding feature data, even for signed in users', function () {
-                    identityApi.isUserLoggedIn = function () {return true;};
+                it('Deletes leftover feature data', function () {
                     setAllFeaturesData({isExpired: false});
                     userFeatures.refresh();
                     expect(userFeatures._deleteOldData).toHaveBeenCalled();


### PR DESCRIPTION
We used to only perform requests for the membership API if switches for the adfree view and adblock messages were on. However, `membership-messages.js` now relies upon this data, and it doesn't have a switch. So the membership requests should always be firing.

The code removed is actually something of a timebomb, because it would be quite easy to break the membership messages just by disabling the adblock-messaging switch (which is the only one on in prod right now). If we turned that off, clients would immediately start deleting their membership data.
