### PR TITLE
Link to existing T&C's for Teachers Network

### DIFF
--- a/identity/app/views/fragments/thirdPartyConditions.scala.html
+++ b/identity/app/views/fragments/thirdPartyConditions.scala.html
@@ -11,11 +11,11 @@
     }
 
     case (Some("GTNF"), true) => {
-        By proceeding, you agree to the Guardian's <a href="http://www.theguardian.com/help/terms-of-service" data-link-name="Terms of Service">Terms of Service</a> &amp; <a href="http://www.theguardian.com/help/privacy-policy" data-link-name="Privacy Policy">Privacy Policy</a> and Guardian Teacher Network's Terms of Service &amp; Privacy Policy.
+        By proceeding, you agree to the Guardian's <a href="http://www.theguardian.com/help/terms-of-service" data-link-name="Terms of Service">Terms of Service</a> &amp; <a href="http://www.theguardian.com/help/privacy-policy" data-link-name="Privacy Policy">Privacy Policy</a> and Guardian Teacher Network's <a href="http://teachers.theguardian.com/Terms.htm">Terms of Service</a> &amp; <a href="http://teachers.theguardian.com/privacypolicy.htm">Privacy Policy</a>.
     }
 
     case (Some("GTNF"), false) => {
-        By proceeding, you agree to Guardian Teacher Network's Terms of Service &amp; Privacy Policy.
+        By proceeding, you agree to Guardian Teacher Network's <a href="http://teachers.theguardian.com/Terms.htm">Terms of Service</a> &amp; <a href="http://teachers.theguardian.com/privacypolicy.htm">Privacy Policy</a>.
     }
 
     case (_, _) => {


### PR DESCRIPTION
Currently the mention of Teachers Network T&C's is not clickable links.

This just changes them to be clickable and link to the existing T&C's pages.
