### PR TITLE
Create new plain email embed

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -24,7 +24,7 @@ GET            /crosswords/lookup                                               
 
 # Email paths
 GET        /email                                                               controllers.EmailSignupController.renderPage()
-GET        /email/form/$emailType<article|footer>/:listId                       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET        /email/form/$emailType<article|footer|plain>/:listId                       controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                       controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                               controllers.EmailSignupController.submit()
 OPTIONS    /email                                                               controllers.EmailSignupController.options()

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -108,6 +108,7 @@ object EmailTypes {
   val footer = "footer"
   val article = "article"
   val landing = "landing"
+  val plain = "plain"
 }
 
 object EmailForm {

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -34,7 +34,7 @@ GET            /crosswords/lookup                                               
 
 # Email paths
 GET            /email                                                                                                            controllers.EmailSignupController.renderPage()
-GET            /email/form/$emailType<article|footer>/:listId                                                                    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET            /email/form/$emailType<article|footer|plain>/:listId                                                                    controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET            /email/:result                                                                                                    controllers.EmailSignupController.subscriptionResult(result: String)
 POST           /email                                                                                                            controllers.EmailSignupController.submit()
 OPTIONS        /email                                                                                                            controllers.EmailSignupController.options()

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -172,7 +172,7 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(interactive|ng-interactive)/.*>.json    
 
 # Email paths
 GET        /email                                                                              controllers.EmailSignupController.renderPage()
-GET        /email/form/$emailType<article|footer>/:listId                                      controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
+GET        /email/form/$emailType<article|footer|plain>/:listId                                      controllers.EmailSignupController.renderForm(emailType: String, listId: Int)
 GET        /email/:result                                                                      controllers.EmailSignupController.subscriptionResult(result: String)
 POST       /email                                                                              controllers.EmailSignupController.submit()
 OPTIONS    /email                                                                              controllers.EmailSignupController.options()

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -222,7 +222,8 @@
     }
 }
 
-.email-sub__form--article {
+.email-sub__form--article,
+.email-sub__form--plain {
     .email-sub__label__icon {
         display: inline-block;
         margin-right: $gs-gutter / 4;
@@ -245,6 +246,13 @@
 
     .email-sub__label {
         line-height: 3;
+    }
+}
+
+// PLAIN MODS
+.email-sub__form--plain {
+    .email-sub__text-input {
+        border-color: guss-colour(guardian-brand, $pasteup-palette);
     }
 }
 

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -251,6 +251,8 @@
 
 // PLAIN MODS
 .email-sub__form--plain {
+    padding: 0;
+
     .email-sub__text-input {
         border-color: guss-colour(guardian-brand, $pasteup-palette);
     }

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -116,7 +116,6 @@ body {
 /**
 * IFRAME PLAIN MODS
 */
-
 .email-sub--plain {
     .email-sub__header,
     .email-sub__label,

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -45,7 +45,8 @@ body {
 
 @include mq($from: 184px) {
     .email-sub__form--footer,
-    .email-sub__form--article {
+    .email-sub__form--article,
+    .email-sub__form--plain {
         // Rounded inline input
         .email-sub__text-input {
             border-right: 0;
@@ -63,7 +64,8 @@ body {
         }
     }
 
-    .email-sub__form--footer {
+    .email-sub__form--footer,
+    .email-sub__form--plain {
         .email-sub__submit-input {
             padding-left: $gs-gutter / 2;
         }
@@ -72,7 +74,8 @@ body {
 
 // It's a fixed layout so only at this width do we want to apply these styles
 @include mq(183px, 183px) {
-    .email-sub__form--footer {
+    .email-sub__form--footer,
+    .email-sub__form--plain {
         padding-right: $gs-gutter / 2;
 
         .email-sub__text-input {
@@ -89,7 +92,7 @@ body {
 
 // Above Phablet
 @include mq($from: 606px) {
-    .email-sub__form--article {
+    .email-sub__form--article, {
         .email-sub__form-wrapper {
             line-height: 3;
         }
@@ -110,4 +113,14 @@ body {
     }
 }
 
+/**
+* IFRAME PLAIN MODS
+*/
 
+.email-sub--plain {
+    .email-sub__header,
+    .email-sub__label,
+    .email-sub__small {
+        display: none;
+    }
+}


### PR DESCRIPTION
A new email embed type that's just the form. Nothing else. Plain. For use in interactives where we already have control of the surroundings.

![screen shot 2016-01-15 at 11 53 47](https://cloud.githubusercontent.com/assets/1607666/12352538/ad5fff5e-bb7e-11e5-9778-8725c5830c02.png)
