### PR TITLE
Remove top margin in facia containers on mobile

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -609,8 +609,6 @@
 .fc-container--advertisement-feature,
 .fc-container--foundation-supported {
     .fc-container__header + .fc-container__body {
-        margin-top: 104px;
-
         @include mq(tablet) {
             margin-top: 78px;
         }


### PR DESCRIPTION
The margin was there (ostensibly) to make space for the header—as the title is floating its height should collapse—but as it has `overflow: hidden` the floating title is counted in nonetheless.

Before:

![screenshot_2015-12-12-09-02-08](https://cloud.githubusercontent.com/assets/629976/11779684/b96aa7a6-a254-11e5-8de0-a078d554b172.png)

After:

![screen shot 2015-12-14 at 11 18 28](https://cloud.githubusercontent.com/assets/629976/11779687/c0fc1072-a254-11e5-89a6-28f77627d4a7.png)
