### PR TITLE
Use picture element

### DIFF
--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -260,7 +260,7 @@ case class WidthsByBreakpoint(
 ) {
   private val allBreakpoints: List[Breakpoint] = List(Wide, LeftCol, Desktop, Tablet, Phablet, MobileLandscape, Mobile)
   private val allWidths: List[Option[BrowserWidth]] = List(wide, leftCol, desktop, tablet, phablet, mobileLandscape, mobile)
-  private val breakpoints: Seq[BreakpointWidth] = allBreakpoints zip allWidths collect {
+  val breakpoints: Seq[BreakpointWidth] = allBreakpoints zip allWidths collect {
       case (breakpoint, Some(width)) => BreakpointWidth(breakpoint, width)
     }
 
@@ -276,7 +276,7 @@ case class WidthsByBreakpoint(
   } mkString ", "
 
 
-  def profiles: Seq[Profile] = (breakpoints flatMap {
+  def breakpointWidthToPixels = (breakpoint: BreakpointWidth) => breakpoint match {
     case BreakpointWidth(breakpoint, PixelWidth(pixels)) =>
       Seq(pixels)
     case BreakpointWidth(Mobile, _: PercentageWidth | _: ViewportWidth) =>
@@ -286,11 +286,11 @@ case class WidthsByBreakpoint(
       val widths: Seq[Int] = pixelWidths.dropWhile(_ > MaximumMobileImageWidth).take(SourcesToEmitOnMobile)
       widths ++ FaciaWidths.ExtraPixelWidthsForMediaMobile.map(_.get)
     case _ => Seq.empty
-  })
-  .distinct
-  .map { (browserWidth: Int) =>
-    Profile(width = Some(browserWidth))
   }
+
+  def profiles: Seq[Profile] = (breakpoints flatMap breakpointWidthToPixels)
+    .distinct
+    .map((browserWidth: Int) => Profile(width = Some(browserWidth)))
 }
 
 case class BreakpointWidth(breakpoint: Breakpoint, width: BrowserWidth)

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -107,11 +107,14 @@
     }
 
     <picture>
+        @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
+        <!--[if IE 9]><video style="display: none;"><![endif]-->
         @widths.breakpoints.map { breakpointWidth =>
             <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                     sizes="@breakpointWidth.width"
                     srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageContainer = Some(picture))" />
         }
+        <!--[if IE 9]></video><![endif]-->
         <img class="@if(isMain) {maxed responsive-img} else {gu-image}"
              itemprop="contentUrl"
              alt="@imageOption.flatMap(_.altText).getOrElse("")"

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -106,12 +106,17 @@
         >
     }
 
