### PR TITLE
Split S3 and Dynamo into code and prod targets

### DIFF
--- a/admin/app/jobs/R2PagePressJob.scala
+++ b/admin/app/jobs/R2PagePressJob.scala
@@ -10,7 +10,7 @@ import org.jsoup.Jsoup
 import pagepresser.{PollsHtmlCleaner, BasicHtmlCleaner}
 import play.api.libs.json.Json
 import play.api.libs.ws.WS
-import services.{S3ArchiveOriginals, PagePresses, S3ArchiveTest}
+import services.{S3Archive, S3ArchiveOriginals, PagePresses}
 import play.api.Play.current
 
 object R2PagePressJob extends ExecutionContexts with Logging {
@@ -93,22 +93,23 @@ object R2PagePressJob extends ExecutionContexts with Logging {
               .toString
 
             try {
-              S3ArchiveTest.putPublic(pressAsUrl, cleanedHtmlString, "text/html")
+              S3Archive.putPublic(pressAsUrl, cleanedHtmlString, "text/html")
             } catch {
-              case e: Exception => log.error(s"Cannot write to bucket ${S3ArchiveTest.bucket} (${e.getMessage}) while pressing $urlIn")
+              case e: Exception => log.error(s"Cannot write to bucket ${S3Archive.bucket} (${e.getMessage}) while pressing $urlIn")
             }
 
             try {
-              S3ArchiveTest.get(pressAsUrl).foreach { result =>
+              S3Archive.get(pressAsUrl).foreach { result =>
                 if (result == cleanedHtmlString) {
                   PagePresses.set(urlIn, pressAsUrl)
                   log.info(s"Pressed $urlIn as $pressAsUrl")
+                  queue.delete(message.handle)
                 } else {
-                  log.error(s"Pressed data did not match original for $pressAsUrl")
+                  log.error(s"Pressed HTML did not match cleaned HTML for $pressAsUrl")
                 }
               }
             } catch {
-              case e: Exception => log.error(s"Cannot read from bucket ${S3ArchiveTest.bucket} (${e.getMessage}) while pressing $urlIn")
+              case e: Exception => log.error(s"Cannot read from bucket ${S3Archive.bucket} (${e.getMessage}) while pressing $urlIn")
             }
           }
           case non200 => {
@@ -119,19 +120,20 @@ object R2PagePressJob extends ExecutionContexts with Logging {
     } else {
       log.error(s"Invalid url: $urlIn")
     }
-    // TODO: only delete if everything is ok?
-    queue.delete(message.handle)
   }
 
   private def takedown(message: Message[String]) {
     val urlIn = (Json.parse(message.get) \ "Message").as[String]
-    if (urlIn.nonEmpty) {
-      PagePresses.remove(urlIn)
-    } else {
-      log.error(s"Invalid url: $urlIn")
+    try {
+      if (urlIn.nonEmpty) {
+        PagePresses.remove(urlIn)
+        takedownQueue.delete(message.handle)
+      } else {
+        log.error(s"Invalid url: $urlIn")
+      }
+    } catch {
+      case e: Exception => log.error(s"Cannot take down $urlIn: ${e.getMessage}")
     }
-    // TODO: only delete if everything is ok?
-    takedownQueue.delete(message.handle)
   }
 
 }

--- a/admin/app/services/PagePresses.scala
+++ b/admin/app/services/PagePresses.scala
@@ -9,7 +9,7 @@ import play.api.Play.current
 import play.api.Play
 
 object PagePresses extends Logging {
-  private lazy val table = if (Configuration.environment.isProd) "redirects" else "redirects-DEV"
+  private lazy val table = if (Configuration.environment.isNonProd) "redirects-CODE" else "redirects"
 
   private lazy val client = {
     val client = new AmazonDynamoDBClient(Configuration.aws.mandatoryCredentials)

--- a/common/app/services/DynamoDB.scala
+++ b/common/app/services/DynamoDB.scala
@@ -20,7 +20,7 @@ case class Archive(location: String) extends Destination
 
 trait DynamoDB extends Logging with ExecutionContexts {
   import play.api.Play.current
-  private val tableName = "redirects"
+  private val tableName = if (Configuration.environment.isNonProd) "redirects-CODE" else "redirects"
   private val DynamoDbGet = "DynamoDB_20120810.GetItem"
 
   // should not directly call AWS during tests.

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -248,7 +248,7 @@ trait SecureS3Request extends implicits.Dates with Logging {
 object SecureS3Request extends SecureS3Request
 
 object S3Archive extends S3 {
- override lazy val bucket = "aws-frontend-archive"
+ override lazy val bucket = if (Configuration.environment.isNonProd) "aws-frontend-archive-code" else "aws-frontend-archive"
  def getHtml(path: String) = get(path)
 }
 
@@ -258,12 +258,6 @@ object S3Infosec extends S3 {
   def getBlockedEmailDomains = get(key)
 }
 
-// TODO: Replace references to S3ArchiveTest with S3Archive when ready for PROD deployment (and delete the S3ArchiveTest object).
-//       S3ArchiveOriginals is new for this work so doesn't need to be changed
-object S3ArchiveTest extends S3 {
-  override lazy val bucket = "aws-frontend-archive-test"
-}
-
 object S3ArchiveOriginals extends S3 {
-  override lazy val bucket = "aws-frontend-archive-originals"
+  override lazy val bucket = if (Configuration.environment.isNonProd) "aws-frontend-archive-code-originals" else "aws-frontend-archive-originals"
 }


### PR DESCRIPTION
**For Page Pressing**

Make sure we have a clean separation of CODE and PROD resources. 

We used to be ok with a single bucket for archived files because we didn't have any means of pressing pages without doing them as a one-off dev task or manually as individual updates.

Now we must prevent work done in CODE from overwriting PROD archived data.

cc @jennysivapalan 
