### PR TITLE
Stop pages with expired commercial tags showing pre-ad-load sponsor text

### DIFF
--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -90,7 +90,7 @@ object PaidForTag {
   def fromLineItems(lineItems: Seq[GuLineItem]): Seq[PaidForTag] = {
 
     val lineItemsGroupedByTag: Map[String, Seq[GuLineItem]] = {
-      val logoLineItems = lineItems filter (_.paidForTags.nonEmpty)
+      val logoLineItems = lineItems filterNot (_.isExpired) filter (_.paidForTags.nonEmpty)
       logoLineItems.foldLeft(Map.empty[String, Seq[GuLineItem]]) { case (soFar, lineItem) =>
         val lineItemTags = lineItem.paidForTags map { tag =>
           val tagLineItems = soFar.get(tag).map(_ :+ lineItem).getOrElse(Seq(lineItem))

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -67,34 +67,15 @@ object InlineMerchandisingTargetedTagsReportParser extends Logging {
 }
 
 
-sealed trait TagType {
-  val name: String
-}
-
-case object Series extends TagType {
-  override val name: String = "series"
-}
-
-case object Keyword extends TagType {
-  override val name: String = "keyword"
-}
+sealed abstract class TagType(val name: String)
+case object Series extends TagType("series")
+case object Keyword extends TagType("keyword")
 
 
-sealed trait PaidForType {
-  val name: String
-}
-
-case object Sponsored extends PaidForType {
-  override val name: String = "sponsoredfeatures"
-}
-
-case object AdvertisementFeature extends PaidForType {
-  override val name: String = "advertisement-features"
-}
-
-case object FoundationFunded extends PaidForType {
-  override val name: String = "foundation-features"
-}
+sealed abstract class PaidForType(val name: String)
+case object Sponsored extends PaidForType("sponsoredfeatures")
+case object AdvertisementFeature extends PaidForType("advertisement-features")
+case object FoundationFunded extends PaidForType("foundation-features")
 
 
 case class PaidForTag(targetedName: String,


### PR DESCRIPTION
This fixes, for example, http://www.theguardian.com/sustainable-business/series/business-and-wellbeing
where expired sponsor's name is shown briefly when page loads.
