### PR TITLE
add nofollow to report-abuse link

### DIFF
--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -115,7 +115,7 @@
                     </div>
 
                     <div class="report-comment-container js-report-comment-container d-comment__action d-comment__action--report">
-                        <a href="@Configuration.discussion.url/components/report-abuse/@comment.id" class="js-report-comment" data-comment-id="@comment.id" target="_blank">Report</a>
+                        <a href="@Configuration.discussion.url/components/report-abuse/@comment.id" rel="nofollow" class="js-report-comment" data-comment-id="@comment.id" target="_blank">Report</a>
                     </div>
                 }
             </div>


### PR DESCRIPTION
We see many, many hits to these URLs in our logs which we suspect most are bots. This link has no value to bots, so marking `rel=nofollow`

_Bots, nothing to see here, please move along..._
CC @guardian/discussion 
