### PR TITLE
Render something when no Main Media is added to an immersive article

### DIFF
--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -5,14 +5,16 @@
 @import views.support.ImgSrc
 @import layout._
 
-<header class="content__head content__head--desktop tonal__head tonal__head--@toneClass(article) @if(article.elements.elements("main").isEmpty) { content__head--empty }">
+<header class="content__head content__head--desktop tonal__head tonal__head--@toneClass(article)
+               @if(article.elements.hasMainEmbed || article.elements.hasMainPicture) { is-fixed-height }">
     <div class="gs-container content__logo-container">
         <a href="@LinkTo{/}">
             @fragments.inlineSvg("guardian-logo-160", "logo", Seq("content__logo"))
         </a>
     </div>
 
-    @if(article.elements.hasMainEmbed) {
+    // hasMainEmbed returns false if it's true. I dunno. Ask Rich when he's back.
+    @if(article.elements.hasMainEmbed || article.elements.elements("main").isEmpty) {
         <div class="content__loading">
             <span class="content__loading-animation is-updating"></span>
             <span class="u-h">Loading header</span>

--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -5,14 +5,14 @@
 @import views.support.ImgSrc
 @import layout._
 
-<header class="content__head content__head--desktop tonal__head tonal__head--@toneClass(article)">
+<header class="content__head content__head--desktop tonal__head tonal__head--@toneClass(article) @if(article.elements.elements("main").isEmpty) { content__head--empty }">
     <div class="gs-container content__logo-container">
         <a href="@LinkTo{/}">
             @fragments.inlineSvg("guardian-logo-160", "logo", Seq("content__logo"))
         </a>
     </div>
 
-    @if(article.elements.hasMainEmbed || article.elements.elements("main").isEmpty) {
+    @if(article.elements.hasMainEmbed) {
         <div class="content__loading">
             <span class="content__loading-animation is-updating"></span>
             <span class="u-h">Loading header</span>

--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -7,8 +7,8 @@
 
 <header class="content__head content__head--desktop tonal__head tonal__head--@toneClass(article)
                @if(article.fields.main.nonEmpty) { is-fixed-height }">
-    <div class="gs-container content__logo-container">
-        <a href="@LinkTo{/}">
+    <div class="content__logo-container">
+        <a class="gs-container" href="@LinkTo{/}">
             @fragments.inlineSvg("guardian-logo-160", "logo", Seq("content__logo"))
         </a>
     </div>

--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -6,14 +6,13 @@
 @import layout._
 
 <header class="content__head content__head--desktop tonal__head tonal__head--@toneClass(article)
-               @if(article.elements.hasMainEmbed || article.elements.hasMainPicture) { is-fixed-height }">
+               @if(article.fields.main.nonEmpty) { is-fixed-height }">
     <div class="gs-container content__logo-container">
         <a href="@LinkTo{/}">
             @fragments.inlineSvg("guardian-logo-160", "logo", Seq("content__logo"))
         </a>
     </div>
 
-    // hasMainEmbed returns false if it's true. I dunno. Ask Rich when he's back.
     @if(article.elements.hasMainEmbed || article.elements.elements("main").isEmpty) {
         <div class="content__loading">
             <span class="content__loading-animation is-updating"></span>

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -136,7 +136,7 @@
                 background-size: cover;
             }
     
-            .content__head--desktop {
+            &.content__head--desktop {
                 background-image: none !important;
             }
     
@@ -153,7 +153,7 @@
         }
     
         @include mq(desktop) {
-            .content__head--desktop {
+            &.content__head--desktop {
                 position: relative;
                 background-position: center center;
                 background-size: cover;

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -24,13 +24,37 @@
 
     .content__logo-container {
         z-index: 2;
+
+        @include mq($until: desktop) {
+            background-color: rgba(0, 0, 0, .6);
+            padding-bottom: $gs-baseline / 2;
+        }
+
+        .gs-container {
+            overflow: auto;
+            display: block;
+
+            @include mq(desktop) {
+                overflow: visible;
+            }
+        }
+
+        .is-fixed-height & {
+            background-color: transparent;
+            padding-bottom: 0;
+
+            .gs-container {
+                overflow: visible;
+            }
+        }
     }
 
     .content__logo {
-        float: right;
         width: gs-span(2) + $gs-gutter;
         height: auto;
         margin-top: $gs-baseline / 2;
+        display: block;
+        float: right;
 
         svg {
             width: 100%;

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -69,22 +69,22 @@
     }
 
     .content__headline {
-        @include fs-headline(7);
+        @include fs-headline(9);
         font-weight: 200;
         line-height: 1;
         padding-top: $gs-baseline / 2;
         padding-bottom: 1.5rem;
 
         @include mq(desktop) {
-            font-size: 3.25rem;
+            font-size: 4rem;
         }
-    }
 
-    .content__headline {
-        @include fs-headline(7);
-        
-        @include mq(desktop) {
-            
+        .is-fixed-height & {
+            @include fs-headline(7, true);
+
+            @include mq(desktop) {
+                font-size: 3.25rem;
+            }
         }
     }
 
@@ -95,19 +95,24 @@
     .content__standfirst {
         position: relative;
         padding-top: .33em;
+        padding-bottom: .5rem;
         margin-bottom: 0;
         color: #ffffff;
 
         @include mq(desktop) {
             padding-bottom: 1rem;
+        }
 
-            &:before {
-                content: '';
-                position: absolute;
-                top: 0;
-                height: 2px;
-                width: gs-span(2);
-                background-color: rgba(255, 255, 255, .2);
+        &:before {
+            content: '';
+            position: absolute;
+            top: 0;
+            height: 2px;
+            width: gs-span(2);
+            background-color: rgba(255, 255, 255, .2);
+
+            .is-fixed-height & {
+                display: none;
             }
         }
 
@@ -119,6 +124,49 @@
                 text-decoration: none;
                 border-bottom-color: rgba(colour(feature-mute), .8);
             }
+        }
+    }
+
+    .content__loading {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: colour(neutral-5);
+        color: colour(neutral-1);
+        display: none;
+
+        // Should be removed when capi returns a no-id element for code embeds in main media
+        .is-fixed-height & {
+            display: block;
+        }
+    }
+
+    .content__loading-animation {
+        display: block;
+        position: absolute;
+        top: 40%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+    }
+
+    &.content__head .element-embed {
+        margin: 0;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+
+        .fenced {
+            height: 100% !important; // Overwrite inline styles
+            opacity: 0;
+            transition: .5s opacity ease-out;
+        }
+
+        .fenced-rendered {
+            opacity: 1;
         }
     }
 
@@ -170,43 +218,6 @@
 
             .content__head--mobile {
                 background-image: none !important;
-            }
-        }
-
-        .content__loading {
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background-color: colour(neutral-5);
-            color: colour(neutral-1);
-        }
-
-        .content__loading-animation {
-            display: block;
-            position: absolute;
-            top: 40%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-        }
-
-        &.content__head .element-embed {
-            margin: 0;
-            position: absolute;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-
-            .fenced {
-                height: 100% !important; // Overwrite inline styles
-                opacity: 0;
-                transition: .5s opacity ease-out;
-            }
-
-            .fenced-rendered {
-                opacity: 1;
             }
         }
     }

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -42,11 +42,11 @@
     }
 
     .content__logo {
+        display: block;
+        float: right;
         width: gs-span(2) + $gs-gutter;
         height: auto;
         margin-top: $gs-baseline / 2;
-        display: block;
-        float: right;
 
         svg {
             width: 100%;

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -27,7 +27,7 @@
         z-index: 10;
 
         @include mq($until: desktop) {
-            background-color: rgba(0, 0, 0, .6);
+            background-color: lighten(colour(neutral-1), 15%);
             padding-bottom: $gs-baseline / 2;
         }
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -23,7 +23,8 @@
     }
 
     .content__logo-container {
-        z-index: 2;
+        position: relative;
+        z-index: 10;
 
         @include mq($until: desktop) {
             background-color: rgba(0, 0, 0, .6);
@@ -35,15 +36,6 @@
             display: block;
 
             @include mq(desktop) {
-                overflow: visible;
-            }
-        }
-
-        .is-fixed-height & {
-            background-color: transparent;
-            padding-bottom: 0;
-
-            .gs-container {
                 overflow: visible;
             }
         }
@@ -102,14 +94,6 @@
         @include mq(desktop) {
             font-size: 4rem;
         }
-
-        .is-fixed-height & {
-            @include fs-headline(7, true);
-
-            @include mq(desktop) {
-                font-size: 3.25rem;
-            }
-        }
     }
 
     .content__series-label + .content__headline {
@@ -134,10 +118,6 @@
             height: 2px;
             width: gs-span(2);
             background-color: rgba(255, 255, 255, .2);
-
-            .is-fixed-height & {
-                display: none;
-            }
         }
 
         a {
@@ -160,11 +140,6 @@
         background-color: colour(neutral-5);
         color: colour(neutral-1);
         display: none;
-
-        // Should be removed when capi returns a no-id element for code embeds in main media
-        .is-fixed-height & {
-            display: block;
-        }
     }
 
     .content__loading-animation {
@@ -175,7 +150,7 @@
         transform: translate(-50%, -50%);
     }
 
-    &.content__head .element-embed {
+    .content__head .element-embed {
         margin: 0;
         position: absolute;
         top: 0;
@@ -243,6 +218,35 @@
             .content__head--mobile {
                 background-image: none !important;
             }
+        }
+
+        .content__logo-container {
+            background-color: transparent;
+            padding-bottom: 0;
+
+            .gs-container {
+                overflow: visible;
+            }
+        }
+
+        .content__headline {
+            @include fs-headline(7, true);
+            line-height: 1;
+
+            @include mq(desktop) {
+                font-size: 3.25rem;
+            }
+        }
+
+        .content__standfirst:before {
+            @include mq($until: desktop) {
+                display: none;
+            }
+        }
+
+        // Should be removed when capi returns a no-id element for code embeds in main media
+        .content__loading {
+            display: block;
         }
     }
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -114,90 +114,92 @@
         }
     }
 
-    .content__head--desktop {
-        height: 100vh;
-        max-height: 800px;
-    }
-
-    .content__header {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        right: 0;
-    }
-
-    @include mq($until: desktop) {
-        .content__head--mobile {
-            position: relative;
-            display: table-cell;
-            vertical-align: bottom;
-            background-position: center center;
-            background-size: cover;
+   .is-fixed-height {
+        &.content__head--desktop {
+            height: 100vh;
+            max-height: 800px;
         }
-
-        .content__head--desktop {
-            background-image: none !important;
-        }
-
+    
         .content__header {
-            display: table;
-            width: 100%;
-            height: 100%;
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
         }
-
-        .content__wrapper--standfirst {
-            display: table-row-group;
-            height: 1px;
+    
+        @include mq($until: desktop) {
+            .content__head--mobile {
+                position: relative;
+                display: table-cell;
+                vertical-align: bottom;
+                background-position: center center;
+                background-size: cover;
+            }
+    
+            .content__head--desktop {
+                background-image: none !important;
+            }
+    
+            .content__header {
+                display: table;
+                width: 100%;
+                height: 100%;
+            }
+    
+            .content__wrapper--standfirst {
+                display: table-row-group;
+                height: 1px;
+            }
         }
-    }
-
-    @include mq(desktop) {
-        .content__head--desktop {
-            position: relative;
-            background-position: center center;
-            background-size: cover;
-            max-height: initial;
+    
+        @include mq(desktop) {
+            .content__head--desktop {
+                position: relative;
+                background-position: center center;
+                background-size: cover;
+                max-height: initial;
+            }
+    
+            .content__head--mobile {
+                background-image: none !important;
+            }
         }
-
-        .content__head--mobile {
-            background-image: none !important;
+    
+        .content__loading {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: colour(neutral-5);
+            color: colour(neutral-1);
         }
-    }
-
-    .content__loading {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: colour(neutral-5);
-        color: colour(neutral-1);
-    }
-
-    .content__loading-animation {
-        display: block;
-        position: absolute;
-        top: 40%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-    }
-
-    .content__head .element-embed {
-        margin: 0;
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-
-        .fenced {
-            height: 100% !important; // Overwrite inline styles
-            opacity: 0;
-            transition: .5s opacity ease-out;
+    
+        .content__loading-animation {
+            display: block;
+            position: absolute;
+            top: 40%;
+            left: 50%;
+            transform: translate(-50%, -50%);
         }
-
-        .fenced-rendered {
-            opacity: 1;
+    
+        &.content__head .element-embed {
+            margin: 0;
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+    
+            .fenced {
+                height: 100% !important; // Overwrite inline styles
+                opacity: 0;
+                transition: .5s opacity ease-out;
+            }
+    
+            .fenced-rendered {
+                opacity: 1;
+            }
         }
     }
 

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -80,6 +80,14 @@
         }
     }
 
+    .content__headline {
+        @include fs-headline(7);
+        
+        @include mq(desktop) {
+            
+        }
+    }
+
     .content__series-label + .content__headline {
         padding-top: 0;
     }
@@ -114,19 +122,19 @@
         }
     }
 
-   .is-fixed-height {
+    .is-fixed-height {
         &.content__head--desktop {
             height: 100vh;
             max-height: 800px;
         }
-    
+
         .content__header {
             position: absolute;
             bottom: 0;
             left: 0;
             right: 0;
         }
-    
+
         @include mq($until: desktop) {
             .content__head--mobile {
                 position: relative;
@@ -135,23 +143,23 @@
                 background-position: center center;
                 background-size: cover;
             }
-    
+
             &.content__head--desktop {
                 background-image: none !important;
             }
-    
+
             .content__header {
                 display: table;
                 width: 100%;
                 height: 100%;
             }
-    
+
             .content__wrapper--standfirst {
                 display: table-row-group;
                 height: 1px;
             }
         }
-    
+
         @include mq(desktop) {
             &.content__head--desktop {
                 position: relative;
@@ -159,12 +167,12 @@
                 background-size: cover;
                 max-height: initial;
             }
-    
+
             .content__head--mobile {
                 background-image: none !important;
             }
         }
-    
+
         .content__loading {
             position: absolute;
             top: 0;
@@ -174,7 +182,7 @@
             background-color: colour(neutral-5);
             color: colour(neutral-1);
         }
-    
+
         .content__loading-animation {
             display: block;
             position: absolute;
@@ -182,7 +190,7 @@
             left: 50%;
             transform: translate(-50%, -50%);
         }
-    
+
         &.content__head .element-embed {
             margin: 0;
             position: absolute;
@@ -190,13 +198,13 @@
             right: 0;
             bottom: 0;
             left: 0;
-    
+
             .fenced {
                 height: 100% !important; // Overwrite inline styles
                 opacity: 0;
                 transition: .5s opacity ease-out;
             }
-    
+
             .fenced-rendered {
                 opacity: 1;
             }


### PR DESCRIPTION
Before we used to just show the loading animation forever. This renders something a little nicer and immediate.

Mobile
![screen shot 2015-12-07 at 15 01 36](https://cloud.githubusercontent.com/assets/1607666/11630330/dfe1acaa-9cf4-11e5-88bc-a1714bf356fe.png)

Desktop
![screen shot 2015-12-07 at 15 01 45](https://cloud.githubusercontent.com/assets/1607666/11630331/e093fb30-9cf4-11e5-8cfb-1b8adbd02398.png)
