### PR TITLE
Add guard to rtrt ab test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
@@ -48,7 +48,8 @@ define([
                 version = detect.getUserAgent.version,
                 allArticleEls = $('> *', $articleBody),
                 lastFiveElsParas = every([].slice.call(allArticleEls, allArticleEls.length - 5), isParagraph),
-                pageIsBlacklisted = contains(config.page.keywords.split(','), 'NHS');
+                keywords = config.page.keywords ? config.page.keywords.split(',') : "",
+                pageIsBlacklisted = contains(keywords, 'NHS');
 
             // User referred from a front, is not logged in and not lte IE9
             return !pageIsBlacklisted &&

--- a/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/rtrt-email-form-article-promo.js
@@ -48,7 +48,7 @@ define([
                 version = detect.getUserAgent.version,
                 allArticleEls = $('> *', $articleBody),
                 lastFiveElsParas = every([].slice.call(allArticleEls, allArticleEls.length - 5), isParagraph),
-                keywords = config.page.keywords ? config.page.keywords.split(',') : "",
+                keywords = config.page.keywords ? config.page.keywords.split(',') : '',
                 pageIsBlacklisted = contains(keywords, 'NHS');
 
             // User referred from a front, is not logged in and not lte IE9


### PR DESCRIPTION
This test is causing issues on profile pages (these pages don't have a `keywords` key)
