### PR TITLE
Fix a race condition on the stripe icons

### DIFF
--- a/static/src/javascripts/projects/membership/payment-form.js
+++ b/static/src/javascripts/projects/membership/payment-form.js
@@ -528,7 +528,7 @@ define([
             $existing = $('#stripe-sprite'),
             $head = $('head');
 
-        if (!$existing.length) {
+        if (!$existing.length && spriteSheetUrl) {
             link.id = 'stripe-sprite';
             link.rel = 'stylesheet';
             link.type = 'text/css';


### PR DESCRIPTION
The digital pack stripe form will attempt to set an empty card icon until it becomes visible all the time
