### PR TITLE
Get rid of percentage units in srcset sizes

### DIFF
--- a/common/app/layout/BrowserWidth.scala
+++ b/common/app/layout/BrowserWidth.scala
@@ -4,6 +4,7 @@ object BrowserWidth {
   implicit class RichInt(n: Int) {
     def px = PixelWidth(n)
     def perc = PercentageWidth(n)
+    def vw = ViewportWidth(n)
   }
 }
 
@@ -17,4 +18,8 @@ case class PercentageWidth(get: Int) extends BrowserWidth {
 
 case class PixelWidth(get: Int) extends BrowserWidth {
   override def toString = s"${get}px"
+}
+
+case class ViewportWidth(get: Int) extends BrowserWidth {
+  override def toString = s"${get}vw"
 }

--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -7,7 +7,7 @@ import views.support.Profile
 object FaciaWidths {
   private val MediaMobile = Map[CardType, BrowserWidth](
     (MediaList, 127.px),
-    (Standard, 100.perc)
+    (Standard, 95.vw)
   )
 
   val ExtraPixelWidthsForMediaMobile: Seq[PixelWidth] = List(
@@ -279,8 +279,8 @@ case class WidthsByBreakpoint(
   def profiles: Seq[Profile] = (breakpoints flatMap {
     case BreakpointWidth(breakpoint, PixelWidth(pixels)) =>
       Seq(pixels)
-    case BreakpointWidth(Mobile, _: PercentageWidth) =>
-      // Percentage widths are not explicitly associated with any pixel widths that could be used with a srcset.
+    case BreakpointWidth(Mobile, _: PercentageWidth | _: ViewportWidth) =>
+      // Percentage and viewport widths are not explicitly associated with any pixel widths that could be used with a srcset.
       // So we create a series of profiles by combining usable widths in the class with predefined sensible widths.
       val pixelWidths = breakpoints.collect { case BreakpointWidth(_,width: PixelWidth) => width.get }
       val widths: Seq[Int] = pixelWidths.dropWhile(_ > MaximumMobileImageWidth).take(SourcesToEmitOnMobile)


### PR DESCRIPTION
This gets rid of percentages in our `sizes` attribute and replaces it with `vw` in line with the [spec](https://html.spec.whatwg.org/multipage/embedded-content.html#source-size-value).

We only use a percentage for `fc-item--standard-mobile` images, which work out to 95% of the viewport width, so it's a simple fix to make.

@johnduffell @sndrs 
