### PR TITLE
Upgrade reqwest to 2.0.5

### DIFF
--- a/static/src/javascripts/bower.json
+++ b/static/src/javascripts/bower.json
@@ -11,7 +11,7 @@
     "curl": "~0.8.9",
     "qwery": "3.4.2",
     "react": "0.13.2",
-    "reqwest": "1.1.5",
+    "reqwest": "2.0.5",
     "enhancer": "0.1.3",
     "raven-js": "~1.1.16",
     "requirejs-text": "~2.0.12",

--- a/static/src/javascripts/components/reqwest/reqwest.js
+++ b/static/src/javascripts/components/reqwest/reqwest.js
@@ -1,6 +1,6 @@
 /*!
   * Reqwest! A general purpose XHR connection manager
-  * license MIT (c) Dustin Diaz 2014
+  * license MIT (c) Dustin Diaz 2015
   * https://github.com/ded/reqwest
   */
 
@@ -10,16 +10,28 @@
   else context[name] = definition()
 }('reqwest', this, function () {
 
-  var win = window
-    , doc = document
-    , httpsRe = /^http/
+  var context = this
+
+  if ('window' in context) {
+    var doc = document
+      , byTag = 'getElementsByTagName'
+      , head = doc[byTag]('head')[0]
+  } else {
+    var XHR2
+    try {
+      XHR2 = require('xhr2')
+    } catch (ex) {
+      throw new Error('Peer dependency `xhr2` required! Please npm install xhr2')
+    }
+  }
+
+
+  var httpsRe = /^http/
     , protocolRe = /(^\w+):\/\//
     , twoHundo = /^(20\d|1223)$/ //http://stackoverflow.com/questions/10046972/msie-returns-status-code-of-1223-for-ajax-request
-    , byTag = 'getElementsByTagName'
     , readyState = 'readyState'
     , contentType = 'Content-Type'
     , requestedWith = 'X-Requested-With'
-    , head = doc[byTag]('head')[0]
     , uniqid = 0
     , callbackPrefix = 'reqwest_' + (+new Date())
     , lastValue // data stored by the most recent JSONP callback
@@ -49,16 +61,18 @@
     , xhr = function(o) {
         // is it x-domain
         if (o['crossOrigin'] === true) {
-          var xhr = win[xmlHttpRequest] ? new XMLHttpRequest() : null
+          var xhr = context[xmlHttpRequest] ? new XMLHttpRequest() : null
           if (xhr && 'withCredentials' in xhr) {
             return xhr
-          } else if (win[xDomainRequest]) {
+          } else if (context[xDomainRequest]) {
             return new XDomainRequest()
           } else {
             throw new Error('Browser does not support cross-origin requests')
           }
-        } else if (win[xmlHttpRequest]) {
+        } else if (context[xmlHttpRequest]) {
           return new XMLHttpRequest()
+        } else if (XHR2) {
+          return new XHR2()
         } else {
           return new ActiveXObject('Microsoft.XMLHTTP')
         }
@@ -70,9 +84,9 @@
       }
 
   function succeed(r) {
-    var protocol = protocolRe.exec(r.url);
-    protocol = (protocol && protocol[1]) || window.location.protocol;
-    return httpsRe.test(protocol) ? twoHundo.test(r.request.status) : !!r.request.response;
+    var protocol = protocolRe.exec(r.url)
+    protocol = (protocol && protocol[1]) || context.location.protocol
+    return httpsRe.test(protocol) ? twoHundo.test(r.request.status) : !!r.request.response
   }
 
   function handleReadyState(r, success, error) {
@@ -98,7 +112,7 @@
       || defaultHeaders['accept'][o['type']]
       || defaultHeaders['accept']['*']
 
-    var isAFormData = typeof FormData === 'function' && (o['data'] instanceof FormData);
+    var isAFormData = typeof FormData !== 'undefined' && (o['data'] instanceof FormData);
     // breaks cross-origin requests with legacy browsers
     if (!o['crossOrigin'] && !headers[requestedWith]) headers[requestedWith] = defaultHeaders['requestedWith']
     if (!headers[contentType] && !isAFormData) headers[contentType] = o['contentType'] || defaultHeaders['contentType']
@@ -140,7 +154,7 @@
       url = urlappend(url, cbkey + '=' + cbval) // no callback details, add 'em
     }
 
-    win[cbval] = generalCallback
+    context[cbval] = generalCallback
 
     script.type = 'text/javascript'
     script.src = url
@@ -207,7 +221,7 @@
     http.open(method, url, o['async'] === false ? false : true)
     setHeaders(http, o)
     setCredentials(http, o)
-    if (win[xDomainRequest] && http instanceof win[xDomainRequest]) {
+    if (context[xDomainRequest] && http instanceof context[xDomainRequest]) {
         http.onload = fn
         http.onerror = err
         // NOTE: see
@@ -237,6 +251,7 @@
 
   function setType(header) {
     // json, javascript, text/plain, text/html, xml
+    if (header === null) return undefined; //In case of no content-type.
     if (header.match('json')) return 'json'
     if (header.match('javascript')) return 'js'
     if (header.match('text')) return 'html'
@@ -312,7 +327,7 @@
         switch (type) {
         case 'json':
           try {
-            resp = win.JSON ? win.JSON.parse(r) : eval('(' + r + ')')
+            resp = context.JSON ? context.JSON.parse(r) : eval('(' + r + ')')
           } catch (err) {
             return error(resp, 'Could not parse JSON in response', err)
           }
@@ -347,7 +362,7 @@
 
     function timedOut() {
       self._timedOut = true
-      self.request.abort()      
+      self.request.abort()
     }
 
     function error(resp, msg, t) {


### PR DESCRIPTION
There's [a bug](https://github.com/ded/reqwest/issues/160) in the version of reqwest we use that throws errors on 204 (empty) responses. We get that type of response from an `OPTIONS` request made in the new email form during a CORS `POST`. 

The fix we want was added in version 2. Although this is a major upgrade, the main difference is to support nodejs via `xhr2` and there's a negligible effect on filesize (<400 bytes uncompressed). Once this builds I'll put it on code and make sure everything still works.
- [x] do the testing

@sndrs @OliverJAsh 
