### PR TITLE
Add logging inside sns match

### DIFF
--- a/common/app/services/Notification.scala
+++ b/common/app/services/Notification.scala
@@ -39,6 +39,7 @@ trait Notification extends Logging with ExecutionContexts {
     log.info(s"Issuing SNS notification: ${request.getSubject}:${request.getMessage}")
     sns match {
       case Some(client) =>
+          log.info(s"SNS notification with client $client")
           client.publishFuture(request) onComplete {
             case Success(_) =>
               log.info(s"Successfully published SNS notification: ${request.getSubject}:${request.getMessage}")


### PR DESCRIPTION
No logging after `log.info(s"Issuing SNS notification: ${request.getSubject}:${request.getMessage}")` comes out.

Is it reaching `client.publishFuture`?

@rich-nguyen 
