### PR TITLE
Hide adblock byline image on print

### DIFF
--- a/static/src/javascripts/projects/common/views/commercial/adblock-sticky-message.html
+++ b/static/src/javascripts/projects/common/views/commercial/adblock-sticky-message.html
@@ -9,7 +9,7 @@
                     <%=quoteAuthor%>
                 </p>
             </div>
-            <div class="adblock-byline-img">
+            <div class="byline-img adblock-byline-img">
                 <img class="byline-img__img" src="<%=imageAuthor%>" alt="<%=quoteAuthor%>">
             </div>
             <div class="adblock-sticky__logo">


### PR DESCRIPTION
If a page has an above-nav adblock banner...

![image](https://cloud.githubusercontent.com/assets/3148617/11122484/519fbe5a-8953-11e5-9d11-118abba4d6a0.png)

Then when we print it, the byline image takes over the page:

![image](https://cloud.githubusercontent.com/assets/3148617/11122510/7bdfcb92-8953-11e5-88b2-174cb7e744b9.png)
_Above: George Monbiot is disappointed that you're using Adblock Plus. And paper._

There's already a rule to hide `byline-img` components in print, so I've added that behaviour to the `adblock-byline-img` component too. And now the print is a little more sane -

![image](https://cloud.githubusercontent.com/assets/3148617/11122647/0604ab3a-8954-11e5-8dae-b0f6a55758de.png)
_George is still unhappy that you're using an adblocker, but at least you're consuming a little less paper._
