### PR TITLE
Update email article AB test with keyword blacklist

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -36,7 +36,7 @@ trait ABTestSwitches {
     "ab-rtrt-email-form-article-promo-v2",
     "Testing the email sign up from the bottom of articles of user referred from fronts",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 1, 21),
+    sellByDate = new LocalDate(2016, 2, 3),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
@@ -8,7 +8,8 @@ define([
     'common/utils/detect',
     'lodash/collections/contains',
     'common/utils/config',
-    'lodash/collections/every'
+    'lodash/collections/every',
+    'lodash/collections/some'
 ], function (
     $,
     bean,
@@ -47,10 +48,15 @@ define([
                 browser = detect.getUserAgent.browser,
                 version = detect.getUserAgent.version,
                 allArticleEls = $('> *', $articleBody),
-                lastFiveElsParas = every([].slice.call(allArticleEls, allArticleEls.length - 5), isParagraph);
+                lastFiveElsParas = every([].slice.call(allArticleEls, allArticleEls.length - 5), isParagraph),
+                pageIsBlacklisted = contains(config.page.keywords.split(','), 'NHS');
 
             // User referred from a front, is not logged in and not lte IE9
-            return lastFiveElsParas && urlRegex.test(document.referrer) && !Id.isUserLoggedIn() && !(browser === 'MSIE' && contains(['7','8','9'], version + ''));
+            return !pageIsBlacklisted &&
+                    lastFiveElsParas &&
+                    urlRegex.test(document.referrer) &&
+                    !Id.isUserLoggedIn() &&
+                    !(browser === 'MSIE' && contains(['7','8','9'], version + ''));
         };
 
         function injectEmailForm($position, typeOfInsert) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
@@ -8,8 +8,7 @@ define([
     'common/utils/detect',
     'lodash/collections/contains',
     'common/utils/config',
-    'lodash/collections/every',
-    'lodash/collections/some'
+    'lodash/collections/every'
 ], function (
     $,
     bean,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
@@ -24,7 +24,7 @@ define([
     return function () {
         this.id = 'RtrtEmailFormArticlePromoV2';
         this.start = '2015-12-17';
-        this.expiry = '2016-01-21';
+        this.expiry = '2016-02-03';
         this.author = 'Gareth Trufitt';
         this.description = 'Test promotion of email form at bottom vs three paragraphs from end of article pages (when clicked from front)';
         this.audience = 1;


### PR DESCRIPTION
Avoid showing the Guardian Today email form on NHS pages to avoid clash with their own email campaign
