### PR TITLE
Temporarily remove H2 work in immersive template

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -50,7 +50,6 @@ object BodyCleaner {
       LiveBlogLinkedData(article.isLiveBlog),
       BloggerBylineImage(article),
       LiveBlogShareButtons(article),
-      ImmersiveHeaders(article.isImmersive),
       DropCaps(article.tags.isComment || article.tags.isFeature, article.isImmersive),
       FigCaptionCleaner,
       RichLinkCleaner,

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -499,24 +499,6 @@ case class ImmersiveLinks(isImmersive: Boolean) extends HtmlCleaner {
   }
 }
 
-// Magic rule to stop production staff to stop playing around in javascript
-// Explained here: https://github.com/guardian/frontend/pull/11268
-case class ImmersiveHeaders(isImmersive: Boolean) extends HtmlCleaner {
-  override def clean(document: Document): Document = {
-    if(isImmersive) {
-      document.getElementsByTag("h2").foreach{ h2 =>
-        val beforeH2 = h2.previousElementSibling()
-        if(beforeH2.hasClass("element--immersive")) {
-          beforeH2.addClass("section-image")
-          beforeH2.prepend("""<h2 class="section-title">""" + h2.text() + "</h2>")
-          h2.remove()
-        }
-      }
-    }
-    document
-  }
-}
-
 case class DropCaps(isFeature: Boolean, isImmersive: Boolean) extends HtmlCleaner {
   private def setDropCap(p: Element): String = {
     p.html.replaceFirst(
@@ -537,15 +519,13 @@ case class DropCaps(isFeature: Boolean, isImmersive: Boolean) extends HtmlCleane
     }
 
     document.getElementsByTag("h2").foreach{ h2 =>
-        if (isImmersive) {
+        if (isImmersive && h2.text() == "* * *") {
             h2.before("""<hr class="section-rule" />""")
             val next = h2.nextElementSibling()
             if (next.nodeName() == "p") {
                 next.html(setDropCap(next))
             }
-            if (h2.text() == "* * *") {
-                h2.remove()
-            }
+            h2.remove()
         }
     }
     document


### PR DESCRIPTION
Some of this can cause pages to break and should be an option based on the chapters switch.
