### PR TITLE
Small tweaks to feedback wording

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -25,8 +25,8 @@
                                             If not, to help our developers improve the site, send comments to
                                             <a class="js-tech-feedback-mailto" data-link-name="tech feedback : mailto : dotcom" href="mailto:dotcom.feedback@@theguardian.com">
                                                 dotcom.feedback@@theguardian.com
-                                            </a>.
-                                            <strong>We value all feedback but we are unable to respond directly.</strong>
+                                            </a>.<br>
+                                            <strong>We value and read all of the feedback that we receive, but we are unable to respond directly.</strong>
                                         </p>
                                         <p>If you need help, please contact our user support desk at
                                             <a class="js-userhelp-mailto" data-link-name="tech feedback : mailto : userhelp" href="mailto:userhelp@@theguardian.com">


### PR DESCRIPTION
@johnduffell 

Reasoning behind this is that many people leave feedback that can be a little blue to say the least, then when we reply they are embarrassed as assumed they were shouting into the void. Just tweaking the wording to make it a little more clear that we do read everything (just don't necessarily commit to responding).
