### PR TITLE
Update amp params

### DIFF
--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -108,7 +108,7 @@ case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends
         "edition" -> edition.id.toLowerCase(),
         "se" -> parseIds(article.trail.tags.series).mkString(","),
         "ct" -> article.metadata.contentType,
-        "p" -> "ng",
+        "p" -> "amp",
         "k" -> parseIds(article.trail.tags.keywords).mkString(","),
         "co" -> parseIds(article.trail.tags.contributors).mkString(","),
         "bl" -> parseIds(article.trail.tags.blogs).mkString(",")

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -100,7 +100,8 @@ case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends
 
   def adAfter(element: Element) = {
     val section = article.metadata.section
-    val dataSlot = s"/59666047/theguardian.com/$section"
+    val contentType = article.metadata.contentType.toLowerCase
+    val dataSlot = s"/59666047/theguardian.com/$section/$contentType/amp"
 
     val json = Json.obj(
       "targeting" -> Json.obj(


### PR DESCRIPTION
Adding p=amp and the content type + platform to the ad unit. (As required by Commercial for auditing purposes.)
