### PR TITLE
Fix IE 9 ReferenceError

### DIFF
--- a/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
+++ b/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
@@ -97,6 +97,7 @@
     window.shouldEnhance = mustNotEnhance() ? false : mustEnhance() ? true : couldEnhance() && weWantToEnhance();
 
     // just so we can tell…
+    var console = window.console;
     console && console.info && console.info(`THIS IS ${window.shouldEnhance ? 'ENHANCED' : 'STANDARD ONLY'}`);
 })(window);
 


### PR DESCRIPTION
IE 9 users have been complaining they see an unstyled page:

![image](https://cloud.githubusercontent.com/assets/921609/11954011/c172ab6c-a89c-11e5-8e8a-4a632cfacafd.png)

This is happening because we reference `console`, which throws a `ReferenceError` in IE 9 (when the dev tools are not open). As this happens in the `head`, it breaks parsing (AFAIK).

For this reason it's always best to be explicit when referencing properties on the `window` object.

This was broken by #11371.

/cc @sndrs @gklopper @jennysivapalan 
