### PR TITLE
Change h2 style to match new immersive headers

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -385,6 +385,17 @@
         }
     }
 
+    .section-title,
+    .from-content-api h2 {
+        @include fs-headline(5);
+        font-weight: 200;
+        padding-bottom: .5em;
+
+        @include mq(tablet) {
+            @include fs-headline(7, true);
+        }
+    }
+
     .section-title {
         position: absolute;
         z-index: 20;
@@ -393,17 +404,11 @@
         bottom: 0;
         background-color: rgba(0, 0, 0, .5);
         color: #ffffff;
-        @include fs-headline(5);
-        font-weight: 200;
         padding: .1em $gs-gutter / 2 .5em;
 
         @include mq(mobileLandscape) {
             padding-left: $gs-gutter;
             padding-right: $gs-gutter;
-        }
-
-        @include mq(tablet) {
-            @include fs-headline(7, true);
         }
 
         @include mq(leftCol) {


### PR DESCRIPTION
Just so we don't have two styles of h2 next to each other following [this PR](https://github.com/guardian/frontend/pull/11268)

Before:
![screen shot 2015-12-04 at 14 56 50](https://cloud.githubusercontent.com/assets/1607666/11592688/ffbbc2cc-9a97-11e5-88fd-3b4d39648919.png)

After:
![screen shot 2015-12-04 at 14 56 35](https://cloud.githubusercontent.com/assets/1607666/11592691/04030160-9a98-11e5-8c0b-297e076bbbc3.png)
