### PR TITLE
Increase cache time on form endpoint

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -149,7 +149,7 @@ object EmailSignupController extends Controller with ExecutionContexts with Logg
 
   def renderForm(emailType: String, listId: Int) = Action { implicit request =>
     EmailForm.listIdsWithMaybeTrigger.lift(listId) match {
-      case Some(_) => Cached(60)(Ok(views.html.emailFragment(emailLandingPage, emailType, listId)))
+      case Some(_) => Cached(1.day)(Ok(views.html.emailFragment(emailLandingPage, emailType, listId)))
       case None => NotFound(s"List id $listId does not exist")}}
 
   def subscriptionResult(result: String) = Action { implicit request =>


### PR DESCRIPTION
There are lots of router/applications alarms relating to request spikes. The fastly logs are pointing to urls for the email form, so increasing the cache time to see if this helps.
