### PR TITLE
Load 3rd party code without waiting for DFP

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -40,10 +40,8 @@ define([
 
         // Outbrain needs to be loaded before first ad as it is checking for presence of high relevance component on page
         outbrain.init();
-        // Load third parties after first ad was rendered
-        mediator.once('modules:commercial:dfp:rendered', function () {
-            loadOther();
-        });
+
+        loadOther();
 
         return Promise.resolve(null);
     }


### PR DESCRIPTION
We used to load our 3rd party scripts after the DFP loaded event is fired. This is not guaranteed to happen thanks to Ad blocking, and suppressed ads on sensitive content. 

So I'm removing it.
