### PR TITLE
Add data link name to discussion post button

### DIFF
--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -28,7 +28,7 @@
             <span class="d-discussion__error-text">Your comments are currently being pre-moderated (<a href="/community-faqs#311" target="_blank">why?</a>)</span>
         </div>
         <textarea name="body" class="textarea d-comment-box__body" placeholder="Join the discussion…"></textarea>
-        <button type="submit" class="u-button-reset button button--large button--primary submit-input d-comment-box__submit">Post your comment</button>
+        <button type="submit" data-link-name="post comment" class="u-button-reset button button--large button--primary submit-input d-comment-box__submit">Post your comment</button>
         <span class="u-fauxlink d-comment-box__preview" role="button">Preview</span>
         <span class="u-fauxlink d-comment-box__hide-preview" role="button">Hide preview</span>
         <span class="u-fauxlink d-comment-box__cancel" role="button">Cancel</span>


### PR DESCRIPTION
There is a wider issue here, we shouldn't have to trap every event. But this has happened before; events that don't get read by the clickstream are being handled by Omniture's library as a page view. Add a `data-link-name` to fix it, like @gtrufitt did in https://github.com/guardian/frontend/pull/11064
