### PR TITLE
Report abuse page non ajax

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -242,6 +242,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val apiRoot = configuration.getMandatoryStringProperty("discussion.apiRoot")
     lazy val apiTimeout = configuration.getMandatoryStringProperty("discussion.apiTimeout")
     lazy val apiClientHeader = configuration.getMandatoryStringProperty("discussion.apiClientHeader")
+    lazy val d2Uid = configuration.getMandatoryStringProperty("discussion.d2Uid")
     lazy val url = configuration.getMandatoryStringProperty("discussion.url")
   }
 
@@ -336,6 +337,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       "idOAuthUrl" -> id.oauthUrl,
       "discussionApiRoot" -> discussion.apiRoot,
       "discussionApiClientHeader" -> discussion.apiClientHeader,
+      "discussionD2Uid" -> discussion.d2Uid,
       ("ophanJsUrl", ophan.jsLocation),
       ("ophanEmbedJsUrl", ophan.embedJsLocation),
       ("googletagJsUrl", googletag.jsLocation),

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -36,6 +36,7 @@ discussion.apiRoot=https://discussion-secure.code.dev-guardianapis.com/discussio
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.url=http://discussion.code.dev-theguardian.com
+discussion.d2Uid=zHoBy6HNKsk
 
 # Witness
 witness.apiRoot=http://n0ticeapis.com/2

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -31,6 +31,7 @@ discussion.apiRoot=https://discussion-secure.code.dev-guardianapis.com/discussio
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.url=http://discussion.code.dev-theguardian.com
+discussion.d2Uid=zHoBy6HNKsk
 
 # Witness
 witness.apiRoot=http://n0ticeapis.com/2

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -29,6 +29,7 @@ discussion.apiRoot=https://discussion-secure.code.dev-guardianapis.com/discussio
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
 discussion.url=http://discussion.code.dev-theguardian.com
+discussion.d2Uid=zHoBy6HNKsk
 
 # Witness
 witness.apiRoot=http://n0ticeapis.com/2

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -33,6 +33,7 @@ discussion.apiRoot=https://discussion.guardianapis.com/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen
 discussion.url=http://discussion.theguardian.com
