### PR TITLE
Revert "Add charity donation text to the membership engaged reader banner"

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -37,7 +37,7 @@ define([
             data: {
                 messageText: [
                     'Thank you for reading the Guardian.',
-                    'Become a Supporter today for just £49 per year and we will donate £1 to the Guardian Charity Appeal 2015.'
+                    'Help keep our journalism free and independent by becoming a Supporter for just £5 a month.'
                 ].join(' '),
                 linkText: 'Join'
             }


### PR DESCRIPTION
Take the "we will donate £1 to the Guardian Charity Appeal 2015" off our engaged reader banner and revert to the previous message.

Due today at 12:00

Reverts guardian/frontend#11394

https://trello.com/c/qZ8Rs3TH/274-take-the-we-will-donate-1-to-the-guardian-charity-appeal-2015-off-our-engaged-reader-banner-and-revert-to-the-previous-message-o

@joelochlann @Calanthe 
