### PR TITLE
Bottom responsive banner on tablets

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -231,29 +231,6 @@ define([
                 });
             },
 
-            // Adds a global window:throttledScroll event to mediator, which throttles
-            // scroll events until there's a spare animationFrame.
-            // Callbacks of all listeners to window:throttledScroll are run in a
-            // fastdom.read, meaning they can all perform DOM reads for free
-            // (after the first one that needs layout triggers it).
-            // However, this means it's VITAL that all writes in callbacks are delegated to fastdom
-            throttledScrollEvent: function () {
-                var running = false;
-                var emit = function () {
-                    if (!running) {
-                        running = true;
-                        fastdom.read(function () {
-                            mediator.emitEvent('window:throttledScroll');
-                            running = false;
-                        });
-                    }
-                };
-                var callback = userPrefs.get('use-idle-callback') && 'requestIdleCallback' in window ? function () {
-                    window.requestIdleCallback(emit);
-                } : emit;
-                window.addEventListener('scroll', callback);
-            },
-
             checkIframe: function () {
                 if (window.self !== window.top) {
                     $('html').addClass('iframed');
@@ -392,7 +369,6 @@ define([
                 ['c-test-cookie', modules.testCookie],
                 ['c-ad-cookie', modules.adTestCookie],
                 ['c-event-listeners', modules.windowEventListeners],
-                ['c-throttled-scroll-event', modules.throttledScrollEvent],
                 ['c-breaking-news', modules.loadBreakingNews],
                 ['c-block-link', fauxBlockLink],
                 ['c-iframe', modules.checkIframe],

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -367,22 +367,15 @@ define([
             } else {
                 var scrollTop = window.pageYOffset,
                     viewportHeight = bonzo.viewport().height,
-                    animating = false;
+                    scrollBottom = scrollTop + viewportHeight,
+                    depth = 0.5;
 
-                if (!animating) {
-                    animating = true;
-                    window.requestAnimationFrame(function () {
-                        var scrollBottom = scrollTop + viewportHeight,
-                            depth = 0.5;
-                        animating = false;
-                        chain(slots).and(keys).and(forEach, function (slot) {
-                            // if the position of the ad is above the viewport - offset (half screen size)
-                            if (scrollBottom > document.getElementById(slot).getBoundingClientRect().top + scrollTop - viewportHeight * depth) {
-                                loadSlot(slot);
-                            }
-                        });
-                    });
-                }
+                chain(slots).and(keys).and(forEach, function (slot) {
+                    // if the position of the ad is above the viewport - offset (half screen size)
+                    if (scrollBottom > document.getElementById(slot).getBoundingClientRect().top + scrollTop - viewportHeight * depth) {
+                        loadSlot(slot);
+                    }
+                });
             }
         },
         loadSlot = function (slot) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -129,7 +129,6 @@ define([
     /**
      * Private variables
      */
-    var LAZYLOAD_TIMEOUT     = 200;
     var resizeTimeout,
         adSlotSelector       = '.js-ad-slot',
         displayed            = false,
@@ -296,7 +295,7 @@ define([
             googletag.pubads().collapseEmptyDivs();
             setPublisherProvidedId();
             googletag.enableServices();
-            window.addEventListener('scroll', lazyLoad);
+            mediator.on('window:throttledScroll', lazyLoad);
             instantLoad();
             lazyLoad();
         },
@@ -362,9 +361,9 @@ define([
                 }
             });
         },
-        lazyLoad = debounce(function () {
+        lazyLoad = function () {
             if (slots.length === 0) {
-                window.removeEventListener('scroll', lazyLoad);
+                mediator.off('window:throttledScroll', lazyLoad);
             } else {
                 var scrollTop = window.pageYOffset,
                     viewportHeight = bonzo.viewport().height,
@@ -385,7 +384,7 @@ define([
                     });
                 }
             }
-        }, LAZYLOAD_TIMEOUT),
+        },
         loadSlot = function (slot) {
             googletag.display(slot);
             slots = chain(slots).and(omit, slot).value();

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -370,9 +370,9 @@ define([
                     viewportHeight = bonzo.viewport().height,
                     animating = false;
 
-                if( !animating ) {
+                if (!animating) {
                     animating = true;
-                    window.requestAnimationFrame(function() {
+                    window.requestAnimationFrame(function () {
                         var scrollBottom = scrollTop + viewportHeight,
                             depth = 0.5;
                         animating = false;


### PR DESCRIPTION
So, the responsive takeover at the bottom of the page is not loaded on tablets. On tablets:

![img_0064](https://cloud.githubusercontent.com/assets/629976/11954710/7be44488-a8a2-11e5-9549-610be558a00f.png)

On a desktop:

![screen shot 2015-12-22 at 11 51 01](https://cloud.githubusercontent.com/assets/629976/11954653/1fe81290-a8a2-11e5-95c1-c080b1d26895.png)

It turns out the ad loads, but only if we're at the bottom of the page and hit reload then. So, it must be something with how ads are lazy loaded. Lazy loading happens when a scroll event occurs, and in the codebase scrolls are mediated through another event which wraps event handlers in `fastdom.read`:

```
mediator.on('window:throttledScroll', lazyLoad);
```

`lazyLoad` is never called. Replacing the line above with:

```
window.addEventListener('scroll', lazyLoad);
```

... and the whole thing works. For good measure, `lazyLoad` is debounced at 200ms which is more than enough for us to test whether there's a slot that needs to be loaded in the area, and the bulk of the work is offloaded to the next animation frame.

So if the _traditional approach_ is working, there must be something with the way `throttledScroll` works, and the only difference between the two is Fastdom. While the bug in this case is solved, there may be many more lurking in the codebase, and a deeper inspection of how Fastdom works appears to become an urgent issue.
