### PR TITLE
make liveblog key event links scroll correctly

### DIFF
--- a/article/app/views/liveblog/keyEvents.scala.html
+++ b/article/app/views/liveblog/keyEvents.scala.html
@@ -3,7 +3,7 @@
 
 @keyEvents.map { keyEvent =>
     <li class="timeline__item" data-event-id="@keyEvent.id">
-        <a class="timeline__link" href="@id#block-@keyEvent.id" data-event-id="@keyEvent.id">
+        <a class="timeline__link" href="@id#block-@keyEvent.id" data-event-id="block-@keyEvent.id">
             <span class="timeline__date">@views.html.liveblog.dateBlock(keyEvent.time)</span><span class="timeline__title u-underline">@keyEvent.title</span>
         </a>
     </li>

--- a/article/app/views/liveblog/keyEvents.scala.html
+++ b/article/app/views/liveblog/keyEvents.scala.html
@@ -2,7 +2,7 @@
 @(id: String, keyEvents: Seq[KeyEventData])
 
 @keyEvents.map { keyEvent =>
-    <li class="timeline__item" data-event-id="@keyEvent.id">
+    <li class="timeline__item">
         <a class="timeline__link" href="@id#block-@keyEvent.id" data-event-id="block-@keyEvent.id">
             <span class="timeline__date">@views.html.liveblog.dateBlock(keyEvent.time)</span><span class="timeline__title u-underline">@keyEvent.title</span>
         </a>


### PR DESCRIPTION
Key events are scrolling to the top on click, but they should scroll to the right block.
