### PR TITLE
paginate business and politics blogs

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -87,7 +87,9 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
       if (request.isAmp) {
         NotFound
       } else {
-        val blocks = BodyBlocks(blog.article.content.fields.blocks, pageNo)
+        val PAGINATION_ENABLED_TAGS = Seq("business/series/guardian-business-live", "politics/series/politics-live-with-andrew-sparrow")
+        val pageSize = if (blog.article.content.tags.tags.exists(tag => PAGINATION_ENABLED_TAGS.contains(tag.id))) 10 else 300
+        val blocks = BodyBlocks(pageSize = pageSize, extrasOnFirstPage = 10/* = 29, also update in truncate-liveblog.js*/)(blog.article.content.fields.blocks, pageNo)
         blocks match {
           case Some(blocks) =>
             val htmlResponse = () => views.html.liveBlog (blog, blocks)
@@ -113,14 +115,14 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
 
   def renderLiveBlog(path: String, page: Option[Int] = None) =
     LongCacheAction { implicit request =>
-      mapModel(path, true) {// temporarily only ask for blocks too for things we know are new live blogs until until the migration is done and we can always use blocks
+      mapModel(path, blocks = true) {// temporarily only ask for blocks too for things we know are new live blogs until until the migration is done and we can always use blocks
         render(path, _, page)
       }
     }
 
   def renderLiveBlogJson(path: String, lastUpdate: Option[String], rendered: Option[Boolean]) = {
     LongCacheAction { implicit request =>
-      mapModel(path, true) { model =>
+      mapModel(path, blocks = true) { model =>
         (lastUpdate, rendered) match {
           case (Some(lastUpdate), _) => renderLatestFrom(model, lastUpdate)
           case (None, Some(false)) => blockText(model, 6)

--- a/article/app/liveblog/BodyBlocks.scala
+++ b/article/app/liveblog/BodyBlocks.scala
@@ -2,30 +2,27 @@ package liveblog
 
 object BodyBlocks {
 
-  val PAGE_SIZE = 10
-
-  def apply[B](blocks: Seq[B], page: Option[Int]): Option[BodyBlocks[B]] = {
-    val (main, pages) = getPages(blocks)
+  def apply[B](pageSize: Int, extrasOnFirstPage: Int)(blocks: Seq[B], page: Option[Int]): Option[BodyBlocks[B]] = {
+    val (main, pages) = getPages(pageSize, extrasOnFirstPage)(blocks)
     page match {
-      case Some(pageNo) if pages.length == 0 => None
+      case Some(pageNo) if pages.isEmpty => None
       case Some(pageNo) if pageNo > pages.length || pageNo <= 0 => None
 
-      case Some(pageNo) => {
+      case Some(pageNo) =>
         val higherLater = if (pageNo + 1 < pages.length) PageNumber(pageNo + 1) else FirstPage
         val earlierLower = if (pageNo > 1) Some(pageNo - 1) else None
         Some(BodyBlocks(pages(pageNo - 1), later = higherLater, earlier = earlierLower))
-      }
 
       case None => Some(BodyBlocks(main, later = NoPage, earlier = if(pages.nonEmpty) Some(pages.length) else None))
     }
   }
 
   // returns the pages, newest at the end, oldest at the start
-  def getPages[B](blocks: Seq[B]) = {
+  def getPages[B](pageSize: Int, extrasOnFirstPage: Int)(blocks: Seq[B]) = {
     val length = blocks.size
-    val remainder = length % PAGE_SIZE
-    val (main, rest) = blocks.splitAt(remainder + PAGE_SIZE)
-    (main, rest.grouped(PAGE_SIZE).toList.reverse)
+    val remainder = extrasOnFirstPage + (length % pageSize)
+    val (main, rest) = blocks.splitAt(remainder + pageSize)
+    (main, rest.grouped(pageSize).toList.reverse)
   }
 
 }

--- a/article/app/liveblog/BodyBlocks.scala
+++ b/article/app/liveblog/BodyBlocks.scala
@@ -1,16 +1,40 @@
 package liveblog
 
-import model.liveblog.BodyBlock
-
 object BodyBlocks {
 
-  def apply(blocks: Seq[BodyBlock], page: Option[Int]): Option[BodyBlocks] = {
+  val PAGE_SIZE = 10
+
+  def apply[B](blocks: Seq[B], page: Option[Int]): Option[BodyBlocks[B]] = {
+    val (main, pages) = getPages(blocks)
     page match {
-      case Some(pageNo) => None
-      case None => Some(BodyBlocks(blocks, 1))//TODO use page to produce different blocks
+      case Some(pageNo) if pages.length == 0 => None
+      case Some(pageNo) if pageNo > pages.length || pageNo <= 0 => None
+
+      case Some(pageNo) => {
+        val higherLater = if (pageNo + 1 < pages.length) PageNumber(pageNo + 1) else FirstPage
+        val earlierLower = if (pageNo > 1) Some(pageNo - 1) else None
+        Some(BodyBlocks(pages(pageNo - 1), later = higherLater, earlier = earlierLower))
+      }
+
+      case None => Some(BodyBlocks(main, later = NoPage, earlier = if(pages.nonEmpty) Some(pages.length) else None))
     }
+  }
+
+  // returns the pages, newest at the end, oldest at the start
+  def getPages[B](blocks: Seq[B]) = {
+    val length = blocks.size
+    val remainder = length % PAGE_SIZE
+    val (main, rest) = blocks.splitAt(remainder + PAGE_SIZE)
+    (main, rest.grouped(PAGE_SIZE).toList.reverse)
   }
 
 }
 
-case class BodyBlocks(blocks: Seq[BodyBlock], pageNo: Int)// TODO prev/next
+case class BodyBlocks[B](blocks: Seq[B], later: LaterPage, earlier: Option[Int])
+
+sealed trait LaterPage {
+  def suffix: Option[String]
+}
+case object NoPage extends LaterPage { val suffix = None }
+case object FirstPage extends LaterPage { val suffix = Some("") }
+case class PageNumber(page: Int) extends LaterPage { val suffix = Some(s"?page=$page") }

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -1,6 +1,6 @@
 @import _root_.liveblog.BodyBlocks
-@import model.liveblog.LiveBlogDate
-@(model: LiveBlogPage, blocks: BodyBlocks)(implicit request: RequestHeader)
+@import model.liveblog.{LiveBlogDate, BodyBlock}
+@(model: LiveBlogPage, blocks: BodyBlocks[BodyBlock])(implicit request: RequestHeader)
 
 @import common.LinkTo
 @import layout.{FaciaCardAndIndex, ItemClasses}
@@ -103,6 +103,21 @@
                                     </div>
                                 }
                             </div>
+
+                            <div class="live-navigation">
+                                @blocks.earlier.map { earlierBlock =>
+                                    <a href="/@{article.content.metadata.id}?page=@earlierBlock"
+                                        class="u-button-reset button button--large button--show-more liveblog__show-more"
+                                        data-link-name="next page">
+                                        @fragments.inlineSvg("plus", "icon")
+                                        View older updates
+                                    </a>
+                                }
+                                @*blocks.later.suffix.map { suffix =>
+                                    <a href="/@{article.content.metadata.id}@suffix">Newer posts</a>
+                                }*@
+                            </div>
+
                         </div>
 
                         @fragments.submeta(article)

--- a/article/app/views/fragments/liveBlogBody.scala.html
+++ b/article/app/views/fragments/liveBlogBody.scala.html
@@ -109,13 +109,16 @@
                                     <a href="/@{article.content.metadata.id}?page=@earlierBlock"
                                         class="u-button-reset button button--large button--show-more liveblog__show-more"
                                         data-link-name="next page">
-                                        @fragments.inlineSvg("plus", "icon")
-                                        View older updates
+                                        Go to older updates
                                     </a>
                                 }
-                                @*blocks.later.suffix.map { suffix =>
-                                    <a href="/@{article.content.metadata.id}@suffix">Newer posts</a>
-                                }*@
+                                @blocks.later.suffix.map { suffix =>
+                                    <a href="/@{article.content.metadata.id}@suffix"
+                                        class="u-button-reset button button--large button--show-more liveblog__show-more"
+                                        data-link-name="previous page">
+                                        Go to newer updates
+                                    </a>
+                                }
                             </div>
 
                         </div>

--- a/article/app/views/liveBlog.scala.html
+++ b/article/app/views/liveBlog.scala.html
@@ -1,7 +1,16 @@
 @import _root_.liveblog.BodyBlocks
-@(model: LiveBlogPage, blocks: BodyBlocks)(implicit request: RequestHeader)
+@import model.liveblog.BodyBlock
+@(model: LiveBlogPage, blocks: BodyBlocks[BodyBlock])(implicit request: RequestHeader)
+
+@import common.LinkTo
 
 @main(model){
+    @blocks.earlier.map { earlierBlock =>
+        <link rel="next" href="@LinkTo{ /@{model.article.content.metadata.id}?page=@earlierBlock }">
+    }
+    @blocks.later.suffix.map { suffix =>
+        <link rel="prev" href="@LinkTo{ /@{model.article.content.metadata.id}@suffix }">
+    }
 }{
     @fragments.liveBlogBody(model, blocks)
 }

--- a/article/test/liveblog/BodyBlocksTest.scala
+++ b/article/test/liveblog/BodyBlocksTest.scala
@@ -1,0 +1,72 @@
+package liveblog
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConversions._
+
+class BodyBlocksTest extends FlatSpec with Matchers {
+
+   "BodyBlocks" should "allow 1 block on one page" in {
+     val result = BodyBlocks(Seq(()), None)
+
+     result should be(Some(BodyBlocks(Seq(()), NoPage, None)))
+
+   }
+
+  "BodyBlocks" should "allow 19 blocks on one page" in {
+    val blocks = Seq.fill(19)(())
+    val result = BodyBlocks(blocks, None)
+
+    result should be(Some(BodyBlocks(blocks, NoPage, None)))
+
+  }
+
+  "BodyBlocks" should "put 20 blocks on two pages (main page)" in {
+    val blocks = Seq.fill(20)(()).zipWithIndex.map(_._2).map {
+      case x: Int if (x < 10) => s"new $x"
+      case x: Int => s"old $x"
+    }
+    val result = BodyBlocks(blocks, None)
+
+    val expected = blocks.take(10)
+
+    result should be(Some(BodyBlocks(expected, NoPage, Some(1))))
+
+  }
+
+  "BodyBlocks" should "put 20 blocks on two pages (page 1 - oldest)" in {
+    val blocks = Seq.fill(20)(()).zipWithIndex.map(_._2).map {
+      case x: Int if (x < 10) => s"new $x"
+      case x: Int => s"old $x"
+    }
+    val result = BodyBlocks(blocks, Some(1))
+
+    val expected = blocks.takeRight(10)
+
+    result should be(Some(BodyBlocks(expected, FirstPage, None)))
+
+  }
+
+  "BodyBlocks" should "put 21 blocks on two pages (main page)" in {
+    val blocks = Seq.fill(21)(()).zipWithIndex.map(_._2)
+    val result = BodyBlocks(blocks, None)
+
+    val expected = blocks.take(11)
+
+    result should be(Some(BodyBlocks(expected, NoPage, Some(1))))
+
+  }
+
+  "BodyBlocks" should "put 21 blocks on two pages (page 1 - oldest)" in {
+    val blocks = Seq.fill(21)(()).zipWithIndex.map(_._2)
+    val result = BodyBlocks(blocks, Some(1))
+
+    val expected = blocks.takeRight(10)
+
+    result should be(Some(BodyBlocks(expected, FirstPage, None)))
+
+  }
+
+}

--- a/article/test/liveblog/BodyBlocksTest.scala
+++ b/article/test/liveblog/BodyBlocksTest.scala
@@ -9,64 +9,66 @@ import scala.collection.JavaConversions._
 class BodyBlocksTest extends FlatSpec with Matchers {
 
    "BodyBlocks" should "allow 1 block on one page" in {
-     val result = BodyBlocks(Seq(()), None)
+     val result = BodyBlocks(2, 0)(Seq(()), None)
 
      result should be(Some(BodyBlocks(Seq(()), NoPage, None)))
 
    }
 
-  "BodyBlocks" should "allow 19 blocks on one page" in {
-    val blocks = Seq.fill(19)(())
-    val result = BodyBlocks(blocks, None)
+  "BodyBlocks" should "allow 3 blocks on one page" in {
+    val blocks = Seq.fill(3)(())
+    val result = BodyBlocks(2, 0)(blocks, None)
 
     result should be(Some(BodyBlocks(blocks, NoPage, None)))
 
   }
 
-  "BodyBlocks" should "put 20 blocks on two pages (main page)" in {
-    val blocks = Seq.fill(20)(()).zipWithIndex.map(_._2).map {
-      case x: Int if (x < 10) => s"new $x"
+  "BodyBlocks" should "put 4 blocks on two pages (main page)" in {
+    val blocks = Seq.fill(4)(()).zipWithIndex.map(_._2).map {
+      case x: Int if x < 2 => s"new $x"
       case x: Int => s"old $x"
     }
-    val result = BodyBlocks(blocks, None)
+    val result = BodyBlocks(2, 0)(blocks, None)
 
-    val expected = blocks.take(10)
+    val expected = blocks.take(2)
 
     result should be(Some(BodyBlocks(expected, NoPage, Some(1))))
 
   }
 
-  "BodyBlocks" should "put 20 blocks on two pages (page 1 - oldest)" in {
-    val blocks = Seq.fill(20)(()).zipWithIndex.map(_._2).map {
-      case x: Int if (x < 10) => s"new $x"
+  "BodyBlocks" should "put 4 blocks on two pages (page 1 - oldest)" in {
+    val blocks = Seq.fill(4)(()).zipWithIndex.map(_._2).map {
+      case x: Int if x < 2 => s"new $x"
       case x: Int => s"old $x"
     }
-    val result = BodyBlocks(blocks, Some(1))
+    val result = BodyBlocks(2, 0)(blocks, Some(1))
 
-    val expected = blocks.takeRight(10)
+    val expected = blocks.takeRight(2)
 
     result should be(Some(BodyBlocks(expected, FirstPage, None)))
 
   }
 
-  "BodyBlocks" should "put 21 blocks on two pages (main page)" in {
-    val blocks = Seq.fill(21)(()).zipWithIndex.map(_._2)
-    val result = BodyBlocks(blocks, None)
+  "BodyBlocks" should "put 5 blocks on two pages (main page)" in {
+    val blocks = Seq.fill(5)(()).zipWithIndex.map(_._2)
+    val result = BodyBlocks(2, 0)(blocks, None)
 
-    val expected = blocks.take(11)
+    val expected = blocks.take(3)
 
     result should be(Some(BodyBlocks(expected, NoPage, Some(1))))
 
   }
 
-  "BodyBlocks" should "put 21 blocks on two pages (page 1 - oldest)" in {
-    val blocks = Seq.fill(21)(()).zipWithIndex.map(_._2)
-    val result = BodyBlocks(blocks, Some(1))
+  "BodyBlocks" should "put 5 blocks on two pages (page 1 - oldest)" in {
+    val blocks = Seq.fill(5)(()).zipWithIndex.map(_._2)
+    val result = BodyBlocks(2, 0)(blocks, Some(1))
 
-    val expected = blocks.takeRight(10)
+    val expected = blocks.takeRight(2)
 
     result should be(Some(BodyBlocks(expected, FirstPage, None)))
 
   }
+
+  // FIXME should really test the preload too
 
 }

--- a/common/app/views/fragments/liveFilter.scala.html
+++ b/common/app/views/fragments/liveFilter.scala.html
@@ -1,16 +1,5 @@
 @(isLive: Boolean)
 <div class="live-toolbar js-live-toolbar modern-visible">
-    <div class="live-toggler-wrapper" data-component="live-toggle" data-link-name="live-toolbar">
-        <button class="u-button-reset popup__toggle live-toggler__label" data-link-name="order-by" data-toggle="popup--live-blog">Order by</button>
-        <ul class="popup popup__group is-off popup--live-blog">
-            <li class="popup__item">
-                <button class="u-button-reset popup__action js-live-newest" data-link-name="newest">Newest first</button>
-            </li>
-            <li class="popup__item">
-                <button class="u-button-reset popup__action js-live-oldest" data-link-name="oldest">Oldest first</button>
-            </li>
-        </ul>
-    </div>
     @if(isLive) {
         <div class="update u-h" data-link-name="autoupdate"></div>
     }

--- a/static/src/javascripts/bootstraps/enhanced/article-liveblog-common.js
+++ b/static/src/javascripts/bootstraps/enhanced/article-liveblog-common.js
@@ -43,7 +43,9 @@ define([
         });
     }
 
-    function initTwitter() {
+    function initTruncateAndTwitter() {
+        // Ensure that truncation occurs before the tweet upgrading.
+        truncate();
         twitter.init();
         twitter.enhanceTweets();
     }
@@ -52,7 +54,7 @@ define([
         robust.catchErrorsAndLogAll([
             ['trail-article', initOpenCta],
             ['trail-fence', initFence],
-            ['trail-twitter', initTwitter],
+            ['trail-twitter', initTruncateAndTwitter],
             ['trail-sharing', selectionSharing.init],
             ['trail-last-modified', lastModified]
         ]);

--- a/static/src/javascripts/bootstraps/enhanced/article-liveblog-common.js
+++ b/static/src/javascripts/bootstraps/enhanced/article-liveblog-common.js
@@ -43,9 +43,7 @@ define([
         });
     }
 
-    function initTruncateAndTwitter() {
-        // Ensure that truncation occurs before the tweet upgrading.
-        truncate();
+    function initTwitter() {
         twitter.init();
         twitter.enhanceTweets();
     }
@@ -54,7 +52,7 @@ define([
         robust.catchErrorsAndLogAll([
             ['trail-article', initOpenCta],
             ['trail-fence', initFence],
-            ['trail-twitter', initTruncateAndTwitter],
+            ['trail-twitter', initTwitter],
             ['trail-sharing', selectionSharing.init],
             ['trail-last-modified', lastModified]
         ]);

--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -212,7 +212,7 @@ define([
 
         createAutoUpdate: function () {
 
-            if (config.page.isLive) {
+            if (config.page.isLive && window.location.search === "") {
 
                 var timerDelay = detect.isBreakpoint({ min: 'desktop' }) ? 5000 : 60000;
                 autoUpdate = new AutoUpdate({

--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -212,7 +212,7 @@ define([
 
         createAutoUpdate: function () {
 
-            if (config.page.isLive && window.location.search === "") {
+            if (config.page.isLive && window.location.search === '') {
 
                 var timerDelay = detect.isBreakpoint({ min: 'desktop' }) ? 5000 : 60000;
                 autoUpdate = new AutoUpdate({

--- a/static/src/javascripts/projects/common/modules/article/truncate-liveblog.js
+++ b/static/src/javascripts/projects/common/modules/article/truncate-liveblog.js
@@ -21,7 +21,7 @@ define([
     twitter,
     find) {
     var truncatedClass = 'truncated-block',
-        minVisibleBlocks = detect.getBreakpoint() === 'mobile' ? 5 : 10,
+        minVisibleBlocks = 29,
         blocks = qwery('.block'),
         truncatedBlocks = blocks.slice(minVisibleBlocks),
         $truncatedBlocks = bonzo(truncatedBlocks);


### PR DESCRIPTION
So in preparation for the pagination of live blogs, we will try hard pagination in a basic way.

This PR adds pagination for those once it gets to 29, the 30th post will cause the oldest 10 to be moved to another page.  This will happen every time the main page hits 30.

There will be a rudimentary navigation link at the bottom of each page.

Key events will only be scraped from the current page, but hopefully this can change very soon.

Metadata should be there to keep google happy.

The threshold for hiding old posts used to be set to 10, this has been extended to 29 in the intervening period so that the two mechanisms don't conflict.
