### PR TITLE
Get the tone from the page to style the email form

### DIFF
--- a/common/app/views/fragments/email/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/emailSignUp.scala.html
@@ -12,7 +12,7 @@
 @formId = @{ componentClass + "-email-sub-form" }
 @inputId = @{ componentClass + "-email-sub-input" }
 
-@wrapperClass = @{"email-sub js-email-sub" + " email-sub--" + componentClass }
+@wrapperClass = @{"email-sub js-email-sub" + " email-sub--" + componentClass + " js-email-sub--" + componentClass}
 @formClass = @{ "email-sub__form js-email-sub__form" + " email-sub__form--" + componentClass }
 
 <div class="@wrapperClass">

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -38,6 +38,8 @@ object JavaScriptPage {
     val requiresMembershipAccess = content.map(_.metadata.requiresMembershipAccess).getOrElse(false)
     val membershipAccess = content.flatMap(_.metadata.membershipAccess).getOrElse("")
 
+    val cardStyle = content.map(_.cardStyle.toneString).getOrElse("")
+
     val commercialMetaData = Map(
       "oasHost" -> JsString("oas.theguardian.com"),
       "oasUrl" -> JsString(Configuration.oas.url),
@@ -73,7 +75,8 @@ object JavaScriptPage {
       ("allowUserGeneratedContent", JsBoolean(allowUserGeneratedContent)),
       ("requiresMembershipAccess", JsBoolean(requiresMembershipAccess)),
       ("membershipAccess", JsString(membershipAccess)),
-      ("idWebAppUrl", JsString(Configuration.id.oauthUrl))
+      ("idWebAppUrl", JsString(Configuration.id.oauthUrl)),
+      ("cardStyle", JsString(cardStyle))
     )
   }
 }

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -212,15 +212,9 @@ define([
 
             },
             setTone: function ($el) {
-                var toneClass = 'tonal__main--tone-',
-                    toneClassRegexp = new RegExp('(' + toneClass + ')([a-z-]+)'),
-                    tone;
-
                 if ($el.hasClass('js-email-sub--article')) {
-                    // Get tone from class
-                    tone = $('.tonal__main')[0].className.match(toneClassRegexp)[2];
                     fastdom.write(function () {
-                        $el.addClass('email-sub--tone-' + tone);
+                        $el.addClass('email-sub--tone-' + config.page.cardStyle);
                     });
                 }
             },

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -97,6 +97,7 @@ define([
                 // from the data attributes on the iframe (eg: allowing us to set them from composer)
                 if (isIframed) {
                     ui.updateForm(rootEl, $el);
+                    ui.setTone($el);
                 }
 
                 // Ensure our form is the right height, both in iframe and outside
@@ -209,6 +210,19 @@ define([
                     referrer: window.location.href
                 });
 
+            },
+            setTone: function ($el) {
+                var toneClass = 'tonal__main--tone-',
+                    toneClassRegexp = new RegExp('(' + toneClass + ')([a-z-]+)'),
+                    tone;
+
+                if ($el.hasClass('js-email-sub--article')) {
+                    // Get tone from class
+                    tone = $('.tonal__main')[0].className.match(toneClassRegexp)[2];
+                    fastdom.write(function () {
+                        $el.addClass('email-sub--tone-' + tone);
+                    });
+                }
             },
             freezeHeight: function ($wrapper, reset) {
                 var wrapperHeight,

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -248,3 +248,21 @@
     }
 }
 
+// TONE SPECIFIC MODS
+@each $toneClass, $toneColour in $tones {
+    .email-sub--tone-#{$toneClass} {
+        .email-sub__message__headline {
+            color: $toneColour;
+        }
+
+        .email-sub__submit-input {
+            background-color: $toneColour;
+            border-color: $toneColour;
+        }
+
+        .email-sub__small {
+            color: $toneColour;
+        }
+    }
+}
+

--- a/static/src/stylesheets/module/email/_header.scss
+++ b/static/src/stylesheets/module/email/_header.scss
@@ -44,6 +44,15 @@
     }
 }
 
+// TONE SPECIFIC MODS
+@each $toneClass, $toneColour in $tones {
+    .email-sub--tone-#{$toneClass} {
+        .email-sub__heading {
+            color: $toneColour;
+        }
+    }
+}
+
 // FOOTER MODS
 .email-sub__header--footer {
     .email-sub__heading {

--- a/static/src/stylesheets/module/email/_vars.scss
+++ b/static/src/stylesheets/module/email/_vars.scss
@@ -5,3 +5,17 @@ $form-label-colour: guss-colour(neutral-2, $pasteup-palette);
 $icon-size: 30px;
 $icon-padding: $icon-size + ($gs-gutter / 2);
 $rounded-adjustment: .66em;
+
+$tones: (
+    (analysis, darken(colour(analysis-accent), 15%)),
+    (comment, colour(comment-default)),
+    (dead, colour(live-default)),
+    (editorial, colour(guardian-brand)),
+    (feature, colour(feature-default)),
+    (letters, colour(comment-default)),
+    (live, colour(live-default)),
+    (media, colour(media-default)),
+    (news, colour(news-default)),
+    (review, darken(colour(review-background), 10%)),
+    (special-report, colour(news-support-1))
+);


### PR DESCRIPTION
Update the email form styling so that it uses the tone of the article it is embedded in.

![image](https://cloud.githubusercontent.com/assets/638051/12266364/bb3bb726-b93a-11e5-9205-6129706d63b3.png)

![image](https://cloud.githubusercontent.com/assets/638051/12266407/f516bd88-b93a-11e5-8f75-a35ffabfa5a7.png)
