### PR TITLE
Remove self-help section from tech feedback page to better gauge crashing

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -122,7 +122,7 @@
                         </li>
                         <li class="colophon__item">
                             <a data-link-name="tech feedback" class="js-tech-feedback-report" href="@LinkTo {/info/tech-feedback}">
-                                solve technical issue
+                                report technical issue
                             </a>
                         </li>
                     }

--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -8,7 +8,7 @@
                 <header class="content__head">
                     <div class="gs-container">
                         <div class="content__main-column">
-                            <h1 itemprop="headline" class="content__headline">Solve a technical issue</h1>
+                            <h1 itemprop="headline" class="content__headline">Report a technical issue</h1>
                         </div>
                     </div>
                 </header>
@@ -18,15 +18,7 @@
                             <div class="js-article__container u-cf">
                                 <div class="from-content-api" itemprop="articleBody">
                                     <div class="from-content-api">
-                                        <p>Thanks for coming to solve a technical issue with our web site.</p>
-                                        <h2>Self help</h2>
-                                        <p>If your problem includes the following</p>
-                                        <ul>
-                                            <li>crashing</li>
-                                            <li>reloading</li>
-                                            <li>very slow site access</li>
-                                        </ul>
-                                        <p>please learn about <a href="@LinkTo{/info/2015/sep/22/making-theguardiancom-work-best-for-you}">disabling optional features on our site</a></p>
+                                        <p>Thanks for coming to report a technical issue with our web site.</p>
                                         <h2>Contact us</h2>
                                         <p>Do you need a response?</p>
                                         <p>
@@ -41,8 +33,7 @@
                                                 userhelp@@theguardian.com
                                             </a> and someone should get back to you.
                                         </p>
-                                        <p>Think you can fix it yourself?  <a href="http://developers.theguardian.com/">Work for us</a>!</p>
-
+                                        <p>Think you can fix it yourself? <a href="http://developers.theguardian.com/">Work for us</a>!</p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
We haven't had any feedback about crashing since the end of September. Is this because users are now guided to the self-help page? Feedback is a good indicator of whether we still have a problem, so this temporarily takes away the self-help section to help us better gauge whether users are still having problems.

/cc @johnduffell
