### PR TITLE
Circumvent Chrome bug with positioning, overflow: hidden and columns

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -311,6 +311,10 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item__image-container {
     display: none;
+    // Override u-responsive-ratio
+    // Circumvents Chrome bug with positioning, overflow: hidden and columns
+    // https://code.google.com/p/chromium/issues/detail?id=527709
+    overflow: visible;
 }
 
 .fc-item__slideshow {


### PR DESCRIPTION
This is a temporary workaround for Chrome bug https://code.google.com/p/chromium/issues/detail?id=527709, which is causing images on some of our fronts to disappear.

Smoke tested in Firefox, Safari, Chrome and IE9.
# Before

![image](https://cloud.githubusercontent.com/assets/921609/11144106/235cbe86-89f2-11e5-805d-ee819880f670.png)
# After

![image](https://cloud.githubusercontent.com/assets/921609/11144110/291ff176-89f2-11e5-97bc-d2bf756e1aa8.png)
