### PR TITLE
Sort comments by number of recommendations

### DIFF
--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -33,7 +33,7 @@
                     aria-haspopup="true" aria-controls="comments-order-popup">Order by <span class="js-comment-order"></span></button>
 
             <ul id="comments-order-popup" class="popup popup__group popup--comments-order is-off">
-                @List("newest", "oldest").map { value =>
+                @List("newest", "oldest", "recommendations").map { value =>
                     <li class="popup__item">
                         <button class="u-button-reset popup__action" data-order="@value" data-link-name="comments-@value">@value</button>
                     </li>

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -150,8 +150,13 @@ Comments.prototype.fetchComments = function(options) {
         (options.comment ? 'comment-context/' + options.comment : this.options.discussionId) +
         '.json?' + (options.page ? '&page=' + options.page : '');
 
+    var orderBy = options.order || this.options.order;
+    if (orderBy === 'recommendations') {
+        orderBy = 'mostRecommended';
+    }
+
     var queryParams = {
-        orderBy: options.order || this.options.order,
+        orderBy: orderBy,
         pageSize: options.pagesize || this.options.pagesize,
         displayThreaded: this.options.threading !== 'unthreaded'
     };


### PR DESCRIPTION
Because comments API finally allows that. It's possible to sort asc/desc but I don't see the value of allowing users to sort by least recommended comments.
