### PR TITLE
Add progress bar to the immersive articles

### DIFF
--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -18,6 +18,8 @@
                 <link itemprop="sameAs" href="http://www.theguardian.com">
             </div>
 
+            @fragments.articleProgress(article)
+
             @fragments.headerImmersive(article)
 
             <div class="content__main tonal__main tonal__main--@articleToneClass(article)">

--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -10,7 +10,7 @@
         <article id="article" data-test-id="article-root"
             class="content content--article content--immersive tonal tonal--@articleToneClass(article) section-@article.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
             @if(article.isAdvertisementFeature){content--advertisement-feature}
-            @if(article.isFeature && article.hasShowcaseMainElement){has-feature-showcase-element}"
+            @if(article.isFeature && article.hasShowcaseMainElement){has-feature-showcase-element} js-content--article"
             itemscope itemtype="@article.schemaType" role="main">
             <meta itemprop="mainEntityOfPage" content="@LinkTo(article.url)">
             <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">

--- a/common/app/views/fragments/articleProgress.scala.html
+++ b/common/app/views/fragments/articleProgress.scala.html
@@ -1,5 +1,5 @@
 @(content: model.Article)(implicit request: RequestHeader)
 
-<div class="progress">
-    <div class="progress__indicator"></div>
+<div class="progress js-progress">
+    <div class="progress__indicator js-progress__indicator"></div>
 </div>

--- a/common/app/views/fragments/articleProgress.scala.html
+++ b/common/app/views/fragments/articleProgress.scala.html
@@ -1,0 +1,5 @@
+@(content: model.Article)(implicit request: RequestHeader)
+
+<div class="progress">
+    <div class="progress__indicator"></div>
+</div>

