### PR TITLE
Rename membership profile CSS to manage-account

### DIFF
--- a/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
+++ b/identity/app/views/fragments/profile/membershipDetailsForm.scala.html
@@ -1,5 +1,5 @@
-<div class="membership-tab js-mem-tab" data-sprite-url="@Static("stylesheets/membership-icons.css")">
-    <div class="membership-loader js-mem-loader">
+<div class="manage-account-tab js-mem-tab" data-sprite-url="@Static("stylesheets/membership-icons.css")">
+    <div class="manage-account-loader js-mem-loader">
         <span class="is-updating show-updating"></span>
     </div>
     <div id="qa-success-message" class="form__success is-hidden js-mem-card-change-success-msg">Your card details have been updated</div>

--- a/identity/app/views/fragments/profile/membershipForm/cancelled.scala.html
+++ b/identity/app/views/fragments/profile/membershipForm/cancelled.scala.html
@@ -1,5 +1,5 @@
 <div class="is-hidden js-mem-cancel-tier">
-    <h2 id="qa-cancelled-membership" class="membership-header membership-header--highlight">You've cancelled your membership</h2>
+    <h2 id="qa-cancelled-membership" class="manage-account-header manage-account-header--highlight">You've cancelled your membership</h2>
     <p>
         Now that you've cancelled your membership, your <span class="js-mem-tier"></span> benefits will
         run out on <strong><span class="js-mem-current-period-end"></span></strong>. After that date, the

--- a/identity/app/views/fragments/profile/membershipForm/changed.scala.html
+++ b/identity/app/views/fragments/profile/membershipForm/changed.scala.html
@@ -1,5 +1,5 @@
 <div class="is-hidden js-mem-change-tier">
-    <h2 class="membership-header membership-header--highlight">You've changed packages</h2>
+    <h2 class="manage-account-header manage-account-header--highlight">You've changed packages</h2>
     <p>
         Now that you've switched packages, your <span class="js-mem-tier"></span> benefits will run out on <strong><span class="js-mem-current-period-end"></span></strong>. After that date, you'll default to our Friend level of membership. Your final <span class="js-mem-tier"></span> subscription payment was taken on <strong><span class="js-mem-current-period-start"></span></strong>.
     </p>

--- a/identity/app/views/fragments/profile/membershipForm/details.scala.html
+++ b/identity/app/views/fragments/profile/membershipForm/details.scala.html
@@ -22,7 +22,7 @@
             <div class="fieldset__fields u-cf">
                 <div class="form-field">
                     <span class="js-mem-tier" id="qa-membership-tier"></span>
-                    <a href="@(conf.Configuration.id.membershipUrl)/tier/change" id="qa-change-tier" class="submit-input membership-cta" data-link-name="Change tier">Change tier</a>
+                    <a href="@(conf.Configuration.id.membershipUrl)/tier/change" id="qa-change-tier" class="submit-input manage-account-cta" data-link-name="Change tier">Change tier</a>
                 </div>
             </div>
         </li>

--- a/identity/app/views/fragments/profile/membershipForm/upsell.scala.html
+++ b/identity/app/views/fragments/profile/membershipForm/upsell.scala.html
@@ -1,8 +1,8 @@
-<div class="membership-up-sell is-hidden js-mem-up-sell">
-    <div class="membership-up-sell__heading">
-        <h2 class="membership-header">Join Guardian Membership</h2>
+<div class="manage-account-up-sell is-hidden js-mem-up-sell">
+    <div class="manage-account-up-sell__heading">
+        <h2 class="manage-account-header">Join Guardian Membership</h2>
     </div>
-    <p class="membership-up-sell__content">We're bringing the Guardian to life through live events and meet-ups. Join and be part of the conversations that matter</p>
+    <p class="manage-account-up-sell__content">We're bringing the Guardian to life through live events and meet-ups. Join and be part of the conversations that matter</p>
     <a href="@(conf.Configuration.id.membershipUrl)/join" class="submit-input" data-link-name="Join today">Join today</a>
     <a href="@(conf.Configuration.id.membershipUrl)/about" class="submit-input" data-link-name="More about membership">More about membership</a>
 </div>

--- a/identity/app/views/fragments/profile/stripe.scala.html
+++ b/identity/app/views/fragments/profile/stripe.scala.html
@@ -10,17 +10,17 @@
 
         <div class="fieldset__fields u-cf">
             <div class="form-field">
-                <span class="card-type-display js-mma-card-type"><span class="js-mma-payment-card-text u-h"></span></span>
+                <span class="card-type-display js-manage-account-card-type"><span class="js-manage-account-payment-card-text u-h"></span></span>
                 <span id="qa-card-details" class="card-details">
-                    •••• •••• •••• <span class="js-mma-card-last4"></span>
+                    •••• •••• •••• <span class="js-manage-account-card-last4"></span>
                 </span>
-                <button id="qa-change-card" class="submit-input membership-cta js-mma-change-card is-hidden" data-link-name="Change card">
+                <button id="qa-change-card" class="submit-input manage-account-cta js-manage-account-change-card is-hidden" data-link-name="Change card">
                     Change card</button>
             </div>
         </div>
     </li>
