### PR TITLE
Hide thrasher on injected network front for test

### DIFF
--- a/static/src/stylesheets/module/content/_article.scss
+++ b/static/src/stylesheets/module/content/_article.scss
@@ -86,5 +86,9 @@
     .fc-container--lazy-load {
         display: block !important;
     }
+
+    .fc-container--thrasher {
+        display: none !important;
+    }
 }
 


### PR DESCRIPTION
We aren't upgrading them so it's best to hide them.
