### PR TITLE
Remove "more galleries" component in paid-content-redesign

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -37,7 +37,7 @@
         </div>
     </article>
 
-    @if(gallery.content.showInRelated) {
+    @if(gallery.content.showInRelated && !(gallery.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn) ) {
         <div class="gallery__most-popular facia-container fc-container--media hide-on-childrens-books-site">
             <div class="js-gallery-most-popular tonal--@toneClass(gallery)">
                 <div class="fc-container">

--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -37,7 +37,8 @@
         </div>
     </article>
 
-    @if(gallery.content.showInRelated && !(gallery.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn) ) {
+    @if(gallery.content.showInRelated &&
+        !(gallery.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn) ) {
         <div class="gallery__most-popular facia-container fc-container--media hide-on-childrens-books-site">
             <div class="js-gallery-most-popular tonal--@toneClass(gallery)">
                 <div class="fc-container">


### PR DESCRIPTION
This is part of the paid content redesign. It is a small change to hide the 'more galleries' component when a gallery is paid for by a client (because those links take the user away from partner content).

@Calanthe 