--- a/static/src/javascripts/bootstraps/article.js
+++ b/static/src/javascripts/bootstraps/article.js
@@ -11,6 +11,7 @@ define([
     'common/modules/article/membership-events',
     'common/modules/article/open-module',
     'common/modules/article/chapters',
+    'common/modules/article/progress',
     'common/modules/experiments/ab',
     'common/modules/onward/geo-most-popular',
     'bootstraps/article-liveblog-common',
@@ -27,6 +28,7 @@ define([
     membershipEvents,
     openModule,
     chapters,
+    progress,
     ab,
     geoMostPopular,
     articleLiveblogCommon,
@@ -68,6 +70,7 @@ define([
             richLinks.insertTagRichLink();
             membershipEvents.upgradeEvents();
             chapters.init();
+            progress.init();
             openModule.init();
             mediator.emit('page:article:ready');
         };

--- a/static/src/javascripts/projects/common/modules/article/progress.js
+++ b/static/src/javascripts/projects/common/modules/article/progress.js
@@ -5,13 +5,17 @@ define([
     $,
     mediator
 ) {
+    var articleHeight;
+
     return {
         init: function () {
+            this.getArticleHeight();
             this.bindEvents();
         },
 
         bindEvents: function () {
             mediator.on('window:throttledScroll', this.updateProgress.bind(this));
+            mediator.on('window:resize', this.getArticleHeight.bind(this));
         },
 
         updateProgress: function () {
@@ -19,7 +23,11 @@ define([
         },
 
         getProgressAsPercentage: function () {
-            return window.scrollY + "px"
+            return window.scrollY / articleHeight * 100 + "%"
+        },
+
+        getArticleHeight: function () {
+            articleHeight = $('.content--article').offset().height;
         }
     };
 });

--- a/static/src/javascripts/projects/common/modules/article/progress.js
+++ b/static/src/javascripts/projects/common/modules/article/progress.js
@@ -8,15 +8,18 @@ define([
     return {
         init: function () {
             this.bindEvents();
-            console.log("progress");
         },
 
         bindEvents: function () {
-            mediator.on('window:throttledScroll', this.updateProgress);
+            mediator.on('window:throttledScroll', this.updateProgress.bind(this));
         },
 
         updateProgress: function () {
-            console.log("hey");
+            $('.progress__indicator').css('width', this.getProgressAsPercentage);
+        },
+
+        getProgressAsPercentage: function () {
+            return window.scrollY + "px"
         }
     };
 });

--- a/static/src/javascripts/projects/common/modules/article/progress.js
+++ b/static/src/javascripts/projects/common/modules/article/progress.js
@@ -9,8 +9,11 @@ define([
 
     return {
         init: function () {
-            this.getArticleHeight();
-            this.bindEvents();
+            // Check if progress bar is present
+            if ($('.progress').length) {
+                this.getArticleHeight();
+                this.bindEvents();
+            }
         },
 
         bindEvents: function () {

--- a/static/src/javascripts/projects/common/modules/article/progress.js
+++ b/static/src/javascripts/projects/common/modules/article/progress.js
@@ -10,7 +10,7 @@ define([
     return {
         init: function () {
             // Check if progress bar is present
-            if ($('.progress').length) {
+            if ($('.js-progress').length) {
                 this.getArticleHeight();
                 this.bindEvents();
             }
@@ -22,7 +22,7 @@ define([
         },
 
         updateProgress: function () {
-            $('.progress__indicator').css('width', this.getProgressAsPercentage);
+            $('.js-progress__indicator').css('width', this.getProgressAsPercentage);
         },
 
         getProgressAsPercentage: function () {

--- a/static/src/javascripts/projects/common/modules/article/progress.js
+++ b/static/src/javascripts/projects/common/modules/article/progress.js
@@ -30,7 +30,7 @@ define([
         },
 
         getArticleHeight: function () {
-            articleHeight = $('.content--article').offset().height;
+            articleHeight = $('.js-content--article').offset().height;
         }
     };
 });

--- a/static/src/javascripts/projects/common/modules/article/progress.js
+++ b/static/src/javascripts/projects/common/modules/article/progress.js
@@ -23,7 +23,7 @@ define([
         },
 
         getProgressAsPercentage: function () {
-            return window.scrollY / articleHeight * 100 + "%"
+            return window.scrollY / articleHeight * 100 + '%';
         },
 
         getArticleHeight: function () {

--- a/static/src/javascripts/projects/common/modules/article/progress.js
+++ b/static/src/javascripts/projects/common/modules/article/progress.js
@@ -1,0 +1,22 @@
+define([
+    'common/utils/$',
+    'common/utils/mediator'
+], function (
+    $,
+    mediator
+) {
+    return {
+        init: function () {
+            this.bindEvents();
+            console.log("progress");
+        },
+
+        bindEvents: function () {
+            mediator.on('window:throttledScroll', this.updateProgress);
+        },
+
+        updateProgress: function () {
+            console.log("hey");
+        }
+    };
+});

--- a/static/src/stylesheets/head.content.scss
+++ b/static/src/stylesheets/head.content.scss
@@ -14,6 +14,7 @@
 @import 'module/_layout-hints';
 @import 'module/_live-pulse';
 @import 'module/_chapters';
+@import 'module/_progress';
 @import 'module/content/_article-immersive';
 
 

--- a/static/src/stylesheets/module/_progress.scss
+++ b/static/src/stylesheets/module/_progress.scss
@@ -4,6 +4,7 @@
     height: $gs-baseline / 4;
     width: 100%;
     background-color: rgba(255, 255, 255, .2);
+    pointer-events: none;
 }
 
 .progress__indicator {

--- a/static/src/stylesheets/module/_progress.scss
+++ b/static/src/stylesheets/module/_progress.scss
@@ -1,5 +1,13 @@
 .progress {
-    background-color: aqua;
-    height: 200px;
+    position: fixed;
+    z-index: 1;
+    height: $gs-baseline / 4;
     width: 100%;
+    background-color: rgba(255, 255, 255, 0.2);
+}
+
+.progress__indicator {
+    background-color: colour(feature-default);
+    width: 0%;
+    height: 100%;
 }

--- a/static/src/stylesheets/module/_progress.scss
+++ b/static/src/stylesheets/module/_progress.scss
@@ -1,0 +1,5 @@
+.progress {
+    background-color: aqua;
+    height: 200px;
+    width: 100%;
+}

--- a/static/src/stylesheets/module/_progress.scss
+++ b/static/src/stylesheets/module/_progress.scss
@@ -3,7 +3,7 @@
     z-index: 1;
     height: $gs-baseline / 4;
     width: 100%;
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: rgba(255, 255, 255, .2);
 }
 
 .progress__indicator {


### PR DESCRIPTION
Adds a progress bar to the immersive template for those mammoth long reads. I've tried to build it in a way that means we can use it on other articles if we choose to later.

![screen recording 2015-11-27 at 03 51 pm](https://cloud.githubusercontent.com/assets/1607666/11445048/ef6a06a8-9520-11e5-8e0e-d8c29803320b.gif)
