### PR TITLE
extend quiz score switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -210,7 +210,7 @@ trait FeatureSwitches {
     "quiz-scores-service",
     "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 1, 10),
+    sellByDate = new LocalDate(2016, 3, 10),
     exposeClientSide = false
   )
 

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -210,7 +210,7 @@ trait FeatureSwitches {
     "quiz-scores-service",
     "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 3, 10),
+    sellByDate = new LocalDate(2016, 4, 10),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
People are still getting value out of the temporary quiz score service.  Eventually we will write quizzes properly in frontend (apparently you know more @rich-nguyen ) at which point we'll make a proper solution for quiz scores
