### PR TITLE
handle any liveblog with /live/ in the first 2 dir

### DIFF
--- a/article/conf/routes
+++ b/article/conf/routes
@@ -20,9 +20,9 @@ GET     /_cdn_healthcheck           controllers.CdnHealthcheckController.healthc
 #  e.g. /theguardian/2015/nov/03/mainsection
 GET     /$publication<(theguardian|theobserver)>/$year<\d\d\d\d>/$month<\w\w\w>/$day<\d\d>/$tail<.+>                 controllers.PublicationController.publishedOn(publication, year, month, day, tail)
 
-GET     /$path<[^/]+/(blog/)?live/.*>.json controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean])
+GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean])
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/amp                  controllers.ArticleController.renderArticle(path)
 # temp route for live blogs so we can paginate without getting the blocks for all articles
-GET     /$path<[^/]+/(blog/)?live/.*> controllers.ArticleController.renderLiveBlog(path, page: Option[Int])
+GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.ArticleController.renderLiveBlog(path, page: Option[Int])
 GET     /*path                      controllers.ArticleController.renderArticle(path)

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -405,9 +405,9 @@ GET            /$path<[\w\d-]*(/[\w\d-]*)?(/[\w\d-]*)?>                         
 GET            /$leftSide<[^+]+>+*rightSide                                                                                      controllers.IndexController.renderCombiner(leftSide, rightSide)
 
 # Articles
-GET     /$path<[^/]+/(blog/)?live/.*>.json controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean])
+GET     /$path<[^/]+/([^/]+/)?live/.*>.json controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean])
 GET     /*path.json                 controllers.ArticleController.renderJson(path)
 GET     /*path/amp                  controllers.ArticleController.renderArticle(path)
 # temp route for live blogs so we can paginate without getting the blocks for all articles
-GET     /$path<[^/]+/(blog/)?live/.*> controllers.ArticleController.renderLiveBlog(path, page: Option[Int])
+GET     /$path<[^/]+/([^/]+/)?live/.*> controllers.ArticleController.renderLiveBlog(path, page: Option[Int])
 GET     /*path                      controllers.ArticleController.renderArticle(path)


### PR DESCRIPTION
fix formatting on http://www.theguardian.com/film/filmblog/live/2015/feb/22/oscars-2015-live-red-carpet-and-arrivals-ceremony-and-winners

before it was being treated as an article but it actually did have live in the url so it should have coped with it using the new codepaths
