### PR TITLE
Progressively Enhance email form

### DIFF
--- a/common/app/views/fragments/email/subscriptionResult.scala.html
+++ b/common/app/views/fragments/email/subscriptionResult.scala.html
@@ -1,25 +1,26 @@
 @(result: SubscriptionResult)
 
 @import model.{SubscriptionResult, Subscribed, InvalidEmail, OtherError}
+<div class="email-sub email-sub--article">
+    <div class="email-sub__message">
+        @result match {
+            case Subscribed => {
+                @fragments.inlineSvg("tick", "icon")
+                <h3 class="email-sub__message__headline">You've subscribed!</h3>
+                <p class="email-sub__message__description">Thank you! You are now subscribed to receive the Guardian Today email.</p>
+            }
 
-<div class="email-sub__message">
-    @result match {
-        case Subscribed => {
-            @fragments.inlineSvg("tick", "icon")
-            <h3 class="email-sub__message__headline">You've subscribed!</h3>
-            <p class="email-sub__message__description">Thank you! You are now subscribed to receive the Guardian Today email.</p>
-        }
+            case InvalidEmail => {
+                @fragments.inlineSvg("cross", "icon")
+                <h2 class="email-sub__message__headline">Invalid email address</h2>
+                <p class="email-sub__message__description">Sorry, we couldn't verify that email address. Please try again or contact userhelp@@theguardian.com.</p>
+            }
 
-        case InvalidEmail => {
-            @fragments.inlineSvg("cross", "icon")
-            <h2 class="email-sub__message__headline">Invalid email address</h2>
-            <p class="email-sub__message__description">Sorry, we couldn't verify that email address. Please try again or contact userhelp@@theguardian.com.</p>
+            case OtherError => {
+                @fragments.inlineSvg("cross", "icon")
+                <h2 class="email-sub__message__headline">Subscription error</h2>
+                <p class="email-sub__message__description">Sorry, there was a problem with your subscription request. Please try again or contact userhelp@@theguardian.com.</p>
+            }
         }
-
-        case OtherError => {
-            @fragments.inlineSvg("cross", "icon")
-            <h2 class="email-sub__message__headline">Subscription error</h2>
-            <p class="email-sub__message__description">Sorry, there was a problem with your subscription request. Please try again or contact userhelp@@theguardian.com.</p>
-        }
-    }
+    </div>
 </div>

--- a/common/app/views/fragments/footer.scala.html
+++ b/common/app/views/fragments/footer.scala.html
@@ -39,7 +39,7 @@
 
             @defining(Edition(request)) { currentEdition =>
                 @if(EmailInlineInFooterSwitch.isSwitchedOn) {
-                    <div class="footer__email-container">
+                    <div class="footer__email-container js-footer__email-container">
                     @currentEdition match {
                         case Uk => {
                             @fragments.email.emailIframe("37", "footer-daily-email-uk")

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -9,6 +9,7 @@ define([
     'Promise',
     'common/utils/mediator',
     'lodash/functions/debounce',
+    'lodash/collections/contains',
     'common/utils/template',
     'common/views/svgs',
     'text!common/views/email/submissionResponse.html',
@@ -25,6 +26,7 @@ define([
     Promise,
     mediator,
     debounce,
+    contains,
     template,
     svgs,
     successHtml,
@@ -254,7 +256,7 @@ define([
                 var browser = detect.getUserAgent.browser,
                     version = detect.getUserAgent.version;
                 // If we're in lte IE9, don't run the init and adjust the footer
-                if (browser === 'MSIE' && ['7','8','9'].indexOf(version + '') !== -1) {
+                if (browser === 'MSIE' && contains(['7','8','9'], version + '')) {
                     $('.js-footer__secondary').addClass('l-footer__secondary--no-email');
                     $('.js-footer__email-container', '.js-footer__secondary').addClass('is-hidden');
                 } else {

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -254,8 +254,11 @@ define([
                 var browser = detect.getUserAgent.browser,
                     version = detect.getUserAgent.version;
 
-                // If we're in lte IE9, don't run the init
-                if (browser !== 'MSIE' && [7,8,9].indexOf(version) === -1) {
+                // If we're in lte IE9, don't run the init and adjust the footer
+                if (browser === 'MSIE' && [7,8,9].indexOf(version) !== -1) {
+                    $('.js-footer__secondary').addClass('l-footer__secondary--no-email');
+                    $('.js-footer__email-container', '.js-footer__secondary').addClass('is-hidden');
+                } else {
                     // We're loading through the iframe
                     if (rootEl && rootEl.tagName === 'IFRAME') {
                         // We can listen for a lazy load or reload to catch an update
@@ -267,9 +270,6 @@ define([
                     } else {
                         setup(rootEl, rootEl || document, false);
                     }
-                } else {
-                    $('.js-footer__secondary').addClass('l-footer__secondary--no-email');
-                    $('.js-footer__email-container', '.js-footer__secondary').addClass('is-hidden');
                 }
             }
         };

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -253,7 +253,6 @@ define([
             init: function (rootEl) {
                 var browser = detect.getUserAgent.browser,
                     version = detect.getUserAgent.version;
-                
                 // If we're in lte IE9, don't run the init and adjust the footer
                 if (browser === 'MSIE' && ['7','8','9'].indexOf(version + '') !== -1) {
                     $('.js-footer__secondary').addClass('l-footer__secondary--no-email');

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -253,9 +253,9 @@ define([
             init: function (rootEl) {
                 var browser = detect.getUserAgent.browser,
                     version = detect.getUserAgent.version;
-
+                
                 // If we're in lte IE9, don't run the init and adjust the footer
-                if (browser === 'MSIE' && [7,8,9].indexOf(version) !== -1) {
+                if (browser === 'MSIE' && ['7','8','9'].indexOf(version + '') !== -1) {
                     $('.js-footer__secondary').addClass('l-footer__secondary--no-email');
                     $('.js-footer__email-container', '.js-footer__secondary').addClass('is-hidden');
                 } else {

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -12,7 +12,8 @@ define([
     'common/utils/template',
     'common/views/svgs',
     'text!common/views/email/submissionResponse.html',
-    'common/utils/robust'
+    'common/utils/robust',
+    'common/utils/detect'
 ], function (
     formInlineLabels,
     bean,
@@ -27,7 +28,8 @@ define([
     template,
     svgs,
     successHtml,
-    robust
+    robust,
+    detect
 ) {
     var omniture;
 
@@ -249,19 +251,26 @@ define([
     return {
             updateForm: ui.updateForm,
             init: function (rootEl) {
+                var browser = detect.getUserAgent.browser,
+                    version = detect.getUserAgent.version;
 
-                // We're loading through the iframe
-                if (rootEl && rootEl.tagName === 'IFRAME') {
-                    // We can listen for a lazy load or reload to catch an update
-                    setup(rootEl, rootEl.contentDocument.body, true);
-                    bean.on(rootEl, 'load', function () {
+                // If we're in lte IE9, don't run the init
+                if (browser !== 'MSIE' && [7,8,9].indexOf(version) === -1) {
+                    // We're loading through the iframe
+                    if (rootEl && rootEl.tagName === 'IFRAME') {
+                        // We can listen for a lazy load or reload to catch an update
                         setup(rootEl, rootEl.contentDocument.body, true);
-                    });
+                        bean.on(rootEl, 'load', function () {
+                            setup(rootEl, rootEl.contentDocument.body, true);
+                        });
 
+                    } else {
+                        setup(rootEl, rootEl || document, false);
+                    }
                 } else {
-                    setup(rootEl, rootEl || document, false);
+                    $('.js-footer__secondary').addClass('l-footer__secondary--no-email');
+                    $('.js-footer__email-container', '.js-footer__secondary').addClass('is-hidden');
                 }
-
             }
         };
 });


### PR DESCRIPTION
We've got some cross-origin/protocol/content type/header issues that need to be resolved, but in the meantime we can progressively enhance the email form so that it just submits as a normal form in lte ie-9
