### PR TITLE
Feature articles media fixes

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -119,10 +119,12 @@
 
                 @media match {
                     case v: Video => {
-                        <div class="content__secondary-column content__secondary-column--media content__secondary-column--video hide-on-childrens-books-site"
+                        @if(!(page.media.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn)) {
+                            <div class="content__secondary-column content__secondary-column--media content__secondary-column--video hide-on-childrens-books-site"
                             aria-hidden="true">
-                            <div class="js-video-components-container"></div>
-                        </div>
+                                <div class="js-video-components-container"></div>
+                            </div>
+                        }
                     }
                     case a: Audio if a.fields.body.nonEmpty => {
                         <div class="content__secondary-column content__secondary-column--media content__secondary-column--audio hide-on-childrens-books-site"
@@ -136,7 +138,7 @@
         </div>
     </article>
 
-    @if(mediaType != "video") {
+    @if(mediaType != "video" && (mediaType != "audio" && page.media.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn)) {
         <div class="fc-container fc-container--media">
             <div class="js-media-popular tonal--@toneClass(media)">
                 <div class="fc-container fc-container--popular">

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -807,7 +807,21 @@
         }
 
         .vjs-volume-bar:before {
-            background: colour(neutral-1);
+            background-color: colour(neutral-1);
+        }
+
+        .end-slate-container--video {
+            background-color: colour(paid-article);
+
+            .end-slate-container__heading {
+                color: colour(news-support-7);
+            }
+
+            .fc-item__container {
+                &:before {
+                    background: colour(neutral-2);
+                }
+            }
         }
     }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -752,8 +752,6 @@
         .meta__numbers .commentcount2__heading,
         .tonal__main--tone-media .sharecount__value,
         .tonal__main--tone-media .commentcount2__value,
-        .most-viewed-container--media,
-        .most-viewed-container--media .fc-item__action,
         .content__dateline,
         .submeta__head,
         .content__series-label__link {
@@ -821,6 +819,10 @@
                 &:before {
                     background: colour(neutral-2);
                 }
+            }
+
+            .fc-item__action {
+                color: colour(neutral-2-contrasted);
             }
         }
     }


### PR DESCRIPTION
A few fixes for the new feature audio and video article pages:

Video article page:
- 'Popular videos' section in the right hand column is removed 
- Styling for the end slate overlay is fixed:
  ![screen shot 2016-01-15 at 12 05 11](https://cloud.githubusercontent.com/assets/489567/12352962/3b887af6-bb82-11e5-93bf-71bcb3b38f45.png)

Audio article page:
- 'popular in audio' section (below the article) is removed

@kelvin-chappell 
