### PR TITLE
Update glabs au link in footer

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -163,7 +163,7 @@
                         <li class="colophon__item"><a data-link-name="au : footer : masterclasses" href="@LinkTo {/guardian-masterclasses/guardian-masterclasses-australia}">
                             masterclasses</a>
                         </li>
-                        <li class="colophon__item"><a data-link-name="au : footer : guardian labs" href="@LinkTo {/guardian-labs}">
+                        <li class="colophon__item"><a data-link-name="au : footer : guardian labs" href="@LinkTo {/guardian-labs-australia}">
                             Guardian labs</a>
                         </li>
                         <li class="colophon__item"><a data-link-name="au : footer : subscribe" href="http://subscribe.theguardian.com/au?INTCMP=NGW_FOOTER_AU_GU_SUBSCRIBE">


### PR DESCRIPTION
now points to http://www.theguardian.com/guardian-labs-australia 
