### PR TITLE
Removed omniture tracking from outbrain

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -79,11 +79,6 @@ define([
         },
 
         tracking: function (widgetCode) {
-            var s = window.s;
-            // Omniture
-            s.link2 = 'outbrain';
-            s.tl(true, 'o', 'outbrain');
-
             // Ophan
             require(['ophan/ng'], function (ophan) {
                 ophan.record({


### PR DESCRIPTION
We don't need this anymore as we can get everything from ophan now.
