### PR TITLE
Fix preview liveblogs

### DIFF
--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -188,7 +188,7 @@ GET        /weatherapi/city.json                                                
 GET        /weatherapi/locations                                                               weather.controllers.LocationsController.findCity(query: String)
 
 # Articles
-GET        /*path.json                                                                         controllers.ArticleController.renderArticle(path)
+GET        /*path.json                                                                         controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean])
 
 # Don't forward requests for favicon.ico to the Content API
 GET        /favicon.ico                                                                        controllers.FaviconController.favicon


### PR DESCRIPTION
Autoupdate on liveblogs asks for the json version with lastBlock=.....

However preview runs standalone app which didn't understand these parameters so was ignoring them.  Updating it to send json article requests to the code that can handle these parameters.

Before it was auto updating constantly with the whole page, which made preview useless.
