### PR TITLE
Deploys radiator improvements

### DIFF
--- a/admin/app/controllers/DeploysRadiatorController.scala
+++ b/admin/app/controllers/DeploysRadiatorController.scala
@@ -111,9 +111,9 @@ object DeploysRadiatorController extends Controller with Logging with AuthLoggin
           (response.json).validate[BuildJson] match {
             case JsSuccess(buildJson, _) =>
               Ok(Json.toJson(Build(
-                number,
-                s"${buildJson.buildType.projectName}::${buildJson.buildType.name}",
-                buildJson.`artifact-dependencies`.build.headOption.map(b => b.number),
+                number = number,
+                projectName = s"${buildJson.buildType.projectName}::${buildJson.buildType.name}",
+                parentNumber = buildJson.`artifact-dependencies`.build.headOption.map(b => b.number),
                 revision = buildJson.revisions.revision.headOption.map(_.version).getOrElse(throw new RuntimeException("Missing revision")),
                 commits = buildJson.changes.change.map(change => Commit(change.version, change.username, change.comment))
               )))
@@ -121,8 +121,8 @@ object DeploysRadiatorController extends Controller with Logging with AuthLoggin
               log.error(errors.toString())
               InternalServerError
           }
-        case error =>
-          log.error(s"Invalid status code from TeamCity: $error")
+        case statusCode =>
+          log.error(s"Invalid status code from TeamCity: $statusCode")
           InternalServerError
       }
     }

--- a/admin/app/controllers/DeploysRadiatorController.scala
+++ b/admin/app/controllers/DeploysRadiatorController.scala
@@ -5,11 +5,12 @@ import conf.Configuration
 import controllers.AuthLogging
 import implicits.Requests
 import model.NoCache
-import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.libs.json._
 import play.api.libs.ws.WS
-import play.api.mvc.Controller
+import play.api.mvc.{Results, Result, Controller}
 import play.api.Play.current
 import play.api.libs.concurrent.Execution.Implicits._
