### PR TITLE
Move DFP load exception handling to SessionWrapper

### DIFF
--- a/admin/app/dfp/ServicesWrapper.scala
+++ b/admin/app/dfp/ServicesWrapper.scala
@@ -10,6 +10,8 @@ private[dfp] class ServicesWrapper(session: DfpSession) {
 
   lazy val lineItemService = dfpServices.get(session, classOf[LineItemServiceInterface])
 
+  lazy val licaService = dfpServices.get(session, classOf[LineItemCreativeAssociationServiceInterface])
+
   lazy val customFieldsService = dfpServices.get(session, classOf[CustomFieldServiceInterface])
 
   lazy val customTargetingService = dfpServices.get(session, classOf[CustomTargetingServiceInterface])


### PR DESCRIPTION
Was logging failures as successful loads because exceptions were being swallowed.
