### PR TITLE
Discussion report abuse - return 200 in error cases

### DIFF
--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -114,13 +114,13 @@ object CommentsController extends DiscussionController with ExecutionContexts {
     Action.async { implicit request =>
     val scGuU = request.cookies.get("SC_GU_U")
       userForm.bindFromRequest.fold(
-        formWithErrors => Future.successful(BadRequest(views.html.discussionComments.reportComment(commentId, reportAbusePage, formWithErrors))),
+        formWithErrors => Future.successful(Ok(views.html.discussionComments.reportComment(commentId, reportAbusePage, formWithErrors))),
         userData => {
           postAbuseReportToDiscussionApi(userData, scGuU).map {
             case success if success.status == 200 => NoCache(Redirect(routes.CommentsController.reportAbuseThankYou(commentId)))
-            case error => InternalServerError(views.html.discussionComments.reportComment(commentId, reportAbusePage, userForm.fill(userData), errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage)))
+            case error => Ok(views.html.discussionComments.reportComment(commentId, reportAbusePage, userForm.fill(userData), errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage)))
           }.recover({
-            case NonFatal(e) => InternalServerError(views.html.discussionComments.reportComment(commentId, reportAbusePage, userForm.fill(userData), errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage)))
+            case NonFatal(e) => Ok(views.html.discussionComments.reportComment(commentId, reportAbusePage, userForm.fill(userData), errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage)))
           })
 
         }


### PR DESCRIPTION
Previously if there was an error in form validation or in the server-side DAPI response we returned either a `400` or `500` response. However, those were being intercepted by the router and displaying the generic error page, rather than returning the form with the errors highlighted, so now we return a `200` regardless of the outcome of the form submission.

CC @guardian/discussion @rich-nguyen 
