### PR TITLE
0% AB test removing the sticky nav

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -48,4 +48,13 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 1, 17),
     exposeClientSide = true
   )
+
+  val ABRemoveStickyNav = Switch(
+    "A/B Tests",
+    "ab-remove-sticky-nav",
+    "Removes the sticky nav (0% test)",
+    safeState = On,
+    sellByDate = new LocalDate(2016, 2, 28),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -53,7 +53,7 @@ trait ABTestSwitches {
     "A/B Tests",
     "ab-remove-sticky-nav",
     "Removes the sticky nav (0% test)",
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2016, 2, 28),
     exposeClientSide = true
   )

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -30,7 +30,7 @@
                 var ophanScript = document.createElement('script'),
                         sc = document.getElementsByTagName('script')[0];
 
-                @*ophanScript.src = '@Static("javascripts/bootstraps/enhanced/ophan.js")';*@
+                ophanScript.src = '@Static("javascripts/bootstraps/enhanced/ophan.js")';
                 ophanScript.async = true;
                 sc.parentNode.insertBefore(ophanScript, sc);
             }

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -30,7 +30,7 @@
                 var ophanScript = document.createElement('script'),
                         sc = document.getElementsByTagName('script')[0];
 
-                ophanScript.src = '@Static("javascripts/bootstraps/enhanced/ophan.js")';
+                @*ophanScript.src = '@Static("javascripts/bootstraps/enhanced/ophan.js")';*@
                 ophanScript.async = true;
                 sc.parentNode.insertBefore(ophanScript, sc);
             }

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -142,7 +142,7 @@ define([
                     && config.page.pageId !== 'offline-page') {
 
                     if (ab.isInVariant('RemoveStickyNav', 'new')) {
-                        newSticky.init();
+                        new newSticky();
                     } else {
                         sticky.init();
                     }

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -141,7 +141,7 @@ define([
                     && (!config.switches.newCommercialContent || !config.page.isAdvertisementFeature)
                     && config.page.pageId !== 'offline-page') {
 
-                    if(ab.isInVariant('RemoveStickyNav', 'new')) {
+                    if (ab.isInVariant('RemoveStickyNav', 'new')) {
                         newSticky.init();
                     } else {
                         sticky.init();

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -87,7 +87,7 @@ define([
     CookieRefresh,
     navigation,
     sticky,
-    newSticky,
+    NewSticky,
     Profile,
     Search,
     history,
@@ -142,7 +142,7 @@ define([
                     && config.page.pageId !== 'offline-page') {
 
                     if (ab.isInVariant('RemoveStickyNav', 'new')) {
-                        new newSticky();
+                        new NewSticky();
                     } else {
                         sticky.init();
                     }

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -31,6 +31,7 @@ define([
     'common/modules/identity/cookierefresh',
     'common/modules/navigation/navigation',
     'common/modules/navigation/sticky',
+    'common/modules/navigation/newSticky',
     'common/modules/navigation/profile',
     'common/modules/navigation/search',
     'common/modules/onward/history',
@@ -86,6 +87,7 @@ define([
     CookieRefresh,
     navigation,
     sticky,
+    newSticky,
     Profile,
     Search,
     history,
@@ -138,10 +140,12 @@ define([
                     && config.page.contentType !== 'Crossword'
                     && (!config.switches.newCommercialContent || !config.page.isAdvertisementFeature)
                     && config.page.pageId !== 'offline-page') {
-                    sticky.init();
-                    config.page.hasStickyHeader = true;
-                } else {
-                    config.page.hasStickyHeader = false;
+
+                    if(ab.isInVariant('RemoveStickyNav', 'new')) {
+                        newSticky.init();
+                    } else {
+                        sticky.init();
+                    }
                 }
             },
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -6,6 +6,7 @@ define([
     'common/utils/storage',
     'common/modules/analytics/mvt-cookie',
     'common/modules/experiments/tests/fronts-on-articles2',
+    'common/modules/experiments/tests/remove-sticky-nav',
     'common/modules/experiments/tests/large-top-slot',
     'common/modules/experiments/tests/alternative-related',
     'common/modules/experiments/tests/identity-sign-in-v2',
@@ -27,6 +28,7 @@ define([
     store,
     mvtCookie,
     FrontsOnArticles2,
+    RemoveStickyNav,
     LargeTopAd,
     AlternativeRelated,
     IdentitySignInV2,
@@ -46,7 +48,8 @@ define([
         new LargeTopAd(),
         new AlternativeRelated(),
         new IdentitySignInV2(),
-        new RtrtEmailFormArticlePromo()
+        new RtrtEmailFormArticlePromo(),
+        new RemoveStickyNav()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.js
@@ -1,0 +1,38 @@
+define([
+    'common/utils/config'
+], function (
+    config
+) {
+    return function () {
+        this.id = 'RemoveStickyNav';
+        this.start = '2015-1-07';
+        this.expiry = '2016-2-30';
+        this.author = 'Josh Holder';
+        this.description = '0% AB test for removing the sticky nav';
+        this.audience = 0.0;
+        this.audienceOffset = 0.0;
+        this.successMeasure = '';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            return true;
+        };
+
+        this.variants = [
+            {
+                id: 'old',
+                test: function () {
+
+                }
+            },
+            {
+                id: 'new',
+                test: function () {
+
+                }
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.js
@@ -1,7 +1,5 @@
 define([
-    'common/utils/config'
 ], function (
-    config
 ) {
     return function () {
         this.id = 'RemoveStickyNav';

--- a/static/src/javascripts/projects/common/modules/navigation/newSticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newSticky.js
@@ -1,0 +1,76 @@
+define([
+    'fastdom',
+    'common/utils/$',
+    'common/utils/mediator',
+    'lodash/functions/bindAll'
+], function (
+    fastdom,
+    $,
+    mediator,
+    bindAll) {
+
+    function StickyHeader() {
+
+    }
+
+    StickyHeader.prototype.init = function () {
+        fastdom.read(function () {
+            this.$adBanner = $('.js-top-banner-above-nav');
+            this.$header = $('.js-header');
+            this.headerHeight = this.$header.height();
+            this.adHeight = this.$adBanner.height();
+        }.bind(this));
+
+        fastdom.write(function () {
+            this.$adBanner.css({
+                'width': '100%',
+                'z-index': '1020'
+            });
+
+            this.$header.css({
+                'z-index': '1019'
+            });
+        }.bind(this));
+
+        bindAll(this, 'stickOrUnstick', 'updateHeights');
+
+        mediator.on('window:throttledScroll', this.stickOrUnstick);
+    };
+
+    StickyHeader.prototype.stickOrUnstick = function () {
+        var css;
+        this.updateHeights();
+        if (window.scrollY > this.headerHeight) {
+            css = {
+                'position': 'absolute',
+                'top': this.headerHeight + 'px'
+            };
+        } else {
+            css = {
+                'position': 'fixed',
+                'top': 0
+            };
+        }
+
+        fastdom.write(function () {
+            this.$adBanner.css(css);
+        }.bind(this));
+    };
+
+    StickyHeader.prototype.updateHeights = function () {
+        if (window.scrollY < 300) {
+            fastdom.read(function () {
+                this.headerHeight = this.$header.height();
+                this.adHeight = this.$adBanner.height();
+
+                fastdom.write(function () {
+                    this.$header.css({
+                        'margin-top': this.adHeight + 'px'
+                    });
+                }.bind(this));
+            }.bind(this));
+        }
+    };
+
+    return new StickyHeader();
+});

--- a/static/src/javascripts/projects/common/modules/navigation/newSticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newSticky.js
@@ -2,39 +2,43 @@ define([
     'fastdom',
     'common/utils/$',
     'common/utils/mediator',
-    'lodash/functions/bindAll'
+    'lodash/functions/bindAll',
+    'common/utils/detect'
 ], function (
     fastdom,
     $,
     mediator,
-    bindAll) {
+    bindAll,
+    detect) {
 
     function StickyHeader() {
 
     }
 
     StickyHeader.prototype.init = function () {
-        fastdom.read(function () {
-            this.$adBanner = $('.js-top-banner-above-nav');
-            this.$header = $('.js-header');
-            this.headerHeight = this.$header.height();
-            this.adHeight = this.$adBanner.height();
-        }.bind(this));
+        if (detect.getBreakpoint() !== 'mobile') {
+            fastdom.read(function () {
+                this.$adBanner = $('.js-top-banner-above-nav');
+                this.$header = $('.js-header');
+                this.headerHeight = this.$header.height();
+                this.adHeight = this.$adBanner.height();
+            }.bind(this));
 
-        fastdom.write(function () {
-            this.$adBanner.css({
-                'width': '100%',
-                'z-index': '1020'
-            });
+            fastdom.write(function () {
+                this.$adBanner.css({
+                    'width': '100%',
+                    'z-index': '1020'
+                });
 
-            this.$header.css({
-                'z-index': '1019'
-            });
-        }.bind(this));
+                this.$header.css({
+                    'z-index': '1019'
+                });
+            }.bind(this));
 
-        bindAll(this, 'stickOrUnstick', 'updateHeights');
+            bindAll(this, 'stickOrUnstick', 'updateHeights');
 
-        mediator.on('window:throttledScroll', this.stickOrUnstick);
+            mediator.on('window:throttledScroll', this.stickOrUnstick);
+        }
     };
 
     StickyHeader.prototype.stickOrUnstick = function () {

--- a/static/src/javascripts/projects/common/modules/navigation/newSticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newSticky.js
@@ -12,7 +12,7 @@ define([
     detect) {
 
     function StickyHeader() {
-
+        this.init();
     }
 
     StickyHeader.prototype.init = function () {


### PR DESCRIPTION
This is an initial 0% AB test that replaces the current sticky.js code with a much simplified version that only sticks the top ad.

The current sticky nav implementation is a blocker on the 'toast' element of the upcoming liveblog work (which has a sticky top button) and is also the cause of all of these Github issues: https://github.com/guardian/frontend/labels/sticky-nav

Putting this out there as not prod-ready code but something we can show to people and get feedback on.

Final implementation could be simpler as some of the injected CSS here could be done in the CSS files. 

May need to add some extra workarounds for the Apple banner/adblock banner. 

@OliverJAsh, you may be interested in this?

![nav](https://cloud.githubusercontent.com/assets/2236852/12175282/377f82b2-b559-11e5-8a8e-73b33ac67cff.gif)
