### PR TITLE
Move social buttons into links for A/B test

### DIFF
--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -47,16 +47,16 @@
                 @currentEdition match {
                     case Uk => {
 
-                        <a class="button button--tertiary button--small" data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
+                        <a class="button button--tertiary button--small js-button--social" data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
                             @fragments.inlineSvg("share-facebook", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Facebook</span></a>
-                        <a class="button button--tertiary button--small" data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
+                        <a class="button button--tertiary button--small js-button--social" data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
                             @fragments.inlineSvg("share-twitter", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Twitter</span></a>
 
                         @if(mvt.EmailTextTestV1.isParticipating) {
-                            <a class="button button--tertiary button--small js-button--email" data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                            <a class="button button--tertiary button--small js-button--social" data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
                                 @fragments.inlineSvg("share-email", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Guardian Today email</span></a>
                         } else {
-                            <a class="button button--tertiary button--small js-button--email" data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                            <a class="button button--tertiary button--small js-button--social" data-link-name="uk : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
                                 @fragments.inlineSvg("share-email", "icon", Seq("i","i-left")) <span class="footer__follow-us__item">daily email sign up</span></a>
                         }
 
@@ -81,11 +81,11 @@
                     }
 
                     case International => {
-                        <a class="button button--tertiary button--small" data-link-name="int : footer : facebook" href="https://www.facebook.com/theguardian">
+                        <a class="button button--tertiary button--small js-button--social" data-link-name="int : footer : facebook" href="https://www.facebook.com/theguardian">
                             @fragments.inlineSvg("share-facebook", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Facebook</span></a>
-                        <a class="button button--tertiary button--small" data-link-name="int : footer : twitter" href="https://twitter.com/guardian">
+                        <a class="button button--tertiary button--small js-button--social" data-link-name="int : footer : twitter" href="https://twitter.com/guardian">
                             @fragments.inlineSvg("share-twitter", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">Twitter</span></a>
-                        <a class="button button--tertiary button--small" data-link-name="int : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
+                        <a class="button button--tertiary button--small js-button--social" data-link-name="int : footer : email sign-up" href="@LinkTo {/world/2013/oct/04/1}">
                             @fragments.inlineSvg("share-email", "icon", Seq("i", "i-left")) <span class="footer__follow-us__item">daily email sign up</span></a>
                     }
                 }
@@ -94,6 +94,12 @@
             <ul class="colophon__list">
                 @currentEdition match {
                     case Uk => {
+                        <li class="colophon__item js-colophon__item--social is-hidden"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
+                            Facebook</a>
+                        </li>
+                        <li class="colophon__item js-colophon__item--social is-hidden"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
+                            Twitter</a>
+                        </li>
                         <li class="colophon__item"><a data-link-name="uk : footer : membership" href="https://membership.theguardian.com/?INTCMP=NGW_FOOTER_UK_GU_MEMBERSHIP">
                             membership</a>
                         </li>
@@ -202,6 +208,12 @@
                     }
 
                     case International => {
+                        <li class="colophon__item js-colophon__item--social is-hidden"><a data-link-name="uk : footer : facebook" href="https://www.facebook.com/theguardian">
+                            Facebook</a>
+                        </li>
+                        <li class="colophon__item js-colophon__item--social is-hidden"><a data-link-name="uk : footer : twitter" href="https://twitter.com/guardian">
+                            Twitter</a>
+                        </li>
                         <li class="colophon__item"><a data-link-name="all topics" href="@LinkTo {/index/subjects/a}">
                             all topics</a>
                         </li>

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
@@ -22,7 +22,8 @@ define([
                     .removeClass('l-footer__secondary--no-email')
                     .addClass('l-footer__secondary--has-email');
 
-                $('.js-button--email').remove();
+                $('.js-button--social').remove();
+                $('.js-colophon__item--social').removeClass('is-hidden');
             });
         },
         getIframe = function () {


### PR DESCRIPTION
After discussing with @superfrank, Amy and Andrea, we decided for the A/B test the quickest way to ensure an uncluttered area around email sign-up was to move social buttons back into links. This is an interim decision until we can re-build the footer the ideal way.

![image](https://cloud.githubusercontent.com/assets/638051/11401982/5cbe28dc-938d-11e5-8527-839dd2766458.png)

Ping/ @crifmulholland @desbo 
