### PR TITLE
Fastdom Promise complying with original Fastdom api

### DIFF
--- a/static/src/javascripts/projects/common/utils/fastdom-promise.js
+++ b/static/src/javascripts/projects/common/utils/fastdom-promise.js
@@ -5,20 +5,22 @@ define([
     fastdom,
     Promise
 ) {
-    function fastDomAction(action, fn) {
-        return new Promise(function (resolve) {
-            fastdom[action](function () {
-                resolve(fn());
+    function promisify(fdaction) {
+        return function(fn, ctx) {
+            return new Promise(function (resolve, reject) {
+                fdaction(function () {
+                    try {
+                        resolve(fn());
+                    } catch (e) {
+                        reject(e);
+                    }
+                }, ctx);
             });
-        });
+        }
     }
 
     return {
-        read: function (fn) {
-            return fastDomAction('read', fn);
-        },
-        write: function (fn) {
-            return fastDomAction('write', fn);
-        }
+        read: promisify(fastdom.read),
+        write: promisify(fastdom.write)
     };
 });

--- a/static/src/javascripts/projects/common/utils/fastdom-promise.js
+++ b/static/src/javascripts/projects/common/utils/fastdom-promise.js
@@ -20,7 +20,7 @@ define([
     }
 
     return {
-        read: promisify(fastdom.read),
-        write: promisify(fastdom.write)
+        read: promisify(fastdom.read.bind(fastdom)),
+        write: promisify(fastdom.write.bind(fastdom))
     };
 });

--- a/static/src/javascripts/projects/common/utils/fastdom-promise.js
+++ b/static/src/javascripts/projects/common/utils/fastdom-promise.js
@@ -6,7 +6,7 @@ define([
     Promise
 ) {
     function promisify(fdaction) {
-        return function(fn, ctx) {
+        return function (fn, ctx) {
             return new Promise(function (resolve, reject) {
                 fdaction(function () {
                     try {
@@ -16,7 +16,7 @@ define([
                     }
                 }, ctx);
             });
-        }
+        };
     }
 
     return {

--- a/static/src/javascripts/projects/common/utils/fastdom-promise.js
+++ b/static/src/javascripts/projects/common/utils/fastdom-promise.js
@@ -10,7 +10,7 @@ define([
             return new Promise(function (resolve, reject) {
                 fdaction(function () {
                     try {
-                        resolve(fn());
+                        resolve(fn.call(this));
                     } catch (e) {
                         reject(e);
                     }


### PR DESCRIPTION
Makes the promisified Fastdom comply with [the original API](https://github.com/wilsonpage/fastdom#fastdommeasurecallback-context) which accepts a second parameter.

Minor improvement by making `promisify` a higher order function, saving a function call every time `fastdom.read|write` is called.

/cc @OliverJAsh @sndrs 
