### PR TITLE
Attempt 2 of omniture script for pressed pages.

### DIFF
--- a/dev/teamcity/dist-publish-assets-tc
+++ b/dev/teamcity/dist-publish-assets-tc
@@ -14,9 +14,11 @@ static_folder="static/riffraff"
 rm -rf $static_folder
 
 mkdir -p "$static_folder/packages/frontend-static"
+mkdir -p "$static_folder/packages/frontend-static-r2/non-hashed/javascripts"
 
 cp "static/deploy.json"      "$static_folder"
 cp -r static/hash/*          "$static_folder/packages/frontend-static"
+cp static/public/javascripts/r2-pressed-page.js          "$static_folder/packages/frontend-static-r2/non-hashed/javascripts"
 cp static/abtests.json       "$static_folder/packages/frontend-abtests"
 
 pushd $static_folder

--- a/dist-publish-assets-tc
+++ b/dist-publish-assets-tc
@@ -14,9 +14,11 @@ static_folder="static/riffraff"
 rm -rf $static_folder
 
 mkdir -p "$static_folder/packages/frontend-static"
+mkdir -p "$static_folder/packages/frontend-static-r2/non-hashed/javascripts"
 
 cp "static/deploy.json"      "$static_folder"
 cp -r static/hash/*          "$static_folder/packages/frontend-static"
+cp static/public/javascripts/r2-pressed-page.js          "$static_folder/packages/frontend-static-r2/non-hashed/javascripts"
 cp static/abtests.json       "$static_folder/packages/frontend-abtests"
 
 pushd $static_folder

--- a/static/deploy.json
+++ b/static/deploy.json
@@ -8,6 +8,14 @@
                 "cacheControl":"public, max-age=315360000"
             }
         },
+        "frontend-static-r2":{
+            "type":"aws-s3",
+            "apps":[ "aws-s3" ],
+            "data":{
+                "bucket":"aws-frontend-static",
+                "cacheControl":"public, max-age=3600"
+            }
+        },
         "frontend-abtests":{
             "type":"aws-s3",
             "apps":[ "aws-s3" ],
@@ -19,10 +27,13 @@
     },
     "recipes":{
         "default":{
-            "depends" : ["abTestsFileUpload", "staticFilesUpload"]
+            "depends" : ["abTestsFileUpload", "staticFilesUpload", "staticFilesR2Upload"]
         },
         "staticFilesUpload":{
             "actionsBeforeApp": ["frontend-static.uploadStaticFiles"]
+        },
+        "staticFilesR2Upload":{
+            "actionsBeforeApp": ["frontend-static-r2.uploadStaticFiles"]
         },
         "abTestsFileUpload":{
             "actionsBeforeApp": ["frontend-abtests.uploadStaticFiles"]

--- a/static/public/javascripts/r2-pressed-page.js
+++ b/static/public/javascripts/r2-pressed-page.js
@@ -1,0 +1,3 @@
+var url = 'https://hits-secure.theguardian.com/b/ss/guardiangu-network/1/JS-1.4.1/s985205503180623100/?' + window.trackingQueryParams;
+
+(new Image()).src = url;


### PR DESCRIPTION
Second attempt of https://github.com/guardian/frontend/pull/11416. Turns out there are two `dist-publish-assets-tc` files so I've updated the second one. 

Will chat to @rich-nguyen in the new year to find out why there are two...
