### PR TITLE
Add logo to single-campaign commercial container

### DIFF
--- a/common/app/common/dfp/PaidForTagAgent.scala
+++ b/common/app/common/dfp/PaidForTagAgent.scala
@@ -2,10 +2,10 @@ package common.dfp
 
 import java.net.URLDecoder
 
-import model.pressed.CollectionConfig
 import common.Edition
 import model.Tag
 import model.`package`.frontKeywordIds
+import model.pressed.CollectionConfig
 
 trait PaidForTagAgent {
 
@@ -207,6 +207,14 @@ trait PaidForTagAgent {
 
   def getSponsor(capiTagId: String): Option[String] = {
     findWinningDfpTag(currentPaidForTags, capiTagId, None, None) flatMap (_.lineItems.head.sponsor)
+  }
+
+  def winningTagPair(
+    capiTags: Seq[Tag],
+    sectionId: Option[String],
+    edition: Option[Edition]
+  ): Option[CapiTagAndDfpTag] = {
+    findWinningTagPair(currentPaidForTags, capiTags, sectionId, edition)
   }
 }
 

--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -33,7 +33,7 @@
                             <a class="commercial__cta" href="http://www.theguardian.com/guardian-labs">@inlineSvg("glabs-logo", "logo")</a>
                         </div>
                         <div class="commercial__body">
-                            <ul class="lineitems">
+                            <ul class="lineitems js-container__header">
                                 @for(layout <- container.containerLayout) {
                                     @for( slice <- layout.slices) {
                                         @for(ColumnAndCards(_, cards) <- slice.columns) {
@@ -66,7 +66,6 @@
                                     }
                                 }
                             </ul>
-                            <aside class="commercial__meta">Paid for by <img src="ben-jerrys.png"></aside>
                         </div>
                     </div>
                 </div>

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,9 +1,9 @@
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties = model.FrontProperties.empty)(implicit request: RequestHeader)
 
-@import dfp.{Keyword, Series}
+@import common.dfp.{Keyword, Series}
 @import layout.MetaDataHeader
-@import slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList, DynamicPackage, Commercial}
-@import views.html.fragments.containers.facia_cards.{containerMetaData, mostPopularContainer, navListContainer, navMediaListContainer, standardContainer}
+@import slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList}
+@import views.html.fragments.containers.facia_cards.{commercialContainer, containerMetaData, mostPopularContainer, navListContainer, navMediaListContainer, standardContainer}
 @import views.support.GetClasses
 
 @defining(containerDefinition.displayName, containerDefinition.faciaComponentName) { case (title, componentName) =>


### PR DESCRIPTION
Eg.
![image](https://cloud.githubusercontent.com/assets/1722550/12196011/63d65576-b5f3-11e5-94a4-e2489ad46ec0.png)

It's in the wrong place at the moment - left justified instead of right justified.

@Calanthe 
