### PR TITLE
Support BrowserSync in nginx dev config

### DIFF
--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -1,8 +1,13 @@
+upstream frontend {
+  server localhost:3000;
+  server localhost:9000 backup;
+}
+
 server {
     server_name m.thegulocal.com;
 
     location / {
-        proxy_pass http://localhost:9000/;
+        proxy_pass http://frontend;
         proxy_set_header Host $host;
         proxy_set_header "X-Forwarded-Proto" "http";
     }
@@ -27,7 +32,7 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     location / {
-        proxy_pass http://localhost:9000/;
+        proxy_pass http://frontend;
         proxy_set_header Host $host;
         proxy_set_header "X-Forwarded-Proto" "https";
     }
@@ -52,7 +57,7 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     location / {
-        proxy_pass http://localhost:9009/;
+        proxy_pass http://localhost:9009;
         proxy_set_header "X-Forwarded-Proto" "https";
     }
 }


### PR DESCRIPTION
This means you can use m.thegulocal.com with BrowserSync, and if that isn't running it'll fall back to the usual SBT port.
