### PR TITLE
Fix bootstrap styling for admin troubleshooter

### DIFF
--- a/admin/app/views/troubleshooterResults.scala.html
+++ b/admin/app/views/troubleshooterResults.scala.html
@@ -19,7 +19,7 @@
                         @if(result.isOk){
                             <span class="label label-success">OK</span>
                         } else {
-                            <span class="label label-important">FAILED</span>
+                            <span class="label label-danger">FAILED</span>
                         }
                     </td>
                     <td>@result.name</td>


### PR DESCRIPTION
the `label-important` class is no longer part of Bootstrap css
