### PR TITLE
Fix crossword print URL

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -16,7 +16,7 @@
             <h1 itemprop="headline" class="content__headline js-score">@Html(crosswordPage.crossword.name)</h1>
             @if( gridVisable ) {
                 <div class="crossword__links">
-                    <a target="_blank" href="@LinkTo(s"/crosswords/print/${crosswordPage.crossword.crosswordType}/${crosswordPage.crossword.number}")">Print</a>
+                    <a target="_blank" href="@LinkTo(s"/crosswords/${crosswordPage.crossword.crosswordType}/${crosswordPage.crossword.number}/print")">Print</a>
 
                     @crosswordPage.crossword.pdf.map { pdf =>
                             | <a class="crossword__link" href="@pdf" target="_blank">PDF version</a>

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -15,7 +15,7 @@ GET        /surveys/*file                                                       
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
 GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id.svg       controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
 GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id           controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
-GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id/print     controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|special|genius|speedy>/:id/print          controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
 GET        /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id     controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
 
 # Crosswords search

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -15,7 +15,7 @@ GET        /surveys/*file                                                       
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
 GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id.svg       controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
 GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id           controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
-GET        /crosswords/print/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id     controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
+GET        /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id/print     controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
 GET        /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id     controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
 
 # Crosswords search

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -25,7 +25,7 @@ OPTIONS        /accept-beacon                                                   
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
 GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id.svg               controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
 GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id                   controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
-GET            /crosswords/print/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id             controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
+GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id/print             controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
 GET            /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id        controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
 
 # Crosswords search

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -25,7 +25,7 @@ OPTIONS        /accept-beacon                                                   
 # NOTE: Leave this as it is, otherwise we don't render /crosswords/series/prize, for example.
 GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id.svg               controllers.CrosswordPageController.thumbnail(crosswordType: String, id: Int)
 GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id                   controllers.CrosswordPageController.crossword(crosswordType: String, id: Int)
-GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id/print             controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
+GET            /crosswords/$crosswordType<cryptic|quick|quiptic|prize|everyman|special|genius|speedy>/:id/print                  controllers.CrosswordPageController.printableCrossword(crosswordType: String, id: Int)
 GET            /crosswords/accessible/$crosswordType<cryptic|quick|quiptic|prize|everyman|azed|special|genius|speedy>/:id        controllers.CrosswordPageController.accessibleCrossword(crosswordType: String, id: Int)
 
 # Crosswords search


### PR DESCRIPTION
Move it back to the end of the path to make it consistent with R2.
There's also an incoming fastly change to allow these URLs in nextgen.
