### PR TITLE
AMP tones 

### DIFF
--- a/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
+++ b/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
@@ -2,7 +2,7 @@
 @import conf.Configuration
 
 @* must be served by localhost, not thegulocal *@
-<amp-list layout="fixed-height" height="188" src="@Configuration.ajax.url/@path">
+<amp-list layout="fixed-height" height="188" src="@Configuration.ajax.url/@path" class="onward-list">
     <template type="amp-mustache">
         {{#showContent}}
             <div class="fc-container__inner">

--- a/common/app/views/fragments/amp/stylesheets/onward.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/onward.scala.html
@@ -1,3 +1,7 @@
+.onward-list {
+    clear: both;
+}
+
 .fc-container__inner {
     border-top: 0.0625rem solid #4bc6df;
     padding-top: 0.1875rem;
@@ -88,4 +92,3 @@
         line-height: 18px;
     }
 }
-

--- a/common/app/views/fragments/amp/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/tones.scala.html
@@ -348,7 +348,7 @@ color: #21a2bc;
 }
 
 .fc-item.tone-special-report {
-    border-top-color: #63717a;
+    border-top-color: #aad8f1;
 }
 
 .fc-item.tone-comment {

--- a/common/app/views/fragments/amp/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/tones.scala.html
@@ -82,7 +82,8 @@
 }
 
 .tonal--tone-special-report .tonal__header,
-.fc-item.tone-special-report--item {
+.fc-item.tone-special-report--item,
+.fc-item.tone-special-report {
     background-color: #63717a;
 }
 
@@ -206,7 +207,8 @@
 .tone-media--item .fc-item__title,
 .tone-review--item .fc-item__title,
 .tone-live--item .fc-item__title,
-.tone-special-report--item .fc-item__title {
+.tone-special-report--item .fc-item__title,
+.tone-special-report .fc-item__title {
     color: #fff;
 }
 
@@ -331,7 +333,8 @@ color: #21a2bc;
 }
 
 .fc-item.tone-review--item .fc-item__meta,
-.fc-item.tone-special-report--item .fc-item__meta {
+.fc-item.tone-special-report--item .fc-item__meta,
+.fc-item.tone-special-report .fc-item__meta{
     color: #dcdcdc;
 }
 
@@ -342,6 +345,10 @@ color: #21a2bc;
 .fc-item.tone-live--item,
 .fc-item.tone-feature {
     border-top-color: #fdadba;
+}
+
+.fc-item.tone-special-report {
+    border-top-color: #63717a;
 }
 
 .fc-item.tone-comment {


### PR DESCRIPTION
Added special report tone to onward journeys in AMP. 

![screen shot 2016-01-20 at 14 45 19](https://cloud.githubusercontent.com/assets/14570016/12452086/8efddb8a-bf84-11e5-962f-e684ba390dec.png)

Also prevented them from wrapping if close to an ad:

![screen shot 2016-01-20 at 14 45 28](https://cloud.githubusercontent.com/assets/14570016/12452092/99a4b450-bf84-11e5-9fd4-71648e1fc22b.png)

FAO @NataliaLKB 
