### PR TITLE
Test - End of article email sign up from fronts

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -48,4 +48,13 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 1, 15),
     exposeClientSide = true
   )
+
+  val ABRtrtEmailFormArticlePromo = Switch(
+    "A/B Tests",
+    "ab-rtrt-email-form-article-promo",
+    "Testing the email sign up from the bottom of articles of user referred from fronts",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 1, 17),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -10,6 +10,7 @@ define([
     'common/modules/experiments/tests/video-preroll',
     'common/modules/experiments/tests/alternative-related',
     'common/modules/experiments/tests/identity-sign-in-v2',
+    'common/modules/experiments/tests/rtrt-email-form-article-promo',
     'lodash/arrays/flatten',
     'lodash/collections/forEach',
     'lodash/objects/keys',
@@ -31,6 +32,7 @@ define([
     VideoPreroll,
     AlternativeRelated,
     IdentitySignInV2,
+    RtrtEmailFormArticlePromo,
     flatten,
     forEach,
     keys,
@@ -46,7 +48,8 @@ define([
         new LargeTopAd(),
         new VideoPreroll(),
         new AlternativeRelated(),
-        new IdentitySignInV2()
+        new IdentitySignInV2(),
+        new RtrtEmailFormArticlePromo()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
@@ -6,8 +6,8 @@ define([
     'fastdom',
     'common/modules/email/email',
     'common/utils/detect',
-    'lodash/collections/contains'
-
+    'lodash/collections/contains',
+    'common/utils/config'
 ], function (
     $,
     bean,
@@ -16,7 +16,8 @@ define([
     fastdom,
     email,
     detect,
-    contains
+    contains,
+    config
 ) {
     return function () {
         this.id = 'RtrtEmailFormArticlePromo';
@@ -39,8 +40,8 @@ define([
                 browser = detect.getUserAgent.browser,
                 version = detect.getUserAgent.version;
 
-            // User referred from a front, is not logged in and not lte IE9
-            return urlRegex.test(document.referrer) && !Id.isUserLoggedIn() && !(browser === 'MSIE' && contains(['7','8','9'], version + ''));
+            // User referred from a front in the UK edition, is not logged in and not lte IE9
+            return urlRegex.test(document.referrer) && !Id.isUserLoggedIn() && config.page.edition === 'UK' && !(browser === 'MSIE' && contains(['7','8','9'], version + ''));
         };
 
         this.variants = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
@@ -1,0 +1,68 @@
+define([
+    'common/utils/$',
+    'bean',
+    'bonzo',
+    'common/modules/identity/api',
+    'fastdom',
+    'common/modules/email/email',
+    'common/utils/detect',
+    'lodash/collections/contains'
+
+], function (
+    $,
+    bean,
+    bonzo,
+    Id,
+    fastdom,
+    email,
+    detect,
+    contains
+) {
+    return function () {
+        this.id = 'RtrtEmailFormArticlePromo';
+        this.start = '2015-12-17';
+        this.expiry = '2016-01-17';
+        this.author = 'Gareth Trufitt';
+        this.description = 'Test promotion of email form at bottom of article pages (when clicked from front)';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Increase email sign-up numbers';
+        this.audienceCriteria = 'Visitors hitting articles after visiting a front';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'Email sign-up is increased';
+
+        this.canRun = function () {
+            //Tests for fronts, editions optional.
+            var host = window.location.host,
+                escapedHost = host.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&"), // Escape anything that will mess up the regex
+                urlRegex = new RegExp("^https?:\/\/" + escapedHost + "\/(uk\/|us\/|au\/)?([a-z-])+$", "gi"),
+                browser = detect.getUserAgent.browser,
+                version = detect.getUserAgent.version;
+
+            // User referred from a front, is not logged in and not lte IE9
+            return urlRegex.test(document.referrer) && !Id.isUserLoggedIn() && !(browser === 'MSIE' && contains(['7','8','9'], version + ''));
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+
+                    var iframe = bonzo.create('<iframe src="/email/form/article/37" height="218px" data-form-title="Want stories like this in your inbox?" data-form-description="Sign up to The Guardian Today daily email and get the biggest headlines each morning." data-form-campaign-code="frontReferredTest" scrolling="no" seamless frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"></iframe>')[0];
+
+                    bean.on(iframe, 'load', function () {
+                        email.init(iframe);
+                    });
+
+                    fastdom.write(function () {
+                        $('.js-article__body').append(iframe);
+                    });
+                }
+            },
+            {
+                id: 'variant',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
@@ -34,8 +34,8 @@ define([
         this.canRun = function () {
             //Tests for fronts, editions optional.
             var host = window.location.host,
-                escapedHost = host.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&"), // Escape anything that will mess up the regex
-                urlRegex = new RegExp("^https?:\/\/" + escapedHost + "\/(uk\/|us\/|au\/)?([a-z-])+$", "gi"),
+                escapedHost = host.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), // Escape anything that will mess up the regex
+                urlRegex = new RegExp('^https?:\/\/' + escapedHost + '\/(uk\/|us\/|au\/)?([a-z-])+$', 'gi'),
                 browser = detect.getUserAgent.browser,
                 version = detect.getUserAgent.version;
 


### PR DESCRIPTION
When a user goes to an article from a front, we want to show them the email sign up, we're using an A/B test to segment and roll out to 50%.
