### PR TITLE
Remove unused val which causes exception for some tags

### DIFF
--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -110,5 +110,4 @@ case class Tag private (
   val isSectionTag: Boolean = SectionTagLookUp.sectionId(metadata.id).contains(metadata.section)
   val showSeriesInMeta = metadata.id != "childrens-books-site/childrens-books-site"
   val isKeyword = tagType == "keyword"
-  val tagWithoutSection = metadata.id.split("/")(1) // used for football nav
 }


### PR DESCRIPTION
This fixes an issue where we're unable to access `/global-development` in preview, and the content does not update in production.

This val was throwing an error because some tags do not have a `/`, e.g. `global-development`.

I believe this issue has only just come up because the val used to be lazy (and thus never evaluated) until #11212

/cc @rich-nguyen @jennysivapalan 
