### PR TITLE
Add Quality Dashboard to the Admin panel

### DIFF
--- a/admin/app/controllers/AnalyticsController.scala
+++ b/admin/app/controllers/AnalyticsController.scala
@@ -5,9 +5,17 @@ import common.{ExecutionContexts, Logging}
 import controllers.AuthLogging
 import model.NoCache
 import scala.concurrent.Future
+import play.api.libs.ws.WS
+import play.api.Play.current
 
 object AnalyticsController extends Controller with Logging with AuthLogging with ExecutionContexts {
   def abtests() = AuthActions.AuthActionTest.async { request =>
     Future(NoCache(Ok(views.html.abtests("PROD"))))
+  }
+
+  def renderQuality() = AuthActions.AuthActionTest.async { request =>
+    WS.url("https://s3-eu-west-1.amazonaws.com/omniture-dashboard/index.html").get() map { response =>
+      NoCache(Ok(views.html.quality("PROD", response.body)))
+    }
   }
 }

--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -15,6 +15,7 @@
                                 <li><a href="@controllers.admin.routes.ContentPerformanceController.renderVideoEncodingsDashboard()">Video</a></li>
                             </ul>
                         </li>
+                        <li><a href="@controllers.admin.routes.AnalyticsController.renderQuality()">Quality dashboard</a></li>
                     </ul>
                 </div>
             </div>

--- a/admin/app/views/quality.scala.html
+++ b/admin/app/views/quality.scala.html
@@ -1,0 +1,9 @@
+@(env: String, body: String)
+
+@admin_main("Dashboard", env, isAuthed = true, hasCharts = true) {
+
+    <h1 class="page-header">Quality Dashboard</h1>
+    <div style="width: 100%">
+        @Html(body)
+    </div>
+}

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -56,6 +56,7 @@ POST        /dev/switchboard                                                    
 GET         /analytics/abtests                                                                      controllers.admin.AnalyticsController.abtests()
 GET         /analytics/confidence                                                                   controllers.admin.AnalyticsConfidenceController.renderConfidence()
 GET         /analytics/content/video                                                                controllers.admin.ContentPerformanceController.renderVideoEncodingsDashboard()
+GET         /analytics/quality                                                                      controllers.admin.AnalyticsController.renderQuality()
 
 GET         /analytics/headlines-test                                                               controllers.admin.MetricsController.renderHeadlinesTest()
 


### PR DESCRIPTION
This is part of me and @ScottPainterGNM 's work with the Omniture API.

@johnduffell we spoke about this last week. Basically this displays an html page hosted on S3, which was @uplne 's approach to the [assets frequency graph](https://frontend.gutools.co.uk/metrics/afg).
