### PR TITLE
Create new id privacy tab and move marketing prefs there

### DIFF
--- a/identity/app/controllers/EditProfileController.scala
+++ b/identity/app/controllers/EditProfileController.scala
@@ -12,11 +12,16 @@ import play.api.data.Form
 import play.api.i18n.{ MessagesApi, I18nSupport }
 import play.api.mvc.{AnyContent, Controller, Request}
 import play.filters.csrf.{CSRFAddToken, CSRFCheck}
-import services.{IdentityRequest, _}
+import services._
 import tracking.Omniture
 import utils.SafeLogging
 
 import scala.concurrent.Future
+
+sealed trait EditProfilePage
+case object PublicEditProfilePage extends EditProfilePage
+case object AccountEditProfilePage extends EditProfilePage
+case object PrivacyEditProfilePage extends EditProfilePage
 
 @Singleton
 class EditProfileController @Inject()(idUrlBuilder: IdentityUrlBuilder,
@@ -32,27 +37,39 @@ class EditProfileController @Inject()(idUrlBuilder: IdentityUrlBuilder,
   protected val publicPage = IdentityPage("/public/edit", "Edit Public Profile", "edit public profile")
   protected val membershipPage = IdentityPage("/membership/edit", "Membership", "edit membership details")
   protected val digitalPackPage = IdentityPage("/digitalpack/edit", "Digital Pack", "edit digital pack details")
+  protected val privacyPage = IdentityPage("/privacy/edit", "Privacy", "edit privacy details")
 
   def displayPublicProfileForm = displayForm(publicPage)
   def displayAccountForm = displayForm(accountPage)
   def displayMembershipForm = displayForm(membershipPage)
   def displayDigitalPackForm = displayForm(digitalPackPage)
+  def displayPrivacyForm = displayForm(privacyPage)
 
   protected def displayForm(page: IdentityPage) = CSRFAddToken {
     recentlyAuthenticated.async { implicit request =>
-      profileFormsView(Omniture.tracking(page,idRequestParser(request)), ProfileForms(request.user, false))
+      profileFormsView(Omniture.tracking(page,idRequestParser(request)), ProfileForms(request.user, PublicEditProfilePage))
     }
   }
 
   def submitPublicProfileForm() = submitForm(publicPage)
   def submitAccountForm() = submitForm(accountPage)
+  def submitPrivacyForm() = submitForm(privacyPage)
+
+  def identifyActiveSubmittedForm(page: IdentityPage): EditProfilePage =
+    if(page == publicPage)
+      PublicEditProfilePage
+    else if(page == accountPage)
+      AccountEditProfilePage
+    else
+      PrivacyEditProfilePage
 
   def submitForm(page: IdentityPage) = CSRFCheck {
     authActionWithUser.async {
       implicit request =>
+        val activePage = identifyActiveSubmittedForm(page)
         val idRequest = idRequestParser(request)
         val user = request.user
-        val forms = ProfileForms(user, page == publicPage).bindFromRequest(request)
+        val forms = ProfileForms(user, activePage).bindFromRequest(request)
         val futureFormOpt = forms.activeForm.value map {
           data: UserFormData =>
             identityApiClient.saveUser(user.id, data.toUserUpdate(user), user.auth) map {
@@ -81,11 +98,17 @@ class EditProfileController @Inject()(idUrlBuilder: IdentityUrlBuilder,
   }
 }
 
-case class ProfileForms(publicForm: Form[ProfileFormData], accountForm: Form[AccountFormData], isPublicFormActive: Boolean)
+case class ProfileForms(publicForm: Form[ProfileFormData], accountForm: Form[AccountFormData], privacyForm: Form[PrivacyFormData], activePage: EditProfilePage)
   extends ProfileMapping
-  with AccountDetailsMapping {
+  with AccountDetailsMapping
+  with PrivacyMapping
+{
 
-  lazy val activeForm = if(isPublicFormActive) publicForm else accountForm
+  lazy val activeForm = activePage match {
+    case PublicEditProfilePage => publicForm
+    case AccountEditProfilePage => accountForm
+    case PrivacyEditProfilePage => privacyForm
+  }
 
   def bindFromRequest(implicit request: Request[_]) = update {
     form =>
@@ -100,7 +123,8 @@ case class ProfileForms(publicForm: Form[ProfileFormData], accountForm: Form[Acc
   def bindForms(user: User): ProfileForms = {
     copy(
       publicForm = profileMapping.bindForm(user),
-      accountForm = accountDetailsMapping.bindForm(user)
+      accountForm = accountDetailsMapping.bindForm(user),
+      privacyForm = privacyMapping.bindForm(user)
     )
   }
 
@@ -115,24 +139,30 @@ case class ProfileForms(publicForm: Form[ProfileFormData], accountForm: Form[Acc
     }
   }
 
-  private lazy val activeMapping = if(isPublicFormActive) profileMapping else accountDetailsMapping
+  private lazy val activeMapping = activePage match {
+    case PublicEditProfilePage => profileMapping
+    case AccountEditProfilePage => accountDetailsMapping
+    case PrivacyEditProfilePage => privacyMapping
+  }
 
   private def update(change: (Form[_ <: UserFormData]) => Form[_ <: UserFormData]): ProfileForms = {
-    if(isPublicFormActive){
-      copy(publicForm = change(publicForm).asInstanceOf[Form[ProfileFormData]])
+    activePage match {
+      case PublicEditProfilePage => copy(publicForm = change(publicForm).asInstanceOf[Form[ProfileFormData]])
+      case AccountEditProfilePage => copy(accountForm = change(accountForm).asInstanceOf[Form[AccountFormData]])
+      case PrivacyEditProfilePage => copy(privacyForm = change(privacyForm).asInstanceOf[Form[PrivacyFormData]])
     }
-    else
-      copy(accountForm = change(accountForm).asInstanceOf[Form[AccountFormData]])
   }
 }
 
 object ProfileForms
   extends ProfileMapping
-  with AccountDetailsMapping {
+  with AccountDetailsMapping
+  with PrivacyMapping {
 
-  def apply(user: User, isPublicFormActive: Boolean): ProfileForms = ProfileForms(
+  def apply(user: User, activePage: EditProfilePage): ProfileForms = ProfileForms(
     publicForm = profileMapping.bindForm(user),
     accountForm = accountDetailsMapping.bindForm(user),
-    isPublicFormActive = isPublicFormActive
+    privacyForm = privacyMapping.bindForm(user),
+    activePage = activePage
   )
 }

--- a/identity/app/controllers/EmailController.scala
+++ b/identity/app/controllers/EmailController.scala
@@ -36,26 +36,22 @@ class EmailController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
     authAction.async { implicit request =>
       val idRequest = idRequestParser(request)
       val userId = request.user.getId()
-      val userFuture = api.user(userId, request.user.auth)
       val subscriberFuture = api.userEmails(userId, idRequest.trackingData)
 
       (for {
-        user <- userFuture
         subscriber <- subscriberFuture
       } yield {
-        (user, subscriber) match {
-          case (Right(user), Right(subscriber)) => {
+        subscriber match {
+          case Right(s) => {
             val form = emailPrefsForm.fill(EmailPrefsData(
-              user.statusFields.isReceiveGnmMarketing,
-              user.statusFields.isReceive3rdPartyMarketing,
-              subscriber.htmlPreference,
-              subscriber.subscriptions.map(_.listId)
+              s.htmlPreference,
+              s.subscriptions.map(_.listId)
             ))
             form
           }
 
-          case (user, subscriber) => {
-            val errors = user.left.getOrElse(Nil) ++ subscriber.left.getOrElse(Nil)
+          case s => {
+            val errors = s.left.getOrElse(Nil)
             val formWithErrors = errors.foldLeft(emailPrefsForm) {
               case (formWithErrors, Error(message, description, _, context)) =>
                 formWithErrors.withGlobalError(description)
@@ -111,22 +107,19 @@ class EmailController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
                   (formWithErrors, getEmailSubscriptions(form, add = List(listId)))
               }
           }.getOrElse {
-            val newStatusFields = ("receiveGnmMarketing" -> emailPrefsData.receiveGnmMarketing) ~ ("receive3rdPartyMarketing" -> emailPrefsData.receive3rdPartyMarketing)
             val newSubscriber = Subscriber(emailPrefsData.htmlPreference, Nil)
-            val userFuture = api.updateUser(userId, auth, trackingParameters, "statusFields", newStatusFields)
             val subscriberFuture = api.updateUserEmails(userId, newSubscriber, auth, trackingParameters)
 
             for {
-              user <- userFuture
               subscriber <- subscriberFuture
             } yield {
-              (user, subscriber) match {
-                case (Right(user), Right(subscriber)) => {
+              subscriber match {
+                case Right(s) => {
                   (form, getEmailSubscriptions(form))
                 }
 
-                case (user, subscriber) => {
-                  val errors = user.left.getOrElse(Nil) ++ subscriber.left.getOrElse(Nil)
+                case s => {
+                  val errors = s.left.getOrElse(Nil)
                   val formWithErrors = errors.foldLeft(form) {
                     case (formWithErrors, Error(message, description, _, context)) =>
                       formWithErrors.withError(context.getOrElse(""), description)
@@ -146,15 +139,13 @@ class EmailController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
     EmailSubscriptions(form.data.filter(_._1.startsWith("emailSubscription")).map(_._2).filterNot(remove.toSet) ++ add)
 }
 
-case class EmailPrefsData(receiveGnmMarketing: Boolean, receive3rdPartyMarketing: Boolean, htmlPreference: String, emailSubscriptions: List[String], emailSubscription: Option[String] = None)
+case class EmailPrefsData(htmlPreference: String, emailSubscriptions: List[String], emailSubscription: Option[String] = None)
 object EmailPrefsData {
   protected val validPrefs = Set("HTML", "Text")
   def isValidHtmlPreference(pref: String): Boolean =  validPrefs contains pref
 
   val emailPrefsForm = Form(
     Forms.mapping(
-      "statusFields.receiveGnmMarketing" -> Forms.boolean,
-      "statusFields.receive3rdPartyMarketing" -> Forms.boolean,
       "htmlPreference" -> Forms.text.verifying(isValidHtmlPreference _),
       "emailSubscription" -> Forms.list(Forms.text),
       "addEmailSubscription" -> Forms.optional(Forms.text)

--- a/identity/app/form/PrivacyMapping.scala
+++ b/identity/app/form/PrivacyMapping.scala
@@ -1,0 +1,51 @@
+package form
+
+import com.gu.identity.model.User
+import idapiclient.UserUpdate
+import play.api.data.Forms._
+import play.api.i18n.Messages.Implicits._
+import play.api.Play.current
+
+object PrivacyMapping extends UserFormMapping[PrivacyFormData] {
+  override val messagesApi = applicationMessagesApi
+
+  protected lazy val formMapping = mapping(
+    "receiveGnmMarketing" -> boolean,
+    "receive3rdPartyMarketing" -> boolean
+  )(PrivacyFormData.apply)(PrivacyFormData.unapply)
+
+  protected def fromUser(user: User) = PrivacyFormData(user)
+
+  protected lazy val contextMap =  Map(
+    "statusFields.receiveGnmMarketing" -> "receiveGnmMarketing",
+    "statusFields.receive3rdPartyMarketing" -> "receive3rdPartyMarketing"
+  )
+}
+
+trait PrivacyMapping {
+  val privacyMapping = PrivacyMapping
+}
+
+case class PrivacyFormData(
+                            receiveGnmMarketing: Boolean,
+                            receive3rdPartyMarketing: Boolean
+                            ) extends UserFormData{
+
+  def toUserUpdate(currentUser: User): UserUpdate = {
+    val statusFields = currentUser.statusFields
+    UserUpdate(
+      statusFields = Some(statusFields.copy(
+        receive3rdPartyMarketing = Some(receive3rdPartyMarketing),
+        receiveGnmMarketing = Some(receiveGnmMarketing)
+      ))
+    )
+  }
+
+}
+
+object PrivacyFormData {
+  def apply(user: User): PrivacyFormData = PrivacyFormData(
+    receiveGnmMarketing = user.statusFields.receiveGnmMarketing.getOrElse(false),
+    receive3rdPartyMarketing = user.statusFields.receive3rdPartyMarketing.getOrElse(false)
+  )
+}

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -1,0 +1,42 @@
+@(idUrlBuilder: services.IdentityUrlBuilder,
+  idRequest: services.IdentityRequest,
+  user: com.gu.identity.model.User,
+  privacyForm: Form[form.PrivacyFormData])(implicit request: RequestHeader, messages: play.api.i18n.Messages)
+
+@import views.html.fragments.form.{checkboxField}
+@import form.IdFormHelpers._
+@import helper._
+
+
+<form class="form js-public-profile-form" novalidate action="@idUrlBuilder.buildUrl("/privacy/edit", idRequest)" role="main" method="post">
+    @views.html.helper.CSRF.formField
+
+    @if(privacyForm.globalError.isDefined) {
+        <div class="form__error">@privacyForm.globalErrors.map(_.message).mkString(", ")</div>
+    }
+
+    <fieldset class="fieldset">
+
+        <div class="fieldset__heading">
+            <h2 class="form__heading">Marketing</h2>
+        </div>
+
+        <div class="fieldset__fields">
+            <ul class="u-unstyled">
+                <li class="form-field">
+                    <label class="label">Would you like to receive information from the Guardian and their partners?</label>
+                    <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
+
+                    <div class="form-fields-group">
+                        @checkboxField(Checkbox(privacyForm("receiveGnmMarketing"), '_label -> "Receive email from Guardian News and Media Ltd."))(nonInputFields, messages)
+                        @checkboxField(Checkbox(privacyForm("receive3rdPartyMarketing"), '_label -> "Receive email from other organisations"))(nonInputFields, messages)
+                    </div>
+                </ul>
+                <li>
+                    <button type="submit" class="submit-input" data-link-name="Save privacy preferences">Save changes</button>
+                </li>
+            </ul>
+        </div>
+
+    </fieldset>
+</form>

--- a/identity/app/views/fragments/profile/privacyForm.scala.html
+++ b/identity/app/views/fragments/profile/privacyForm.scala.html
@@ -31,7 +31,8 @@
                         @checkboxField(Checkbox(privacyForm("receiveGnmMarketing"), '_label -> "Receive email from Guardian News and Media Ltd."))(nonInputFields, messages)
                         @checkboxField(Checkbox(privacyForm("receive3rdPartyMarketing"), '_label -> "Receive email from other organisations"))(nonInputFields, messages)
                     </div>
-                </ul>
+                </li>
+
                 <li>
                     <button type="submit" class="submit-input" data-link-name="Save privacy preferences">Save changes</button>
                 </li>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -68,17 +68,6 @@
 
                         </li>
 
-                        <li class="form-field @if((emailPrefsForm("statusFields.receiveGnmMarketing").errors ++ emailPrefsForm("statusFields.receive3rdPartyMarketing").errors).nonEmpty) {form-field--error}">
-                            <label class="label">Would you like to receive information from the Guardian and their partners?</label>
-                            <div class="form-field__note">The Guardian and their partners would like to occasionally send you information about their products, services and events.</div>
-
-                            <div class="form-fields-group">
-                                @checkboxField(Checkbox(emailPrefsForm("statusFields.receiveGnmMarketing"), '_label -> "Receive email from Guardian News and Media Ltd."))(nonInputFields, messages)
-                                @checkboxField(Checkbox(emailPrefsForm("statusFields.receive3rdPartyMarketing"), '_label -> "Receive email from other organisations"))(nonInputFields, messages)
-                            </div>
-
-                        </li>
-
                         <li>
                             <button type="submit" class="submit-input" data-link-name="Save email preferences">Save</button>
                         </li>

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -76,6 +76,9 @@
                 </div>
 
             </fieldset>
+            <ul class="nav nav--registration identity-section" data-link-name="Email prefs footer">
+                <li class="nav__item"><a class="nav__link" href="@controllers.routes.EditProfileController.displayPrivacyForm" data-link-name="Privacy and marketing settings">Privacy &amp; marketing settings</a></li>
+            </ul>
 
         </form>
     </div>

--- a/identity/app/views/profileForms.scala.html
+++ b/identity/app/views/profileForms.scala.html
@@ -39,6 +39,8 @@
             @tab(3, "Membership", "/membership/edit", None, optionalClass="qa-membership-tab")
 
             @tab(4, "Digital Pack", "/digitalpack/edit", None, optionalClass="qa-digitalpack-tab")
+
+            @tab(5, "Privacy", "/privacy/edit", None, optionalClass="qa-privacy-tab")
         </ol>
 
         <div class="tabs__content">
@@ -49,6 +51,8 @@
             @content(3, "/membership/edit")(fragments.profile.membershipDetailsForm())
 
             @content(4, "/digitalpack/edit")(fragments.profile.digitalPackDetailsForm())
+
+            @content(5, "/privacy/edit")(fragments.profile.privacyForm(idUrlBuilder, idRequest, user, forms.privacyForm))
         </div>
     </div>
 

--- a/identity/conf/routes
+++ b/identity/conf/routes
@@ -36,7 +36,9 @@ POST        /public/edit                            @controllers.EditProfileCont
 GET         /account/edit                           @controllers.EditProfileController.displayAccountForm
 GET         /membership/edit                        @controllers.EditProfileController.displayMembershipForm
 GET         /digitalpack/edit                       @controllers.EditProfileController.displayDigitalPackForm
+GET         /privacy/edit                           @controllers.EditProfileController.displayPrivacyForm
 POST        /account/edit                           @controllers.EditProfileController.submitAccountForm
+POST        /privacy/edit                           @controllers.EditProfileController.submitPrivacyForm
 GET         /verify-email/:token                    @controllers.EmailVerificationController.verify(token: String)
 GET         /verify-email                           @controllers.EmailVerificationController.resendEmailValidationEmail()
 

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -88,6 +88,46 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
     }
   }
 
+  "Given the submitPrivacyForm method is called" - {
+    val receive3rdPartyMarketing = false
+    val receiveGnmMarketing = true
+
+    "with a valid CSRF request" - Fake{
+      val fakeRequest = FakeCSRFRequest()
+        .withFormUrlEncodedBody(
+          "receiveGnmMarketing" -> receiveGnmMarketing.toString,
+          "receive3rdPartyMarketing" -> receive3rdPartyMarketing.toString
+        )
+
+      val updatedUser = user.copy(
+        statusFields = StatusFields(
+          receiveGnmMarketing = Some(receiveGnmMarketing),
+          receive3rdPartyMarketing = Some(receive3rdPartyMarketing)
+        )
+      )
+      when(api.saveUser(Matchers.any[String], Matchers.any[UserUpdate], Matchers.any[Auth]))
+        .thenReturn(Future.successful(Right(updatedUser)))
+
+      val result = controller.submitPrivacyForm().apply(fakeRequest)
+
+      Await.result(result, 10.seconds)
+
+      "then the user should be saved on the ID API" in {
+        val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdate])
+        verify(api).saveUser(Matchers.eq(userId), userUpdateCapture.capture(), Matchers.eq(testAuth))
+        val userUpdate = userUpdateCapture.getValue
+
+        userUpdate.statusFields.value.receive3rdPartyMarketing.value should equal(receive3rdPartyMarketing)
+        userUpdate.statusFields.value.receiveGnmMarketing.value should equal(receiveGnmMarketing)
+      }
+
+      "then a status 200 should be returned" in {
+        status(result) should be(200)
+      }
+
+    }
+  }
+
   "Given the submitAccountForm method is called" - {
     object FakeRequestAccountData {
       val primaryEmailAddress = "john.smith@bobmail.com"

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -69,7 +69,7 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
 
       val result = controller.submitPublicProfileForm().apply(fakeRequest)
 
-      Await.result(result, 10.seconds)
+      Await.result(result, 2.seconds)
 
       "then the user should be saved on the ID API" in {
         val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdate])
@@ -110,7 +110,7 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
 
       val result = controller.submitPrivacyForm().apply(fakeRequest)
 
-      Await.result(result, 10.seconds)
+      Await.result(result, 2.seconds)
 
       "then the user should be saved on the ID API" in {
         val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdate])
@@ -233,7 +233,7 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
         .thenReturn(Future.successful(Right(updatedUser)))
 
       val result = controller.submitAccountForm().apply(fakeRequest)
-      Await.result(result, 1.seconds)
+      Await.result(result, 2.second)
 
       "then the user should be saved on the ID API" in {
         val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdate])


### PR DESCRIPTION
A number of new privacy / data settings are going to be made available to our users. We need to create a new home for these within edit profile.

Marketing preferences are currently at the bottom of the email preferences area. We should move these under a new tab within edit profile.

By moving these settings to the edit profile, we're forcing the user to re-authenticate.

Before:
![screenshot from 2016-01-14 15 36 44](https://cloud.githubusercontent.com/assets/1684649/12328749/b94cc626-bad4-11e5-958b-118771a16c3b.png)

After:
![upload_1_13_2016_at_11_23_30_am](https://cloud.githubusercontent.com/assets/1684649/12328696/6c886534-bad4-11e5-98f9-ad2c60cc9b0d.png)

![upload_11_19_2015_at_2_53_21_pm](https://cloud.githubusercontent.com/assets/1684649/12328702/757f871c-bad4-11e5-9a14-e4f39a1c0fe7.png)
