### PR TITLE
Remove the content-age-message switch

### DIFF
--- a/article/test/ArticleMetaDataTest.scala
+++ b/article/test/ArticleMetaDataTest.scala
@@ -19,24 +19,11 @@ import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
   }
 
   val oldToneNewsArticleUrl = "australia-news/2015/oct/01/bronwyn-bishop-will-not-face-charges-over-helicopter-flights"
-  it should "include an old article message on an article that is tagged with tone/news (switch is ON)" in {
-    conf.switches.Switches.contentAgeMessageSwitch.switchOn()
+  it should "include an old article message on an article that is tagged with tone/news" in {
     val result = controllers.ArticleController.renderArticle(oldToneNewsArticleUrl, None, None)(TestRequest(oldToneNewsArticleUrl))
     MetaDataMatcher.ensureOldArticleMessage(result, oldToneNewsArticleUrl)
   }
-  it should "not include an old article message on an article that is not tagged with tone/news (switch is ON)" in {
-    conf.switches.Switches.contentAgeMessageSwitch.switchOn()
-    val result = controllers.ArticleController.renderArticle(articleUrl, None, None)(TestRequest(articleUrl))
-    MetaDataMatcher.ensureNoOldArticleMessage(result, articleUrl)
-  }
-
-  it should "not include an old article message on an article that is tagged with tone/news (switch is OFF)" in {
-    conf.switches.Switches.contentAgeMessageSwitch.switchOff()
-    val result = controllers.ArticleController.renderArticle(oldToneNewsArticleUrl, None, None)(TestRequest(oldToneNewsArticleUrl))
-    MetaDataMatcher.ensureNoOldArticleMessage(result, oldToneNewsArticleUrl)
-  }
-  it should "not include an old article message on an article that is not tagged with tone/news (switch is OFF)" in {
-    conf.switches.Switches.contentAgeMessageSwitch.switchOff()
+  it should "not include an old article message on an article that is not tagged with tone/news" in {
     val result = controllers.ArticleController.renderArticle(articleUrl, None, None)(TestRequest(articleUrl))
     MetaDataMatcher.ensureNoOldArticleMessage(result, articleUrl)
   }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -5,15 +5,6 @@ import org.joda.time.LocalDate
 
 trait FeatureSwitches {
 
-  val contentAgeMessageSwitch = Switch(
-    "Feature",
-    "content-age-message",
-    "Show old content message on... old content (tagged tone/news)",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 1, 6),
-    exposeClientSide = false
-  )
-
   val FixturesAndResultsContainerSwitch = Switch(
     "Feature",
     "fixtures-and-results-container",

--- a/common/app/views/fragments/collections/popular.scala.html
+++ b/common/app/views/fragments/collections/popular.scala.html
@@ -5,7 +5,6 @@
 @import views.support._
 @import TrailCssClasses.toneClass
 @import views.support.MostPopular.{showMPU, tabsPaneCssClass}
-@import conf.switches.Switches.contentAgeMessageSwitch
 
 @defining(popular.size > 1){ isTabbed =>
     <div id="popular-trails" class="fc-slice fc-slice--popular" data-link-name="most popular Test" data-test-id="popular-in">
@@ -38,11 +37,9 @@
                             <p class="headline-list__count">@info.rowNum</p>
                             <div class="headline-list__text">
                                 @title(FaciaCardHeader.fromTrail(trail, None), 2, 2, "headline-list__body")
-                                @if(contentAgeMessageSwitch.isSwitchedOn) {
-                                    @trail.properties.maybeContent.map { content =>
-                                        @if(content.tags.tags.exists(_.id == "tone/news")) {
-                                            @fragments.contentAgeNotice(ContentOldAgeDescriber(content))
-                                        }
+                                @trail.properties.maybeContent.map { content =>
+                                    @if(content.tags.tags.exists(_.id == "tone/news")) {
+                                        @fragments.contentAgeNotice(ContentOldAgeDescriber(content))
                                     }
                                 }
                             </div>

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -1,5 +1,5 @@
 @(item: model.ContentType, showBadge: Boolean = true)(implicit request: RequestHeader)
-@import conf.switches.Switches._
+@import conf.switches.Switches.SaveForLaterSwitch
 @import model._
 @import views.support.ContentOldAgeDescriber
 
@@ -30,10 +30,8 @@
         <div class="meta__social" data-component="share">
             @fragments.social(item, "top")
         </div>
-        @if(contentAgeMessageSwitch.isSwitchedOn) {
-            @if(item.content.tags.tags.exists(_.id == "tone/news")) {
-                @fragments.contentAgeNotice(ContentOldAgeDescriber(item.content))
-            }
+        @if(item.content.tags.tags.exists(_.id == "tone/news")) {
+            @fragments.contentAgeNotice(ContentOldAgeDescriber(item.content))
         }
         <div class="meta__numbers modern-visible">
             <div class="u-h meta__number js-sharecount">


### PR DESCRIPTION
This feature doesn't seem to be causing problems - let's kill the switch.
