### PR TITLE
Restore Spacefinder Fix

### DIFF
--- a/static/src/javascripts/core.js
+++ b/static/src/javascripts/core.js
@@ -19,6 +19,7 @@ define([
     // shared modules
     'common/modules/analytics/beacon',
     'common/modules/article/spacefinder',
+    'common/modules/article/space-filler',
     'common/modules/commercial/badges',
     'common/modules/commercial/build-page-targeting',
     'common/modules/commercial/create-ad-slot',

--- a/static/src/javascripts/projects/common/modules/article/rich-links.js
+++ b/static/src/javascripts/projects/common/modules/article/rich-links.js
@@ -8,7 +8,7 @@ define([
     'common/utils/detect',
     'common/utils/mediator',
     'common/utils/template',
-    'common/modules/article/spacefinder',
+    'common/modules/article/space-filler',
     'common/modules/ui/images',
     'text!common/views/content/richLinkTag.html',
     'lodash/collections/contains'
@@ -22,7 +22,7 @@ define([
     detect,
     mediator,
     template,
-    spacefinder,
+    spaceFiller,
     imagesModule,
     richLinkTagTmpl,
     contains) {
@@ -66,7 +66,8 @@ define([
     }
 
     function insertTagRichLink() {
-        var richLinkHrefs = $('.element-rich-link a')
+        var $insertedEl,
+            richLinkHrefs = $('.element-rich-link a')
                 .map(function (el) { return $(el).attr('href'); }),
             testIfDuplicate = function (richLinkHref) {
                 // Tag-targeted rich links can be absolute
@@ -75,21 +76,20 @@ define([
             isDuplicate = richLinkHrefs.some(testIfDuplicate),
             isSensitive = config.page.shouldHideAdverts || !config.page.showRelatedContent;
 
-        if (config.page.richLink && config.page.richLink.indexOf(config.page.pageId) === -1
-            && !isSensitive && !isDuplicate) {
-
-            return spacefinder.getParaWithSpace(getSpacefinderRules()).then(function (space) {
-                return new Promise(function (resolve) {
-                    if (space) {
-                        fastdom.write(function () {
-                            var $el = $.create(template(richLinkTagTmpl, {href: config.page.richLink}));
-                            $el.insertBefore(space);
-                            resolve(upgradeRichLink($el[0]));
-                        });
-                    } else {
-                        resolve(null);
-                    }
-                });
+        if (config.page.richLink &&
+            config.page.richLink.indexOf(config.page.pageId) === -1 &&
+            !isSensitive &&
+            !isDuplicate
+        ) {
+            return spaceFiller.insertAtFirstSpace(getSpacefinderRules(), function (para) {
+                $insertedEl = $.create(template(richLinkTagTmpl, {href: config.page.richLink}));
+                $insertedEl.insertBefore(para);
+            }).then(function (didInsert) {
+                if (didInsert) {
+                    return Promise.resolve(upgradeRichLink($insertedEl[0]));
+                } else {
+                    return Promise.resolve(null);
+                }
             });
         } else {
             return Promise.resolve(null);
@@ -101,7 +101,6 @@ define([
     }
 
     return {
-        upgradeRichLink: upgradeRichLink,
         upgradeRichLinks: upgradeRichLinks,
         insertTagRichLink: insertTagRichLink,
         getSpacefinderRules: getSpacefinderRules

--- a/static/src/javascripts/projects/common/modules/article/space-filler.js
+++ b/static/src/javascripts/projects/common/modules/article/space-filler.js
@@ -1,0 +1,66 @@
+/* jscs:disable disallowDanglingUnderscores */
+define([
+    'common/utils/$',
+    'common/utils/fastdom-idle',
+    'Promise',
+    'raven',
+    'common/modules/article/spacefinder'
+], function (
+    $,
+    idleFastdom,
+    Promise,
+    raven,
+    spacefinder
+) {
+    return new SpaceFiller();
+
+    function SpaceFiller() {
+        var lastInsertion = Promise.resolve(false);
+
+        /**
+         * A safer way of using spacefinder.
+         * Given a set of spacefinder rules, applies a writer to the first matching paragraph.
+         * Uses fastdom to avoid layout-thrashing, but queues up asynchronous writes to avoid race conditions. We don't
+         * seek a slot for a new component until all the other component writes have finished.
+         *
+         * @param rules - a spacefinder ruleset
+         * @param writer - function, takes a para element and injects a container for the new content synchronously. It should NOT use Fastdom.
+         * @param debug - flag to enable debugging in spacefinder
+         *
+         * @returns {Promise} - when insertion attempt completed, resolves 'true' if inserted, or 'false' if no space found
+         */
+        this.insertAtFirstSpace = function insertAtFirstSpace(rules, writer, debug) {
+            lastInsertion = lastInsertion.then(insertNextContent).catch(onInsertionError);
+
+            function insertNextContent() {
+                return spacefinder.getParaWithSpace(rules, debug).then(function applyParaToWriter(para) {
+                    if (para) {
+                        return insertionPromise(para);
+                    } else {
+                        return false;
+                    }
+                });
+            }
+
+            function insertionPromise(para) {
+                return new Promise(function (resolve, reject) {
+                    idleFastdom.write(function () {
+                        try {
+                            writer(para);
+                            resolve(true);
+                        } catch (e) {
+                            reject(e);
+                        }
+                    });
+                });
+            }
+
+            function onInsertionError(e) {
+                raven.captureException(e);
+                return false;
+            }
+
+            return lastInsertion;
+        };
+    }
+});

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -154,7 +154,8 @@ define([
         return Promise.resolve();
     }
 
-    // getParaWithSpace returns a paragraph that satisfies the given/default rules:
+    // Rather than calling this directly, use spaceFiller to inject content into the page.
+    // SpaceFiller will safely queue up all the various asynchronous DOM actions to avoid any race conditions.
     function getParaWithSpace(rules, debug) {
         var bodyBottom, paraElems, slots;
         rules = rules || defaultRules;

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -3,8 +3,7 @@ define([
     'common/utils/$',
     'common/utils/config',
     'common/utils/detect',
-    'common/utils/fastdom-idle',
-    'common/modules/article/spacefinder',
+    'common/modules/article/space-filler',
     'common/modules/commercial/create-ad-slot',
     'common/modules/commercial/commercial-features',
     'lodash/objects/cloneDeep'
@@ -13,8 +12,7 @@ define([
     $,
     config,
     detect,
-    idleFastdom,
-    spacefinder,
+    spaceFiller,
     createAdSlot,
     commercialFeatures,
     cloneDeep) {
@@ -49,85 +47,68 @@ define([
     }
 
     // Add new ads while there is still space
-    function getAdSpace() {
-        return spacefinder.getParaWithSpace(getLongArticleRules()).then(function (nextSpace) {
-            // check if spacefinder found another space
-            if (typeof nextSpace === 'undefined' || ads.length >= 9) {
-                return Promise.resolve(null);
-            }
-
-            // if yes add another ad and try another run
-            adNames.push(['inline' + (ads.length + 1), 'inline']);
-            return insertAdAtP(nextSpace).then(function () {
-                return getAdSpace();
+    function addLongArticleAds(count) {
+        if (count < 1) {
+            return Promise.resolve(null);
+        } else {
+            return tryAddingAdvert().then(function (trySuccessful) {
+                // If last attempt worked, recurse another
+                if (trySuccessful) {
+                    return addLongArticleAds(count - 1);
+                } else {
+                    return Promise.resolve(null);
+                }
             });
-        });
+        }
+
+        function tryAddingAdvert() {
+            return spaceFiller.insertAtFirstSpace(getLongArticleRules(), function (para) {
+                adNames.push(['inline' + (ads.length + 1), 'inline']);
+                insertAdAtPara(para);
+            });
+        }
+    }
+
+    function insertAdAtPara(para) {
+        var adName = adNames[ads.length],
+            $ad    = $.create(createAdSlot(adName[0], adName[1]));
+
+        ads.push($ad);
+        $ad.insertBefore(para);
     }
 
     var ads = [],
         adNames = [['inline1', 'inline'], ['inline2', 'inline']],
-        insertAdAtP = function (para) {
-            if (para) {
-                var adName = adNames[ads.length],
-                    $ad    = $.create(createAdSlot(adName[0], adName[1]));
-
-                ads.push($ad);
-                return new Promise(function (resolve) {
-                    idleFastdom.write(function () {
-                        $ad.insertBefore(para);
-                        resolve(null);
-                    });
-                });
-            } else {
-                return Promise.resolve(null);
-            }
-        },
         init = function () {
-            var rules, inlineMercPromise;
-
             if (!commercialFeatures.articleBodyAdverts) {
                 return false;
             }
 
-            rules = getRules();
+            var rules = getRules();
 
             if (config.page.hasInlineMerchandise) {
-                inlineMercPromise = spacefinder.getParaWithSpace(getInlineMerchRules()).then(function (space) {
-                    if (space) {
-                        adNames.unshift(['im', 'im']);
-                    }
-                    return insertAdAtP(space);
+                spaceFiller.insertAtFirstSpace(getInlineMerchRules(), function (para) {
+                    adNames.unshift(['im', 'im']);
+                    insertAdAtPara(para);
                 });
-            } else {
-                inlineMercPromise = Promise.resolve(null);
             }
 
             if (config.switches.viewability && detect.getBreakpoint() !== 'mobile') {
-                return inlineMercPromise.then(function () {
-                    return spacefinder.getParaWithSpace(rules).then(function (space) {
-                        return insertAdAtP(space);
-                    }).then(function () {
-                        return spacefinder.getParaWithSpace(rules).then(function (nextSpace) {
-                            return insertAdAtP(nextSpace);
-                        }).then(function () {
-                            return getAdSpace();
-                        });
-                    });
+                return tryAddingAdvert().then(tryAddingAdvert).then(function () {
+                    return addLongArticleAds(8);
                 });
             } else {
-                return inlineMercPromise.then(function () {
-                    return spacefinder.getParaWithSpace(rules).then(function (space) {
-                        return insertAdAtP(space);
-                    }).then(function () {
-                        if (detect.isBreakpoint({max: 'tablet'})) {
-                            return spacefinder.getParaWithSpace(rules).then(function (nextSpace) {
-                                return insertAdAtP(nextSpace);
-                            });
-                        } else {
-                            return Promise.resolve(null);
-                        }
-                    });
+                return tryAddingAdvert().then(function () {
+                    if (detect.isBreakpoint({max: 'tablet'})) {
+                        return tryAddingAdvert();
+                    } else {
+                        return Promise.resolve(null);
+                    }
                 });
+            }
+
+            function tryAddingAdvert() {
+                return spaceFiller.insertAtFirstSpace(rules, insertAdAtPara);
             }
         };
 
@@ -135,7 +116,7 @@ define([
         init: init,
         // rules exposed for spacefinder debugging
         getRules: getRules,
-        getLenientRules: getInlineMerchRules,
+        getInlineMerchRules: getInlineMerchRules,
 
         reset: function () {
             ads = [];

--- a/static/test/javascripts/spec/common/article/rich-links.spec.js
+++ b/static/test/javascripts/spec/common/article/rich-links.spec.js
@@ -31,19 +31,21 @@ define([
         };
 
         var articleBodyFixtureElement,
-            richLinks, config, spacefinder,
+            richLinks, config, spaceFiller,
             injector = new Injector();
 
         beforeEach(function (done) {
             articleBodyFixtureElement = fixtures.render(articleBodyConf);
 
-            injector.require(['common/modules/article/rich-links', 'common/utils/config', 'common/modules/article/spacefinder'], function () {
+            injector.require(['common/modules/article/rich-links', 'common/utils/config', 'common/modules/article/space-filler'], function () {
                 richLinks = arguments[0];
                 config = arguments[1];
-                spacefinder = arguments[2];
+                spaceFiller = arguments[2];
 
-                spacefinder.getParaWithSpace = function () {
-                    return Promise.resolve($('#article-body p').first());
+                spaceFiller.insertAtFirstSpace = function (rules, writer) {
+                    var space = $('#article-body p').first();
+                    writer(space);
+                    return Promise.resolve(true);
                 };
 
                 done();

--- a/static/test/javascripts/spec/common/commercial/article-body-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/article-body-adverts.spec.js
@@ -14,218 +14,278 @@ define([
     Injector
 ) {
     describe('Article Body Adverts', function () {
-        var getParaWithSpaceStub, $fixturesContainer, $style,
-            fixturesConfig = {
-                id: 'article-body-adverts',
-                fixtures: [
-                    '<p class="first-para"></p>',
-                    '<p class="second-para"></p>',
-                    '<p class="third-para"></p>',
-                    '<p class="para"></p>',
-                    '<p class="para"></p>',
-                    '<p class="para"></p>',
-                    '<p class="para"></p>',
-                    '<p class="para"></p>',
-                    '<p class="para"></p>',
-                    '<p class="para"></p>',
-                    '<p class="para"></p>'
-                ]
-            },
-            injector = new Injector(),
-            articleBodyAdverts, config, detect, spacefinder, commercialFeatures;
+        var injector = new Injector(),
+            articleBodyAdverts,
+            spaceFiller,
+            commercialFeatures,
+            config,
+            detect;
 
         beforeEach(function (done) {
 
             injector.require([
                 'common/modules/commercial/article-body-adverts',
+                'common/modules/commercial/commercial-features',
+                'common/modules/article/space-filler',
                 'common/utils/config',
-                'common/utils/detect',
-                'common/modules/article/spacefinder',
-                'common/modules/commercial/commercial-features'
+                'common/utils/detect'
             ], function () {
                 articleBodyAdverts = arguments[0];
-                config = arguments[1];
-                detect = arguments[2];
-                spacefinder = arguments[3];
-                commercialFeatures = arguments[4];
 
-                $fixturesContainer = fixtures.render(fixturesConfig);
-                $style = $.create('<style type="text/css"></style>')
-                    .html('body:after{ content: "desktop"}')
-                    .appendTo('head');
-
-                config.switches = {
-                    standardAdverts: true,
-                    viewability: true
-                };
-                config.tests = {
-                    mobileTopBannerRemove: false
-                };
-                detect.getBreakpoint = function () {
-                    return 'desktop';
-                };
-
-                getParaWithSpaceStub = sinon.stub();
-                var paras = qwery('p', $fixturesContainer);
-                getParaWithSpaceStub.onCall(0).returns(Promise.resolve(paras[0]));
-                getParaWithSpaceStub.onCall(1).returns(Promise.resolve(paras[1]));
-                getParaWithSpaceStub.onCall(2).returns(Promise.resolve(paras[2]));
-                getParaWithSpaceStub.onCall(3).returns(Promise.resolve(paras[3]));
-                getParaWithSpaceStub.onCall(4).returns(Promise.resolve(paras[4]));
-                getParaWithSpaceStub.onCall(5).returns(Promise.resolve(paras[5]));
-                getParaWithSpaceStub.onCall(6).returns(Promise.resolve(paras[6]));
-                getParaWithSpaceStub.onCall(7).returns(Promise.resolve(paras[7]));
-                getParaWithSpaceStub.onCall(8).returns(Promise.resolve(paras[8]));
-                getParaWithSpaceStub.onCall(9).returns(Promise.resolve(paras[9]));
-                getParaWithSpaceStub.onCall(10).returns(Promise.resolve(paras[10]));
-                getParaWithSpaceStub.onCall(11).returns(Promise.resolve(undefined));
-                spacefinder.getParaWithSpace = getParaWithSpaceStub;
-
+                commercialFeatures = arguments[1];
                 commercialFeatures.articleBodyAdverts = true;
+
+                spaceFiller = arguments[2];
+                spyOn(spaceFiller, 'insertAtFirstSpace').and.callFake(function () {
+                    return new Promise.resolve(true);
+                });
+
+                config = arguments[3];
+                config.page = {};
+                config.switches = {};
+
+                detect = arguments[4];
 
                 done();
             });
-        });
-
-        afterEach(function () {
-            fixtures.clean(fixturesConfig.id);
-            $style.remove();
-            articleBodyAdverts.reset();
         });
 
         it('should exist', function () {
             expect(articleBodyAdverts).toBeDefined();
         });
 
-        it('should call "getParaWithSpace" with correct arguments', function (done) {
-            detect.isBreakpoint = function () {
-                return false;
-            };
-
-            config.switches.viewability = false;
-
-            articleBodyAdverts.init()
-                .then(function () {
-                    expect(getParaWithSpaceStub).toHaveBeenCalledWith({
-                        minAbove: 700,
-                        minBelow: 300,
-                        selectors: {
-                            ' > h2': {minAbove: 0, minBelow: 250},
-                            ' > *:not(p):not(h2)': {minAbove: 35, minBelow: 400},
-                            ' .ad-slot': {minAbove: 500, minBelow: 500}
-                        }
-                    });
-                    done();
-                });
-        });
-
-        it('should call "getParaWithSpace" with correct arguments multiple times - in test', function (done) {
-            config.switches.viewability = true;
-
-            articleBodyAdverts.init()
-                .then(function () {
-                    expect(getParaWithSpaceStub).toHaveBeenCalledWith({
-                        minAbove: 700,
-                        minBelow: 300,
-                        selectors: {
-                            ' > h2': {minAbove: 0, minBelow: 250},
-                            ' > *:not(p):not(h2)': {minAbove: 35, minBelow: 400},
-                            ' .ad-slot': {minAbove: 500, minBelow: 500}
-                        }
-                    });
-                    done();
-                })
-                .then(function () {
-                    expect(getParaWithSpaceStub).toHaveBeenCalledWith({
-                        minAbove: 700,
-                        minBelow: 300,
-                        selectors: {
-                            ' > h2': {minAbove: 0, minBelow: 250},
-                            ' > *:not(p):not(h2)': {minAbove: 35, minBelow: 400},
-                            ' .ad-slot': {minAbove: 500, minBelow: 500}
-                        }
-                    });
-                    done();
-                })
-                .then(function () {
-                    expect(getParaWithSpaceStub).toHaveBeenCalledWith({
-                        minAbove: 700,
-                        minBelow: 300,
-                        selectors: {
-                            ' > h2': {minAbove: 0, minBelow: 250},
-                            ' > *:not(p):not(h2)': {minAbove: 35, minBelow: 400},
-                            ' .ad-slot': {minAbove: 1300, minBelow: 1300}
-                        }
-                    });
-                    done();
-                });
-        });
-
-        it('should call "getParaWithSpace" max 2 times when not viewability and on max tablet', function (done) {
-            config.switches.viewability = false;
-            detect.isBreakpoint = function () { return true; };
-
-            articleBodyAdverts.init()
-                .then(function () {
-                    expect(getParaWithSpaceStub.callCount).toEqual(2);
-                    done();
-                });
-        });
-
-        it('should call "getParaWithSpace" max 2 times when not viewability and on desktop', function (done) {
-            config.switches.viewability = false;
-            detect.isBreakpoint = function () { return false; };
-
-            articleBodyAdverts.init()
-                .then(function () {
-                    expect(getParaWithSpaceStub.callCount).toEqual(1);
-                    done();
-                });
-        });
-
-        it('should call "getParaWithSpace" max 2 times when not on mobile', function (done) {
-            config.switches.viewability = true;
-            detect.getBreakpoint = function () { return 'mobile'; };
-            detect.isBreakpoint = function () { return true; };
-
-            articleBodyAdverts.init()
-                .then(function () {
-                    expect(getParaWithSpaceStub.callCount).toEqual(2);
-                    done();
-                });
-        });
-
-        it('should call "getParaWithSpace" max 10 times', function (done) {
-            config.switches.viewability = true;
-
-            articleBodyAdverts.init()
-                .then(function () {
-                    expect(getParaWithSpaceStub.callCount).toEqual(10);
-                    done();
-                });
-        });
-
-        it('should not not display ad slot if turned off in commercial features', function () {
+        it('should exit if commercial feature disabled', function () {
             commercialFeatures.articleBodyAdverts = false;
-            expect(articleBodyAdverts.init()).toBe(false);
+            var executionResult = articleBodyAdverts.init();
+            expect(executionResult).toBe(false);
+            expect(spaceFiller.insertAtFirstSpace).not.toHaveBeenCalled();
         });
 
-        it('should insert an inline ad container to the available slot', function (done) {
+        it('should call space-filler`s insertion method with the correct arguments', function (done) {
             articleBodyAdverts.init().then(function () {
-                expect(getParaWithSpaceStub).toHaveBeenCalled();
-                expect(qwery('#dfp-ad--inline1', $fixturesContainer).length).toBe(1);
+                var args = spaceFiller.insertAtFirstSpace.calls.first().args,
+                    rulesArg = args[0],
+                    writerArg = args[1];
+
+                expect(rulesArg.minAbove).toBeDefined();
+                expect(rulesArg.minBelow).toBeDefined();
+                expect(rulesArg.selectors).toBeDefined();
+
+                expect(writerArg).toEqual(jasmine.any(Function));
+
                 done();
             });
         });
 
-        it('should insert an inline merchandising slot if page has one', function (done) {
-            config.page.hasInlineMerchandise = true;
-            articleBodyAdverts.init().then(function () {
-                expect(qwery('#dfp-ad--im', $fixturesContainer).length).toBe(1);
-                expect(qwery('#dfp-ad--inline1', $fixturesContainer).length).toBe(1);
-                done();
+        describe('When merchandising components enabled', function () {
+            beforeEach(function () {
+                config.page.hasInlineMerchandise = true;
+            });
+
+            it('its first call to space-filler uses the inline-merch rules', function (done) {
+                articleBodyAdverts.init().then(function () {
+                    var firstCall = spaceFiller.insertAtFirstSpace.calls.first(),
+                        rules = firstCall.args[0];
+
+                    expect(rules.minAbove).toEqual(300);
+                    expect(rules.selectors[' > h2'].minAbove).toEqual(20);
+
+                    done();
+                });
+            });
+
+            it('its first call to space-filler passes an inline-merch writer', function (done) {
+                var fixture = document.createElement('div'),
+                    paragraph = document.createElement('p');
+                fixture.appendChild(paragraph);
+
+                articleBodyAdverts.init().then(function () {
+                    var firstCall = spaceFiller.insertAtFirstSpace.calls.first(),
+                        writer = firstCall.args[1];
+                    writer(paragraph);
+
+                    var expectedAd = fixture.querySelector('#dfp-ad--im');
+                    expect(expectedAd).toBeTruthy();
+
+                    done();
+                });
             });
         });
 
+        describe('Non-merchandising adverts', function () {
+            beforeEach(function () {
+                config.page.hasInlineMerchandise = false; // exclude IM components from count
+            });
+
+            describe('When viewability enabled', function () {
+                beforeEach(function () {
+                    config.switches.viewability = true;
+                });
+
+                it('inserts up to two on mobile', function (done) {
+                    detect.getBreakpoint = function () {return 'mobile';};
+                    detect.isBreakpoint = function () {
+                        return true; // fudge breakpoint check
+                    };
+
+                    articleBodyAdverts.init().then(function () {
+                        expect(spaceFiller.insertAtFirstSpace.calls.count()).toBe(2);
+                        done();
+                    });
+                });
+
+                describe('On mobiles and desktops', function () {
+                    beforeEach(function () {
+                        detect.getBreakpoint = function () {
+                            return 'tablet';
+                        };
+                    });
+
+                    it('inserts up to ten adverts', function (done) {
+                        articleBodyAdverts.init().then(function () {
+                            expect(spaceFiller.insertAtFirstSpace.calls.count()).toBe(10);
+                            done();
+                        });
+                    });
+
+                    it('inserts the third+ adverts with greater vertical spacing', function (done) {
+                        // We do not want the same ad-density on long-read
+                        // articles that we have on shorter pieces
+                        articleBodyAdverts.init().then(function () {
+                            var insertionCalls = spaceFiller.insertAtFirstSpace.calls.all();
+                            var longArticleInsertionCalls = insertionCalls.slice(2);
+                            var longArticleInsertionRules = longArticleInsertionCalls.map(function (call) {
+                                return call.args[0];
+                            });
+                            longArticleInsertionRules.forEach(function (ruleset) {
+                                var adSlotSpacing = ruleset.selectors[' .ad-slot'];
+                                expect(adSlotSpacing).toEqual({minAbove: 1300, minBelow: 1300});
+                            });
+                            done();
+                        });
+                    });
+                });
+            });
+
+            describe('When viewability disabled', function () {
+                beforeEach(function () {
+                    config.switches.viewability = false;
+                });
+
+                it('tries to add two on mobiles and tablets', function (done) {
+                    detect.isBreakpoint = function () {
+                        return true; // fudge check for max:tablet
+                    };
+
+                    articleBodyAdverts.init().then(function () {
+                        expect(spaceFiller.insertAtFirstSpace.calls.count()).toBe(2);
+                        done();
+                    });
+                });
+
+                it('tries to add just one on desktop', function (done) {
+                    detect.isBreakpoint = function () {
+                        return false; //fudge check for max:tablet
+                    };
+
+                    articleBodyAdverts.init().then(function () {
+                        expect(spaceFiller.insertAtFirstSpace.calls.count()).toBe(1);
+                        done();
+                    });
+                });
+            });
+
+            describe('Spacefinder rules', function () {
+
+                it('includes basic rules for all circumstances', function (done) {
+                    getFirstRulesUsed().then(function (rules) {
+                        // do not appear in the bottom 300px of the article
+                        expect(rules.minBelow).toBe(300);
+
+                        // do not appear above headings
+                        expect(rules.selectors[' > h2'].minBelow).toEqual(250);
+
+                        // do not appear next to other adverts
+                        expect(rules.selectors[' .ad-slot']).toEqual({
+                            minAbove : 500,
+                            minBelow : 500
+                        });
+
+                        // do not appear next to non-paragraph elements
+                        expect(rules.selectors[' > *:not(p):not(h2)']).toEqual({
+                            minAbove : 35,
+                            minBelow : 400
+                        });
+
+                        done();
+                    });
+                });
+
+                it('includes rules for mobile phones', function (done) {
+                    detect.getBreakpoint = function () {
+                        return 'mobile';
+                    };
+                    detect.isBreakpoint = function () {
+                        return true; // fudge check for max:tablet
+                    };
+
+                    getFirstRulesUsed().then(function (rules) {
+                        // adverts can appear higher up the page
+                        expect(rules.minAbove).toEqual(300);
+
+                        // give headings more vertical clearance
+                        expect(rules.selectors[' > h2'].minAbove).toEqual(20);
+
+                        done();
+                    });
+                });
+
+                it('includes rules for tablet devices', function (done) {
+                    detect.getBreakpoint = function () {
+                        return 'tablet';
+                    };
+                    detect.isBreakpoint = function () {
+                        return true; // fudge check for max:tablet
+                    };
+
+                    getFirstRulesUsed().then(function (rules) {
+                        // adverts can appear higher up the page
+                        expect(rules.minAbove).toEqual(300);
+
+                        // give headings no vertical clearance
+                        expect(rules.selectors[' > h2'].minAbove).toEqual(0);
+
+                        done();
+                    });
+                });
+
+                it('includes rules for larger screens', function (done) {
+                    detect.getBreakpoint = function () {
+                        return 'desktop';
+                    };
+                    detect.isBreakpoint = function () {
+                        return false; // fudge check for max:tablet
+                    };
+
+                    getFirstRulesUsed().then(function (rules) {
+                        // adverts give the top of the page more clearance
+                        expect(rules.minAbove).toEqual(700);
+
+                        // give headings no vertical clearance
+                        expect(rules.selectors[' > h2'].minAbove).toEqual(0);
+
+                        done();
+                    });
+                });
+
+                function getFirstRulesUsed() {
+                    return articleBodyAdverts.init().then(function () {
+                        var firstCall = spaceFiller.insertAtFirstSpace.calls.first();
+                        return firstCall.args[0];
+                    });
+                }
+
+            });
+        });
     });
 });

--- a/static/test/javascripts/spec/common/content/space-filler.spec.js
+++ b/static/test/javascripts/spec/common/content/space-filler.spec.js
@@ -1,0 +1,129 @@
+define([
+    'helpers/injector'
+], function (
+    Injector
+) {
+    var injector = new Injector();
+
+    describe('Space filler', function () {
+        var spaceFiller,
+            spaceFinder,
+            raven,
+            mockRules = {},
+            mockSpacefinderResult,
+            mockException = new Error('Mock writer exception');
+
+        beforeEach(function (done) {
+            injector.require([
+                'common/modules/article/space-filler',
+                'common/modules/article/spacefinder',
+                'raven'
+            ], function () {
+                spaceFiller = arguments[0];
+                spaceFinder = arguments[1];
+                raven = arguments[2];
+
+                spaceFiller = new spaceFiller.constructor();
+
+                spyOn(spaceFinder, 'getParaWithSpace').and.callFake(function () {
+                    return new Promise.resolve(mockSpacefinderResult);
+                });
+
+                spyOn(raven, 'captureException');
+
+                done();
+            });
+        });
+
+        it('Returns a promise that resolves when the insertion completes', function (done) {
+            mockSpacefinderResult = null;
+            var insertion = spaceFiller.insertAtFirstSpace(mockRules, function mockWriter() {});
+            expect(insertion).toEqual(jasmine.any(Promise));
+            insertion.then(done);
+        });
+
+        it('Passes a ruleset and a debug flag to the spacefinder', function (done) {
+            var insertion = spaceFiller.insertAtFirstSpace(mockRules, function mockWriter() {}, true);
+            insertion.then(function () {
+                var spaceFinderArgs = spaceFinder.getParaWithSpace.calls.mostRecent().args;
+                expect(spaceFinderArgs[0]).toBe(mockRules);
+                expect(spaceFinderArgs[1]).toBe(true);
+                done();
+            });
+        });
+
+        it('If it finds a space, it calls the writer', function (done) {
+            mockSpacefinderResult = document.createElement('p');
+            spaceFiller.insertAtFirstSpace(mockRules, function mockWriter() {
+                done();
+            });
+        });
+
+        it('If it finds a space, it resolves the promise with `true`', function (done) {
+            mockSpacefinderResult = document.createElement('p');
+            var insertion = spaceFiller.insertAtFirstSpace(mockRules, function () {});
+
+            insertion.then(function onFulfilled(resolution) {
+                expect(resolution).toBe(true);
+                done();
+            });
+        });
+
+        it('If there are no spaces, it resolves the promise with "false" and does not call the writer', function (done) {
+            var mockWriter = jasmine.createSpy('mockWriter'),
+            insertion = spaceFiller.insertAtFirstSpace(mockRules, mockWriter);
+            mockSpacefinderResult = null;
+
+            insertion.then(function (insertionResult) {
+                expect(insertionResult).toBe(false);
+                expect(mockWriter).not.toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it('Calls writers in order', function (done) {
+            // This resolves a longstanding race condition where spacefinder calls would come
+            // before the scripts that inject content into spaces had completely ran
+            mockSpacefinderResult = document.createElement('p');
+            var firstWriter = jasmine.createSpy('first write');
+
+            spaceFiller.insertAtFirstSpace(mockRules, firstWriter);
+            spaceFiller.insertAtFirstSpace(mockRules, function secondWriter() {
+                expect(firstWriter).toHaveBeenCalled();
+                done();
+            });
+        });
+
+        it('If a writer throws an exception, we record it', function (done) {
+            mockSpacefinderResult = document.createElement('p');
+            var insertion = spaceFiller.insertAtFirstSpace(mockRules, function () {
+                throw mockException;
+            });
+
+            insertion.then(function () {
+                expect(raven.captureException).toHaveBeenCalledWith(mockException);
+                done();
+            });
+        });
+
+        it('If a writer throws an exception, we still call subsequent writers', function (done) {
+            mockSpacefinderResult = document.createElement('p');
+            spaceFiller.insertAtFirstSpace(mockRules, function () {
+                throw mockException;
+            });
+            spaceFiller.insertAtFirstSpace(mockRules, done);
+        });
+
+        it('If a writer throws an exception, the promise is resolved with "false"', function (done) {
+            mockSpacefinderResult = document.createElement('p');
+            var insertion = spaceFiller.insertAtFirstSpace(mockRules, function () {
+                throw mockException;
+            });
+
+            insertion.then(function (result) {
+                expect(result).toBe(false);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
@uplne 

A previous fix for a [Spacefinder race condition](https://github.com/guardian/frontend/pull/11159) had to be pulled because a new file, 'space-filler', was being called from both the `commercial.js` and `enhanced.js` bundles.

I've resolved the issue by adding space-filler to `core.js`. See the final commit, b85aefa.
