### PR TITLE
Allow users to insist on receiving enhanced content

### DIFF
--- a/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
+++ b/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
@@ -15,6 +15,17 @@
         }
     };
 
+    var personDemandsFeatures = function () {
+        var locationHash = window.location.hash;
+        if (locationHash === '#featureson' || locationHash === '#nocore' || locationHash === '#gu.prefs.force-core=off') return true;
+        try {
+            var preference = window.localStorage.getItem('gu.prefs.force-core') || 'unknown';
+            return /"value":"off"/.test(preference);
+        } catch (e) {
+            return false;
+        }
+    };
+
     // Guess whether the device is too old, regardless of whether it cuts the mustard
     //
     // 'older' iOS normally indicates a device with lower power (they stop being upgradeable at some point).
@@ -35,7 +46,7 @@
         return (navigator.platform === 'iPad');
     };
 
-    window.shouldEnhance = !personPrefersCore() && !isOlderIOSDevice() && !(@item.isFront && isIpad());
+    window.shouldEnhance = personDemandsFeatures() || (!personPrefersCore() && !isOlderIOSDevice() && !(@item.isFront && isIpad()));
     window.shouldEnhance || console && console.info && console.info("THIS IS CORE");
 })(navigator, window);
 


### PR DESCRIPTION
(Ignore the -ipads part of the branch name!)

As discussed with @michaelwmcnamara - some users don't have problems on older devices, but they can't opt back in to enhanced mode if they're on an iPad or an older iOS device.

@sndrs I'd appreciate your opinion too, is this too broad in scope do you think? It would affect anyone on any device with the appropriate hash or stored preference.
