### PR TITLE
Extend ad-free-web switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -244,7 +244,7 @@ trait CommercialSwitches {
     "advert-opt-out",
     "Enable adfree experience. See with cookie 'gu_adfree_user' = true",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 12, 9),
+    sellByDate = new LocalDate(2016, 1, 31),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
We haven't tested the ad-free experience as of yet, and it seems unlikely we'll do so before Christmas, so I've opted to extend this until the end of next January.
