### PR TITLE
Add logos to multiple-campaign commercial container

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -102,37 +102,35 @@
                         </div>
                         <div class="commercial__body">
                             <ul class="lineitems">
-                                @for((maybeCard, maybeSponsorData) <- Commercial.containerCard.cardsAndSponsorDataAttributes(container)) {
-                                    @for(card <- maybeCard) {
-                                        @for(sponsorData <- maybeSponsorData) {
-                                            <li class="lineitem js-sponsored-container"
-                                                data-sponsorship="@sponsorData.sponsorshipType"
-                                                @for(seriesId <- sponsorData.seriesId) {
-                                                    data-series="@seriesId"
-                                                }
-                                                @for( keywordId <- sponsorData.keywordId) {
-                                                    data-keywords="@keywordId"
-                                                }
-                                            >
-                                                <div class="rich-link tone-paidfor--item">
-                                                    <div class="rich-link__container js-container__header">
-                                                        <div class="fc-item__image-container u-responsive-ratio">
-                                                        @for( InlineImage(imageContainer) <- card.displayElement) {
-                                                            @itemImage(imageContainer.images)
-                                                        }
-                                                        </div>
-                                                        <div class="rich-link__header">
-                                                            <h2 class="rich-link__title">
-                                                                <a class="rich-link__link">@title(card.header, 0, container.index)</a>
-                                                            </h2>
-                                                        </div>
-                                                        <div class="rich-link__standfirst u-cf">@for( text <- card.trailText) {@Html(text)}</div>
-                                                        <a class="rich-link__link u-faux-block-link__overlay" @Html(card.header.url.hrefWithRel)>@RemoveOuterParaHtml(card.header.headline)</a>
-                                                    </div>
-                                                </div>
-                                            </li>
+                                @for(cardWithSponsorData <- Commercial.containerCard.mkCardsWithSponsorDataAttributes(container)) {
+                                    <li class="lineitem js-sponsored-container"
+                                        @for(sponsorData <- cardWithSponsorData.sponsorData) {
+                                            data-sponsorship="@sponsorData.sponsorshipType"
+                                            @for(seriesId <- sponsorData.seriesId) {
+                                                data-series="@seriesId"
+                                            }
+                                            @for( keywordId <- sponsorData.keywordId) {
+                                                data-keywords="@keywordId"
+                                            }
                                         }
-                                    }
+                                    >
+                                        <div class="rich-link tone-paidfor--item">
+                                            <div class="rich-link__container js-container__header">
+                                                <div class="fc-item__image-container u-responsive-ratio">
+                                                @for( InlineImage(imageContainer) <- cardWithSponsorData.card.displayElement) {
+                                                    @itemImage(imageContainer.images)
+                                                }
+                                                </div>
+                                                <div class="rich-link__header">
+                                                    <h2 class="rich-link__title">
+                                                        <a class="rich-link__link">@title(cardWithSponsorData.card.header, 0, container.index)</a>
+                                                    </h2>
+                                                </div>
+                                                <div class="rich-link__standfirst u-cf">@for( text <- cardWithSponsorData.card.trailText) {@Html(text)}</div>
+                                                <a class="rich-link__link u-faux-block-link__overlay" @Html(cardWithSponsorData.card.header.url.hrefWithRel)>@RemoveOuterParaHtml(cardWithSponsorData.card.header.headline)</a>
+                                            </div>
+                                        </div>
+                                    </li>
                                 }
                             </ul>
                         </div>

--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -7,7 +7,7 @@
 @import views.html.fragments.containers.facia_cards.standardContainer
 @import views.html.fragments.inlineSvg
 @import views.html.fragments.items.elements.facia_cards.{itemImage, title}
-@import views.support.RemoveOuterParaHtml
+@import views.support.{Commercial, RemoveOuterParaHtml}
 
     @containerType match {
 
@@ -102,36 +102,29 @@
                         </div>
                         <div class="commercial__body">
                             <ul class="lineitems">
-                                @for(layout <- container.containerLayout) {
-                                    @for( slice <- layout.slices) {
-                                        @for(ColumnAndCards(_, cards) <- slice.columns) {
-                                            @for(card <- cards) {
-                                                @card.item match {
-                                                    case content: ContentCard => {
-                                                        <li class="lineitem">
-                                                            <div class="rich-link tone-paidfor--item">
-                                                                <div class="rich-link__container">
-                                                                    <div class="fc-item__image-container u-responsive-ratio">
-                                                                        @for(InlineImage(imageContainer) <- content.displayElement) {
-                                                                            @itemImage(imageContainer.images)
-                                                                        }
-                                                                    </div>
-                                                                    <div class="rich-link__header">
-                                                                        <h2 class="rich-link__title">
-                                                                            <a class="rich-link__link">@title(content.header, card.index, container.index)</a>
-                                                                        </h2>
-                                                                    </div>
-                                                                    <div class="rich-link__standfirst u-cf">@for(text <- content.trailText) {@Html(text)}</div>
-                                                                    <aside class="rich-link__meta">Paid for by <img src="gourmet.png"></aside>
-                                                                    <a class="rich-link__link u-faux-block-link__overlay" @Html(content.header.url.hrefWithRel)>@RemoveOuterParaHtml(content.header.headline)</a>
-                                                                </div>
-                                                            </div>
-                                                        </li>
+                                @for((maybeCard, sponsorData) <- Commercial.containerCard.cardsAndSponsorDataAttributes(container)) {
+                                    @for(card <- maybeCard) {
+                                        <li class="lineitem js-sponsored-container"
+                                        @for(sponsorshipType <- sponsorData.sponsorshipType) {data-sponsorship="@sponsorshipType"}
+                                        @for(seriesId <- sponsorData.seriesId) {data-series="@seriesId"}
+                                        @for(keywordId <- sponsorData.keywordId) {data-keywords="@keywordId"}>
+                                            <div class="rich-link tone-paidfor--item">
+                                                <div class="rich-link__container js-container__header">
+                                                    <div class="fc-item__image-container u-responsive-ratio">
+                                                    @for(InlineImage(imageContainer) <- card.displayElement) {
+                                                        @itemImage(imageContainer.images)
                                                     }
-                                                    case _ => {}
-                                                }
-                                            }
-                                        }
+                                                    </div>
+                                                    <div class="rich-link__header">
+                                                        <h2 class="rich-link__title">
+                                                            <a class="rich-link__link">@title(card.header, 0, container.index)</a>
+                                                        </h2>
+                                                    </div>
+                                                    <div class="rich-link__standfirst u-cf">@for(text <- card.trailText) {@Html(text)}</div>
+                                                    <a class="rich-link__link u-faux-block-link__overlay" @Html(card.header.url.hrefWithRel)>@RemoveOuterParaHtml(card.header.headline)</a>
+                                                </div>
+                                            </div>
+                                        </li>
                                     }
                                 }
                             </ul>

--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -102,29 +102,36 @@
                         </div>
                         <div class="commercial__body">
                             <ul class="lineitems">
-                                @for((maybeCard, sponsorData) <- Commercial.containerCard.cardsAndSponsorDataAttributes(container)) {
+                                @for((maybeCard, maybeSponsorData) <- Commercial.containerCard.cardsAndSponsorDataAttributes(container)) {
                                     @for(card <- maybeCard) {
-                                        <li class="lineitem js-sponsored-container"
-                                        @for(sponsorshipType <- sponsorData.sponsorshipType) {data-sponsorship="@sponsorshipType"}
-                                        @for(seriesId <- sponsorData.seriesId) {data-series="@seriesId"}
-                                        @for(keywordId <- sponsorData.keywordId) {data-keywords="@keywordId"}>
-                                            <div class="rich-link tone-paidfor--item">
-                                                <div class="rich-link__container js-container__header">
-                                                    <div class="fc-item__image-container u-responsive-ratio">
-                                                    @for(InlineImage(imageContainer) <- card.displayElement) {
-                                                        @itemImage(imageContainer.images)
-                                                    }
+                                        @for(sponsorData <- maybeSponsorData) {
+                                            <li class="lineitem js-sponsored-container"
+                                                data-sponsorship="@sponsorData.sponsorshipType"
+                                                @for(seriesId <- sponsorData.seriesId) {
+                                                    data-series="@seriesId"
+                                                }
+                                                @for( keywordId <- sponsorData.keywordId) {
+                                                    data-keywords="@keywordId"
+                                                }
+                                            >
+                                                <div class="rich-link tone-paidfor--item">
+                                                    <div class="rich-link__container js-container__header">
+                                                        <div class="fc-item__image-container u-responsive-ratio">
+                                                        @for( InlineImage(imageContainer) <- card.displayElement) {
+                                                            @itemImage(imageContainer.images)
+                                                        }
+                                                        </div>
+                                                        <div class="rich-link__header">
+                                                            <h2 class="rich-link__title">
+                                                                <a class="rich-link__link">@title(card.header, 0, container.index)</a>
+                                                            </h2>
+                                                        </div>
+                                                        <div class="rich-link__standfirst u-cf">@for( text <- card.trailText) {@Html(text)}</div>
+                                                        <a class="rich-link__link u-faux-block-link__overlay" @Html(card.header.url.hrefWithRel)>@RemoveOuterParaHtml(card.header.headline)</a>
                                                     </div>
-                                                    <div class="rich-link__header">
-                                                        <h2 class="rich-link__title">
-                                                            <a class="rich-link__link">@title(card.header, 0, container.index)</a>
-                                                        </h2>
-                                                    </div>
-                                                    <div class="rich-link__standfirst u-cf">@for(text <- card.trailText) {@Html(text)}</div>
-                                                    <a class="rich-link__link u-faux-block-link__overlay" @Html(card.header.url.hrefWithRel)>@RemoveOuterParaHtml(card.header.headline)</a>
                                                 </div>
-                                            </div>
-                                        </li>
+                                            </li>
+                                        }
                                     }
                                 }
                             </ul>

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -87,8 +87,9 @@ object Commercial {
       keywordId: Option[String]
     )
 
-    def cardsAndSponsorDataAttributes(container: FaciaContainer):
-    Seq[(Option[ContentCard], Option[SponsorDataAttributes])] = {
+    case class CardWithSponsorDataAttributes(card: ContentCard, sponsorData: Option[SponsorDataAttributes])
+
+    def mkCardsWithSponsorDataAttributes(container: FaciaContainer): Seq[CardWithSponsorDataAttributes] = {
 
       def sponsorDataAttributes(item: PressedContent): Option[SponsorDataAttributes] = {
 
@@ -129,7 +130,10 @@ object Commercial {
         }
       } getOrElse Nil
 
-      contentCards zip (container.collectionEssentials.items map sponsorDataAttributes)
+      contentCards zip container.collectionEssentials.items flatMap {
+        case (card, content) =>
+          card map (CardWithSponsorDataAttributes(_, sponsorDataAttributes(content)))
+      }
     }
   }
 }

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -2,9 +2,11 @@ package views.support
 
 import common.Edition
 import common.dfp.AdSize.{leaderboardSize, responsiveSize}
-import common.dfp.{AdSize, AdSlot, TopAboveNavSlot, TopSlot}
+import common.dfp._
 import conf.switches.Switches._
-import model.{MetaData, Page}
+import layout.{ColumnAndCards, ContentCard, FaciaContainer}
+import model.pressed.PressedContent
+import model.{ContentType, MetaData, Page, Tag}
 
 object Commercial {
 
@@ -74,6 +76,64 @@ object Commercial {
 
     def hasResponsiveAd(metaData: MetaData, edition: Edition): Boolean = {
       hasAdOfSize(TopSlot, responsiveSize, metaData, edition)
+    }
+  }
+
+  object containerCard {
+
+    case class SponsorDataAttributes(
+      sponsorshipType: Option[String],
+      seriesId: Option[String],
+      keywordId: Option[String]
+    )
+
+    def cardsAndSponsorDataAttributes(container: FaciaContainer): Seq[(Option[ContentCard], SponsorDataAttributes)] = {
+
+      def sponsorDataAttributes(item: PressedContent): SponsorDataAttributes = {
+
+        def mkFromItem(item: PressedContent): Option[SponsorDataAttributes] = {
+
+          def sponsoredTagPair(content: ContentType): Option[CapiTagAndDfpTag] = {
+            DfpAgent.winningTagPair(
+              capiTags = content.tags.tags,
+              sectionId = Some(content.metadata.section),
+              edition = None
+            )
+          }
+
+          def mkFromSponsoredTagPair(tagProps: CapiTagAndDfpTag): SponsorDataAttributes = {
+            val capiTag = tagProps.capiTag
+            val dfpTag = tagProps.dfpTag
+
+            def tagId(p: Tag => Boolean): Option[String] = if (p(capiTag)) Some(capiTag.id) else None
+
+            SponsorDataAttributes(
+              sponsorshipType = Some(dfpTag.paidForType.name),
+              seriesId = tagId(_.isSeries),
+              keywordId = tagId(_.isKeyword)
+            )
+          }
+
+          item.properties.maybeContent flatMap (sponsoredTagPair(_) map mkFromSponsoredTagPair)
+        }
+
+        mkFromItem(item) getOrElse SponsorDataAttributes(sponsorshipType = None, seriesId = None, keywordId = None)
+      }
+
+      val contentCards = container.containerLayout map {
+        _.slices flatMap {
+          _.columns flatMap { case ColumnAndCards(_, cards) =>
+            cards map {
+              _.item match {
+                case card: ContentCard => Some(card)
+                case _ => None
+              }
+            }
+          }
+        }
+      } getOrElse Nil
+
+      contentCards zip (container.collectionEssentials.items map sponsorDataAttributes)
     }
   }
 }


### PR DESCRIPTION
It looks like this at the moment:

![image](https://cloud.githubusercontent.com/assets/1722550/12238438/e9eb6522-b87b-11e5-9f1b-b443334ff831.png)

So more styling will be required.

/cc @Calanthe 
