### PR TITLE
Make sure assets fallback to source file in dev, if missing from the hash list

### DIFF
--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -165,5 +165,5 @@ object AssetFinder {
 
 case class AssetNotFoundException(assetPath: String) extends Exception {
   override val getMessage: String =
-    s"Cannot find asset $assetPath. You probably need to run 'make compile'."
+    s"Cannot find asset $assetPath. Have you got the right path? Or do need to run 'make compile', or 'make compile-dev'?."
 }

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -165,5 +165,5 @@ object AssetFinder {
 
 case class AssetNotFoundException(assetPath: String) extends Exception {
   override val getMessage: String =
-    s"Cannot find asset $assetPath. Have you got the right path? Or do need to run 'make compile', or 'make compile-dev'?."
+    s"Cannot find asset $assetPath. Have you got the right path? Or do you need to run 'make compile', or 'make compile-dev'?."
 }

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -22,7 +22,7 @@ class AssetMap(base: String, assetMap: String) {
 
     // Avoid memoizing the asset map in Dev.
     if (Play.current.mode == Mode.Dev) {
-      assets().getOrElse(path, throw AssetNotFoundException(path))
+      assets().getOrElse(path, Asset(path))
     } else {
       memoizedAssets(path)
     }

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -1,6 +1,7 @@
 package common.Assets
 
 import java.net.URL
+import java.io.File
 
 import common.{Logging, RelativePathEscaper}
 import conf.Configuration
@@ -22,7 +23,11 @@ class AssetMap(base: String, assetMap: String) {
 
     // Avoid memoizing the asset map in Dev.
     if (Play.current.mode == Mode.Dev) {
-      assets().getOrElse(path, Asset(path))
+      assets().getOrElse(path, if (new File(s"static/src/$path").exists()) {
+        Asset(path)
+      } else {
+        throw AssetNotFoundException(path)
+      })
     } else {
       memoizedAssets(path)
     }

--- a/makefile
+++ b/makefile
@@ -5,10 +5,10 @@ watch: compile-dev
 		./node_modules/.bin/gulp --cwd ./dev watch:css & \
 		./node_modules/browser-sync/bin/browser-sync.js start --config ./dev/bs-config.js
 
-compile:
+compile: clean-assets
 	@grunt compile-assets
 
-compile-dev:
+compile-dev: clean-assets
 	@grunt compile-assets --dev
 
 install:
@@ -42,6 +42,9 @@ validate-js:
 shrinkwrap:
 	@npm shrinkwrap --dev && node dev/clean-shrinkwrap.js
 	@node tools/messages.js did-shrinkwrap
+
+clean-assets:
+	@rm -rf static/target static/hash static/requirejs
 
 
 # internal targets


### PR DESCRIPTION
#11109 broke the model whereby any files that are not compiled in dev (most JS) but which _are_ required by `@Static` in scala (e.g. in [analytics.scala.html](https://github.com/guardian/frontend/blob/master/common/app/views/fragments/analytics.scala.html#L33)) will error because they were missing from the asset hash json.

This PR:
- removes `static/target`, `static/hash` and `static/requirejs` directories before compiling, to ensure they're completely clean
- ensures the path lookup fallsback to `src` dir if it's missing from the asset map in dev, and errors if that `src` file doesn't exist.

@rich-nguyen @jennysivapalan you might want to check this :wink: – that file lookup feels nasty but actual io happens in different places for different ways in (http request, `@Static` etc)
