### PR TITLE
Make GLab image links accessible

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -37,7 +37,10 @@
                                 } else {
                                     href="@LinkTo("/guardian-labs")"
                                 }
-                                >@inlineSvg("glabs-logo", "logo")</a>
+                                >
+                                @inlineSvg("glabs-logo", "logo")
+                                <span class='u-h'>Guardian Labs</span>
+                            </a>
                         </div>
                         <div class="commercial__body">
                             <ul class="lineitems l-row l-row--cols-4 js-container__header">

--- a/common/app/views/fragments/guBand.scala.html
+++ b/common/app/views/fragments/guBand.scala.html
@@ -26,6 +26,7 @@
                 href="@LinkTo("/guardian-labs")"
             }>
             @fragments.inlineSvg("glabs-logo", "logo")
+            <span class='u-h'>Guardian Labs</span>
         </a>
     </div>
 </div>


### PR DESCRIPTION
This is another change for the sponsored content redesign. We add unseen anchor text for the sake of screenreaders.
