### PR TITLE
Video prerolls skip button tracking fixed in omniture

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -182,6 +182,7 @@ define([
 
             player.one('video:preroll:request', this.sendNamedEvent.bind(this, 'preroll:request', true));
             player.one('video:preroll:play', this.onPrerollPlay.bind(this));
+            player.one('video:preroll:skip', this.sendNamedEvent.bind(this, 'preroll:skip', true));
             player.one('video:preroll:end', this.sendNamedEvent.bind(this, 'preroll:end', true));
             player.one('video:content:play', this.onContentPlay.bind(this));
             player.one('audio:content:play', this.sendNamedEvent.bind(this, 'audio:play'));


### PR DESCRIPTION
The event number `event99` was set some time ago but we didn't fire that event at all. 

After:
![screen shot 2015-12-02 at 13 40 18](https://cloud.githubusercontent.com/assets/489567/11532117/92676158-98f9-11e5-8ba7-0e5f8150cefb.png)
