### PR TITLE
A/B test definition for Identity Sign in v2 test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -39,4 +39,13 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 1, 6),
     exposeClientSide = true
   )
+
+  val ABIdentitySignInV2 = Switch(
+    "A/B Tests",
+    "ab-identity-sign-in-v2",
+    "New sign in page variant for Identity",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 1, 15),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -9,6 +9,7 @@ define([
     'common/modules/experiments/tests/large-top-slot',
     'common/modules/experiments/tests/video-preroll',
     'common/modules/experiments/tests/alternative-related',
+    'common/modules/experiments/tests/identity-sign-in-v2',
     'lodash/arrays/flatten',
     'lodash/collections/forEach',
     'lodash/objects/keys',
@@ -29,6 +30,7 @@ define([
     LargeTopAd,
     VideoPreroll,
     AlternativeRelated,
+    IdentitySignInV2,
     flatten,
     forEach,
     keys,
@@ -43,7 +45,8 @@ define([
         new FrontsOnArticles(),
         new LargeTopAd(),
         new VideoPreroll(),
-        new AlternativeRelated()
+        new AlternativeRelated(),
+        new IdentitySignInV2()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/identity-sign-in-v2.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/identity-sign-in-v2.js
@@ -1,0 +1,39 @@
+/**
+ * Defines test to record usage of new sign in variant for Identity.
+ *
+ * Code for recording test events is in the new identity-frontend repo, and will
+ * run automatically when users are routed to the new service.
+ *
+ * @see https://github.com/guardian/identity-frontend
+ */
+define([], function () {
+
+    return function () {
+
+        this.id = 'IdentitySignInV2';
+        this.start = '2015-12-15';
+        this.expiry = '2016-01-15';
+        this.author = 'James Pamplin';
+        this.description = 'New sign in page variant for Identity';
+        this.audience = 0.1;
+        this.audienceOffset = 0.5;
+        this.successMeasure = 'More people sign in';
+        this.audienceCriteria = 'everyone';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'More people sign in';
+
+        this.canRun = function () {
+            // Test data will be recorded automatically when run on new identity-frontend service.
+            return false;
+        };
+
+        this.variants = [
+            {
+                id: 'A',
+                test: function () {}
+            }
+        ];
+
+    };
+
+});


### PR DESCRIPTION
The identity team have been working on a new variant for Sign in pages. The source is separated from frontend and is available at https://github.com/guardian/identity-frontend - which is hosted at https://profile-origin.theguardian.com/signin

This PR defines a A/B test definition for recording the outcome of the new pages. This is required by the data team to record test outcomes for reporting.

We'll control the participation of users for the test by routing with fastly on https://profile.theguardian.com - which will route 10% of users to the new service. The new service will automatically record ab event data with omniture and ophan.

I've spoken to the data team about decoupling this process, but we'll have to look at this next year.

/cc @rich-nguyen 
