### PR TITLE
Follow guideline for numbered list style (no bold and no period after number)

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -359,9 +359,9 @@
         > li:before {
             position: absolute;
             left: -16px;
-            content: counter(li)'.';
+            content: counter(li);
             counter-increment: li;
-            @include fs-header(1);
+            @include fs-header(1, true);
             color: colour(neutral-3);
 
             @include mq(tablet) {

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -45,9 +45,9 @@
         counter-reset: li;
     }
     > ol > li:before {
-        content: counter(li)'.';
+        content: counter(li);
         counter-increment: li;
-        @include fs-header(1);
+        @include fs-header(1, true);
         margin-right: 4px;
 
         @include mq(tablet) {


### PR DESCRIPTION
Guideline:

```
lists
1 Similar to bullet points.
2 Like this.
3 With no full points after the number.
```

http://www.theguardian.com/guardian-observer-style-guide-l

Before:
<img width="338" alt="picture 6" src="https://cloud.githubusercontent.com/assets/233326/12149798/9d2bb7e6-b49d-11e5-9d00-c939732141e2.png">

After:
<img width="395" alt="picture 7" src="https://cloud.githubusercontent.com/assets/233326/12149802/a1f5345a-b49d-11e5-9166-3519da8ba30a.png">
