### PR TITLE
RTRT - Email inline footer - AB test to 50%

### DIFF
--- a/applications/app/views/emailFragment.scala.html
+++ b/applications/app/views/emailFragment.scala.html
@@ -4,6 +4,6 @@
 @mainEmail(page){ }{
     @(result match {
         case Some(result) => fragments.email.subscriptionResult(result)
-        case None => fragments.email.emailSignUp("footer", "The Guardian Today email")
+        case None => fragments.email.emailSignUp("footer", "Subscribe to our daily email")
     })
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -6,10 +6,10 @@ trait ABTestSwitches {
 
   val ABRtrtEmailFormInlineFooter = Switch(
     "A/B Tests",
-    "ab-rtrt-email-form-inline-footer",
+    "ab-rtrt-email-form-inline-footer-v2",
     "Switch to show the email form inline in the footer",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 12, 15),
+    sellByDate = new LocalDate(2015, 12, 8),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
@@ -30,6 +30,31 @@ define([
         },
         getIframe = function () {
             return bonzo.create('<iframe src="/email/form" scrolling="no" seamless id="footer__email-form" frameborder="0" class="iframed--overflow-hidden email-sub__iframe"></iframe>');
+        },
+        makeABChanges = function (iFrameEl, opts) {
+            // Once our iframe had loaded, make the A/B test changes
+            bean.on(iFrameEl, 'load', function () {
+                if (opts && opts.headline) {
+                    updateHeadline(opts.headline, iFrameEl);
+                }
+                if (opts && opts.removeComforter) {
+                    removeComforter(iFrameEl);
+                }
+
+                email.init(iFrameEl);
+            });
+
+            return iFrameEl;
+        },
+        updateHeadline = function (headline, iFrameEl) {
+            fastdom.write(function () {
+                $('.email-sub__heading', iFrameEl.contentDocument.body).text(headline);
+            });
+        },
+        removeComforter = function (iFrameEl) {
+            fastdom.write(function () {
+                $('.email-sub__small', iFrameEl.contentDocument.body).remove();
+            });
         };
 
         this.id = 'RtrtEmailFormInlineFooter';
@@ -54,7 +79,9 @@ define([
                 test: function () {
                     updateFooter();
                     fastdom.write(function () {
-                        $('.footer__follow-us').prepend(getIframe());
+                        $('.footer__follow-us').prepend(
+                            makeABChanges(getIframe()[0], {headline: 'daily email sign up'})
+                        );
                     });
                 }
             }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
@@ -28,31 +28,6 @@ define([
         },
         getIframe = function () {
             return bonzo.create('<iframe src="/email/form" scrolling="no" seamless id="footer__email-form" frameborder="0" class="iframed--overflow-hidden email-sub__iframe"></iframe>');
-        },
-        makeABChanges = function (iFrameEl, opts) {
-            // Once our iframe had loaded, make the A/B test changes
-            bean.on(iFrameEl, 'load', function () {
-                if (opts && opts.headline) {
-                    updateHeadline(opts.headline, iFrameEl);
-                }
-                if (opts && opts.removeComforter) {
-                    removeComforter(iFrameEl);
-                }
-
-                email.init(iFrameEl);
-            });
-
-            return iFrameEl;
-        },
-        updateHeadline = function (headline, iFrameEl) {
-            fastdom.write(function () {
-                $('.email-sub__heading', iFrameEl.contentDocument.body).text(headline);
-            });
-        },
-        removeComforter = function (iFrameEl) {
-            fastdom.write(function () {
-                $('.email-sub__small', iFrameEl.contentDocument.body).remove();
-            });
         };
 
         this.id = 'RtrtEmailFormInlineFooter';
@@ -77,9 +52,7 @@ define([
                 test: function () {
                     updateFooter();
                     fastdom.write(function () {
-                        $('.footer__follow-us').prepend(
-                            makeABChanges(getIframe()[0], {headline: 'daily email sign up'})
-                        );
+                        $('.footer__follow-us').prepend(getIframe());
                     });
                 }
             }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
@@ -4,14 +4,16 @@ define([
     'bonzo',
     'common/modules/identity/api',
     'fastdom',
-    'common/modules/email/email'
+    'common/modules/email/email',
+    'common/utils/config'
 ], function (
     $,
     bean,
     bonzo,
     Id,
     fastdom,
-    email
+    email,
+    config
 ) {
 
     return function () {
@@ -31,24 +33,24 @@ define([
         };
 
         this.id = 'RtrtEmailFormInlineFooter';
-        this.start = '2015-11-13';
-        this.expiry = '2015-12-13';
+        this.start = '2015-11-30';
+        this.expiry = '2015-12-08';
         this.author = 'Gareth Trufitt';
-        this.description = 'Test headings and comfort text (No spam, one click subscribe)';
-        this.audience = 0; // Initial 0% test to allow opt in for team testing
-        this.audienceOffset = 0.90;
-        this.successMeasure = 'X% more users sign up to the email in the footer';
-        this.audienceCriteria = 'All non logged-in users, not on the email landing page';
+        this.description = 'Test inline footer Guardian Today email sign-up with 50% of logged-out, UK users';
+        this.audience = 50;
+        this.audienceOffset = 0.50;
+        this.successMeasure = 'Increase conversion of email sign-up';
+        this.audienceCriteria = 'Logged-out UK users';
         this.dataLinkNames = '';
-        this.idealOutcome = 'Comfort messaging and headlines with stronger CTA get more sign-ups';
+        this.idealOutcome = 'Email sign-up conversion and engagement is increased';
 
         this.canRun = function () {
-            return true;
+            return config.page.edition === 'UK' && !Id.isUserLoggedIn();
         };
 
         this.variants = [
             {
-                id: 'headline-a-with-comforter',
+                id: 'control',
                 test: function () {
                     updateFooter();
                     fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
@@ -62,8 +62,8 @@ define([
         this.expiry = '2015-12-08';
         this.author = 'Gareth Trufitt';
         this.description = 'Test inline footer Guardian Today email sign-up with 50% of logged-out, UK users';
-        this.audience = 50;
-        this.audienceOffset = 0.50;
+        this.audience = 100;
+        this.audienceOffset = 0;
         this.successMeasure = 'Increase conversion of email sign-up';
         this.audienceCriteria = 'Logged-out UK users';
         this.dataLinkNames = '';
@@ -76,6 +76,10 @@ define([
         this.variants = [
             {
                 id: 'control',
+                test: function () {}
+            },
+            {
+                id: 'show-form',
                 test: function () {
                     updateFooter();
                     fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
@@ -57,7 +57,7 @@ define([
             });
         };
 
-        this.id = 'RtrtEmailFormInlineFooter';
+        this.id = 'RtrtEmailFormInlineFooterV2';
         this.start = '2015-11-30';
         this.expiry = '2015-12-08';
         this.author = 'Gareth Trufitt';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-inline-footer.js
@@ -80,7 +80,7 @@ define([
                     updateFooter();
                     fastdom.write(function () {
                         $('.footer__follow-us').prepend(
-                            makeABChanges(getIframe()[0], {headline: 'daily email sign up'})
+                            makeABChanges(getIframe()[0])
                         );
                     });
                 }

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -53,7 +53,7 @@
 
 .email-sub__text-input {
     border: 1px solid $form-primary-colour;
-    color: guss-colour(neutral-2, $pasteup-palette);
+    color: guss-colour(neutral-1, $pasteup-palette);
     height: 3em;
     outline: none;
     padding: ($gs-gutter * .4) ($gs-gutter * .75);


### PR DESCRIPTION
Open up the inline footer to 50% of logged-out UK audience.

There are a few prerequisites to sign-off before merging this:
- [x] ~~Update tracking with campaign codes to ensure we're able to test engagement~~ ( me )(Seperate campaign codes are not required initially with one segment, but this will need to be passed through the API to enable us to track across A/B tests)
- [x] Are we tracking all we need? We have hits for 'subscribe' and 'success shown' ( @amyhughes )
- [x] Any other design updates? ( @superfrank - outside of footer adjustments which can roll out soon after if not ready before)
- [x] Update actual email to link to Register page ( @crifmulholland @desbo )
- [x] Adding to the correct email list ( @crifmulholland )

(Feel free to add any other requirements before merging this)
