### PR TITLE
Onward Journeys on AMP only take 4 stories, 5 for popular

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -182,8 +182,13 @@
     }
 
     .logo-wrapper {
-        float: right;
-        margin: 0.1875rem 0.625rem 0.34rem 0;
+        display: block;
+        padding: 0.5rem;
+    }
+
+    .logo-wrapper svg {
+        display: block;
+        margin: 0 auto;
     }
 
     .from-content-api h2, .from-content-api .block-elements h2, .from-content-api p strong {

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -66,8 +66,8 @@
                 }
             }
 
-            @fragments.amp.onwardTemplateAmp("container-mf2/1/0/international.json")
             @fragments.amp.onwardTemplateAmp("most-read-mf2.json")
+            @fragments.amp.onwardTemplateAmp("container-mf2/1/0/international.json")
             @fragments.amp.onwardTemplateAmp("container-mf2/1/1/international.json")
             @fragments.amp.onwardTemplateAmp("container-mf2/1/2/international.json")
 

--- a/common/app/views/support/FaciaToMicroFormat2Helpers.scala
+++ b/common/app/views/support/FaciaToMicroFormat2Helpers.scala
@@ -11,7 +11,7 @@ object FaciaToMicroFormat2Helpers {
       "href" -> pressedCollection.href,
       "id" -> pressedCollection.id,
       "showContent" -> pressedCollection.curatedPlusBackfillDeduplicated.nonEmpty,
-      "content" -> pressedCollection.curatedPlusBackfillDeduplicated.take(8).map(isCuratedContent))
+      "content" -> pressedCollection.curatedPlusBackfillDeduplicated.take(4).map(isCuratedContent))
 
   def isCuratedContent(content: PressedContent): JsValue = content match {
     case c: CuratedContent => getContent(c)

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -84,7 +84,7 @@ object MostPopularController extends Controller with Logging with ExecutionConte
 
   def renderPopularMicroformat2 = Action { implicit request =>
     val edition = Edition(request)
-    val mostPopular = MostPopularAgent.mostPopular(edition)
+    val mostPopular = MostPopularAgent.mostPopular(edition) take 5
 
     Cached(900) {
       JsonComponent(


### PR DESCRIPTION
On mobile, there are just too make stories to scroll through at the bottom of an article. this makes it so there are only 4 that show per section except for popular which shows 5. This is because it seems weird to show "top 4", "top 5" is better.

cc @stephanfowler 
