### PR TITLE
Show lazy loaded containers if not modern

### DIFF
--- a/static/src/stylesheets/module/facia/_container.scss
+++ b/static/src/stylesheets/module/facia/_container.scss
@@ -634,9 +634,10 @@ $header-image-size-desktop: 100px;
 .fc-container--lazy-load {
     @include mq($until: desktop) {
         display: none;
-    }
 
-    .is-not-modern & {
-        display: none;
+        .is-not-modern & {
+            // Unset
+            display: block;
+        }
     }
 }


### PR DESCRIPTION
Several iOS users have complained they are missing containers on fronts. This is because we lazy load containers for breakpoints less than desktop, and the JS for doing this currently lives in standard.

The choices:
1. Move that JS to standard
2. Just show the containers in standard to avoid extra JS

I've sided with the latter. If we have performance problems with extra containers, we can re-introduce the lazy loading JS into standard. What do people think @sndrs @rich-nguyen?
