### PR TITLE
test top banner transition hunch

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyRenderConditions.scala.js
@@ -87,6 +87,15 @@
         }
     }
 
+    (function (window) {
+        try {
+            var bannerPref = JSON.parse(window.localStorage.getItem('gu.prefs.no-banner-transition')).value;
+            if (bannerPref) {
+                docClass += ' no-banner-transition';
+            }
+        } catch (e) {};
+    })(window);
+
     // MINIMISE DOM THRASHING…
 
     // READs

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -124,9 +124,10 @@
     transform: translateZ(0);
     transition: height 1s cubic-bezier(0, 0, 0, .985);
 
-    .new-sticky-ad & {
-        // overwrite if in the new sticky ad AB test
+    .new-sticky-ad &, // overwrite if in the new sticky ad AB test
+    .no-banner-transition & {
         transition: none;
+        transform: none;
     }
 }
 .top-banner-ad-container--above-nav {


### PR DESCRIPTION
this is just a pref to test a hunch that transitioning the height of the top banner contributes to crashes we're currently seeing. 

i cannot reproduce the crashes, but if people who see them constantly report a change with this pref, i'll beacon it to see if anything wider can be detected. 

if not, i'll just remove it.

optin with http://www.theguardian.com/uk#gu.prefs.no-banner-transition=true

cc @gtrufitt 
