### PR TITLE
Store cookies without subdomains on pre-production environments

### DIFF
--- a/static/src/javascripts/projects/common/utils/cookies.js
+++ b/static/src/javascripts/projects/common/utils/cookies.js
@@ -7,7 +7,7 @@ define([
 
     function getShortDomain() {
         // Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
-        return getDocument().domain.replace(/^(www|dev|m)\./, '.');
+        return getDocument().domain.replace(/^(www|m.code|dev|m)\./, '.');
     }
 
     function cleanUp(names) {

--- a/static/src/javascripts/projects/common/utils/cookies.js
+++ b/static/src/javascripts/projects/common/utils/cookies.js
@@ -7,7 +7,7 @@ define([
 
     function getShortDomain() {
         // Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
-        return getDocument().domain.replace(/^(www|m.code|dev|m)\./, '.');
+        return getDocument().domain.replace(/^(www|m\.code|dev|m)\./, '.');
     }
 
     function cleanUp(names) {

--- a/static/src/javascripts/projects/common/utils/cookies.js
+++ b/static/src/javascripts/projects/common/utils/cookies.js
@@ -6,8 +6,8 @@ define([
     var documentObject;
 
     function getShortDomain() {
-        // Remove www (and dev bit, for localhost set up with dev.theguardian.com domain)
-        return getDocument().domain.replace(/^(www|dev)\./, '.');
+        // Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
+        return getDocument().domain.replace(/^(www|dev|m)\./, '.');
     }
 
     function cleanUp(names) {


### PR DESCRIPTION
Sometimes we need to store cookies against the broad `.theguardian.com` superdomain, so that services running on different subdomains can share them. We do this automatically on production, and on development when nextgen is run under `dev.theguardian.com`, but not under `m.thegulocal.com`, or `m.code-dev.theguardian.com`.

This is a requirement to testing an upcoming story to remove the `gu_paying_user` cookie on membership-frontend.
