### PR TITLE
Liveblogs on amp should 404, not redirect

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -83,7 +83,7 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
   private def render(path: String, page: PageWithStoryPackage)(implicit request: RequestHeader) = page match {
     case blog: LiveBlogPage =>
       if (request.isAmp) {
-        MovedPermanently(path)
+        NotFound
       } else {
         val htmlResponse = () => views.html.liveBlog(blog)
         val jsonResponse = () => views.html.fragments.liveBlogBody(blog)

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -35,7 +35,7 @@
     <link rel="manifest" href="/2015-06-24-manifest.json" crossorigin="use-credentials">
 
     @Page.getContentPage(page).map { content =>
-        @if((content.item.tags.isArticle && !content.item.tags.isLiveBlog) || (content.item.tags.isArticle && !content.metadata.isImmersive)) {
+        @if(content.item.tags.isArticle && !content.item.tags.isLiveBlog && !content.metadata.isImmersive) {
             <link rel="amphtml" href="@LinkTo{/@page.metadata.id/amp}">
         }
     }


### PR DESCRIPTION
Currently if you go to `/<liveblog path>/amp`, there is a strange redirect. This should make it simply respond with a 404
#11425
