### PR TITLE
Fronts on Articles changes

### DIFF
--- a/common/app/views/support/ContentFooterContainersLayout.scala
+++ b/common/app/views/support/ContentFooterContainersLayout.scala
@@ -51,8 +51,8 @@ object ContentFooterContainersLayout {
         Some(networkFrontContainers1),
         optional(content.trail.isCommentable, commentsPlaceholder),
         Some(mostPopularPlaceholder),
-        Some(networkFrontContainers2),
-        optional(!content.shouldHideAdverts, standardCommercialComponent)
+        optional(!content.shouldHideAdverts, standardCommercialComponent),
+        Some(networkFrontContainers2)
       ).flatten
 
       includeOutbrainPlaceholder(apartFromOutbrain)

--- a/common/test/views/support/ContentFooterContainersLayoutTest.scala
+++ b/common/test/views/support/ContentFooterContainersLayoutTest.scala
@@ -63,8 +63,8 @@ class ContentFooterContainersLayoutTest extends FlatSpec with Matchers {
   it should "show all footer containers in right order by default" in {
     val html = buildHtml(contentItem())
     html.toString shouldBe
-      "highRelevanceCommercialHtml storyPackageHtml outbrainHtml onwardHtml sectionFrontHtml networkFrontHtml1 commentsHtml mostPopularHtml networkFrontHtml2 " +
-        "standardCommercialHtml "
+      "highRelevanceCommercialHtml storyPackageHtml outbrainHtml onwardHtml sectionFrontHtml networkFrontHtml1 commentsHtml mostPopularHtml " +
+        "standardCommercialHtml networkFrontHtml2 "
   }
 
   it should "omit commercial containers on sensitive content" in {
@@ -80,34 +80,34 @@ class ContentFooterContainersLayoutTest extends FlatSpec with Matchers {
   it should "omit comments when article won't allow them" in {
     val html = buildHtml(contentItem(commentable = false))
     html.toString shouldBe
-      "highRelevanceCommercialHtml storyPackageHtml outbrainHtml onwardHtml sectionFrontHtml networkFrontHtml1 mostPopularHtml networkFrontHtml2 standardCommercialHtml "
+      "highRelevanceCommercialHtml storyPackageHtml outbrainHtml onwardHtml sectionFrontHtml networkFrontHtml1 mostPopularHtml standardCommercialHtml networkFrontHtml2 "
   }
 
   it should "include story package placeholder even when there's no story package to show" in {
     val html = buildHtml(contentItem(showInRelatedContent = false), emptyRelatedContent)
     html.toString shouldBe
-      "highRelevanceCommercialHtml storyPackageHtml onwardHtml outbrainHtml sectionFrontHtml networkFrontHtml1 commentsHtml mostPopularHtml networkFrontHtml2 " +
-        "standardCommercialHtml "
+      "highRelevanceCommercialHtml storyPackageHtml onwardHtml outbrainHtml sectionFrontHtml networkFrontHtml1 commentsHtml mostPopularHtml " +
+        "standardCommercialHtml networkFrontHtml2 "
   }
 
   it should "show onward HTML before outbrain if article is part of a series and has no story package" in {
     val html = buildHtml(contentItem(seriesId = Some("seriesId")), emptyRelatedContent)
     html.toString shouldBe
-      "highRelevanceCommercialHtml storyPackageHtml onwardHtml outbrainHtml sectionFrontHtml networkFrontHtml1 commentsHtml mostPopularHtml networkFrontHtml2 " +
-        "standardCommercialHtml "
+      "highRelevanceCommercialHtml storyPackageHtml onwardHtml outbrainHtml sectionFrontHtml networkFrontHtml1 commentsHtml mostPopularHtml " +
+        "standardCommercialHtml networkFrontHtml2 "
   }
 
   it should "show onward HTML before outbrain if article is part of a blog and has no story package" in {
     val html = buildHtml(contentItem(blogId = Some("blogId")), emptyRelatedContent)
     html.toString shouldBe
-      "highRelevanceCommercialHtml storyPackageHtml onwardHtml outbrainHtml sectionFrontHtml networkFrontHtml1 commentsHtml mostPopularHtml networkFrontHtml2 " +
-        "standardCommercialHtml "
+      "highRelevanceCommercialHtml storyPackageHtml onwardHtml outbrainHtml sectionFrontHtml networkFrontHtml1 commentsHtml mostPopularHtml " +
+        "standardCommercialHtml networkFrontHtml2 "
   }
 
   it should "show containers in correct order when article doesn't have story package but has related content" in {
     val html = buildHtml(contentItem(), emptyRelatedContent)
     html.toString shouldBe
-      "highRelevanceCommercialHtml storyPackageHtml outbrainHtml onwardHtml sectionFrontHtml networkFrontHtml1 commentsHtml mostPopularHtml networkFrontHtml2 " +
-        "standardCommercialHtml "
+      "highRelevanceCommercialHtml storyPackageHtml outbrainHtml onwardHtml sectionFrontHtml networkFrontHtml1 commentsHtml mostPopularHtml " +
+        "standardCommercialHtml networkFrontHtml2 "
   }
 }

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -360,7 +360,7 @@ GET            /$path<(uk|au|us|international)(/(culture|sport|commentisfree|bus
 GET            /*path/lite.json                                                                                                  controllers.FaciaController.renderFrontJsonLite(path)
 GET            /*path/deduped.json                                                                                               controllers.DedupedController.getDedupedForPath(path)
 GET            /container/essential-read/:contentSource/:edition.json                                                            controllers.FaciaController.renderEssentialRead(contentSource: String, edition: String)
-GET            /container/*path/some/:num/:offset/:containerNameToFilter.json                                                                     controllers.FaciaController.renderSomeFrontContainers(path, num, offset, containerNameToFilter)
+GET            /container/*path/some/:num/:offset/:containerNameToFilter/:edition.json                                           controllers.FaciaController.renderSomeFrontContainers(path, num, offset, containerNameToFilter, edition)
 GET            /container/use-layout/*id.json                                                                                    controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
 GET            /container/*id.json                                                                                               controllers.FaciaController.renderContainerJson(id)
 GET            /most-relevant-container/*path.json                                                                               controllers.FaciaController.renderMostRelevantContainerJson(path)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -46,7 +46,7 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
   def renderFrontJson(id: String) = renderFront(id)
   def renderContainerJson(id: String) = renderContainer(id, false)
 
-  def renderSomeFrontContainers(path: String, rawNum: String, rawOffset: String, sectionNameToFilter: String) = MemcachedAction { implicit request =>
+  def renderSomeFrontContainers(path: String, rawNum: String, rawOffset: String, sectionNameToFilter: String, edition: String) = MemcachedAction { implicit request =>
     def returnContainers(num: Int, offset: Int) = getSomeCollections(Editionalise(path, Edition(request)), num, offset, sectionNameToFilter).map { collections =>
       Cached(60) {
         val containers = collections.getOrElse(List()).zipWithIndex.map { case (collection: PressedCollection, index) =>

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -4,32 +4,32 @@
 
 
 # For dev machines
-GET        /assets/*path                                                 dev.DevAssetsController.at(path)
+GET        /assets/*path                                                            dev.DevAssetsController.at(path)
 
-GET        /_healthcheck                                                 conf.HealthCheck.healthcheck()
-GET        /_fronts_cdn_healthcheck                                      conf.HealthCheck.cdnHealthcheck()
+GET        /_healthcheck                                                            conf.HealthCheck.healthcheck()
+GET        /_fronts_cdn_healthcheck                                                 conf.HealthCheck.cdnHealthcheck()
 
-GET        /_agentcontents                                               controllers.FaciaController.renderAgentContents
+GET        /_agentcontents                                                          controllers.FaciaController.renderAgentContents
 
-GET        /humans.txt                                                   controllers.Assets.at(path="/public", file="humans.txt")
-GET        /rockabox/rockabox_buster.html                                controllers.Assets.at(path="/public", file="rockabox_buster.html")
-GET        /external/eyeblaster/addineyeV2.html                          controllers.Assets.at(path="/public", file="addineyeV2.html")
+GET        /humans.txt                                                              controllers.Assets.at(path="/public", file="humans.txt")
+GET        /rockabox/rockabox_buster.html                                           controllers.Assets.at(path="/public", file="rockabox_buster.html")
+GET        /external/eyeblaster/addineyeV2.html                                     controllers.Assets.at(path="/public", file="addineyeV2.html")
 
 
 #Facia Press
-GET        /collection/*id/rss                                           controllers.FaciaController.renderCollectionRss(id)
-GET        /container/use-layout/*id.json                                controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
-GET        /container/essential-read/:contentSource/:edition.json        controllers.FaciaController.renderEssentialRead(contentSource: String, edition: String)
-GET        /container/*path/some/:num/:offset/:size.json                controllers.FaciaController.renderSomeFrontContainers(path, num, offset, size)
-GET        /container/*id.json                                           controllers.FaciaController.renderContainerJson(id)
-GET        /most-relevant-container/*path.json                           controllers.FaciaController.renderMostRelevantContainerJson(path)
+GET        /collection/*id/rss                                                      controllers.FaciaController.renderCollectionRss(id)
+GET        /container/use-layout/*id.json                                           controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
+GET        /container/essential-read/:contentSource/:edition.json                   controllers.FaciaController.renderEssentialRead(contentSource: String, edition: String)
+GET        /container/*path/some/:num/:offset/:containerNameToFilter/:edition.json  controllers.FaciaController.renderSomeFrontContainers(path, num, offset, containerNameToFilter, edition)
+GET        /container/*id.json                                                      controllers.FaciaController.renderContainerJson(id)
+GET        /most-relevant-container/*path.json                                      controllers.FaciaController.renderMostRelevantContainerJson(path)
 
 # Editionalised pages
-GET        /*path/show-more/*id.json                                     controllers.FaciaController.renderShowMore(path, id)
-GET        /rss                                                          controllers.FaciaController.renderRootFrontRss()
-GET        /*path/rss                                                    controllers.FaciaController.renderFrontRss(path)
-GET        /*path/lite.json                                              controllers.FaciaController.renderFrontJsonLite(path)
-GET        /*path/deduped.json                                           controllers.DedupedController.getDedupedForPath(path)
-GET        /*path.json                                                   controllers.FaciaController.renderFrontJson(path)
-GET        /                                                             controllers.FaciaController.rootEditionRedirect()
-GET        /*path                                                        controllers.FaciaController.renderFront(path)
+GET        /*path/show-more/*id.json                                                controllers.FaciaController.renderShowMore(path, id)
+GET        /rss                                                                     controllers.FaciaController.renderRootFrontRss()
+GET        /*path/rss                                                               controllers.FaciaController.renderFrontRss(path)
+GET        /*path/lite.json                                                         controllers.FaciaController.renderFrontJsonLite(path)
+GET        /*path/deduped.json                                                      controllers.DedupedController.getDedupedForPath(path)
+GET        /*path.json                                                              controllers.FaciaController.renderFrontJson(path)
+GET        /                                                                        controllers.FaciaController.rootEditionRedirect()
+GET        /*path                                                                   controllers.FaciaController.renderFront(path)

--- a/static/src/javascripts/bootstraps/trail.js
+++ b/static/src/javascripts/bootstraps/trail.js
@@ -45,7 +45,7 @@ define([
 ) {
     // messy but removed within a week
     var blogIdsCheck = (ab.getParticipations().FrontsOnArticles &&
-    ab.getParticipations().FrontsOnArticles.variant === 'variant' &&
+    (ab.getParticipations().FrontsOnArticles.variant === 'oneAndThree' || ab.getParticipations().FrontsOnArticles.variant === 'twoAndTwo') &&
     ab.testCanBeRun('FrontsOnArticles')) ? (config.page.blogIds && !(config.page.blogIds.indexOf('commentisfree') > -1)) : config.page.blogIds;
 
     function insertOrProximity(selector, insert) {
@@ -107,7 +107,7 @@ define([
 
     function initFrontsContainers() {
         if (config.page.section !== 'childrens-books-site' && config.page.contentType !== 'LiveBlog' && ab.getParticipations().FrontsOnArticles &&
-            ab.getParticipations().FrontsOnArticles.variant === 'variant' &&
+            (ab.getParticipations().FrontsOnArticles.variant === 'oneAndThree' || ab.getParticipations().FrontsOnArticles.variant === 'twoAndTwo') &&
             ab.testCanBeRun('FrontsOnArticles')) {
             insertOrProximity('.js-onward', function () {
                 new FrontsContainers();

--- a/static/src/javascripts/bootstraps/trail.js
+++ b/static/src/javascripts/bootstraps/trail.js
@@ -106,7 +106,7 @@ define([
     }
 
     function initFrontsContainers() {
-        if (config.page.section !== 'childrens-books-site' && ab.getParticipations().FrontsOnArticles &&
+        if (config.page.section !== 'childrens-books-site' && config.page.contentType !== 'LiveBlog' && ab.getParticipations().FrontsOnArticles &&
             ab.getParticipations().FrontsOnArticles.variant === 'variant' &&
             ab.testCanBeRun('FrontsOnArticles')) {
             insertOrProximity('.js-onward', function () {

--- a/static/src/javascripts/bootstraps/trail.js
+++ b/static/src/javascripts/bootstraps/trail.js
@@ -95,7 +95,7 @@ define([
                 new Onward(qwery('.js-onward'));
             } else if (config.page.tones !== '') {
                 if (!(ab.getParticipations().FrontsOnArticles &&
-                    ab.getParticipations().FrontsOnArticles.variant === 'variant' &&
+                    (ab.getParticipations().FrontsOnArticles.variant === 'oneAndThree' || ab.getParticipations().FrontsOnArticles.variant === 'twoAndTwo') &&
                     ab.testCanBeRun('FrontsOnArticles'))) {
                     $('.js-onward').each(function (c) {
                         new TonalComponent().fetch(c, 'html');

--- a/static/src/javascripts/projects/common/modules/experiments/tests/fronts-on-articles.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/fronts-on-articles.js
@@ -17,7 +17,7 @@ define([
         this.idealOutcome = '';
 
         this.canRun = function () {
-            return !config.page.isFront && config.page.section !== 'childrens-books-site';
+            return !config.page.isFront && config.page.section !== 'childrens-books-site' && config.page.contentType !== 'LiveBlog';
         };
 
         this.variants = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/fronts-on-articles.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/fronts-on-articles.js
@@ -28,7 +28,13 @@ define([
                 }
             },
             {
-                id: 'variant',
+                id: 'oneAndThree',
+                test: function () {
+
+                }
+            },
+            {
+                id: 'twoAndTwo',
                 test: function () {
 
                 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/fronts-on-articles.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/fronts-on-articles.js
@@ -5,8 +5,8 @@ define([
 ) {
     return function () {
         this.id = 'FrontsOnArticles';
-        this.start = '2015-11-30';
-        this.expiry = '2015-12-30';
+        this.start = '2015-12-08';
+        this.expiry = '2016-1-30';
         this.author = 'Josh Holder';
         this.description = 'Inject fronts containers on articles';
         this.audience = 0.0;

--- a/static/src/javascripts/projects/common/modules/onward/fronts-containers.js
+++ b/static/src/javascripts/projects/common/modules/onward/fronts-containers.js
@@ -56,10 +56,10 @@ define([
         insertContainers(edition, $('.js-fronts-network-2'), 2, offset, toFilter, function () {});
     }
 
-    function insertContainers(section, $el, num, offset, size, callback) {
+    function insertContainers(section, $el, num, offset, sectionToFilter, callback) {
         proximityLoader.add($el, 1500, function () {
             fastdom.write(function () {
-                injectContainer.injectContainer('/container/' + section + '/some/' + num + '/' + offset + '/' + size + '.json', $el, 'inject-network-front-' + num, callback);
+                injectContainer.injectContainer('/container/' + section + '/some/' + num + '/' + offset + '/' + sectionToFilter + '/' + edition + '.json', $el, 'inject-network-front-' + num, callback);
             });
         });
     }

--- a/static/src/javascripts/projects/common/modules/onward/fronts-containers.js
+++ b/static/src/javascripts/projects/common/modules/onward/fronts-containers.js
@@ -11,7 +11,8 @@ define([
     'lodash/collections/contains',
     'common/modules/identity/api',
     'common/utils/scroller',
-    'common/views/svgs'
+    'common/views/svgs',
+    'common/modules/experiments/ab'
 ], function (
     fastdom,
     bean,
@@ -25,35 +26,53 @@ define([
     contains,
     identity,
     scroller,
-    svgs
+    svgs,
+    ab
 ) {
     var sectionsToLoadSectionFronts = ['commentisfree', 'sport', 'football', 'fashion', 'lifeandstyle', 'education', 'culture', 'business', 'technology', 'politics', 'environment', 'travel', 'film', 'media', 'money', 'society', 'science', 'music', 'books', 'stage', 'cities', 'tv-and-radio', 'artanddesign', 'global-development'],
         loadSection = (contains(sectionsToLoadSectionFronts, config.page.section)) ? true : false,
-        edition = (config.page.edition === 'INT') ? 'international' : config.page.edition.toLowerCase();
+        edition = (config.page.edition === 'INT') ? 'international' : config.page.edition.toLowerCase(),
+        isOneAndThree = ab.getParticipations().FrontsOnArticles.variant === 'oneAndThree';
 
     function FrontsContainers() {
         moveComments();
-        insertFirstTwo();
+        insertFirstFew();
     }
 
-    function insertFirstTwo() {
+    function insertFirstFew() {
+        var numToLoad = (isOneAndThree) ? 1 : 2;
+
         if (loadSection) {
-            insertContainers(config.page.section, $('.js-fronts-section'), 1, 0, 'original', function () {});
-            insertContainers(edition, $('.js-fronts-network-1'), 1, 0, 'none', function () {
-                insertFinalTwo();
-            });
+            insertContainers(config.page.section, $('.js-fronts-section'), 1, 0, 'none', function () {});
+
+            if(!isOneAndThree) {
+                insertContainers(edition, $('.js-fronts-network-1'), 1, 0, 'none', function () {
+                    insertFinalFew();
+                });
+            } else {
+                insertFinalFew();
+            }
         } else {
-            insertContainers(edition, $('.js-fronts-network-1'), 2, 0, 'none', function () {
-                insertFinalTwo();
+            insertContainers(edition, $('.js-fronts-network-1'), numToLoad, 0, 'none', function () {
+                insertFinalFew();
             });
         }
     }
 
-    function insertFinalTwo() {
-        var offset = (loadSection) ? 1 : 2,
-            toFilter = (config.page.section === 'sport') ? 'sport' : 'none';
+    function insertFinalFew() {
+        var toFilter = (config.page.section === 'sport') ? 'sport' : 'none',
+            offset,
+            numberToLoad = (isOneAndThree) ? 3 : 2;
 
-        insertContainers(edition, $('.js-fronts-network-2'), 2, offset, toFilter, function () {});
+        if (isOneAndThree && loadSection) {
+            offset = 0;
+        } else if ((isOneAndThree && !loadSection) || (!isOneAndThree && loadSection)) {
+            offset = 1;
+        } else {
+            offset = 2;
+        }
+
+        insertContainers(edition, $('.js-fronts-network-2'), numberToLoad, offset, toFilter, function () {});
     }
 
     function insertContainers(section, $el, num, offset, sectionToFilter, callback) {

--- a/static/src/javascripts/projects/common/modules/onward/fronts-containers.js
+++ b/static/src/javascripts/projects/common/modules/onward/fronts-containers.js
@@ -45,7 +45,7 @@ define([
         if (loadSection) {
             insertContainers(config.page.section, $('.js-fronts-section'), 1, 0, 'none', function () {});
 
-            if(!isOneAndThree) {
+            if (!isOneAndThree) {
                 insertContainers(edition, $('.js-fronts-network-1'), 1, 0, 'none', function () {
                     insertFinalFew();
                 });


### PR DESCRIPTION
- The test now has two variants with different layouts. Either 2 containers before most popular and 2 after most popular, or 1 container before most popular and 3 after most popular. **Most of fronts-containers.js can be cleared out once we can move this out of the 'test' stage - it's currently a spaghetti of variations**
- Previously the endpoint requests were getting editionalised but then cached. The endpoint's cache isn't fragmented by edition so you often got the wrong edition's containers. This adds the edition to the endpoint.
- Mike (QA) recommended live blogs be excluded from this due to page weight concerns. This can be changed once live blogs are paginated.
