### PR TITLE
Small improvement to switches tests

### DIFF
--- a/admin/app/views/email/expiringSwitches.scala.html
+++ b/admin/app/views/email/expiringSwitches.scala.html
@@ -1,6 +1,6 @@
-@(expiringImminently: Seq[conf.switches.SwitchTrait], expiringSoon: Seq[conf.switches.SwitchTrait])
+@(expiringImminently: Seq[conf.switches.Switch], expiringSoon: Seq[conf.switches.Switch])
 
-@showSwitch(switch: conf.switches.SwitchTrait) = {
+@showSwitch(switch: conf.switches.Switch) = {
     <li>
         <div>@{switch.name}</div>
         <div>expires @{switch.sellByDate.toString("E dd MMM")} 00:01 UTC</div>

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -1,7 +1,7 @@
 @(  charts: Seq[tools.AwsLineChart],
     hitMissCharts: Seq[tools.AwsLineChart],
     cost: tools.MaximumMetric,
-    switches: Seq[conf.switches.SwitchTrait],
+    switches: Seq[conf.switches.Switch],
     env: String,
     external: Boolean)
 

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -4,12 +4,11 @@ import java.util.concurrent.TimeoutException
 
 import akka.pattern.CircuitBreakerOpenException
 import com.gu.contentapi.client.GuardianContentApiError
+import conf.switches.Switch
 import contentapi.ErrorResponseHandler.isCommercialExpiry
-import conf.switches.SwitchTrait
 import model.{Cached, NoCache}
 import org.apache.commons.lang.exception.ExceptionUtils
 import play.api.Logger
-import play.api.libs.json.{JsObject, JsString}
 import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 
@@ -62,7 +61,7 @@ object `package` extends implicits.Strings with implicits.Requests with play.api
       Ok(htmlResponse())
   }
 
-  def renderFormat(htmlResponse: () => Html, jsonResponse: () => Html, page: model.Page, switches: Seq[SwitchTrait])(implicit request: RequestHeader) = Cached(page) {
+  def renderFormat(htmlResponse: () => Html, jsonResponse: () => Html, page: model.Page, switches: Seq[Switch])(implicit request: RequestHeader) = Cached(page) {
     if (request.isJson)
       JsonComponent(page, jsonResponse())
     else

--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -1,36 +1,35 @@
 package conf.switches
 
 import org.joda.time.{DateTimeConstants, LocalDate}
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.concurrent.ScalaFutures._
+import org.scalatest.{AppendedClues, FlatSpec, Matchers}
 
-class SwitchesTest extends FlatSpec with Matchers {
+class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
 
-  val SwitchNamePattern = """([a-z\d-]+)""".r
+  private val SwitchNamePattern = """([a-z\d-]+)""".r
+
+  private def forAllSwitches(test: Switch => Unit): Unit = {
+    whenReady(Switches.eventuallyAll)(_ foreach { switch => test(switch) withClue s"(switch: '${switch.name}')" })
+  }
 
   "Switches" should "have names consisting only of lowercase letters, numbers and hyphens" in {
-    Switches.all.map(_.name).foreach{
-      case SwitchNamePattern(_) => Unit
-      case badName => fail("'" + badName + "' is not a good switch name, it may only consist of lowercase letters, numbers and hyphens")
-    }
+    forAllSwitches(_.name should fullyMatch regex SwitchNamePattern)
   }
 
   they should "have a description" in {
-    Switches.all foreach { _.description.trim should not be("") }
+    forAllSwitches(_.description.trim should not be empty)
   }
 
   // If you are wondering why this test has failed then read, https://github.com/guardian/frontend/pull/2711
   they should "be deleted once expired" in {
-    Switches.all foreach { switch =>
-      assert(switch.sellByDate.isAfter(LocalDate.now()), switch.name)
-    }
+    forAllSwitches(_.hasExpired shouldBe false)
   }
 
   they should "have weekday expiry dates" in {
-    Switches.all foreach { switch =>
-     val day = switch.sellByDate.getDayOfWeek()
-     val isWeekend = day == DateTimeConstants.SATURDAY || day == DateTimeConstants.SUNDAY
-     assert(!isWeekend, switch.name)
+    def isWeekend(date: LocalDate) = {
+      val day = date.getDayOfWeek
+      day == DateTimeConstants.SATURDAY || day == DateTimeConstants.SUNDAY
     }
+    forAllSwitches(switch => isWeekend(switch.sellByDate) shouldBe false)
   }
 }


### PR DESCRIPTION
I was perplexed.  The switch tests I was expecting to fail were passing.
This was because if you inspect the state of an akka agent you can't guarantee it's up-to-date.
So I've modified the tests a bit to get predictable results.  
This is only likely to affect you if you run the switch tests in isolation.

I've also removed the `SwitchTrait` which had become redundant.
