### PR TITLE
Use render other status for picture content

### DIFF
--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -7,6 +7,7 @@ import conf.switches.Switches
 import model._
 import play.api.mvc.{Action, Controller, RequestHeader, Result}
 import services.ImageQuery
+import views.support.RenderOtherStatus
 
 import scala.concurrent.Future
 
@@ -26,7 +27,7 @@ object ImageContentController extends Controller with RendersItemResponse with I
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = image(Edition(request), path).map {
     case Left(content) => renderImageContent(content)
-    case Right(result) => result
+    case Right(result) => RenderOtherStatus(result)
   }
 
   private def isSupported(c: ApiContent) = c.isImageContent


### PR DESCRIPTION
Rather than return a 410 http status, picture content should show the content removed page.
