### PR TITLE
Unit tests for adblock messages

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
@@ -16,7 +16,7 @@ define([
     }
 
     function noAdblockMsg() {
-        return sharedRules() && userFeatures.isPayingMember();
+        return (sharedRules() && userFeatures.isPayingMember()) || !sharedRules();
     }
 
     function showAdblockMsg() {

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
@@ -9,18 +9,24 @@ define([
     storage,
     userFeatures
 ) {
-    function sharedRules() {
-        var alreadyVisted = storage.local.get('gu.alreadyVisited') || 0;
+    /*function sharedRules() {
+        var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0;
 
-        return detect.getBreakpoint() !== 'mobile' && detect.adblockInUse() && config.switches.adblock && alreadyVisted > 1;
-    }
+        return detect.getBreakpoint() !== 'mobile' && detect.adblockInUse() && config.switches.adblock && alreadyVisited > 1;
+    }*/
 
     function noAdblockMsg() {
-        return (sharedRules() && userFeatures.isPayingMember()) || !sharedRules();
+        var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0;
+
+        return detect.adblockInUse() && detect.getBreakpoint() !== 'mobile' && (
+                alreadyVisited <= 1 ||
+                !config.switches.adblock ||
+                (config.switches.adblock && alreadyVisited > 1 && userFeatures.isPayingMember()));
     }
 
     function showAdblockMsg() {
-        return sharedRules() && !userFeatures.isPayingMember();
+        var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0;
+        return detect.getBreakpoint() !== 'mobile' && detect.adblockInUse() && config.switches.adblock && alreadyVisited > 1 && !userFeatures.isPayingMember();
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
@@ -9,18 +9,41 @@ define([
     storage,
     userFeatures
 ) {
-    function noAdblockMsg() {
+    function adblockInUse() {
+        return detect.adblockInUse();
+    }
+
+    function notMobile() {
+        return detect.getBreakpoint() !== 'mobile';
+    }
+
+    function isPayingMember() {
+        return userFeatures.isPayingMember();
+    }
+
+    function visitedMoreThanOnce() {
         var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0;
 
-        return detect.adblockInUse() && detect.getBreakpoint() !== 'mobile' && (
-                alreadyVisited <= 1 ||
-                !config.switches.adblock ||
-                (config.switches.adblock && alreadyVisited > 1 && userFeatures.isPayingMember()));
+        return alreadyVisited > 1;
+    }
+
+    function isAdblocSwitchOn() {
+        return config.switches.adblock;
+    }
+
+    function noAdblockMsg() {
+        return adblockInUse() && notMobile() && (
+                !visitedMoreThanOnce() ||
+                !isAdblocSwitchOn() ||
+                (isAdblocSwitchOn() && visitedMoreThanOnce() && isPayingMember()));
     }
 
     function showAdblockMsg() {
-        var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0;
-        return detect.getBreakpoint() !== 'mobile' && detect.adblockInUse() && config.switches.adblock && alreadyVisited > 1 && !userFeatures.isPayingMember();
+        return isAdblocSwitchOn() &&
+                adblockInUse() &&
+                !isPayingMember() &&
+                visitedMoreThanOnce() &&
+                notMobile();
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
@@ -9,12 +9,6 @@ define([
     storage,
     userFeatures
 ) {
-    /*function sharedRules() {
-        var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0;
-
-        return detect.getBreakpoint() !== 'mobile' && detect.adblockInUse() && config.switches.adblock && alreadyVisited > 1;
-    }*/
-
     function noAdblockMsg() {
         var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0;
 

--- a/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
@@ -27,19 +27,19 @@ define([
         return alreadyVisited > 1;
     }
 
-    function isAdblocSwitchOn() {
+    function isAdblockSwitchOn() {
         return config.switches.adblock;
     }
 
     function noAdblockMsg() {
         return adblockInUse() && notMobile() && (
                 !visitedMoreThanOnce() ||
-                !isAdblocSwitchOn() ||
-                (isAdblocSwitchOn() && visitedMoreThanOnce() && isPayingMember()));
+                !isAdblockSwitchOn() ||
+                (isAdblockSwitchOn() && visitedMoreThanOnce() && isPayingMember()));
     }
 
     function showAdblockMsg() {
-        return isAdblocSwitchOn() &&
+        return isAdblockSwitchOn() &&
                 adblockInUse() &&
                 !isPayingMember() &&
                 visitedMoreThanOnce() &&

--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -66,28 +66,28 @@ define([
 
     function showAdblockBanner() {
         var variations = [{
-                supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=ADBLOCK_BANNER_MONBIOT',
+                supporterLink: 'https://membership.theguardian.com/supporter?INTCMP=ADBLOCK_BANNER_MONBIOT',
                 quoteText: 'Become a Guardian Member and support independent journalism',
                 quoteAuthor: 'George Monbiot',
                 customCssClass: 'monbiot',
                 imageAuthor: '//i.guim.co.uk/img/static/sys-images/Guardian/Pix/contributor/2015/7/9/1436429159376/George-Monbiot-L.png?w=300&amp;q=85&amp;auto=format&amp;sharp=10&amp;s=903233b032379d7529d7337b8c26bcc9'
             },
             {
-                supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=ADBLOCK_BANNER_MUIR',
+                supporterLink: 'https://membership.theguardian.com/supporter?INTCMP=ADBLOCK_BANNER_MUIR',
                 quoteText: 'Support and become part of the Guardian',
                 quoteAuthor: 'Hugh Muir',
                 customCssClass: 'muir',
                 imageAuthor: '//i.guim.co.uk/img/static/sys-images/Guardian/Pix/pictures/2014/3/13/1394733739000/HughMuir.png?w=300&amp;q=85&amp;auto=format&amp;sharp=10&amp;s=c1eeb35230ad2a215ec9de76b3eb69fb'
             },
             {
-                supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=ADBLOCK_BANNER_TOYNBEE',
+                supporterLink: 'https://membership.theguardian.com/supporter?INTCMP=ADBLOCK_BANNER_TOYNBEE',
                 quoteText: 'If you read the Guardian, join the Guardian',
                 quoteAuthor: 'Polly Toynbee',
                 customCssClass: 'toynbee',
                 imageAuthor: '//i.guim.co.uk/img/static/sys-images/Guardian/Pix/contributor/2014/6/30/1404146756739/Polly-Toynbee-L.png?w=300&amp;q=85&amp;auto=format&amp;sharp=10&amp;s=abf0ce1a1a7935e82612b330322f5fa4'
             },
             {
-                supporterLink: 'https://membership.theguardian.com/about/supporter?INTCMP=ADBLOCK_BANNER_MACASKILL',
+                supporterLink: 'https://membership.theguardian.com/supporter?INTCMP=ADBLOCK_BANNER_MACASKILL',
                 quoteText: 'The Guardian enjoys rare freedom and independence. Support our journalism',
                 quoteAuthor: 'Ewen MacAskill',
                 customCssClass: 'macaskill',

--- a/static/test/javascripts/spec/common/commercial/adblock-messages.spec.js
+++ b/static/test/javascripts/spec/common/commercial/adblock-messages.spec.js
@@ -1,0 +1,79 @@
+define([
+    'helpers/injector',
+    'common/utils/storage'
+], function (
+    Injector,
+    storage
+) {
+    var injector = new Injector();
+
+    describe('Adblock messages', function () {
+        var adblockMessage, config, detect, userFeatures;
+
+        beforeEach(function (done) {
+            injector.require([
+                'common/modules/commercial/adblock-messages',
+                'common/utils/config',
+                'common/utils/detect',
+                'common/modules/commercial/user-features'
+            ], function () {
+                adblockMessage = arguments[0];
+                config = arguments[1];
+                detect = arguments[2];
+                userFeatures = arguments[3];
+                done();
+            });
+        });
+
+        describe('If adblock banners and messages should be shown', function () {
+            it('should not show adblock messages for users who are for the first time', function () {
+                storage.local.set('gu.alreadyVisited', 0);
+                config.switches.adblock = true;
+                detect.adblockInUse = function () {
+                    return true;
+                };
+                detect.getBreakpoint = function () {
+                    return 'desktop';
+                };
+                userFeatures.isPayingMember = function () {
+                    return true;
+                };
+
+                console.log(adblockMessage.noAdblockMsg());
+                expect(adblockMessage.noAdblockMsg()).toBe(true);
+            });
+
+            it('should not show adblock messages for paying members', function () {
+                storage.local.set('gu.alreadyVisited', 10);
+                config.switches.adblock = true;
+                detect.adblockInUse = function () {
+                    return true;
+                };
+                detect.getBreakpoint = function () {
+                    return 'desktop';
+                };
+                userFeatures.isPayingMember = function () {
+                    return true;
+                };
+
+                expect(adblockMessage.noAdblockMsg()).toBe(true);
+            });
+
+            it('should show adblock messages for non paying members', function () {
+                storage.local.set('gu.alreadyVisited', 10);
+                config.switches.adblock = true;
+                detect.adblockInUse = function () {
+                    return true;
+                };
+                detect.getBreakpoint = function () {
+                    return 'desktop';
+                };
+                userFeatures.isPayingMember = function () {
+                    return false;
+                };
+
+                expect(adblockMessage.showAdblockMsg()).toBe(true);
+            });
+        });
+    });
+});

--- a/static/test/javascripts/spec/common/commercial/adblock-messages.spec.js
+++ b/static/test/javascripts/spec/common/commercial/adblock-messages.spec.js
@@ -26,7 +26,7 @@ define([
         });
 
         describe('If adblock banners and messages should be shown', function () {
-            it('should not show adblock messages for users who are for the first time', function () {
+            it('should not show adblock messages for the first time users', function () {
                 storage.local.set('gu.alreadyVisited', 0);
                 config.switches.adblock = true;
                 detect.adblockInUse = function () {
@@ -35,12 +35,34 @@ define([
                 detect.getBreakpoint = function () {
                     return 'desktop';
                 };
-                userFeatures.isPayingMember = function () {
+
+                expect(adblockMessage.noAdblockMsg()).toBe(true);
+            });
+
+            it('should not show adblock messages when the adblock switch is off', function () {
+                storage.local.set('gu.alreadyVisited', 10);
+                config.switches.adblock = false;
+                detect.adblockInUse = function () {
                     return true;
                 };
+                detect.getBreakpoint = function () {
+                    return 'desktop';
+                };
 
-                console.log(adblockMessage.noAdblockMsg());
                 expect(adblockMessage.noAdblockMsg()).toBe(true);
+            });
+
+            it('should not show adblock messages for non adblock users', function () {
+                storage.local.set('gu.alreadyVisited', 10);
+                config.switches.adblock = true;
+                detect.adblockInUse = function () {
+                    return false;
+                };
+                detect.getBreakpoint = function () {
+                    return 'desktop';
+                };
+
+                expect(adblockMessage.showAdblockMsg()).toBe(false);
             });
 
             it('should not show adblock messages for paying members', function () {

--- a/static/test/javascripts/spec/common/commercial/adblock-messages.spec.js
+++ b/static/test/javascripts/spec/common/commercial/adblock-messages.spec.js
@@ -7,8 +7,8 @@ define([
 ) {
     var injector = new Injector();
 
-    describe('Adblock messages', function () {
-        var adblockMessage, config, detect, userFeatures;
+    describe('Adblock messages/banners rules', function () {
+        var adblockMessage, config, detect, userFeatures, mockUserHasAdblock, mockBreakpoint;
 
         beforeEach(function (done) {
             injector.require([
@@ -21,81 +21,66 @@ define([
                 config = arguments[1];
                 detect = arguments[2];
                 userFeatures = arguments[3];
+
+                detect.adblockInUse = function () {
+                    return mockUserHasAdblock;
+                };
+                detect.getBreakpoint = function () {
+                    return mockBreakpoint;
+                };
                 done();
             });
         });
 
-        describe('If adblock banners and messages should be shown', function () {
-            it('should not show adblock messages for the first time users', function () {
-                storage.local.set('gu.alreadyVisited', 0);
-                config.switches.adblock = true;
-                detect.adblockInUse = function () {
-                    return true;
-                };
-                detect.getBreakpoint = function () {
-                    return 'desktop';
-                };
+        it('should not show adblock messages for the first time users', function () {
+            storage.local.set('gu.alreadyVisited', 0);
+            config.switches.adblock = true;
+            mockUserHasAdblock = true;
+            mockBreakpoint = 'desktop';
 
-                expect(adblockMessage.noAdblockMsg()).toBe(true);
-            });
+            expect(adblockMessage.noAdblockMsg()).toBe(true);
+        });
 
-            it('should not show adblock messages when the adblock switch is off', function () {
-                storage.local.set('gu.alreadyVisited', 10);
-                config.switches.adblock = false;
-                detect.adblockInUse = function () {
-                    return true;
-                };
-                detect.getBreakpoint = function () {
-                    return 'desktop';
-                };
+        it('should not show adblock messages when the adblock switch is off', function () {
+            storage.local.set('gu.alreadyVisited', 10);
+            config.switches.adblock = false;
+            mockUserHasAdblock = true;
+            mockBreakpoint = 'desktop';
 
-                expect(adblockMessage.noAdblockMsg()).toBe(true);
-            });
+            expect(adblockMessage.noAdblockMsg()).toBe(true);
+        });
 
-            it('should not show adblock messages for non adblock users', function () {
-                storage.local.set('gu.alreadyVisited', 10);
-                config.switches.adblock = true;
-                detect.adblockInUse = function () {
-                    return false;
-                };
-                detect.getBreakpoint = function () {
-                    return 'desktop';
-                };
+        it('should not show adblock messages for non adblock users', function () {
+            storage.local.set('gu.alreadyVisited', 10);
+            config.switches.adblock = true;
+            mockUserHasAdblock = false;
+            mockBreakpoint = 'desktop';
 
-                expect(adblockMessage.showAdblockMsg()).toBe(false);
-            });
+            expect(adblockMessage.showAdblockMsg()).toBe(false);
+        });
 
-            it('should not show adblock messages for paying members', function () {
-                storage.local.set('gu.alreadyVisited', 10);
-                config.switches.adblock = true;
-                detect.adblockInUse = function () {
-                    return true;
-                };
-                detect.getBreakpoint = function () {
-                    return 'desktop';
-                };
-                userFeatures.isPayingMember = function () {
-                    return true;
-                };
+        it('should not show adblock messages for paying members', function () {
+            storage.local.set('gu.alreadyVisited', 10);
+            config.switches.adblock = true;
+            mockUserHasAdblock = true;
+            mockBreakpoint = 'desktop';
+            userFeatures.isPayingMember = function () {
+                return true;
+            };
 
-                expect(adblockMessage.noAdblockMsg()).toBe(true);
-            });
+            expect(adblockMessage.noAdblockMsg()).toBe(true);
+        });
 
-            it('should show adblock messages for non paying members', function () {
-                storage.local.set('gu.alreadyVisited', 10);
-                config.switches.adblock = true;
-                detect.adblockInUse = function () {
-                    return true;
-                };
-                detect.getBreakpoint = function () {
-                    return 'desktop';
-                };
-                userFeatures.isPayingMember = function () {
-                    return false;
-                };
+        it('should show adblock messages for non paying members', function () {
+            storage.local.set('gu.alreadyVisited', 10);
+            config.switches.adblock = true;
+            mockUserHasAdblock = true;
+            mockBreakpoint = 'desktop';
+            userFeatures.isPayingMember = function () {
+                return false;
+            };
 
-                expect(adblockMessage.showAdblockMsg()).toBe(true);
-            });
+            expect(adblockMessage.showAdblockMsg()).toBe(true);
         });
     });
 });

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -166,6 +166,7 @@ define([
             audienceScienceGateway.getSegments = function () {
                 return {};
             };
+            storage.local.set('gu.alreadyVisited', 0);
 
             var opts = {
                 window: {

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -88,6 +88,7 @@ define([
                             asg2: 'value-two'
                         };
                     };
+                    storage.local.set('gu.alreadyVisited', 0);
                     done();
                 });
         });
@@ -166,7 +167,6 @@ define([
             audienceScienceGateway.getSegments = function () {
                 return {};
             };
-            storage.local.set('gu.alreadyVisited', 0);
 
             var opts = {
                 window: {

--- a/static/test/javascripts/spec/common/navigation/sticky.spec.js
+++ b/static/test/javascripts/spec/common/navigation/sticky.spec.js
@@ -1,11 +1,16 @@
-define(['common/modules/navigation/sticky'], function (sut) {
+define([
+    'common/modules/commercial/adblock-messages',
+    'common/modules/navigation/sticky'
+], function (
+    adblockMsg,
+    sut
+) {
     describe('Sticky Header', function () {
 
         describe('getUpdateMethod', function () {
 
             beforeEach(function () {
                 sut.isMobile = false;
-                sut.isAdblockInUse = false;
                 sut.isAppleCampaign = false;
                 sut.isProfilePage = false;
             });
@@ -15,9 +20,29 @@ define(['common/modules/navigation/sticky'], function (sut) {
                 expect(sut.getUpdateMethod()).toEqual('updatePositionMobile');
             });
 
-            it('should return updatePositionApple for when Apple campaing is on', function () {
+            it('should return updatePositionAdblock when Adblock is on and there is no message', function () {
+                adblockMsg.noAdblockMsg = function () {
+                    return true;
+                };
+
+                expect(sut.getUpdateMethod()).toEqual('updatePositionAdblock');
+            });
+
+            it('should return updatePositionApple when Apple campaign is on', function () {
                 sut.isAppleCampaign = true;
+                adblockMsg.noAdblockMsg = function () {
+                    return false;
+                };
+
                 expect(sut.getUpdateMethod()).toEqual('updatePositionApple');
+            });
+
+            it('should return updatePosition when Adblock is on and there is a message', function () {
+                adblockMsg.showAdblockMsg = function () {
+                    return true;
+                };
+
+                expect(sut.getUpdateMethod()).toEqual('updatePosition');
             });
 
             it('should return updatePosition for all other pages', function () {


### PR DESCRIPTION
While writing them I found out that the logic in `adblock-messages.js` module wasn't working properly for scenario with first time users and when adblock switch was off. In those cases, users shouldn't see adblock messages too.
