### PR TITLE
A/B: Restrict injection of email form

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
@@ -7,7 +7,8 @@ define([
     'common/modules/email/email',
     'common/utils/detect',
     'lodash/collections/contains',
-    'common/utils/config'
+    'common/utils/config',
+    'lodash/collections/every'
 ], function (
     $,
     bean,
@@ -17,7 +18,8 @@ define([
     email,
     detect,
     contains,
-    config
+    config,
+    every
 ) {
     return function () {
         this.id = 'RtrtEmailFormArticlePromoV2';
@@ -32,7 +34,10 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'Email sign-up is increased';
 
-        var $articleBody = $('.js-article__body');
+        var $articleBody = $('.js-article__body'),
+            isParagraph = function ($el) {
+                return $el.nodeName && $el.nodeName === 'P';
+            };
 
         this.canRun = function () {
             //Tests for fronts, editions optional.
@@ -42,13 +47,7 @@ define([
                 browser = detect.getUserAgent.browser,
                 version = detect.getUserAgent.version,
                 allArticleEls = $('> *', $articleBody),
-                lastFiveElsParas = true;
-
-            for (var i = allArticleEls.length - 1; i > allArticleEls.length - 6; i--) {
-                if (allArticleEls[i] && allArticleEls[i].nodeName !== 'P') {
-                    lastFiveElsParas = false;
-                }
-            }
+                lastFiveElsParas = every([].slice.call(allArticleEls, allArticleEls.length - 5), isParagraph);
 
             // User referred from a front, is not logged in and not lte IE9
             return lastFiveElsParas && urlRegex.test(document.referrer) && !Id.isUserLoggedIn() && !(browser === 'MSIE' && contains(['7','8','9'], version + ''));

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
@@ -32,16 +32,26 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = 'Email sign-up is increased';
 
+        var $articleBody = $('.js-article__body');
+
         this.canRun = function () {
             //Tests for fronts, editions optional.
             var host = window.location.host,
                 escapedHost = host.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), // Escape anything that will mess up the regex
                 urlRegex = new RegExp('^https?:\/\/' + escapedHost + '\/(uk\/|us\/|au\/|international\/)?([a-z-])+$', 'gi'),
                 browser = detect.getUserAgent.browser,
-                version = detect.getUserAgent.version;
+                version = detect.getUserAgent.version,
+                allArticleEls = $('> *', $articleBody),
+                lastFiveElsParas = true;
+
+            for (var i = allArticleEls.length - 1; i > allArticleEls.length - 6; i--) {
+                if (allArticleEls[i] && allArticleEls[i].nodeName !== 'P') {
+                    lastFiveElsParas = false;
+                }
+            }
 
             // User referred from a front, is not logged in and not lte IE9
-            return urlRegex.test(document.referrer) && !Id.isUserLoggedIn() && !(browser === 'MSIE' && contains(['7','8','9'], version + ''));
+            return lastFiveElsParas && urlRegex.test(document.referrer) && !Id.isUserLoggedIn() && !(browser === 'MSIE' && contains(['7','8','9'], version + ''));
         };
 
         function injectEmailForm($position, typeOfInsert) {
@@ -81,13 +91,13 @@ define([
             {
                 id: 'bottom-of-page',
                 test: function () {
-                    injectEmailForm($('.js-article__body'));
+                    injectEmailForm($articleBody);
                 }
             },
             {
                 id: 'three-paras-from-bottom',
                 test: function () {
-                    var articleParas = $('.js-article__body > p'),
+                    var articleParas = $('> p', $articleBody),
                         para = $(articleParas[articleParas.length - 3]); // This is a little bit heavy handed but should be ok for test.
 
                     injectEmailForm(para, 'insertBefore');


### PR DESCRIPTION
Restrict to only injecting when the page’s last 5 elements are paragraphs
