### PR TITLE
Prevent gallery lightbox controls from causing FOUC

### DIFF
--- a/static/src/javascripts/projects/common/modules/gallery/lightbox.js
+++ b/static/src/javascripts/projects/common/modules/gallery/lightbox.js
@@ -23,7 +23,8 @@ define([
     'lodash/collections/map',
     'lodash/functions/throttle',
     'lodash/collections/forEach',
-    'common/utils/chain'
+    'common/utils/chain',
+    'common/utils/load-css-promise'
 ], function (
     bean,
     bonzo,
@@ -49,7 +50,8 @@ define([
     map,
     throttle,
     forEach,
-    chain) {
+    chain,
+    loadCssPromise) {
 
     function GalleryLightbox() {
 
@@ -509,40 +511,42 @@ define([
     };
 
     function bootstrap() {
-        if ('lightboxImages' in config.page && config.page.lightboxImages.images.length > 0) {
-            var lightbox,
-                galleryId,
-                match,
-                galleryHash = window.location.hash,
-                images = config.page.lightboxImages,
-                res;
+        loadCssPromise.then(function () {
+            if ('lightboxImages' in config.page && config.page.lightboxImages.images.length > 0) {
+                var lightbox,
+                    galleryId,
+                    match,
+                    galleryHash = window.location.hash,
+                    images = config.page.lightboxImages,
+                    res;
 
-            bean.on(document.body, 'click', '.js-gallerythumbs', function (e) {
-                e.preventDefault();
+                bean.on(document.body, 'click', '.js-gallerythumbs', function (e) {
+                    e.preventDefault();
 
-                var $el = bonzo(e.currentTarget),
-                    galleryHref = $el.attr('href') || $el.attr('data-gallery-url'),
-                    galleryHrefParts = galleryHref.split('#img-'),
-                    parsedGalleryIndex = parseInt(galleryHrefParts[1], 10),
-                    galleryIndex = isNaN(parsedGalleryIndex) ? 1 : parsedGalleryIndex;// 1-based index
+                    var $el = bonzo(e.currentTarget),
+                        galleryHref = $el.attr('href') || $el.attr('data-gallery-url'),
+                        galleryHrefParts = galleryHref.split('#img-'),
+                        parsedGalleryIndex = parseInt(galleryHrefParts[1], 10),
+                        galleryIndex = isNaN(parsedGalleryIndex) ? 1 : parsedGalleryIndex;// 1-based index
+                    lightbox = lightbox || new GalleryLightbox();
+
+                    lightbox.loadGalleryfromJson(images, galleryIndex);
+                });
+
                 lightbox = lightbox || new GalleryLightbox();
-
-                lightbox.loadGalleryfromJson(images, galleryIndex);
-            });
-
-            lightbox = lightbox || new GalleryLightbox();
-            galleryId = '/' + config.page.pageId;
-            match = /\?index=(\d+)/.exec(document.location.href);
-            if (match) { // index specified so launch lightbox at that index
-                url.pushUrl(null, document.title, galleryId, true); // lets back work properly
-                lightbox.loadGalleryfromJson(images, parseInt(match[1], 10));
-            } else {
-                res = /^#(?:img-)?(\d+)$/.exec(galleryHash);
-                if (res) {
-                    lightbox.loadGalleryfromJson(images, parseInt(res[1], 10));
+                galleryId = '/' + config.page.pageId;
+                match = /\?index=(\d+)/.exec(document.location.href);
+                if (match) { // index specified so launch lightbox at that index
+                    url.pushUrl(null, document.title, galleryId, true); // lets back work properly
+                    lightbox.loadGalleryfromJson(images, parseInt(match[1], 10));
+                } else {
+                    res = /^#(?:img-)?(\d+)$/.exec(galleryHash);
+                    if (res) {
+                        lightbox.loadGalleryfromJson(images, parseInt(res[1], 10));
+                    }
                 }
             }
-        }
+        });
     }
 
     return {


### PR DESCRIPTION
Similar to https://github.com/guardian/frontend/pull/10924, but this time for gallery lightbox controls, which get injected on any compatible content page.

This is a race condition: if the CSS loads before the JS executes, you don't get a flash, otherwise you do.

This solution will force the JS to wait until the CSS has loaded before injecting the DOM element.
# Before

![1](https://cloud.githubusercontent.com/assets/921609/12064036/e1111c2c-afb0-11e5-98b1-f0e541f1138f.gif)
# After

There is no flash.
