### PR TITLE
Age notice only shows when it is supposed to on AMP

### DIFF
--- a/common/app/views/fragments/amp/onward.scala.html
+++ b/common/app/views/fragments/amp/onward.scala.html
@@ -41,8 +41,8 @@
                             </div>
                             <aside class="fc-item__meta">
                                 <time class="fc-item__timestamp" data-relativeformat="short">
-                                    @fragments.inlineSvg("clock", "icon")
                                     {{#showWebPublicationDate}}
+                                        @fragments.inlineSvg("clock", "icon")
                                         <span class="timestamp__text">
                                             <span class="u-h">Published: </span>
                                             {{webPublicationDate}}

--- a/common/app/views/support/ContentOldAgeDescriber.scala
+++ b/common/app/views/support/ContentOldAgeDescriber.scala
@@ -1,6 +1,7 @@
 package views.support
 
 import java.util.concurrent.TimeUnit
+import model.pressed.CuratedContent
 import org.joda.time.DateTime
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
 
@@ -17,6 +18,10 @@ class ContentOldAgeDescriber {
 
   def apply(apiContent: com.gu.contentapi.client.model.v1.Content): String = {
     message(apiContent.webPublicationDate.map(_.toJodaDateTime))
+  }
+
+  def apply(curatedContent: CuratedContent): String = {
+    message(curatedContent.card.webPublicationDateOption)
   }
 
   private def message(maybePubDate: Option[DateTime]) = {

--- a/common/app/views/support/FaciaToMicroFormat2Helpers.scala
+++ b/common/app/views/support/FaciaToMicroFormat2Helpers.scala
@@ -18,7 +18,10 @@ object FaciaToMicroFormat2Helpers {
     case _ => Json.obj()
   }
 
-  private def getContent(content: CuratedContent): JsValue =
+  private def getContent(content: CuratedContent): JsValue = {
+    lazy val toneClass = TrailCssClasses.toneClass(content)
+    lazy val webPublicationDate = if (toneClass == "tone-news") ContentOldAgeDescriber(content) else ""
+
     JsObject(
       Json.obj(
         "headline" -> content.header.headline,
@@ -26,14 +29,15 @@ object FaciaToMicroFormat2Helpers {
         "url" -> content.properties.href,
         "thumbnail" -> content.properties.maybeContent.flatMap(_.trail.thumbnailPath),
         "id" -> content.properties.maybeContent.map(_.metadata.id),
-        "frontPublicationDate" -> content.properties.maybeFrontPublicationDate,
         "byline" -> content.properties.byline,
         "isComment" -> content.header.isComment,
         "isVideo" -> content.header.isVideo,
         "isAudio" -> content.header.isAudio,
         "isGallery" -> content.header.isGallery,
-        "toneClass" -> TrailCssClasses.toneClass(content),
-        "showWebPublicationDate" -> false)
+        "toneClass" -> toneClass,
+        "webPublicationDate" -> webPublicationDate,
+        "showWebPublicationDate" -> !webPublicationDate.isEmpty)
       .fields
-      .filterNot{ case (_, v) => v == JsNull})
+      .filterNot { case (_, v) => v == JsNull })
+  }
 }


### PR DESCRIPTION
Shows the old content message on anything 30 days old or more and that is tagged with tone/news. 

This is specifically only for the onward journeys on AMP
