### PR TITLE
Headline list text wrapping

### DIFF
--- a/static/src/stylesheets/module/_headline-list.scss
+++ b/static/src/stylesheets/module/_headline-list.scss
@@ -34,7 +34,9 @@
 }
 
 .headline-list__count {
-    float: left;
+    position: absolute;
+    top: 0;
+    left: 0;
     width: gs-span(1);
     color: colour(neutral-4);
     @include font($f-serif-headline, 200, 44px);
@@ -53,6 +55,11 @@
 
     .fc-item__title {
         margin-top: -1 * ($gs-baseline / 3);
+        margin-left: gs-span(1);
+
+        @include mq(mobile) {
+            margin-left: gs-span(1) - $gs-gutter / 2;
+        }
     }
 
     .inline-icon {


### PR DESCRIPTION
Long headlines wrap beneath the number.

Before
![screen shot 2015-11-09 at 14 57 59](https://cloud.githubusercontent.com/assets/14570016/11037078/dfb923d2-86f3-11e5-8994-00d00b6f4232.png)

After
![screen shot 2015-11-09 at 14 57 31](https://cloud.githubusercontent.com/assets/14570016/11037077/df9e931e-86f3-11e5-872d-ab08b28dea8f.png)
