### PR TITLE
Use members-data-api for card updates

### DIFF
--- a/static/src/javascripts/projects/membership/payment-form.js
+++ b/static/src/javascripts/projects/membership/payment-form.js
@@ -34,7 +34,7 @@ define([
             ERROR_CARD_EXPIRY: 'js-error--card-expiry',
             HIDE: 'is-hidden',
             PAYMENT_ERRORS: 'js-payment-errors',
-            FORM_SUBMIT: 'js-submit-input',
+            FORM_SUBMIT: 'submit-input',
             CREDIT_CARD_NUMBER: 'js-credit-card-number',
             CREDIT_CARD_CVC: 'js-credit-card-cvc',
             CREDIT_CARD_EXPIRY_MONTH: 'js-credit-card-exp-month',
@@ -94,7 +94,7 @@ define([
             token = response.id;
 
             ajax({
-                url: config.page.membershipUrl + '/subscription/update-card',
+                url: config.page.userAttributesApiUrl + '/me/membership-update-card',
                 crossOrigin: true,
                 withCredentials: true,
                 method: 'post',
@@ -105,6 +105,7 @@ define([
                     stripeToken: token
                 }
             }).then(function success() {
+                $(self.config.DOM.FORM_SUBMIT).removeAttr('disabled');
                 self.stopLoader();
                 self.reset();
                 self.successCallback.apply(this, arguments);
@@ -254,7 +255,7 @@ define([
 
             // turn month select errors on when submitting
             self.displayMonthError = true;
-
+            $(self.config.DOM.FORM_SUBMIT).attr('disabled', true);
             var formValidationResult = self.isFormValid();
 
             if (formValidationResult.isValid) {

--- a/static/src/javascripts/projects/membership/payment-form.js
+++ b/static/src/javascripts/projects/membership/payment-form.js
@@ -34,7 +34,7 @@ define([
             ERROR_CARD_EXPIRY: 'js-error--card-expiry',
             HIDE: 'is-hidden',
             PAYMENT_ERRORS: 'js-payment-errors',
-            FORM_SUBMIT: 'submit-input',
+            FORM_SUBMIT: 'js-mem-change-cc-submit',
             CREDIT_CARD_NUMBER: 'js-credit-card-number',
             CREDIT_CARD_CVC: 'js-credit-card-cvc',
             CREDIT_CARD_EXPIRY_MONTH: 'js-credit-card-exp-month',

--- a/static/test/javascripts/fixtures/membership/paymentForm.fixture.html
+++ b/static/test/javascripts/fixtures/membership/paymentForm.fixture.html
@@ -81,7 +81,7 @@
         </div>
         <div class="fieldset__fields">
             <div class="actions top">
-                <button type="submit" class="submit-input default-action js-submit-input">Subscribe</button>
+                <button type="submit" class="submit-input default-action js-mem-change-cc-submit">Subscribe</button>
             </div>
         </div>
     </fieldset>

--- a/static/test/javascripts/spec/membership/payment-form.spec.js
+++ b/static/test/javascripts/spec/membership/payment-form.spec.js
@@ -66,7 +66,7 @@ define([
             errorMessageContainer = paymentFormFixtureElement.querySelectorAll('.js-payment-errors')[0];
             creditCardNumberInputElement = paymentFormFixtureElement.querySelectorAll('.js-credit-card-number')[0];
             creditCardVerificationCodeInputElement = paymentFormFixtureElement.querySelectorAll('.js-credit-card-cvc')[0];
-            submitButtonElement = paymentFormFixtureElement.querySelectorAll('.js-submit-input')[0];
+            submitButtonElement = paymentFormFixtureElement.querySelectorAll('.js-mem-change-cc-submit')[0];
             errorMessageDisplayElement = paymentFormFixtureElement.querySelectorAll('.js-payment-errors')[0];
             creditCardImageElement = paymentFormFixtureElement.querySelectorAll('.js-credit-card-image')[0];
             expiryMonthElement = paymentFormFixtureElement.querySelectorAll('.js-credit-card-exp-month')[0];


### PR DESCRIPTION
This is due to some backend changes we're making
We also disable the button when you submit a payment to prevent double submits
If there's an error it gets enabled when you change the value of a field
