### PR TITLE
remove secure-omniture switch

### DIFF
--- a/article/test/AnalyticsFeatureTest.scala
+++ b/article/test/AnalyticsFeatureTest.scala
@@ -29,7 +29,7 @@ import conf.Configuration
         Then("the Omniture webbug should record my visit")
         val webbug = findFirst("#omnitureNoScript img")
 
-        webbug.getAttribute("src") should startWith("http://hits.theguardian.com/b/ss/guardiangu-network-dev/1/H.25.3/")
+        webbug.getAttribute("src") should startWith("https://hits-secure.theguardian.com/b/ss/guardiangu-network-dev/1/H.25.3/")
 
         // test a few token properties in the web bug
         webbug.getAttribute("src") should include("c11=sport")

--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -127,13 +127,8 @@ class CanonicalLink {
 object CanonicalLink extends CanonicalLink
 
 object AnalyticsHost extends implicits.Requests {
-  def apply()(implicit request: RequestHeader): String =
-    if (Switches.SecureOmniture.isSwitchedOn ||
-      request.headers.get("X-Forwarded-Proto").exists(_.equalsIgnoreCase("https"))) {
-      "https://hits-secure.theguardian.com"
-    } else {
-      "http://hits.theguardian.com"
-    }
+  // safest to always use secure host as we avoid mixed content if we fail to detect https
+  def apply(): String = "https://hits-secure.theguardian.com"
 }
 
 object SubscribeLink {

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -60,13 +60,4 @@ trait MonitoringSwitches {
     exposeClientSide = true
   )
 
-  val SecureOmniture = Switch(
-    "Monitoring",
-    "secure-omniture",
-    "Send omniture tracking to the https url for all pages",
-    safeState = Off,
-    new LocalDate(2015, 11, 16),
-    exposeClientSide = false
-  )
-
 }


### PR DESCRIPTION
this doesn't seem to have caused any tracking issues so removing the means to turn it off.

Now all no-js and amp omniture calls will go over https.   This avoids any mixed content errors when you hit an https page (amp, or info section) and it fails to detect that, thus serving an http fallback url.

@mkopka you haven't seen any issues have you?
