### PR TITLE
Adding serverside switch for turning off amp

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -340,4 +340,12 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val AmpSwitch = Switch(
+    "Server-side A/B Tests",
+    "amp-switch",
+    "If this switch is on, link to amp pages will be in the metadata for articles",
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false
+  )
 }

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -7,6 +7,7 @@
 @import play.api.Play
 @import play.api.Play.current
 @import views.support.{SeoThumbnail, StripHtmlTags}
+@import conf.switches.Switches.AmpSwitch
 
 @* Critical meta data that have an impact on rendering speed *@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
@@ -35,7 +36,7 @@
     <link rel="manifest" href="/2015-06-24-manifest.json" crossorigin="use-credentials">
 
     @Page.getContentPage(page).map { content =>
-        @if(content.item.tags.isArticle && !content.item.tags.isLiveBlog && !content.metadata.isImmersive) {
+        @if(content.item.tags.isArticle && !content.item.tags.isLiveBlog && !content.metadata.isImmersive && AmpSwitch.isSwitchedOn) {
             <link rel="amphtml" href="@LinkTo{/@page.metadata.id/amp}">
         }
     }


### PR DESCRIPTION
We want the ability to stop amp pages being found on our site if the need arises. The quickest way to do that is to not show the link to the `amphtml` in the metadata

cc @stephanfowler 
