### PR TITLE
Onward Journeys with Amp List

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -7,7 +7,7 @@
         font-stretch: normal
     }
 
-    .content__headline, .element-rich-link--not-upgraded a, .content__labels, .element-pullquote , .tonal__standfirst, .drop-cap__inner, .byline {
+    .content__headline, .element-rich-link--not-upgraded a, .content__labels, .element-pullquote , .tonal__standfirst, .drop-cap__inner, .byline, .headline-list__count {
         font-family: "Guardian Egyptian Web","Guardian Text Egyptian Web",Georgia,serif;
     }
 

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -248,6 +248,7 @@
     @fragments.amp.stylesheets.inlineSvgs()
     @fragments.amp.stylesheets.social()
     @fragments.amp.stylesheets.footer()
+    @fragments.amp.stylesheets.mostPopular()
     @if(metaData.id == "australia-news/postcolonial-blog/2015/jul/21/enduring-controversy-bp-sponsorship-ignites-new-row-over-british-museums-indigenous-exhibition"){
         @fragments.amp.stylesheets.fonts()
     }

--- a/common/app/views/fragments/amp/stylesheets/mostPopular.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/mostPopular.scala.html
@@ -62,6 +62,7 @@
     box-sizing: border-box;
     padding-top: 0.25rem;
     padding-bottom: 1.5rem;
+    min-height: 9%;
 }
 
 .headline-list__item:before {

--- a/common/app/views/fragments/amp/stylesheets/mostPopular.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/mostPopular.scala.html
@@ -1,0 +1,83 @@
+.fc-container__inner {
+    border-top: 0.0625rem solid #4bc6df;
+    padding-top: 0.1875rem;
+    overflow: hidden;
+    position: relative;
+    margin-left: 0.625rem;
+    margin-right: 0.625rem;
+}
+
+.fc-container__header__title {
+    position: relative;
+    padding-bottom: 1rem;
+    font-size: 1.375rem;
+    line-height: 1.75rem;
+    font-family: "Guardian Egyptian Web","Guardian Text Egyptian Web",Georgia,serif;
+    font-weight: 900;
+    line-height: 1.5rem;
+    color: #00456e;
+}
+
+.headline-list__count {
+    float: left;
+    width: 3.75rem;
+    color: #dcdcdc;
+    font-weight: 200;
+    font-size: 2.75rem;
+    line-height: 2.75rem;
+}
+
+@@media (min-width: 20em) {
+    .headline-list__count {
+        width: 3.125rem;
+    }
+}
+
+.fc-item__title {
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    word-wrap: break-word;
+}
+
+.fc-item__link {
+    color: #333;
+}
+
+.headline-list__link .fc-item__title {
+    margin-top: -0.25rem;
+    margin-left: 3.75rem;
+}
+
+@@media (min-width: 20em) {
+    .headline-list__link .fc-item__title {
+        margin-left: 3.125rem;
+    }
+}
+
+.headline-list__item {
+    position: relative;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    padding-top: 0.25rem;
+    padding-bottom: 1.5rem;
+}
+
+.headline-list__item:before {
+    position: absolute;
+    top: 0;
+    right: 0.625rem;
+    left: 0;
+    content: '';
+    display: block;
+    width: 100%;
+    height: 0.0625rem;
+    background-color: #dcdcdc;
+}
+
+@@media (max-width: 46.24em) {
+    .headline-list__item:first-child:before {
+        display: none;
+    }
+}

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -15,7 +15,7 @@
         <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
-        <script custom-template="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async ></script>
+        <script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async ></script>
         <script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async ></script>
         <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
         <script src="https://cdn.ampproject.org/v0.js" async></script>
@@ -42,15 +42,21 @@
 
             @body
 
-            <amp-list width="600" height="600" layout="responsive" src="https://www.thegulocal.com//most-read-amp.json">
-                <template type="amp-mustache">
-                    <div class="headline-list__item">
-                        <h2 class="fc-item__title">
-                            <a href="{{url}}">{{headline}}</a>
-                        </h2>
-                    </div>
-                </template>
-            </amp-list>
+            <div class="fc-container__inner">
+                <div class="fc-container__header__title">
+                    <span>popular</span>
+                </div>
+                <amp-list width="600" height="1000" layout="responsive" src="@Configuration.ajax.url/most-read-amp.json">
+                    <template type="amp-mustache">
+                        <div class="headline-list__item">
+                            <p class="headline-list__count">{{index}}</p>
+                            <h2 class="fc-item__title">
+                                <a href="{{url}}" class="fc-item__link">{{headline}}</a>
+                            </h2>
+                        </div>
+                    </template>
+                </amp-list>
+            </div>
 
             @fragments.footerAMP(metaData)
         </div>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -46,7 +46,7 @@
                 <div class="fc-container__header__title">
                     <span>popular</span>
                 </div>
-                <amp-list width="600" height="1000" layout="responsive" src="@if(Play.isDev) {https://www.thegulocal.com} else {@Configuration.ajax.url}/most-read-amp.json">
+                <amp-list width="600" height="1000" layout="responsive" src="@if(Play.isDev) {https://www.thegulocal.com} else {@Configuration.ajax.url}/most-read-mf2.json">
                     <template type="amp-mustache">
                         <div class="headline-list__item">
                             <p class="headline-list__count">{{index}}</p>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -11,12 +11,14 @@
         <meta charset="utf-8">
         @fragments.metaData(metaData, true)
         <title>@views.support.Title(metaData)</title>
-        <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
         @fragments.amp.stylesheets.main(metaData)
-        <script src="https://cdn.ampproject.org/v0.js" async></script>
         <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
+        <script custom-template="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async ></script>
+        <script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async ></script>
+        <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
+        <script src="https://cdn.ampproject.org/v0.js" async></script>
     </head>
     <body>
         @defining(s"${request.host}${request.path}") { path =>
@@ -39,6 +41,16 @@
             </header>
 
             @body
+
+            <amp-list width="600" height="600" layout="responsive" src="https://www.thegulocal.com//most-read-amp.json">
+                <template type="amp-mustache">
+                    <div class="headline-list__item">
+                        <h2 class="fc-item__title">
+                            <a href="{{url}}">{{headline}}</a>
+                        </h2>
+                    </div>
+                </template>
+            </amp-list>
 
             @fragments.footerAMP(metaData)
         </div>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -46,7 +46,7 @@
                 <div class="fc-container__header__title">
                     <span>popular</span>
                 </div>
-                <amp-list width="600" height="1000" layout="responsive" src="@Configuration.ajax.url/most-read-amp.json">
+                <amp-list width="600" height="1000" layout="responsive" src="@if(Play.isDev) {https://www.thegulocal.com} else {@Configuration.ajax.url}/most-read-amp.json">
                     <template type="amp-mustache">
                         <div class="headline-list__item">
                             <p class="headline-list__count">{{index}}</p>

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -92,7 +92,7 @@ GET            /most-read-facebook.json                                         
 GET            /most-read-twitter.json                                                                                           controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "twitter")
 GET            /most-read.json                                                                                                   controllers.MostPopularController.render(path = "")
 GET            /most-read/*path.json                                                                                             controllers.MostPopularController.render(path)
-GET            /most-read-amp.json                                                                                               controllers.MostPopularController.renderPopularAmp()
+GET            /most-read-mf2.json                                                                                               controllers.MostPopularController.renderPopularMicroformat2()
 GET            /most-read-geo.json                                                                                               controllers.MostPopularController.renderPopularGeo()
 GET            /most-read-day.json                                                                                               controllers.MostPopularController.renderPopularDay(countryCode)
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -92,6 +92,7 @@ GET            /most-read-facebook.json                                         
 GET            /most-read-twitter.json                                                                                           controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "twitter")
 GET            /most-read.json                                                                                                   controllers.MostPopularController.render(path = "")
 GET            /most-read/*path.json                                                                                             controllers.MostPopularController.render(path)
+GET            /most-read-amp.json                                                                                               controllers.MostPopularController.renderPopularAmp()
 GET            /most-read-geo.json                                                                                               controllers.MostPopularController.renderPopularGeo()
 GET            /most-read-day.json                                                                                               controllers.MostPopularController.renderPopularDay(countryCode)
 

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -83,7 +83,7 @@ object MostPopularController extends Controller with Logging with ExecutionConte
     }
   }
 
-  def renderPopularAmp = Action { implicit request =>
+  def renderPopularMicroformat2 = Action { implicit request =>
     val edition = Edition(request)
 
     Cached(900) {

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -88,8 +88,9 @@ object MostPopularController extends Controller with Logging with ExecutionConte
 
     Cached(900) {
       JsonComponent(
-        "items" -> JsArray(MostPopularAgent.mostPopular(edition).map{ trail =>
+        "items" -> JsArray(MostPopularAgent.mostPopular(edition).zipWithIndex.map{ case (trail, index) =>
           Json.obj(
+            ("index", index + 1),
             ("url", trail.url),
             ("headline", trail.headline)
           )

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -33,7 +33,7 @@ object MostPopularController extends Controller with Logging with ExecutionConte
     sectionPopular.map { sectionPopular =>
       val sectionFirst = sectionPopular ++ globalPopular
       val globalFirst = globalPopular.toList ++ sectionPopular
-      
+
       val mostPopular = if ( path.contains("global-development") ) sectionFirst else globalFirst
 
       mostPopular match {
@@ -74,6 +74,21 @@ object MostPopularController extends Controller with Logging with ExecutionConte
     Cached(900) {
       JsonComponent(
         "trails" -> JsArray(DayMostPopularAgent.mostPopular(countryCode).map{ trail =>
+          Json.obj(
+            ("url", trail.url),
+            ("headline", trail.headline)
+          )
+        })
+      )
+    }
+  }
+
+  def renderPopularAmp = Action { implicit request =>
+    val edition = Edition(request)
+
+    Cached(900) {
+      JsonComponent(
+        "items" -> JsArray(MostPopularAgent.mostPopular(edition).map{ trail =>
           Json.obj(
             ("url", trail.url),
             ("headline", trail.headline)

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -26,6 +26,7 @@ GET        /most-read-facebook.json                   controllers.MostViewedSoci
 GET        /most-read-twitter.json                    controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "twitter")
 GET        /most-read.json                            controllers.MostPopularController.render(path = "")
 GET        /most-read/*path.json                      controllers.MostPopularController.render(path)
+GET        /most-read-amp.json                        controllers.MostPopularController.renderPopularAmp()
 GET        /most-read-geo.json                        controllers.MostPopularController.renderPopularGeo()
 GET        /most-read-day.json                        controllers.MostPopularController.renderPopularDay(countryCode)
 

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -26,7 +26,7 @@ GET        /most-read-facebook.json                   controllers.MostViewedSoci
 GET        /most-read-twitter.json                    controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "twitter")
 GET        /most-read.json                            controllers.MostPopularController.render(path = "")
 GET        /most-read/*path.json                      controllers.MostPopularController.render(path)
-GET        /most-read-amp.json                        controllers.MostPopularController.renderPopularAmp()
+GET        /most-read-mf2.json                        controllers.MostPopularController.renderPopularMicroformat2()
 GET        /most-read-geo.json                        controllers.MostPopularController.renderPopularGeo()
 GET        /most-read-day.json                        controllers.MostPopularController.renderPopularDay(countryCode)
 


### PR DESCRIPTION
First iteration on onward journeys in AMP. I thought that most popular would be the easiest thing to test the new `amp-list` component out. Here is what it looks like so far:

![image](https://cloud.githubusercontent.com/assets/8774970/11468629/e8cc7c52-9748-11e5-9934-789c5cdebde7.png)

cc @johnduffell @stephanfowler 
