### PR TITLE
Add observer comment to /theobserver nav bar

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -220,7 +220,7 @@ trait Navigation {
 
   // Guardian newspaper
   val todaysPaper = SectionLink("todayspaper", "today's paper", "Today's Paper", "/theguardian")
-  val editorialsandletters = SectionLink("todayspaper", "editorials and letters", "Editorials and Letters", "/theguardian/mainsection/editorialsandreply")
+  val editorialsandletters = SectionLink("todayspaper", "editorials & letters", "Editorials & Letters", "/theguardian/mainsection/editorialsandreply")
   val obituaries = SectionLink("todayspaper", "obituaries", "Obituaries", "/tone/obituaries")
   val g2 = SectionLink("todayspaper", "g2", "G2", "/theguardian/g2")
   val weekend = SectionLink("todayspaper", "weekend", "Weekend", "/theguardian/weekend")
@@ -230,6 +230,7 @@ trait Navigation {
 
   // Observer newspaper
   val sundayPaper = SectionLink("theobserver", "sunday's paper", "The Observer", "/theobserver")
+  val observerComment = SectionLink("theobserver", "comment", "The Observer Comment", "/theobserver/news/comment")
   val observerNewReview = SectionLink("theobserver", "the new review", "Observer The New Review", "/theobserver/new-review")
   val observerMagazine = SectionLink("theobserver", "observer magazine", "Observer Magazine", "/theobserver/magazine")
 

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -111,7 +111,7 @@ object International extends Edition(
       NavItem(guardianProfessional),
       NavItem(observer),
       NavItem(todaysPaper, Seq(editorialsandletters, obituaries, g2, weekend, theGuide, saturdayreview)),
-      NavItem(sundayPaper, Seq(observerNewReview, observerMagazine)),
+      NavItem(sundayPaper, Seq(observerComment, observerNewReview, observerMagazine)),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),
       NavItem(video)

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -112,7 +112,7 @@ object Uk extends Edition(
       NavItem(guardianProfessional),
       NavItem(observer),
       NavItem(todaysPaper, Seq(editorialsandletters, obituaries, g2, weekend, theGuide, saturdayreview)),
-      NavItem(sundayPaper, Seq(observerNewReview, observerMagazine)),
+      NavItem(sundayPaper, Seq(observerComment, observerNewReview, observerMagazine)),
       NavItem(membership),
       NavItem(crosswords, crosswordsLocalNav),
       NavItem(video)


### PR DESCRIPTION
Adds comment to the /theobserver nav bar and changes "editorial and lettes" to "editorial & letters" for /theguardian.
:speech_balloon: :incoming_envelope: 
