### PR TITLE
Video preroll AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -52,7 +52,7 @@ trait ABTestSwitches {
   val ABVideoPreroll = Switch(
     "A/B Tests",
     "ab-video-preroll",
-    "A test to see if a non australian audience will be interested in video pre-rolls",
+    "A test to see if a UK or INT audience will be interested in video pre-rolls",
     safeState = Off,
     sellByDate = new LocalDate(2015, 12, 11),
     exposeClientSide = true

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -49,4 +49,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABVideoPreroll = Switch(
+    "A/B Tests",
+    "ab-video-preroll",
+    "A test to see if a non australian audience will be interested in video pre-rolls",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 12, 11),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -11,6 +11,7 @@ define([
     'common/modules/experiments/tests/inject-headlines-test',
     'common/modules/experiments/tests/inject-network-front-test',
     'common/modules/experiments/tests/large-top-slot',
+    'common/modules/experiments/tests/video-preroll',
     'lodash/arrays/flatten',
     'lodash/collections/forEach',
     'lodash/objects/keys',
@@ -33,6 +34,7 @@ define([
     InjectHeadlinesTest,
     InjectNetworkFrontTest,
     LargeTopAd,
+    VideoPreroll,
     flatten,
     forEach,
     keys,
@@ -49,7 +51,8 @@ define([
         new RtrtEmailMessage(),
         new InjectHeadlinesTest(),
         new InjectNetworkFrontTest(),
-        new LargeTopAd()
+        new LargeTopAd(),
+        new VideoPreroll()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-preroll.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-preroll.js
@@ -8,13 +8,13 @@ define([
         this.start = '2015-11-11';
         this.expiry = '2015-12-11';
         this.author = 'Zofia Korcz';
-        this.description = 'A test to see if a non australian audience will be interested in video pre-rolls.';
+        this.description = 'A test to see if an audience from UK or INT will be interested in video pre-rolls.';
         this.audience = 0.5;
         this.audienceOffset = 0.5;
         this.successMeasure = 'We will see clear difference between user behavior';
-        this.audienceCriteria = 'Users not in AU edition';
+        this.audienceCriteria = 'Users not in AU nor US edition';
         this.dataLinkNames = '';
-        this.idealOutcome = 'Non australian audience will be interested in video pre-rolls.';
+        this.idealOutcome = 'British and international audience will be interested in video pre-rolls.';
 
         this.canRun = function () {
             return config.page.edition === 'UK' || config.page.edition === 'INT';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-preroll.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-preroll.js
@@ -9,7 +9,7 @@ define([
         this.expiry = '2015-12-11';
         this.author = 'Zofia Korcz';
         this.description = 'A test to see if a non australian audience will be interested in video pre-rolls.';
-        this.audience = 0.01;
+        this.audience = 0.5;
         this.audienceOffset = 0.5;
         this.successMeasure = 'We will see clear difference between user behavior';
         this.audienceCriteria = 'Users not in AU edition';
@@ -17,7 +17,7 @@ define([
         this.idealOutcome = 'Non australian audience will be interested in video pre-rolls.';
 
         this.canRun = function () {
-            return config.page.edition !== 'AU';
+            return config.page.edition === 'UK' || config.page.edition === 'INT';
         };
 
         this.variants = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-preroll.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-preroll.js
@@ -1,0 +1,34 @@
+define([
+    'common/utils/config'
+], function (
+    config
+) {
+    return function () {
+        this.id = 'VideoPreroll';
+        this.start = '2015-11-11';
+        this.expiry = '2015-12-11';
+        this.author = 'Zofia Korcz';
+        this.description = 'A test to see if a non australian audience will be interested in video pre-rolls.';
+        this.audience = 0.01;
+        this.audienceOffset = 0.5;
+        this.successMeasure = 'We will see clear difference between user behavior';
+        this.audienceCriteria = 'Users not in AU edition';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'Non australian audience will be interested in video pre-rolls.';
+
+        this.canRun = function () {
+            return config.page.edition !== 'AU';
+        };
+
+        this.variants = [
+            {
+                id: 'preroll',
+                test: function () {}
+            },
+            {
+                id: 'nopreroll',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-preroll.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-preroll.js
@@ -14,7 +14,7 @@ define([
         this.successMeasure = 'We will see clear difference between user behavior';
         this.audienceCriteria = 'Users not in AU nor US edition';
         this.dataLinkNames = '';
-        this.idealOutcome = 'British and international audience will be interested in video pre-rolls.';
+        this.idealOutcome = 'UK and INT audience will be interested in video pre-rolls.';
 
         this.canRun = function () {
             return config.page.edition === 'UK' || config.page.edition === 'INT';


### PR DESCRIPTION
The test video ad will be served by DFP only to UK or INT audience who will be inside AB test.
