### PR TITLE
Amp-Font

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -6,8 +6,14 @@
         font-style: normal;
         font-stretch: normal
     }
-
-    .content__headline, .element-rich-link--not-upgraded a, .content__labels, .element-pullquote , .tonal__standfirst, .drop-cap__inner, .byline, .headline-list__count {
+    .guardian-egyptian-loaded .content__headline,
+    .guardian-egyptian-loaded .element-rich-link--not-upgraded a,
+    .guardian-egyptian-loaded .content__labels,
+    .guardian-egyptian-loaded .element-pullquote,
+    .guardian-egyptian-loaded .tonal__standfirst,
+    .guardian-egyptian-loaded .drop-cap__inner,
+    .guardian-egyptian-loaded .headline-list__count,
+    .guardian-egyptian-loaded .byline {
         font-family: "Guardian Egyptian Web","Guardian Text Egyptian Web",Georgia,serif;
     }
 

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -12,6 +12,7 @@
         @fragments.metaData(metaData, true)
         <title>@views.support.Title(metaData)</title>
         @fragments.amp.stylesheets.main(metaData)
+        <script custom-element="amp-font" src="https://cdn.ampproject.org/v0/amp-font-0.1.js" async></script>
         <script custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js" async></script>
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
@@ -20,7 +21,7 @@
         <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
         <script src="https://cdn.ampproject.org/v0.js" async></script>
     </head>
-    <body>
+    <body class="guardian-egyptian-loading">
         @defining(s"${request.host}${request.path}") { path =>
             @defining({
                 val params = OmnitureAnalyticsData(metaData, "No Javascript", path, "GoogleAMP", Map(("r", "DOCUMENT_REFERRER")))
@@ -42,21 +43,34 @@
 
             @body
 
-            <div class="fc-container__inner">
-                <div class="fc-container__header__title">
-                    <span>popular</span>
+            @if(metaData.id == "australia-news/postcolonial-blog/2015/jul/21/enduring-controversy-bp-sponsorship-ignites-new-row-over-british-museums-indigenous-exhibition"){
+
+                <div class="fc-container__inner">
+                    <div class="fc-container__header__title">
+                        <span>popular</span>
+                    </div>
+                    <amp-list width="600" height="1000" layout="responsive" src="@if(Play.isDev) {https://www.thegulocal.com} else {@Configuration.ajax.url}/most-read-mf2.json">
+                        <template type="amp-mustache">
+                            <div class="headline-list__item">
+                                <p class="headline-list__count">{{index}}</p>
+                                <h2 class="fc-item__title">
+                                    <a href="{{url}}" class="fc-item__link">{{headline}}</a>
+                                </h2>
+                            </div>
+                        </template>
+                    </amp-list>
                 </div>
-                <amp-list width="600" height="1000" layout="responsive" src="@if(Play.isDev) {https://www.thegulocal.com} else {@Configuration.ajax.url}/most-read-mf2.json">
-                    <template type="amp-mustache">
-                        <div class="headline-list__item">
-                            <p class="headline-list__count">{{index}}</p>
-                            <h2 class="fc-item__title">
-                                <a href="{{url}}" class="fc-item__link">{{headline}}</a>
-                            </h2>
-                        </div>
-                    </template>
-                </amp-list>
-            </div>
+
+                <amp-font
+                    layout="nodisplay"
+                    font-family="Guardian Egyptian Web"
+                    timeout="3000"
+                    on-load-add-class="guardian-egyptian-loaded"
+                    on-load-remove-class="guardian-egyptian-loading"
+                    on-error-remove-class="guardian-egyptian-loading"
+                    on-error-add-class="guardian-egyptian-missing">
+                </amp-font>
+            }
 
             @fragments.footerAMP(metaData)
         </div>


### PR DESCRIPTION
This PR:
- Trials `amp-font`
- Moves `amp-list` to load on only one article

The reason to only load these components on a test article is because we are experimenting with them to provide feedback to the AMP team. Once they are stable, we can add them to all the articles.

`amp-list`/`amp-mustache` is an experiment for amp. To see it, add `#development=1` onto the end of the url and also in your devtools console type in:

```
AMP.toggleExperiment('mustache')
```

cc @stephanfowler 