-    <li class="details-list__item membership-tab__change-cc-form is-closed js-mma-card-details-form-container">
-        <form class="js-mma-stripe-form">
+    <li class="details-list__item manage-account-tab__change-cc-form is-closed js-manage-account-card-details-form-container">
+        <form class="js-manage-account-stripe-form">
 
             <div class="js-payment-errors qa-form-error form__error is-hidden"></div>
 
@@ -30,8 +30,8 @@
             <div class="fieldset__fields">
                 <div class="form-field">
                     <label class="label" for="cc-num">Card Number</label>
-                    <div class="input membership-tab__credit-card-container">
-                        <i class="js-credit-card-image membership-tab__card-types--in-field"></i>
+                    <div class="input manage-account-tab__credit-card-container">
+                        <i class="js-credit-card-image manage-account-tab__card-types--in-field"></i>
                         <input type="tel"
                         size="20"
                         data-stripe="number"
@@ -77,7 +77,7 @@
                     </p>
                 </div>
                 <div class="form-field">
-                    <button class="js-submit-input submit-input js-mma-change-cc-submit"
+                    <button class="js-submit-input submit-input js-manage-account-change-cc-submit"
                     type="submit"
                     data-link-name="Update card details">Update</button>
                     <div class="is-updating js-updating"></div>

