### PR TITLE
Newspaper links

### DIFF
--- a/applications/app/services/NewspaperQuery.scala
+++ b/applications/app/services/NewspaperQuery.scala
@@ -2,7 +2,8 @@ package services
 
 import _root_.model.Content
 import com.gu.contentapi.client.model.{Content => ApiContent, Tag}
-import com.gu.facia.api.models.{CollectionConfig, FaciaContent}
+import com.gu.facia.api.models.{LinkSnap, CollectionConfig, FaciaContent}
+import com.gu.facia.api.utils.{ResolvedMetaData, ContentProperties}
 import common._
 import conf.LiveContentApi
 import implicits.Dates
@@ -21,17 +22,18 @@ case class BookSectionContentByPage(page: Int, booksectionContent: BookSectionCo
 object NewspaperQuery extends ExecutionContexts with Dates with Logging {
 
   val dateForFrontPagePattern = DateTimeFormat.forPattern("EEEE d MMMM y")
+  private val hrefFormat = DateTimeFormat.forPattern("yyyy/MMM/dd").withZone(DateTimeZone.UTC)
   val FRONT_PAGE_DISPLAY_NAME = "front page"
   val pathToTag = Map("theguardian" -> "theguardian/mainsection", "theobserver" -> "theobserver/news")
 
   def fetchLatestGuardianNewspaper: Future[List[FaciaContainer]] = {
     val now = DateTime.now(DateTimeZone.UTC)
-    bookSectionContainers("theguardian/mainsection", getLatestGuardianPageFor(now))
+    bookSectionContainers("theguardian/mainsection", getLatestGuardianPageFor(now), "theguardian")
   }
 
   def fetchLatestObserverNewspaper: Future[List[FaciaContainer]] = {
     val now = DateTime.now(DateTimeZone.UTC)
-    bookSectionContainers("theobserver/news", getPastSundayDateFor(now))
+    bookSectionContainers("theobserver/news", getPastSundayDateFor(now), "theobserver")
   }
 
   def fetchNewspaperForDate(path: String, day: String, month: String, year: String): Future[List[FaciaContainer]] = {
@@ -41,11 +43,11 @@ object NewspaperQuery extends ExecutionContexts with Dates with Logging {
       .parseDateTime(s"$year/$month/$day")
       .toDateTime
 
-    pathToTag.get(path).map(tag => bookSectionContainers(tag, date)).getOrElse(Future.successful(Nil))
+    pathToTag.get(path).map(tag => bookSectionContainers(tag, date, path)).getOrElse(Future.successful(Nil))
   }
 
 
-  private def bookSectionContainers(itemId: String, newspaperDate: DateTime): Future[List[FaciaContainer]] = {
+  private def bookSectionContainers(itemId: String, newspaperDate: DateTime, publication: String): Future[List[FaciaContainer]] = {
 
     val itemQuery = LiveContentApi.item(itemId)
       .useDate("newspaper-edition")
@@ -63,8 +65,8 @@ object NewspaperQuery extends ExecutionContexts with Dates with Logging {
 
       val firstPageContainer = {
         val content = firstPageContent.map(c => FaciaContentConvert.frontendContentToFaciaContent(Content(c)))
-
-        bookSectionContainer(None, Some(FRONT_PAGE_DISPLAY_NAME), Some(newspaperDate.toString(dateForFrontPagePattern)), content, 0)
+        val snaps = createSnapsForFrontPage(newspaperDate, publication)
+        bookSectionContainer(None, Some(FRONT_PAGE_DISPLAY_NAME), Some(newspaperDate.toString(dateForFrontPagePattern)), content, 0, snaps)
       }
 
       val unorderedBookSections = createBookSections(otherContent)
@@ -72,7 +74,7 @@ object NewspaperQuery extends ExecutionContexts with Dates with Logging {
 
       val bookSectionContainers = orderedBookSections.map { list =>
         val content = list.content.map(c => FaciaContentConvert.frontendContentToFaciaContent(Content(c)))
-        bookSectionContainer(Some(list.tag.id), Some(lowercaseDisplayName(list.tag.webTitle)), None, content, orderedBookSections.indexOf(list) + 1)
+        bookSectionContainer(Some(list.tag.id), Some(lowercaseDisplayName(list.tag.webTitle)), None, content, orderedBookSections.indexOf(list) + 1, Nil)
       }
 
       firstPageContainer :: bookSectionContainers
@@ -111,7 +113,7 @@ object NewspaperQuery extends ExecutionContexts with Dates with Logging {
   }
 
   private def bookSectionContainer(dataId: Option[String], containerName: Option[String],
-                                   containerDescription: Option[String], trails: Seq[FaciaContent], index: Int): FaciaContainer = {
+                                   containerDescription: Option[String], trails: Seq[FaciaContent], index: Int, linkSnaps: List[LinkSnap]): FaciaContainer = {
     val containerDefinition = trails.length match {
       case 1 => FixedContainers.fixedSmallSlowI
       case 2 => FixedContainers.fixedSmallSlowII
@@ -123,7 +125,7 @@ object NewspaperQuery extends ExecutionContexts with Dates with Logging {
       index,
       Fixed(containerDefinition),
       CollectionConfigWithId(dataId.getOrElse(""), CollectionConfig.empty.copy(displayName = containerName, description = containerDescription)),
-      CollectionEssentials(trails, Nil, containerName, dataId, None, None)
+      CollectionEssentials(trails, linkSnaps, containerName, dataId, None, None)
     ).copy(hasShowMoreEnabled = false)
   }
 
@@ -139,4 +141,15 @@ object NewspaperQuery extends ExecutionContexts with Dates with Logging {
   }
 
   def getLatestGuardianPageFor(date: DateTime) = if(date.getDayOfWeek() == DateTimeConstants.SUNDAY) date.minusDays(1) else date
+
+  private def createSnapsForFrontPage(date: DateTime, publication: String): List[LinkSnap] = {
+
+    val datesAroundNewspaperDate = if(publication == "theobserver") List(date.plusDays(7), date.minusDays(7)) else List(date.plusDays(1), date.minusDays(1))
+    datesAroundNewspaperDate.filter( d => d.isBeforeNow).map { d =>
+      val displayFormat = d.toString(dateForFrontPagePattern)
+      val href = s"/$publication/${d.toString(hrefFormat).toLowerCase}"
+
+      LinkSnap("no-id", None, "no-snap-type", None, None, Some(displayFormat), Some(href), None, "group", None, ContentProperties.fromResolvedMetaData(ResolvedMetaData.Default), None, None)
+    }
+  }
 }


### PR DESCRIPTION
Adds links to other newspaper pages to help aid navigation.
- `/theguardian` a link to the previous day is provided
  ![screen shot 2015-11-27 at 11 43 16](https://cloud.githubusercontent.com/assets/944375/11440635/2300c8aa-94fc-11e5-9f36-ccd6a43eff66.png)
- For date in the past on `/theguardian` e.g. `/theguardian/2015/nov/21` show links to either side of this (Sunday dates direct to `/theobserver` e.g `/theobserver/2015/nov/22`)
  ![screen shot 2015-11-27 at 11 44 31](https://cloud.githubusercontent.com/assets/944375/11440648/405bcb84-94fc-11e5-9606-802de6871df9.png)
- `/theobserver` a link to the previous day (`/theguardian/[date]`) and the previous sunday (`/theobserver/[date]`)
  ![screen shot 2015-11-27 at 11 45 17](https://cloud.githubusercontent.com/assets/944375/11440665/5c842f2c-94fc-11e5-8a8f-90756e7a2785.png)
- For a date in the past on `/theobserver` e.g. `/theobserver/2015/nov/22` shows a link to Sunday either side and the Saturday date edition before date requested
  ![screen shot 2015-11-27 at 11 45 51](https://cloud.githubusercontent.com/assets/944375/11440673/70b264aa-94fc-11e5-8601-8e8b063b5a38.png)
