### PR TITLE
Article styling fixes

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -502,12 +502,10 @@ case class ImmersiveLinks(isImmersive: Boolean) extends HtmlCleaner {
 case class DropCaps(isFeature: Boolean, isImmersive: Boolean) extends HtmlCleaner {
 
   private def setDropCap(p: Element): String = {
-    val html = p.html
-    if ( html.length > 200 && html.matches("^[\"a-zA-Z].*") ) {
-      s"""<span class="drop-cap"><span class="drop-cap__inner">${html.head}</span></span>${html.tail}"""
-    } else {
-      html
-    }
+    p.html.replaceFirst(
+      "^([\"'“‘]*[a-zA-Z])(.{199,})",
+      """<span class="drop-cap"><span class="drop-cap__inner">$1</span></span>$2"""
+    )
   }
 
   override def clean(document: Document): Document = {

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -503,7 +503,7 @@ case class DropCaps(isFeature: Boolean, isImmersive: Boolean) extends HtmlCleane
 
   private def setDropCap(p: Element): String = {
     val html = p.html
-    if ( html.length > 200 && html.matches("^[\"a-zA-Z].*") && html.split("\\s+").head.length >= 2 ) {
+    if ( html.length > 200 && html.matches("^[\"a-zA-Z].*") ) {
       s"""<span class="drop-cap"><span class="drop-cap__inner">${html.head}</span></span>${html.tail}"""
     } else {
       html

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -131,6 +131,26 @@ class TemplatesTest extends FlatSpec with Matchers {
     body should not include ("""<span class="drop-cap__inner">""")
   }
 
+  it should "add the dropcap span when the paragraph begins with a single prime" in {
+    val body = "'Hello"
+    body should include ("""<span class="drop-cap__inner">'H</span>""")
+  }
+
+  it should "add the dropcap span when the paragraph begins with a double prime" in {
+    val body = """"Hello"""
+    body should include ("""<span class="drop-cap__inner">"H</span>""")
+  }
+
+  it should "add the dropcap span when the paragraph begins with a single quote mark" in {
+    val body = "‘Hello"
+    body should include ("""<span class="drop-cap__inner">‘H</span>""")
+  }
+
+  it should "add the dropcap span when the paragraph begins with a double quote mark" in {
+    val body = "“Hello"
+    body should include ("""<span class="drop-cap__inner">“H</span>""")
+  }
+
   "RowInfo" should "add row info to a sequence" in {
 
     val items = Seq("a", "b", "c", "d")

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -121,11 +121,6 @@ class TemplatesTest extends FlatSpec with Matchers {
     body should not include ("""<span class="drop-cap__inner">""")
   }
 
-  it should "not add the dropcap span when the paragraph is which begins with a word of less than one Letter" in {
-    val body = withJsoup(bodyStartsWithOneLetter)(DropCaps(true, false)).body.trim
-    body should not include ("""<span class="drop-cap__inner">""")
-  }
-
   it should "not add the dropcap span when first body element is not a paragraph" in {
     val body = withJsoup(bodyWithHeadingBeforePara)(DropCaps(true, false)).body.trim
     body should not include ("""<span class="drop-cap__inner">""")

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -131,24 +131,9 @@ class TemplatesTest extends FlatSpec with Matchers {
     body should not include ("""<span class="drop-cap__inner">""")
   }
 
-  it should "add the dropcap span when the paragraph begins with a single prime" in {
-    val body = "'Hello"
-    body should include ("""<span class="drop-cap__inner">'H</span>""")
-  }
-
-  it should "add the dropcap span when the paragraph begins with a double prime" in {
-    val body = """"Hello"""
-    body should include ("""<span class="drop-cap__inner">"H</span>""")
-  }
-
-  it should "add the dropcap span when the paragraph begins with a single quote mark" in {
-    val body = "‘Hello"
-    body should include ("""<span class="drop-cap__inner">‘H</span>""")
-  }
-
   it should "add the dropcap span when the paragraph begins with a double quote mark" in {
-    val body = "“Hello"
-    body should include ("""<span class="drop-cap__inner">“H</span>""")
+    val body = withJsoup(bodyStartsWithDoubleQuote)(DropCaps(true, false)).body.trim
+    body should include ("""<span class="drop-cap__inner">“S</span>""")
   }
 
   "RowInfo" should "add row info to a sequence" in {
@@ -298,6 +283,13 @@ class TemplatesTest extends FlatSpec with Matchers {
     """
       <body>
         <h2>The recipe</h2><p>Season four chicken thighs then brown them on  both sides in a little oil  in a casserole or heavy  deep-sided pan. Roughly chop and thoroughly wash two small leeks. Lift out the browned thighs and set aside, then tip the chopped leeks into the pan and let them soften over a low heat, stirring regularly so they do not brown. Return the chicken thighs to the pan, pour over  a litre of chicken stock, and leave to simmer for about 20 minutes.</p><p>Remove the pods from 450g of broad beans. Break 50g of linguine into short lengths (about 2cm)  and add to the pan, turning the heat up so the liquid boils, then cook for  eight or nine minutes until the pasta is cooked. A few minutes before the pasta is ready, add the podded beans and 200g (shelled weight) of peas to the soup. Finish with a good handful of freshly chopped parsley, check the seasoning and serve. Serves 2.</p><p></p><h2>The trick</h2><p>Brown the chicken thoroughly, a little more than usual, so the caramelised notes enrich the stock. The chicken pieces will also look better that way. You can use chicken or vegetable stock for this. I like to lift the chicken out of the cooking liquor before  I add the pasta, then return it just as the pasta is ready. It won't come to grief if you leave it in, but by removing the chicken you will reduce the risk of overcooking.</p><p></p><h2>The twist</h2><p>Instead of broad beans, use green French beans, chopped into short lengths, like the pasta. Add a hit  of lemon by adding lemon thyme  and a good tablespoon of chopped  leaves. At the last moment, fold  a handful of young spinach or garlic leaves into the stock.</p>
+      </body>
+    """
+
+  val bodyStartsWithDoubleQuote =
+    """
+      <body>
+        <p>“Season four chicken thighs then brown them on  both sides in a little oil  in a casserole or heavy  deep-sided pan.” Roughly chop and thoroughly wash two small leeks. Lift out the browned thighs and set aside, then tip the chopped leeks into the pan and let them soften over a low heat, stirring regularly so they do not brown. Return the chicken thighs to the pan, pour over  a litre of chicken stock, and leave to simmer for about 20 minutes.</p><p>Remove the pods from 450g of broad beans. Break 50g of linguine into short lengths (about 2cm)  and add to the pan, turning the heat up so the liquid boils, then cook for  eight or nine minutes until the pasta is cooked. A few minutes before the pasta is ready, add the podded beans and 200g (shelled weight) of peas to the soup. Finish with a good handful of freshly chopped parsley, check the seasoning and serve. Serves 2.</p><p></p><h2>The trick</h2><p>Brown the chicken thoroughly, a little more than usual, so the caramelised notes enrich the stock. The chicken pieces will also look better that way. You can use chicken or vegetable stock for this. I like to lift the chicken out of the cooking liquor before  I add the pasta, then return it just as the pasta is ready. It won't come to grief if you leave it in, but by removing the chicken you will reduce the risk of overcooking.</p><p></p><h2>The twist</h2><p>Instead of broad beans, use green French beans, chopped into short lengths, like the pasta. Add a hit  of lemon by adding lemon thyme  and a good tablespoon of chopped  leaves. At the last moment, fold  a handful of young spinach or garlic leaves into the stock.</p>
       </body>
     """
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -596,8 +596,8 @@
         }
     }
 
-    .element--showcase + * {
-        clear: both;
+    .element--showcase {
+        float: none;
     }
 
     .ad-slot--inline {

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -596,6 +596,10 @@
         }
     }
 
+    .element--showcase + * {
+        clear: both;
+    }
+
     .ad-slot--inline {
         @include mq(desktop) {
             margin-right: -(gs-span(4) + $gs-gutter);


### PR DESCRIPTION
- _drop caps have no minimum word length_

![screen shot 2015-11-13 at 12 16 41](https://cloud.githubusercontent.com/assets/867233/11146132/670e42e2-8a03-11e5-8ab2-efe53296f09b.png)

![screen shot 2015-11-13 at 12 14 20](https://cloud.githubusercontent.com/assets/867233/11146128/5fbaff30-8a03-11e5-8733-2d0534eb9fec.png)

---
- _`'`, `“` and `‘` can now accompany a drop cap_

![screen shot 2015-11-13 at 12 16 30](https://cloud.githubusercontent.com/assets/867233/11146149/7d477f56-8a03-11e5-84a6-9378e8fa9930.png)
![screen shot 2015-11-13 at 12 14 05](https://cloud.githubusercontent.com/assets/867233/11146152/80f04c50-8a03-11e5-886e-69bbdde4e8a6.png)

---
- _showcase elements force the following element to clear left and right, regardless of showcase's negative margin_

![screen shot 2015-11-13 at 12 16 23](https://cloud.githubusercontent.com/assets/867233/11146160/8e004bb6-8a03-11e5-8d3b-65e77e55a822.png)
![screen shot 2015-11-13 at 12 14 43](https://cloud.githubusercontent.com/assets/867233/11146162/90654c1c-8a03-11e5-9e4c-3c6907c293bc.png)

cc @sammorrisdesign you'll probably be interested in this?
