### PR TITLE
Repositioned selection sharing buttons

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -57,7 +57,7 @@ define([
         if (selection && selection.rangeCount > 0 && selection.toString()) {
             range = selection.getRangeAt(0);
             rect = clientRects.getBoundingClientRect(range);
-            top = $body.scrollTop() + rect.bottom;
+            top = $body.scrollTop() + rect.top;
             twitterMessage = range.toString();
 
             if (!isValidSelection(range)) {

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -191,8 +191,8 @@ category: Common
 
 .selection-sharing {
     position: absolute;
+    margin-top: -$gs-baseline * 3;
     top: 0;
-    padding-top: $gs-baseline / 3;
     opacity: 0;
     visibility: hidden;
     transition: opacity .15s ease;


### PR DESCRIPTION
Something I've been meaning to do for a while now. 

For people that habitually highlight text whilst reading it, the sharing buttons cover the text they're about to read. I've repositioned them to remedy this. 

Lots of people in dotcom feedback have had the same gripe:
https://groups.google.com/a/guardian.co.uk/forum/#!searchin/dotcom.feedback/sharing/dotcom.feedback/KaBFVsJp5Zg/MLAo5M-PEgAJ

Before:
![screen shot 2016-01-12 at 17 02 50](https://cloud.githubusercontent.com/assets/14570016/12270576/a74f2414-b94e-11e5-8448-8d14394af6c3.png)

After:
![screen shot 2016-01-12 at 17 02 24](https://cloud.githubusercontent.com/assets/14570016/12270575/a741f99c-b94e-11e5-9ab1-6febeeacf9ce.png)
