### PR TITLE
show clear this and anagram helper buttons on everyman crosswords

### DIFF
--- a/static/src/javascripts/projects/common/modules/crosswords/controls.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/controls.js
@@ -44,33 +44,14 @@ define([
                 }));
             }
 
-            // HIGHLIGHTED CLUE CONTROLS
-            if (hasFocus && hasSolutions) {
+            // HIGHLIGHTED CLUE CONTROLS  - published solution
+            if (hasFocus) {
                 controls.clue.unshift(React.createElement('button', {
                     className: buttonClassName + ' ' + buttonCurrentClassName,
                     onClick: this.props.onClearSingle,
                     key: 'clear-single',
                     'data-link-name': 'Clear this'
                 }, 'Clear this'));
-
-                controls.clue.unshift(React.createElement(
-                    'button', {
-                        className: buttonClassName + ' ' + buttonCurrentClassName,
-                        onClick: this.props.onCheat,
-                        key: 'cheat',
-                        'data-link-name': 'Reveal this'
-                    },
-                    'Reveal this'
-                ));
-                controls.clue.unshift(React.createElement(
-                    'button', {
-                        className: buttonClassName + ' ' + buttonCurrentClassName,
-                        onClick: this.props.onCheck,
-                        key: 'check',
-                        'data-link-name': 'Check this'
-                    },
-                    'Check this'
-                ));
 
                 // anagram helper
                 controls.clue.push(React.createElement(
@@ -82,6 +63,27 @@ define([
                     },
                     'Anagram helper'
                 ));
+
+                if(hasSolutions) {
+                    controls.clue.unshift(React.createElement(
+                        'button', {
+                            className: buttonClassName + ' ' + buttonCurrentClassName,
+                            onClick: this.props.onCheat,
+                            key: 'cheat',
+                            'data-link-name': 'Reveal this'
+                        },
+                        'Reveal this'
+                    ));
+                    controls.clue.unshift(React.createElement(
+                        'button', {
+                            className: buttonClassName + ' ' + buttonCurrentClassName,
+                            onClick: this.props.onCheck,
+                            key: 'check',
+                            'data-link-name': 'Check this'
+                        },
+                        'Check this'
+                    ));
+                }
             }
 
             return React.createElement(


### PR DESCRIPTION
This fixes a problem raised by Hugh - the 'Clear this' and 'Anagram helper' buttons sometimes do not appear on Everyman puzzles. This is because Everyman puzzles do not have solutions included until sometime after publication and the code checks for focus AND a solution before showing these controls. So, for these two buttons, just check for focus:

Before:
![everyman-before](https://cloud.githubusercontent.com/assets/986155/12088720/a9d40e68-b2d5-11e5-874c-eaa18de22750.png)

After: 
![everyman-after](https://cloud.githubusercontent.com/assets/986155/12088736/d29dfca0-b2d5-11e5-931e-2dec55447360.png)
