### PR TITLE
Add test of Ophan analytics for AMP

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -19,6 +19,11 @@
         @if(page.metadata.id == "australia-news/postcolonial-blog/2015/jul/21/enduring-controversy-bp-sponsorship-ignites-new-row-over-british-museums-indigenous-exhibition") {
             <script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async ></script>
         }
+        @if(page.metadata.id == "info/developer-blog/2015/jan/05/delivering-continuous-delivery-continuously") {
+            <script custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js" async></script>
+            <amp-analytics config="https://j.ophan.co.uk/amp.json">
+            </amp-analytics>
+        }
         <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
         <script src="https://cdn.ampproject.org/v0.js" async></script>
     </head>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -21,8 +21,6 @@
         }
         @if(page.metadata.id == "info/developer-blog/2015/jan/05/delivering-continuous-delivery-continuously") {
             <script custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js" async></script>
-            <amp-analytics config="https://j.ophan.co.uk/amp.json">
-            </amp-analytics>
         }
         <style>body {opacity: 0}</style><noscript><style>body {opacity: 1}</style></noscript>
         <script src="https://cdn.ampproject.org/v0.js" async></script>
@@ -37,6 +35,9 @@
                 <amp-pixel src="@Html(omnitureCall)"></amp-pixel>
                 <amp-pixel src="//beacon.guim.co.uk/count/pva.gif"></amp-pixel>
             }
+        }
+        @if(page.metadata.id == "info/developer-blog/2015/jan/05/delivering-continuous-delivery-continuously") {
+            <amp-analytics config="https://j.ophan.co.uk/amp.json"></amp-analytics>
         }
 
         <div class="main-body">


### PR DESCRIPTION
https://github.com/guardian/ophan/pull/1293/files was the corresponding PR for the config living in Ophan.

In order to see this make a request, you currently need to use `AMP.toggleExperiment('amp-analytics')` in the console. You will also see some validation errors until https://github.com/ampproject/amphtml/issues/1087 is addressed.

cc @NataliaLKB @johnduffell 
