### PR TITLE
Improve Discussion call behaviour

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -233,7 +233,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   }
 
   object discussion {
-    lazy val apiRoot = configuration.getMandatoryStringProperty("discussion.apiRoot")
     lazy val secureApiRoot = configuration.getMandatoryStringProperty("discussion.secureApiRoot")
     lazy val apiTimeout = configuration.getMandatoryStringProperty("discussion.apiTimeout")
     lazy val apiClientHeader = configuration.getMandatoryStringProperty("discussion.apiClientHeader")
@@ -306,8 +305,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       "googleSearchUrl" -> "//www.google.co.uk/cse/cse.js",
       "idApiUrl" -> id.apiRoot,
       "idOAuthUrl" -> id.oauthUrl,
-      "discussionApiRoot" -> discussion.apiRoot,
-      ("secureDiscussionApiRoot", discussion.secureApiRoot),
+      "secureDiscussionApiRoot" -> discussion.secureApiRoot,
       "discussionApiClientHeader" -> discussion.apiClientHeader,
       ("ophanJsUrl", ophan.jsLocation),
       ("ophanEmbedJsUrl", ophan.embedJsLocation),

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -33,8 +33,7 @@ id.membership.url=https://membership.theguardian.com
 id.membership.stripePublicToken=pk_test_Qm3CGRdrV4WfGYCpm0sftR0f
 
 # Discussion
-discussion.apiRoot=http://discussion.code.dev-guardianapis.com/discussion-api
-discussion.secureApiRoot=https://discussion-secure.code.dev-guardianapis.com/discussion-api
+discussion.secureApiRoot=https://m.code.dev-theguardian.com/guardianapis/discussion/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.url=http://discussion.code.dev-theguardian.com

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -27,8 +27,7 @@ id.membership.url=https://mem.thegulocal.com
 id.membership.stripePublicToken=pk_test_Qm3CGRdrV4WfGYCpm0sftR0f
 
 # Discussion
-discussion.apiRoot=http://discussion.guardianapis.com/discussion-api
-discussion.secureApiRoot=https://discussion.guardianapis.com/discussion-api
+discussion.secureApiRoot=https://www.theguardian.com/guardianapis/discussion/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.url=http://discussion.code.dev-theguardian.com

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -26,8 +26,7 @@ id.webapp.url=https://id.thegulocal.com
 id.oauth.url=https://oauth.thegulocal.com
 
 # Discussion
-discussion.apiRoot=http://discussion.code.dev-guardianapis.com/discussion-api
-discussion.secureApiRoot=https://discussion-secure.code.dev-guardianapis.com/discussion-api
+discussion.secureApiRoot=https://m.code.dev-theguardian.com/guardianapis/discussion/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.url=http://discussion.code.dev-theguardian.com

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -30,8 +30,7 @@ id.membership.url=https://membership.theguardian.com
 id.membership.stripePublicToken=pk_live_2O6zPMHXNs2AGea4bAmq5R7Z
 
 # Discussion
-discussion.apiRoot=http://discussion.guardianapis.com/discussion-api
-discussion.secureApiRoot=https://discussion.guardianapis.com/discussion-api
+discussion.secureApiRoot=https://www.theguardian.com/guardianapis/discussion/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen
 discussion.url=http://discussion.theguardian.com

--- a/discussion/app/controllers/DiscussionController.scala
+++ b/discussion/app/controllers/DiscussionController.scala
@@ -8,7 +8,7 @@ import discussion.DiscussionApi
 object delegate {
   // var allows us to inject test api
   var api = new DiscussionApi {
-    override protected val apiRoot = Configuration.discussion.apiRoot
+    override protected val apiRoot = Configuration.discussion.secureApiRoot
     override protected val clientHeaderValue: String = Configuration.discussion.apiClientHeader
   }
 

--- a/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
+++ b/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
@@ -22,7 +22,7 @@ import play.api.libs.ws.WS
     var headersReceived: Map[String,String] = Map.empty
     val testUrl = "http://test-url"
 
-    override protected val apiRoot = Configuration.discussion.apiRoot
+    override protected val apiRoot = Configuration.discussion.secureApiRoot
     override protected val clientHeaderValue: String = Configuration.discussion.apiClientHeader
   }
 

--- a/discussion/test/package.scala
+++ b/discussion/test/package.scala
@@ -57,7 +57,7 @@ object DiscussionApiHttpRecorder extends HttpRecorder[WSResponse] {
 class DiscussionApiStub extends DiscussionApi {
   import play.api.Play.current
   protected val clientHeaderValue: String =""
-  protected val apiRoot = conf.Configuration.discussion.apiRoot
+  protected val apiRoot = conf.Configuration.discussion.secureApiRoot
   protected val apiTimeout = conf.Configuration.discussion.apiTimeout
 
   override protected def GET(url: String, headers: (String, String)*) = DiscussionApiHttpRecorder.load(url, Map.empty){

--- a/static/src/javascripts/projects/common/modules/discussion/api.js
+++ b/static/src/javascripts/projects/common/modules/discussion/api.js
@@ -14,15 +14,10 @@ define([
      * Singleton to deal with Discussion API requests
      * @type {Object}
      */
-    var root = (document.location.protocol === 'https:')
-            ? config.page.secureDiscussionApiRoot
-            : config.page.discussionApiRoot,
-        Api = {
-            root: root,
-            // TODO get rid of discussion proxy completely when we're changed over to https
-            proxyRoot: (config.switches.discussionProxy ? (config.page.host + '/guardianapis/discussion/discussion-api') : root),
-            clientHeader: config.page.discussionApiClientHeader
-        };
+    var Api = {
+        secureRoot: config.page.secureDiscussionApiRoot,
+        clientHeader: config.page.discussionApiClientHeader
+    };
 
     /**
      * @param {string} endpoint
@@ -31,11 +26,8 @@ define([
      * @return {Reqwest} a promise
      */
     Api.send = function (endpoint, method, data) {
-        var root = (method === 'post' && document.location.protocol === 'http:') ? Api.proxyRoot : Api.root;
+        var root = Api.secureRoot
         data = data || {};
-        if (cookies.get('GU_U')) {
-            data.GU_U = cookies.get('GU_U');
-        }
 
         var request = ajax({
             url: root + endpoint,


### PR DESCRIPTION
Use theguardian.com proxy and always over HTTPS.
