### PR TITLE
Adjust page press timings

### DIFF
--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -18,7 +18,7 @@ trait AdminLifecycle extends GlobalSettings with Logging {
   lazy val adminPressJobHighPushRateInMinutes: Int = Configuration.faciatool.adminPressJobHighPushRateInMinutes
   lazy val adminPressJobLowPushRateInMinutes: Int = Configuration.faciatool.adminPressJobLowPushRateInMinutes
   lazy val adminRebuildIndexRateInMinutes: Int = Configuration.indexes.adminRebuildIndexRateInMinutes
-  lazy val r2PagePressRateInMinutes: Int = Configuration.r2Press.pressRateInMinutes
+  lazy val r2PagePressRateInSeconds: Int = Configuration.r2Press.pressRateInSeconds
 
   private def scheduleJobs(): Unit = {
 
@@ -37,7 +37,7 @@ trait AdminLifecycle extends GlobalSettings with Logging {
       FastlyCloudwatchLoadJob.run()
     }
 
-    Jobs.scheduleEveryNMinutes("R2PagePressJob", r2PagePressRateInMinutes) {
+    Jobs.scheduleEveryNSeconds("R2PagePressJob", r2PagePressRateInSeconds) {
       R2PagePressJob.run()
     }
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -390,9 +390,9 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   object r2Press {
     lazy val sqsQueueUrl = configuration.getStringProperty("admin.r2.page.press.sqs.queue.url")
     lazy val sqsTakedownQueueUrl = configuration.getStringProperty("admin.r2.page.press.takedown.sqs.queue.url")
-    lazy val pressRateInMinutes = configuration.getIntegerProperty("admin.r2.page.press.rate.minutes").getOrElse(15)
-    lazy val pressQueueWaitTimeInSeconds = configuration.getIntegerProperty("admin.r2.press.queue.wait.seconds").getOrElse(20)
-    lazy val pressQueueMaxMessages = configuration.getIntegerProperty("admin.r2.press.queue.max.messages").getOrElse(50)
+    lazy val pressRateInSeconds = configuration.getIntegerProperty("admin.r2.page.press.rate.seconds").getOrElse(60)
+    lazy val pressQueueWaitTimeInSeconds = configuration.getIntegerProperty("admin.r2.press.queue.wait.seconds").getOrElse(10)
+    lazy val pressQueueMaxMessages = configuration.getIntegerProperty("admin.r2.press.queue.max.messages").getOrElse(10)
   }
 
   object memcached {


### PR DESCRIPTION
We can't pull more than 10 messages from an SQS queue at once (according to Amazon docs). Reduce this limit and increase the duty cycle to compensate.

cc @jennysivapalan 
