### PR TITLE
Enable top-above-nav ad slot to show full set of ad sizes

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -217,7 +217,7 @@ trait CommercialSwitches {
     "fixed-top-above-nav",
     "Fixes size of top-above-nav ad slot on fronts.",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 12, 16),
+    sellByDate = new LocalDate(2016, 3, 16),
     exposeClientSide = false
   )
 

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -29,20 +29,9 @@ object Commercial {
     }
 
     def adSizes(metaData: MetaData, edition: Edition): Map[String, Seq[String]] = {
-      val desktopSizes = {
-        if (FixedTopAboveNavAdSlotSwitch.isSwitchedOn && isBusinessFront(metaData)) {
-          if (hasAdOfSize(TopAboveNavSlot, leaderboardSize, metaData, edition)) {
-            Seq("728,90")
-          } else if (hasAdOfSize(TopAboveNavSlot, responsiveSize, metaData, edition)) {
-            Seq("88,70")
-          } else {
-            Seq("1,1", "900,250", "970,250")
-          }
-        } else Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250")
-      }
       Map(
         "mobile" -> Seq("1,1", "88,70", "728,90"),
-        "desktop" -> desktopSizes
+        "desktop" -> Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250")
       )
     }
 

--- a/common/test/views/support/CommercialTest.scala
+++ b/common/test/views/support/CommercialTest.scala
@@ -30,13 +30,7 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
     FixedTopAboveNavAdSlotSwitch.switchOn()
   }
 
-  "topAboveNavSlot ad sizes" should "be fixed for UK business front" in {
-    pageShouldRequestAdSizes("uk/business", Nil)(
-      Seq("1,1", "900,250", "970,250")
-    )
-  }
-
-  they should "be variable for any other page" in {
+  "topAboveNavSlot ad sizes" should "be variable for all pages" in {
     pageShouldRequestAdSizes("uk/culture", Nil)(
       Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250")
     )


### PR DESCRIPTION
Lifting restriction on sizes in business front because it was having unexpected effect for ad ops.
