### PR TITLE
Moving adtest cookie setter to Standard mode.

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -270,15 +270,6 @@ define([
                 }
             },
 
-            adTestCookie: function () {
-                var queryParams = url.getUrlVars();
-                if (queryParams.adtest === 'clear') {
-                    cookies.remove('adtest');
-                } else if (queryParams.adtest) {
-                    cookies.add('adtest', encodeURIComponent(queryParams.adtest), 10);
-                }
-            },
-
             initOpenOverlayOnClick: function () {
                 var offset;
 
@@ -371,7 +362,6 @@ define([
                 ['c-adverts', userAdTargeting.requestUserSegmentsFromId],
                 ['c-discussion', modules.initDiscussion],
                 ['c-test-cookie', modules.testCookie],
-                ['c-ad-cookie', modules.adTestCookie],
                 ['c-event-listeners', modules.windowEventListeners],
                 ['c-breaking-news', modules.loadBreakingNews],
                 ['c-block-link', fauxBlockLink],

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -21,7 +21,9 @@ define([
     'common/utils/$',
     'common/utils/ajax',
     'common/utils/mediator',
-    'common/modules/identity/api'
+    'common/modules/identity/api',
+    'common/utils/url',
+    'common/utils/cookies'
 ], function (
     raven,
     fastdom,
@@ -32,7 +34,9 @@ define([
     $,
     ajax,
     mediator,
-    identity
+    identity,
+    url,
+    cookies
 ) {
     return function () {
         var guardian = window.guardian;
@@ -112,6 +116,20 @@ define([
             ab.segmentUser();
             ab.run();
         }
+
+        //
+        // Set adtest query if url param declares it.
+        //
+        var setAdTestCookie = function () {
+            var queryParams = url.getUrlVars();
+            if (queryParams.adtest === 'clear') {
+                cookies.remove('adtest');
+            } else if (queryParams.adtest) {
+                cookies.add('adtest', encodeURIComponent(queryParams.adtest), 10);
+            }
+        };
+        setAdTestCookie();
+
 
         //
         // Images


### PR DESCRIPTION
The adtest cookie setter is essential for testing ads on the platform. Unfortunately, it was only run in Enhanced mode. 

Moving the function to Standard mode only increased the package size by 200B. The function only manipulates a domain cookie, so it shouldn't be a significant performance hit.
