### PR TITLE
Extend a/b video preroll switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -45,7 +45,7 @@ trait ABTestSwitches {
     "ab-video-preroll",
     "A test to see if a UK or INT audience will be interested in video pre-rolls",
     safeState = Off,
-    sellByDate = new LocalDate(2015, 12, 11),
+    sellByDate = new LocalDate(2016, 1, 6),
     exposeClientSide = true
   )
 }


### PR DESCRIPTION
Test ends at end of year.  Switch should probably be removed during the following week.
