### PR TITLE
Amp ads right aligned instead of left

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/ads.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/ads.scala.html
@@ -1,19 +1,19 @@
 .amp-ad-container {
     background: #f6f6f6;
     border-top: 0.0625rem solid #dfdfdf;
-    float: left;
+    float: right;
     height: 272px;
     width: 300px;
-    margin: 0.25rem 1.25rem 0.75rem 0;
+    margin: 0.25rem 0 0.75rem 1.25rem;
 }
 
 @@media (max-width: 550px) {
     .amp-ad-container {
-    clear: both;
-    float: none;
-    text-align: center;
-    margin-right: auto;
-    margin-left: auto;
+        clear: both;
+        float: none;
+        text-align: center;
+        margin-right: auto;
+        margin-left: auto;
     }
 }
 


### PR DESCRIPTION
Aligning Ads in AMP right, just the website.

Before:
![image](https://cloud.githubusercontent.com/assets/8774970/12352404/a075950c-bb7d-11e5-93c5-02b7a2a32220.png)

After
![image](https://cloud.githubusercontent.com/assets/8774970/12352307/b3865c54-bb7c-11e5-9462-a8188a6d3d6e.png)

cc @zeftilldeath @stephanfowler 
