### PR TITLE
Disable async CSS for crossword pages

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -10,7 +10,7 @@
 @head
 
 @* stylesheet <link>s - get the stylesheets downloading ASAP *@
-@fragments.stylesheets(projectName)
+@fragments.stylesheets(projectName, metaData.isCrossword)
 
 @* inline JS - blocking *@
 @fragments.inlineJSBlocking(metaData)

--- a/common/app/views/fragments/stylesheetLink.scala.html
+++ b/common/app/views/fragments/stylesheetLink.scala.html
@@ -1,7 +1,8 @@
-@(stylesheet: String)
+@(stylesheet: String, isCrossword: Boolean = false)
 @import conf.switches.Switches._
 
-@if(AsyncCss.isSwitchedOn) {
+@* temporarily disable async css on crossword pages so they're usable on safari 6 and below *@
+@if(AsyncCss.isSwitchedOn && !isCrossword) {
     <link rel="stylesheet" type="text/css" href="@Static(stylesheet)" media="only x" />
     <noscript>
         <link rel="stylesheet" type="text/css" href="@Static(stylesheet)" />

--- a/common/app/views/fragments/stylesheets.scala.html
+++ b/common/app/views/fragments/stylesheets.scala.html
@@ -1,4 +1,4 @@
-@(projectName: Option[String])(implicit request: RequestHeader)
+@(projectName: Option[String], isCrossword: Boolean = false)(implicit request: RequestHeader)
 
 @import conf.switches.Switches._
 
@@ -49,8 +49,8 @@
   - Exclude IE Mobile [&(!IEMobile)]
 *@
 <!--[if (lt IE 9)&(!IEMobile)]>
-    @fragments.stylesheetLink(Static.css.headOldIE(projectName))
-    @fragments.stylesheetLink("stylesheets/old-ie.content.css")
+    @fragments.stylesheetLink(Static.css.headOldIE(projectName), isCrossword)
+    @fragments.stylesheetLink("stylesheets/old-ie.content.css", isCrossword)
 <![endif]-->
 
 @*
@@ -58,8 +58,8 @@
   - Exclude IE Mobile [&(!IEMobile)]
 *@
 <!--[if (IE 9)&(!IEMobile)]>
-    @fragments.stylesheetLink(Static.css.headIE9(projectName))
-    @fragments.stylesheetLink("stylesheets/ie9.content.css")
+    @fragments.stylesheetLink(Static.css.headIE9(projectName), isCrossword)
+    @fragments.stylesheetLink("stylesheets/ie9.content.css", isCrossword)
 <![endif]-->
 
 @*
@@ -75,7 +75,7 @@
         @Html(Static.css.head(projectName))
     </style>
 }
-@fragments.stylesheetLink(Static.css.projectCss(projectName))
+@fragments.stylesheetLink(Static.css.projectCss(projectName), isCrossword)
 <!--<![endif]-->
 
 <link rel="stylesheet" media="print" type="text/css" href="@Static("stylesheets/print.css")" />


### PR DESCRIPTION
We have a bug with the `async-css` feature that stops anyone on Safari 6 or below from downloading stylesheets. One of the effects is unusable crosswords: 

![unnamed](https://cloud.githubusercontent.com/assets/1064734/11440818/a0e92e78-94fd-11e5-99ad-309e0d6b4289.png)

We've understandably had a lot of complaints about this so this is a temporary hack to disable async CSS for individual crossword pages until we fix the wider issue.
