### PR TITLE
Membership adblock banner print fix

### DIFF
--- a/static/src/stylesheets/print.scss
+++ b/static/src/stylesheets/print.scss
@@ -7,6 +7,7 @@
 .block-share__link,
 .l-header,
 .top-banner-ad-container,
+.adblock-sticky__message,
 .content__secondary-column,
 .content__labels,
 .content-footer,


### PR DESCRIPTION
It shouldn't be visible on print pages.
