### PR TITLE
Removed inline-block

### DIFF
--- a/static/src/stylesheets/module/_headline-list.scss
+++ b/static/src/stylesheets/module/_headline-list.scss
@@ -31,19 +31,19 @@
             width: 40%;
         }
     }
+
+    &.headline-column--desktop__item {
+        display: block;
+        margin-bottom: $gs-baseline / 2;  
+    }
 }
 
 .headline-list__count {
     position: absolute;
     top: 0;
     left: 0;
-    width: gs-span(1);
     color: colour(neutral-4);
     @include font($f-serif-headline, 200, 44px);
-
-    @include mq(mobile) {
-        width: gs-span(1) - $gs-gutter / 2;
-    }
 }
 
 .headline-list__link {


### PR DESCRIPTION
Seems a bug with column (-webkit-column-gap etc) was pushing the absolute positioned numbers all over the place.

Managed to solve it by removing inline-block from list items. Let me know if this is stupid in any way.

Before (Note: number 5, 10):
![screen shot 2015-11-19 at 17 31 25](https://cloud.githubusercontent.com/assets/14570016/11278578/9e40b3a0-8ee3-11e5-903f-744fb70f16dd.png)

After:
![screen shot 2015-11-19 at 17 31 42](https://cloud.githubusercontent.com/assets/14570016/11278577/9e2e5dfe-8ee3-11e5-9013-3de2b351427a.png)
