### PR TITLE
Crosswords bug: Bind this to anon func

### DIFF
--- a/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/hidden-input.js
@@ -28,7 +28,7 @@ define([
                 fastdom.read(function () {
                     var offsets = bonzo(React.findDOMNode(this.refs.input)).offset();
                     scroller.scrollTo(offsets.top - offsets.height * 1.5 - $('.crossword__sticky-clue').offset().height, 250, 'easeOutQuad');
-                });
+                }.bind(this));
             }
         },
 


### PR DESCRIPTION
Fixes clicking on label not scrolling to the cells on narrow
