### PR TITLE
Fix uglify settings

### DIFF
--- a/grunt-configs/uglify.js
+++ b/grunt-configs/uglify.js
@@ -33,8 +33,10 @@ module.exports = function (grunt, options) {
                 dest: 'common/conf/assets/vendor'
             }],
             options: options.isDev ? {} : {
-                // Set to false retain constant expressions, used to avoid writing HTML like </script>.
-                compress: false
+                compress: {
+                    // Set to false retain constant expressions, used to avoid writing HTML like </script>.
+                    evaluate: false
+                }
             }
         }
     };


### PR DESCRIPTION
Fixes #11193, #11188 and #11194

Broken by #11181. I got the uglify settings wrong! :unamused: 

This is causing #11193, because without `compress: { evaluate: false }`, the code looks like:

```
var s = s_gi();
function s_gi() {}
```

… which exhibits the Firefox bug described in #11193. With `compress: { evaluate: false }`, Uglify will output

```
function s_gi() {}
var s = s_gi();
```

… which, by chance, circumvents the Firefox bug by declaring the function before its usage.

/cc @sndrs @paperboyo
