### PR TITLE
Fix asset map lookups for any JS not compiled in dev

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,10 +134,7 @@ module.exports = function (grunt) {
         grunt.task.run([
             'copy:inlineSVGs',
             'clean:js',
-            'copy:javascript',
-            // The app file must exist in dev to avoid compilation errors due to
-            // the SW. For testing the SW, do a proper compile.
-            'shell:stubAppJs'
+            'copy:javascript'
         ]);
 
         if (isOnlyTask(this) && !fullCompile) {

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -22,20 +22,39 @@ class AssetMap(base: String, assetMap: String = "assets/assets.map") {
 
   def assets(): Map[String, Asset] = {
 
-    // Use the grunt-generated asset map in Dev.
-    val json: String = if (Play.current.mode == Mode.Dev) {
-      val assetMapUri = new java.io.File(s"static/hash/assets/assets.map").toURI
-      IOUtils.toString(assetMapUri)
-    } else {
-      val url = AssetFinder(assetMap)
-      IOUtils.toString(url)
-    }
-    val paths: Map[String, String] = Json.parse(json).validate[Map[String, String]] match {
-      case JsSuccess(m, _) => m
+    def jsonToAssetMap(json: String): Map[String, Asset] = Json.parse(json).validate[Map[String, String]] match {
+      case JsSuccess(m, _) => m mapValues { path => Asset(base + path) }
       case JsError(_) => Map.empty
     }
 
-    paths mapValues { path => Asset(base + path) }
+    // Given a map, add a pair for missing entries where key and value are identical
+    def addIfMissing(map: Map[String, Asset], entries: Seq[String]): Map[String, Asset] =
+      entries.foldLeft(map)((accumulator, entry) => accumulator.get(entry) match {
+        case Some(_) => accumulator
+        case None => accumulator + (entry -> Asset(base + entry))
+      })
+    
+    if (Play.current.mode == Mode.Dev) {
+      // Use the grunt-generated asset map in Dev.
+      val assetMapUri = new java.io.File(s"static/hash/assets/assets.map").toURI
+      val serviceWorkerWhitelist = Seq(
+        "javascripts/app.js",
+        "javascripts/enhanced-vendor.js",
+        "javascripts/bootstraps/enhanced/main.js",
+        "javascripts/bootstraps/enhanced/crosswords.js",
+        "javascripts/bootstraps/commercial.js",
+        "javascripts/components/react/react.js"
+      )
+      // We reference these files using the asset map in dev, but because they're not compiled,
+      // they don't exist as entries in the asset map.
+      // To test the service worker in dev, one must compile the JS.
+      val whitelist = Seq("javascripts/bootstraps/enhanced/ophan.js") ++ serviceWorkerWhitelist
+      val map = jsonToAssetMap(IOUtils.toString(assetMapUri))
+      addIfMissing(map, whitelist)
+    } else {
+      val url = AssetFinder(assetMap)
+      jsonToAssetMap(IOUtils.toString(url))
+    }
   }
 
   private lazy val memoizedAssets = assets()

--- a/common/app/dev/DevAssetsController.scala
+++ b/common/app/dev/DevAssetsController.scala
@@ -10,12 +10,12 @@ import play.Play
 
 object DevAssetsController extends Controller with ExecutionContexts {
   // This asset map is used for finding files on local disk.
-  private val localAssets = new common.Assets.Assets("static/hash/")
+  private val localAssets = new common.Assets.Assets(base = "")
 
-  private val findDevAsset: PartialFunction[String, Asset] = {
-    case path if new File(s"static/hash/$path").exists() => Asset(s"static/hash/$path")
-    case path if new File(s"static/src/$path").exists() => Asset(s"static/src/$path")
-    case path if new File(s"static/public/$path").exists() => Asset(s"static/public/$path")
+  private val findDevAsset: PartialFunction[String, String] = {
+    case path if new File(s"static/hash/$path").exists() => s"static/hash/$path"
+    case path if new File(s"static/src/$path").exists() => s"static/src/$path"
+    case path if new File(s"static/public/$path").exists() => s"static/public/$path"
   }
 
   def at(path: String): Action[AnyContent] = Action { implicit request =>
@@ -25,11 +25,17 @@ object DevAssetsController extends Controller with ExecutionContexts {
     }
 
     // In dev mode we must consistently reload the asset map, to account for changes to the map.
-    val asset = localAssets.lookup.assets().getOrElse(path, findDevAsset.lift(path).getOrElse {
-        throw AssetNotFoundException(path)
-      })
+    val resolvedPath = findDevAsset.lift(
+      localAssets.lookup
+        .assets()
+        .get(path)
+        .map(_.path)
+        .getOrElse(path)
+    ).getOrElse {
+      throw AssetNotFoundException(path)
+    }
 
-    val resolved = new File(asset.path).toURI.toURL
+    val resolved = new File(resolvedPath).toURI.toURL
 
     Result(
       ResponseHeader(OK, Map(CONTENT_TYPE -> contentType.getOrElse(BINARY))),

--- a/common/app/dev/DevAssetsController.scala
+++ b/common/app/dev/DevAssetsController.scala
@@ -25,12 +25,15 @@ object DevAssetsController extends Controller with ExecutionContexts {
     }
 
     // In dev mode we must consistently reload the asset map, to account for changes to the map.
-    val resolvedPath = findDevAsset.lift(
-      localAssets.lookup
+
+    val maybeAssetMapPath = localAssets.lookup
         .assets()
         .get(path)
         .map(_.path)
-        .getOrElse(path)
+
+    val resolvedPath = findDevAsset.lift(
+      // Use the asset map path if we have one, otherwise use the provided path
+      maybeAssetMapPath.getOrElse(path)
     ).getOrElse {
       throw AssetNotFoundException(path)
     }

--- a/grunt-configs/shell.js
+++ b/grunt-configs/shell.js
@@ -36,10 +36,6 @@ module.exports = function () {
             command: 'node dev/eslint-rules/tests/*'
         },
 
-        stubAppJs: {
-            command: 'touch static/target/javascripts/app.js'
-        },
-
         makeDeploysRadiator: {
             command: [
                 'npm install',


### PR DESCRIPTION
Broken by https://github.com/guardian/frontend/pull/11472

On master, after `make compile-dev`:

![image](https://cloud.githubusercontent.com/assets/921609/12170412/366dbada-b539-11e5-8eb3-d196699f45e6.png)

This was happening because we used to allow invalid asset map lookups, but now this throws an error (correctly).

This proposes a whitelist for assets which are not compiled in dev but we still want them to be accessible via the asset map. Coincidentally, this also solves a problem we had with the dev workflow for the offline page.
