### PR TITLE
Fix duplicate calls to DFP for the most popular MPU

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -375,7 +375,6 @@ define([
         },
         loadSlot = function (slot) {
             googletag.display(slot);
-            slots = chain(slots).and(omit, slot).value();
             displayed = true;
         },
         addSlot = function ($adSlot) {
@@ -385,7 +384,7 @@ define([
                         isRendered: false,
                         slot: defineSlot($adSlot)
                     };
-                    googletag.display(slotId);
+                    loadSlot(slotId);
                 };
             if (displayed && !slots[slotId]) { // dynamically add ad slot
                 // this is horrible, but if we do this before the initial ads have loaded things go awry

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -525,6 +525,7 @@ define([
             if (slots[slotId] && !slots[slotId].isRendered) {
                 slots[slotId].isLoading = false;
                 slots[slotId].isRendered = true;
+                slots[slotId].slot = null;
             }
 
             if (every(slots, 'isRendered')) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -271,6 +271,7 @@ define([
                 }).and(map, function ($adSlot) {
                     return [$adSlot.attr('id'), {
                         isRendered: false,
+                        isLoading: false,
                         slot: defineSlot($adSlot)
                     }];
                 }).and(zipObject).valueOf();
@@ -365,15 +366,18 @@ define([
                     scrollBottom = scrollTop + viewportHeight,
                     depth = 0.5;
 
-                chain(slots).and(keys).and(forEach, function (slot) {
-                    // if the position of the ad is above the viewport - offset (half screen size)
-                    if (scrollBottom > document.getElementById(slot).getBoundingClientRect().top + scrollTop - viewportHeight * depth) {
-                        loadSlot(slot);
-                    }
+                chain(slots).and(keys).and(filter, function (slot) {
+                    return !slots[slot].isLoading &&
+                        !slots[slot].isRendered &&
+                        // if the position of the ad is above the viewport - offset (half screen size)
+                        scrollBottom > document.getElementById(slot).getBoundingClientRect().top + scrollTop - viewportHeight * depth;
+                }).and(forEach, function (slot) {
+                    loadSlot(slot);
                 });
             }
         },
         loadSlot = function (slot) {
+            slots[slot].isLoading = true;
             googletag.display(slot);
             displayed = true;
         },
@@ -382,6 +386,7 @@ define([
                 displayAd = function ($adSlot) {
                     slots[slotId] = {
                         isRendered: false,
+                        isLoading: false,
                         slot: defineSlot($adSlot)
                     };
                     loadSlot(slotId);
@@ -518,6 +523,7 @@ define([
         },
         allAdsRendered = function (slotId) {
             if (slots[slotId] && !slots[slotId].isRendered) {
+                slots[slotId].isLoading = false;
                 slots[slotId].isRendered = true;
             }
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp-api.js
@@ -525,7 +525,6 @@ define([
             if (slots[slotId] && !slots[slotId].isRendered) {
                 slots[slotId].isLoading = false;
                 slots[slotId].isRendered = true;
-                slots[slotId].slot = null;
             }
 
             if (every(slots, 'isRendered')) {


### PR DESCRIPTION
There is a race condition where a slot added via `addSlot` triggers two calls to `googletag.display`. This change addresses this behaviour by:
- keeping track of all the slots, whether they are just added, loaded or rendered
- removing the duplicate call to `googletag.display`
- making sure the lazyload algorithm does not load ads that are already loading but not rendered yet
