### PR TITLE
Remove pan domain

### DIFF
--- a/common/app/services/Notification.scala
+++ b/common/app/services/Notification.scala
@@ -37,14 +37,17 @@ trait Notification extends Logging with ExecutionContexts {
 
   private def sendAsync(request: PublishRequest) = AkkaAsync {
     log.info(s"Issuing SNS notification: ${request.getSubject}:${request.getMessage}")
-    sns foreach { client =>
-      client.publishFuture(request) onComplete {
-        case Success(_) =>
-          log.info(s"Successfully published SNS notification: ${request.getSubject}:${request.getMessage}")
+    sns match {
+      case Some(client) =>
+          client.publishFuture(request) onComplete {
+            case Success(_) =>
+              log.info(s"Successfully published SNS notification: ${request.getSubject}:${request.getMessage}")
 
-        case Failure(error) =>
-          log.error(s"Failed to publish SNS notification: ${request.getSubject}:${request.getMessage}", error)
-      }
+            case Failure(error) =>
+              log.error(s"Failed to publish SNS notification: ${request.getSubject}:${request.getMessage}", error)
+          }
+      case None =>
+        log.error(s"There is NO SNS client available")
     }
   }
 }

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -1,26 +1,24 @@
 package services
 
-import com.gu.googleauth.UserIdentity
-import com.gu.pandomainauth.model.User
-import conf.Configuration
-import common.Logging
-import com.amazonaws.services.s3.AmazonS3Client
-import com.amazonaws.services.s3.model._
-import com.amazonaws.services.s3.model.CannedAccessControlList.{Private, PublicRead}
-import com.amazonaws.util.StringInputStream
-import conf.switches.Switches
-import scala.io.{Codec, Source}
-import org.joda.time.DateTime
-import play.Play
-import play.api.libs.ws.{WSRequest, WS}
+import java.io._
+import java.util.zip.GZIPOutputStream
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
-import sun.misc.BASE64Encoder
+
 import com.amazonaws.auth.AWSSessionCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.CannedAccessControlList.{Private, PublicRead}
+import com.amazonaws.services.s3.model._
+import com.amazonaws.util.StringInputStream
+import common.Logging
 import common.S3Metrics.S3ClientExceptionsMetric
-import com.gu.googleauth.UserIdentity
-import java.util.zip.GZIPOutputStream
-import java.io._
+import conf.Configuration
+import org.joda.time.DateTime
+import play.Play
+import play.api.libs.ws.{WS, WSRequest}
+import sun.misc.BASE64Encoder
+
+import scala.io.{Codec, Source}
 
 trait S3 extends Logging {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,6 @@ object Dependencies {
   val openCsv = "net.sf.opencsv" % "opencsv" % "2.3"
   val paClient = "com.gu" %% "pa-client" % "5.0.1-NG"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.0"
-  val panDomainAuth = "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.6"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.2.1"
   val rome = "rome" % "rome" % "1.0"
   val romeModules = "org.rometools" % "rome-modules" % "1.0"

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -35,7 +35,6 @@ object Frontend extends Build with Prototypes {
       jSoup,
       liftJson,
       playGoogleAuth,
-      panDomainAuth,
       quartzScheduler,
       rome,
       romeModules,


### PR DESCRIPTION
This removes the pandomain dependency and adds extra logging into `Notification.scala`.

@rich-nguyen @johnduffell 
