### PR TITLE
Discussion omniture tracking

### DIFF
--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -70,7 +70,7 @@
                     data-comment-id="@comment.id"
                     data-user-id="@comment.profile.userId"
                     data-recommend-count="@comment.numRecommends"
-                    title="@comment.numRecommends recommendations">
+                    title="@comment.numRecommends recommendations" data-link-name="Recommend comment">
                     <button class="u-button-reset d-comment__recommend-button rounded-icon">
                         <span class="d-comment__recommend-pulse"></span>
                         @fragments.inlineSvg("arrow-up-white", "icon")
@@ -100,7 +100,7 @@
                 </div>
                 @if(!comment.isBlocked){
                     <div class="d-comment__actions d-comment__actions--left modern-visible">
-                        <a class="d-comment__action d-comment__action--reply" href="https://profile.theguardian.com/signin?returnUrl=@Configuration.discussion.url/comment-permalink/@comment.id"
+                        <a class="d-comment__action d-comment__action--reply" data-link-name="Comment permalink" href="https://profile.theguardian.com/signin?returnUrl=@Configuration.discussion.url/comment-permalink/@comment.id"
                                 data-link-name="reply to comment" data-comment-id="@comment.id" role="button">
                             @fragments.inlineSvg("reply", "icon", List("blue"))
                             Reply
@@ -110,12 +110,12 @@
 
                         <button class="u-button-reset d-comment__action d-comment__action--pick d-staff-required" role="button"
                             data-comment-id="@comment.id"
-                            data-comment-highlighted="@comment.isHighlighted">@if(comment.isHighlighted){Unpick}else{Pick}</button>
+                            data-comment-highlighted="@comment.isHighlighted" data-link-name="Pick comment">@if(comment.isHighlighted){Unpick}else{Pick}</button>
 
                     </div>
 
                     <div class="report-comment-container js-report-comment-container d-comment__action d-comment__action--report">
-                        <a href="@Configuration.discussion.url/components/report-abuse/@comment.id" rel="nofollow" class="js-report-comment" data-comment-id="@comment.id" target="_blank">Report</a>
+                        <a href="@Configuration.discussion.url/components/report-abuse/@comment.id" rel="nofollow" class="js-report-comment" data-comment-id="@comment.id" target="_blank" data-link-name="Open report abuse">Report</a>
                     </div>
                 }
             </div>

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -43,7 +43,7 @@
                     </a>
                 }
                 <div class="d-comment__timestamp">
-                    <a href="@Configuration.discussion.url/comment-permalink/@comment.id" class="d-comment__timestamp block-time" data-link-name="Comment permalink">
+                    <a href="@Configuration.discussion.url/comment-permalink/@comment.id" class="d-comment__timestamp block-time">
                         <time class="js-timestamp" itemprop="dateCreated"
                             datetime="@comment.date.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")"
                             data-timestamp="@comment.date.getMillis" data-relativeformat="med"

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -70,8 +70,8 @@
                     data-comment-id="@comment.id"
                     data-user-id="@comment.profile.userId"
                     data-recommend-count="@comment.numRecommends"
-                    title="@comment.numRecommends recommendations" data-link-name="Recommend comment">
-                    <button class="u-button-reset d-comment__recommend-button rounded-icon">
+                    title="@comment.numRecommends recommendations">
+                    <button class="u-button-reset d-comment__recommend-button rounded-icon" @if(!isClosedForRecommendation){data-link-name="Recommend comment"} @if(isClosedForRecommendation){disabled="true"}>
                         <span class="d-comment__recommend-pulse"></span>
                         @fragments.inlineSvg("arrow-up-white", "icon")
                     </button>

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -43,7 +43,7 @@
                     </a>
                 }
                 <div class="d-comment__timestamp">
-                    <a href="@Configuration.discussion.url/comment-permalink/@comment.id" class="d-comment__timestamp block-time">
+                    <a href="@Configuration.discussion.url/comment-permalink/@comment.id" class="d-comment__timestamp block-time" data-link-name="Comment permalink">
                         <time class="js-timestamp" itemprop="dateCreated"
                             datetime="@comment.date.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")"
                             data-timestamp="@comment.date.getMillis" data-relativeformat="med"
@@ -100,7 +100,7 @@
                 </div>
                 @if(!comment.isBlocked){
                     <div class="d-comment__actions d-comment__actions--left modern-visible">
-                        <a class="d-comment__action d-comment__action--reply" data-link-name="Comment permalink" href="https://profile.theguardian.com/signin?returnUrl=@Configuration.discussion.url/comment-permalink/@comment.id"
+                        <a class="d-comment__action d-comment__action--reply" href="https://profile.theguardian.com/signin?returnUrl=@Configuration.discussion.url/comment-permalink/@comment.id"
                                 data-link-name="reply to comment" data-comment-id="@comment.id" role="button">
                             @fragments.inlineSvg("reply", "icon", List("blue"))
                             Reply

--- a/discussion/app/views/fragments/reportComment.scala.html
+++ b/discussion/app/views/fragments/reportComment.scala.html
@@ -29,5 +29,5 @@
         <input type="text" class="d-report-comment__field" id="d-report-comment__email" name="email"></textarea>
     </div>
 
-    <button class="d-report-comment__submit" type="submit">Report</button>
+    <button class="d-report-comment__submit" type="submit" data-link-name="Post report abuse">Report</button>
 </form>


### PR DESCRIPTION
- Add `data-link-name` to previously untracked discussion events
- Disable recommend button if discussion is closed for recommendations

CC @chriswilk @guardian/discussion 
