### PR TITLE
Add HTTPS opt-in controller

### DIFF
--- a/applications/app/controllers/HTTPSCookieController.scala
+++ b/applications/app/controllers/HTTPSCookieController.scala
@@ -1,0 +1,22 @@
+package controllers
+
+import model.Cached
+import play.api.mvc.{DiscardingCookie, Cookie, Action, Controller}
+import scala.concurrent.duration._
+
+object HTTPSCookieController extends Controller {
+  private val HTTPSOptIn = "https_opt_in"
+  private val lifetime = 90.days.toSeconds.toInt
+
+  def optIn() = Action { implicit request =>
+    Cached(60)(SeeOther("/").withCookies(
+      Cookie(HTTPSOptIn, "true", maxAge = Some(lifetime))
+    ))
+  }
+
+  def optOut() = Action { implicit request =>
+    Cached(60)(SeeOther("/").discardingCookies(
+      DiscardingCookie(HTTPSOptIn)
+    ))
+  }
+}

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -41,6 +41,9 @@ GET        /preferences                                                         
 GET        /crosswords/optin                                                    controllers.CrosswordPreferencesController.crosswordsOptIn
 GET        /crosswords/optout                                                   controllers.CrosswordPreferencesController.crosswordsOptOut
 
+GET        /https/optin                                                         controllers.HTTPSCookieController.optIn()
+GET        /https/optout                                                        controllers.HTTPSCookieController.optOut()
+
 # Web App paths
 GET        /offline-page.json                                                   controllers.WebAppController.offlinePage()
 GET        /service-worker.js                                                   controllers.WebAppController.serviceWorker()


### PR DESCRIPTION
This adds or removes the `https_opt_in` cookie as used by https://github.com/guardian/fastly-edge-cache/pull/527.
