### PR TITLE
Reduce scope

### DIFF
--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -314,7 +314,9 @@ $fc-item-gutter: $gs-gutter / 4;
     // Override u-responsive-ratio
     // Circumvents Chrome bug with positioning, overflow: hidden and columns
     // https://code.google.com/p/chromium/issues/detail?id=527709
-    overflow: visible;
+    .fc-item--list-compact--media & {
+        overflow: visible;
+    }
 }
 
 .fc-item__slideshow {

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -311,12 +311,6 @@ $fc-item-gutter: $gs-gutter / 4;
 
 .fc-item__image-container {
     display: none;
-    // Override u-responsive-ratio
-    // Circumvents Chrome bug with positioning, overflow: hidden and columns
-    // https://code.google.com/p/chromium/issues/detail?id=527709
-    .fc-item--list-compact--media & {
-        overflow: visible;
-    }
 }
 
 .fc-item__slideshow {

--- a/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-compact--media.scss
+++ b/static/src/stylesheets/module/facia/item-layouts/_fc-item--list-compact--media.scss
@@ -17,6 +17,13 @@ x x x x x x x x x x x x x x x x x x x x x x x
     min-height: $item-min-height;
     padding-left: $image-width;
 
+    // Override u-responsive-ratio
+    // Circumvents Chrome bug with positioning, overflow: hidden and columns
+    // https://code.google.com/p/chromium/issues/detail?id=527709
+    .fc-item__image-container {
+        overflow: visible;
+    }
+
     .fc-item__image-container {
         display: block;
     }


### PR DESCRIPTION
#11116 broke the huge facia card style on CODE, as per below. This just reduces the scope.
# Before

![image](https://cloud.githubusercontent.com/assets/921609/11147341/2549dec0-8a0d-11e5-902e-2f8fbc74c8a0.png)
http://m.code.dev-theguardian.com/uk
# After

![image](https://cloud.githubusercontent.com/assets/921609/11147392/855c851a-8a0d-11e5-8741-bbd3e6dc1945.png)

/cc @sndrs 
