### PR TITLE
Hiding the Most Popular tabs for video front

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/geo-most-popular-front.js
@@ -26,6 +26,7 @@ define([
 
     GeoMostPopularFront.prototype.endpoint = '/most-read-geo.json';
     GeoMostPopularFront.prototype.isNetworkFront = config.page.contentType === 'Network Front';
+    GeoMostPopularFront.prototype.isVideoFront = config.page.pageId === 'video';
     GeoMostPopularFront.prototype.isInternational = config.page.pageId === 'international';
     GeoMostPopularFront.prototype.manipulationType = 'html';
 
@@ -43,7 +44,7 @@ define([
         this.parent = qwery('.js-popular-trails')[0];
 
         if (this.parent) {
-            if (this.isInternational && this.isNetworkFront) {
+            if ((this.isInternational && this.isNetworkFront) || this.isVideoFront) {
                 // hide the tabs
                 hideTabs(this.parent);
             } else {


### PR DESCRIPTION
On the video front we only show across the guardian most popular, and geo most popular. However, the tab says "in video". As you can see from the screenshot below, none of these are videos.

![image](https://cloud.githubusercontent.com/assets/8774970/11499025/13c18376-981b-11e5-92f8-59f4c05f645d.png)

As a quick fix, I propose we hide the tabs like we do with the network front so at least it wont say "in video".

cc @OliverJAsh @Jholder112233 
