### PR TITLE
Enable fluid ads

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -32,6 +32,15 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val FluidAdvertsSwitch = Switch(
+    "Commercial",
+    "fluid-adverts",
+    "Enable fluid ads",
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val CommercialComponentsSwitch = Switch(
     "Commercial",
     "commercial-components",

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -35,9 +35,9 @@ trait CommercialSwitches {
   val FluidAdvertsSwitch = Switch(
     "Commercial",
     "fluid-adverts",
-    "Enable fluid ads",
+    "Enable fluid ads, which occupy 100% of the width of their parent container but have a fixed height",
     safeState = Off,
-    sellByDate = never,
+    sellByDate = new LocalDate(2015, 12, 15),
     exposeClientSide = true
   )
 

--- a/common/app/views/fragments/commercial/adSlot.scala.html
+++ b/common/app/views/fragments/commercial/adSlot.scala.html
@@ -14,7 +14,7 @@
 
 <div
     id="dfp-ad--@name"
-    class="js-ad-slot ad-slot ad-slot--dfp ad-slot--@name @adTypes.map{ adType =>ad-slot--@adType}.mkString(" ")@if(forceDisplay) { ad-slot--force-display}@if(fluid && FluidAdvertsSwitch.isSwitchedOn) { ad-slot--fluid}"
+    class="js-ad-slot ad-slot ad-slot--dfp ad-slot--@name @adTypes.map{ adType =>ad-slot--@adType}.mkString(" ")@if(forceDisplay) { ad-slot--force-display}"
     data-link-name="ad slot @name"
     @for(sponsor <- contentSponsor) { data-sponsor="@sponsor" }
     @for(paidForType <- paidForContentType) { data-sponsorship="@paidForType" }

--- a/common/app/views/fragments/commercial/adSlot.scala.html
+++ b/common/app/views/fragments/commercial/adSlot.scala.html
@@ -7,12 +7,14 @@
     outOfPage: Boolean = false,
     forceDisplay: Boolean = false,
     contentSponsor: Option[String] = None,
-    paidForContentType: Option[String] = None
+    paidForContentType: Option[String] = None,
+    fluid: Boolean = false
 )(placeholderContent: Html)
+@import conf.switches.Switches._
 
 <div
     id="dfp-ad--@name"
-    class="js-ad-slot ad-slot ad-slot--dfp ad-slot--@name @adTypes.map{ adType =>ad-slot--@adType}.mkString(" ")@if(forceDisplay) { ad-slot--force-display}"
+    class="js-ad-slot ad-slot ad-slot--dfp ad-slot--@name @adTypes.map{ adType =>ad-slot--@adType}.mkString(" ")@if(forceDisplay) { ad-slot--force-display}@if(fluid && FluidAdvertsSwitch.isSwitchedOn) { ad-slot--fluid}"
     data-link-name="ad slot @name"
     @for(sponsor <- contentSponsor) { data-sponsor="@sponsor" }
     @for(paidForType <- paidForContentType) { data-sponsorship="@paidForType" }
@@ -23,4 +25,6 @@
     @if(outOfPage){ data-out-of-page="true" }
     @sizeMapping.map{ case(breakpoint, sizes) =>
         data-@breakpoint="@sizes.mkString("|")"
-    }>@placeholderContent</div>
+    }
+    @if(fluid && FluidAdvertsSwitch.isSwitchedOn){ data-fluid="true" }
+    >@placeholderContent</div>

--- a/common/app/views/fragments/commercial/standardAd.scala.html
+++ b/common/app/views/fragments/commercial/standardAd.scala.html
@@ -4,10 +4,11 @@
     sizeMapping: Map[String, Seq[String]],
     showLabel: Boolean = true,
     refresh: Boolean = true,
-    outOfPage: Boolean = false
+    outOfPage: Boolean = false,
+    fluid: Boolean = false
 )
 @import conf.switches.Switches._
 
 @if(StandardAdvertsSwitch.isSwitchedOn) {
-    @fragments.commercial.adSlot(name, adTypes, sizeMapping, showLabel, refresh, outOfPage){ }
+    @fragments.commercial.adSlot(name, adTypes, sizeMapping, showLabel, refresh, outOfPage, fluid = fluid){ }
 }

