### PR TITLE
amp font on all the pages

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -249,10 +249,7 @@
     @fragments.amp.stylesheets.social()
     @fragments.amp.stylesheets.footer()
     @fragments.amp.stylesheets.mostPopular()
-    @if(metaData.id == "australia-news/postcolonial-blog/2015/jul/21/enduring-controversy-bp-sponsorship-ignites-new-row-over-british-museums-indigenous-exhibition" ||
-        metaData.id == "technology/2014/sep/17/apple-iphone-6-thinner-faster-slightly-cheaper-review"){
-        @fragments.amp.stylesheets.fonts()
-    }
+    @fragments.amp.stylesheets.fonts()
 
     @* temporarily hiding these for demo *@
     .inline-expand-image, .content__dateline-lm , .block-share, .witness-cta-wrapper {

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -101,18 +101,15 @@
                 </div>
             }
 
-            @if(page.metadata.id == "australia-news/postcolonial-blog/2015/jul/21/enduring-controversy-bp-sponsorship-ignites-new-row-over-british-museums-indigenous-exhibition" ||
-                page.metadata.id == "technology/2014/sep/17/apple-iphone-6-thinner-faster-slightly-cheaper-review"){
-                <amp-font
-                    layout="nodisplay"
-                    font-family="Guardian Egyptian Web"
-                    timeout="3000"
-                    on-error-remove-class="guardian-egyptian-loading"
-                    on-error-add-class="guardian-egyptian-missing"
-                    on-load-remove-class="guardian-egyptian-loading"
-                    on-load-add-class="guardian-egyptian-loaded">
-                </amp-font>
-            }
+            <amp-font
+                layout="nodisplay"
+                font-family="Guardian Egyptian Web"
+                timeout="3000"
+                on-error-remove-class="guardian-egyptian-loading"
+                on-error-add-class="guardian-egyptian-missing"
+                on-load-remove-class="guardian-egyptian-loading"
+                on-load-add-class="guardian-egyptian-loaded">
+            </amp-font>
 
             @fragments.footerAMP(page)
         </div>


### PR DESCRIPTION
Amp font is now validating. It still doesn't show up in the cache, but we still have our default styling

cc @stephanfowler 
