### PR TITLE
Observer logo

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -229,7 +229,7 @@ trait Navigation {
 
 
   // Observer newspaper
-  val sundayPaper = SectionLink("theobserver", "the observer", "The Observer", "/theobserver")
+  val sundayPaper = SectionLink("theobserver", "sunday's paper", "The Observer", "/theobserver")
   val observerMainNews = SectionLink("theobserver", "news", "The Observer Main section", "/theobserver/news")
   val observerComment = SectionLink("theobserver", "comment", "Observer comment", "/theobserver/news/comment")
   val observerSport = SectionLink("theobserver", "observer sport", "Observer sport", "/theobserver/sport")

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -91,7 +91,7 @@
             <div class="popup popup--search is-off js-popup--search"><div class="js-search-placeholder"></div></div>
 
             <div class="l-header-main">
-                @if(metaData.section == "observer" && metaData.isFront) {
+                @if((metaData.section == "observer" && metaData.isFront) || metaData.id == "theobserver") {
                     <a href="@LinkTo{@metaData.url}" data-link-name="site logo" id="logo" class="logo-wrapper logo-wrapper--observer" data-component="logo">
                         @if(metaData.hasSlimHeader) {
                             @fragments.inlineSvg("observer-logo-160", "logo")


### PR DESCRIPTION
/theobserver gets the Observer logo! Also renamed section navigation so that it does not clash with /observer.

cc @JustinPinner 
