### PR TITLE
Extend period for Identity Sign in V2 AB test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -27,7 +27,7 @@ trait ABTestSwitches {
     "ab-identity-sign-in-v2",
     "New sign in page variant for Identity",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 1, 15),
+    sellByDate = new LocalDate(2016, 3, 1),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/identity-sign-in-v2.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/identity-sign-in-v2.js
@@ -12,10 +12,10 @@ define([], function () {
 
         this.id = 'IdentitySignInV2';
         this.start = '2015-12-15';
-        this.expiry = '2016-01-15';
+        this.expiry = '2016-03-01';
         this.author = 'James Pamplin';
-        this.description = 'New sign in page variant for Identity';
-        this.audience = 0.1;
+        this.description = 'New sign in page variants for Identity';
+        this.audience = 0.2;
         this.audienceOffset = 0.5;
         this.successMeasure = 'More people sign in';
         this.audienceCriteria = 'everyone';
@@ -30,6 +30,10 @@ define([], function () {
         this.variants = [
             {
                 id: 'A',
+                test: function () {}
+            },
+            {
+                id: 'B',
                 test: function () {}
             }
         ];


### PR DESCRIPTION
We're adding a new variant (B) for the new Identity Sign in guardian/identity#54

To support this, we need to extend IdentitySignInV2 test period, audience (now 20%), and add variant B.