-    <img src="@ImgSrc.getFallbackUrl(picture)"
-    srcset="@ImgSrc.srcset(picture, widths)"
-    sizes="@widths.sizes"
-    class="@if(isMain) {maxed responsive-img} else {gu-image}"
-    itemprop="contentUrl"
-    alt="@imageOption.flatMap(_.altText).getOrElse("")" />
+    <picture>
+        @widths.breakpoints.map { breakpointWidth =>
+            <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
+                    sizes="@breakpointWidth.width"
+                    srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageContainer = Some(picture))" />
+        }
+        <img class="@if(isMain) {maxed responsive-img} else {gu-image}"
+             itemprop="contentUrl"
+             alt="@imageOption.flatMap(_.altText).getOrElse("")"
+             src="@ImgSrc.getFallbackUrl(picture)" />
+    </picture>
 
     @picture.largestImage.map{ largestImage =>
         </div>

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -1,10 +1,24 @@
-@(classes: Seq[String], srcset: String, sizes: String, src: Option[String] = None)
+@import layout.WidthsByBreakpoint
+@(classes: Seq[String], widths: WidthsByBreakpoint, maybeImageContainer: Option[model.ImageContainer] = None, maybeUrl: Option[String] = None, maybeSrc: Option[String] = None)
 
-<img class="@RenderClasses(classes: _*)"
-    alt=""
-    srcset="@srcset"
-    sizes="@sizes"
-    @src.map { src =>
-        src="@src"
+<picture>
+    @widths.breakpoints.map { breakpointWidth =>
+        <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
+                sizes="@breakpointWidth.width"
+                srcset="@{
+                    widths.breakpointWidthToPixels(breakpointWidth)
+                        .map(browserWidth => Profile(width = Some(browserWidth)))
+                        .map(profile => {
+                            if (maybeUrl.isDefined) {
+                                ImgSrc.srcsetForProfile(profile, maybeUrl.get)
+                            } else {
+                                ImgSrc.srcsetForProfile(profile, maybeImageContainer.get)
+                            }
+                        })
+                        .mkString(", ")
+                }" />
     }
->
+    <img class="@RenderClasses(classes: _*)"
+         alt=""
+         @maybeSrc.map { src => src="@src" } />
+</picture>

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -1,11 +1,11 @@
 @import layout.WidthsByBreakpoint
-@(classes: Seq[String], widths: WidthsByBreakpoint, maybeImageContainer: Option[model.ImageContainer] = None, maybeUrl: Option[String] = None, maybeSrc: Option[String] = None)
+@(classes: Seq[String], widths: WidthsByBreakpoint, maybeImageContainer: Option[model.ImageContainer] = None, maybePath: Option[String] = None, maybeSrc: Option[String] = None)
 
 <picture>
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybeUrl, maybeImageContainer)" />
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageContainer)" />
     }
     <img class="@RenderClasses(classes: _*)"
          alt=""

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -5,7 +5,7 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                 sizes="@breakpointWidth.width"
-                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths, maybeUrl, maybeImageContainer)" />
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybeUrl, maybeImageContainer)" />
     }
     <img class="@RenderClasses(classes: _*)"
          alt=""

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -5,18 +5,7 @@
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                 sizes="@breakpointWidth.width"
-                srcset="@{
-                    widths.breakpointWidthToPixels(breakpointWidth)
-                        .map(browserWidth => Profile(width = Some(browserWidth)))
-                        .map(profile => {
-                            if (maybeUrl.isDefined) {
-                                ImgSrc.srcsetForProfile(profile, maybeUrl.get)
-                            } else {
-                                ImgSrc.srcsetForProfile(profile, maybeImageContainer.get)
-                            }
-                        })
-                        .mkString(", ")
-                }" />
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths, maybeUrl, maybeImageContainer)" />
     }
     <img class="@RenderClasses(classes: _*)"
          alt=""

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -2,11 +2,14 @@
 @(classes: Seq[String], widths: WidthsByBreakpoint, maybeImageContainer: Option[model.ImageContainer] = None, maybePath: Option[String] = None, maybeSrc: Option[String] = None)
 
 <picture>
+    @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
+    <!--[if IE 9]><video style="display: none;"><![endif]-->
     @widths.breakpoints.map { breakpointWidth =>
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                 sizes="@breakpointWidth.width"
                 srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageContainer)" />
     }
+    <!--[if IE 9]></video><![endif]-->
     <img class="@RenderClasses(classes: _*)"
          alt=""
          @maybeSrc.map { src => src="@src" } />

--- a/common/app/views/fragments/items/elements/facia_cards/itemImage.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/itemImage.scala.html
@@ -9,9 +9,9 @@
             case Some(widths) => {
                 @image(
                     classes = Seq("responsive-img"),
-                    srcset = ImgSrc.srcset(imageContainer, widths),
-                    sizes = widths.sizes,
-                    src = if(inlineImage) ImgSrc.getFallbackUrl(imageContainer) else None
+                    widths = widths,
+                    maybeImageContainer = Some(imageContainer),
+                    maybeSrc = if(inlineImage) ImgSrc.getFallbackUrl(imageContainer) else None
                 )
             }
 

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -98,15 +98,15 @@ data-test-id="facia-card"
                     @imageElements.headOption.map { imageElement =>
                         @image(
                             classes = Seq("responsive-img"),
-                            srcset = ImgSrc.srcset(imageElement.url, item.mediaWidthsByBreakpoint),
-                            sizes = item.mediaWidthsByBreakpoint.sizes,
-                            src = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None
+                            widths = item.mediaWidthsByBreakpoint,
+                            maybeUrl = Some(imageElement.url),
+                            maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None
                         )
                         @imageElements.tail.map { imageElement =>
                             @image(
                                 classes = Seq("responsive-img "),
-                                srcset = ImgSrc.srcset(imageElement.url, item.mediaWidthsByBreakpoint),
-                                sizes = item.mediaWidthsByBreakpoint.sizes
+                                widths = item.mediaWidthsByBreakpoint,
+                                maybeUrl = Some(imageElement.url)
                             )
                         }
                     }
