### PR TITLE
Fail the build when tests aren't passing

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -9,7 +9,7 @@ trait ABTestSwitches {
     "ab-alternative-related",
     "show alternative related content based on the tags to users in the test",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 1, 23),
+    sellByDate = new LocalDate(2016, 1, 25),
     exposeClientSide = true
   )
 
@@ -27,7 +27,7 @@ trait ABTestSwitches {
     "ab-fronts-on-articles2",
     "Injects fronts on articles for the test",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 1, 30),
+    sellByDate = new LocalDate(2016, 2, 1),
     exposeClientSide = true
   )
 
@@ -45,7 +45,7 @@ trait ABTestSwitches {
     "ab-rtrt-email-form-article-promo",
     "Testing the email sign up from the bottom of articles of user referred from fronts",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 1, 17),
+    sellByDate = new LocalDate(2016, 1, 18),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -244,7 +244,7 @@ trait CommercialSwitches {
     "advert-opt-out",
     "Enable adfree experience. See with cookie 'gu_adfree_user' = true",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 1, 31),
+    sellByDate = new LocalDate(2016, 2, 1),
     exposeClientSide = true
   )
 
@@ -253,7 +253,7 @@ trait CommercialSwitches {
     "new-commercial-content",
     "New commercial content designs",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 1, 31),
+    sellByDate = new LocalDate(2016, 2, 1),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -210,7 +210,7 @@ trait FeatureSwitches {
     "quiz-scores-service",
     "If switched on, the diagnostics server will provide a service to store quiz results in memcached",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 4, 10),
+    sellByDate = new LocalDate(2016, 4, 11),
     exposeClientSide = false
   )
 

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -34,7 +34,7 @@ trait Initializable[T] extends ExecutionContexts with Logging {
 }
 
 
-trait SwitchTrait extends Switchable with Initializable[SwitchTrait] {
+sealed trait SwitchTrait extends Switchable with Initializable[SwitchTrait] {
   val group: String
   val name: String
   val description: String
@@ -82,22 +82,6 @@ case class Switch(
   sellByDate: LocalDate,
   exposeClientSide: Boolean
 ) extends SwitchTrait
-
-case class TimerSwitch(
-  group: String,
-  name: String,
-  description: String,
-  safeState: SwitchState,
-  sellByDate: LocalDate,
-  activePeriods: Seq[Interval],
-  exposeClientSide: Boolean
-) extends SwitchTrait with Logging {
-
-  def isSwitchedOnAndActive: Boolean = {
-    val active = activePeriods.exists(_.containsNow())
-    isSwitchedOn && (environment.isNonProd || active)
-  }
-}
 
 object Switch {
   val switches = AkkaAgent[List[SwitchTrait]](Nil)

--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -1,6 +1,6 @@
 package conf.switches
 
-import org.joda.time.LocalDate
+import org.joda.time.{DateTimeConstants, LocalDate}
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
@@ -16,17 +16,21 @@ class SwitchesTest extends FlatSpec with Matchers {
   }
 
   they should "have a description" in {
-    Switches.all foreach {
-      case Switch(_, _, description, _, _, _) => description.trim should not be("")
-      case TimerSwitch(_, _, description, _, _, _, _) => description.trim should not be("")
-    }
+    Switches.all foreach { _.description.trim should not be("") }
   }
 
   // If you are wondering why this test has failed then read, https://github.com/guardian/frontend/pull/2711
   they should "be deleted once expired" in {
-    Switches.all foreach {
-      case Switch(_, id, _, _, sellByDate, _) => assert(sellByDate.isAfter(LocalDate.now()), id)
-      case TimerSwitch(_, id, _, _, sellByDate, _, _) => assert(sellByDate.isAfter(LocalDate.now()), id)
+    Switches.all foreach { switch =>
+      assert(switch.sellByDate.isAfter(LocalDate.now()), switch.name)
+    }
+  }
+
+  they should "have weekday expiry dates" in {
+    Switches.all foreach { switch =>
+     val day = switch.sellByDate.getDayOfWeek()
+     val isWeekend = day == DateTimeConstants.SATURDAY || day == DateTimeConstants.SUNDAY
+     assert(!isWeekend, switch.name)
     }
   }
 }

--- a/dev/teamcity/dist-play-tc
+++ b/dev/teamcity/dist-play-tc
@@ -2,7 +2,6 @@
 
 set -o xtrace
 set -o nounset
-set -o errexit
 
 echo "Dist play jars."
 
@@ -10,6 +9,19 @@ set +x
 echo "##teamcity[progressStart 'sbt test and dist']"
 set -x
 
-./dev/teamcity/sbt-tc "project root" compile assets test riffRaffUpload
+./dev/teamcity/sbt-tc "project root" compile assets test
+testPassed=$?
+
+if [[ $BUILD_IS_PERSONAL == 'true' ]]; then
+    echo "personal build complete."
+    exit $testPassed
+fi
+
+if [[ $testPassed -eq 0 ]]; then
+    echo "sbt passed, performing riff raff upload."
+    ./dev/teamcity/sbt-tc "project root" riffRaffUpload
+else
+    echo "sbt tests failed, riff raff upload not performed."
+fi
 
 echo "Done disting."


### PR DESCRIPTION
This makes sure that switches which expire over the weekend cause a test failure. And that test failures prevent a riff raff upload/deploy.
