### PR TITLE
Show Example Page of MPU Container Templates

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -291,6 +291,9 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val gLabsTeam = configuration.getStringProperty("email.gLabsTeam")
 
     lazy val expiredAdFeatureUrl = s"${site.host}/info/2015/feb/06/paid-content-removal-policy"
+
+    lazy val showMpuInAllContainersPageId =
+      configuration.getStringProperty("commercial.showMpuInAllContainersPageId")
   }
 
   object open {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -6,8 +6,8 @@ import com.amazonaws.AmazonClientException
 import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.gu.conf.ConfigurationFactory
-import conf.{Static, Configuration}
 import conf.switches.Switches
+import conf.{Configuration, Static}
 import org.apache.commons.io.IOUtils
 import play.api.Play
 import play.api.Play.current
@@ -248,11 +248,14 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val dfpAdUnitRoot = configuration.getMandatoryStringProperty("guardian.page.dfpAdUnitRoot")
     lazy val dfpAccountId = configuration.getMandatoryStringProperty("guardian.page.dfpAccountId")
     lazy val books_url = configuration.getMandatoryStringProperty("commercial.books_url")
-    lazy val masterclasses_url = configuration.getMandatoryStringProperty("commercial.masterclasses_url")
+    lazy val masterclasses_url =
+      configuration.getMandatoryStringProperty("commercial.masterclasses_url")
     lazy val soulmates_url = configuration.getMandatoryStringProperty("commercial.soulmates_url")
     lazy val travel_url = configuration.getMandatoryStringProperty("commercial.travel_url")
-    lazy val traveloffers_url = configuration.getStringProperty("traveloffers.api.url") map (u => s"$u/consumerfeed")
-    lazy val guMerchandisingAdvertiserId = configuration.getMandatoryStringProperty("dfp.guMerchandising.advertiserId")
+    lazy val traveloffers_url =
+      configuration.getStringProperty("traveloffers.api.url") map (u => s"$u/consumerfeed")
+    lazy val guMerchandisingAdvertiserId =
+      configuration.getMandatoryStringProperty("commercial.dfp.guMerchandising.advertiserId")
 
     private lazy val commercialRoot = s"${environment.stage.toUpperCase}/commercial"
 

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -4,9 +4,10 @@ import com.gu.facia.api.models._
 import common.dfp.{AdSize, AdSlot, DfpAgent}
 import common.{Edition, NavItem}
 import conf.Configuration
+import conf.Configuration.commercial.showMpuInAllContainersPageId
 import contentapi.Paths
 import model.facia.PressedCollection
-import play.api.libs.json.{JsString, JsValue, Json}
+import play.api.libs.json.{JsBoolean, JsString, JsValue, Json}
 
 import scala.language.postfixOps
 
@@ -69,7 +70,7 @@ case class PressedPage(id: String,
     "keywords" -> JsString(webTitle.capitalize),
     "keywordIds" -> JsString(keywordIds.mkString(",")),
     "contentType" -> JsString(contentType)
-  )
+  ) ++ (if (showMpuInAllContainers) Map("showMpuInAllContainers" -> JsBoolean(true)) else Nil)
 
   val isNetworkFront: Boolean = Edition.all.exists(_.id.toLowerCase == id)
 
