### PR TITLE
Remove expired bounce test

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -233,13 +233,4 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
-  val NoBounceIndicator = Switch(
-    "Performance",
-    "no-bounce-indicator",
-    "If this switch is on then some beacons will be dropped to gauge if people move onto a new piece of content before Omniture runs",
-    safeState = On,
-    sellByDate = new LocalDate(2016, 1, 20),
-    exposeClientSide = true
-  )
-
 }

--- a/common/app/templates/inlineJS/blocking/analytics.scala.js
+++ b/common/app/templates/inlineJS/blocking/analytics.scala.js
@@ -1,7 +1,6 @@
 @()
 @import conf.Static
 @import org.joda.time.DateTime
-@import conf.switches.Switches.NoBounceIndicator
 
 try {
 
@@ -169,14 +168,6 @@ try {
 
                 var pageView = new Image();
                 pageView.src = "@{Configuration.debug.beaconUrl}/count/pva.gif";
-
-                if (guardian.isModernBrowser && @NoBounceIndicator.isSwitchedOn) {
-                    try {
-                        window.sessionStorage.removeItem('gu-bounce-test');
-                    } catch (e) { }
-                }
-
-
             }
         }, 100);
 

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -3,7 +3,6 @@
 @import common.AnalyticsHost
 @import views.support.{OmnitureAnalyticsData, OmnitureAnalyticsAccount}
 @import conf.Static
-@import conf.switches.Switches.NoBounceIndicator
 
 @defining(s"${request.host}${request.path}") { path =>
 
@@ -45,28 +44,3 @@
 </noscript>
 
 <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
-
-@if(NoBounceIndicator.isSwitchedOn) {
-    @* NOTE for removal - there is a corresponding entry in omniture.js *@
-    <script type="text/javascript">
-
-        @* Limit to "modern browsers" *@
-        if (guardian.isModernBrowser) {
-            try {
-                @* sessionStorage is part of the isModernBrowser test *@
-                var session = window.sessionStorage;
-
-                @*
-                    If this key is still present then the user went to a new page before Omniture ran
-                    and we did not count the page view
-                *@
-                if (session.getItem('gu-bounce-test') === 'true') {
-                    var img = new Image();
-                    img.src = '@{Configuration.debug.beaconUrl}/count/user-navigated-early.gif';
-                }
-
-                session.setItem('gu-bounce-test', 'true');
-            } catch (e) {};
-        }
-    </script>
-}

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -13,15 +13,11 @@ object Metric extends Logging {
 
   lazy val namespace = "Diagnostics"
 
-  // TODO delete bounce-test-present when this goes
-  import conf.switches.Switches.NoBounceIndicator
-
   lazy val metrics = Map(
 
     // page views
     ("pv", CountMetric("kpis-page-views")),            // raw page views - simple <img> in body, no javascript involved
     ("pva", CountMetric("kpis-analytics-page-views")), // page view fires after analytics
-    ("user-navigated-early", CountMetric("user-navigated-early")),
     ("omniture-library-error", CountMetric("omniture-library-error")),
     ("omniture-pageview-error", CountMetric("omniture-pageview-error")),
 


### PR DESCRIPTION
This switch has now expired. We should still be measuring this, we need more detail about the time when the page view has registered.
