### PR TITLE
Masterclasses nav bar

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -316,6 +316,14 @@ object Navigation {
       SectionLink("careers", "courses", "courses", "http://jobs.theguardian.com/courses"),
       SectionLink("careers", "jobs", "jobs", "http://jobs.theguardian.com"),
       SectionLink("careers", "top employers UK", "top employers UK", "/careers/britains-top-employers")
+    ),
+    "guardian-masterclasses" -> Seq(
+      SectionLink("guardian-masterclasses", "guardian masterclasses", "guardian masterclasses", "/guardian-masterclasses"),
+      SectionLink("guardian-masterclasses", "writing", "writing", "/guardian-masterclasses/writing-and-publishing"),
+      SectionLink("guardian-masterclasses", "culture", "culture", "/guardian-masterclasses/culture"),
+      SectionLink("guardian-masterclasses", "business", "business", "/guardian-masterclasses/business"),
+      SectionLink("guardian-masterclasses", "journalism", "journalism", "/guardian-masterclasses/journalism"),
+      SectionLink("guardian-masterclasses", "corporate training", "corporate training", "/guardian-masterclasses/corporate-training")
     )
   ).withDefault( _ => Nil)
 


### PR DESCRIPTION
Add guardian masterclasses links to the second nav bar, similar to careers it's not allowed in the all-sections list.
:school_satchel: 
