### PR TITLE
add azed to types in crossword search page

### DIFF
--- a/applications/app/crosswords/CrosswordPage.scala
+++ b/applications/app/crosswords/CrosswordPage.scala
@@ -50,7 +50,8 @@ final case class CrosswordSearchPage(override val metadata: MetaData) extends St
     "quiptic",
     "genius",
     "speedy",
-    "everyman"
+    "everyman",
+    "azed"
   )
 
   val setters: Seq[String] = Seq(

--- a/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordSearchForm.scala.html
@@ -74,7 +74,7 @@
                     <li class="form-field">
                         <label class="label" for="crossword_type">Type</label>
                         <select id="crossword_type" name="crossword_type">
-                        @page.crosswordTypes.map { crosswordType =>
+                        @page.crosswordTypes.filterNot( _ == "azed" ).map { crosswordType =>
                             <option value="@crosswordType">@crosswordType</option>
                         }
                         </select>


### PR DESCRIPTION
Adds azed crosswords to the search form here: http://www.theguardian.com/crosswords/search. 

Since there's still a lode of missing azeds in the api ( see http://www.theguardian.com/crosswords/series/azed ) and they're rendered at normal articles(with a different form of URL to other crosswords), rather than crosswords, we'll continue to exclude them from the lookup form until we can implement a workable solution (I've run this by @ScottPainterGNM and @crifmulholland ): 

What you think @desbo ? 
