### PR TITLE
Show pre-logo-load sponsor text on commercial containers

### DIFF
--- a/common/app/common/dfp/PaidForTagAgent.scala
+++ b/common/app/common/dfp/PaidForTagAgent.scala
@@ -120,7 +120,7 @@ trait PaidForTagAgent {
     isPaidFor(capiTagId, maybeSectionId, maybeEdition = None, FoundationFunded)
   }
 
-  private def findContainerCapiTagIdAndDfpTag(config: CollectionConfig):
+  def findContainerCapiTagIdAndDfpTag(config: CollectionConfig):
   Option[CapiTagIdAndDfpTag] = {
 
     def containerCapiTagIds(config: CollectionConfig): Seq[String] = {
@@ -143,34 +143,8 @@ trait PaidForTagAgent {
     None
   }
 
-  private def isPaidFor(config: CollectionConfig, paidForType: PaidForType): Boolean = {
-    findContainerCapiTagIdAndDfpTag(config) exists (_.dfpTag.paidForType == paidForType)
-  }
-
-  def sponsorshipType(config: CollectionConfig): Option[String] = {
-    findContainerCapiTagIdAndDfpTag(config) map (_.dfpTag.paidForType.name)
-  }
-
-  def isSponsored(config: CollectionConfig): Boolean = {
-    isPaidFor(config, Sponsored)
-  }
-
-  def isAdvertisementFeature(config: CollectionConfig): Boolean = {
-    isPaidFor(config, AdvertisementFeature)
-  }
-
-  def isFoundationSupported(config: CollectionConfig): Boolean = {
-    isPaidFor(config, FoundationFunded)
-  }
-
   def sponsorshipTag(capiTags: Seq[Tag], maybeSectionId: Option[String]): Option[Tag] = {
     findWinningTagPair(currentPaidForTags, capiTags, maybeSectionId, None) map (_.capiTag)
-  }
-
-  def sponsorshipTag(config: CollectionConfig): Option[SponsorshipTag] = {
-    findContainerCapiTagIdAndDfpTag(config) map { tagPair =>
-      SponsorshipTag(tagPair.dfpTag.tagType, tagPair.capiTagId)
-    }
   }
 
   private def hasMultiplesOfAPaidForType(capiTags: Seq[Tag],

--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -101,13 +101,10 @@
                                 @for(cardWithSponsorData <- Commercial.containerCard.mkCardsWithSponsorDataAttributes(container)) {
                                     <li class="lineitem l-row__item l-row__item--span-1 js-sponsored-container"
                                         @for(sponsorData <- cardWithSponsorData.sponsorData) {
+                                            @for(sponsor <- sponsorData.sponsor) { data-sponsor="@sponsor" }
                                             data-sponsorship="@sponsorData.sponsorshipType"
-                                            @for(seriesId <- sponsorData.seriesId) {
-                                                data-series="@seriesId"
-                                            }
-                                            @for( keywordId <- sponsorData.keywordId) {
-                                                data-keywords="@keywordId"
-                                            }
+                                            @for(seriesId <- sponsorData.seriesId) { data-series="@seriesId" }
+                                            @for(keywordId <- sponsorData.keywordId) { data-keywords="@keywordId" }
                                         }
                                     >
                                         <div class="rich-link tone-paidfor--item">

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -6,7 +6,7 @@
 @import views.html.fragments.containers.facia_cards.{commercialContainer, containerMetaData, mostPopularContainer, navListContainer, navMediaListContainer, standardContainer}
 @import views.support.GetClasses
 
-@defining(containerDefinition.displayName, containerDefinition.faciaComponentName) { case (title, componentName) =>
+@defining((containerDefinition.displayName, containerDefinition.faciaComponentName)) { case (title, componentName) =>
     @containerDefinition.customHeader.map {
         case header: MetaDataHeader => {
             @containerMetaData(header)
@@ -17,6 +17,7 @@
              class="@GetClasses.forContainerDefinition(containerDefinition)"
              data-link-name="container-@{containerDefinition.index + 1} | @componentName"
              data-id="@containerDefinition.dataId"
+             @for(sponsor <- containerDefinition.commercialOptions.sponsor) { data-sponsor="@sponsor" }
              @for(tag <- containerDefinition.commercialOptions.sponsorshipTag) {
                  @tag.tagType match {
                      case Series => { data-series="@{tag.tagId}" }

--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -1,21 +1,20 @@
 @(trails: Seq[model.pressed.PressedContent], containerLayout: layout.ContainerLayout, containerIndex: Int, actualDate: org.joda.time.DateTime, page: model.MetaData, nav: PreviousAndNext, tzOverride: Option[org.joda.time.DateTimeZone] = None)(implicit request: RequestHeader, config: model.pressed.CollectionConfig)
 
-@import views.html.fragments.containers.facia_cards.{slice, date}
-@import views.support.{GetClasses, PreviousAndNext}
 @import common.LinkTo
-@import dfp.DfpAgent
-@import services.FaciaContentConvert
+@import views.html.fragments.containers.facia_cards.{date, slice}
+@import views.support.Commercial.container
+@import views.support.{GetClasses, PreviousAndNext}
 
 @* TODO Consolidate this with the master container template to get rid of repetition *@
 
 @defining(page.webTitle) { case (webTitle) =>
     <section class="@GetClasses.forTagContainer(webTitle.nonEmpty)"
         data-link-name="all index"
-        @DfpAgent.sponsorshipTag(config).map { keyword =>
-            data-keywords="@keyword"
-        }
-        @DfpAgent.sponsorshipType(config).map { sponsorshipType =>
-            data-sponsorship="@sponsorshipType"
+        @for(sponsorData <- container.mkSponsorDataAttributes(config)) {
+            @for(sponsor <- sponsorData.sponsor) { data-sponsor="@sponsor" }
+            @for(seriesId <- sponsorData.seriesId) { data-keywords="@seriesId" }
+            @for(keywordId <- sponsorData.keywordId) { data-keywords="@keywordId" }
+            @for(sponsorshipType <- sponsorData.sponsorshipType) { data-sponsorship="@sponsorshipType" }
         }
         data-component="all index">
         <div class="fc-container__inner">

--- a/common/test/common/dfp/PaidForTagAgentTest.scala
+++ b/common/test/common/dfp/PaidForTagAgentTest.scala
@@ -27,8 +27,6 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
     toTag(ApiTagType.Keyword, tagId, sectionId)
   private def toSeries(tagId: String, sectionId: Option[String] = None): Tag =
     toTag(ApiTagType.Series, tagId, sectionId)
-  private val adFeatureToneTagId = "tone/advertisement-features"
-  private val adFeatureTone = toTag(ApiTagType.Tone, adFeatureToneTagId, None)
 
   private def toLineItem(state: String = "DELIVERING",
                          editionId: Option[String] = None,
@@ -154,6 +152,22 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
 
     override protected def tagToAdvertisementFeatureSponsorsMap: Map[String, Set[String]] = Map
       .empty
+
+    private def isPaidFor(config: CollectionConfig, paidForType: PaidForType): Boolean = {
+      findContainerCapiTagIdAndDfpTag(config) exists (_.dfpTag.paidForType == paidForType)
+    }
+
+    def isSponsored(config: CollectionConfig): Boolean = {
+      isPaidFor(config, Sponsored)
+    }
+
+    def isAdvertisementFeature(config: CollectionConfig): Boolean = {
+      isPaidFor(config, AdvertisementFeature)
+    }
+
+    def isFoundationSupported(config: CollectionConfig): Boolean = {
+      isPaidFor(config, FoundationFunded)
+    }
   }
 
   private def apiQuery(apiQuery: String) = {


### PR DESCRIPTION
Before a logo loads, and if ads are blocked, we show the sponsor's name instead.
This now works for all sponsored containers, but the new commercial containers don't show at all if ad-blocked.

/cc @JonNorman @Calanthe 
