### PR TITLE
Enable the test that checks switches have a valid date

### DIFF
--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -22,10 +22,10 @@ class SwitchesTest extends FlatSpec with Matchers {
   }
 
   // If you are wondering why this test has failed then read, https://github.com/guardian/frontend/pull/2711
-  //they should "be deleted once expired" in {
-  //  Switches.all foreach {
-  //    case Switch(_, id, _, _, sellByDate, _) => assert(sellByDate.isAfter(new LocalDate()), id)
-  //    case TimerSwitch(_, id, _, _, sellByDate, _, _) => assert(sellByDate.isAfter(new LocalDate()), id)
-  //  }
-  //}
+  they should "be deleted once expired" in {
+    Switches.all foreach {
+      case Switch(_, id, _, _, sellByDate, _) => assert(sellByDate.isAfter(new LocalDate()), id)
+      case TimerSwitch(_, id, _, _, sellByDate, _, _) => assert(sellByDate.isAfter(new LocalDate()), id)
+    }
+  }
 }

--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -1,5 +1,6 @@
 package conf.switches
 
+import org.joda.time.LocalDate
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
@@ -24,8 +25,8 @@ class SwitchesTest extends FlatSpec with Matchers {
   // If you are wondering why this test has failed then read, https://github.com/guardian/frontend/pull/2711
   they should "be deleted once expired" in {
     Switches.all foreach {
-      case Switch(_, id, _, _, sellByDate, _) => assert(sellByDate.isAfter(new LocalDate()), id)
-      case TimerSwitch(_, id, _, _, sellByDate, _, _) => assert(sellByDate.isAfter(new LocalDate()), id)
+      case Switch(_, id, _, _, sellByDate, _) => assert(sellByDate.isAfter(LocalDate.now()), id)
+      case TimerSwitch(_, id, _, _, sellByDate, _, _) => assert(sellByDate.isAfter(LocalDate.now()), id)
     }
   }
 }


### PR DESCRIPTION
Putting this back in the test suite because a lot of switches are going past their expiry date.
