### PR TITLE
Inject ads in liveblogs every 5th post

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -77,6 +77,15 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val LiveblogDynamicAdvertsSwitch = Switch(
+    "Commercial",
+    "liveblog-dynamic-adverts",
+    "Dynamically insert inline adverts on liveblogs",
+    safeState = Off,
+    sellByDate = new LocalDate(2015, 12, 14),
+    exposeClientSide = true
+  )
+
   val AudienceScienceSwitch = Switch(
     "Commercial",
     "audience-science",

--- a/static/src/javascripts/bootstraps/liveblog.js
+++ b/static/src/javascripts/bootstraps/liveblog.js
@@ -13,6 +13,7 @@ define([
     'common/modules/accessibility/helpers',
     'common/modules/article/rich-links',
     'common/modules/commercial/liveblog-adverts',
+    'common/modules/commercial/liveblog-dynamic-adverts',
     'common/modules/experiments/affix',
     'common/modules/live/filter',
     'common/modules/ui/autoupdate',
@@ -38,6 +39,7 @@ define([
     accessibility,
     richLinks,
     liveblogAdverts,
+    liveblogDynamicAdverts,
     Affix,
     LiveFilter,
     AutoUpdate,
@@ -168,7 +170,11 @@ define([
     modules = {
 
         initAdverts: function () {
-            liveblogAdverts.init();
+            if (config.switches.liveblogDynamicAdverts) {
+                liveblogDynamicAdverts.init();
+            } else if (config.switches.liveblogAdverts) {
+                liveblogAdverts.init();
+            }
         },
 
         createFilter: function () {

--- a/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
@@ -1,0 +1,240 @@
+define([
+    'Promise',
+    'bonzo',
+    'bean',
+    'fastdom',
+    'common/utils/config',
+    'common/utils/mediator',
+    'common/modules/commercial/create-ad-slot',
+    'common/modules/commercial/dfp-api',
+    'lodash/functions/once',
+    'lodash/functions/debounce',
+    'lodash/arrays/rest',
+    'lodash/collections/map',
+    'lodash/collections/filter',
+    'lodash/collections/forEach'
+], function (
+    Promise,
+    bonzo,
+    bean,
+    fastdom,
+    config,
+    mediator,
+    createAdSlot,
+    dfp,
+    once,
+    debounce,
+    drop,
+    map,
+    filter,
+    forEach
+) {
+    var settings = {
+        INTERVAL: 5,      // number of posts between ads
+        OFFSET: 0.5,      // ratio of the screen height from which ads are loaded
+        SCROLLTIMER: 50   // the time we wait before responding to a scroll event
+    };
+
+    var truncatedClass = 'truncated-block';
+
+    // Keep a check if the module is currently listening to scroll events
+    var listening = false;
+
+    // Keep track of ad slots that are not yet initialized
+    var slots = [];
+    var slotCounter = 0;
+
+    var posts, altitudes, firstPost, firstPostIndex, vh, vstart, voffset, onScrollDebounced;
+
+    function init() {
+        if ('complete' === document.readyState) {
+            onLoad();
+        } else {
+            window.addEventListener('load', onLoad);
+        }
+        mediator.on('modules:autoupdate:updates', onUpdate);
+    }
+
+    function onLoad() {
+        posts = document.querySelectorAll('.js-liveblog-body > .block');
+
+        new Promise(function (resolve) {
+            fastdom.read(function () {
+                vh = document.documentElement.clientHeight;
+                vstart = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop;
+                altitudes = map(posts, function (post) {
+                    var rect = post.getBoundingClientRect();
+                    return rect.bottom - vstart;
+                });
+                voffset = vh * settings.OFFSET;
+                resolve();
+            });
+        })
+        .then(findFirstInsertPosition)
+        .then(insertSlots)
+        .then(handleTruncatedSlots)
+        .then(listenForScrolls);
+    }
+
+    function onUpdate(newPosts) {
+        if (!newPosts || newPosts.length === 0) {
+            return;
+        }
+
+        mediator.off('modules:autoupdate:updates', onUpdate);
+
+        // We need to inject new ad slots if there is space for them. If yes,
+        // then after the injection we just make sure firstPost is updated so
+        // it won't break the process on the next update
+        new Promise(function (resolve) {
+            fastdom.read(function () {
+                var pcur = bonzo(firstPost).previous();
+                var pprev;
+
+                posts = [pcur[0]];
+                // Update first post if necessary
+                if (posts.length % settings.INTERVAL === 0) {
+                    firstPost = pcur[0];
+                }
+
+                while ((pprev = pcur.previous()) && pprev.length) {
+                    posts.push(pprev[0]);
+                    pcur = pprev;
+                    // Update first post if necessary
+                    if (posts.length % settings.INTERVAL === 0) {
+                        firstPost = pcur[0];
+                    }
+                }
+
+                // insertSlots expect a number of posts to be dropped from the
+                // beginning. In this case, we must make sure the first n
+                // (as per corresponding setting) are skipped.
+                resolve(settings.INTERVAL - 1);
+            });
+        })
+        .then(insertSlots)
+        .then(listenForScrolls)
+        .then(function () {
+            mediator.on('modules:autoupdate:updates', onUpdate);
+        });
+    }
+
+    function findFirstInsertPosition() {
+        // Let's find the first post that ends below the viewport
+        firstPostIndex = (function () {
+            var i = 0;
+            while (i < altitudes.length && altitudes[i] < vh) {
+                i++;
+            }
+            return i === altitudes.length ? -1 : i;
+        }());
+
+        // If all the posts appear within the viewport then we don't load any ad
+        if (firstPostIndex === -1) {
+            throw firstPostIndex;
+        }
+
+        firstPost = posts[firstPostIndex];
+
+        return firstPostIndex;
+    }
+
+    function insertSlots(firstPostIndex) {
+        // Let's get every nth post after the first post, as per the corresponding setting
+        function nth(_, index) {
+            return index % settings.INTERVAL === 0;
+        }
+
+        posts = filter(drop(posts, firstPostIndex), nth);
+
+        if (!posts.length) {
+            throw 0;
+        }
+
+        // Insert ad slots after all the selected posts and keep track of the ones
+        // sitting between truncated posts
+        return new Promise(function (resolve) {
+            fastdom.write(function () {
+                var truncated = [];
+                slots = map(posts, function (post) {
+                    var $post = bonzo(post);
+                    var $adSlot = bonzo(createAdSlot('inline1' + slotCounter++, 'liveblog-inline'));
+                    if (truncated.length ||
+                        $post.hasClass(truncatedClass) && $post.next().hasClass(truncatedClass)
+                    ) {
+                        truncated.push($adSlot);
+                        $adSlot.addClass(truncatedClass);
+                    }
+                    $post.after($adSlot);
+                    return $adSlot;
+                }).concat(slots);
+
+                mediator.emit('modules:liveblog:slots', slots);
+
+                resolve(truncated);
+            });
+        });
+    }
+
+    function handleTruncatedSlots(truncated) {
+        function truncation(onOrOff) {
+            bean[onOrOff](document.body, 'click', '.article-elongator', removeTruncation);
+            mediator[onOrOff]('module:liveblog:showkeyevents', removeTruncation);
+            mediator[onOrOff]('module:filter:toggle', removeTruncation);
+        }
+
+        function removeTruncation() {
+            forEach(truncated, function ($slot) {
+                $slot.removeClass(truncatedClass);
+            });
+            truncated.length = 0;
+            truncation('off');
+        }
+
+        if (truncated.length) {
+            truncation('on');
+        }
+    }
+
+    function listenForScrolls() {
+        if (!listening) {
+            if (onScrollDebounced === undefined) {
+                onScrollDebounced = debounce(onScroll, settings.SCROLLTIMER);
+            }
+            mediator.on('window:throttledScroll', onScrollDebounced);
+            listening = true;
+        }
+    }
+
+    function onScroll() {
+        // We need each ad slot current position relative to the viewport in
+        // order to decide which ones are within range and then load them
+        var rects = map(slots, function ($slot) {
+            return $slot[0].getBoundingClientRect();
+        });
+
+        // We'll filter out all the slots who are displayed so that they
+        // we don't repeat the whole process for them on the next scroll event
+        slots = filter(slots, function ($slot, index) {
+            if ($slot.hasClass('truncated-block')) {
+                return true;
+            }
+            var rect = rects[index];
+            if (-voffset < rect.bottom && rect.top < vh + voffset) {
+                dfp.addSlot($slot);
+                return false;
+            }
+            return true;
+        });
+
+        if (slots.length === 0) {
+            mediator.off('window:throttledScroll', onScrollDebounced);
+            listening = false;
+        }
+    }
+
+    return {
+        init: once(init),
+        settings: settings
+    };
+});

--- a/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
@@ -58,7 +58,7 @@ define([
     function onLoad() {
         posts = document.querySelectorAll('.js-liveblog-body > .block');
 
-        new Promise(function (resolve) {
+        return new Promise(function (resolve) {
             fastdom.read(function () {
                 vh = document.documentElement.clientHeight;
                 vstart = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop;
@@ -86,7 +86,7 @@ define([
         // We need to inject new ad slots if there is space for them. If yes,
         // then after the injection we just make sure firstPost is updated so
         // it won't break the process on the next update
-        new Promise(function (resolve) {
+        return new Promise(function (resolve) {
             fastdom.read(function () {
                 var pcur = bonzo(firstPost).previous();
                 var pprev;
@@ -169,8 +169,6 @@ define([
                     return $adSlot;
                 }).concat(slots);
 
-                mediator.emit('modules:liveblog:slots', slots);
-
                 resolve(truncated);
             });
         });
@@ -235,6 +233,8 @@ define([
 
     return {
         init: once(init),
-        settings: settings
+        settings: settings,
+        onLoad: onLoad,
+        onUpdate: onUpdate
     };
 });

--- a/static/test/javascripts/spec/common/commercial/liveblog-dynamic-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/liveblog-dynamic-adverts.spec.js
@@ -9,7 +9,8 @@ define([
     fixtures,
     $
 ) {
-    var $style;
+    var $style, body;
+    var firstAd, slotsCounter;
 
     describe('Liveblog Dynamic Adverts', function () {
         var fixturesConfig = {
@@ -33,6 +34,7 @@ define([
 
         beforeEach(function (done) {
             fixtures.render(fixturesConfig);
+            body = document.querySelector('.js-liveblog-body');
             $style = $.create('<style type="text/css"></style>')
                 .html('.block{ height: 1200px }')
                 .appendTo('head');
@@ -49,12 +51,41 @@ define([
         });
 
         it('should insert ads every ' + liveblogDynamicAdverts.settings.INTERVAL + 'th block', function () {
-            mediator.on('modules:liveblog:slots', function (slots) {
-                var candidates = document.querySelectorAll('.js-liveblog-body > *:nth-child(1+'+liveblogDynamicAdverts.settings.INTERVAL+'n)');
-                var allSlots = Array.prototype.every.call(candidates, function(c) { return c.classList.contains('ad-slot') });
+            liveblogDynamicAdverts.onLoad().then(function () {
+                slotsCounter = body.querySelectorAll('.ad-slot').length;
+                var candidates = document.querySelectorAll('.js-liveblog-body > *:nth-child(1+' + liveblogDynamicAdverts.settings.INTERVAL + 'n)');
+                var allSlots =
+                    Array.prototype.every.call(candidates, function (c) { return c.classList.contains('ad-slot'); }) &&
+                    candidates.length === slotsCounter;
+                firstAd = body.children[1];
                 expect(allSlots).toBe(true);
             });
-            liveblogDynamicAdverts.init();
+        });
+
+        it('should insert ads every ' + liveblogDynamicAdverts.settings.INTERVAL + 'th block after an update', function () {
+            for( var i = 0; i < 12; i++ ) {
+                var d = document.createElement('div');
+                d.classList.add('block');
+                body.insertBefore(d, body.firstChild);
+            }
+
+            liveblogDynamicAdverts.onUpdate([0]).then(function () {
+                var candidates = [];
+                var ncur = firstAd;
+                var index = 0;
+                var nprev;
+
+                while (nprev = ncur.previousElementSibling) {
+                    index += 1;
+                    if (index % (liveblogDynamicAdverts.settings.INTERVAL + 1) === 0) {
+                        candidates.push(nprev);
+                    }
+                    ncur = nprev;
+                }
+                var allSlots = Array.prototype.every.call(candidates, function (c) { return c.classList.contains('ad-slot'); }) &&
+                    candidates.length === body.querySelectorAll('.ad-slot').length - slotsCounter;
+                expect(allSlots).toBe(true);
+            });
         });
     });
 });

--- a/static/test/javascripts/spec/common/commercial/liveblog-dynamic-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/liveblog-dynamic-adverts.spec.js
@@ -63,7 +63,7 @@ define([
         });
 
         it('should insert ads every ' + liveblogDynamicAdverts.settings.INTERVAL + 'th block after an update', function () {
-            for( var i = 0; i < 12; i++ ) {
+            for (var i = 0; i < 12; i++) {
                 var d = document.createElement('div');
                 d.classList.add('block');
                 body.insertBefore(d, body.firstChild);
@@ -75,7 +75,7 @@ define([
                 var index = 0;
                 var nprev;
 
-                while (nprev = ncur.previousElementSibling) {
+                while ((nprev = ncur.previousElementSibling)) {
                     index += 1;
                     if (index % (liveblogDynamicAdverts.settings.INTERVAL + 1) === 0) {
                         candidates.push(nprev);

--- a/static/test/javascripts/spec/common/commercial/liveblog-dynamic-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/liveblog-dynamic-adverts.spec.js
@@ -1,0 +1,60 @@
+define([
+    'common/modules/commercial/liveblog-dynamic-adverts',
+    'common/utils/mediator',
+    'helpers/fixtures',
+    'common/utils/$'
+], function (
+    liveblogDynamicAdverts,
+    mediator,
+    fixtures,
+    $
+) {
+    var $style;
+
+    describe('Liveblog Dynamic Adverts', function () {
+        var fixturesConfig = {
+            id: 'liveblog-body',
+            fixtures: [
+                '<div class="js-liveblog-body">' +
+                '<div class="block"></div>' +
+                '<div class="block"></div>' +
+                '<div class="block"></div>' +
+                '<div class="block"></div>' +
+                '<div class="block"></div>' +
+                '<div class="block"></div>' +
+                '<div class="block"></div>' +
+                '<div class="block"></div>' +
+                '<div class="block"></div>' +
+                '<div class="block"></div>' +
+                '<div class="block"></div>' +
+                '</div>'
+            ]
+        };
+
+        beforeEach(function (done) {
+            fixtures.render(fixturesConfig);
+            $style = $.create('<style type="text/css"></style>')
+                .html('.block{ height: 1200px }')
+                .appendTo('head');
+            done();
+        });
+
+        afterEach(function () {
+            fixtures.clean(fixturesConfig.id);
+            $style.remove();
+        });
+
+        it('should exist', function () {
+            expect(liveblogDynamicAdverts).toBeDefined();
+        });
+
+        it('should insert ads every ' + liveblogDynamicAdverts.settings.INTERVAL + 'th block', function () {
+            mediator.on('modules:liveblog:slots', function (slots) {
+                var candidates = document.querySelectorAll('.js-liveblog-body > *:nth-child(1+'+liveblogDynamicAdverts.settings.INTERVAL+'n)');
+                var allSlots = Array.prototype.every.call(candidates, function(c) { return c.classList.contains('ad-slot') });
+                expect(allSlots).toBe(true);
+            });
+            liveblogDynamicAdverts.init();
+        });
+    });
+});


### PR DESCRIPTION
This update addresses the UC where very long liveblogs would only see a handful of ads at the beginning and then no more. Now ads are injected every 5th post, even when live updates have arrived.

The process starts by finding the first post which ends below the viewport–this is the point where the insertion will begin. Ad slots are injected as soon as there's enough room for them, but ads themselves are lazy loaded when they fall inside the `[top - h/2, bottom + h/2]` where `top`, `bottom` and `h` are the position and height of the viewport, respectively.

A switch (`liveblogDynamicAdverts`) controls whether the module is triggered, and if so will take precedence over the current behaviour, itself hidden behind the `liveblogAdverts` switch.
