### PR TITLE
Add ESLint rule to prevent whole Lodash import

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,6 +169,7 @@ module.exports = function (grunt) {
     /**
      * Test tasks
      */
+    grunt.registerTask('eslintTests', ['shell:eslintTests']);
     grunt.registerTask('test:unit', function (app) {
         var target = app ? ':' + app : '';
         if (options.singleRun === false) {
@@ -178,6 +179,7 @@ module.exports = function (grunt) {
 
         grunt.task.run(['copy:inlineSVGs']);
         grunt.task.run('karma' + target);
+        grunt.task.run('eslintTests');
     });
     grunt.registerTask('test', ['test:unit']);
     grunt.registerTask('coverage', function () {

--- a/dev/eslint-rules/no-all-lodash-import.js
+++ b/dev/eslint-rules/no-all-lodash-import.js
@@ -1,0 +1,36 @@
+var isIdentifier = function (node) {
+    return node.type === 'Identifier';
+};
+var isArrayExpression = function (node) {
+    return node.type === 'ArrayExpression';
+};
+var isDefine = function (node) {
+    return isIdentifier(node) && node.name === 'define';
+};
+
+module.exports = function (context) {
+    return {
+        'CallExpression': function (node) {
+            var callee = node.callee;
+            var firstArg = node.arguments[0];
+            var hasDepsArray = firstArg && isArrayExpression(firstArg);
+
+            if (isDefine(callee) && hasDepsArray) {
+                var depsArray = firstArg;
+
+                var lodashImports = depsArray.elements.filter(function (literalNode) {
+                    var moduleId = literalNode.value;
+                    // Require format of "lodash/foo/bar"
+                    return moduleId.match(/^lodash($|\/)/) && moduleId.split('/').length !== 3;
+                });
+
+                lodashImports.forEach(function (literalNode) {
+                    context.report({
+                        node: literalNode,
+                        message: 'Use Lodash modules instead'
+                    });
+                });
+            }
+        }
+    };
+};

--- a/dev/eslint-rules/tests/no-all-lodash-import.js
+++ b/dev/eslint-rules/tests/no-all-lodash-import.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var rule = require('../no-all-lodash-import');
+var RuleTester = require('eslint/lib/testers/rule-tester');
+
+var ruleTester = new RuleTester();
+ruleTester.run('no-all-lodash-import', rule, {
+    valid: [
+        'define([\'lodash/foo/bar\'])'
+    ],
+    invalid: [
+        {
+            code: 'define([\'lodash\'])',
+            errors: [{ message: 'Use Lodash modules instead', type: 'Literal'}]
+        }
+    ]
+});

--- a/grunt-configs/eslint.js
+++ b/grunt-configs/eslint.js
@@ -1,6 +1,9 @@
 'use strict';
 module.exports = function () {
     return {
+        options: {
+            rulePaths: ['./dev/eslint-rules']
+        },
         'Gruntfile.js': [
             'Gruntfile.js'
         ],

--- a/grunt-configs/shell.js
+++ b/grunt-configs/shell.js
@@ -30,6 +30,10 @@ module.exports = function () {
 
         updateCanIUse: {
             command: 'npm update caniuse-db'
+        },
+
+        eslintTests: {
+            command: 'node dev/eslint-rules/tests/*'
         }
     };
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3533,6 +3533,708 @@
         }
       }
     },
+    "eslint": {
+      "version": "1.9.0",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0"
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.5.1",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1"
+            },
+            "typedarray": {
+              "version": "0.0.6"
+            },
+            "readable-stream": {
+              "version": "2.0.4",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1"
+                },
+                "isarray": {
+                  "version": "0.0.1"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.3"
+                },
+                "string_decoder": {
+                  "version": "0.10.31"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2"
+                }
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1"
+            }
+          }
+        },
+        "doctrine": {
+          "version": "0.7.0",
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6"
+            },
+            "isarray": {
+              "version": "0.0.1"
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.3"
+        },
+        "escope": {
+          "version": "3.2.0",
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.2",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1"
+                },
+                "es5-ext": {
+                  "version": "0.10.8"
+                },
+                "es6-iterator": {
+                  "version": "2.0.0"
+                },
+                "es6-set": {
+                  "version": "0.1.2"
+                },
+                "es6-symbol": {
+                  "version": "3.0.1"
+                },
+                "event-emitter": {
+                  "version": "0.3.4"
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "0.1.4",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1"
+                },
+                "es5-ext": {
+                  "version": "0.10.8",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "2.0.0"
+                    },
+                    "es6-symbol": {
+                      "version": "3.0.1"
+                    }
+                  }
+                },
+                "es6-iterator": {
+                  "version": "0.1.3"
+                },
+                "es6-symbol": {
+                  "version": "2.0.1"
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "3.1.1"
+            },
+            "estraverse": {
+              "version": "3.1.0"
+            }
+          }
+        },
+        "espree": {
+          "version": "2.2.5"
+        },
+        "estraverse": {
+          "version": "4.1.1"
+        },
+        "estraverse-fb": {
+          "version": "1.3.1"
+        },
+        "esutils": {
+          "version": "2.0.2"
+        },
+        "file-entry-cache": {
+          "version": "1.2.4",
+          "dependencies": {
+            "flat-cache": {
+              "version": "1.0.10",
+              "dependencies": {
+                "del": {
+                  "version": "2.0.2",
+                  "dependencies": {
+                    "globby": {
+                      "version": "3.0.1",
+                      "dependencies": {
+                        "array-union": {
+                          "version": "1.0.1",
+                          "dependencies": {
+                            "array-uniq": {
+                              "version": "1.0.2"
+                            }
+                          }
+                        },
+                        "arrify": {
+                          "version": "1.0.0"
+                        }
+                      }
+                    },
+                    "is-path-cwd": {
+                      "version": "1.0.0"
+                    },
+                    "is-path-in-cwd": {
+                      "version": "1.0.0",
+                      "dependencies": {
+                        "is-path-inside": {
+                          "version": "1.0.0"
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0"
+                    },
+                    "pinkie-promise": {
+                      "version": "1.0.0",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "1.0.0"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.4.3"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.2"
+                },
+                "read-json-sync": {
+                  "version": "1.1.0",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "3.0.8"
+                    }
+                  }
+                },
+                "write": {
+                  "version": "0.2.1",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1"
+            },
+            "once": {
+              "version": "1.3.2",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1"
+                }
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "8.11.0"
+        },
+        "handlebars": {
+          "version": "4.0.4",
+          "dependencies": {
+            "async": {
+              "version": "1.5.0"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3"
+                },
+                "minimist": {
+                  "version": "0.0.10"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.4.24",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2"
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1"
+                    },
+                    "decamelize": {
+                      "version": "1.1.1"
+                    },
+                    "window-size": {
+                      "version": "0.1.0"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.11.0",
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.1.0"
+            },
+            "ansi-regex": {
+              "version": "2.0.0"
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "dependencies": {
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "dependencies": {
+                    "exit-hook": {
+                      "version": "1.1.1"
+                    },
+                    "onetime": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "cli-width": {
+              "version": "1.1.0"
+            },
+            "figures": {
+              "version": "1.4.0"
+            },
+            "readline2": {
+              "version": "1.0.1",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "mute-stream": {
+                  "version": "0.0.5"
+                }
+              }
+            },
+            "run-async": {
+              "version": "0.1.0",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.2",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "rx-lite": {
+              "version": "3.1.2"
+            },
+            "strip-ansi": {
+              "version": "3.0.0"
+            },
+            "through": {
+              "version": "2.3.8"
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.12.3",
+          "dependencies": {
+            "generate-function": {
+              "version": "2.0.0"
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "dependencies": {
+                "is-property": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "jsonpointer": {
+              "version": "2.0.0"
+            },
+            "xtend": {
+              "version": "4.0.1"
+            }
+          }
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "dependencies": {
+            "tryit": {
+              "version": "1.0.2"
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.4.3",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.3",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.0"
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.0",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0"
+            }
+          }
+        },
+        "lodash.clonedeep": {
+          "version": "3.0.2",
+          "dependencies": {
+            "lodash._baseclone": {
+              "version": "3.3.0",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0"
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0"
+                },
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1"
+                    }
+                  }
+                },
+                "lodash._basefor": {
+                  "version": "3.0.2"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.4"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1"
+            }
+          }
+        },
+        "lodash.merge": {
+          "version": "3.3.2",
+          "dependencies": {
+            "lodash._arraycopy": {
+              "version": "3.0.0"
+            },
+            "lodash._arrayeach": {
+              "version": "3.0.0"
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9"
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1"
+                }
+              }
+            },
+            "lodash._getnative": {
+              "version": "3.9.1"
+            },
+            "lodash.isarguments": {
+              "version": "3.0.4"
+            },
+            "lodash.isarray": {
+              "version": "3.0.4"
+            },
+            "lodash.isplainobject": {
+              "version": "3.2.0",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.2"
+                }
+              }
+            },
+            "lodash.istypedarray": {
+              "version": "3.0.2"
+            },
+            "lodash.keys": {
+              "version": "3.1.2"
+            },
+            "lodash.keysin": {
+              "version": "3.0.8"
+            },
+            "lodash.toplainobject": {
+              "version": "3.0.0",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1"
+                }
+              }
+            }
+          }
+        },
+        "lodash.omit": {
+          "version": "3.1.0",
+          "dependencies": {
+            "lodash._arraymap": {
+              "version": "3.0.0"
+            },
+            "lodash._basedifference": {
+              "version": "3.0.3",
+              "dependencies": {
+                "lodash._baseindexof": {
+                  "version": "3.1.0"
+                },
+                "lodash._cacheindexof": {
+                  "version": "3.0.2"
+                },
+                "lodash._createcache": {
+                  "version": "3.1.2",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._baseflatten": {
+              "version": "3.1.4",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.4"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4"
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1"
+            },
+            "lodash._pickbyarray": {
+              "version": "3.0.2"
+            },
+            "lodash._pickbycallback": {
+              "version": "3.0.0",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.2"
+                }
+              }
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.4"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.0",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.1",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.1"
+                },
+                "concat-map": {
+                  "version": "0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.0.1"
+        },
+        "optionator": {
+          "version": "0.6.0",
+          "dependencies": {
+            "prelude-ls": {
+              "version": "1.1.2"
+            },
+            "deep-is": {
+              "version": "0.1.3"
+            },
+            "wordwrap": {
+              "version": "0.0.3"
+            },
+            "type-check": {
+              "version": "0.3.1"
+            },
+            "levn": {
+              "version": "0.2.5"
+            },
+            "fast-levenshtein": {
+              "version": "1.0.7"
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0"
+        },
+        "path-is-inside": {
+          "version": "1.0.1"
+        },
+        "shelljs": {
+          "version": "0.5.3"
+        },
+        "strip-json-comments": {
+          "version": "1.0.4"
+        },
+        "text-table": {
+          "version": "0.2.0"
+        },
+        "to-double-quotes": {
+          "version": "2.0.0"
+        },
+        "to-single-quotes": {
+          "version": "2.0.0"
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.1"
+            }
+          }
+        },
+        "xml-escape": {
+          "version": "1.0.0"
+        }
+      }
+    },
     "eslint-plugin-jasmine": {
       "version": "1.5.0"
     },
@@ -3780,6 +4482,20 @@
     "grunt-autoprefixer": {
       "version": "3.0.3",
       "dependencies": {
+        "autoprefixer-core": {
+          "version": "5.2.1",
+          "dependencies": {
+            "browserslist": {
+              "version": "0.4.0"
+            },
+            "num2fraction": {
+              "version": "1.2.2"
+            },
+            "caniuse-db": {
+              "version": "1.0.30000350"
+            }
+          }
+        },
         "chalk": {
           "version": "1.0.0",
           "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "babel": "5.8.21",
     "btoa": "1.1.2",
     "check-dependencies": "^0.11.0",
+    "eslint": "^1.9.0",
     "eslint-plugin-jasmine": "^1.5.0",
     "eslint-plugin-react": "^3.5.0",
     "esprima": "1.2.2",

--- a/static/src/.eslintrc
+++ b/static/src/.eslintrc
@@ -10,6 +10,7 @@
         "no-shadow": 0,
         "strict": 0,
         "no-use-before-define": 0,
-        "no-alert": 0
+        "no-alert": 0,
+        "no-all-lodash-import": 2
     }
 }


### PR DESCRIPTION
Instead of importing all of Lodash, we must now be import individual modules, re. #11066.

This lint task will prevent us from accidentally importing all of Lodash, and thereby we can avoid file sizes jumping unexpectedly.

E.g.

``` js
// core.js
define(['lodash'], function () {});
```

Error:

```
$ grunt eslint:static/src
Running "eslint:static/src" (eslint) task

/Users/OliverJAsh/Development/frontend/static/src/javascripts/core.js
  1:9  error  Use Lodash modules instead  no-all-lodash-import
```

If you're using the ESLint plugin for Sublime, you have to add the rules to your global config, unfortunately: https://github.com/roadhump/SublimeLinter-eslint#i-want-to-use-custom-rules-global-eslintignore-file-etc
