### PR TITLE
Cope with nulls in DFP API fetch

### DIFF
--- a/admin/app/dfp/ApiHelper.scala
+++ b/admin/app/dfp/ApiHelper.scala
@@ -16,7 +16,7 @@ object ApiHelper extends Logging {
     @tailrec
     def fetch(soFar: Seq[T]): Seq[T] = {
       val (pageOfResults, totalResultSetSize) = fetchPage(statementBuilder.toStatement)
-      val resultsSoFar = soFar ++ pageOfResults
+      val resultsSoFar = Option(pageOfResults).map(soFar ++ _).getOrElse(soFar)
       if (resultsSoFar.size >= totalResultSetSize) {
         resultsSoFar
       } else {

--- a/admin/test/dfp/ApiHelperTest.scala
+++ b/admin/test/dfp/ApiHelperTest.scala
@@ -1,0 +1,29 @@
+package dfp
+
+import com.google.api.ads.dfp.axis.utils.v201508.StatementBuilder
+import org.scalatest.{FlatSpec, Matchers}
+
+class ApiHelperTest extends FlatSpec with Matchers {
+
+  "fetch" should "fetch a single page of results" in {
+    val stmtBuilder = new StatementBuilder()
+    val result = ApiHelper.fetch[Int](stmtBuilder) { statement =>
+      (Array(1, 2, 3, 4, 5), 5)
+    }
+    result shouldBe Seq(1, 2, 3, 4, 5)
+  }
+
+  it should "fetch multiple pages of results" in {
+    val stmtBuilder = new StatementBuilder()
+    val result = ApiHelper.fetch[Int](stmtBuilder) { statement =>
+      ((1 to 10).toArray, 30)
+    }
+    result shouldBe Seq.fill[Seq[Int]](3)((1 to 10).toSeq).flatten
+  }
+
+  it should "cope with a null result" in {
+    val stmtBuilder = new StatementBuilder()
+    val result = ApiHelper.fetch[Int](stmtBuilder) { statement => (null, 0) }
+    result shouldBe empty
+  }
+}


### PR DESCRIPTION
The DFP API client library gives nulls rather than empty result arrays.
