### PR TITLE
Improve grid alignment of new sponsored content containers

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,10 +1,11 @@
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties = model.FrontProperties.empty)(implicit request: RequestHeader)
 
 @import common.dfp.{Keyword, Series}
+@import conf.switches.Switches
 @import layout.MetaDataHeader
 @import slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList}
 @import views.html.fragments.containers.facia_cards.{commercialContainer, containerMetaData, mostPopularContainer, navListContainer, navMediaListContainer, standardContainer}
-@import views.support.GetClasses
+@import views.support.{GetClasses, RenderClasses}
 
 @defining((containerDefinition.displayName, containerDefinition.faciaComponentName)) { case (title, componentName) =>
     @containerDefinition.customHeader.map {
@@ -38,28 +39,39 @@
                 }
              }
 
-        <div class="fc-container__inner">
             @containerDefinition.container match {
                 case _: Dynamic | _: Fixed => {
-                    @standardContainer(containerDefinition, frontProperties)
+                    <div class="fc-container__inner">
+                        @standardContainer(containerDefinition, frontProperties)
+                    </div>
                 }
 
                 case NavList => {
-                    @navListContainer(containerDefinition, frontProperties)
+                    <div class="fc-container__inner">
+                        @navListContainer(containerDefinition, frontProperties)
+                    </div>
                 }
 
                 case NavMediaList => {
-                    @navMediaListContainer(containerDefinition, frontProperties)
+                    <div class="fc-container__inner">
+                        @navMediaListContainer(containerDefinition, frontProperties)
+                    </div>
                 }
 
                 case MostPopular => {
-                    @mostPopularContainer(containerDefinition, frontProperties)
+                    <div class="fc-container__inner">
+                        @mostPopularContainer(containerDefinition, frontProperties)
+                    </div>
                 }
 
                 case slices.Commercial(container) => {
-                    @commercialContainer(container, containerDefinition, frontProperties)
+                    <div class="@RenderClasses(
+                        Map("fc-container__inner--full-span fc-container__inner--paidfor" -> Switches.NewCommercialContent.isSwitchedOn),
+                        "fc-container__inner"
+                    )">
+                        @commercialContainer(container, containerDefinition, frontProperties)
+                    </div>
                 }
             }
-        </div>
     </section>
 }

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -1,6 +1,12 @@
 /* ==========================================================================
    Paid for component
    ========================================================================== */
+
+.fc-container .fc-container__inner--paidfor {
+    border: none;
+    padding: 0;
+}
+
 .commercial--paidfor {
 
     .commercial__header,
@@ -55,6 +61,7 @@
     .lineitems {
         display: flex;
         flex-flow: row nowrap;
+        width: auto;
     }
 
     .lineitem {

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -15,6 +15,10 @@
         @include f-headlineSans;
     }
 
+    .commercial__body {
+        padding-top: $gs-gutter / 2;
+    }
+
     .rich-link__standfirst {
         @include fs-textSans(4);
     }

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .fc-container .fc-container__inner--paidfor {
-    border: none;
+    border: 0;
     padding: 0;
 }
 


### PR DESCRIPTION
They used to look like this...

![image](https://cloud.githubusercontent.com/assets/3148617/12480403/fe131c1e-c039-11e5-89af-842953060b0f.png)

Now they look like this...

_Desktop_
![image](https://cloud.githubusercontent.com/assets/3148617/12481184/5707d42c-c03f-11e5-9386-d7d01f559bb4.png)

_Tablet_
![image](https://cloud.githubusercontent.com/assets/3148617/12481222/85534b22-c03f-11e5-9486-13245742790f.png)

_Mobile_
![image](https://cloud.githubusercontent.com/assets/3148617/12481213/77add4a6-c03f-11e5-858c-86761c4cf3b7.png)

I still need to fix the styling of the 'paid for' logos. This PR just handles the layout of the boxes.

I'm not sure if the way I've done this is the best possible. I'm not terribly au fait with Scala or Play templates, so I'm happy to hear any suggestions about a better approach.

@Calanthe 