@@ -156,8 +156,8 @@ data-test-id="facia-card"
             <div class="fc-item__avatar">
                 @image(
                     classes = Seq("fc-item__avatar__media", cutOut.cssClass),
-                    srcset = ImgSrc.srcset(imageUrl, FaciaWidths.cutOutFromItemClasses(item.cardTypes)),
-                    sizes = FaciaWidths.cutOutFromItemClasses(item.cardTypes).sizes
+                    widths = FaciaWidths.cutOutFromItemClasses(item.cardTypes),
+                    maybeUrl = Some(imageUrl)
                 )
             </div>
             }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -99,14 +99,14 @@ data-test-id="facia-card"
                         @image(
                             classes = Seq("responsive-img"),
                             widths = item.mediaWidthsByBreakpoint,
-                            maybeUrl = Some(imageElement.url),
+                            maybePath = Some(imageElement.url),
                             maybeSrc = if(containerIndex == 0 && index < 4) Some(imageElement.url) else None
                         )
                         @imageElements.tail.map { imageElement =>
                             @image(
                                 classes = Seq("responsive-img "),
                                 widths = item.mediaWidthsByBreakpoint,
-                                maybeUrl = Some(imageElement.url)
+                                maybePath = Some(imageElement.url)
                             )
                         }
                     }
@@ -157,7 +157,7 @@ data-test-id="facia-card"
                 @image(
                     classes = Seq("fc-item__avatar__media", cutOut.cssClass),
                     widths = FaciaWidths.cutOutFromItemClasses(item.cardTypes),
-                    maybeUrl = Some(imageUrl)
+                    maybePath = Some(imageUrl)
                 )
             </div>
             }

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -4,7 +4,7 @@ import java.net.{URI, URISyntaxException}
 import common.Logging
 import conf.switches.Switches.ImageServerSwitch
 import conf.Configuration
-import layout.WidthsByBreakpoint
+import layout.{BreakpointWidth, WidthsByBreakpoint}
 import model._
 import org.apache.commons.math3.fraction.Fraction
 import org.apache.commons.math3.util.Precision
