### PR TITLE
Don't call s.tl for untagged page clicks

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -88,7 +88,7 @@ define([
             storage.session.set(NG_STORAGE_KEY, storeObj);
         } else {
             // Do not perform a same-page track link when there isn't a tag.
-            if (!spec.tag) {
+            if (spec.tag) {
                 // this is confusing: if s.tl() first param is "true" then it *doesn't* delay.
                 delay = spec.samePage ? true : spec.target;
                 this.trackLink(delay, spec.tag, {customEventProperties: spec.customEventProperties});

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -87,9 +87,12 @@ define([
             try { sessionStorage.setItem(R2_STORAGE_KEY, storeObj.tag); } catch (e) {/**/}
             storage.session.set(NG_STORAGE_KEY, storeObj);
         } else {
-            // this is confusing: if s.tl() first param is "true" then it *doesn't* delay.
-            delay = spec.samePage ? true : spec.target;
-            this.trackLink(delay, spec.tag, { customEventProperties: spec.customEventProperties });
+            // Do not perform a same-page track link when there isn't a tag.
+            if (!spec.tag) {
+                // this is confusing: if s.tl() first param is "true" then it *doesn't* delay.
+                delay = spec.samePage ? true : spec.target;
+                this.trackLink(delay, spec.tag, {customEventProperties: spec.customEventProperties});
+            }
         }
     };
 

--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -4,9 +4,8 @@ define([
     'common/utils/config',
     'common/modules/analytics/omniture',
     'lodash/objects/values',
-    'common/utils/chain',
-    'common/modules/experiments/ab'
-], function (qwery, config, omniture, values, chain, ab) {
+    'common/utils/chain'
+], function (qwery, config, omniture, values, chain) {
 
     function OmnitureMedia(player) {
 

--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -39,7 +39,6 @@ define([
                 // extra events with no set ordering
                 duration: 'event57'
             },
-            abTestParticipation = ab.makeOmnitureTag(),
             trackingVars = [
                 // these tracking vars are specific to media events.
                 'eVar11',   // embedded or on platform
@@ -71,6 +70,7 @@ define([
         };
 
         this.sendEvent = function (event, eventName, ad) {
+            omniture.populateEventProperties(eventName || event);
             s.eVar74 = ad ?  mediaType + ' ad' : mediaType + ' content';
 
             // Set these each time because they are shared global variables, but OmnitureMedia is instanced.
@@ -80,14 +80,11 @@ define([
                 // Any event after 'video:preroll:play' should be tagged with this value.
                 s.prop41 = 'PrerollMilestone';
             }
-            s.linkTrackVars = omniture.getStandardProps() + ',' + chain(trackingVars).join(',');
-            s.linkTrackEvents = values(events).join(',');
-            s.events = event;
+            s.linkTrackVars += ',' + chain(trackingVars).join(',');
+            s.linkTrackEvents +=  ',' + values(events).join(',');
+            s.events += ',' + event;
             s.tl(true, 'o', eventName || event);
-            s.prop41 = s.eVar44 = s.prop44 = s.eVar43 = s.prop43 = undefined;
-
-            s.list1 = abTestParticipation;
-
+            s.prop41 = s.eVar44 = s.prop44 = s.eVar43 = s.prop43 = s.eVar74 = undefined;
         };
 
         this.sendNamedEvent = function (eventName, ad) {
@@ -105,8 +102,6 @@ define([
 
             s.eVar11 = isEmbed ? 'Embedded' : config.page.sectionName || '';
             s.eVar7 = s.pageName;
-
-            s.list1 = abTestParticipation;
 
             s.Media.open(mediaId, this.getDuration(), 'HTML5 Video');
 

--- a/static/test/javascripts/spec/common/analytics/omniture.spec.js
+++ b/static/test/javascripts/spec/common/analytics/omniture.spec.js
@@ -113,7 +113,7 @@ define([
             omniture.go();
             mediator.emit('module:clickstream:click', clickSpec);
 
-            expect(s.tl).toHaveBeenCalledTwice();
+            expect(s.tl).toHaveBeenCalledOnce();
         });
 
         it('should not log clickstream events with an invalidTarget', function () {


### PR DESCRIPTION
The omniture analytics module was firing track links which didn't have a tag. These were interpreted as page views. Now, same-page clicks that do not have a `data-link-name` won't be tracked by omniture at all.
