### PR TITLE
Remove dependency on GU_U from adfree pre-render scripts

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyAdfreeRenderCondition.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyAdfreeRenderCondition.scala.js
@@ -4,17 +4,9 @@
     var htmlClassToAdd = '';
 
     function showAdfreeView() {
-        if (userLoggedOut()) {
-            return false;
-        } else {
-            var adfreeUser = readCookie('gu_adfree_user');
-            // If the user doesn't have the cookie yet, we keep displaying ads until we know their status
-            return adfreeUser === 'true';
-        }
-    }
-
-    function userLoggedOut() {
-        return readCookie('GU_U') === null;
+        // Signed out users and users who are signed in, but whose status hasn't been confirmed, will continue seeing ads
+        // See user-features.js for details of the cookie's lifecycle
+        return readCookie('gu_adfree_user') === 'true';
     }
 
     function readCookie(name) {


### PR DESCRIPTION
The identity team want to pull the GU_U cookie, as it's been deemed a security risk. Most of our commercial code only relies on this cookie through methods on the identity/api module, which can be changed to use a more secure implementation, but our adfree pre-flight scripts call the GU_U cookie directly.

That dependency is actually unnecessary, though. Adfree does not - at the moment - differentiate between users who are signed out, and users who are signed in but who haven't been confirmed as adfree-eligible. So we can strip the check to GU_U out entirely.

@sndrs @kelvin-chappell 
