### PR TITLE
Prevent the MPU to appear on top of headlines in the popular section

### DIFF
--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -48,12 +48,12 @@
                         </div>
                     </li>
                     }
+                    @if(showMPU(containerDefinition)&&info.rowNum==1) {
+                    <li class="js-fc-slice-mpu-candidate-onload">
+                    </li>
+                    }
                 </ul>
             </div>
-        }
-
-        @if(showMPU(containerDefinition)) {
-            <div class="fc-slice__popular-mpu js-fc-slice-mpu-candidate fc-slice__item--mpu-candidate fc-slice__item--no-mpu"></div>
         }
 
         @if(isTabbed) {

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -114,11 +114,13 @@ define([
 
     function onHeadlines() {
         var $li = $('.js-popular-trails .js-fc-slice-mpu-candidate-onload').first();
-        $li.removeClass('js-fc-slice-mpu-candidate-onload')
-            .addClass('fc-slice__popular-mpu')
-            .addClass('fc-slice__item--mpu-candidate');
-        sliceAdvertSlot($li, index).then(function ($slot) {
-            dfp.addSlot($slot);
+        idleFastdom.write(function () {
+            $li.removeClass('js-fc-slice-mpu-candidate-onload')
+                .addClass('fc-slice__popular-mpu')
+                .addClass('fc-slice__item--mpu-candidate');
+            sliceAdvertSlot($li, index).then(function ($slot) {
+                dfp.addSlot($slot);
+            });
         });
         mediator.off('modules:geomostpopular:ready', onHeadlines);
         mediator.off('modules:onward:geo-most-popular:ready', onHeadlines);

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -117,7 +117,7 @@ define([
         $li.removeClass('js-fc-slice-mpu-candidate-onload')
             .addClass('fc-slice__popular-mpu')
             .addClass('fc-slice__item--mpu-candidate');
-        sliceAdvertSlot($li, index).then(function($slot) {
+        sliceAdvertSlot($li, index).then(function ($slot) {
             dfp.addSlot($slot);
         });
         mediator.off('modules:geomostpopular:ready', onHeadlines);

--- a/static/src/stylesheets/module/facia/_slices.scss
+++ b/static/src/stylesheets/module/facia/_slices.scss
@@ -199,7 +199,6 @@ Hence why a greater depth of selector specificity is needed.
 
     @include mq(tablet) {
         .fc-slice__popular-mpu {
-            position: absolute;
             width: 320px;
 
             .ad-slot {
@@ -210,8 +209,6 @@ Hence why a greater depth of selector specificity is needed.
 
     @include mq(tablet, desktop) {
         .fc-slice__popular-mpu {
-            bottom: 0;
-            right: 0;
             width: gs-span(4.5);
 
             .ad-slot--container-inline {
@@ -223,6 +220,7 @@ Hence why a greater depth of selector specificity is needed.
 
     @include mq(desktop) {
         .fc-slice__popular-mpu {
+            position: absolute;
             top: $gs-baseline;
             right: -($gs-gutter / 2);
         }

--- a/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
@@ -64,18 +64,14 @@ define([
         });
 
         it('should only create a maximum of 3 advert slots', function (done) {
-            sliceAdverts.init();
-
-            fastdom.defer(function () {
+            sliceAdverts.init().then(function () {
                 expect(qwery('.ad-slot', $fixtureContainer).length).toEqual(3);
                 done();
             });
         });
 
         it('should remove the "fc-slice__item--no-mpu" class', function (done) {
-            sliceAdverts.init();
-
-            fastdom.defer(function () {
+            sliceAdverts.init().then(function () {
                 $('.ad-slot', $fixtureContainer).each(function (adSlot) {
                     expect(bonzo(adSlot).parent().hasClass('fc-slice__item--no-mpu')).toBe(false);
                 });
@@ -85,15 +81,12 @@ define([
         });
 
         it('should have the correct ad names', function (done) {
-            sliceAdverts.init();
-
-            fastdom.defer(function () {
-                var $adSlots = $('.ad-slot', $fixtureContainer).map(function (slot) { return $(slot); });
-
-                expect($adSlots[0].data('name')).toEqual('inline1');
-                expect($adSlots[1].data('name')).toEqual('inline2');
-                expect($adSlots[2].data('name')).toEqual('inline3');
-
+            sliceAdverts.init().then(function () {
+                $('.ad-slot', $fixtureContainer)
+                    .map(function (slot) { return $(slot); })
+                    .forEach(function ($adSlot, index) {
+                        expect($adSlot.data('name')).toEqual('inline' + (index + 1));
+                    });
                 done();
             });
         });
@@ -102,23 +95,18 @@ define([
             detect.getBreakpoint = function () {
                 return 'mobile';
             };
-            sliceAdverts.init();
-
-            fastdom.defer(function () {
-                var $adSlots = $('.ad-slot', $fixtureContainer).map(function (slot) { return $(slot); });
-
-                expect($adSlots[0].data('name')).toEqual('inline1');
-                expect($adSlots[1].data('name')).toEqual('inline2');
-                expect($adSlots[2].data('name')).toEqual('inline3');
-
+            sliceAdverts.init().then(function () {
+                $('.ad-slot', $fixtureContainer)
+                    .map(function (slot) { return $(slot); })
+                    .forEach(function ($adSlot, index) {
+                        expect($adSlot.data('name')).toEqual('inline' + (index + 1));
+                    });
                 done();
             });
         });
 
         it('should have the correct size mappings', function (done) {
-            sliceAdverts.init();
-
-            fastdom.defer(function () {
+            sliceAdverts.init().then(function () {
                 $('.ad-slot--inline1', $fixtureContainer).each(function (adSlot) {
                     var $adSlot = bonzo(adSlot);
 
@@ -139,10 +127,9 @@ define([
         });
 
         it('should have at least one non-advert containers between advert containers', function (done) {
-            sliceAdverts.init();
-
-            fastdom.defer(function () {
+            sliceAdverts.init().then(function () {
                 expect(qwery('.fc-container-first .ad-slot', $fixtureContainer).length).toBe(1);
+                expect(qwery('.fc-container-second .ad-slot', $fixtureContainer).length).toBe(0);
                 expect(qwery('.fc-container-third .ad-slot', $fixtureContainer).length).toBe(1);
                 done();
             });
@@ -157,12 +144,8 @@ define([
 
         it('should not add ad to first container if network front', function (done) {
             config.page.pageId = 'uk';
-            sliceAdverts.init();
-
-            fastdom.defer(function () {
+            sliceAdverts.init().then(function () {
                 expect(qwery('.fc-container-first .ad-slot', $fixtureContainer).length).toBe(0);
-                expect(qwery('.fc-container-third .ad-slot', $fixtureContainer).length).toBe(1);
-                expect(qwery('.fc-container-fifth .ad-slot', $fixtureContainer).length).toBe(1);
                 done();
             });
         });
@@ -176,8 +159,7 @@ define([
             sliceAdverts.init();
 
             fastdom.defer(function () {
-                expect(qwery('.fc-container-third .ad-slot', $fixtureContainer).length).toBe(1);
-                expect(qwery('.fc-container-fifth .ad-slot', $fixtureContainer).length).toBe(1);
+                expect(qwery('.fc-container-first .ad-slot', $fixtureContainer).length).toBe(0);
                 done();
             });
         });

--- a/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
@@ -156,9 +156,7 @@ define([
             prefs[containerId] = 'closed';
             $('.fc-container-first', $fixtureContainer).attr('data-id', containerId);
             userPrefs.set('container-states', prefs);
-            sliceAdverts.init();
-
-            fastdom.defer(function () {
+            sliceAdverts.init().then(function () {
                 expect(qwery('.fc-container-first .ad-slot', $fixtureContainer).length).toBe(0);
                 done();
             });


### PR DESCRIPTION
## The problem

So, there's this small layout bug on tablets:

![screen shot 2015-12-08 at 10 04 18](https://cloud.githubusercontent.com/assets/629976/11653016/0b63e7f0-9d93-11e5-9e0c-ce60b2d76a1a.png)

The MPU is absolutely positioned, thus we had a choice: either provide ample space below the headlines or put the MPU back in the multi-column layout. I say 'back' because it originally was; it was presumably taken out because the whole content of the popular section may be overwritten by a more up-to-date version fetched in JS. I say 'may' because the behaviour is different whether on the front page on on a facia page: in the former case, the content get overwritten, in the latter case, it is fed into another tab.

Under this behaviour, there was a risk of generating two impressions—because async.
## The solution

The whole process is quite convoluted and so is the solution I'm afraid. In order to restore the MPU in its initial position, a bona fide `LI` is added after the headlines in the Scala template, where ultimately the ad slot will be added—the only way to restore it in the MC algorithm. But this element does not have the usual `js-fc-slice-mpu-candidate` class; this to prevent the process in `slice-adverts` from adding a slot where it will potentially be overwritten. Instead, it has a new class, `js-fc-slice-mpu-candidate-onload`, and we're going to use it a bit later. This solves our first issue, which is running the risk of a double impression.

Now we need to wait until the most read items have been fetched and fed into the DOM. When it is done, then we can safely ad the slot to the page. One would argue this process is unnecessary on facia pages, but this section is far down the page and branching for this condition wouldn't add much to the UX. So, waiting it is, and there are two events we need to wait for: `modules:geomostpopular:ready` and `modules:onward:geo-most-popular:ready`. As soon as one of them is emitted, `onHeadlines` is called where we can safely look for our `js-fc-slice-mpu-candidate-onload` and insert the ad slot.
## The tests

Much of the tests has been updated: since `sliceAdverts` returns a `Promise`, let's use the monadic way to wait for it to finish, by way of the `then` binding function, instead of waiting for the next layout frame using `fastdom.defer`.
