### PR TITLE
Wait for DOM ready, attempt 2

### DIFF
--- a/static/src/javascripts/boot.js
+++ b/static/src/javascripts/boot.js
@@ -40,11 +40,15 @@ define([
 
     var bootStandard = function () {
         return domReadyPromise.then(function () {
-            return promiseRequire(['bootstraps/standard/main']);
+            return promiseRequire(['bootstraps/standard/main'])
+                .then(function (boot) { boot(); });
         });
     };
 
-    var bootEnhanced = function () { return promiseRequire(['bootstraps/enhanced/main']); };
+    var bootEnhanced = function () {
+        return promiseRequire(['bootstraps/enhanced/main'])
+            .then(function (boot) { boot(); });
+    };
 
     var bootCommercial = function () {
         return promiseRequire(['raven'])

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -151,5 +151,5 @@ define([
 
         // Mark the end of synchronous execution.
         userTiming.mark('App End');
-    }
+    };
 });

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -25,130 +25,131 @@ define([
     common,
     sport
 ) {
-    var bootstrapContext = function (featureName, bootstrap) {
-        raven.context(
-            { tags: { feature: featureName } },
-            bootstrap.init,
-            []
-        );
-    };
+    return function () {
+        var bootstrapContext = function (featureName, bootstrap) {
+            raven.context(
+                { tags: { feature: featureName } },
+                bootstrap.init,
+                []
+            );
+        };
 
 
-    userTiming.mark('App Begin');
-    bootstrapContext('common', common);
+        userTiming.mark('App Begin');
+        bootstrapContext('common', common);
 
-    // Front
-    if (config.page.isFront) {
-        require(['bootstraps/enhanced/facia'], function (facia) {
-            bootstrapContext('facia', facia);
-        });
-    }
-
-    if (config.page.section === 'lifeandstyle' && config.page.series === 'Sudoku') {
-        require(['bootstraps/enhanced/sudoku'], function (sudoku) {
-            bootstrapContext('sudoku', sudoku);
-        });
-    }
-
-    if (config.page.contentType === 'Article') {
-        require(['bootstraps/enhanced/article', 'bootstraps/enhanced/image-content'], function (article, imageContent) {
-            bootstrapContext('article', article);
-            bootstrapContext('article : image-content', imageContent);
-        });
-    }
-
-    if (config.page.contentType === 'Crossword' || config.page.pageId === 'offline-page') {
-        require(['bootstraps/enhanced/crosswords'], function (crosswords) {
-            bootstrapContext('crosswords', crosswords);
-        });
-    }
-
-    if (config.page.contentType === 'LiveBlog') {
-        require(['bootstraps/enhanced/liveblog', 'bootstraps/enhanced/image-content'], function (liveBlog, imageContent) {
-            bootstrapContext('liveBlog', liveBlog);
-            bootstrapContext('liveBlog : image-content', imageContent);
-        });
-    }
-
-    if (config.isMedia || config.page.contentType === 'Interactive') {
-        require(['bootstraps/enhanced/trail'], function (trail) {
-            bootstrapContext('media : trail', {
-                init: trail
+        // Front
+        if (config.page.isFront) {
+            require(['bootstraps/enhanced/facia'], function (facia) {
+                bootstrapContext('facia', facia);
             });
-        });
-    }
-
-    if (config.isMedia || qwery('video, audio').length) {
-        require(['bootstraps/enhanced/media/main'], function (media) {
-            bootstrapContext('media', media);
-        });
-    }
-
-    if (config.page.contentType === 'Gallery') {
-        require(['bootstraps/enhanced/gallery', 'bootstraps/enhanced/image-content'], function (gallery, imageContent) {
-            bootstrapContext('gallery', gallery);
-            bootstrapContext('gallery : image-content', imageContent);
-        });
-    }
-
-    if (config.page.contentType === 'ImageContent') {
-        require(['bootstraps/enhanced/image-content', 'bootstraps/enhanced/trail'], function (imageContent, trail) {
-            bootstrapContext('image-content', imageContent);
-            bootstrapContext('image-content : trail', {
-                init: trail
-            });
-        });
-    }
-
-    if (config.page.section === 'football') {
-        require(['bootstraps/enhanced/football'], function (football) {
-            bootstrapContext('football', football);
-        });
-    }
-
-    if (config.page.section === 'sport') {
-        // Leaving this here for now as it's a tiny bootstrap.
-        bootstrapContext('sport', sport);
-    }
-
-    if (config.page.section === 'identity') {
-        require(['bootstraps/enhanced/profile'], function (profile) {
-            bootstrapContext('profile', profile);
-        });
-    }
-
-    if (config.page.isPreferencesPage) {
-        require(['bootstraps/enhanced/preferences'], function (preferences) {
-            bootstrapContext('preferences', preferences);
-        });
-    }
-
-    var isDev = window.location.hostname === 'localhost';
-    if ((window.location.protocol === 'https:' || isDev)
-        && config.page.section !== 'identity') {
-        var navigator = window.navigator;
-        if (navigator && navigator.serviceWorker) {
-            navigator.serviceWorker.register('/service-worker.js');
         }
-    }
 
-    if (config.page.pageId === 'offline-page') {
-        var $button = $('.js-open-crossword-btn');
-        bean.on($button[0], 'click', function () {
-            fastdom.write(function () {
-                $('.js-crossword-container').removeClass('is-hidden');
-                $button.remove();
+        if (config.page.section === 'lifeandstyle' && config.page.series === 'Sudoku') {
+            require(['bootstraps/enhanced/sudoku'], function (sudoku) {
+                bootstrapContext('sudoku', sudoku);
             });
-        });
+        }
+
+        if (config.page.contentType === 'Article') {
+            require(['bootstraps/enhanced/article', 'bootstraps/enhanced/image-content'], function (article, imageContent) {
+                bootstrapContext('article', article);
+                bootstrapContext('article : image-content', imageContent);
+            });
+        }
+
+        if (config.page.contentType === 'Crossword' || config.page.pageId === 'offline-page') {
+            require(['bootstraps/enhanced/crosswords'], function (crosswords) {
+                bootstrapContext('crosswords', crosswords);
+            });
+        }
+
+        if (config.page.contentType === 'LiveBlog') {
+            require(['bootstraps/enhanced/liveblog', 'bootstraps/enhanced/image-content'], function (liveBlog, imageContent) {
+                bootstrapContext('liveBlog', liveBlog);
+                bootstrapContext('liveBlog : image-content', imageContent);
+            });
+        }
+
+        if (config.isMedia || config.page.contentType === 'Interactive') {
+            require(['bootstraps/enhanced/trail'], function (trail) {
+                bootstrapContext('media : trail', {
+                    init: trail
+                });
+            });
+        }
+
+        if (config.isMedia || qwery('video, audio').length) {
+            require(['bootstraps/enhanced/media/main'], function (media) {
+                bootstrapContext('media', media);
+            });
+        }
+
+        if (config.page.contentType === 'Gallery') {
+            require(['bootstraps/enhanced/gallery', 'bootstraps/enhanced/image-content'], function (gallery, imageContent) {
+                bootstrapContext('gallery', gallery);
+                bootstrapContext('gallery : image-content', imageContent);
+            });
+        }
+
+        if (config.page.contentType === 'ImageContent') {
+            require(['bootstraps/enhanced/image-content', 'bootstraps/enhanced/trail'], function (imageContent, trail) {
+                bootstrapContext('image-content', imageContent);
+                bootstrapContext('image-content : trail', {
+                    init: trail
+                });
+            });
+        }
+
+        if (config.page.section === 'football') {
+            require(['bootstraps/enhanced/football'], function (football) {
+                bootstrapContext('football', football);
+            });
+        }
+
+        if (config.page.section === 'sport') {
+            // Leaving this here for now as it's a tiny bootstrap.
+            bootstrapContext('sport', sport);
+        }
+
+        if (config.page.section === 'identity') {
+            require(['bootstraps/enhanced/profile'], function (profile) {
+                bootstrapContext('profile', profile);
+            });
+        }
+
+        if (config.page.isPreferencesPage) {
+            require(['bootstraps/enhanced/preferences'], function (preferences) {
+                bootstrapContext('preferences', preferences);
+            });
+        }
+
+        var isDev = window.location.hostname === 'localhost';
+        if ((window.location.protocol === 'https:' || isDev)
+            && config.page.section !== 'identity') {
+            var navigator = window.navigator;
+            if (navigator && navigator.serviceWorker) {
+                navigator.serviceWorker.register('/service-worker.js');
+            }
+        }
+
+        if (config.page.pageId === 'offline-page') {
+            var $button = $('.js-open-crossword-btn');
+            bean.on($button[0], 'click', function () {
+                fastdom.write(function () {
+                    $('.js-crossword-container').removeClass('is-hidden');
+                    $button.remove();
+                });
+            });
+        }
+
+        if (config.page.pageId === 'help/accessibility-help') {
+            require(['bootstraps/enhanced/accessibility'], function (accessibility) {
+                bootstrapContext('accessibility', accessibility);
+            });
+        }
+
+        // Mark the end of synchronous execution.
+        userTiming.mark('App End');
     }
-
-    if (config.page.pageId === 'help/accessibility-help') {
-        require(['bootstraps/enhanced/accessibility'], function (accessibility) {
-            bootstrapContext('accessibility', accessibility);
-        });
-    }
-
-    // Mark the end of synchronous execution.
-    userTiming.mark('App End');
-
 });

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -28,146 +28,148 @@ define([
     ajax,
     identity
 ) {
-    var guardian = window.guardian;
-    var config = guardian.config;
+    return function () {
+        var guardian = window.guardian;
+        var config = guardian.config;
 
-    //
-    // Raven
-    //
+        //
+        // Raven
+        //
 
-    raven.config(
-        'http://' + config.page.sentryPublicApiKey + '@' + config.page.sentryHost,
-        {
-            whitelistUrls: [
-                /localhost/, // will not actually log errors, but `shouldSendCallback` will be called
-                /assets\.guim\.co\.uk/,
-                /ophan\.co\.uk/
-            ],
-            tags: {
-                edition:        config.page.edition,
-                contentType:    config.page.contentType,
-                revisionNumber: config.page.revisionNumber,
-                loaderType:     'Curl'
-            },
-            dataCallback: function (data) {
-                if (data.culprit) {
-                    data.culprit = data.culprit.replace(/\/[a-z\d]{32}(\/[^\/]+)$/, '$1');
-                }
-                data.tags.origin = (/j.ophan.co.uk/.test(data.culprit)) ? 'ophan' : 'app';
-                return data;
-            },
-            shouldSendCallback: function (data) {
-                var isDev = config.page.isDev;
-                if (isDev) {
-                    // Some environments don't support or don't always expose the console object
-                    if (window.console && window.console.warn) {
-                        window.console.warn('Raven captured error.', data);
+        raven.config(
+            'http://' + config.page.sentryPublicApiKey + '@' + config.page.sentryHost,
+            {
+                whitelistUrls: [
+                    /localhost/, // will not actually log errors, but `shouldSendCallback` will be called
+                    /assets\.guim\.co\.uk/,
+                    /ophan\.co\.uk/
+                ],
+                tags: {
+                    edition:        config.page.edition,
+                    contentType:    config.page.contentType,
+                    revisionNumber: config.page.revisionNumber,
+                    loaderType:     'Curl'
+                },
+                dataCallback: function (data) {
+                    if (data.culprit) {
+                        data.culprit = data.culprit.replace(/\/[a-z\d]{32}(\/[^\/]+)$/, '$1');
                     }
+                    data.tags.origin = (/j.ophan.co.uk/.test(data.culprit)) ? 'ophan' : 'app';
+                    return data;
+                },
+                shouldSendCallback: function (data) {
+                    var isDev = config.page.isDev;
+                    if (isDev) {
+                        // Some environments don't support or don't always expose the console object
+                        if (window.console && window.console.warn) {
+                            window.console.warn('Raven captured error.', data);
+                        }
+                    }
+
+                    return config.switches.diagnosticsLogging &&
+                        Math.random() < 0.2 &&
+                        !isDev; // don't actually notify sentry in dev mode
                 }
-
-                return config.switches.diagnosticsLogging &&
-                    Math.random() < 0.2 &&
-                    !isDev; // don't actually notify sentry in dev mode
             }
-        }
-    );
+        );
 
-    // Report uncaught exceptions
-    raven.install();
+        // Report uncaught exceptions
+        raven.install();
 
-    var oldOnError = window.onerror;
-    window.onerror = function (message, filename, lineno, colno, error) {
-        // Not all browsers pass the error object
-        if (!error || !error.reported) {
-            oldOnError.apply(window, arguments);
-        }
-    };
-
-    // IE8 and below use attachEvent
-    if (!window.addEventListener) {
-        window.addEventListener = window.attachEvent;
-    }
-
-    // Report unhandled promise rejections
-    // https://github.com/cujojs/when/blob/master/docs/debug-api.md#browser-window-events
-    window.addEventListener('unhandledRejection', function (event) {
-        var error = event.detail.reason;
-        if (error && !error.reported) {
-            raven.captureException(error);
-        }
-    });
-
-    //
-    // A/B tests
-    //
-
-    if (guardian.isModernBrowser) {
-        ab.segmentUser();
-        ab.run();
-    }
-
-    //
-    // Images
-    //
-
-    if (config.page.isFront) {
-        if (!document.addEventListener) { // IE8 and below
-            window.onload = images.upgradePictures;
-        }
-    }
-    images.upgradePictures();
-    images.listen();
-
-    //
-    // set local storage: gu.alreadyVisited
-    //
-
-    var alreadyVisted;
-    if (guardian.isModernBrowser) {
-        alreadyVisted = storage.local.get('gu.alreadyVisited') || 0;
-        storage.local.set('gu.alreadyVisited', alreadyVisted + 1);
-    }
-
-    //
-    // Membership access
-    //
-
-    /**
-     * Items with either of the following fields require Membership access
-     * - membershipAccess=members-only
-     * - membershipAccess=paid-members-only
-     */
-    // Authenticating requires CORS and withCredentials. If we don't cut the mustard then pass through.
-    if (config.page.requiresMembershipAccess) {
-        var membershipUrl = config.page.membershipUrl,
-            membershipAccess = config.page.membershipAccess,
-            requiresPaidTier = (membershipAccess.indexOf('paid-members-only') !== -1),
-            membershipAuthUrl = membershipUrl + '/choose-tier?membershipAccess=' + membershipAccess;
-
-        var redirect = function () {
-            window.location.href = membershipAuthUrl;
+        var oldOnError = window.onerror;
+        window.onerror = function (message, filename, lineno, colno, error) {
+            // Not all browsers pass the error object
+            if (!error || !error.reported) {
+                oldOnError.apply(window, arguments);
+            }
         };
 
-        if (identity.isUserLoggedIn()) {
-            ajax({
-                url: membershipUrl + '/user/me',
-                type: 'json',
-                crossOrigin: true,
-                withCredentials: true
-            }).then(function (resp) {
-                // Check the users access matches the content
-                var canViewContent = (requiresPaidTier) ? !!resp.tier && resp.isPaidTier : !!resp.tier;
-                if (canViewContent) {
-                    $('body').removeClass('has-membership-access-requirement');
-                } else {
-                    redirect();
-                }
-            }).fail(function () {
-                // If the request fails assume non-member
-                redirect();
-            });
-        } else {
-            redirect();
+        // IE8 and below use attachEvent
+        if (!window.addEventListener) {
+            window.addEventListener = window.attachEvent;
         }
-    }
+
+        // Report unhandled promise rejections
+        // https://github.com/cujojs/when/blob/master/docs/debug-api.md#browser-window-events
+        window.addEventListener('unhandledRejection', function (event) {
+            var error = event.detail.reason;
+            if (error && !error.reported) {
+                raven.captureException(error);
+            }
+        });
+
+        //
+        // A/B tests
+        //
+
+        if (guardian.isModernBrowser) {
+            ab.segmentUser();
+            ab.run();
+        }
+
+        //
+        // Images
+        //
+
+        if (config.page.isFront) {
+            if (!document.addEventListener) { // IE8 and below
+                window.onload = images.upgradePictures;
+            }
+        }
+        images.upgradePictures();
+        images.listen();
+
+        //
+        // set local storage: gu.alreadyVisited
+        //
+
+        var alreadyVisted;
+        if (guardian.isModernBrowser) {
+            alreadyVisted = storage.local.get('gu.alreadyVisited') || 0;
+            storage.local.set('gu.alreadyVisited', alreadyVisted + 1);
+        }
+
+        //
+        // Membership access
+        //
+
+        /**
+         * Items with either of the following fields require Membership access
+         * - membershipAccess=members-only
+         * - membershipAccess=paid-members-only
+         */
+        // Authenticating requires CORS and withCredentials. If we don't cut the mustard then pass through.
+        if (config.page.requiresMembershipAccess) {
+            var membershipUrl = config.page.membershipUrl,
+                membershipAccess = config.page.membershipAccess,
+                requiresPaidTier = (membershipAccess.indexOf('paid-members-only') !== -1),
+                membershipAuthUrl = membershipUrl + '/choose-tier?membershipAccess=' + membershipAccess;
+
+            var redirect = function () {
+                window.location.href = membershipAuthUrl;
+            };
+
+            if (identity.isUserLoggedIn()) {
+                ajax({
+                    url: membershipUrl + '/user/me',
+                    type: 'json',
+                    crossOrigin: true,
+                    withCredentials: true
+                }).then(function (resp) {
+                    // Check the users access matches the content
+                    var canViewContent = (requiresPaidTier) ? !!resp.tier && resp.isPaidTier : !!resp.tier;
+                    if (canViewContent) {
+                        $('body').removeClass('has-membership-access-requirement');
+                    } else {
+                        redirect();
+                    }
+                }).fail(function () {
+                    // If the request fails assume non-member
+                    redirect();
+                });
+            } else {
+                redirect();
+            }
+        }
+    };
 });


### PR DESCRIPTION
#11366 didn't work. The body of a module is actually executed at `define` time, not at `require` time. Thus, `bootstraps/standard/main` was executing before the DOM was ready.

https://github.com/guardian/frontend/pull/11375/files?w=1
