### PR TITLE
Editionalise life and style

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -24,7 +24,8 @@ abstract class Edition(
       "technology",
       "media",
       "environment",
-      "film"
+      "film",
+      "lifeandstyle"
     )
   ) extends Navigation {
 


### PR DESCRIPTION
Adds lifeandstyle section to the editionalised list, so UK, US and AU users who go to `/lifeandstyle` will be redirected to `/uk/lifeandstyle`
