### PR TITLE
Convert hard coded API URL into a parameter

### DIFF
--- a/static/src/javascripts/projects/membership/membership-tab.js
+++ b/static/src/javascripts/projects/membership/membership-tab.js
@@ -81,7 +81,7 @@ define([
     }
 
     function setupPaymentForm() {
-        stripeForm.init($(CARD_DETAILS)[0], $(CARD_CHANGE_SUCCESS_MSG));
+        stripeForm.init($(CARD_DETAILS)[0], $(CARD_CHANGE_SUCCESS_MSG), '/me/membership-update-card');
     }
 
     function populateUserDetails(userDetails) {

--- a/static/src/javascripts/projects/membership/payment-form.js
+++ b/static/src/javascripts/projects/membership/payment-form.js
@@ -131,7 +131,7 @@ define([
             token = response.id;
 
             ajax({
-                url: config.page.userAttributesApiUrl + '/me/membership-update-card',
+                url: config.page.userAttributesApiUrl + self.apiUrl,
                 crossOrigin: true,
                 withCredentials: true,
                 method: 'post',
@@ -529,9 +529,10 @@ define([
         }
     };
 
-    StripePaymentForm.prototype.init = function (form, successElement) {
+    StripePaymentForm.prototype.init = function (form, successElement, url) {
         this.context = form;
         this.successElement = successElement;
+        this.apiUrl = url;
         this.addIconCss();
         if (this.context) {
             this.domElementSetup();


### PR DESCRIPTION
I considered adding objects which inherited the payment-form prototype object and set the URL themselves but decided it was quite a lot of code for no real benefit