+discussion.d2Uid=zHoBy6HNKsk
 
 # Witness
 witness.apiRoot=http://n0ticeapis.com/2

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -87,7 +87,8 @@ GET            /discussion/profile/:id/replies.json                             
 GET            /discussion/profile/:id/picks.json                                                                                controllers.ProfileActivityController.profilePicks(id: String)
 GET            /discussion/profile/:id/witness.json                                                                              controllers.WitnessActivityController.witnessActivity(id: String)
 GET            /open/cta/article/*discussionKey.json                                                                             controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)
-GET         /discussion/report-abuse/*commentId                           controllers.CommentsController.reportAbuse(commentId: Int)
+GET            /discussion/report-abuse/*commentId                                                                               controllers.CommentsController.reportAbuseForm(commentId: Int)
+POST           /discussion/report-abuse/*commentId                                                                               controllers.CommentsController.reportAbuseSubmission(commentId: Int)
 # Onward
 GET            /most-read-facebook.json                                                                                          controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "facebook")
 GET            /most-read-twitter.json                                                                                           controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "twitter")

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -87,8 +87,10 @@ GET            /discussion/profile/:id/replies.json                             
 GET            /discussion/profile/:id/picks.json                                                                                controllers.ProfileActivityController.profilePicks(id: String)
 GET            /discussion/profile/:id/witness.json                                                                              controllers.WitnessActivityController.witnessActivity(id: String)
 GET            /open/cta/article/*discussionKey.json                                                                             controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)
+GET            /discussion/report-abuse/:commentId/thankyou                                                                      controllers.CommentsController.reportAbuseThankYou(commentId: Int)
 GET            /discussion/report-abuse/*commentId                                                                               controllers.CommentsController.reportAbuseForm(commentId: Int)
 POST           /discussion/report-abuse/*commentId                                                                               controllers.CommentsController.reportAbuseSubmission(commentId: Int)
+
 # Onward
 GET            /most-read-facebook.json                                                                                          controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "facebook")
 GET            /most-read-twitter.json                                                                                           controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "twitter")

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -87,7 +87,7 @@ GET            /discussion/profile/:id/replies.json                             
 GET            /discussion/profile/:id/picks.json                                                                                controllers.ProfileActivityController.profilePicks(id: String)
 GET            /discussion/profile/:id/witness.json                                                                              controllers.WitnessActivityController.witnessActivity(id: String)
 GET            /open/cta/article/*discussionKey.json                                                                             controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)
-
+GET         /discussion/report-abuse/*commentId                           controllers.CommentsController.reportAbuse(commentId: Int)
 # Onward
 GET            /most-read-facebook.json                                                                                          controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "facebook")
 GET            /most-read-twitter.json                                                                                           controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "twitter")

--- a/discussion/app/Global.scala
+++ b/discussion/app/Global.scala
@@ -1,8 +1,13 @@
 import common.CloudWatchApplicationMetrics
 import conf.{SwitchboardLifecycle, CorsErrorHandler, Filters}
-import play.api.mvc.WithFilters
+import play.api.mvc.{EssentialFilter, WithFilters}
+import play.filters.csrf.CSRFFilter
 
-object Global extends WithFilters(Filters.common: _*)
+object DiscussionFilters {
+  def apply(): List[EssentialFilter] = CSRFFilter() +: Filters.common
+}
+
+object Global extends WithFilters(DiscussionFilters(): _*)
   with CloudWatchApplicationMetrics
   with CorsErrorHandler
   with SwitchboardLifecycle {

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import model.{Cached, TinyResponse}
+import model.{MetaData, SimplePage, Cached, TinyResponse}
 import scala.concurrent.Future
 import common.JsonComponent
 import play.api.mvc.{ Action, RequestHeader, Result }
@@ -44,6 +44,11 @@ object CommentsController extends DiscussionController {
   // Get the top comments for a discussion.
   def topCommentsJson(key: DiscussionKey) = Action.async { implicit request => getTopComments(key) }
   def topCommentsJsonOptions(key: DiscussionKey) = Action { implicit request => TinyResponse.noContent(Some("GET, OPTIONS")) }
+
+  def reportAbuse(commentId: Int) = Action { implicit request =>
+    val page = SimplePage(MetaData.make("/reportAbuse", "Discussion", "Report Abuse", "GFE: Report Abuse"))
+    Cached(60) { Ok(views.html.discussionComments.reportComment(commentId, page)) }
+  }
 
   private def getComments(key: DiscussionKey, optParams: Option[DiscussionParams] = None)(implicit request: RequestHeader): Future[Result] = {
     val params = optParams.getOrElse(DiscussionParams(request))

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import model.{MetaData, SimplePage, Cached, TinyResponse}
+import play.api.data.Forms._
 import scala.concurrent.Future
 import common.JsonComponent
 import play.api.mvc.{ Action, RequestHeader, Result }
@@ -57,12 +58,13 @@ object CommentsController extends DiscussionController {
 
   def reportAbuseSubmission(commentId: Int)  = Action { implicit request =>
 
+
     val userForm = Form(
       Forms.mapping(
-        "categoryId" -> Forms.number,
+        "categoryId" -> Forms.number(min = 1, max = 9),
         "commentId" -> Forms.number,
-        "reason" -> Forms.text,
-        "email" -> Forms.text
+        "reason" -> optional(Forms.text(maxLength = 250)),
+        "email" -> optional(Forms.email)
       )(DiscussionAbuseReport.apply)(DiscussionAbuseReport.unapply)
     )
 

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -69,6 +69,13 @@ object CommentsController extends DiscussionController with ExecutionContexts {
     Cached(60) { Ok(views.html.discussionComments.reportComment(commentId, reportAbusePage, userForm)) }
   }
 
+  val reportAbuseThankYouPage = SimplePage(MetaData.make("/reportAbuseThankYou", "Discussion", "Report Abuse Thank You", "GFE: Report Abuse Thank You"))
+
+
+  def reportAbuseThankYou(commentId: Int) = Action { implicit request =>
+
+    Cached(60) { Ok(views.html.discussionComments.reportCommentThankYou(commentId, reportAbuseThankYouPage)) }
+  }
 
   def abuseReportToMap(abuseReport: DiscussionAbuseReport): Map[String, Seq[String]] = {
   Map("categoryId" -> Seq(abuseReport.categoryId.toString),
@@ -101,7 +108,7 @@ object CommentsController extends DiscussionController with ExecutionContexts {
       formWithErrors => Future.successful(BadRequest(views.html.discussionComments.reportComment(commentId, reportAbusePage, formWithErrors))),
       userData => {
         postAbuseReportToDiscussionApi(userData).map {
-          case success if success.status == 200 => NoCache(Ok(success.body))
+          case success if success.status == 200 => NoCache(Redirect(routes.CommentsController.reportAbuseThankYou(commentId)))
           case error => InternalServerError(views.html.discussionComments.reportComment(commentId, reportAbusePage, userForm.fill(userData), errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage)))
         }.recover({
           case NonFatal(e) => InternalServerError(views.html.discussionComments.reportComment(commentId, reportAbusePage, userForm.fill(userData), errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage)))

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -67,9 +67,19 @@ object CommentsController extends DiscussionController {
         "email" -> optional(Forms.email)
       )(DiscussionAbuseReport.apply)(DiscussionAbuseReport.unapply)
     )
+    userForm.bindFromRequest.fold(
+      formWithErrors => BadRequest(formWithErrors.errors.mkString(", ")),
+      userData => {
+        Ok(userData.toString)
+      }
+    )
 
-  val result =  userForm.bindFromRequest().get
-    NoCache(Ok(result.toString))
+
+
+    //  val result =  userForm.bindFromRequest().get
+    //    NoCache(Ok(result.toString))
+    //  }
+
   }
 
   private def getComments(key: DiscussionKey, optParams: Option[DiscussionParams] = None)(implicit request: RequestHeader): Future[Result] = {

--- a/discussion/app/discussion/model/DiscussionAbuseReport.scala
+++ b/discussion/app/discussion/model/DiscussionAbuseReport.scala
@@ -1,3 +1,3 @@
 package discussion.model
 
-case class DiscussionAbuseReport(categoryId: Int, commentId: Int, reason: String, email: String)
+case class DiscussionAbuseReport(categoryId: Int, commentId: Int, reason: Option[String], email: Option[String])

--- a/discussion/app/discussion/model/DiscussionAbuseReport.scala
+++ b/discussion/app/discussion/model/DiscussionAbuseReport.scala
@@ -1,0 +1,3 @@
+package discussion.model
+
+case class DiscussionAbuseReport(categoryId: Int, commentId: Int, reason: String, email: String)

--- a/discussion/app/filters/Filters.scala
+++ b/discussion/app/filters/Filters.scala
@@ -1,0 +1,10 @@
+package filters
+
+import javax.inject.Inject
+
+import play.api.http.HttpFilters
+import play.filters.csrf.CSRFFilter
+
+class Filters @Inject() (csrfFilter: CSRFFilter) extends HttpFilters {
+  def filters = Seq(csrfFilter)
+}

--- a/discussion/app/views/discussionComments/reportComment.scala.html
+++ b/discussion/app/views/discussionComments/reportComment.scala.html
@@ -22,7 +22,7 @@
             <div class="gs-container">
                 <div class="content__main-column">
                     <form class="form" method="post" action="/discussion/report-abuse/@commentId">
-                        <input type="hidden" name="D2-X-UID" value="zHoBy6HNKsk">
+                        <input type="hidden" name="D2-X-UID" value=@conf.Configuration.discussion.d2Uid>
                         <input type="hidden" name="GU-Client" value="@conf.Configuration.discussion.apiClientHeader">
                         <input type="hidden" name="commentId" value="@commentId">
                         <fieldset class="fieldset">

--- a/discussion/app/views/discussionComments/reportComment.scala.html
+++ b/discussion/app/views/discussionComments/reportComment.scala.html
@@ -1,4 +1,5 @@
 @import _root_.model.SimplePage
+@import views.html.fragments.reportCommentForm
 
 
 @(commentId: Int, page: SimplePage, userForm: Form[discussion.model.DiscussionAbuseReport], errorMessage: Option[String] = None)(implicit request: RequestHeader)
@@ -23,69 +24,7 @@
         <div class="content__main tonal__main tonal__main--tone-news">
             <div class="gs-container">
                 <div class="content__main-column">
-                    @if(errorMessage) {
-                        <div class="form-field--error">
-                            <label class="label">@errorMessage.get</label>
-                        </div>
-                    }
-                    @defining(userForm.error("categoryId")) { categoryIdError =>
-                        @defining(userForm.error("email")) { emailError =>
-                            @defining(userForm.error("reason")) { reasonError =>
-
-                                @helper.form(controllers.routes.CommentsController.reportAbuseSubmission(commentId), 'class -> "form") {
-                                    <fieldset class="fieldset">
-                                        <div class="fieldset__heading" />
-                                        <input type="hidden" name="commentId" value="@commentId">
-                                        <div class="fieldset__fields">
-                                            <div class="form-field @{if(categoryIdError) "form-field--error"}}">
-                                                <label class="label" for="categoryId">Category</label>
-
-
-                                                <select class="select select--wide" name="categoryId" id="categoryId">
-                                                    <option value="0" selected="selected">Please select</option>
-                                                    <option value="1">Personal abuse</option>
-                                                    <option value="2">Off topic</option>
-                                                    <option value="3">Legal issue</option>
-                                                    <option value="4">Trolling</option>
-                                                    <option value="5">Hate speech</option>
-                                                    <option value="6">Offensive/Threatening language</option>
-                                                    <option value="7">Copyright</option>
-                                                    <option value="8">Spam</option>
-                                                    <option value="9">Other</option>
-                                                </select>
-                                @if(categoryIdError) {
-                                    <p class="form-field__error-message">@categoryIdError.get.message</p>
-                                }
-                                            </div>
-
-                            <div class="form-field @{if(reasonError) {"form-field--error"}}">
-                            <label class="label" for="reason">Reason</label><span class="form-note">(optional)</span>
-                                            <textarea class="fieldset__fields" id="reason" name="reason"></textarea>
-                                @if(reasonError) {
-                                    <p class="form-field__error-message">@reasonError.get.message</p>
-                                }
-                            </div>
-
-                            <div class="form-field @{if(emailError) {"form-field--error"}}">
-                                            <label class="label" for="email">Email</label><span class="form-note">(optional)</span>
-                                            <input type="email" class="email" id="email" name="email" />
-                                @if(emailError) {
-                                    <p class="form-field__error-message">@emailError.get.message</p>
-                                }
-                                </div>
-                                        </div>
-                                    </fieldset>
-                                <fieldset class="fieldset fieldset--simple">
-                                    <div class="fieldset__heading"></div>
-                                    <div class="fieldset__fields">
-                                        <div class="actions">
-                                            <button type="submit" class="button button--primary button--large">Report</button>
-                                        </div>
-                                    </div>
-                                </fieldset>
-                                }
-                        }
-                    }
+                    @reportCommentForm(commentId,userForm,errorMessage)
                 </div>
             </div>
         </div>

--- a/discussion/app/views/discussionComments/reportComment.scala.html
+++ b/discussion/app/views/discussionComments/reportComment.scala.html
@@ -1,0 +1,32 @@
+@import _root_.model.SimplePage
+@(commentId: Int, page: SimplePage)(implicit request: RequestHeader)
+@main(page){ }{
+
+    <form class="d-report-comment-form js-report-comment-form">
+
+        <select class="d-report-comment__field d-report-comment__field--category" name="category">
+            <option value="0">Please select</option>
+            <option value="1">Personal abuse</option>
+            <option value="2">Off topic</option>
+            <option value="3">Legal issue</option>
+            <option value="4">Trolling</option>
+            <option value="5">Hate speech</option>
+            <option value="6">Offensive/Threatening language</option>
+            <option value="7">Copyright</option>
+            <option value="8">Spam</option>
+            <option value="9">Other</option>
+        </select>
+
+        <div class="d-report-comment__comment">
+            <label class="d-report-comment__label" for="d-report-comment__reason">Reason (optional)</label>
+            <textarea class="d-report-comment__field" id="d-report-comment__reason" name="comment"></textarea>
+        </div>
+
+        <div class="d-report-comment__email">
+            <label class="d-report-comment__label" for="d-report-comment__email">Email (optional)</label>
+            <input type="text" class="d-report-comment__field" id="d-report-comment__email" name="email"></textarea>
+        </div>
+
+        <button class="d-report-comment__submit" type="submit">Report</button>
+    </form>
+}

--- a/discussion/app/views/discussionComments/reportComment.scala.html
+++ b/discussion/app/views/discussionComments/reportComment.scala.html
@@ -22,8 +22,6 @@
             <div class="gs-container">
                 <div class="content__main-column">
                     <form class="form" method="post" action="/discussion/report-abuse/@commentId">
-                        <input type="hidden" name="D2-X-UID" value=@conf.Configuration.discussion.d2Uid>
-                        <input type="hidden" name="GU-Client" value="@conf.Configuration.discussion.apiClientHeader">
                         <input type="hidden" name="commentId" value="@commentId">
                         <fieldset class="fieldset">
                             <div class="form-fields__inline">

--- a/discussion/app/views/discussionComments/reportComment.scala.html
+++ b/discussion/app/views/discussionComments/reportComment.scala.html
@@ -1,4 +1,5 @@
 @import _root_.model.SimplePage
+@import conf.Configuration.discussion
 @(commentId: Int, page: SimplePage)(implicit request: RequestHeader)
 @main(page){ }{
 
@@ -9,7 +10,6 @@
                     <div class="content__main-column">
                         <div class="content__labels">
                             <div class="content__section-label">
-                                @*<a class="tone-colour" data-link-name="article section" href="@LinkTo("/crosswords")">Crosswords</a>*@
                             </div>
                         </div>
                         <h1 itemprop="headline" class="content__headline js-score">Report Abuse</h1>
@@ -21,13 +21,14 @@
         <div class="content__main tonal__main tonal__main--tone-news">
             <div class="gs-container">
                 <div class="content__main-column">
-
-
-                    <form class="form" method="post">
+                    <form class="form" method="post" action="/discussion/report-abuse/@commentId">
+                        <input type="hidden" name="D2-X-UID" value="zHoBy6HNKsk">
+                        <input type="hidden" name="GU-Client" value="@conf.Configuration.discussion.apiClientHeader">
+                        <input type="hidden" name="commentId" value="@commentId">
                         <fieldset class="fieldset">
                             <div class="form-fields__inline">
                         <label class="label" for="category">Category</label>
-                        <select class="fieldset__fields" name="category">
+                        <select class="fieldset__fields" name="categoryId" id="categoryId">
                             <option value="0">Please select</option>
                             <option value="1">Personal abuse</option>
                             <option value="2">Off topic</option>
@@ -41,12 +42,13 @@
                         </select>
 
                             <label class="label" for="reason">Reason (optional)</label>
-                            <textarea class="fieldset__fields" id="reason" name="comment"></textarea>
+                            <textarea class="fieldset__fields" id="reason" name="reason"></textarea>
 
                             <label class="label" for="email">Email (optional)</label>
-                            <textarea type="text" class="email" id="email" name="email"></textarea>
+                            <input type="email" class="email" id="email" name="email" />
                             </div>
                         <button class="submit-input" type="submit">Report</button>
+
                         </fieldset>
                     </form>
                 </div>

--- a/discussion/app/views/discussionComments/reportComment.scala.html
+++ b/discussion/app/views/discussionComments/reportComment.scala.html
@@ -29,7 +29,7 @@
                             <div class="form-fields__inline">
                         <label class="label" for="category">Category</label>
                         <select class="fieldset__fields" name="categoryId" id="categoryId">
-                            <option value="0">Please select</option>
+                            <option value="0" selected="selected">Please select</option>
                             <option value="1">Personal abuse</option>
                             <option value="2">Off topic</option>
                             <option value="3">Legal issue</option>
@@ -47,9 +47,8 @@
                             <label class="label" for="email">Email (optional)</label>
                             <input type="email" class="email" id="email" name="email" />
                             </div>
-                        <button class="submit-input" type="submit">Report</button>
-
                         </fieldset>
+                        <button class="submit-input" type="submit">Report</button>
                     </form>
                 </div>
             </div>

--- a/discussion/app/views/discussionComments/reportComment.scala.html
+++ b/discussion/app/views/discussionComments/reportComment.scala.html
@@ -2,31 +2,56 @@
 @(commentId: Int, page: SimplePage)(implicit request: RequestHeader)
 @main(page){ }{
 
-    <form class="d-report-comment-form js-report-comment-form">
+    <div class="l-side-margins">
+        <article class="content content--article tonal tonal--tone-news" role="main">
+            <header class="content__head tonal__head tonal__head--tone-news">
+                <div class="gs-container">
+                    <div class="content__main-column">
+                        <div class="content__labels">
+                            <div class="content__section-label">
+                                @*<a class="tone-colour" data-link-name="article section" href="@LinkTo("/crosswords")">Crosswords</a>*@
+                            </div>
+                        </div>
+                        <h1 itemprop="headline" class="content__headline js-score">Report Abuse</h1>
+                    </div>
+                </div>
+            </header>
+        </article>
 
-        <select class="d-report-comment__field d-report-comment__field--category" name="category">
-            <option value="0">Please select</option>
-            <option value="1">Personal abuse</option>
-            <option value="2">Off topic</option>
-            <option value="3">Legal issue</option>
-            <option value="4">Trolling</option>
-            <option value="5">Hate speech</option>
-            <option value="6">Offensive/Threatening language</option>
-            <option value="7">Copyright</option>
-            <option value="8">Spam</option>
-            <option value="9">Other</option>
-        </select>
+        <div class="content__main tonal__main tonal__main--tone-news">
+            <div class="gs-container">
+                <div class="content__main-column">
 
-        <div class="d-report-comment__comment">
-            <label class="d-report-comment__label" for="d-report-comment__reason">Reason (optional)</label>
-            <textarea class="d-report-comment__field" id="d-report-comment__reason" name="comment"></textarea>
+
+                    <form class="form" method="post">
+                        <fieldset class="fieldset">
+                            <div class="form-fields__inline">
+                        <label class="label" for="category">Category</label>
+                        <select class="fieldset__fields" name="category">
+                            <option value="0">Please select</option>
+                            <option value="1">Personal abuse</option>
+                            <option value="2">Off topic</option>
+                            <option value="3">Legal issue</option>
+                            <option value="4">Trolling</option>
+                            <option value="5">Hate speech</option>
+                            <option value="6">Offensive/Threatening language</option>
+                            <option value="7">Copyright</option>
+                            <option value="8">Spam</option>
+                            <option value="9">Other</option>
+                        </select>
+
+                            <label class="label" for="reason">Reason (optional)</label>
+                            <textarea class="fieldset__fields" id="reason" name="comment"></textarea>
+
+                            <label class="label" for="email">Email (optional)</label>
+                            <textarea type="text" class="email" id="email" name="email"></textarea>
+                            </div>
+                        <button class="submit-input" type="submit">Report</button>
+                        </fieldset>
+                    </form>
+                </div>
+            </div>
         </div>
+    </div>
 
-        <div class="d-report-comment__email">
-            <label class="d-report-comment__label" for="d-report-comment__email">Email (optional)</label>
-            <input type="text" class="d-report-comment__field" id="d-report-comment__email" name="email"></textarea>
-        </div>
-
-        <button class="d-report-comment__submit" type="submit">Report</button>
-    </form>
-}
+        }

--- a/discussion/app/views/discussionComments/reportComment.scala.html
+++ b/discussion/app/views/discussionComments/reportComment.scala.html
@@ -1,7 +1,9 @@
 @import _root_.model.SimplePage
-@import conf.Configuration.discussion
-@(commentId: Int, page: SimplePage)(implicit request: RequestHeader)
-@main(page){ }{
+
+
+@(commentId: Int, page: SimplePage, userForm: Form[discussion.model.DiscussionAbuseReport], errorMessage: Option[String] = None)(implicit request: RequestHeader)
+@main(page) { } {
+
 
     <div class="l-side-margins">
         <article class="content content--article tonal tonal--tone-news" role="main">
@@ -21,36 +23,75 @@
         <div class="content__main tonal__main tonal__main--tone-news">
             <div class="gs-container">
                 <div class="content__main-column">
-                    <form class="form" method="post" action="/discussion/report-abuse/@commentId">
-                        <input type="hidden" name="commentId" value="@commentId">
-                        <fieldset class="fieldset">
-                            <div class="form-fields__inline">
-                        <label class="label" for="category">Category</label>
-                        <select class="fieldset__fields" name="categoryId" id="categoryId">
-                            <option value="0" selected="selected">Please select</option>
-                            <option value="1">Personal abuse</option>
-                            <option value="2">Off topic</option>
-                            <option value="3">Legal issue</option>
-                            <option value="4">Trolling</option>
-                            <option value="5">Hate speech</option>
-                            <option value="6">Offensive/Threatening language</option>
-                            <option value="7">Copyright</option>
-                            <option value="8">Spam</option>
-                            <option value="9">Other</option>
-                        </select>
+                    @if(errorMessage) {
+                        <div class="form-field--error">
+                            <label class="label">@errorMessage.get</label>
+                        </div>
+                    }
+                    @defining(userForm.error("categoryId")) { categoryIdError =>
+                        @defining(userForm.error("email")) { emailError =>
+                            @defining(userForm.error("reason")) { reasonError =>
 
-                            <label class="label" for="reason">Reason (optional)</label>
-                            <textarea class="fieldset__fields" id="reason" name="reason"></textarea>
+                                @helper.form(controllers.routes.CommentsController.reportAbuseSubmission(commentId), 'class -> "form") {
+                                    <fieldset class="fieldset">
+                                        <div class="fieldset__heading" />
+                                        <input type="hidden" name="commentId" value="@commentId">
+                                        <div class="fieldset__fields">
+                                            <div class="form-field @{if(categoryIdError) "form-field--error"}}">
+                                                <label class="label" for="categoryId">Category</label>
 
-                            <label class="label" for="email">Email (optional)</label>
-                            <input type="email" class="email" id="email" name="email" />
+
+                                                <select class="select select--wide" name="categoryId" id="categoryId">
+                                                    <option value="0" selected="selected">Please select</option>
+                                                    <option value="1">Personal abuse</option>
+                                                    <option value="2">Off topic</option>
+                                                    <option value="3">Legal issue</option>
+                                                    <option value="4">Trolling</option>
+                                                    <option value="5">Hate speech</option>
+                                                    <option value="6">Offensive/Threatening language</option>
+                                                    <option value="7">Copyright</option>
+                                                    <option value="8">Spam</option>
+                                                    <option value="9">Other</option>
+                                                </select>
+                                @if(categoryIdError) {
+                                    <p class="form-field__error-message">@categoryIdError.get.message</p>
+                                }
+                                            </div>
+
+                            <div class="form-field @{if(reasonError) {"form-field--error"}}">
+                            <label class="label" for="reason">Reason</label><span class="form-note">(optional)</span>
+                                            <textarea class="fieldset__fields" id="reason" name="reason"></textarea>
+                                @if(reasonError) {
+                                    <p class="form-field__error-message">@reasonError.get.message</p>
+                                }
                             </div>
-                        </fieldset>
-                        <button class="submit-input" type="submit">Report</button>
-                    </form>
+
+                            <div class="form-field @{if(emailError) {"form-field--error"}}">
+                                            <label class="label" for="email">Email</label><span class="form-note">(optional)</span>
+                                            <input type="email" class="email" id="email" name="email" />
+                                @if(emailError) {
+                                    <p class="form-field__error-message">@emailError.get.message</p>
+                                }
+                                </div>
+                                        </div>
+                                    </fieldset>
+                                <fieldset class="fieldset fieldset--simple">
+                                    <div class="fieldset__heading"></div>
+                                    <div class="fieldset__fields">
+                                        <div class="actions">
+                                            <button type="submit" class="button button--primary button--large">Report</button>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                                }
+                        }
+                    }
                 </div>
             </div>
         </div>
     </div>
+}
 
-        }
+
+
+

--- a/discussion/app/views/discussionComments/reportCommentThankYou.scala.html
+++ b/discussion/app/views/discussionComments/reportCommentThankYou.scala.html
@@ -1,0 +1,34 @@
+@import _root_.model.SimplePage
+@import conf.Configuration
+@(commentId: Int, page: SimplePage)(implicit request: RequestHeader)
+@main(page) { } {
+
+
+    <div class="l-side-margins">
+        <article class="content content--article tonal tonal--tone-news" role="main">
+            <header class="content__head tonal__head tonal__head--tone-news">
+                <div class="gs-container">
+                    <div class="content__main-column">
+                        <div class="content__labels">
+                            <div class="content__section-label">
+                            </div>
+                        </div>
+                        <h1 itemprop="headline" class="content__headline js-score">Thank You</h1>
+                    </div>
+                </div>
+            </header>
+        </article>
+
+        <div class="content__main tonal__main tonal__main--tone-news">
+            <div class="gs-container">
+                <div class="content__main-column">
+                 Thank you for your report. <a href="@Configuration.discussion.url/comment-permalink/@commentId">Return to comment</a>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+
+
+

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -115,7 +115,7 @@
                     </div>
 
                     <div class="report-comment-container js-report-comment-container d-comment__action d-comment__action--report">
-                        <a href="/discussion/report-abuse/@comment.id" rel="nofollow" class="js-report-comment" data-comment-id="@comment.id" target="_blank">Report</a>
+                        <a href="@Configuration.discussion.url/components/report-abuse/@comment.id" rel="nofollow" class="js-report-comment" data-comment-id="@comment.id" target="_blank">Report</a>
                     </div>
                 }
             </div>

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -115,7 +115,7 @@
                     </div>
 
                     <div class="report-comment-container js-report-comment-container d-comment__action d-comment__action--report">
-                        <a href="@Configuration.discussion.url/components/report-abuse/@comment.id" rel="nofollow" class="js-report-comment" data-comment-id="@comment.id" target="_blank">Report</a>
+                        <a href="/discussion/report-abuse/@comment.id" rel="nofollow" class="js-report-comment" data-comment-id="@comment.id" target="_blank">Report</a>
                     </div>
                 }
             </div>

--- a/discussion/app/views/fragments/reportCommentForm.scala.html
+++ b/discussion/app/views/fragments/reportCommentForm.scala.html
@@ -4,63 +4,65 @@
         <label class="label">@errorMessage.get</label>
     </div>
 }
-@defining(userForm.error("categoryId")) { categoryIdError =>
-    @defining(userForm.error("email")) { emailError =>
-        @defining(userForm.error("reason")) { reasonError =>
+@defining(userForm.apply("email").value) { emailUserInput =>
+    @defining(userForm.error("categoryId")) { categoryIdError =>
+        @defining(userForm.error("email")) { emailError =>
+            @defining(userForm.error("reason")) { reasonError =>
 
-            @helper.form(controllers.routes.CommentsController.reportAbuseSubmission(commentId), 'class -> "form") {
-            @helper.CSRF.formField
-                <fieldset class="fieldset">
-                    <div class="fieldset__heading" />
-                    <input type="hidden" name="commentId" value="@commentId">
-                    <div class="fieldset__fields">
-                        <div class="form-field @{if(categoryIdError) {"form-field--error"}}">
-        <label class="label" for="categoryId">Category</label>
+                @helper.form(controllers.routes.CommentsController.reportAbuseSubmission(commentId), 'class -> "form") {
+                    @helper.CSRF.formField
+                    <fieldset class="fieldset">
+                        <div class="fieldset__heading" />
+                        <input type="hidden" name="commentId" value="@commentId">
+                        <div class="fieldset__fields">
+                            <div class="form-field @{if(categoryIdError) {"form-field--error"}}">
+                                <label class="label" for="categoryId">Category</label>
 
 
-        <select class="select select--wide" name="categoryId" id="categoryId">
-            <option value="0" selected="selected">Please select</option>
-            <option value="1">Personal abuse</option>
-            <option value="2">Off topic</option>
-            <option value="3">Legal issue</option>
-            <option value="4">Trolling</option>
-            <option value="5">Hate speech</option>
-            <option value="6">Offensive/Threatening language</option>
-            <option value="7">Copyright</option>
-            <option value="8">Spam</option>
-            <option value="9">Other</option>
-        </select>
-            @if(categoryIdError) {
-                <p class="form-field__error-message">@categoryIdError.get.message</p>
+                                <select class="select select--wide" name="categoryId" id="categoryId">
+                                    <option value="0" selected="selected">Please select</option>
+                                    <option value="1">Personal abuse</option>
+                                    <option value="2">Off topic</option>
+                                    <option value="3">Legal issue</option>
+                                    <option value="4">Trolling</option>
+                                    <option value="5">Hate speech</option>
+                                    <option value="6">Offensive/Threatening language</option>
+                                    <option value="7">Copyright</option>
+                                    <option value="8">Spam</option>
+                                    <option value="9">Other</option>
+                                </select>
+                                @if(categoryIdError) {
+                                    <p class="form-field__error-message">@categoryIdError.get.message</p>
+                                }
+                            </div>
+
+                            <div class="form-field @{if(reasonError) {"form-field--error"}}">
+                                <label class="label" for="reason">Reason</label><span class="form-note">(optional)</span>
+                                <textarea class="input-textarea" id="reason" name="reason" maxlength="250"></textarea>
+                                @if(reasonError) {
+                                    <p class="form-field__error-message">@reasonError.get.message</p>
+                                }
+                            </div>
+
+                            <div class="form-field @{if(emailError) {"form-field--error"}}">
+                                <label class="label" for="email">Email</label><span class="form-note">(optional)</span>
+                                <input type="email" class="input-text" id="email" name="email" value="@emailUserInput" />
+                                @if(emailError) {
+                                    <p class="form-field__error-message">@emailError.get.message</p>
+                                }
+                            </div>
+                        </div>
+                    </fieldset>
+                    <fieldset class="fieldset fieldset--simple">
+                        <div class="fieldset__heading"></div>
+                        <div class="fieldset__fields">
+                            <div class="actions">
+                                <button type="submit" class="button button--primary button--large">Report</button>
+                            </div>
+                        </div>
+                    </fieldset>
+                }
             }
-        </div>
-
-        <div class="form-field @{if(reasonError) {"form-field--error"}}">
-            <label class="label" for="reason">Reason</label><span class="form-note">(optional)</span>
-            <textarea class="input-textarea" id="reason" name="reason" maxlength="250"></textarea>
-            @if(reasonError) {
-                <p class="form-field__error-message">@reasonError.get.message</p>
-            }
-        </div>
-
-        <div class="form-field @{if(emailError) {"form-field--error"}}">
-            <label class="label" for="email">Email</label><span class="form-note">(optional)</span>
-            <input type="email" class="input-text" id="email" name="email" />
-            @if(emailError) {
-                <p class="form-field__error-message">@emailError.get.message</p>
-            }
-        </div>
-        </div>
-        </fieldset>
-            <fieldset class="fieldset fieldset--simple">
-                <div class="fieldset__heading"></div>
-                <div class="fieldset__fields">
-                    <div class="actions">
-                        <button type="submit" class="button button--primary button--large">Report</button>
-                    </div>
-                </div>
-            </fieldset>
         }
     }
-}
 }

--- a/discussion/app/views/fragments/reportCommentForm.scala.html
+++ b/discussion/app/views/fragments/reportCommentForm.scala.html
@@ -1,0 +1,64 @@
+@(commentId: Int, userForm: Form[discussion.model.DiscussionAbuseReport], errorMessage: Option[String] = None)(implicit request: RequestHeader)
+@if(errorMessage) {
+    <div class="form-field--error">
+        <label class="label">@errorMessage.get</label>
+    </div>
+}
+@defining(userForm.error("categoryId")) { categoryIdError =>
+    @defining(userForm.error("email")) { emailError =>
+        @defining(userForm.error("reason")) { reasonError =>
+
+            @helper.form(controllers.routes.CommentsController.reportAbuseSubmission(commentId), 'class -> "form") {
+                <fieldset class="fieldset">
+                    <div class="fieldset__heading" />
+                    <input type="hidden" name="commentId" value="@commentId">
+                    <div class="fieldset__fields">
+                        <div class="form-field @{if(categoryIdError) "form-field--error"}}">
+        <label class="label" for="categoryId">Category</label>
+
+
+        <select class="select select--wide" name="categoryId" id="categoryId">
+            <option value="0" selected="selected">Please select</option>
+            <option value="1">Personal abuse</option>
+            <option value="2">Off topic</option>
+            <option value="3">Legal issue</option>
+            <option value="4">Trolling</option>
+            <option value="5">Hate speech</option>
+            <option value="6">Offensive/Threatening language</option>
+            <option value="7">Copyright</option>
+            <option value="8">Spam</option>
+            <option value="9">Other</option>
+        </select>
+            @if(categoryIdError) {
+                <p class="form-field__error-message">@categoryIdError.get.message</p>
+            }
+        </div>
+
+        <div class="form-field @{if(reasonError) {"form-field--error"}}">
+            <label class="label" for="reason">Reason</label><span class="form-note">(optional)</span>
+            <textarea class="fieldset__fields" id="reason" name="reason"></textarea>
+            @if(reasonError) {
+                <p class="form-field__error-message">@reasonError.get.message</p>
+            }
+        </div>
+
+        <div class="form-field @{if(emailError) {"form-field--error"}}">
+            <label class="label" for="email">Email</label><span class="form-note">(optional)</span>
+            <input type="email" class="email" id="email" name="email" />
+            @if(emailError) {
+                <p class="form-field__error-message">@emailError.get.message</p>
+            }
+        </div>
+        </div>
+        </fieldset>
+            <fieldset class="fieldset fieldset--simple">
+                <div class="fieldset__heading"></div>
+                <div class="fieldset__fields">
+                    <div class="actions">
+                        <button type="submit" class="button button--primary button--large">Report</button>
+                    </div>
+                </div>
+            </fieldset>
+        }
+    }
+}

--- a/discussion/app/views/fragments/reportCommentForm.scala.html
+++ b/discussion/app/views/fragments/reportCommentForm.scala.html
@@ -37,7 +37,7 @@
 
         <div class="form-field @{if(reasonError) {"form-field--error"}}">
             <label class="label" for="reason">Reason</label><span class="form-note">(optional)</span>
-            <textarea class="fieldset__fields" id="reason" name="reason"></textarea>
+            <textarea class="input-textarea" id="reason" name="reason" maxlength="250"></textarea>
             @if(reasonError) {
                 <p class="form-field__error-message">@reasonError.get.message</p>
             }
@@ -45,7 +45,7 @@
 
         <div class="form-field @{if(emailError) {"form-field--error"}}">
             <label class="label" for="email">Email</label><span class="form-note">(optional)</span>
-            <input type="email" class="email" id="email" name="email" />
+            <input type="email" class="input-text" id="email" name="email" />
             @if(emailError) {
                 <p class="form-field__error-message">@emailError.get.message</p>
             }

--- a/discussion/app/views/fragments/reportCommentForm.scala.html
+++ b/discussion/app/views/fragments/reportCommentForm.scala.html
@@ -9,11 +9,12 @@
         @defining(userForm.error("reason")) { reasonError =>
 
             @helper.form(controllers.routes.CommentsController.reportAbuseSubmission(commentId), 'class -> "form") {
+            @helper.CSRF.formField
                 <fieldset class="fieldset">
                     <div class="fieldset__heading" />
                     <input type="hidden" name="commentId" value="@commentId">
                     <div class="fieldset__fields">
-                        <div class="form-field @{if(categoryIdError) "form-field--error"}}">
+                        <div class="form-field @{if(categoryIdError) {"form-field--error"}}">
         <label class="label" for="categoryId">Category</label>
 
 
@@ -61,4 +62,5 @@
             </fieldset>
         }
     }
+}
 }

--- a/discussion/app/views/fragments/reportCommentForm.scala.html
+++ b/discussion/app/views/fragments/reportCommentForm.scala.html
@@ -4,19 +4,20 @@
         <label class="label">@errorMessage.get</label>
     </div>
 }
+
 @defining(
     userForm.apply("email").value,
     userForm.error("categoryId"),
     userForm.error("email"),
     userForm.error("reason")
-) { formValidationErrors =>
+) { case (emailInput: Option[String], categoryError: Option[FormError], emailError: Option[FormError], reasonError: Option[FormError]) =>
                 @helper.form(controllers.routes.CommentsController.reportAbuseSubmission(commentId), 'class -> "form") {
                     @helper.CSRF.formField
                     <fieldset class="fieldset">
                         <div class="fieldset__heading" />
                         <input type="hidden" name="commentId" value="@commentId">
                         <div class="fieldset__fields">
-                            <div class="form-field @{if(formValidationErrors._2) {"form-field--error"}}">
+                            <div class="form-field @{if(categoryError) {"form-field--error"}}">
                                 <label class="label" for="categoryId">Category</label>
 
 
@@ -32,24 +33,24 @@
                                     <option value="8">Spam</option>
                                     <option value="9">Other</option>
                                 </select>
-                                @if(formValidationErrors._2) {
-                                    <p class="form-field__error-message">@formValidationErrors._2.get.message</p>
+                                @if(categoryError) {
+                                    <p class="form-field__error-message">@categoryError.get.message</p>
                                 }
                             </div>
 
-                            <div class="form-field @{if(formValidationErrors._4) {"form-field--error"}}">
+                            <div class="form-field @{if(reasonError) {"form-field--error"}}">
                                 <label class="label" for="reason">Reason</label><span class="form-note">(optional)</span>
                                 <textarea class="input-textarea" id="reason" name="reason" maxlength="250"></textarea>
-                                @if(formValidationErrors._4) {
-                                    <p class="form-field__error-message">@formValidationErrors._4.get.message</p>
+                                @if(reasonError) {
+                                    <p class="form-field__error-message">@reasonError.get.message</p>
                                 }
                             </div>
 
-                            <div class="form-field @{if(formValidationErrors._3) {"form-field--error"}}">
+                            <div class="form-field @{if(emailError) {"form-field--error"}}">
                                 <label class="label" for="email">Email</label><span class="form-note">(optional)</span>
-                                <input type="email" class="input-text" id="email" name="email" value="@formValidationErrors._1" />
-                                @if(formValidationErrors._3) {
-                                    <p class="form-field__error-message">@formValidationErrors._3.get.message</p>
+                                <input type="email" class="input-text" id="email" name="email" value="@emailInput" />
+                                @if(emailError) {
+                                    <p class="form-field__error-message">@emailError.get.message</p>
                                 }
                             </div>
                         </div>

--- a/discussion/app/views/fragments/reportCommentForm.scala.html
+++ b/discussion/app/views/fragments/reportCommentForm.scala.html
@@ -4,18 +4,19 @@
         <label class="label">@errorMessage.get</label>
     </div>
 }
-@defining(userForm.apply("email").value) { emailUserInput =>
-    @defining(userForm.error("categoryId")) { categoryIdError =>
-        @defining(userForm.error("email")) { emailError =>
-            @defining(userForm.error("reason")) { reasonError =>
-
+@defining(
+    userForm.apply("email").value,
+    userForm.error("categoryId"),
+    userForm.error("email"),
+    userForm.error("reason")
+) { formValidationErrors =>
                 @helper.form(controllers.routes.CommentsController.reportAbuseSubmission(commentId), 'class -> "form") {
                     @helper.CSRF.formField
                     <fieldset class="fieldset">
                         <div class="fieldset__heading" />
                         <input type="hidden" name="commentId" value="@commentId">
                         <div class="fieldset__fields">
-                            <div class="form-field @{if(categoryIdError) {"form-field--error"}}">
+                            <div class="form-field @{if(formValidationErrors._2) {"form-field--error"}}">
                                 <label class="label" for="categoryId">Category</label>
 
 
@@ -31,24 +32,24 @@
                                     <option value="8">Spam</option>
                                     <option value="9">Other</option>
                                 </select>
-                                @if(categoryIdError) {
-                                    <p class="form-field__error-message">@categoryIdError.get.message</p>
+                                @if(formValidationErrors._2) {
+                                    <p class="form-field__error-message">@formValidationErrors._2.get.message</p>
                                 }
                             </div>
 
-                            <div class="form-field @{if(reasonError) {"form-field--error"}}">
+                            <div class="form-field @{if(formValidationErrors._4) {"form-field--error"}}">
                                 <label class="label" for="reason">Reason</label><span class="form-note">(optional)</span>
                                 <textarea class="input-textarea" id="reason" name="reason" maxlength="250"></textarea>
-                                @if(reasonError) {
-                                    <p class="form-field__error-message">@reasonError.get.message</p>
+                                @if(formValidationErrors._4) {
+                                    <p class="form-field__error-message">@formValidationErrors._4.get.message</p>
                                 }
                             </div>
 
-                            <div class="form-field @{if(emailError) {"form-field--error"}}">
+                            <div class="form-field @{if(formValidationErrors._3) {"form-field--error"}}">
                                 <label class="label" for="email">Email</label><span class="form-note">(optional)</span>
-                                <input type="email" class="input-text" id="email" name="email" value="@emailUserInput" />
-                                @if(emailError) {
-                                    <p class="form-field__error-message">@emailError.get.message</p>
+                                <input type="email" class="input-text" id="email" name="email" value="@formValidationErrors._1" />
+                                @if(formValidationErrors._3) {
+                                    <p class="form-field__error-message">@formValidationErrors._3.get.message</p>
                                 }
                             </div>
                         </div>
@@ -63,6 +64,4 @@
                     </fieldset>
                 }
             }
-        }
-    }
-}
+

--- a/discussion/conf/application.conf
+++ b/discussion/conf/application.conf
@@ -35,8 +35,14 @@ play {
   il8n {
     langs: "en"
   }
-
-  ws {
+  filters {
+      csrf {
+          cookie.name = GU_CSRF
+          cookie.secure = true
+          sign.tokens = true
+      }
+  }
+    ws {
     compressionEnabled: true
   }
 }

--- a/discussion/conf/application.conf
+++ b/discussion/conf/application.conf
@@ -36,11 +36,11 @@ play {
     langs: "en"
   }
   filters {
-      csrf {
-          cookie.name = GU_CSRF
-          cookie.secure = true
-          sign.tokens = true
-      }
+    csrf {
+      cookie.name = GU_CSRF
+      cookie.secure = true
+      sign.tokens = true
+    }
   }
     ws {
     compressionEnabled: true

--- a/discussion/conf/routes
+++ b/discussion/conf/routes
@@ -29,7 +29,8 @@ GET         /discussion/profile/:id/replies.json                                
 GET         /discussion/profile/:id/picks.json                                  controllers.ProfileActivityController.profilePicks(id: String)
 GET         /discussion/profile/:id/witness.json                                controllers.WitnessActivityController.witnessActivity(id: String)
 
+GET         /discussion/report-abuse/:commentId/thankyou                        controllers.CommentsController.reportAbuseThankYou(commentId: Int)
 GET         /discussion/report-abuse/*commentId                                 controllers.CommentsController.reportAbuseForm(commentId: Int)
 POST        /discussion/report-abuse/*commentId                                 controllers.CommentsController.reportAbuseSubmission(commentId: Int)
 
-GET         /open/cta/article/*discussionKey.json                        controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)
+GET         /open/cta/article/*discussionKey.json                               controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)

--- a/discussion/conf/routes
+++ b/discussion/conf/routes
@@ -29,4 +29,6 @@ GET         /discussion/profile/:id/replies.json                                
 GET         /discussion/profile/:id/picks.json                                  controllers.ProfileActivityController.profilePicks(id: String)
 GET         /discussion/profile/:id/witness.json                                controllers.WitnessActivityController.witnessActivity(id: String)
 
-GET         /open/cta/article/*discussionKey.json                               controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)
+GET         /discussion/report-abuse/*commentId                           controllers.CommentsController.reportAbuse(commentId: Int)
+
+GET         /open/cta/article/*discussionKey.json                        controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)

--- a/discussion/conf/routes
+++ b/discussion/conf/routes
@@ -29,6 +29,7 @@ GET         /discussion/profile/:id/replies.json                                
 GET         /discussion/profile/:id/picks.json                                  controllers.ProfileActivityController.profilePicks(id: String)
 GET         /discussion/profile/:id/witness.json                                controllers.WitnessActivityController.witnessActivity(id: String)
 
-GET         /discussion/report-abuse/*commentId                           controllers.CommentsController.reportAbuse(commentId: Int)
+GET         /discussion/report-abuse/*commentId                                 controllers.CommentsController.reportAbuseForm(commentId: Int)
+POST        /discussion/report-abuse/*commentId                                 controllers.CommentsController.reportAbuseSubmission(commentId: Int)
 
 GET         /open/cta/article/*discussionKey.json                        controllers.CtaController.cta(discussionKey: discussion.model.DiscussionKey)

--- a/static/src/javascripts/projects/common/modules/discussion/api.js
+++ b/static/src/javascripts/projects/common/modules/discussion/api.js
@@ -26,7 +26,8 @@ define([
                     toHTTPS(config.page.host + '/guardianapis/discussion/discussion-api') :
                 config.page.host + '/guardianapis/discussion/discussion-api') :
                 root),
-            clientHeader: config.page.discussionApiClientHeader
+            clientHeader: config.page.discussionApiClientHeader,
+            d2Uid: config.page.discussionD2Uid
         };
 
     /**
@@ -51,7 +52,7 @@ define([
             crossOrigin: true,
             data: data,
             headers: {
-                'D2-X-UID': 'zHoBy6HNKsk',
+                'D2-X-UID': Api.d2Uid,
                 'GU-Client': Api.clientHeader
             },
             withCredentials: true

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -902,7 +902,6 @@ $comment-recommend-button-size: 19px;
    ======================================================= */
 
 .d-report-comment-form {
-    position: absolute;
     top: 0;
     right: 0;
     z-index: $zindex-content;
@@ -912,6 +911,11 @@ $comment-recommend-button-size: 19px;
     border: 2px solid colour(neutral-6);
     background: #ffffff;
 }
