### PR TITLE
Frequency param in DFP call set to 20plus

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -98,16 +98,7 @@ define([
             }
         },
         getVisitedValue = function () {
-            var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0,
-                visitedValue;
-
-            if (alreadyVisited > 19) {
-                visitedValue = '20plus';
-            } else {
-                visitedValue = alreadyVisited.toString();
-            }
-
-            return visitedValue;
+            return storage.local.get('gu.alreadyVisited') || 0;
         };
 
     return function (opts) {
@@ -132,7 +123,7 @@ define([
                 co:      parseIds(page.authorIds),
                 bl:      parseIds(page.blogIds),
                 ms:      formatTarget(page.source),
-                fr:      getVisitedValue(),
+                fr:      getVisitedValue().toString(),
                 tn:      uniq(compact([page.sponsorshipType].concat(parseIds(page.tones)))),
                 // round video duration up to nearest 30 multiple
                 vl:      page.contentType === 'Video' ? (Math.ceil(page.videoDuration / 30.0) * 30).toString() : undefined

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -101,8 +101,8 @@ define([
             var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0,
                 visitedValue;
 
-            if (alreadyVisited > 4) {
-                visitedValue = '5plus';
+            if (alreadyVisited > 19) {
+                visitedValue = '20plus';
             } else {
                 visitedValue = alreadyVisited.toString();
             }

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -195,10 +195,10 @@ define([
                 expect(buildPageTargeting().fr).toEqual('3');
             });
 
-            it('should set 5+ frequency param', function () {
+            it('should set 20+ frequency param', function () {
                 storage.local.set('gu.alreadyVisited', 67);
 
-                expect(buildPageTargeting().fr).toEqual('5plus');
+                expect(buildPageTargeting().fr).toEqual('20plus');
             });
         });
     });

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -194,12 +194,6 @@ define([
 
                 expect(buildPageTargeting().fr).toEqual('3');
             });
-
-            it('should set 20+ frequency param', function () {
-                storage.local.set('gu.alreadyVisited', 67);
-
-                expect(buildPageTargeting().fr).toEqual('20plus');
-            });
         });
     });
 });


### PR DESCRIPTION
So we can track user behaviour more deeply and possibly stop showing high relevance commercial components on the lower numbers which will allow us to show more Outbrain.
