### PR TITLE
Hotfix broken embeds (CAPI client upgrade)

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -5,6 +5,15 @@ import org.joda.time.LocalDate
 
 trait FeatureSwitches {
 
+  val CapiEmbedHotfixSwitch = Switch(
+    "Feature",
+    "capi-embed-hotfix",
+    "Applies hotfix for broken embeds due to CAPI upgrade",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 1, 11),
+    exposeClientSide = false
+  )
+
   val FixturesAndResultsContainerSwitch = Switch(
     "Feature",
     "fixtures-and-results-container",

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -123,12 +123,15 @@ final case class AudioMedia(audioAssets: List[AudioAsset]) {
 object EmbedMedia {
   def make(capiElement: ApiElement): EmbedMedia = {
     EmbedMedia(
-      embedAssets = capiElement.assets.filter(asset =>
-        // HOTFIX: Updated CAPI client represents Embed assets types as Image asset types.
-        // This hotfix circumvents this so we can continue to render content correctly, e.g.
-        // http://localhost:9000/us-news/2015/dec/10/kern-county-california-police-killings-misconduct-district-attorney
-        asset.`type`.name == "Embed" || (asset.`type`.name == "Image" && asset.file.getOrElse("").endsWith("/boot.js"))
-      ).map(EmbedAsset.make)
+      embedAssets = capiElement.assets
+        .filter(asset =>
+          // HOTFIX: Updated CAPI client represents Embed assets types as Image asset types.
+          // This hotfix circumvents this so we can continue to render content correctly, e.g.
+          // http://localhost:9000/us-news/2015/dec/10/kern-county-california-police-killings-misconduct-district-attorney
+          asset.`type`.name == "Embed" || (conf.switches.Switches.CapiEmbedHotfixSwitch.isSwitchedOn &&
+            asset.`type`.name == "Image" && asset.file.getOrElse("").endsWith("/boot.js"))
+        )
+        .map(EmbedAsset.make)
     )
   }
 }

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -121,9 +121,16 @@ final case class AudioMedia(audioAssets: List[AudioAsset]) {
 }
 
 object EmbedMedia {
-  def make(capiElement: ApiElement): EmbedMedia = EmbedMedia(
-    embedAssets = capiElement.assets.filter(_.`type`.name == "Embed").map(EmbedAsset.make)
-  )
+  def make(capiElement: ApiElement): EmbedMedia = {
+    EmbedMedia(
+      embedAssets = capiElement.assets.filter(asset =>
+        // HOTFIX: Updated CAPI client represents Embed assets types as Image asset types.
+        // This hotfix circumvents this so we can continue to render content correctly, e.g.
+        // http://localhost:9000/us-news/2015/dec/10/kern-county-california-police-killings-misconduct-district-attorney
+        asset.`type`.name == "Embed" || (asset.`type`.name == "Image" && asset.file.getOrElse("").endsWith("/boot.js"))
+      ).map(EmbedAsset.make)
+    )
+  }
 }
 final case class EmbedMedia(embedAssets: Seq[EmbedAsset])
 


### PR DESCRIPTION
[Updated CAPI client](https://github.com/guardian/frontend/pull/11466) represents Embed assets types as Image asset types. Doh. I think this is because CAPI client is missing the Embed asset type: https://github.com/guardian/content-api-scala-client/blob/0c9c4475c6ccd0e4cdf4910e40f47d3691b94cdf/src/main/thrift/content/v1.thrift#L158
# Before

http://www.theguardian.com/us-news/2015/dec/10/kern-county-california-police-killings-misconduct-district-attorney

![image](https://cloud.githubusercontent.com/assets/921609/12183531/3ec489d6-b587-11e5-8d17-804a3c9a29e5.png)
# After

![image](https://cloud.githubusercontent.com/assets/921609/12183533/42e6ff08-b587-11e5-8ba2-1d5e5bdf4a55.png)

/cc @rich-nguyen
