### PR TITLE
Add referrer to dfp call

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -108,6 +108,9 @@ define([
             }
 
             return visitedValue;
+        },
+        getReferrer = function () {
+            return referrer;
         };
 
     return function (opts) {
@@ -129,6 +132,7 @@ define([
                 si:      identity.isUserLoggedIn() ? 't' : 'f',
                 gdncrm:  userAdTargeting.getUserSegments(),
                 ab:      abParam(),
+                ref:     getReferrer(),
                 co:      parseIds(page.authorIds),
                 bl:      parseIds(page.blogIds),
                 ms:      formatTarget(page.source),

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -110,6 +110,11 @@ define([
             return visitedValue;
         },
         getReferrer = function () {
+            var referrerTypes = [
+                {id: 'facebook', match: 'facebook.com'},
+                {id: 'twitter', match: 't.co'}
+            ];
+
             return referrer;
         };
 

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -111,11 +111,15 @@ define([
         },
         getReferrer = function () {
             var referrerTypes = [
-                {id: 'facebook', match: 'facebook.com'},
-                {id: 'twitter', match: 't.co'}
-            ];
+                    {id: 'facebook', match: 'facebook.com'},
+                    {id: 'twitter', match: 't.co'},
+                    {id: 'googleplus', match: 'plus.url.google'}
+                ],
+                matchedRef = referrerTypes.filter(function (referrerType) {
+                    return detect.getReferrer().indexOf(referrerType.match) > -1;
+                })[0] || {};
 
-            return referrer;
+            return matchedRef.id;
         };
 
     return function (opts) {

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -428,6 +428,10 @@ define([
         return sacrificialAd;
     }
 
+    function getReferrer() {
+        return document.referrer || '';
+    }
+
     detect = {
         hasCrossedBreakpoint: hasCrossedBreakpoint,
         getConnectionSpeed: getConnectionSpeed,
@@ -456,7 +460,8 @@ define([
         breakpoints: breakpoints,
         isModernBrowser: isModernBrowser,
         adblockInUse: adblockInUse,
-        getFirefoxAdblockPlusInstalled: getFirefoxAdblockPlusInstalled
+        getFirefoxAdblockPlusInstalled: getFirefoxAdblockPlusInstalled,
+        getReferrer: getReferrer
     };
     return detect;
 });

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -93,6 +93,10 @@ define([
                 });
         });
 
+        afterEach(function () {
+            document.referrer = '';
+        });
+
         it('should exist', function () {
             expect(buildPageTargeting).toBeDefined();
         });
@@ -203,12 +207,31 @@ define([
         });
 
         describe('Referrer', function () {
+            afterEach(function () {
+                detect.getReferrer = function () {
+                    return '';
+                };
+            });
+
             it('should set ref to Facebook', function () {
+                detect.getReferrer = function () {
+                    return 'https://www.facebook.com/feel-the-force';
+                };
                 expect(buildPageTargeting().ref).toEqual('facebook');
             });
 
             it('should set ref to Twitter', function () {
-                expect(buildPageTargeting().fr).toEqual('twitter');
+                detect.getReferrer = function () {
+                    return 'https://www.t.co/you-must-unlearn-what-you-have-learned';
+                };
+                expect(buildPageTargeting().ref).toEqual('twitter');
+            });
+
+            it('should set ref to Google+', function () {
+                detect.getReferrer = function () {
+                    return 'https://plus.url.google.com/always-pass-on-what-you-have-learned';
+                };
+                expect(buildPageTargeting().ref).toEqual('googleplus');
             });
         });
     });

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -233,6 +233,14 @@ define([
                 };
                 expect(buildPageTargeting().ref).toEqual('googleplus');
             });
+
+            it('should set ref empty string if referrer does not match', function () {
+                detect.getReferrer = function () {
+                    return 'https://theguardian.com';
+                };
+
+                expect(buildPageTargeting().ref).toEqual(undefined);
+            });
         });
     });
 });

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -201,5 +201,15 @@ define([
                 expect(buildPageTargeting().fr).toEqual('5plus');
             });
         });
+
+        describe('Referrer', function () {
+            it('should set ref to Facebook', function () {
+                expect(buildPageTargeting().ref).toEqual('facebook');
+            });
+
+            it('should set ref to Twitter', function () {
+                expect(buildPageTargeting().fr).toEqual('twitter');
+            });
+        });
     });
 });


### PR DESCRIPTION
We want to see in DFP from where user came as users from different referrers have different behaviour. So we can target commercial components more precisely and possibly have more space for outbrain.

This adds another parameter to be send to DFP.
