### PR TITLE
Say 'fearless' not 'free' in membership banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -37,7 +37,7 @@ define([
             data: {
                 messageText: [
                     'Thank you for reading the Guardian.',
-                    'Help keep our journalism free and independent by becoming a Supporter for just £5 a month.'
+                    'Help keep our journalism fearless and independent by becoming a Supporter for just £5 a month.'
                 ].join(' '),
                 linkText: 'Join'
             }


### PR DESCRIPTION
#### Before

![picture 124](https://cloud.githubusercontent.com/assets/5122968/12479640/6acb0958-c034-11e5-869f-3aec741408d5.png)
#### After

![picture 125](https://cloud.githubusercontent.com/assets/5122968/12479858/f786bd0a-c035-11e5-9f5a-5698e920c0a7.png)

@Calanthe
