### PR TITLE
Wait for DOM ready

### DIFF
--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -16,6 +16,7 @@ window.curlConfig = {
             bonzo:                          'components/bonzo/bonzo',
             react:                          'components/react/react',
             classnames:                     'components/classnames/index',
+            domReady:                       'components/domready/ready',
             enhancer:                       'components/enhancer/enhancer',
             EventEmitter:                   'components/eventEmitter/EventEmitter',
             fastclick:                      'components/fastclick/fastclick',

--- a/grunt-configs/requirejs.js
+++ b/grunt-configs/requirejs.js
@@ -9,6 +9,7 @@ module.exports = function (grunt, options) {
                 membership:           'projects/membership',
                 bean:                 'components/bean/bean',
                 bonzo:                'components/bonzo/bonzo',
+                domReady:             'components/domready/ready',
                 enhancer:             'components/enhancer/enhancer',
                 EventEmitter:         'components/eventEmitter/EventEmitter',
                 fastdom:              'components/fastdom/index',

--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -19,11 +19,13 @@ Bundles we need to run: commercial + (enhanced-vendor + enhanced)*
 define([
     'Promise',
     'lodash/collections/map',
-    'lodash/collections/forEach'
+    'lodash/collections/forEach',
+    'domReady'
 ], function (
     Promise,
     map,
-    forEach
+    forEach,
+    domReady
 ) {
     // curl’s promise API is broken, so we must cast it to a real Promise
     // https://github.com/cujojs/curl/issues/293
@@ -34,7 +36,13 @@ define([
     var guardian = window.guardian;
     var config = guardian.config;
 
-    var bootStandard = function () { return promiseRequire(['bootstraps/standard/main', 'domReady!']); };
+    var domReadyPromise = new Promise(function (resolve) { domReady(resolve); });
+
+    var bootStandard = function () {
+        return domReadyPromise.then(function () {
+            return promiseRequire(['bootstraps/standard/main']);
+        });
+    };
 
     var bootEnhanced = function () { return promiseRequire(['bootstraps/enhanced/main']); };
 

--- a/static/src/javascripts/bootstraps/admin.js
+++ b/static/src/javascripts/bootstraps/admin.js
@@ -5,7 +5,8 @@ define([
     'admin/bootstraps/browserstats',
     'admin/bootstraps/radiator',
     'admin/bootstraps/commercial',
-    'admin/bootstraps/commercial/adTests'
+    'admin/bootstraps/commercial/adTests',
+    'domReady'
 ], function (
     ajax,
     abTests,
@@ -13,10 +14,11 @@ define([
     browserstats,
     radiator,
     commercial,
-    adTests
+    adTests,
+    domReady
 ) {
 
-    require(['domReady!'], function () {
+    domReady(function () {
         ajax.setHost('');
 
         switch (window.location.pathname) {

--- a/static/src/javascripts/bower.json
+++ b/static/src/javascripts/bower.json
@@ -3,6 +3,7 @@
   "version": "0.1.0 ",
   "dependencies": {
     "bean": "~1.0.14",
+    "domready": "ded/domready#v0.3.0",
     "eventEmitter": "~4.2.6",
     "fastdom": "0.8.5",
     "lodash-amd": "~2.4.1",
@@ -33,6 +34,7 @@
         }
       ],
       "lodash-amd": "bower_components/lodash-amd/compat/**",
+      "domready": "bower_components/domready/ready.js",
       "when": "bower_components/when/es6-shim/Promise.js",
       "video.js": "bower_components/video.js/dist/video.min.js",
       "videojs-contrib-ads": "bower_components/videojs-contrib-ads/dist/videojs.ads.min.js",

--- a/static/src/javascripts/components/domready/ready.js
+++ b/static/src/javascripts/components/domready/ready.js
@@ -1,0 +1,55 @@
+/*!
+  * domready (c) Dustin Diaz 2012 - License MIT
+  */
+!function (name, definition) {
+  if (typeof module != 'undefined') module.exports = definition()
+  else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
+  else this[name] = definition()
+}('domready', function (ready) {
+
+  var fns = [], fn, f = false
+    , doc = document
+    , testEl = doc.documentElement
+    , hack = testEl.doScroll
+    , domContentLoaded = 'DOMContentLoaded'
+    , addEventListener = 'addEventListener'
+    , onreadystatechange = 'onreadystatechange'
+    , readyState = 'readyState'
+    , loadedRgx = hack ? /^loaded|^c/ : /^loaded|c/
+    , loaded = loadedRgx.test(doc[readyState])
+
+  function flush(f) {
+    loaded = 1
+    while (f = fns.shift()) f()
+  }
+
+  doc[addEventListener] && doc[addEventListener](domContentLoaded, fn = function () {
+    doc.removeEventListener(domContentLoaded, fn, f)
+    flush()
+  }, f)
+
+
+  hack && doc.attachEvent(onreadystatechange, fn = function () {
+    if (/^c/.test(doc[readyState])) {
+      doc.detachEvent(onreadystatechange, fn)
+      flush()
+    }
+  })
+
+  return (ready = hack ?
+    function (fn) {
+      self != top ?
+        loaded ? fn() : fns.push(fn) :
+        function () {
+          try {
+            testEl.doScroll('left')
+          } catch (e) {
+            return setTimeout(function() { ready(fn) }, 50)
+          }
+          fn()
+        }()
+    } :
+    function (fn) {
+      loaded ? fn() : fns.push(fn)
+    })
+})


### PR DESCRIPTION
We used to wait for `DOMContentLoaded` before running any of our JS. I attempted to copy this across in #11258, but I inevitably broke it. We've had a about three complaints regarding images not loading on fronts, and this is why (Picturefill is running too early).

Here I have switched to using [ded’s `domReady`](https://github.com/ded/domready) (v0.3.0 for IE8 support) because the `domReady!` plugin doesn't fully cover the curl API (i.e. `require.next`). In any case, I don't think it makes sense to tie this to our module loader, and removing it means we can more easily reason about switching module loaders (although I won't be the one to instigate that…).

The `domReady` script is 459 bytes gzipped. I hoped we could switch to the standard version of curl, but sadly not, because [`curl+domReady` is the only distributed version that contains the `js!` plugin](https://github.com/cujojs/curl/tree/master/dist). Not a biggie because it doesn't add much weight (`curl+domReady+js` - `curl` = 957 bytes gzipped).