--- a/static/src/javascripts/projects/membership/payment-form.js
+++ b/static/src/javascripts/projects/membership/payment-form.js
@@ -27,11 +27,11 @@ define([
 
     StripePaymentForm.prototype.config = {
         classes: {
-            CARD_TYPE: 'js-mma-card-type',
-            CARD_LAST4: 'js-mma-card-last4',
-            CHANGE_CARD: 'js-mma-change-card',
+            CARD_TYPE: 'js-manage-account-card-type',
+            CARD_LAST4: 'js-manage-account-card-last4',
+            CHANGE_CARD: 'js-manage-account-change-card',
             IS_CLOSED: 'is-closed',
-            CARD_DETAILS_FORM_CONTAINER: 'js-mma-card-details-form-container',
+            CARD_DETAILS_FORM_CONTAINER: 'js-manage-account-card-details-form-container',
             CTA_DISABLED_CLASSNAME: 'membership-cta--disabled',
             STRIPE_FORM: 'js-stripe-form',
             FORM_FIELD_ERROR: 'form-field--error',
@@ -40,7 +40,7 @@ define([
             ERROR_CARD_EXPIRY: 'js-error--card-expiry',
             HIDE: 'is-hidden',
             PAYMENT_ERRORS: 'js-payment-errors',
-            FORM_SUBMIT: 'js-mma-change-cc-submit',
+            FORM_SUBMIT: 'js-manage-account-change-cc-submit',
             CREDIT_CARD_NUMBER: 'js-credit-card-number',
             CREDIT_CARD_CVC: 'js-credit-card-cvc',
             CREDIT_CARD_EXPIRY_MONTH: 'js-credit-card-exp-month',

--- a/static/src/stylesheets/head.identity.scss
+++ b/static/src/stylesheets/head.identity.scss
@@ -13,5 +13,5 @@
 
 @import 'components/pasteup-forms/src/_forms';
 @import 'module/identity/_identity';
-@import 'module/identity/_membership-tab';
+@import 'module/identity/_manage-account-tab';
 @import 'module/identity/_formstack';

--- a/static/src/stylesheets/module/identity/_manage-account-tab.scss
+++ b/static/src/stylesheets/module/identity/_manage-account-tab.scss
@@ -1,13 +1,13 @@
-/* Edit profile Membership tab
+/* Edit profile manage-account tab
    ========================================================================== */
-.membership-tab {
+.manage-account-tab {
     padding-bottom: $gs-baseline*2;
 
     .show-updating {
         display: inline-block;
     }
 
-    .membership-loader {
+    .manage-account-loader {
         text-align: center;
         min-height: 200px;
         margin-top: $gs-baseline*4;
@@ -15,15 +15,15 @@
 
     /* Up sell
     ========================================================================== */
-    .membership-up-sell {
+    .manage-account-up-sell {
         padding: $gs-gutter*2;
     }
 
-    .membership-up-sell__heading {
+    .manage-account-up-sell__heading {
         margin-bottom: $gs-baseline;
     }
 
-    .membership-up-sell__content {
+    .manage-account-up-sell__content {
         margin-bottom: 18px;
     }
 
@@ -54,9 +54,9 @@
         vertical-align: middle;
     }
 
-    /* Membership CTA
+    /* manage-account CTA
    ========================================================================== */
-    .membership-cta {
+    .manage-account-cta {
         width: $gs-baseline*10;
         margin: ($gs-baseline/2) 0 0;
         display: block;
@@ -73,7 +73,7 @@
         }
     }
 
-    .membership-cta--disabled {
+    .manage-account-cta--disabled {
         background: none;
         color: colour(news-default);
 
@@ -89,11 +89,11 @@
 
     /* Header
        ========================================================================== */
-    .membership-header {
+    .manage-account-header {
         @include fs-header(3);
     }
 
-    .membership-header--highlight {
+    .manage-account-header--highlight {
         padding: 15px 0 15px 4px;
         margin: 32px 0 15px;
         background-color: #fff8e5;
@@ -224,7 +224,7 @@
 
     /* Credit card change form
    ========================================================================== */
-    .membership-tab__change-cc-form {
+    .manage-account-tab__change-cc-form {
         overflow: hidden;
         max-height: 424px;
         transition: all .25s ease-in-out;
@@ -249,11 +249,11 @@
         $small-card: 32px;
         $large-card: 35px;
 
-        .membership-tab__credit-card-container {
+        .manage-account-tab__credit-card-container {
             position: relative;
         }
 
-        .membership-tab__card-types--in-field {
+        .manage-account-tab__card-types--in-field {
             position: absolute;
             right: 2px;
             top: 2px;
@@ -262,7 +262,7 @@
         }
 
         @include mq(tablet) {
-            .membership-tab__card-types--in-field {
+            .manage-account-tab__card-types--in-field {
                 width: 49px !important;
                 height: $small-card !important;
                 background-size: 49px $small-card;

--- a/static/test/javascripts/fixtures/membership/paymentForm.fixture.html
+++ b/static/test/javascripts/fixtures/membership/paymentForm.fixture.html
@@ -9,16 +9,16 @@
 
             <div class="fieldset__fields u-cf">
                 <div class="form-field">
-                    <span class="card-type-display js-mma-card-type"><span class="js-mma-payment-card-text u-h"></span></span>
+                    <span class="card-type-display js-manage-account-card-type"><span class="js-manage-account-payment-card-text u-h"></span></span>
                 <span id="qa-card-details" class="card-details">
-                        •••• •••• •••• <span class="js-mma-card-last4"></span>
+                        •••• •••• •••• <span class="js-manage-account-card-last4"></span>
                     </span>
-                    <button id="qa-change-card" class="submit-input mma-cta js-mma-change-card is-hidden" data-link-name="Change card">Change card</button>
+                    <button id="qa-change-card" class="submit-input manage-account-cta js-manage-account-change-card is-hidden" data-link-name="Change card">Change card</button>
                 </div>
             </div>
         </li>
-        <li class="details-list__item mma-tab__change-cc-form is-closed js-mma-card-details-form-container">
-            <form class="js-mma-stripe-form">
+        <li class="details-list__item manage-account-tab__change-cc-form is-closed js-manage-account-card-details-form-container">
+            <form class="js-manage-account-stripe-form">
 
                 <div class="js-payment-errors qa-form-error form__error is-hidden"></div>
 
@@ -28,8 +28,8 @@
                 <div class="fieldset__fields">
                     <div class="form-field">
                         <label class="label" for="cc-num">Card Number</label>
-                        <div class="input mma-tab__credit-card-container">
-                            <i class="js-credit-card-image mma-tab__card-types--in-field"></i>
+                        <div class="input manage-account-tab__credit-card-container">
+                            <i class="js-credit-card-image manage-account-tab__card-types--in-field"></i>
                             <input type="tel"
                                    size="20"
                                    data-stripe="number"
@@ -101,7 +101,7 @@
                         </p>
                     </div>
                     <div class="form-field">
-                        <button class="js-submit-input submit-input js-mma-change-cc-submit"
+                        <button class="js-submit-input submit-input js-manage-account-change-cc-submit"
                                 type="submit"
                                 data-link-name="Update card details">Update</button>
                         <div class="is-updating js-updating"></div>

--- a/static/test/javascripts/spec/membership/payment-form.spec.js
+++ b/static/test/javascripts/spec/membership/payment-form.spec.js
@@ -66,7 +66,7 @@ define([
             errorMessageContainer = paymentFormFixtureElement.querySelectorAll('.js-payment-errors')[0];
             creditCardNumberInputElement = paymentFormFixtureElement.querySelectorAll('.js-credit-card-number')[0];
             creditCardVerificationCodeInputElement = paymentFormFixtureElement.querySelectorAll('.js-credit-card-cvc')[0];
-            submitButtonElement = paymentFormFixtureElement.querySelectorAll('.js-mma-change-cc-submit')[0];
+            submitButtonElement = paymentFormFixtureElement.querySelectorAll('.js-manage-account-change-cc-submit')[0];
             errorMessageDisplayElement = paymentFormFixtureElement.querySelectorAll('.js-payment-errors')[0];
             creditCardImageElement = paymentFormFixtureElement.querySelectorAll('.js-credit-card-image')[0];
             expiryMonthElement = paymentFormFixtureElement.querySelectorAll('.js-credit-card-exp-month')[0];


### PR DESCRIPTION
Do the same with the JS stripe selectors

mma was indeed too opaque for people outside of membership & subs

This is required as we're adding a tab using the same styles which is not related to membership
