### PR TITLE
Dedupe dynamic containers on non-network editorial fronts

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -344,9 +344,8 @@ object Front extends implicits.Collections {
     ): (Set[TrailUrl], Seq[FaciaContent], (Seq[DedupedItem], Seq[DedupedItem])) = {
     container match {
       case Dynamic(dynamicContainer) =>
-        /** Although Dynamic Containers participate in de-duplication, insofar as trails that appear in Dynamic
-          * Containers will not be duplicated further down on the page, they themselves retain all their trails, no
-          * matter what occurred further up the page.
+        /** We won't remove items from a dynamic container to avoid unexpected layout, but we will add items in the
+          * container to the list of things to remove later.
           */
         dynamicContainer.containerDefinitionFor(
           faciaContentList.map(Story.fromFaciaContent)

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -327,8 +327,8 @@ object DedupedFrontResult {
 object Front extends implicits.Collections {
   type TrailUrl = String
 
-  def itemsVisible(containerDefinition: ContainerDefinition) =
-    containerDefinition.slices.flatMap(_.layout.columns.map(_.numItems)).sum
+  def itemsVisible(slices: Seq[Slice]) =
+    slices.flatMap(_.layout.columns.map(_.numItems)).sum
 
   // Never de-duplicate snaps.
   def participatesInDeduplication(faciaContent: FaciaContent) = faciaContent.embedType.isEmpty
@@ -340,22 +340,51 @@ object Front extends implicits.Collections {
   def deduplicate(
     seen: Set[TrailUrl],
     container: Container,
-    faciaContentList: Seq[FaciaContent]
-    ): (Set[TrailUrl], Seq[FaciaContent], (Seq[DedupedItem], Seq[DedupedItem])) = {
+    faciaContentList: Seq[FaciaContent],
+    isNetworkFront: Boolean
+    )(implicit request: RequestHeader): (Set[TrailUrl], Seq[FaciaContent], (Seq[DedupedItem], Seq[DedupedItem])) = {
+    def dedupeContainer: (Int) => (Set[TrailUrl], Seq[FaciaContent], (Seq[DedupedItem], Seq[DedupedItem])) = (nToTake: Int) => {
+      val usedInThisIteration: Seq[FaciaContent] =
+        faciaContentList
+          .filter(c => seen.contains(c.url))
+
+      val usedButNotDeduped = usedInThisIteration
+        .filter(c => !participatesInDeduplication(c))
+        .map(_.url)
+        .map(DedupedItem(_))
+
+      val usedAndDeduped = usedInThisIteration
+        .filter(participatesInDeduplication)
+        .map(_.url)
+        .map(DedupedItem(_))
+
+      val notUsed = faciaContentList.filter(faciaContent => !seen.contains(faciaContent.url) || !participatesInDeduplication(faciaContent))
+        .distinctBy(_.url)
+      (seen ++ notUsed.take(nToTake).filter(participatesInDeduplication).map(_.url), notUsed, (usedAndDeduped, usedButNotDeduped))
+    }
+
     container match {
+
       case Dynamic(dynamicContainer) =>
-        /** We won't remove items from a dynamic container to avoid unexpected layout, but we will add items in the
-          * container to the list of things to remove later.
-          */
-        dynamicContainer.containerDefinitionFor(
-          faciaContentList.map(Story.fromFaciaContent)
-        ) map { containerDefinition =>
-          val newSeen = seen ++ faciaContentList
-            .map(_.url)
-            .take(itemsVisible(containerDefinition))
-          (newSeen, faciaContentList, (Nil, Nil))
-        } getOrElse {
-          (seen, faciaContentList, (Nil, Nil))
+        if (mvt.DedupeDynamicContainers.isParticipating && !isNetworkFront) {
+          /** Dynamic Containers participate in de-duplication. */
+          val slices = dynamicContainer.slicesFor(faciaContentList.map(Story.fromFaciaContent))
+          val nToTake = itemsVisible(slices.getOrElse(Nil))
+          dedupeContainer(nToTake)
+        } else {
+          /** We won't remove items from a dynamic container to avoid unexpected layout, but we will add items in the
+            * container to the list of things to remove later.
+            */
+          dynamicContainer.containerDefinitionFor(
+            faciaContentList.map(Story.fromFaciaContent)
+          ) map { containerDefinition =>
+            val newSeen = seen ++ faciaContentList
+              .map(_.url)
+              .take(itemsVisible(containerDefinition.slices))
+            (newSeen, faciaContentList, (Nil, Nil))
+          } getOrElse {
+            (seen, faciaContentList, (Nil, Nil))
+          }
         }
 
       /** Singleton containers (such as the eyewitness one or the thrasher one) do not participate in deduplication */
@@ -363,26 +392,9 @@ object Front extends implicits.Collections {
         (seen, faciaContentList, (Nil, Nil))
 
       case Fixed(containerDefinition) =>
-        /** Fixed Containers participate in de-duplication.
-          */
-        val nToTake = itemsVisible(containerDefinition)
-        val usedInThisIteration: Seq[FaciaContent] =
-          faciaContentList
-            .filter(c => seen.contains(c.url))
-
-       val usedButNotDeduped = usedInThisIteration
-            .filter(c => !participatesInDeduplication(c))
-            .map(_.url)
-            .map(DedupedItem(_))
-
-        val usedAndDeduped = usedInThisIteration
-            .filter(participatesInDeduplication)
-            .map(_.url)
-            .map(DedupedItem(_))
-
-        val notUsed = faciaContentList.filter(faciaContent => !seen.contains(faciaContent.url) || !participatesInDeduplication(faciaContent))
-          .distinctBy(_.url)
-        (seen ++ notUsed.take(nToTake).filter(participatesInDeduplication).map(_.url), notUsed, (usedAndDeduped, usedButNotDeduped))
+        /** Fixed Containers participate in de-duplication. */
+        val nToTake = itemsVisible(containerDefinition.slices)
+        dedupeContainer(nToTake)
 
       case _ =>
         /** Nav lists and most popular do not participate in de-duplication at all */
@@ -393,7 +405,7 @@ object Front extends implicits.Collections {
   def fromConfigsAndContainers(
     configs: Seq[((ContainerDisplayConfig, CollectionEssentials), Container)],
     initialContext: ContainerLayoutContext = ContainerLayoutContext.empty
-  ) = {
+  )(implicit request: RequestHeader) = {
     import scalaz.std.list._
     import scalaz.syntax.traverse._
 
@@ -403,7 +415,7 @@ object Front extends implicits.Collections {
       ) { case ((seenTrails, context), (((config, collection), container), index)) =>
 
         //We don't need the used in the case of fromConfigsAndContainers
-        val (newSeen, newItems, _) = deduplicate(seenTrails, container, collection.items)
+        val (newSeen, newItems, _) = deduplicate(seenTrails, container, collection.items, isNetworkFront = false)
 
         ContainerLayout.fromContainer(container, context, config, newItems) map {
           case (containerLayout, newContext) => ((newSeen, newContext), FaciaContainer.fromConfig(
@@ -428,7 +440,7 @@ object Front extends implicits.Collections {
     )
   }
 
-  def fromConfigs(configs: Seq[(CollectionConfigWithId, CollectionEssentials)]) = {
+  def fromConfigs(configs: Seq[(CollectionConfigWithId, CollectionEssentials)])(implicit request: RequestHeader) = {
     fromConfigsAndContainers(configs.map {
       case (config, collectionEssentials) =>
         ((ContainerDisplayConfig.withDefaults(config), collectionEssentials), Container.fromConfig(config.config))
@@ -437,7 +449,7 @@ object Front extends implicits.Collections {
 
   def fromPressedPageWithDeduped(pressedPage: PressedPage,
                                  edition: Edition,
-                                 initialContext: ContainerLayoutContext = ContainerLayoutContext.empty): ((Set[Front.TrailUrl], ContainerLayoutContext, DedupedFrontResult), List[FaciaContainer]) = {
+                                 initialContext: ContainerLayoutContext = ContainerLayoutContext.empty)(implicit request: RequestHeader): ((Set[Front.TrailUrl], ContainerLayoutContext, DedupedFrontResult), List[FaciaContainer]) = {
     import scalaz.std.list._
     import scalaz.syntax.traverse._
 
@@ -447,8 +459,9 @@ object Front extends implicits.Collections {
         (Set.empty[TrailUrl], initialContext, emptyDedupedResultWithPath)
       ) { case ((seenTrails, context, dedupedFrontResult), (pressedCollection, index)) =>
         val omitMPU = pressedPage.metadata.omitMPUsFromContainers(edition)
+        val isNetworkFront = pressedPage.metadata.isNetworkFront
         val container = Container.fromPressedCollection(pressedCollection, omitMPU)
-        val (newSeen, newItems, (usedAndDeduped, usedButNotDeduped)) = deduplicate(seenTrails, container, pressedCollection.curatedPlusBackfillDeduplicated)
+        val (newSeen, newItems, (usedAndDeduped, usedButNotDeduped)) = deduplicate(seenTrails, container, pressedCollection.curatedPlusBackfillDeduplicated, isNetworkFront)
 
         val dedupedContainerResult: DedupedContainerResult = DedupedContainerResult(pressedCollection.id, pressedCollection.displayName, usedAndDeduped.toList, usedButNotDeduped.toList)
 
@@ -480,7 +493,7 @@ object Front extends implicits.Collections {
 
   def fromPressedPage(pressedPage: PressedPage,
                       edition: Edition,
-                      initialContext: ContainerLayoutContext = ContainerLayoutContext.empty): Front =
+                      initialContext: ContainerLayoutContext = ContainerLayoutContext.empty)(implicit request: RequestHeader): Front =
     Front(fromPressedPageWithDeduped(pressedPage, edition, initialContext)._2)
 
   def makeLinkedData(url: String, collections: Seq[FaciaContainer])(implicit request: RequestHeader): ItemList = {

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -350,9 +350,10 @@ object Front extends implicits.Collections {
         dynamicContainer.containerDefinitionFor(
           faciaContentList.map(Story.fromFaciaContent)
         ) map { containerDefinition =>
-          (seen ++ faciaContentList
+          val newSeen = seen ++ faciaContentList
             .map(_.url)
-            .take(itemsVisible(containerDefinition)), faciaContentList, (Nil, Nil))
+            .take(itemsVisible(containerDefinition))
+          (newSeen, faciaContentList, (Nil, Nil))
         } getOrElse {
           (seen, faciaContentList, (Nil, Nil))
         }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -210,6 +210,8 @@ final case class MetaData (
   twitterPropertiesOverrides: Map[String, String] = Map()
 ){
 
+  val isNetworkFront: Boolean = isFront && Edition.all.exists(_.id.toLowerCase == id)
+
   def hasPageSkin(edition: Edition) = if (isPressedPage){
     DfpAgent.isPageSkinned(adUnitSuffix, edition)
   } else false

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -25,8 +25,15 @@ object TopBannerPosition extends TestDefinition(
   new LocalDate(2016, 1, 25)
 )
 
+object DedupeDynamicContainers extends TestDefinition(
+  List(Variant5),
+  "dedupe-dynamic-containers",
+  "Test deduping dynamic containers on all fronts except network fronts",
+  new LocalDate(2016, 1, 27)
+)
+
 object ActiveTests extends Tests {
-  val tests: Seq[TestDefinition] = List(TopBannerPosition)
+  val tests: Seq[TestDefinition] = List(TopBannerPosition, DedupeDynamicContainers)
 
   def getJavascriptConfig(implicit request: RequestHeader): String = {
 

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -41,6 +41,11 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
       Future.successful(configAgent.get())
     }
 
+  def getPriorityForPath(path: String): Option[String] = {
+    val config = configAgent.get()
+    config.flatMap(_.fronts.get(path).flatMap(_.priority))
+  }
+
   def getPathIds: List[String] = {
     val config = configAgent.get()
     config.map(_.fronts.keys.toList).getOrElse(Nil)

--- a/common/app/services/IndexPage.scala
+++ b/common/app/services/IndexPage.scala
@@ -48,7 +48,7 @@ object IndexPage {
     case _ => None
   }
 
-  def makeFront(indexPage: IndexPage, edition: Edition): Front = {
+  def makeFront(indexPage: IndexPage, edition: Edition)(implicit request: RequestHeader): Front = {
     val isCartoonPage = indexPage.isTagWithId("type/cartoon")
     val isReviewPage = indexPage.isTagWithId("tone/reviews")
 

--- a/common/app/slices/DynamicContainer.scala
+++ b/common/app/slices/DynamicContainer.scala
@@ -11,7 +11,7 @@ private [slices] case class BigsAndStandards(
   standards: Seq[Story]
 )
 
-private [slices] trait DynamicContainer {
+trait DynamicContainer {
   protected def standardSlices(stories: Seq[Story], firstSlice: Option[Slice]): Seq[Slice]
 
   protected def optionalFirstSlice(stories: Seq[Story]): Option[(Slice, Seq[Story])] = {

--- a/common/test/layout/FrontTest.scala
+++ b/common/test/layout/FrontTest.scala
@@ -10,8 +10,11 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.scalatestplus.play.OneAppPerSuite
 import services.FaciaContentConvert
 import slices._
+import test.TestRequest
 
 class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
+  val testRequest = TestRequest()
+
   def trailWithUrl(theUrl: String): FaciaContent = FaciaContentConvert.contentToFaciaContent(
     emptyApiContent.copy(id = theUrl, webUrl = theUrl)
   )
@@ -51,10 +54,10 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
 
 
   "itemsVisible" should "return a correct count of items visible (not behind 'show more')" in {
-    Front.itemsVisible(FixedContainers.fixedMediumFastXI) shouldEqual 11
-    Front.itemsVisible(FixedContainers.fixedMediumSlowVII) shouldEqual 7
+    Front.itemsVisible(FixedContainers.fixedMediumFastXI.slices) shouldEqual 11
+    Front.itemsVisible(FixedContainers.fixedMediumSlowVII.slices) shouldEqual 7
     /** Don't know why this is called 12 when it contains 9 items ... */
-    Front.itemsVisible(FixedContainers.fixedMediumSlowXIIMpu) shouldEqual 9
+    Front.itemsVisible(FixedContainers.fixedMediumSlowXIIMpu.slices) shouldEqual 9
   }
 
   "deduplicate" should "not remove items from a dynamic container" in {
@@ -62,7 +65,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("one"),
       trailWithUrl("two"),
       trailWithUrl("three")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     dedupedTrails.flatMap(_.webUrl) shouldEqual Seq("one", "two", "three")
   }
@@ -72,7 +75,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("one"),
       trailWithUrl("two"),
       trailWithUrl("three")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     nowSeen shouldEqual Set("/one", "/two", "/three")
   }
@@ -82,7 +85,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("one"),
       trailWithUrl("two"),
       trailWithUrl("three")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     dedupedTrails.flatMap(_.webUrl) shouldEqual Seq("three")
   }
@@ -92,7 +95,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("one"),
       trailWithUrl("two"),
       trailWithUrl("three")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     nowSeen shouldEqual Set("/one", "/two", "/three")
   }
@@ -102,7 +105,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("one"),
       trailWithUrl("two"),
       trailWithUrl("three")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     dedupedTrails.flatMap(_.webUrl) shouldEqual Seq("one", "two", "three")
   }
@@ -112,7 +115,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("one"),
       trailWithUrl("two"),
       trailWithUrl("three")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     nowSeen shouldEqual Set("/one", "/two")
   }
@@ -122,7 +125,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("one"),
       trailWithUrl("two"),
       trailWithUrl("three")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     dedupedTrails.flatMap(_.webUrl) shouldEqual Seq("one", "two", "three")
   }
@@ -130,7 +133,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
   it should "not include items seen in a singleton container in the set of urls for further deduplication" in {
     val (nowSeen, _, _) = Front.deduplicate(Set.empty, Fixed(FixedContainers.thrasher), Seq(
       trailWithUrl("one")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     nowSeen shouldEqual Set.empty
   }
@@ -138,7 +141,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
   it should "not remove items from a singleton container" in {
     val (_, dedupedTrails, _) = Front.deduplicate(Set("one"), Fixed(FixedContainers.thrasher), Seq(
       trailWithUrl("one")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     dedupedTrails.flatMap(_.webUrl) shouldEqual Seq("one")
   }
@@ -148,7 +151,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("one"),
       trailWithUrl("two"),
       trailWithUrl("three")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     nowSeen shouldEqual Set("/one", "/two")
   }
@@ -158,7 +161,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("one"),
       trailWithUrl("two"),
       trailWithUrl("three")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     dedupedTrails.flatMap(_.webUrl) shouldEqual Seq("one", "two", "three")
   }
@@ -168,7 +171,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("one"),
       trailWithUrl("two"),
       trailWithUrl("three")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     nowSeen shouldEqual Set("/one", "/two")
   }
@@ -176,7 +179,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
   it should "not deduplicate dream snaps" in {
     val (_, dedupedTrails, _) = Front.deduplicate(Set("one", "two"), Fixed(FixedContainers.fixedMediumFastXI), Seq(
       dreamSnapWithUrl("one")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     dedupedTrails.flatMap(_.webUrl) shouldEqual Seq("one")
   }
@@ -189,7 +192,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
       trailWithUrl("four"),
       trailWithUrl("five"),
       trailWithUrl("six")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     nowSeen shouldEqual Set("/three", "/four")
   }
@@ -197,7 +200,7 @@ class FrontTest extends FlatSpec with Matchers with OneAppPerSuite {
   it should "not include dream snaps in the seen urls" in {
     val (nowSeen, _, _) = Front.deduplicate(Set.empty, Fixed(FixedContainers.fixedMediumFastXI), Seq(
       dreamSnapWithUrl("one")
-    ))
+    ), isNetworkFront = false, isEditorialFront = false)(testRequest)
 
     nowSeen shouldEqual Set()
   }

--- a/facia/app/controllers/DedupedController.scala
+++ b/facia/app/controllers/DedupedController.scala
@@ -10,7 +10,7 @@ trait DedupedController extends Controller with Logging with ExecutionContexts {
 
   val frontJsonFapi: FrontJsonFapi = FrontJsonFapiLive
 
-  def getDedupedForPath(path: String) = Action.async { request =>
+  def getDedupedForPath(path: String) = Action.async { implicit request =>
     frontJsonFapi.get(path).map {
       case Some(pressedFront) =>
         val ((_, _, dedupedFrontResult), _) =


### PR DESCRIPTION
We don't currently dedupe dynamic containers because deduping would effect their layout when actually we want their layout to be an editorial decision. However, we get a lot of complaints about "deduping not working" as these containers increase in usage.

Katie and I have thought of a solution: dedupe dynamic containers for all editorial fronts except the network front. The network front team are happy to manually dedupe as a compromise for keeping the integrity of their layout inside dynamic containers.

We need to do this so we can deprecate the old fixed containers in favour of the new `dynamic/slow-mpu`.

This is a test so CP can do a quick sanity check before we push it live.

/cc @janua @crifmulholland 
