### PR TITLE
InjectNetworkFrontTest fixes

### DIFF
--- a/static/src/javascripts/bootstraps/trail.js
+++ b/static/src/javascripts/bootstraps/trail.js
@@ -114,7 +114,6 @@ define([
 
                 $('.js-tabs-content', $parent).addClass('tabs__content--no-border');
                 $('.js-tabs', $parent).addClass('u-h');
-                mediator.emit('modules:popular:loaded', this.elem);
             }.bind(this));
         }
     }

--- a/static/src/javascripts/projects/common/modules/onward/inject-container.js
+++ b/static/src/javascripts/projects/common/modules/onward/inject-container.js
@@ -21,8 +21,10 @@ define([
         }).then(function (resp) {
             if (resp.html) {
                 fastdom.write(function () {
-                    var $el = $(containerSelector);
-                    $el.after(resp.html);
+                    var $el = $(containerSelector),
+                        htmlToInject = resp.html.replace(/js-ad-slot ad-slot ad-slot--dfp/g, '');
+
+                    $el.after(htmlToInject.replace(/js-fc-slice-mpu-candidate/g, ''));
                     if (!(config.page && config.page.hasStoryPackage)) {
                         $el.css({
                             display: 'none'


### PR DESCRIPTION
The unexpected adslots that end up on the page when injecting the network front were causing problems with the DFP code. This removes them in the most hacky manner. Hopefully fine for a 5 day test?
