### PR TITLE
Amp pages now support ?adtest= param setting

### DIFF
--- a/amp/remote-2.html
+++ b/amp/remote-2.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex">
+    <script>
+        (function() {
+            var v = location.search.substr(1);
+            if (!(/^\d+$/.test(v))) return;
+            var u = 'https://3p.ampproject.net/'+encodeURIComponent(v)+'/f.js';
+            document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
+        })();
+    </script>
+</head>
+<body style="margin:0">
+<div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;">
+    <script>draw3p(function(config, done){
+        var url = (window.location != window.parent.location)
+            ? document.referrer
+            : document.location;
+
+        var fragments = url.split('adtest=');
+        if (fragments.length === 2) {
+            config.targeting.at = fragments[1]
+        }
+
+        done(config);
+    })</script>
+</div>
+<script>if (window.docEndCallback) window.docEndCallback()</script>
+</body>
+</html>

--- a/amp/remote-2.html
+++ b/amp/remote-2.html
@@ -20,7 +20,7 @@
 
         var fragments = url.split('adtest=');
         if (fragments.length === 2) {
-            config.targeting.at = fragments[1]
+            config.targeting.at = fragments[1];
         }
 
         done(config);

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -8,7 +8,7 @@
     <head>
         @* "utf-8" meta tag needs to be first according to AMP spec *@
         <meta charset="utf-8">
-            <meta name="amp-3p-iframe-src" content="https://static.theguardian.com/amp/remote.html">
+        <meta name="amp-3p-iframe-src" content="https://static.theguardian.com/amp/remote-2.html">
 
         @fragments.metaData(page, true)
         <title>@views.support.Title(page)</title>


### PR DESCRIPTION
If you attach ?adtest=tester1 to an AMP url, AMP will use the adtest param to set a new targeting param of at=tester1 to DFP... just like in NextGen
