### PR TITLE
Only intercept fetch events in SW if they're to secure endpoints

### DIFF
--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -92,41 +92,43 @@ self.addEventListener('install', function (event) {
 
 this.addEventListener('fetch', function (event) {
     var request = event.request;
-
-    if (doesRequestAcceptHtml(request)) {
-        isCacheUpdated().then(function (isUpdated) {
-            if (!isUpdated) {
-                updateCache().then(deleteOldCaches);
-            }
-        });
-    }
-
     var url = new URL(request.url);
-    var isRootRequest = url.host === self.location.host;
-    // To workaround a bug in Chrome which results in broken HTTPS->HTTP
-    // redirects, we only handle root requests if they match the developer
-    // blog. The info section often hosts holding pages which will could
-    // eventually redirect to a HTTP page.
-    // https://github.com/guardian/frontend/issues/10936
-    var isRequestToDeveloperBlog = url.pathname.match(/^\/info\/developer-blog($|\/.*$)/);
-    if (isRootRequest && isRequestToDeveloperBlog && doesRequestAcceptHtml(request)) {
-        // HTML pages fallback to offline page
-        event.respondWith(
-            fetch(request)
-                .catch(function () {
-                    return caches.match('/offline-page');
-                })
-        );
-    @* In dev, all requests come from one server (by default) *@
-    } else if (@if(play.Play.isDev()) { true } else { !isRootRequest }) {
-        // Default fetch behaviour
-        // Cache first for all other requests
-        event.respondWith(
-            caches.match(request)
-                .then(function (response) {
-                    return response || fetch(request);
-                })
-        );
+
+    if (/^https/.match(url.protocol)) {
+        if (doesRequestAcceptHtml(request)) {
+            isCacheUpdated().then(function (isUpdated) {
+                if (!isUpdated) {
+                    updateCache().then(deleteOldCaches);
+                }
+            });
+        }
+
+        var isRootRequest = url.host === self.location.host;
+        // To workaround a bug in Chrome which results in broken HTTPS->HTTP
+        // redirects, we only handle root requests if they match the developer
+        // blog. The info section often hosts holding pages which will could
+        // eventually redirect to a HTTP page.
+        // https://github.com/guardian/frontend/issues/10936
+        var isRequestToDeveloperBlog = url.pathname.match(/^\/info\/developer-blog($|\/.*$)/);
+        if (isRootRequest && isRequestToDeveloperBlog && doesRequestAcceptHtml(request)) {
+            // HTML pages fallback to offline page
+            event.respondWith(
+                fetch(request)
+                    .catch(function () {
+                        return caches.match('/offline-page');
+                    })
+            );
+        @* In dev, all requests come from one server (by default) *@
+        } else if (@if(play.Play.isDev()) { true } else { !isRootRequest }) {
+            // Default fetch behaviour
+            // Cache first for all other requests
+            event.respondWith(
+                caches.match(request)
+                    .then(function (response) {
+                        return response || fetch(request);
+                    })
+            );
+        }
     }
 });
 


### PR DESCRIPTION
it doesn't let you fetch them anyway, should stop errors like these:

![screen shot 2016-01-04 at 11 43 25](https://cloud.githubusercontent.com/assets/867233/12089039/87c5aaa4-b2d8-11e5-94bd-5fda4e184edf.png)
![screen shot 2016-01-04 at 11 43 54](https://cloud.githubusercontent.com/assets/867233/12089040/89c204f6-b2d8-11e5-8367-4b70c5615bc2.png)
