### PR TITLE
Upgrade aws sdk to 1.10.37

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,9 +7,7 @@ object Dependencies {
   val identityLibVersion = "3.46"
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
-
-  // Check SES works before upgrading this
-  val awsVersion = "1.9.16"
+  val awsVersion = "1.10.37"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.3.5"


### PR DESCRIPTION
This matches facia-json, hopefully to stop mixed dependency versions. A better fix is being discussed.
