### PR TITLE
Fix empty response for masterclass component

### DIFF
--- a/commercial/app/model/commercial/masterclasses/EventbriteApi.scala
+++ b/commercial/app/model/commercial/masterclasses/EventbriteApi.scala
@@ -9,6 +9,7 @@ import play.api.libs.json.{JsArray, JsValue, Json}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.control.NonFatal
 
 object EventbriteApi extends ExecutionContexts with Logging {
 
@@ -50,6 +51,10 @@ object EventbriteApi extends ExecutionContexts with Logging {
     }
 
     val eventualEvents = events flatMap identity
+
+    eventualEvents onFailure {
+      case NonFatal(e) => log.error(s"Failed to load from $feedName: ${e.getMessage}")
+    }
 
     eventualEvents onSuccess {
       case results => log.info(s"Loaded ${results.size} $feedName from $url")

--- a/commercial/app/model/commercial/masterclasses/MasterClass.scala
+++ b/commercial/app/model/commercial/masterclasses/MasterClass.scala
@@ -40,9 +40,10 @@ object EventbriteMasterClass {
         for {
           ticketClass <- ticketClasses
           hidden <- (ticketClass \ "hidden").asOpt[Boolean]
+          cost <- (ticketClass \ "cost").asOpt[JsValue]
           if !hidden
         } yield {
-          val price = (ticketClass \ "cost" \ "value").as[Int] / 100
+          val price = (cost \ "value").as[Int] / 100
           new Ticket(price)
         }
       }


### PR DESCRIPTION
There was an event in the feed that didn't have a cost value, which was assumed to have a value for all events.

/cc @Calanthe 
