### PR TITLE
Call members data api for better scalability

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -183,7 +183,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val domain = """^https?://(?:profile\.)?([^/:]+)""".r.unapplySeq(url).flatMap(_.headOption).getOrElse("theguardian.com")
     lazy val apiClientToken = configuration.getStringProperty("id.apiClientToken").getOrElse("")
     lazy val oauthUrl = configuration.getStringProperty("id.oauth.url").getOrElse("")
-    lazy val membershipUrl = configuration.getStringProperty("id.membership.url").getOrElse("membership.theguardian.com")
+    lazy val membershipUrl = configuration.getStringProperty("id.membership.url").getOrElse("https://membership.theguardian.com")
     lazy val stripePublicToken =  configuration.getStringProperty("id.membership.stripePublicToken").getOrElse("")
   }
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -184,6 +184,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val apiClientToken = configuration.getStringProperty("id.apiClientToken").getOrElse("")
     lazy val oauthUrl = configuration.getStringProperty("id.oauth.url").getOrElse("")
     lazy val membershipUrl = configuration.getStringProperty("id.membership.url").getOrElse("https://membership.theguardian.com")
+    lazy val membersDataApiUrl = configuration.getStringProperty("id.membership.url").getOrElse("https://members-data-api.theguardian.com")
     lazy val stripePublicToken =  configuration.getStringProperty("id.membership.stripePublicToken").getOrElse("")
   }
 

--- a/common/app/templates/inlineJS/blocking/membershipAccess.scala.js
+++ b/common/app/templates/inlineJS/blocking/membershipAccess.scala.js
@@ -35,9 +35,9 @@
                     crossOrigin: true,
                     withCredentials: true
                 }).then(function (resp) {
-                    var access = resp.contentAccess
+                    var access = resp.contentAccess;
                     // Check the users access matches the content
-                    var canViewContent = access && (requiresPaidTier) ? !!access.paidMember : !!access.member;
+                    var canViewContent = access && (requiresPaidTier ? access.paidMember : access.member);
                     if (canViewContent) {
                         $('body').removeClass('has-membership-access-requirement');
                     } else {

--- a/common/app/templates/inlineJS/blocking/membershipAccess.scala.js
+++ b/common/app/templates/inlineJS/blocking/membershipAccess.scala.js
@@ -19,6 +19,7 @@
         ], function($, ajax, identity) {
 
             var membershipUrl = "@Configuration.id.membershipUrl",
+                membersDataApiUrl = "@Configuration.id.membersDataApiUrl",
                 membershipAccess = "@membershipAccess",
                 requiresPaidTier = (membershipAccess.indexOf('paid-members-only') !== -1),
                 membershipAuthUrl = membershipUrl + '/choose-tier?membershipAccess=' + membershipAccess;
@@ -29,13 +30,14 @@
 
             if (identity.isUserLoggedIn()) {
                 ajax({
-                    url: membershipUrl + '/user/me',
+                    url: membersDataApiUrl + '/user-attributes/me/membership',
                     type: 'json',
                     crossOrigin: true,
                     withCredentials: true
                 }).then(function (resp) {
+                    var access = resp.contentAccess
                     // Check the users access matches the content
-                    var canViewContent = (requiresPaidTier) ? !!resp.tier && resp.isPaidTier : !!resp.tier;
+                    var canViewContent = access && (requiresPaidTier) ? !!access.paidMember : !!access.member;
                     if (canViewContent) {
                         $('body').removeClass('has-membership-access-requirement');
                     } else {

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -29,7 +29,6 @@ id.apiRoot=https://idapi.code.dev-theguardian.com
 id.apiClientToken=frontend-code-client-token
 id.webapp.url=https://id.code.dev-theguardian.com
 id.oauth.url=https://oauth.code.dev-theguardian.com
-id.membership.url=https://membership.theguardian.com
 id.membership.stripePublicToken=pk_test_Qm3CGRdrV4WfGYCpm0sftR0f
 
 # Discussion

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -26,7 +26,6 @@ id.url=https://profile.theguardian.com
 id.apiRoot=https://idapi.theguardian.com
 id.webapp.url=https://id.theguardian.com
 id.oauth.url=https://oauth.theguardian.com
-id.membership.url=https://membership.theguardian.com
 id.membership.stripePublicToken=pk_live_2O6zPMHXNs2AGea4bAmq5R7Z
 
 # Discussion


### PR DESCRIPTION
Stop the Members Area client-side restriction code from hitting the https://membership.theguardian.com/user/me endpoint (severely restricted by Salesforce API quotas and scaleability), and make it hit our new `members-data-api` (DynamoDB-backed store).

https://members-data-api.theguardian.com/user-attributes/me/membership
https://github.com/guardian/membership-attribute-service

Here is a sample piece of restricted content:

http://www.theguardian.com/membership/2015/apr/27/the-spin-london-cycle-festival-save-mop

See also #8999 - Initial PR for Members area restriction

https://trello.com/c/KhTyeT4p/193-restricted-content-change-user-me-endpoint-to-member-data-api

cc @joelochlann @OliverJAsh 
