### PR TITLE
Add frontend profile name to project AWSCredentialsProviderChain

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -414,6 +414,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       val provider = new AWSCredentialsProviderChain(
         new EnvironmentVariableCredentialsProvider(),
         new SystemPropertiesCredentialsProvider(),
+        new ProfileCredentialsProvider("frontend"),
         new ProfileCredentialsProvider("nextgen"),
         new InstanceProfileCredentialsProvider
       )

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -5,6 +5,15 @@ import org.joda.time.LocalDate
 
 trait FeatureSwitches {
 
+  val AWSCredentialsProfileSwitchOver = Switch(
+    "Feature",
+    "aws-credentials-switchover",
+    "Switch to remind us to remove the 'nextgen' profile from the default AWS credentials provider chain",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 2, 2), //Tuesday
+    exposeClientSide = false
+  )
+
   val FixturesAndResultsContainerSwitch = Switch(
     "Feature",
     "fixtures-and-results-container",


### PR DESCRIPTION
The default profile in `janus` is `frontend` for our project.

This is an annoying mismatch; you CAN change the profile in `janus` and I have added `localStorage` caching for it and also added `--alias <profileName>` to `feria`, but I think the real fix is to align with `janus`.

@rich-nguyen Not sure whether to leave `nextgen` profile and have `frontend` take precedence over `nextgen` or just remove it. Thoughts?

See https://github.com/guardian/feria/pull/3 and https://github.com/guardian/janus/pull/191

Goo tool is also on `nextgen`, I will PR this also.