--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -5,6 +5,7 @@
     @fragments.commercial.standardAd(
         "top-above-nav",
         Seq("top-banner-ad"),
-        topAboveNavSlot.adSizes(metaData, edition)
+        topAboveNavSlot.adSizes(metaData, edition),
+        fluid = true
     )
 </div>

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -415,7 +415,7 @@ define([
             } else if ($adSlot.data('fluid') && cookies.get('adtest') === 'tm2') {
                 $adSlot.addClass('ad-slot--fluid');
                 sizeMapping = defineSlotSizes($adSlot);
-                // regis kuckaertz (Nov 30) – SizeMappingBuilder does not handle 'fluid' very well,
+                // SizeMappingBuilder does not handle 'fluid' very well,
                 // so instead we add it manually ourselves to the end of each array of sizes
                 forEach(sizeMapping, function (sizeMap) { sizeMap[1].push('fluid'); });
                 slot = googletag.defineSlot(adUnit, 'fluid', id).defineSizeMapping(sizeMapping);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -404,24 +404,24 @@ define([
                 adUnit         = adUnitOverride ?
                     ['/', config.page.dfpAccountId, '/', adUnitOverride].join('') : config.page.adUnit,
                 id             = $adSlot.attr('id'),
-                sizeMapping    = defineSlotSizes($adSlot),
+                slot,
+                size,
+                sizeMapping;
+
+            if ($adSlot.data('out-of-page')) {
+                slot = googletag.defineOutOfPageSlot(adUnit, id);
+            } else if ($adSlot.data('fluid')) {
+                slot = googletag.defineSlot(adUnit, 'fluid', id);
+            } else {
+                sizeMapping = defineSlotSizes($adSlot);
                 // as we're using sizeMapping, pull out all the ad sizes, as an array of arrays
-                size           = uniq(
-                    flatten(sizeMapping, true, function (map) {
-                        return map[1];
-                    }),
-                    function (size) {
-                        return size[0] + '-' + size[1];
-                    }
-                ),
-                slot = (
-                    $adSlot.data('out-of-page') ?
-                        googletag.defineOutOfPageSlot(adUnit, id) :
-                        googletag.defineSlot(adUnit, size, id)
-                    )
-                    .addService(googletag.pubads())
-                    .defineSizeMapping(sizeMapping)
-                    .setTargeting('slot', slotTarget);
+                size = uniq(
+                    flatten(sizeMapping, true, function (map) { return map[1]; }),
+                    function (size) { return size[0] + '-' + size[1]; }
+                );
+                slot = googletag.defineSlot(adUnit, size, id);
+                slot.defineSizeMapping(sizeMapping);
+            }
 
             if ($adSlot.data('series')) {
                 slot.setTargeting('se', parseKeywords($adSlot.data('series')));
@@ -430,6 +430,9 @@ define([
             if ($adSlot.data('keywords')) {
                 slot.setTargeting('k', parseKeywords($adSlot.data('keywords')));
             }
+
+            slot.addService(googletag.pubads())
+                .setTargeting('slot', slotTarget);
 
             // Add to the array of ads to be refreshed (when the breakpoint changes)
             // only if it's `data-refresh` attribute isn't set to false.

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -411,7 +411,11 @@ define([
             if ($adSlot.data('out-of-page')) {
                 slot = googletag.defineOutOfPageSlot(adUnit, id);
             } else if ($adSlot.data('fluid')) {
-                slot = googletag.defineSlot(adUnit, 'fluid', id);
+                sizeMapping = defineSlotSizes($adSlot);
+                // regis kuckaertz (Nov 30) – SizeMappingBuilder does not handle 'fluid' very well,
+                // so instead we add it manually ourselves to the end of each array of sizes
+                forEach(sizeMapping, function (sizeMap) { sizeMap[1].push('fluid'); });
+                slot = googletag.defineSlot(adUnit, 'fluid', id).defineSizeMapping(sizeMapping);
             } else {
                 sizeMapping = defineSlotSizes($adSlot);
                 // as we're using sizeMapping, pull out all the ad sizes, as an array of arrays
@@ -419,8 +423,7 @@ define([
                     flatten(sizeMapping, true, function (map) { return map[1]; }),
                     function (size) { return size[0] + '-' + size[1]; }
                 );
-                slot = googletag.defineSlot(adUnit, size, id);
-                slot.defineSizeMapping(sizeMapping);
+                slot = googletag.defineSlot(adUnit, size, id).defineSizeMapping(sizeMapping);
             }
 
             if ($adSlot.data('series')) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -17,6 +17,7 @@ define([
     'common/utils/user-timing',
     'common/utils/sha1',
     'common/utils/fastdom-idle',
+    'common/utils/cookies',
     'common/modules/commercial/ads/sticky-mpu',
     'common/modules/commercial/build-page-targeting',
     'common/modules/commercial/commercial-features',
@@ -59,6 +60,7 @@ define([
     userTiming,
     sha1,
     idleFastdom,
+    cookies,
     StickyMpu,
     buildPageTargeting,
     commercialFeatures,
@@ -410,7 +412,8 @@ define([
 
             if ($adSlot.data('out-of-page')) {
                 slot = googletag.defineOutOfPageSlot(adUnit, id);
-            } else if ($adSlot.data('fluid')) {
+            } else if ($adSlot.data('fluid') && cookies.get('adtest') === 'tm2') {
+                $adSlot.addClass('ad-slot--fluid');
                 sizeMapping = defineSlotSizes($adSlot);
                 // regis kuckaertz (Nov 30) – SizeMappingBuilder does not handle 'fluid' very well,
                 // so instead we add it manually ourselves to the end of each array of sizes

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -136,6 +136,14 @@
         padding-left: $left-column-wide + $gs-gutter;
     }
 
+    @include mq(wide) {
+        /* Fluid ads just expand horizontally to the size of their container */
+        &.ad-slot--fluid {
+            padding-left: 0;
+            width: auto;
+        }
+    }
+
     .top-banner-ad-container--mobile & {
         height: 50px;
         padding: $gs-baseline 0;


### PR DESCRIPTION
This change will enable fluid ads for the top banner only. It is hidden behind the `FluidAdverts` switch.
### SASS

I created a `.ad-slot--fluid` modifier but because currently top banner ads have a fixed width and left padding on desktop, I had to compound classes to cancel it. There may be a more idiomatic way of doing this at the Guardian though.
