### PR TITLE
Remove unused module parameter

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -130,7 +130,7 @@ define([
     /**
      * Private variables
      */
-    var resizeTimeout,
+    var resizeTimeout        = 2000,
         adSlotSelector       = '.js-ad-slot',
         displayed            = false,
         rendered             = false,
@@ -310,8 +310,6 @@ define([
             mediator.on('window:resize', windowResize);
         },
         setupAdvertising = function () {
-            resizeTimeout = 2000;
-
             // if we don't already have googletag, create command queue and load it async
             if (!window.googletag) {
                 window.googletag = { cmd: [] };

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -309,12 +309,8 @@ define([
         postDisplay = function () {
             mediator.on('window:resize', windowResize);
         },
-        setupAdvertising = function (options) {
-            var opts = defaults(options || {}, {
-                resizeTimeout: 2000
-            });
-
-            resizeTimeout = opts.resizeTimeout;
+        setupAdvertising = function () {
+            resizeTimeout = 2000;
 
             // if we don't already have googletag, create command queue and load it async
             if (!window.googletag) {
@@ -347,9 +343,9 @@ define([
         /**
          * Public functions
          */
-        init = function (options) {
+        init = function () {
             if (commercialFeatures.dfpAdvertising) {
-                setupAdvertising(options);
+                setupAdvertising();
             } else {
                 $(adSlotSelector).remove();
             }


### PR DESCRIPTION
This is just a little change to remove an 'options' parameter in dfp-api.js that isn't actually set by anything - either in production or in test code.
