### PR TITLE
Related and Headlines on AMP

### DIFF
--- a/common/app/views/fragments/amp/onward.scala.html
+++ b/common/app/views/fragments/amp/onward.scala.html
@@ -15,17 +15,17 @@
                     <div class="fc-item__header">
                         <h2 class="fc-item__title">
                             <span>
-                                                {{#isVideo}}
-                                @fragments.inlineSvg("video-icon", "icon")
+                                {{#isVideo}}
+                                    @fragments.inlineSvg("video-icon", "icon")
                                 {{/isVideo}}
                                 {{#isGallery}}
-                                @fragments.inlineSvg("camera", "icon")
+                                    @fragments.inlineSvg("camera", "icon")
                                 {{/isGallery}}
                                 {{#isAudio}}
-                                @fragments.inlineSvg("volume-high", "icon")
+                                    @fragments.inlineSvg("volume-high", "icon")
                                 {{/isAudio}}
                                 {{#isComment}}
-                                @fragments.inlineSvg("quote", "icon")
+                                    @fragments.inlineSvg("quote", "icon")
                                 {{/isComment}}
                             </span>
                             {{headline}}

--- a/common/app/views/fragments/amp/onward.scala.html
+++ b/common/app/views/fragments/amp/onward.scala.html
@@ -5,7 +5,8 @@
     <div class="fc-container__header__title">
         <span>@title</span>
     </div>
-    <amp-list layout="responsive" height="80", width="320" src="@if(Play.isDev) {https://www.thegulocal.com} else {@Configuration.ajax.url}/@path">
+    @* must be served by localhost, not thegulocal *@
+    <amp-list layout="responsive" height="80" width="320" src="@Configuration.ajax.url/@path">
         <template type="amp-mustache">
             <div class="fc-item {{toneClass}}">
                 <div class="fc-item__image-container">

--- a/common/app/views/fragments/amp/onward.scala.html
+++ b/common/app/views/fragments/amp/onward.scala.html
@@ -1,0 +1,57 @@
+@(title: String, path: String)
+@import conf.Configuration
+
+<div class="fc-container__inner">
+    <div class="fc-container__header__title">
+        <span>@title</span>
+    </div>
+    <amp-list layout="responsive" height="80", width="320" src="@if(Play.isDev) {https://www.thegulocal.com} else {@Configuration.ajax.url}/@path">
+        <template type="amp-mustache">
+            <div class="fc-item {{toneClass}}">
+                <div class="fc-item__image-container">
+                    <amp-img src="{{thumbnail}}" layout="fixed" width=126 height=75></amp-img>
+                </div>
+                <div class="fc-item__content">
+                    <div class="fc-item__header">
+                        <h2 class="fc-item__title">
+                            <span>
+                                                {{#isVideo}}
+                                @fragments.inlineSvg("video-icon", "icon")
+                                {{/isVideo}}
+                                {{#isGallery}}
+                                @fragments.inlineSvg("camera", "icon")
+                                {{/isGallery}}
+                                {{#isAudio}}
+                                @fragments.inlineSvg("volume-high", "icon")
+                                {{/isAudio}}
+                                {{#isComment}}
+                                @fragments.inlineSvg("quote", "icon")
+                                {{/isComment}}
+                            </span>
+                            {{headline}}
+                        </h2>
+                        {{#isComment}}
+                        <div class="fc-item__byline">
+                                                {{byline}}
+                        </div>
+                        {{/isComment}}
+                    </div>
+                    <aside class="fc-item__meta">
+                        <time
+                            class="fc-item__timestamp"
+                            data-relativeformat="short">
+                                @fragments.inlineSvg("clock", "icon")
+                            {{#showWebPublicationDate}}
+                                <span class="timestamp__text">
+                                    <span class="u-h">Published: </span>
+                                    {{webPublicationDate}}
+                                </span>
+                            {{/showWebPublicationDate}}
+                        </time>
+                    </aside>
+                </div>
+                <a href="{{url}}" class="fc-item__link">{{headline}}</a>
+            </div>
+        </template>
+    </amp-list>
+</div>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -46,6 +46,7 @@
 
             @if(page.metadata.id == "australia-news/postcolonial-blog/2015/jul/21/enduring-controversy-bp-sponsorship-ignites-new-row-over-british-museums-indigenous-exhibition"){
                 @fragments.amp.onward("related content", "related-mf2/" + page.metadata.id + ".json")
+                @fragments.amp.onward("headlines", "container-mf2/1/0/international.json")
                 @fragments.amp.onward("popular", "most-read-mf2.json")
             }
 

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -2,7 +2,6 @@
 @import common.{AnalyticsHost, LinkTo}
 @import conf.Configuration
 @import views.support.OmnitureAnalyticsData
-@import org.joda.time.DateTime
 
 <!doctype html>
 <html AMP>
@@ -46,59 +45,8 @@
             @body
 
             @if(page.metadata.id == "australia-news/postcolonial-blog/2015/jul/21/enduring-controversy-bp-sponsorship-ignites-new-row-over-british-museums-indigenous-exhibition"){
-
-                <div class="fc-container__inner">
-                    <div class="fc-container__header__title">
-                        <span>popular</span>
-                    </div>
-                    <amp-list height="940" layout="fixed-height" src="@if(Play.isDev) {https://www.thegulocal.com} else {@Configuration.ajax.url}/most-read-mf2.json">
-                        <template type="amp-mustache">
-                            <div class="fc-item {{toneClass}}">
-                                <div class="fc-item__image-container">
-                                    <amp-img src="{{thumbnail}}" layout="fixed" width=126 height=75></amp-img>
-                                </div>
-                                <div class="fc-item__content">
-                                    <div class="fc-item__header">
-                                        <h2 class="fc-item__title">
-                                            <span>
-                                                {{#isVideo}}
-                                                    @fragments.inlineSvg("video-icon", "icon")
-                                                {{/isVideo}}
-                                                {{#isGallery}}
-                                                    @fragments.inlineSvg("camera", "icon")
-                                                {{/isGallery}}
-                                                {{#isAudio}}
-                                                    @fragments.inlineSvg("volume-high", "icon")
-                                                {{/isAudio}}
-                                                {{#isComment}}
-                                                    @fragments.inlineSvg("quote", "icon")
-                                                {{/isComment}}
-                                            </span>
-                                            {{headline}}
-                                        </h2>
-                                        {{#isComment}}
-                                            <div class="fc-item__byline">
-                                                {{byline}}
-                                            </div>
-                                        {{/isComment}}
-                                    </div>
-                                    <aside class="fc-item__meta">
-                                        <time
-                                        class="fc-item__timestamp"
-                                        data-relativeformat="short">
-                                            @fragments.inlineSvg("clock", "icon")
-                                            <span class="timestamp__text">
-                                                <span class="u-h">Published: </span>
-                                                {{webPublicationDate}}
-                                            </span>
-                                        </time>
-                                    </aside>
-                                </div>
-                                <a href="{{url}}" class="fc-item__link">{{headline}}</a>
-                            </div>
-                        </template>
-                    </amp-list>
-                </div>
+                @fragments.amp.onward("related content", "related-mf2/" + page.metadata.id + ".json")
+                @fragments.amp.onward("popular", "most-read-mf2.json")
             }
 
             <amp-font

--- a/common/app/views/support/FaciaToMicroFormat2Helpers.scala
+++ b/common/app/views/support/FaciaToMicroFormat2Helpers.scala
@@ -1,0 +1,44 @@
+package views.support
+
+import com.gu.facia.api.models.{CuratedContent, FaciaContent}
+import model.facia.PressedCollection
+import play.api.libs.json.{JsNull, JsObject, Json, JsValue}
+import implicits.FaciaContentImplicits._
+
+object FaciaToMicroFormat2Helpers {
+  def getCollection(pressedCollection: PressedCollection): JsValue =
+    JsObject(
+      Json.obj(
+        "displayName" -> pressedCollection.displayName,
+        "href" -> pressedCollection.href,
+        "id" -> pressedCollection.id,
+        "content" -> pressedCollection.curatedPlusBackfillDeduplicated.map(isCuratedContent)
+      )
+        .fields
+        .filterNot { case (_, v) => v == JsNull }
+    )
+
+  def isCuratedContent(content: FaciaContent): JsValue = content match {
+    case c: CuratedContent => getContent(c)
+    case _ => Json.obj()
+  }
+
+  private def getContent(content: CuratedContent): JsValue =
+    JsObject(
+      Json.obj(
+        "headline" -> content.headline,
+        "trailText" -> content.trailText,
+        "url" -> content.href,
+        "thumbnail" -> content.maybeContent.flatMap(_.safeFields.get("thumbnail")),
+        "id" -> content.maybeContent.map(_.id),
+        "frontPublicationDate" -> content.maybeFrontPublicationDate,
+        "byline" -> content.byline,
+        "isComment" -> content.isComment,
+        "isVideo" -> content.isVideo,
+        "isAudio" -> content.isAudio,
+        "isGallery" -> content.isGallery,
+        "toneClass" -> TrailCssClasses.toneClass(content),
+        "showWebPublicationDate" -> false)
+      .fields
+      .filterNot{ case (_, v) => v == JsNull})
+}

--- a/common/app/views/support/FaciaToMicroFormat2Helpers.scala
+++ b/common/app/views/support/FaciaToMicroFormat2Helpers.scala
@@ -2,21 +2,12 @@ package views.support
 
 import com.gu.facia.api.models.{CuratedContent, FaciaContent}
 import model.facia.PressedCollection
-import play.api.libs.json.{JsNull, JsObject, Json, JsValue}
+import play.api.libs.json._
 import implicits.FaciaContentImplicits._
 
 object FaciaToMicroFormat2Helpers {
-  def getCollection(pressedCollection: PressedCollection): JsValue =
-    JsObject(
-      Json.obj(
-        "displayName" -> pressedCollection.displayName,
-        "href" -> pressedCollection.href,
-        "id" -> pressedCollection.id,
-        "content" -> pressedCollection.curatedPlusBackfillDeduplicated.map(isCuratedContent)
-      )
-        .fields
-        .filterNot { case (_, v) => v == JsNull }
-    )
+  def getCollection(pressedCollection: PressedCollection): JsArray =
+    JsArray(pressedCollection.curatedPlusBackfillDeduplicated.map(isCuratedContent))
 
   def isCuratedContent(content: FaciaContent): JsValue = content match {
     case c: CuratedContent => getContent(c)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -100,6 +100,7 @@ GET            /top-stories.json                                                
 GET            /top-stories/trails.json                                                                                          controllers.TopStoriesController.renderTrails()
 GET            /related/*path.json                                                                                               controllers.RelatedController.render(path)
 GET            /related/*path                                                                                                    controllers.RelatedController.renderHtml(path)
+GET            /related-mf2/*path.json                                                                                           controllers.RelatedController.renderMf2(path)
 GET            /related-alt/*path.json                                                                                           controllers.RelatedController.renderTags(path)
 GET            /popular-in-tag/*tag.json                                                                                         controllers.PopularInTag.render(tag)
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -362,6 +362,7 @@ GET            /$path<(uk|au|us|international)(/(culture|sport|commentisfree|bus
 GET            /*path/lite.json                                                                                                  controllers.FaciaController.renderFrontJsonLite(path)
 GET            /*path/deduped.json                                                                                               controllers.DedupedController.getDedupedForPath(path)
 GET            /container/*path/some/:num/:offset/:containerNameToFilter/:edition.json                                           controllers.FaciaController.renderSomeFrontContainers(path, num, offset, containerNameToFilter, edition)
+GET            /container-mf2/:num/:offset/*path.json                                                                            controllers.FaciaController.renderSomeFrontContainersMf2(num, offset, path)
 GET            /container/use-layout/*id.json                                                                                    controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
 GET            /container/*id.json                                                                                               controllers.FaciaController.renderContainerJson(id)
 GET            /most-relevant-container/*path.json                                                                               controllers.FaciaController.renderMostRelevantContainerJson(path)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -98,7 +98,6 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
 
     def returnContainers(num: Int, offset: Int) = getSomeCollections("International", num, offset, "none").map { collections =>
       Cached(60) {
-        println(collections)
         JsonComponent(
           "items" -> collections.getOrElse(List()).map(getCollection)
         )

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -1,9 +1,8 @@
 package controllers
 
-import com.gu.facia.api.models.{FaciaContent, CuratedContent, CollectionConfig}
+import com.gu.facia.api.models.CollectionConfig
 import common.FaciaMetrics._
 import common._
-import implicits.FaciaContentImplicits._
 import controllers.front._
 import layout.{CollectionEssentials, FaciaContainer, Front}
 import model._
@@ -11,12 +10,11 @@ import model.facia.PressedCollection
 import performance.MemcachedAction
 import play.api.libs.json._
 import play.api.mvc._
-import play.api.templates
 import play.twirl.api.Html
 import services.{CollectionConfigWithId, ConfigAgent}
 import slices._
 import views.html.fragments.containers.facia_cards.container
-import views.support.TrailCssClasses
+import views.support.FaciaToMicroFormat2Helpers.getCollection
 
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
@@ -113,46 +111,6 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
         BadRequest
       })
     }
-  }
-
-  private def getCollection(pressedCollection: PressedCollection): JsValue = {
-    JsObject(
-      Json.obj(
-        "displayName" -> pressedCollection.displayName,
-        "href" -> pressedCollection.href,
-        "id" -> pressedCollection.id,
-        "content" -> pressedCollection.curatedPlusBackfillDeduplicated.map(isCuratedContent)
-      )
-      .fields
-      .filterNot { case (_, v) => v == JsNull }
-    )
-  }
-
-  private def isCuratedContent(content: FaciaContent): JsValue = content match {
-    case c: CuratedContent => getContent(c)
-    case _ => Json.obj()
-  }
-
-  private def getContent(content: CuratedContent): JsValue = {
-    JsObject(
-      Json.obj(
-        "headline" -> content.headline,
-        "trailText" -> content.trailText,
-        "url" -> content.href,
-        "thumbnail" -> content.maybeContent.flatMap(_.safeFields.get("thumbnail")),
-        "id" -> content.maybeContent.map(_.id),
-        "frontPublicationDate" -> content.maybeFrontPublicationDate,
-        "byline" -> content.byline,
-        "isComment" -> content.isComment,
-        "isVideo" -> content.isVideo,
-        "isAudio" -> content.isAudio,
-        "isGallery" -> content.isGallery,
-        "toneClass" -> TrailCssClasses.toneClass(content),
-        "showWebPublicationDate" -> false
-      )
-      .fields
-      .filterNot{ case (_, v) => v == JsNull}
-    )
   }
 
   def renderContainerJsonWithFrontsLayout(id: String) = renderContainer(id, true)

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -20,6 +20,7 @@ GET        /external/eyeblaster/addineyeV2.html                                 
 GET        /collection/*id/rss                                                      controllers.FaciaController.renderCollectionRss(id)
 GET        /container/use-layout/*id.json                                           controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
 GET        /container/*path/some/:num/:offset/:containerNameToFilter/:edition.json  controllers.FaciaController.renderSomeFrontContainers(path, num, offset, containerNameToFilter, edition)
+GET        /container-mf2/:num/:offset/*path.json                                   controllers.FaciaController.renderSomeFrontContainersMf2(num, offset, path)
 GET        /container/*id.json                                                      controllers.FaciaController.renderContainerJson(id)
 GET        /most-relevant-container/*path.json                                      controllers.FaciaController.renderMostRelevantContainerJson(path)
 

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -99,7 +99,8 @@ object MostPopularController extends Controller with Logging with ExecutionConte
             ("isVideo", item.content.tags.isVideo),
             ("isAudio", item.content.tags.isAudio),
             ("isGallery", item.content.tags.isGallery),
-            ("webPublicationDate", Format(item.content.trail.webPublicationDate, "d MMM y"))
+            ("webPublicationDate", Format(item.content.trail.webPublicationDate, "d MMM y")),
+            ("showWebPublicationDate", true)
           )
         })
       )

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -1,9 +1,12 @@
 package controllers
 
 
+import com.gu.facia.api.models.{CuratedContent, FaciaContent}
+import implicits.FaciaContentImplicits._
 import common._
 import containers.Containers
 import model._
+import play.api.libs.json._
 import play.api.mvc.{ RequestHeader, Controller }
 import services._
 import performance.MemcachedAction
@@ -19,11 +22,13 @@ object RelatedController extends Controller with Related with Containers with Lo
   )
 
   def renderHtml(path: String) = render(path)
-  def render(path: String) = MemcachedAction { implicit request =>
+  def renderMf2(path: String) = render(path, true)
+  def render(path: String, isMf2: Boolean = false) = MemcachedAction { implicit request =>
     val edition = Edition(request)
     val excludeTags = request.queryString.getOrElse("exclude-tag", Nil)
     related(edition, path, excludeTags) map {
       case related if related.items.isEmpty => JsonNotFound()
+      case stories if isMf2 => renderRelatedMf2(stories.items.sortBy(-_.content.trail.webPublicationDate.getMillis), "related content")
       case trails => renderRelated(trails.items.sortBy(-_.content.trail.webPublicationDate.getMillis), "related content")
     }
   }
@@ -53,5 +58,33 @@ object RelatedController extends Controller with Related with Containers with Lo
     } else {
       Ok(views.html.relatedContent(page, relatedTrails.map(_.faciaContent)))
     }
+  }
+
+  private def renderRelatedMf2(trails: Seq[RelatedContentItem], title: String)(implicit request: RequestHeader) = Cached(30.minutes) {
+    val relatedTrails = trails take 8
+
+    JsonComponent(
+      "items" -> JsArray(trails.map( collection => isCuratedContent(collection.faciaContent)))
+    )
+  }
+
+  private def isCuratedContent(content: FaciaContent): JsValue = content match {
+    case c: CuratedContent => getContent(c)
+    case _ => Json.obj()
+  }
+
+  private def getContent(content: CuratedContent): JsValue = {
+    JsObject(
+      Json.obj(
+        "headline" -> content.headline,
+        "trailText" -> content.trailText,
+        "href" -> content.href,
+        "thumbnail" -> content.maybeContent.flatMap(_.safeFields.get("thumbnail")),
+        "id" -> content.maybeContent.map(_.id),
+        "frontPublicationDate" -> content.maybeFrontPublicationDate
+      )
+      .fields
+      .filterNot{ case (_, v) => v == JsNull}
+    )
   }
 }

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -1,8 +1,6 @@
 package controllers
 
 
-import com.gu.facia.api.models.{CuratedContent, FaciaContent}
-import implicits.FaciaContentImplicits._
 import common._
 import containers.Containers
 import model._
@@ -10,7 +8,7 @@ import play.api.libs.json._
 import play.api.mvc.{ RequestHeader, Controller }
 import services._
 import performance.MemcachedAction
-import views.support.{Format, TrailCssClasses}
+import views.support.FaciaToMicroFormat2Helpers.isCuratedContent
 import scala.concurrent.duration._
 
 object RelatedController extends Controller with Related with Containers with Logging with ExecutionContexts {
@@ -66,33 +64,6 @@ object RelatedController extends Controller with Related with Containers with Lo
 
     JsonComponent(
       "items" -> JsArray(relatedTrails.map( collection => isCuratedContent(collection.faciaContent)))
-    )
-  }
-
-  private def isCuratedContent(content: FaciaContent): JsValue = content match {
-    case c: CuratedContent => getContent(c)
-    case _ => Json.obj()
-  }
-
-  private def getContent(content: CuratedContent): JsValue = {
-    JsObject(
-      Json.obj(
-        "headline" -> content.headline,
-        "trailText" -> content.trailText,
-        "url" -> content.href,
-        "thumbnail" -> content.maybeContent.flatMap(_.safeFields.get("thumbnail")),
-        "id" -> content.maybeContent.map(_.id),
-        "frontPublicationDate" -> content.maybeFrontPublicationDate,
-        "byline" -> content.byline,
-        "isComment" -> content.isComment,
-        "isVideo" -> content.isVideo,
-        "isAudio" -> content.isAudio,
-        "isGallery" -> content.isGallery,
-        "toneClass" -> TrailCssClasses.toneClass(content),
-        "showWebPublicationDate" -> false
-      )
-      .fields
-      .filterNot{ case (_, v) => v == JsNull}
     )
   }
 }

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -55,6 +55,7 @@ GET        /embed/card/*path                          controllers.RichLinkContro
 # For tests
 GET        /most-read/*path                           controllers.MostPopularController.renderHtml(path)
 GET        /related/*path                             controllers.RelatedController.renderHtml(path)
+GET        /related-mf2/*path.json                    controllers.RelatedController.renderMf2(path)
 GET        /related-alt/*path.json                    controllers.RelatedController.renderTags(path)
 GET        /top-stories                               controllers.TopStoriesController.renderTopStoriesHtml()
 GET        /gallery/most-viewed                       controllers.MostViewedGalleryController.renderMostViewedHtml()


### PR DESCRIPTION
Adding Related and Headlines to AMP.

in the Next PR will add the other containers to the network front as well. The order would then be:
- Related Content (or Further Reading)
- Headlines
- Most Popular
- Highlights
- Sport

cc @stephanfowler and @johnduffell 
