### PR TITLE
Upgrade to facia scala client 0.65

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,8 +29,8 @@ object Dependencies {
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
   val dispatchTest = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3" % Test
   val exactTargetClient = "com.gu" %% "exact-target-client" % "2.24"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.63"
-  val faciaScalaClient = "com.gu" %% "facia-json" % "0.63"
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.64"
+  val faciaScalaClient = "com.gu" %% "facia-json" % "0.64"
   val flexibleContentBlockToText = "com.gu" %% "flexible-content-block-to-text" % "0.4"
   val flexibleContentBodyParser = "com.gu" %% "flexible-content-body-parser" % "0.6"
   val googleSheetsApi = "com.google.gdata" % "core" % "1.47.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,8 +29,8 @@ object Dependencies {
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
   val dispatchTest = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3" % Test
   val exactTargetClient = "com.gu" %% "exact-target-client" % "2.24"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.64"
-  val faciaScalaClient = "com.gu" %% "facia-json" % "0.64"
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.65"
+  val faciaScalaClient = "com.gu" %% "facia-json" % "0.65"
   val flexibleContentBlockToText = "com.gu" %% "flexible-content-block-to-text" % "0.4"
   val flexibleContentBodyParser = "com.gu" %% "flexible-content-body-parser" % "0.6"
   val googleSheetsApi = "com.google.gdata" % "core" % "1.47.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,8 +29,8 @@ object Dependencies {
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
   val dispatchTest = "net.databinder.dispatch" %% "dispatch-core" % "0.11.3" % Test
   val exactTargetClient = "com.gu" %% "exact-target-client" % "2.24"
-  val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.65"
-  val faciaScalaClient = "com.gu" %% "facia-json" % "0.65"
+  val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.66"
+  val faciaScalaClient = "com.gu" %% "facia-json" % "0.66"
   val flexibleContentBlockToText = "com.gu" %% "flexible-content-block-to-text" % "0.4"
   val flexibleContentBodyParser = "com.gu" %% "flexible-content-body-parser" % "0.6"
   val googleSheetsApi = "com.google.gdata" % "core" % "1.47.1"


### PR DESCRIPTION
This version of the library uses capi client 7.13, the one with all the fixes. It also adds the `This is the NHS` tag to special report.
