### PR TITLE
Increase the ceiling on the previous visit count sent for advert targeting

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -98,7 +98,7 @@ define([
             }
         },
         getVisitedValue = function () {
-            var visitCount = storage.local.get('gu.alreadyVisited') || 1;
+            var visitCount = storage.local.get('gu.alreadyVisited') || 0;
 
             if (visitCount <= 5) {
                 return visitCount.toString();

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -98,16 +98,21 @@ define([
             }
         },
         getVisitedValue = function () {
-            var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0,
-                visitedValue;
+            var visitCount = storage.local.get('gu.alreadyVisited') || 1;
 
-            if (alreadyVisited > 4) {
-                visitedValue = '5plus';
-            } else {
-                visitedValue = alreadyVisited.toString();
+            if (visitCount <= 5) {
+                return visitCount.toString();
+            } else if (visitCount >= 6 && visitCount <= 9) {
+                return '6-9';
+            } else if (visitCount >= 10 && visitCount <= 15) {
+                return '10-15';
+            } else if (visitCount >= 16 && visitCount <= 19) {
+                return '16-19';
+            } else if (visitCount >= 20 && visitCount <= 29) {
+                return '20-29';
+            } else if (visitCount >= 30) {
+                return '30plus';
             }
-
-            return visitedValue;
         },
         getReferrer = function () {
             var referrerTypes = [

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -203,14 +203,14 @@ define([
                 expect(buildPageTargeting().fr).toEqual('16-19');
             });
 
-            it('over thirty, includes it in a boundless bucket', function () {
+            it('over thirty, includes it in the bucket "30plus"', function () {
                 storage.local.set('gu.alreadyVisited', 300);
                 expect(buildPageTargeting().fr).toEqual('30plus');
             });
 
             it('passes a value of 0 if the value is not stored', function () {
                 storage.local.remove('gu.alreadyVisited');
-                expect(buildPageTargeting().fr).toEqual('1');
+                expect(buildPageTargeting().fr).toEqual('0');
             });
         });
 

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -188,7 +188,7 @@ define([
                 si: 't',
                 ab: ['MtMaster-v'],
                 pv: '123456',
-                fr: '1'
+                fr: '0'
             });
         });
 
@@ -208,7 +208,7 @@ define([
                 expect(buildPageTargeting().fr).toEqual('30plus');
             });
 
-            it('passes a value of 1 if the value is not stored', function () {
+            it('passes a value of 0 if the value is not stored', function () {
                 storage.local.remove('gu.alreadyVisited');
                 expect(buildPageTargeting().fr).toEqual('1');
             });

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -188,21 +188,29 @@ define([
                 si: 't',
                 ab: ['MtMaster-v'],
                 pv: '123456',
-                fr: '0'
+                fr: '1'
             });
         });
 
         describe('Already visited frequency', function () {
-            it('should set 3 frequency param', function () {
-                storage.local.set('gu.alreadyVisited', 3);
-
-                expect(buildPageTargeting().fr).toEqual('3');
+            it('can pass a value of five or less', function () {
+                storage.local.set('gu.alreadyVisited', 5);
+                expect(buildPageTargeting().fr).toEqual('5');
             });
 
-            it('should set 5+ frequency param', function () {
-                storage.local.set('gu.alreadyVisited', 67);
+            it('between five and thirty, includes it in a bucket in the form "x-y"', function () {
+                storage.local.set('gu.alreadyVisited', 18);
+                expect(buildPageTargeting().fr).toEqual('16-19');
+            });
 
-                expect(buildPageTargeting().fr).toEqual('5plus');
+            it('over thirty, includes it in a boundless bucket', function () {
+                storage.local.set('gu.alreadyVisited', 300);
+                expect(buildPageTargeting().fr).toEqual('30plus');
+            });
+
+            it('passes a value of 1 if the value is not stored', function () {
+                storage.local.remove('gu.alreadyVisited');
+                expect(buildPageTargeting().fr).toEqual('1');
             });
         });
 


### PR DESCRIPTION
This is a pretty simple change - rather than sending the values 1, 2, 3, 4 and '5plus', we now send the count of the user's previous visits in the format 1, 2, 3, 4, 5, '6-9', '10-15', '11-19', '20-29' and '30plus'. This will allow the Merchandising team to do some more granular ad targeting.

@Calanthe 
