### PR TITLE
Upload omniture script for R2 pressed pages

### DIFF
--- a/dist-publish-assets-tc
+++ b/dist-publish-assets-tc
@@ -14,9 +14,11 @@ static_folder="static/riffraff"
 rm -rf $static_folder
 
 mkdir -p "$static_folder/packages/frontend-static"
+mkdir -p "$static_folder/packages/frontend-static-non-hashed/non-hashed/javascripts"
 
 cp "static/deploy.json"      "$static_folder"
 cp -r static/hash/*          "$static_folder/packages/frontend-static"
+cp static/public/javascripts/r2-pressed-page.js          "$static_folder/packages/frontend-static-non-hashed/non-hashed/javascripts"
 cp static/abtests.json       "$static_folder/packages/frontend-abtests"
 
 pushd $static_folder

--- a/dist-publish-assets-tc
+++ b/dist-publish-assets-tc
@@ -14,11 +14,11 @@ static_folder="static/riffraff"
 rm -rf $static_folder
 
 mkdir -p "$static_folder/packages/frontend-static"
-mkdir -p "$static_folder/packages/frontend-static-non-hashed/non-hashed/javascripts"
+mkdir -p "$static_folder/packages/frontend-static-r2/non-hashed/javascripts"
 
 cp "static/deploy.json"      "$static_folder"
 cp -r static/hash/*          "$static_folder/packages/frontend-static"
-cp static/public/javascripts/r2-pressed-page.js          "$static_folder/packages/frontend-static-non-hashed/non-hashed/javascripts"
+cp static/public/javascripts/r2-pressed-page.js          "$static_folder/packages/frontend-static-r2/non-hashed/javascripts"
 cp static/abtests.json       "$static_folder/packages/frontend-abtests"
 
 pushd $static_folder

--- a/static/deploy.json
+++ b/static/deploy.json
@@ -27,7 +27,7 @@
     },
     "recipes":{
         "default":{
-            "depends" : ["abTestsFileUpload", "staticFilesUpload", "staticFilesNonHashedUpload"]
+            "depends" : ["abTestsFileUpload", "staticFilesUpload", "staticFilesR2Upload"]
         },
         "staticFilesUpload":{
             "actionsBeforeApp": ["frontend-static.uploadStaticFiles"]

--- a/static/deploy.json
+++ b/static/deploy.json
@@ -8,7 +8,7 @@
                 "cacheControl":"public, max-age=315360000"
             }
         },
-        "frontend-static-non-hashed":{
+        "frontend-static-r2":{
             "type":"aws-s3",
             "apps":[ "aws-s3" ],
             "data":{
@@ -32,8 +32,8 @@
         "staticFilesUpload":{
             "actionsBeforeApp": ["frontend-static.uploadStaticFiles"]
         },
-        "staticFilesNonHashedUpload":{
-            "actionsBeforeApp": ["frontend-static-non-hashed.uploadStaticFiles"]
+        "staticFilesR2Upload":{
+            "actionsBeforeApp": ["frontend-static-r2.uploadStaticFiles"]
         },
         "abTestsFileUpload":{
             "actionsBeforeApp": ["frontend-abtests.uploadStaticFiles"]

--- a/static/deploy.json
+++ b/static/deploy.json
@@ -8,6 +8,14 @@
                 "cacheControl":"public, max-age=315360000"
             }
         },
+        "frontend-static-non-hashed":{
+            "type":"aws-s3",
+            "apps":[ "aws-s3" ],
+            "data":{
+                "bucket":"aws-frontend-static",
+                "cacheControl":"public, max-age=3600"
+            }
+        },
         "frontend-abtests":{
             "type":"aws-s3",
             "apps":[ "aws-s3" ],
@@ -19,10 +27,13 @@
     },
     "recipes":{
         "default":{
-            "depends" : ["abTestsFileUpload", "staticFilesUpload"]
+            "depends" : ["abTestsFileUpload", "staticFilesUpload", "staticFilesNonHashedUpload"]
         },
         "staticFilesUpload":{
             "actionsBeforeApp": ["frontend-static.uploadStaticFiles"]
+        },
+        "staticFilesNonHashedUpload":{
+            "actionsBeforeApp": ["frontend-static-non-hashed.uploadStaticFiles"]
         },
         "abTestsFileUpload":{
             "actionsBeforeApp": ["frontend-abtests.uploadStaticFiles"]

--- a/static/public/javascripts/r2-pressed-page.js
+++ b/static/public/javascripts/r2-pressed-page.js
@@ -1,0 +1,3 @@
+var url = 'https://hits-secure.theguardian.com/b/ss/guardiangu-network/1/JS-1.4.1/s985205503180623100/?' + window.trackingQueryParams;
+
+(new Image()).src = url;


### PR DESCRIPTION
This PR will allows us to control the R2 omniture tracking outside of a R2 pressed page. We need to upload this file to static S3 directory so that we can refer to it in the HTML. We don't want to combine this with hashed folders as the pressed pages will not dynamically update.

I'm not sure what is the best way to test this other than putting my branch to CODE?
