### PR TITLE
Apply a "frontendarchive" omniture param for cleaned, pressed pages.

### DIFF
--- a/admin/app/pagepresser/HtmlCleaner.scala
+++ b/admin/app/pagepresser/HtmlCleaner.scala
@@ -71,8 +71,15 @@ object BasicHtmlCleaner extends HtmlCleaner {
     val omnitureCode = document.getElementById("omnitureNoScript").getElementsByTag("img").attr("src")
     val params = parse(omnitureCode).query.paramMap
 
-    val requiredParams: Map[String, Seq[String]] = params.filterKeys(key => List("pageName", "ch", "g", "ns", "c19").contains(key)) ++
-      Map("AQB" -> List("1"), "ndh" -> List("1"), "ce" -> List("UTF-8"), "cpd" -> List("2"), "AQE" -> List("1"), "v14" -> List("D=r"), "v9" -> List("D=g"))
+    val requiredParams: Map[String, Seq[String]] = params.filterKeys(key => List("pageName", "ch", "g", "ns").contains(key)) ++
+      Map("AQB" -> List("1"),
+          "ndh" -> List("1"),
+          "c19" -> List("frontendarchive"),
+          "ce" -> List("UTF-8"),
+          "cpd" -> List("2"),
+          "AQE" -> List("1"),
+          "v14" -> List("D=r"),
+          "v9" -> List("D=g"))
 
     requiredParams.flatMap { case ((key: String, value: Seq[String])) =>
       for (v <- value) yield {

--- a/admin/test/pagepresser/HtmlCleanerTest.scala
+++ b/admin/test/pagepresser/HtmlCleanerTest.scala
@@ -35,14 +35,14 @@ import scala.io.Source
   it should "get the omniture parameters for the simple page tracking" in {
     val html = "<html><head></head><body><noscript id=\"omnitureNoScript\">\n <div><img alt=\"\" src='http://hits.theguardian.com/b/ss/guardiangu-network/1/H.25.7/37802?ns=guardian&pageName=Life+%26+style%3AFeatures%3ACompetition%3Apollyjeans%3A1334360&ch=Life+and+style&c3=GU.co.uk&c4=Womad+2013%2CMusic+festivals&c5=Festivals&c6=&c7=2013%2F06%2F08+12%3A05&c8=1918994&c9=Competition&c10=&c13=&c19=GUK&c47=UK&c64=UK&c65=Win+one+of+50+pairs+of+tickets+to+WOMAD&c66=Culture&c67=nextgen-non-compatible&c72=Culture%3AMusic%3AWomad+2013&c73=Culture%3AMusic%3AWomad+2013&c74=Culture%3AMusic&c75=Culture&h2=GU%2FCulture%2FMusic%2FWomad+2013&c2=GUID:(none)' width=\"1\" height=\"1\" /></div>\n</noscript></body>"
 
-    BasicHtmlCleaner.fetchOmnitureTags(Jsoup.parse(html)) should be ("ns=guardian&ndh=1&c19=GUK&AQE=1&ch=Life+and+style&ce=UTF-8&AQB=1&cpd=2&v9=D=g&pageName=Life+%26+style:Features:Competition:pollyjeans:1334360&v14=D=r")
+    BasicHtmlCleaner.fetchOmnitureTags(Jsoup.parse(html)) should be ("ns=guardian&ndh=1&c19=frontendarchive&AQE=1&ch=Life+and+style&ce=UTF-8&AQB=1&cpd=2&v9=D=g&pageName=Life+%26+style:Features:Competition:pollyjeans:1334360&v14=D=r")
   }
 
   it should "add the basic omniture tag" in {
     val html = "<html><head></head><body> some text </body></html>"
-    val expectedDoc = Jsoup.parse("<html><head></head><body> some text <!---Omniture page tracking for pressed page ---> <img src=\"https://hits-secure.theguardian.com/b/ss/guardiangu-network/1/JS-1.4.1/s985205503180623100?ns=guardian&ndh=1&c19=GUK&AQE=1&ch=Music&ce=UTF-8&AQB=1&cpd=2&v9=D=g&pageName=pageName=Life+%26+style:Features:Competition:pollyjeans:1334360&v14=D=r\" width=\"1\" height=\"1\"/></body></html>")
+    val expectedDoc = Jsoup.parse("<html><head></head><body> some text <!---Omniture page tracking for pressed page ---> <img src=\"https://hits-secure.theguardian.com/b/ss/guardiangu-network/1/JS-1.4.1/s985205503180623100?ns=guardian&ndh=1&c19=frontendarchive&AQE=1&ch=Music&ce=UTF-8&AQB=1&cpd=2&v9=D=g&pageName=pageName=Life+%26+style:Features:Competition:pollyjeans:1334360&v14=D=r\" width=\"1\" height=\"1\"/></body></html>")
 
-    val actualResult = BasicHtmlCleaner.createSimplePageTracking(Jsoup.parse(html), "ns=guardian&ndh=1&c19=GUK&AQE=1&ch=Music&ce=UTF-8&AQB=1&cpd=2&v9=D=g&pageName=pageName=Life+%26+style:Features:Competition:pollyjeans:1334360&v14=D=r")
+    val actualResult = BasicHtmlCleaner.createSimplePageTracking(Jsoup.parse(html), "ns=guardian&ndh=1&c19=frontendarchive&AQE=1&ch=Music&ce=UTF-8&AQB=1&cpd=2&v9=D=g&pageName=pageName=Life+%26+style:Features:Competition:pollyjeans:1334360&v14=D=r")
     actualResult.html().replace(" ", "") should be(expectedDoc.html().replace(" ", ""))
   }
 


### PR DESCRIPTION
So that we can differentiate NGW archived pages vs. legacy R2-sourced pages in omniture data.

cc @jennysivapalan