@@ -136,6 +136,18 @@ object ImgSrc extends Logging {
 
   def srcset(imageContainer: ImageContainer, widths: WidthsByBreakpoint): String = {
     widths.profiles.map { profile => srcsetForProfile(profile, imageContainer) } mkString ", "
+  }
+
+  def srcsetForBreakpoint(breakpointWidth: BreakpointWidth, widths: WidthsByBreakpoint, maybeUrl: Option[String] = None, maybeImageContainer: Option[ImageContainer] = None) = {
+    widths.breakpointWidthToPixels(breakpointWidth)
+      .map(browserWidth => Profile(width = Some(browserWidth)))
+      .map { profile => {
+        maybeUrl
+          .map(url => srcsetForProfile(profile, url))
+          .orElse(maybeImageContainer.map(imageContainer => srcsetForProfile(profile, imageContainer)))
+          .getOrElse("")
+      } }
+      .mkString(", ")
   }
 
   def srcsetForProfile(profile: Profile, imageContainer: ImageContainer): String = {

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -138,8 +138,8 @@ object ImgSrc extends Logging {
     widths.profiles.map { profile => srcsetForProfile(profile, imageContainer) } mkString ", "
   }
 
-  def srcsetForBreakpoint(breakpointWidth: BreakpointWidth, widths: WidthsByBreakpoint, maybeUrl: Option[String] = None, maybeImageContainer: Option[ImageContainer] = None) = {
-    widths.breakpointWidthToPixels(breakpointWidth)
+  def srcsetForBreakpoint(breakpointWidth: BreakpointWidth, breakpointWidths: Seq[BreakpointWidth], maybeUrl: Option[String] = None, maybeImageContainer: Option[ImageContainer] = None) = {
+    breakpointWidth.toPixels(breakpointWidths)
       .map(browserWidth => Profile(width = Some(browserWidth)))
       .map { profile => {
         maybeUrl

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -135,19 +135,19 @@ object ImgSrc extends Logging {
   }
 
   def srcset(imageContainer: ImageContainer, widths: WidthsByBreakpoint): String = {
-    widths.profiles.map { profile =>
-      if(ImageServerSwitch.isSwitchedOn) {
-        s"${findLargestSrc(imageContainer, profile).get} ${profile.width.get}w"
-      } else {
-        s"${findNearestSrc(imageContainer, profile).get} ${profile.width.get}w"
-      }
-    } mkString ", "
+    widths.profiles.map { profile => srcsetForProfile(profile, imageContainer) } mkString ", "
   }
 
-  def srcset(path: String, widths: WidthsByBreakpoint): String = {
-    widths.profiles map { profile =>
-      s"${ImgSrc(path, profile)} ${profile.width.get}w"
-    } mkString ", "
+  def srcsetForProfile(profile: Profile, imageContainer: ImageContainer): String = {
+    if(ImageServerSwitch.isSwitchedOn) {
+      s"${findLargestSrc(imageContainer, profile).get} ${profile.width.get}w"
+    } else {
+      s"${findNearestSrc(imageContainer, profile).get} ${profile.width.get}w"
+    }
+  }
+
+  def srcsetForProfile(profile: Profile, path: String): String = {
+    s"${ImgSrc(path, profile)} ${profile.width.get}w"
   }
 
   def getFallbackUrl(imageContainer: ImageContainer): Option[String] = {

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -138,11 +138,11 @@ object ImgSrc extends Logging {
     widths.profiles.map { profile => srcsetForProfile(profile, imageContainer) } mkString ", "
   }
 
-  def srcsetForBreakpoint(breakpointWidth: BreakpointWidth, breakpointWidths: Seq[BreakpointWidth], maybeUrl: Option[String] = None, maybeImageContainer: Option[ImageContainer] = None) = {
+  def srcsetForBreakpoint(breakpointWidth: BreakpointWidth, breakpointWidths: Seq[BreakpointWidth], maybePath: Option[String] = None, maybeImageContainer: Option[ImageContainer] = None) = {
     breakpointWidth.toPixels(breakpointWidths)
       .map(browserWidth => Profile(width = Some(browserWidth)))
       .map { profile => {
-        maybeUrl
+        maybePath
           .map(url => srcsetForProfile(profile, url))
           .orElse(maybeImageContainer.map(imageContainer => srcsetForProfile(profile, imageContainer)))
           .getOrElse("")

--- a/static/src/javascripts/projects/common/modules/ui/images.js
+++ b/static/src/javascripts/projects/common/modules/ui/images.js
@@ -16,7 +16,7 @@ function (
     var images = {
 
         upgradePictures: function (context) {
-            var images = [].slice.call($('img[srcset]', context || document.body));
+            var images = [].slice.call($('img[srcset], picture img', context || document.body));
             picturefill({ elements: images });
         },
 

--- a/static/src/stylesheets/module/facia/_item.scss
+++ b/static/src/stylesheets/module/facia/_item.scss
@@ -349,13 +349,17 @@ $fc-item-gutter: $gs-gutter / 4;
         }
     }
     @include mq(tablet) {
-        .fc-item__slideshow--#{$i} img {
-            animation-duration: #{$totalLoopTime}s;
-            animation-name: fc-item__slideshow--#{$i};
+        .fc-item__slideshow--#{$i} {
+            img {
+                animation-duration: #{$totalLoopTime}s;
+                animation-name: fc-item__slideshow--#{$i};
+            }
 
             @for $j from 2 through $i {
-                &:nth-child(#{$j}) {
-                    animation-delay: #{($totalLoopTime / $i) * ($j - 1)}s;
+                picture:nth-child(#{$j}) {
+                    img {
+                        animation-delay: #{($totalLoopTime / $i) * ($j - 1)}s;
+                    }
                 }
             }
         }


### PR DESCRIPTION
We currently accidentally serve retina images to high DPR devices on mobile (because the `srcset` contains images for wider breakpoints, but the browser picks this for high DPRs). @paperboyo came up with the idea of using `<picture>` in combination with `srcset/sizes` to avoid this. Instead of:

``` html
<img src="300.jpg" sizes="(min-width: 500px) 600px, 300px" srcset="600.jpg 600w, 300.jpg 300w" />
```

We would do this:

``` html
<picture>
  <source media="(min-width: 500px)" sizes="600px" srcset=" 600.jpg 600w" />
  <img src="300.jpg" />
</picture>
```

This means the `srcset` containing the higher resolution image won't be available until the media query is met.

I ran this as a test locally. When viewing a front as DPR 2, with the picture method all images downloaded in 600 KB, whereas our current method downloaded in 1 MB. That's a big saving!

We run a modified version of picturefill. I added back the necessary parts to polyfill `<picture>`. I've heard that we've suffered with perf issues using picturefill once upon a time, especially Mobile Safari, so I will make sure this gets tested rigorously.

@johnduffell @jennysivapalan @rich-nguyen I'm not too sure about my Scala…
# To do
- [x] Add [comment workaround for IE 9](https://scottjehl.github.io/picturefill/)
- [x] Apply change to content pages