@@ -96,6 +97,8 @@ case class PressedPage(id: String,
   override def omitMPUsFromContainers(edition: Edition): Boolean = {
     DfpAgent.omitMPUsFromContainers(id, edition)
   }
+
+  val showMpuInAllContainers: Boolean = showMpuInAllContainersPageId contains id
 
   def allItems = collections.flatMap(_.curatedPlusBackfillDeduplicated).distinct
 

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -1,10 +1,9 @@
 package views.support
 
 import common.Maps.RichMap
-import common.{StaticPage, Edition, InternationalEdition}
+import common.{Edition, InternationalEdition, StaticPage}
 import conf.Configuration
 import conf.Configuration.environment
-import conf.switches.Switches.IdentitySocialOAuthSwitch
 import model.{CommercialExpiryPage, Content, MetaData}
 import org.joda.time.DateTime
 import play.api.Play
@@ -44,7 +43,6 @@ case class JavaScriptPage(metaData: MetaData)(implicit request: RequestHeader) {
       ("assetsPath", JsString(Configuration.assets.path)),
       ("hasPageSkin", JsBoolean(metaData.hasPageSkin(edition))),
       ("hasBelowTopNavSlot", JsBoolean(metaData.hasAdInBelowTopNavSlot(edition))),
-      ("omitMPUs", JsBoolean(metaData.omitMPUsFromContainers(edition))),
       ("shouldHideAdverts", JsBoolean(metaData match {
         case c: Content if c.shouldHideAdverts => true
         case p: StaticPage => true

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -76,6 +76,7 @@ commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
 commercial.dfp.guMerchandising.advertiserId=24113847
+commercial.showMpuInAllContainersPageId=dynamic-mpu
 
 #Pressing
 admin.pressjob.standard.push.rate.inminutes=5

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -75,7 +75,7 @@ commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
-dfp.guMerchandising.advertiserId=24113847
+commercial.dfp.guMerchandising.advertiserId=24113847
 
 #Pressing
 admin.pressjob.standard.push.rate.inminutes=5

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -68,6 +68,7 @@ commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
 commercial.dfp.guMerchandising.advertiserId=24113847
+commercial.showMpuInAllContainersPageId=dynamic-mpu
 
 faciatool.show_test_containers=true
 

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -67,7 +67,7 @@ commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
-dfp.guMerchandising.advertiserId=24113847
+commercial.dfp.guMerchandising.advertiserId=24113847
 
 faciatool.show_test_containers=true
 

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -72,7 +72,7 @@ commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
-dfp.guMerchandising.advertiserId=24113847
+commercial.dfp.guMerchandising.advertiserId=24113847
 
 # Pressing
 admin.pressjob.standard.push.rate.inminutes=5

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -28,7 +28,7 @@ define([
     contains,
     map,
     chain) {
-    var adNames = ['inline1', 'inline2', 'inline3'],
+    var maxAdsToShow = config.page.showMpuInAllContainers ? 999 : 3,
         init = function (options) {
             if (!commercialFeatures.sliceAdverts) {
                 return false;
@@ -57,16 +57,21 @@ define([
                 // don't display ad in the first container on the fronts
                 isFrontFirst = contains(['uk', 'us', 'au'], config.page.pageId) && index === 0;
 
-                if ($adSlice.length && !isFrontFirst && (!prefs || prefs[containerId] !== 'closed')) {
+                if (config.page.showMpuInAllContainers) {
                     adSlices.push($adSlice.first());
-                    index += (containerGap + 1);
-                } else {
                     index++;
+                } else {
+                    if ($adSlice.length && !isFrontFirst && (!prefs || prefs[containerId] !== 'closed')) {
+                        adSlices.push($adSlice.first());
+                        index += (containerGap + 1);
+                    } else {
+                        index++;
+                    }
                 }
             }
 
-            return Promise.all(chain(adSlices).slice(0, adNames.length).and(map, function ($adSlice, index) {
-                    var adName        = adNames[index],
+            return Promise.all(chain(adSlices).slice(0, maxAdsToShow).and(map, function ($adSlice, index) {
+                    var adName        = 'inline' + (index + 1),
                         $mobileAdSlot = bonzo(createAdSlot(adName, 'container-inline'))
                             .addClass('ad-slot--mobile'),
                         $tabletAdSlot = bonzo(createAdSlot(adName, 'container-inline'))

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -49,7 +49,7 @@ define([
                 containerGap = 1,
                 prefs        = userPrefs.get('container-states');
 
-            // pull out ad slices which are have at least x containers between them
+            // pull out ad slices which have at least x containers between them
             while (index < containers.length) {
                 container    = containers[index];
                 containerId  = bonzo(container).data('id');
@@ -57,11 +57,10 @@ define([
                 // don't display ad in the first container on the fronts
                 isFrontFirst = contains(['uk', 'us', 'au'], config.page.pageId) && index === 0;
 
-                if ($adSlice.length && !isFrontFirst && (!prefs || prefs[containerId] !== 'closed') && !config.page.omitMPUs) {
+                if ($adSlice.length && !isFrontFirst && (!prefs || prefs[containerId] !== 'closed')) {
                     adSlices.push($adSlice.first());
                     index += (containerGap + 1);
                 } else {
-                    $(container).addClass('omitted-mpus');
                     index++;
                 }
             }

--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -333,12 +333,6 @@
     @include fc-item--list-compact--media;
 }
 
-.omitted-mpus .l-row--cols-3 .l-row__item--span-1 .fc-item__avatar__media {
-    @include mq(tablet) {
-        right: -5%;
-    }
-}
-
 //Live blog items
 .fc-slice--single-col {
 


### PR DESCRIPTION
This change enables us to show an example page where all containers have an MPU.

It also cleans up some leftover code and does a bit of refactoring.

The key commit is cf7ab32.

/cc @Calanthe @uplne @jbreckmckye 
