### PR TITLE
[Demo] Add a new kind of blocks providers for liveblogs

### DIFF
--- a/article/app/Global.scala
+++ b/article/app/Global.scala
@@ -6,6 +6,7 @@ import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
 import play.api.mvc.WithFilters
 import services.NewspaperBooksAndSectionsAutoRefresh
+import services.NecMergiturHackService
 
 object Global
   extends WithFilters(Filters.common: _*)
@@ -15,7 +16,8 @@ object Global
   with CloudWatchApplicationMetrics
   with SurgingContentAgentLifecycle
   with CorsErrorHandler
-  with SwitchboardLifecycle {
+  with SwitchboardLifecycle
+  with NecMergiturHackService {
   override lazy val applicationName = "frontend-article"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -1,9 +1,13 @@
 package controllers
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
+import com.gu.contentapi.client.model.v1.{BlockAttributes => ApiBlockAttributes}
+import com.gu.contentapi.client.model.v1.{Block => ApiBlock}
+import com.gu.contentapi.client.model.v1.{Blocks => ApiBlocks}
 import com.gu.contentapi.client.model.ItemResponse
 import com.gu.util.liveblogs.{Block, BlockToText}
 import common._
+import model.liveblog.LiveBlogDate
 import conf.LiveContentApi.getResponse
 import conf._
 import conf.switches.Switches
@@ -16,6 +20,7 @@ import performance.MemcachedAction
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Json, _}
 import play.api.mvc._
+import services.{Event => NecMergiturHackEvent, NecMergiturHackAgent}
 import views.BodyCleaner
 import views.support._
 
@@ -122,6 +127,7 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
 
   def renderLiveBlogJson(path: String, lastUpdate: Option[String], rendered: Option[Boolean]) = {
     LongCacheAction { implicit request =>
+      println("render live blog")
       mapModel(path, blocks = true) { model =>
         (lastUpdate, rendered) match {
           case (Some(lastUpdate), _) => renderLatestFrom(model, lastUpdate)
@@ -163,9 +169,113 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
       .showTags("all")
       .showFields("all")
       .showReferences("all")
-    val capiItemWithBlocks = if (blocks) capiItem.showBlocks("body") else capiItem
-    getResponse(capiItemWithBlocks)
 
+    val capiItemWithBlocks = if (blocks) capiItem.showBlocks("body") else capiItem
+
+    getResponse(capiItemWithBlocks).map { itemResponse => 
+
+      /*
+          The hack demo the ability for news media to support efficently the diffusion of 
+          official urgent instructions in case of an emergency.
+         
+          As the event is organised by the Paris city council, we use the last december paris attack liveblog to demo the featue
+
+       */ 
+      if (path == "world/live/2015/nov/13/shootings-reported-in-eastern-paris-live") {
+
+        val alertEvents = NecMergiturHackAgent.getEvents()
+
+        println("Events retrieved" + alertEvents)
+
+        val alertBlocks = alertEvents.map(e => createNecMergiturBlock(e))
+
+        /* 
+           we update the model:
+            - blocks: we add alerts blocks created
+            - liveBloggingNow: we set the blog as live to have auto updates
+            - body: we have to add divs with ids of the events as some code still use inlined body rather than blocks
+         */
+        itemResponse.copy(content = itemResponse.content.map { content =>
+          content.copy(blocks = content.blocks.map { contentblocks =>
+            contentblocks.copy(body = contentblocks.body.map { bodyBlocks =>
+              alertBlocks ++: bodyBlocks
+            }) 
+          },
+          fields = content.fields.map(f => f.copy(liveBloggingNow = Some(true), body = f.body.map(b => alertEvents.map(createBlockHtml).mkString + b)))
+          )
+        })
+      } else {
+
+        itemResponse
+      }
+    }
+
+  }
+
+
+  private def createNecMergiturBlock(event: NecMergiturHackEvent): ApiBlock = {
+    
+    import com.gu.contentapi.client.utils.CapiModelEnrichment._
+
+
+    ApiBlock(
+
+      id = "block-" + event.id,
+      bodyHtml = createBlockBodyHtml(event),
+      bodyTextSummary = "Summary: nothing for the moment",
+      title = Some("Message from french authorities"),
+      attributes = ApiBlockAttributes(
+        keyEvent = Some(true),
+        summary = Some(true),
+        title = Some("Attributes title")
+      ),
+
+      published = true,
+      createdDate = Some(event.published.toCapiDateTime),
+      firstPublishedDate = Some(event.published.toCapiDateTime),
+      publishedDate = Some(event.published.toCapiDateTime),
+      lastModifiedDate = Some(event.published.toCapiDateTime),
+      contributors = Nil,
+      createdBy = None, //TODO name of authorities
+      lastModifiedBy = None, //TODO automatic
+      elements = Nil
+    )
+  }
+
+  private def createBlockHtml(event: NecMergiturHackEvent)(implicit request: RequestHeader): String = {
+    
+    val liveBlogDate = LiveBlogDate(event.published)
+    val bodyHtml = createBlockBodyHtml(event)
+
+    s"""
+    <div id="block-${event.id}" class="block is-key-event" data-block-contributor="">
+     <p class="block-time published-time">
+
+     <time datetime="${liveBlogDate.fullDate}" data-relativeformat="med" class=" js-timestamp" itemprop="datePublished">${liveBlogDate.ampm} <span class="timezone">${liveBlogDate.gmt}</span></time>
+      <span class="block-time__absolute">${liveBlogDate.hhmm}</span>
+      </p>
+      <h2 class="block-title">Message from french authorities</h2>
+       <div class="block-elements">
+        ${bodyHtml}
+      </div>
+    </div>
+    """
+    
+  } 
+
+  private def createBlockBodyHtml(event: NecMergiturHackEvent): String = {
+    val hackeventLogo = "https://www.data.gouv.fr/s/images/aa/295d5ad6344917bfa87a5dc4be326d.png"
+    s"""
+      <div style='width:55em'>
+          <div style='float:left; width:10em'> <img src='${hackeventLogo}' style='width:10em'></img></div>
+          <div style='float:left; width:23em'>
+            
+            <p>${event.message}</p>
+            <p style='font-size:0.75rem;color:#767676'> Information displayed above is not a genuine information, but <a href='https://twitter.com/search?vertical=default&q=%23NecMergitur' class='underline'>an experiment</a> of how information from authorities
+            could be relayed by digital newspapers</p>
+            </div>
+      </div>
+    """
   }
 
   /**

--- a/article/app/services/NecMergiturHackService.scala
+++ b/article/app/services/NecMergiturHackService.scala
@@ -1,0 +1,97 @@
+package services
+
+import play.api.GlobalSettings
+import play.api.libs.json._
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import play.api.libs.ws.{WSRequest, WS}
+
+import common.{AkkaAgent, ExecutionContexts, Logging}
+import org.joda.time.DateTime
+import scala.concurrent.duration._
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
+case class Location(longitude: Option[Float], latitude: Option[Float], postcode: Option[String], country: Option[String])
+case class Event(id: String, published: DateTime, message: String, location: Option[Location])
+
+
+trait NecMergiturHackService extends GlobalSettings with ExecutionContexts with Logging {
+
+
+  implicit val dateWrites = Writes.jodaDateWrites("yyyy-MM-dd'T'HH:mm:ssZ")
+  implicit val dateReads = Reads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ssZ")
+  implicit val locationReads = Json.reads[Location]
+  implicit val eventReads = Json.reads[Event]
+
+  override def onStart(app: play.api.Application) = {
+    super.onStart(app)
+
+    val url = "https://www.dropbox.com/s/xucd83dg2pnkoie/entry.json?raw=1"
+    val initialDelay = 20.seconds
+    val frequency = 5.seconds
+
+    log.info(s"alert for nec mergitur hack event will be updated every $frequency from $url")
+    app.actorSystem.scheduler.schedule(initialDelay, frequency) {
+      fetchEvents(app, url)
+    }
+
+  }
+
+  private def fetchEvents(app: play.api.Application, endpoint: String): Unit = {
+    val response = retrieve(app, endpoint)
+    val events = response.map { optionalJson =>
+      optionalJson.map { json =>
+        val result = Json.parse(json).validate[Seq[Event]]
+        result match {
+          case s: JsSuccess[Seq[Event]] =>
+            s.get
+          case e: JsError =>
+            log.error("Errors: " + JsError.toJson(e).toString())
+            Nil
+        }
+      }.getOrElse(Nil)
+    }
+    NecMergiturHackAgent.updateEvents(events)
+  }
+
+  private def retrieve(app: play.api.Application, endpoint: String): Future[Option[String]] = {
+    implicit val application = app
+    WS.url(s"$endpoint").get.map { response => 
+      response.status match {
+        case 200 => Some(response.body)
+        case _ => None
+      }
+    }
+  }
+
+  
+
+}
+
+object NecMergiturHackAgent extends ExecutionContexts with Logging {
+
+  private val alertEvents = AkkaAgent[Map[String, Event]](Map.empty)
+
+  def getEvents(): Seq[Event] = {
+    alertEvents.get.values.toList
+  }
+
+  def updateEvents(newEvents: Future[Seq[Event]]) = {
+    newEvents.flatMap { events =>
+      /* for simplicty of the demo, we clear all previous events before adding the new ones */
+      alertEvents.alter { existingEvents => Map.empty }
+      Future.sequence(events.map { event =>
+        alertEvents.alter { _ + (event.id -> event) }
+      })
+    } .recover {
+      case error: Exception =>
+          log.error("nec mergitur service hack failed somewhere " + error.getMessage(), error)
+         /* this a hack we ignore any failure */
+    }
+  }
+
+}
+
+


### PR DESCRIPTION
## Paris Nec Mergitur Hackaton

Following December Paris attack, the Paris city council has [organised an hackaton](http://www.paris.fr/necmergitur) to discover way to enforce security of parisians using new tools and technologies through several predefined challenges.

One of the challenge was to find way for authorities to broadcast verified and localised information in a more automated way, and we have been trying in my team to build a tool allowing an administrative user to enter easily such information and select the digital channels he would like to choose. On my side I have been trying to show how we could integrate without to much effort this kind of communication in a liveblog.

<img width="1008" alt="screen shot 2016-01-17 at 03 22 43" src="https://cloud.githubusercontent.com/assets/615085/12376002/e4e55c96-bcd5-11e5-87ce-051831042d11.png">

Frankly the code is a bit messy, and I have been fighting quite a lot with the kind of transition state liveblog rendering currently is (using the blocks in some part and the article body in another) but doing so was much more interesting than doing it directly inside the Content API (allowing me as well to have those changes only to our web frontend).

Anyway those changes are not intended to be merged, but document how the demo has been set up.
