### PR TITLE
An expired switch should retain it's value

### DIFF
--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -44,7 +44,7 @@ sealed trait SwitchTrait extends Switchable with Initializable[SwitchTrait] {
 
   val delegate = DefaultSwitch(name, description, initiallyOn = safeState == On)
 
-  def isSwitchedOn: Boolean = delegate.isSwitchedOn && new LocalDate().isBefore(sellByDate)
+  def isSwitchedOn: Boolean = delegate.isSwitchedOn
 
   /*
    * If the switchboard hasn't been read yet, the "safe state" is returned instead of the real switch value.


### PR DESCRIPTION
This is needed to ensure that we don't accidentally schedule unwanted behaviour when a switch expires. The expiry is only used to fail the tests.
