### PR TITLE
Add charity donation text to the membership engaged reader banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -37,7 +37,7 @@ define([
             data: {
                 messageText: [
                     'Thank you for reading the Guardian.',
-                    'Help keep our journalism free and independent by becoming a Supporter for just £5 a month.'
+                    'Become a Supporter today for just £49 per year and we will donate £1 to the Guardian Charity Appeal 2015.'
                 ].join(' '),
                 linkText: 'Join'
             }


### PR DESCRIPTION
Tweak the messaging for the membership engaged reader banner to mention the charity donation which the Guardian will make on behalf of supporters.
#### Before

![picture 76](https://cloud.githubusercontent.com/assets/5122968/11897440/b7bc4802-a587-11e5-864e-bdb5cdea5eef.png)
#### After

![picture 77](https://cloud.githubusercontent.com/assets/5122968/11897459/d954aa86-a587-11e5-9a8e-e3659c68d0d9.png)
