### PR TITLE
Newspaper page for /theguardian

### DIFF
--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -9,7 +9,7 @@ import services.TodaysNewspaperQuery
 object NewspaperController extends Controller with Logging with ExecutionContexts {
 
   def today() = Action.async { implicit request =>
-    val page = model.Page(request.path, "News", "Main section | News | The Guardian", "Newspaper books Main Section")
+    val page = model.Page(request.path, "News", "Main section | News | The Guardian", "GFE: Newspaper books Main Section")
 
     val paper = TodaysNewspaperQuery.fetchTodaysPaper
 

--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -1,12 +1,25 @@
 package controllers
 
 import common.{ExecutionContexts, Logging}
+import layout.FaciaContainer
+import model.MetaData
 import play.api.mvc.{Action, Controller}
+import services.TodaysNewspaperQuery
 
 object NewspaperController extends Controller with Logging with ExecutionContexts {
+  //todo rename to today?
+  //todo this response needs caching
+  def index() = Action.async { implicit request =>
+    val page = model.Page(request.path, "todo", "Todo", "Todo")
 
-  def index() = Action {
-    Ok("blah")
+    val paper = TodaysNewspaperQuery.fetchTodaysPaper
+
+    val todaysPaper = paper.map(p => TodayNewspaper(page, p))
+
+    for( tp <- todaysPaper) yield Ok(views.html.todaysNewspaper(tp))
 
   }
 }
+
+//todo add metadata
+case class TodayNewspaper(page: MetaData, bookSections: Seq[FaciaContainer])

--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -1,0 +1,12 @@
+package controllers
+
+import common.{ExecutionContexts, Logging}
+import play.api.mvc.{Action, Controller}
+
+object NewspaperController extends Controller with Logging with ExecutionContexts {
+
+  def index() = Action {
+    Ok("blah")
+
+  }
+}

--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -7,9 +7,9 @@ import play.api.mvc.{Action, Controller}
 import services.TodaysNewspaperQuery
 
 object NewspaperController extends Controller with Logging with ExecutionContexts {
-  //todo rename to today?
+
   //todo this response needs caching
-  def index() = Action.async { implicit request =>
+  def today() = Action.async { implicit request =>
     val page = model.Page(request.path, "News", "Main section | News | The Guardian", "Newspaper books Main Section")
 
     val paper = TodaysNewspaperQuery.fetchTodaysPaper

--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -10,7 +10,7 @@ object NewspaperController extends Controller with Logging with ExecutionContext
   //todo rename to today?
   //todo this response needs caching
   def index() = Action.async { implicit request =>
-    val page = model.Page(request.path, "todo", "Todo", "Todo")
+    val page = model.Page(request.path, "News", "Main section | News | The Guardian", "Newspaper books Main Section")
 
     val paper = TodaysNewspaperQuery.fetchTodaysPaper
 
@@ -21,5 +21,4 @@ object NewspaperController extends Controller with Logging with ExecutionContext
   }
 }
 
-//todo add metadata
 case class TodayNewspaper(page: MetaData, bookSections: Seq[FaciaContainer])

--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -2,13 +2,12 @@ package controllers
 
 import common.{ExecutionContexts, Logging}
 import layout.FaciaContainer
-import model.MetaData
+import model.{Cached, MetaData}
 import play.api.mvc.{Action, Controller}
 import services.TodaysNewspaperQuery
 
 object NewspaperController extends Controller with Logging with ExecutionContexts {
 
-  //todo this response needs caching
   def today() = Action.async { implicit request =>
     val page = model.Page(request.path, "News", "Main section | News | The Guardian", "Newspaper books Main Section")
 
@@ -16,7 +15,7 @@ object NewspaperController extends Controller with Logging with ExecutionContext
 
     val todaysPaper = paper.map(p => TodayNewspaper(page, p))
 
-    for( tp <- todaysPaper) yield Ok(views.html.todaysNewspaper(tp))
+    for( tp <- todaysPaper) yield Cached(300)(Ok(views.html.todaysNewspaper(tp)))
 
   }
 }

--- a/applications/app/services/TodaysNewspaperQuery.scala
+++ b/applications/app/services/TodaysNewspaperQuery.scala
@@ -98,7 +98,7 @@ object TodaysNewspaperQuery extends ExecutionContexts with Dates with Logging {
       Fixed(containerDefinition),
       CollectionConfigWithId(dataId.getOrElse(""), CollectionConfig.empty.copy(displayName = displayName)),
       CollectionEssentials(trails, Nil, displayName, dataId, None, None)
-    )
+    ).copy(hasShowMoreEnabled = false)
   }
 
   private def getNewspaperPageNumber(content: ApiContent) = content.fields.getOrElse(Map.empty).get("newspaperPageNumber").map(_.toInt)

--- a/applications/app/services/TodaysNewspaperQuery.scala
+++ b/applications/app/services/TodaysNewspaperQuery.scala
@@ -36,7 +36,7 @@ object TodaysNewspaperQuery extends ExecutionContexts with Dates with Logging {
 
       val firstPageContainer = {
         val content = firstPageContent.map(c => FaciaContentConvert.frontendContentToFaciaContent(Content(c)))
-        bookSectionContainer("front-page", Some("Front Page"), content, 0)
+        bookSectionContainer(None, Some("Front Page"), content, 0)
       }
 
       val unorderedBookSections = createBookSections(otherContent)
@@ -44,7 +44,7 @@ object TodaysNewspaperQuery extends ExecutionContexts with Dates with Logging {
 
       val bookSectionContainers = orderedBookSections.map { list =>
         val content = list.content.map(c => FaciaContentConvert.frontendContentToFaciaContent(Content(c)))
-        bookSectionContainer(list.tag.id, Some(list.tag.webTitle), content, orderedBookSections.indexOf(list) + 1)
+        bookSectionContainer(Some(list.tag.id), Some(list.tag.webTitle), content, orderedBookSections.indexOf(list) + 1)
       }
 
       firstPageContainer :: bookSectionContainers
@@ -86,7 +86,7 @@ object TodaysNewspaperQuery extends ExecutionContexts with Dates with Logging {
     pageNumberToContent.sortBy(_._1).map(_._2)
   }
 
-  private def bookSectionContainer(dataId: String, displayName: Option[String], trails: Seq[FaciaContent], index: Int): FaciaContainer = {
+  private def bookSectionContainer(dataId: Option[String], displayName: Option[String], trails: Seq[FaciaContent], index: Int): FaciaContainer = {
     val containerDefinition = trails.length match {
       case 1 => FixedContainers.fixedSmallSlowI
       case 2 => FixedContainers.fixedSmallSlowII
@@ -96,8 +96,8 @@ object TodaysNewspaperQuery extends ExecutionContexts with Dates with Logging {
     FaciaContainer(
       index,
       Fixed(containerDefinition),
-      CollectionConfigWithId(dataId, CollectionConfig.empty.copy(displayName = displayName)),
-      CollectionEssentials(trails, Nil, displayName, Some(dataId), None, None)
+      CollectionConfigWithId(dataId.getOrElse(""), CollectionConfig.empty.copy(displayName = displayName)),
+      CollectionEssentials(trails, Nil, displayName, dataId, None, None)
     )
   }
 

--- a/applications/app/services/TodaysNewspaperQuery.scala
+++ b/applications/app/services/TodaysNewspaperQuery.scala
@@ -20,7 +20,7 @@ object TodaysNewspaperQuery extends ExecutionContexts with Dates with Logging {
   def fetchTodaysPaper: Future[List[FaciaContainer]] = {
     val today = DateTime.now(DateTimeZone.UTC)
 
-    val item = LiveContentApi.item("publication/theguardian")
+    val item = LiveContentApi.item("theguardian/mainsection")
       .useDate("newspaper-edition")
       .showFields("all")
       .showElements("all")

--- a/applications/app/services/TodaysNewspaperQuery.scala
+++ b/applications/app/services/TodaysNewspaperQuery.scala
@@ -1,0 +1,93 @@
+package services
+
+import _root_.model.Content
+import com.gu.contentapi.client.model.{Content => ApiContent, Tag}
+import com.gu.facia.api.models.{CollectionConfig, FaciaContent}
+import common._
+import conf.LiveContentApi
+import implicits.Dates
+import layout.{CollectionEssentials, FaciaContainer}
+import org.joda.time.{DateTime, DateTimeZone}
+import slices.{ContainerDefinition, Fixed, FixedContainers, TTT}
+
+import scala.concurrent.Future
+
+case class TagWithContent(tag: Tag, content: ApiContent)
+case class BookSectionContent(tag: Tag, content: List[ApiContent])
+
+object TodaysNewspaperQuery extends ExecutionContexts with Dates with Logging {
+
+  def fetchTodaysPaper: Future[List[FaciaContainer]] = {
+    val today = DateTime.now(DateTimeZone.UTC)
+
+    val item = LiveContentApi.item("publication/theguardian")
+      .useDate("newspaper-edition")
+      .showFields("all")
+      .showElements("all")
+      .showTags("newspaper-book-section")
+      .pageSize(200)
+      .fromDate(today.withTimeAtStartOfDay())
+      .toDate(today)
+
+    LiveContentApi.getResponse(item).map { resp =>
+
+
+      val unorderedBookSections = createBookSections(resp.results)
+      val orderedBookSections = orderBookSectionsByPageNumber(unorderedBookSections)
+
+      orderedBookSections.map { list =>
+        val content = list.content.map(c => FaciaContentConvert.frontendContentToFaciaContent(Content(c)))
+        bookSectionContainer(list.tag.id, Some(list.tag.webTitle), content, orderedBookSections.indexOf(list))
+      }
+    }
+  }
+
+  private def createBookSections(contentList: List[ApiContent]): List[BookSectionContent] = {
+    val tagWithContent: List[TagWithContent] = contentList.flatMap { content =>
+      content.tags.find(_.`type` == "newspaper-book-section").map(t => TagWithContent(t, content))
+    }
+
+    //group content by booksection tag type
+    tagWithContent.groupBy(_.tag).map( bookSectionContent => BookSectionContent(bookSectionContent._1, bookSectionContent._2.map(_.content))).toList
+  }
+
+  private def orderBookSectionsByPageNumber(unorderedBookSections: List[BookSectionContent]): List[BookSectionContent] = {
+
+    //order content for each book section
+    val orderedContentForBookSection: List[BookSectionContent] = unorderedBookSections.map { bookSection =>
+      bookSection.copy(content = getResultsOrderByNewspaperNumber(bookSection.content))
+    }
+
+    //order booksections by first content item in each booksection
+    val pageNumberToFaciaContainer: List[(Int, BookSectionContent)] = orderedContentForBookSection.flatMap { bookSection =>
+      val pageNumberOpt = bookSection.content.headOption.flatMap(c => c.fields.getOrElse(Map.empty).get("newspaperPageNumber").map(_.toInt))
+      pageNumberOpt.map(_ -> bookSection)
+
+    }
+    pageNumberToFaciaContainer.sortBy(_._1).map(_._2)
+  }
+
+
+  private def getResultsOrderByNewspaperNumber(unorderedContent: List[ApiContent]): List[ApiContent] = {
+    val pageNumberToContent: List[(Int, ApiContent)] = unorderedContent.flatMap { c =>
+      val pageNumberOpt = c.fields.getOrElse(Map.empty).get("newspaperPageNumber").map(_.toInt)
+      pageNumberOpt.map(_ -> c)
+    }
+    pageNumberToContent.sortBy(_._1).map(_._2)
+  }
+
+  private def bookSectionContainer(dataId: String, displayName: Option[String], trails: Seq[FaciaContent], index: Int): FaciaContainer = {
+    val containerDefinition = trails.length match {
+      case 1 => FixedContainers.fixedSmallSlowI
+      case 2 => FixedContainers.fixedSmallSlowII
+      case 3 => ContainerDefinition.ofSlices(TTT)
+      case _ => FixedContainers.fixedMediumFastXII }
+
+    FaciaContainer(
+      index,
+      Fixed(containerDefinition),
+      CollectionConfigWithId(dataId, CollectionConfig.empty.copy(displayName = displayName)),
+      CollectionEssentials(trails, Nil, displayName, Some(dataId), None, None)
+    )
+  }
+}

--- a/applications/app/views/todaysNewspaper.scala.html
+++ b/applications/app/views/todaysNewspaper.scala.html
@@ -1,0 +1,10 @@
+@(paper: controllers.TodayNewspaper)(implicit request: RequestHeader)
+
+@main(paper.page) { } {
+
+    @for(bookSection <- paper.bookSections) {
+
+        @fragments.containers.facia_cards.container(bookSection)
+
+    }
+}

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -46,7 +46,7 @@ GET        /$path<.+>/all                                                       
 GET        /sudokus/:id                                                         controllers.SudokusController.render(id)
 
 # Guardian newspaper page
-GET        /theguardian                                                         controllers.NewspaperController.index()
+GET        /theguardian                                                         controllers.NewspaperController.today()
 
 # Gallery paths
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/gallery/.*>/lightbox.json                controllers.GalleryController.lightboxJson(path)

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -45,6 +45,9 @@ GET        /$path<.+>/all                                                       
 # Sudokus
 GET        /sudokus/:id                                                         controllers.SudokusController.render(id)
 
+# Guardian newspaper page
+GET        /theguardian                                                         controllers.NewspaperController.index()
+
 # Gallery paths
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/gallery/.*>/lightbox.json                controllers.GalleryController.lightboxJson(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/gallery/.*>.json                         controllers.GalleryController.renderJson(path)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -315,7 +315,7 @@ GET            /embed/video/*path                                               
 GET            /$shortCode<p/[\w]+>                                                                                              controllers.ShortUrlsController.redirectShortUrl(shortCode)
 GET            /$shortCode<p/[\w]+>/:campaignCode                                                                                controllers.ShortUrlsController.fetchCampaignAndRedirectShortCode(shortCode, campaignCode)
 
-GET            /theguardian                                                                                                      controllers.NewspaperController.index()
+GET            /theguardian                                                                                                      controllers.NewspaperController.today()
 
 GET            /$path<.+/\d\d\d\d/\w\w\w/\d\d>                                                                                   controllers.AllIndexController.on(path)
 GET            /$path<.+>/latest                                                                                                 controllers.LatestIndexController.latest(path)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -315,6 +315,8 @@ GET            /embed/video/*path                                               
 GET            /$shortCode<p/[\w]+>                                                                                              controllers.ShortUrlsController.redirectShortUrl(shortCode)
 GET            /$shortCode<p/[\w]+>/:campaignCode                                                                                controllers.ShortUrlsController.fetchCampaignAndRedirectShortCode(shortCode, campaignCode)
 
+GET            /theguardian                                                                                                      controllers.NewspaperController.index()
+
 GET            /$path<.+/\d\d\d\d/\w\w\w/\d\d>                                                                                   controllers.AllIndexController.on(path)
 GET            /$path<.+>/latest                                                                                                 controllers.LatestIndexController.latest(path)
 GET            /$path<.+>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/all                                                          controllers.AllIndexController.allOn(path, day, month, year)

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -145,7 +145,7 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                        
 
 GET        /container/*id.json                                                                 controllers.FaciaDraftController.renderContainerJson(id)
 
-GET        /theguardian                                                                        controllers.NewspaperController.index()
+GET        /theguardian                                                                        controllers.NewspaperController.today()
 
 GET        /$path<.+/\d\d\d\d/\w\w\w/\d\d>                                                     controllers.AllIndexController.on(path)
 GET        /$path<.+>/latest                                                                   controllers.LatestIndexController.latest(path)

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -145,6 +145,8 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>.json                        
 
 GET        /container/*id.json                                                                 controllers.FaciaDraftController.renderContainerJson(id)
 
+GET        /theguardian                                                                        controllers.NewspaperController.index()
+
 GET        /$path<.+/\d\d\d\d/\w\w\w/\d\d>                                                     controllers.AllIndexController.on(path)
 GET        /$path<.+>/latest                                                                   controllers.LatestIndexController.latest(path)
 GET        /$path<.+>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/all                            controllers.AllIndexController.allOn(path, day, month, year)


### PR DESCRIPTION
As part of moving newspaper pages over to dotcom I've created `/theguardian` endpoint. Following the [R2 version](http://www.theguardian.com/theguardian) this page
- Queries the Content API to fetch results for today for the newspaper book path `theguardian/mainsection` using the query parameter `use-date=newspaper-edition` (which ensures just content that was in the paper will be returned).
- If today is Sunday then fallback to Saturday edition
- Results which have a page number of 1 will be in a `Front Page` container
- Other results are grouped by `newspaper-book-section` and ordered by page number
- Each grouped content by newspaper-book-section is transformed into a container.
- Containers are limited to 12 results, if the user wants to see more content for a container they can click through to the newspaper-book-section e.g.`theguardian/mainsection/uknews`

![screen shot 2015-11-10 at 17 23 34](https://cloud.githubusercontent.com/assets/944375/11069785/daaa3bf6-87cf-11e5-9868-851d699b73a7.png)

![screen shot 2015-11-10 at 17 23 44](https://cloud.githubusercontent.com/assets/944375/11069786/daad78fc-87cf-11e5-9cc7-fe6ade967262.png)