+import scala.concurrent.Future
 
 case class Deploy(
   uuid: String,
@@ -43,7 +44,7 @@ case class RevisionJson(version: String)
 object RevisionJson { implicit val format = Json.format[RevisionJson] }
 case class RevisionsJson(revision: List[RevisionJson])
 object RevisionsJson { implicit val format = Json.format[RevisionsJson] }
-case class BuildJson(buildType: BuildTypeJson, changes: ChangesJson, `artifact-dependencies`: ArtifactDependenciesJson, revisions: RevisionsJson)
+case class BuildJson(number: String, buildType: BuildTypeJson, changes: ChangesJson, `artifact-dependencies`: ArtifactDependenciesJson, revisions: RevisionsJson)
 
 object BuildTypeJson {
   implicit val format = Json.format[BuildTypeJson]
@@ -70,8 +71,42 @@ object BuildJson {
 }
 
 object DeploysRadiatorController extends Controller with Logging with AuthLogging with Requests{
+  //
+  // API types
+  //
 
-  def getDeploys(pageSize: Option[String], projectName: Option[String], stage: Option[String]) = AuthActions.AuthActionTest.async {
+  case class ApiError(message: String, statusCode: Int)
+  object ApiError { implicit val format = Json.format[ApiError] }
+
+  case class ApiErrors(errors: List[ApiError]) {
+    def statusCode = errors.map(_.statusCode).max
+  }
+
+  type ApiResponse[T] = Either[ApiErrors, T]
+
+  object ApiResponse extends Results {
+    def apply[T](action: => ApiResponse[T])(implicit tjs: Writes[T]): Result ={
+      action.fold(
+        apiErrors =>
+          Status(apiErrors.statusCode) {
+            JsObject(Seq(
+              "status" -> JsString("error"),
+              "statusCode" -> JsNumber(apiErrors.statusCode),
+              "errors" -> Json.toJson(apiErrors.errors)
+            ))
+          },
+        response =>
+          Ok {
+            JsObject(Seq(
+              "status" -> JsString("ok"),
+              "response" -> Json.toJson(response)
+            ))
+          }
+      )
+    }
+  }
+
+  def getRiffRaffDeploys(pageSize: Option[String], projectName: Option[String], stage: Option[String]): Future[ApiResponse[JsValue]] = {
     val url = s"${Configuration.riffraff.url}/api/history"
 
     WS.url(url)
@@ -83,49 +118,88 @@ object DeploysRadiatorController extends Controller with Logging with AuthLoggin
       .get()
       .map { response =>
       response.status match {
-        case 200 =>
-          (response.json \ "response" \ "results").validate[List[Deploy]] match {
-            case JsSuccess(listOfDeploys, _) => Ok(Json.toJson(listOfDeploys))
-            case JsError(errors) =>
-              log.error(errors.toString())
-              InternalServerError
-          }
-        case error =>
-          log.error(s"Invalid status code from RiffRaff: $error")
-          InternalServerError
+        case 200 => Right(response.json)
+        case statusCode => Left(ApiErrors(List(ApiError(
+          message = s"Invalid status code from RiffRaff: $statusCode",
+          statusCode = 500
+        ))))
       }
     }
   }
 
-  def getBuild(number: String) = AuthActions.AuthActionTest.async {
+  def jsonToDeploys(json: JsValue): ApiResponse[List[Deploy]] = {
+    (json \ "response" \ "results").validate[List[Deploy]] match {
+      case JsSuccess(listOfDeploys, _) => Right(listOfDeploys)
+      case JsError(errors) => Left(ApiErrors(List(ApiError("Failed to validate JSON", 500))))
+    }
+  }
+
+  def getTeamCityBuild(number: String): Future[ApiResponse[JsValue]] = {
     val apiPath = "/guestAuth/app/rest"
     val url = s"${Configuration.teamcity.host}${apiPath}/builds/number:$number,state:any"
 
     WS.url(url)
       .withHeaders("Accept" -> "application/json")
-      .withQueryString("fields" -> "buildType(name,projectName),revisions(revision(version)),changes(change(username,comment,version)),artifact-dependencies(build(number))")
+      .withQueryString("fields" -> "number,buildType(name,projectName),revisions(revision(version)),changes(change(username,comment,version)),artifact-dependencies(build(number))")
       .get()
       .map { response =>
-      response.status match {
-        case 200 =>
-          (response.json).validate[BuildJson] match {
-            case JsSuccess(buildJson, _) =>
-              Ok(Json.toJson(Build(
-                number = number,
-                projectName = s"${buildJson.buildType.projectName}::${buildJson.buildType.name}",
-                parentNumber = buildJson.`artifact-dependencies`.build.headOption.map(b => b.number),
-                revision = buildJson.revisions.revision.headOption.map(_.version).getOrElse(throw new RuntimeException("Missing revision")),
-                commits = buildJson.changes.change.map(change => Commit(change.version, change.username, change.comment))
-              )))
-            case JsError(errors) =>
-              log.error(errors.toString())
-              InternalServerError
-          }
-        case statusCode =>
-          log.error(s"Invalid status code from TeamCity: $statusCode")
-          InternalServerError
+        response.status match {
+          case 200 => Right(response.json)
+          case statusCode => Left(ApiErrors(List(ApiError(
+            message = s"Invalid status code from TeamCity: $statusCode",
+            statusCode = 500
+          ))))
+        }
       }
+  }
+
+  def buildJsonToBuild(buildJson: BuildJson): ApiResponse[Build] = {
+    val maybeBuild = buildJson.revisions.revision.headOption.map(_.version).map(revision => {
+      Build(
+        number = buildJson.number,
+        projectName = s"${buildJson.buildType.projectName}::${buildJson.buildType.name}",
+        parentNumber = buildJson.`artifact-dependencies`.build.headOption.map(b => b.number),
+        revision = revision,
+        commits = buildJson.changes.change.map(change => Commit(change.version, change.username, change.comment))
+      )
+    })
+
+    maybeBuild
+      .map(Right(_))
+      .getOrElse(Left(ApiErrors(List(ApiError("Missing revision", 500)))))
+  }
+
+  def jsonToBuild(json: JsValue): ApiResponse[Build] = {
+    json.validate[BuildJson] match {
+      case JsSuccess(buildJson, _) => buildJsonToBuild(buildJson)
+      case JsError(errors) => Left(ApiErrors(List(ApiError("Failed to validate JSON", 500))))
     }
+  }
+
+  //
+  // Routes
+  //
+
+  def getDeploys(pageSize: Option[String], projectName: Option[String], stage: Option[String]) = AuthActions.AuthActionTest.async {
+    getRiffRaffDeploys(pageSize, projectName, stage).map(riffRaffDeploysJson => {
+      ApiResponse {
+        for {
+          json <- riffRaffDeploysJson.right
+          deploys <- jsonToDeploys(json).right
+        } yield deploys
+      }
+    })
+  }
+
+  def getBuild(number: String) = AuthActions.AuthActionTest.async {
+    getTeamCityBuild(number).map(teamCityBuildJson => {
+      ApiResponse {
+        for {
+          json <- teamCityBuildJson.right
+          build <- jsonToBuild(json).right
+        } yield build
+      }
+    })
   }
 
   def renderDeploysRadiator() = AuthActions.AuthActionTest {

--- a/static/src/deploys-radiator/app/main.ts
+++ b/static/src/deploys-radiator/app/main.ts
@@ -10,7 +10,7 @@ import {
     Deploy, DeployRecord, createDeployRecord,
     Build, BuildRecord, createBuildRecord,
     DeployGroup, DeployGroupRecord, createDeployGroupRecord,
-    DeployJson, BuildJson, Commit,
+    DeploysJson, BuildJson, Commit,
     GitHubCompareJson, GitHubCommitJson, GitHubCommit,
     GitHubErrorJson
 } from './model';
@@ -232,8 +232,8 @@ const renderPage: (
 const apiPath = '/deploys-radiator/api';
 const getDeploys = (stage: string): Promise<List<DeployRecord>> => (
     fetch(`${apiPath}/deploys?projectName=dotcom:&stage=${stage}&pageSize=200`, { credentials: 'same-origin' })
-        .then((response): Promise<Array<DeployJson>> => response.json())
-        .then(deploys => List(deploys.map(deploy => createDeployRecord({
+        .then((response): Promise<DeploysJson> => response.json())
+        .then(deploys => List(deploys.response.map(deploy => createDeployRecord({
             build: Number(deploy.build),
             uuid: deploy.uuid,
             projectName: deploy.projectName.replace(/^dotcom:/, ''),
@@ -244,6 +244,7 @@ const getDeploys = (stage: string): Promise<List<DeployRecord>> => (
 const getBuild = (build: number): Promise<BuildRecord> => (
     fetch(`${apiPath}/builds/${build}`, { credentials: 'same-origin' })
         .then((response): Promise<BuildJson> => response.json())
+        .then(build => build.response)
         .then(build => createBuildRecord({
             number: Number(build.number),
             projectName: build.projectName,

--- a/static/src/deploys-radiator/app/main.ts
+++ b/static/src/deploys-radiator/app/main.ts
@@ -312,9 +312,10 @@ const run = (): Promise<void> => {
 
 
 const intervalSeconds = 10;
+const wait = (): Promise<{}> => new Promise(resolve => setTimeout(resolve, intervalSeconds * 1000));
 const update = (): Promise<void> => {
     return run()
-        .then(() => new Promise(resolve => setTimeout(resolve, intervalSeconds * 1000)))
+        .then(wait, wait)
         .then(update);
 };
 update();

--- a/static/src/deploys-radiator/app/model.ts
+++ b/static/src/deploys-radiator/app/model.ts
@@ -26,6 +26,7 @@ export interface Build {
     number: number;
     // TODO: This is confusing, same name as deploy.projectName
     projectName: string;
+    revision: string;
     commits: Array<Commit>
 }
 
@@ -39,6 +40,7 @@ export type BuildRecord = Record.IRecord<Build>;
 export const createBuildRecord = Record<Build>({
     number: undefined,
     projectName: undefined,
+    revision: undefined,
     commits: undefined,
 }, 'Build');
 
@@ -65,6 +67,7 @@ export interface DeployJson {
 export interface BuildJson {
     number: string;
     projectName: string;
+    revision: string;
     commits: Array<CommitJson>
 }
 

--- a/static/src/deploys-radiator/app/model.ts
+++ b/static/src/deploys-radiator/app/model.ts
@@ -56,7 +56,7 @@ export const createDeployGroupRecord = Record<DeployGroup>({
 }, 'DeployGroup');
 
 
-export interface DeployJson {
+interface DeployJson {
     build: string;
     uuid: string;
     projectName: string;
@@ -64,11 +64,21 @@ export interface DeployJson {
     time: string;
 }
 
-export interface BuildJson {
+export interface DeploysJson {
+    status: string;
+    response: Array<DeployJson>;
+}
+
+interface BuildResponseJson {
     number: string;
     projectName: string;
     revision: string;
     commits: Array<CommitJson>
+}
+
+export interface BuildJson {
+    status: string;
+    response: BuildResponseJson;
 }
 
 interface CommitJson {


### PR DESCRIPTION
- Use build revision instead of first commit (useful for re-run builds where there are no changes)
- If the update fails, schedule another update
- Model API errors using Scala’s `Either` type. Thanks @adamnfish!
