### PR TITLE
Fix test expectations

### DIFF
--- a/static/test/javascripts/spec/common/commercial/creatives/expandable.spec.js
+++ b/static/test/javascripts/spec/common/commercial/creatives/expandable.spec.js
@@ -35,8 +35,8 @@ define([
             $fixturesContainer = fixtures.render(fixturesConfig);
             new Expandable(qwery('.expandable-ad-slot', $fixturesContainer), {}).create();
             fastdom.defer(function () {
-                expect(qwery('.ad-exp--expand').length).toBe(1);
-                expect(qwery('.ad-exp__close-button').length).toBe(1);
+                expect(qwery('.ad-exp--expand', $fixturesContainer).length).toBe(1);
+                expect(qwery('.ad-exp__close-button', $fixturesContainer).length).toBe(1);
                 done();
             });
         });


### PR DESCRIPTION
When the Expandable Video test runs before the Expandable test, the Expandable test will fail. Most of the time the tests will not run in this order, but for some reason, they do appear to run in this order with my changes in #11066.
