### PR TITLE
Adding a case for amp message type

### DIFF
--- a/static/src/javascripts/vendor/formstack-interactive/0.1/boot.js
+++ b/static/src/javascripts/vendor/formstack-interactive/0.1/boot.js
@@ -82,6 +82,9 @@ define([], function () {
                         case 'set-height':
                             iframe.height = message.value;
                             break;
+                        case 'embed-size':
+                            // AMP specific resizing
+                            break;
                         case 'navigate':
                             document.location.href = message.value;
                             break;


### PR DESCRIPTION
Relating to https://github.com/guardian/iframe-messenger/pull/10

AMP requires a specific postmessage to be send for iframe resizing. This just adds a case to handle this new message type.

cc @andymason