+
+.d-comment .d-report-comment-form {
+    position: absolute;
+}
+
 .d-report-comment__label,
 .d-report-comment__field {
     box-sizing: border-box;


### PR DESCRIPTION
Adds a form at `/discussion/report-abuse/:commentId` to Report Abuse on comments for non AJAX users. This is to replace the form currently provided by D2 microapp e.g. http://discussion.theguardian.com/components/report-abuse/27576482 which we would like to deprecate.

_N.B_ The styling will look a bit uglier that that shown until the changes in https://github.com/guardian/frontend/pull/11447 are merged. I believe @jamespamplin is looking into this.
## Tasks after merging this PR:
- [ ] Ship sister PR https://github.com/guardian/fastly-edge-cache/pull/542 to make routes HTTPS only
- [ ] Add link to new route 

<img width="799" alt="screen shot 2016-01-08 at 12 17 22" src="https://cloud.githubusercontent.com/assets/1764158/12197899/1cab5a38-b603-11e5-8d65-92a328fbee01.png">
<img width="866" alt="screen shot 2016-01-08 at 12 17 07" src="https://cloud.githubusercontent.com/assets/1764158/12197900/1cad37c2-b603-11e5-9f8e-fa6476030016.png">
<img width="409" alt="screen shot 2016-01-08 at 12 27 03" src="https://cloud.githubusercontent.com/assets/1764158/12197901/1cae1f66-b603-11e5-9e39-527427358a52.png">

CC @guardian/discussion @adamnfish 
