### PR TITLE
extend quiz scores switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -210,7 +210,7 @@ trait FeatureSwitches {
     "quiz-scores-service",
     "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 12, 1),
+    sellByDate = new LocalDate(2016, 1, 10),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
We want to turn off the legacy quiz scores service as it's part of the prototype.  tools team are still working on a quizzes page to replace the hacked together quiz builder/app.  This is still in progress.  There's still value provided by the scores service and it's not causing any effort expended other than extending it occasionally, so we may as well keep it on.
