### PR TITLE
Fix broken prefetch in old IE

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -18,16 +18,14 @@ Bundles we need to run: commercial + (enhanced-vendor + enhanced)*
 
 define([
     'Promise',
-    'lodash/collections/map',
     'lodash/collections/forEach',
     'domReady',
-    'common/utils/ajax-promise'
+    'common/utils/pre-fetch-modules'
 ], function (
     Promise,
-    map,
     forEach,
     domReady,
-    ajaxPromise
+    preFetchModules
 ) {
     // curl’s promise API is broken, so we must cast it to a real Promise
     // https://github.com/cujojs/curl/issues/293
@@ -66,60 +64,18 @@ define([
             });
     };
 
-    var curlConfig = window.curlConfig;
-    var resolveModuleId = function (moduleId) {
-        return curlConfig.paths[moduleId];
-    };
 
-    var preFetch = function (moduleIds) {
-        if (isDev) {
-            // We don't prefetch in dev because curl won't recognise the anonymous
-            // module definition when we execute it.
-            return Promise.resolve([]);
-        } else {
-            var urls = map(moduleIds, resolveModuleId);
-            // IE 8 and 9 don't support requests that are cross origin *and*
-            // cross scheme due to limitations with XDomainRequest. Thus, we
-            // make all URLs protocol relative.
-            // See http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx
-            // If testing in dev, disable cross origin and provide an absolute
-            // url.
-            var urlToProtocolRelative = function (url) { return url.replace(/^https?:/, ''); };
-            var protocolRelativeUrls = map(urls, urlToProtocolRelative);
-            return Promise.all(map(protocolRelativeUrls, function (url) {
-                return ajaxPromise({
-                    url: url,
-                    // We have to override the type because otherwise reqwest
-                    // will infer this as JS and eval it :-(
-                    // See https://github.com/ded/reqwest/issues/131
-                    type: 'html',
-                    crossOrigin: true
-                });
-            }))
-                // We want the app to run even if prefetching fails.
-                .catch(function (error) {
-                    /* eslint-disable no-console */
-                    var console = window.console;
-                    if (console && console.error) {
-                        console.error('Caught error while prefetching.', error.stack);
-                    }
-                    /* eslint-enable no-console */
-                    return [];
-                });
-        }
-    };
 
     var shouldRunEnhance = guardian.isModernBrowser;
 
-    var isDev = config.page.isDev;
-    var commercialResponsesPromise = preFetch(['bootstraps/commercial']);
+    var commercialResponsesPromise = preFetchModules(['bootstraps/commercial']);
     var enhancedModuleIds = [
         'enhanced-vendor',
         'bootstraps/enhanced/main'
     ];
     var enhancedResponsesPromise = (
         shouldRunEnhance
-            ? preFetch(enhancedModuleIds)
+            ? preFetchModules(enhancedModuleIds)
             : Promise.resolve()
     );
 

--- a/static/src/javascripts/projects/common/utils/pre-fetch-modules.js
+++ b/static/src/javascripts/projects/common/utils/pre-fetch-modules.js
@@ -1,0 +1,54 @@
+define([
+    'lodash/collections/map',
+    'common/utils/ajax-promise'
+], function (
+    map,
+    ajaxPromise
+) {
+    var curlConfig = window.curlConfig;
+    var resolveModuleId = function (moduleId) {
+        return curlConfig.paths[moduleId];
+    };
+
+    var guardian = window.guardian;
+    var isDev = guardian.config.page.isDev;
+    var preFetchModules = function (moduleIds) {
+        if (isDev) {
+            // We don't prefetch in dev because curl won't recognise the anonymous
+            // module definition when we execute it.
+            return Promise.resolve([]);
+        } else {
+            var urls = map(moduleIds, resolveModuleId);
+            // IE 8 and 9 don't support requests that are cross origin *and*
+            // cross scheme due to limitations with XDomainRequest. Thus, we
+            // make all URLs protocol relative.
+            // See http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx
+            // If testing in dev, disable cross origin and provide an absolute
+            // url.
+            var urlToProtocolRelative = function (url) { return url.replace(/^https?:/, ''); };
+            var protocolRelativeUrls = map(urls, urlToProtocolRelative);
+            return Promise.all(map(protocolRelativeUrls, function (url) {
+                return ajaxPromise({
+                    url: url,
+                    // We have to override the type because otherwise reqwest
+                    // will infer this as JS and eval it :-(
+                    // See https://github.com/ded/reqwest/issues/131
+                    type: 'html',
+                    crossOrigin: true
+                });
+            }))
+                // We want the app to run even if prefetching fails.
+                .catch(function (error) {
+                    /* eslint-disable no-console */
+                    var console = window.console;
+                    if (console && console.error) {
+                        console.error('Caught error while prefetching.', error.stack);
+                    }
+                    /* eslint-enable no-console */
+                    return [];
+                });
+        }
+    };
+
+    return preFetchModules;
+});


### PR DESCRIPTION
#11258 breaks the JS app in IE 9, because the prefetch fails due to a limitation whereby `XHMLHttpRequest` cannot make cross origin requests. Instead, IE 8 and 9 provide `XDomainRequest` for cross origin requests. reqwest uses this under the hood, so I switched to that.

/cc @gtrufitt 
