### PR TITLE
Increase GU_EDITION cookie expiry time

### DIFF
--- a/common/app/controllers/PreferenceController.scala
+++ b/common/app/controllers/PreferenceController.scala
@@ -30,10 +30,11 @@ trait PreferenceController extends Results {
     NoCache(
       Found(url)
       .withCookies(cookies.map{ case (name, value) =>
-        // 60 days expiration, or expire if value is empty
+        // Expire after one year or if value is empty
+        val oneYearInSeconds = 31536000
         Cookie( name,
                 value,
-                maxAge = if (value.nonEmpty) { Some(5184000) } else { Some(-1) },
+                maxAge = if (value.nonEmpty) { Some(oneYearInSeconds) } else { Some(-1) },
                 domain = getShortenedDomain(request.domain),
                 httpOnly = false)
       }.toSeq:_*)

--- a/data/database/6dfb70eadb40d19c6a2df1e3dd0eeecff4d88f4ea8c7a7f39d6d8c22e7ce282f
+++ b/data/database/6dfb70eadb40d19c6a2df1e3dd0eeecff4d88f4ea8c7a7f39d6d8c22e7ce282f
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/7604a978c8388f12fef4a8ffe0b79e2c3f978638fa1ac47f53766a1ebd27e9de
+++ b/data/database/7604a978c8388f12fef4a8ffe0b79e2c3f978638fa1ac47f53766a1ebd27e9de
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/91a393957dc8f3af27f4604f9b7ade6a844f772ff31da4962402311a1ea5d60e
+++ b/data/database/91a393957dc8f3af27f4604f9b7ade6a844f772ff31da4962402311a1ea5d60e
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/b172936ce94c5ab604105e09ff01300f2754f0c91188e494a9d7b1e8da7aeee7
+++ b/data/database/b172936ce94c5ab604105e09ff01300f2754f0c91188e494a9d7b1e8da7aeee7
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/c7514f29f5eb11f1cb29cc4280774b79ad9fd1cdf3c231d59e283680e9614d70
+++ b/data/database/c7514f29f5eb11f1cb29cc4280774b79ad9fd1cdf3c231d59e283680e9614d70
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/data/database/d2c69259040d61fae2d9d72585e474c46f890d8c2e999d77026b062a86ecdfda
+++ b/data/database/d2c69259040d61fae2d9d72585e474c46f890d8c2e999d77026b062a86ecdfda
@@ -1,0 +1,1 @@
+{"response":{"status":"ok","userTier":"internal","total":0,"startIndex":0,"pageSize":1,"currentPage":1,"pages":0,"orderBy":"newest","tag":{"webTitle":"Crossword","id":"type/crossword","type":"type","webUrl":"http://www.theguardian.com/crossword","apiUrl":"http://content.guardianapis.com/type/crossword","references":[]},"results":[],"leadContent":[]}}

--- a/onward/test/controllers/ChangeEditionControllerTest.scala
+++ b/onward/test/controllers/ChangeEditionControllerTest.scala
@@ -8,6 +8,7 @@ import test.{ConfiguredTestSuite, TestRequest}
 @DoNotDiscover class ChangeEditionControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite with BeforeAndAfterEach {
 
   val callbackName = "aFunction"
+  val oneYearInSeconds = 31536000
 
 
   "ChangeEditionController" should "redirect to correct page" in {
@@ -20,7 +21,7 @@ import test.{ConfiguredTestSuite, TestRequest}
     val result = controllers.ChangeEditionController.render("au")(TestRequest())
     val GU_EDITION = playCookies(result).apply("GU_EDITION")
 
-    GU_EDITION.maxAge.getOrElse(0) should be (5184000 +- 1)  // 60 days, this is seconds
+    GU_EDITION.maxAge.getOrElse(0) should be (oneYearInSeconds +- 1)
     GU_EDITION.value should be ("AU")
   }
 
@@ -29,7 +30,7 @@ import test.{ConfiguredTestSuite, TestRequest}
     val result = controllers.ChangeEditionController.render("int")(TestRequest())
     val GU_EDITION = playCookies(result).apply("GU_EDITION")
 
-    GU_EDITION.maxAge.getOrElse(0) should be (5184000 +- 1)  // 60 days, this is seconds
+    GU_EDITION.maxAge.getOrElse(0) should be (oneYearInSeconds +- 1)
     GU_EDITION.value should be ("INT")
 
     header("Location", result).head should endWith ("/international?INTCMP=CE_INT")


### PR DESCRIPTION
This will improve the UX so users don't have to keep switching their preference every 2 months (as one user complained).

Apparently we did this in the early days of Guardian US to increase traffic on their side, but now it's grown significantly, it's no longer necessary.
