### PR TITLE
Protect against reference errors

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -12,5 +12,16 @@
 
 <link rel="prefetch" href="@Static("javascripts/app.js")">
 
+@*
+Protect against ReferenceErrors in IE:
+`window.console` only exists when the dev tools are open. If you reference
+something that doesn't exist, JavaScript will throw a `ReferenceError`. Here, we
+ensure console always exists one can safely reference it.
+Example: http://output.jsbin.com/jodureg/1
+*@
+<script>
+    window.console = window.console || undefined;
+</script>
+
 @* inline JS - blocking *@
 @fragments.inlineJSBlocking(page)


### PR DESCRIPTION
This is to prevent errors such as https://github.com/guardian/frontend/pull/11406 from happening again. I've seen this happen multiple times.
