### PR TITLE
Reinstate the h2 immersive headers

### DIFF
--- a/article/app/views/package.scala
+++ b/article/app/views/package.scala
@@ -51,6 +51,7 @@ object BodyCleaner {
       BloggerBylineImage(article),
       LiveBlogShareButtons(article),
       DropCaps(article.tags.isComment || article.tags.isFeature, article.isImmersive),
+      ImmersiveHeaders(article.isImmersive),
       FigCaptionCleaner,
       RichLinkCleaner,
       MembershipEventCleaner,

--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -499,6 +499,24 @@ case class ImmersiveLinks(isImmersive: Boolean) extends HtmlCleaner {
   }
 }
 
+case class ImmersiveHeaders(isImmersive: Boolean) extends HtmlCleaner {
+  override def clean(document: Document): Document = {
+    if(isImmersive) {
+      document.getElementsByTag("h2").foreach{ h2 =>
+        val beforeH2 = h2.previousElementSibling()
+        if (beforeH2 != null) {
+          if(beforeH2.hasClass("element--immersive")) {
+            beforeH2.addClass("section-image")
+            beforeH2.prepend("""<h2 class="section-title">""" + h2.text() + "</h2>")
+            h2.remove()
+          }
+        }
+      }
+    }
+    document
+  }
+}
+
 case class DropCaps(isFeature: Boolean, isImmersive: Boolean) extends HtmlCleaner {
   private def setDropCap(p: Element): String = {
     p.html.replaceFirst(

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -389,7 +389,6 @@
     .from-content-api h2 {
         @include fs-headline(5);
         font-weight: 200;
-        padding-bottom: .5em;
 
         @include mq(tablet) {
             @include fs-headline(7, true);


### PR DESCRIPTION
They were added with [this](https://github.com/guardian/frontend/pull/11268) and quickly removed with [this](https://github.com/guardian/frontend/pull/11288) as stuff was on fire. I've now put out the fires. :fire_engine: 
