### PR TITLE
Test moving omniture to the footer

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -14,6 +14,15 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
+  val NonBlockingOmniture = Switch(
+    "Performance",
+    "non-blocking-omniture",
+    "If this switch is on, omniture will be inlined in the footer. If it is off, it will be inlined in the head",
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
   // Performance
   val LazyLoadContainersSwitch = Switch(
     "Performance",

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -3,6 +3,17 @@
 @import common.AnalyticsHost
 @import views.support.{OmnitureAnalyticsData, OmnitureAnalyticsAccount}
 @import conf.Static
+@import conf.switches.Switches.NonBlockingOmniture
+@import common.InlineJs
+
+@if(NonBlockingOmniture.isSwitchedOn) {
+    @fragments.omnitureScript(Some(page.metadata))
+
+    <script>
+        // analytics code
+        @InlineJs(templates.inlineJS.blocking.js.analytics().body, "analytics.js")
+    </script>
+}
 
 @defining(s"${request.host}${request.path}") { path =>
 

--- a/common/app/views/fragments/inlineJSBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSBlocking.scala.html
@@ -7,7 +7,9 @@
     <script src="@Static("javascripts/components/html5shiv/html5shiv.js")"></script>
 <![endif]-->
 
-@fragments.omnitureScript(Some(page.metadata))
+@if(NonBlockingOmniture.isSwitchedOff) {
+    @fragments.omnitureScript(Some(page.metadata))
+}
 
 @* NOTE the order of these includes is important  *@
 <script id="gu">
@@ -38,8 +40,10 @@
     // page config
     @Html(config(page).body)
 
-    // analytics code
-    @InlineJs(analytics().body, "analytics.js")
+    @if(NonBlockingOmniture.isSwitchedOff) {
+        // analytics code
+        @InlineJs(analytics().body, "analytics.js")
+    }
 
     // apply render conditions
     @InlineJs(applyRenderConditions().body, "applyRenderConditions.js")

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -94,9 +94,19 @@ http://developers.theguardian.com/join-the-team.html
 
         @fragments.footer(page)
 
-        @fragments.analytics(page)
+        @if(NonBlockingOmniture.isSwitchedOn) {
 
-        @fragments.inlineJSNonBlocking()
+            @fragments.inlineJSNonBlocking()
+
+            @fragments.analytics(page)
+
+        } else {
+
+            @fragments.analytics(page)
+
+            @fragments.inlineJSNonBlocking()
+
+        }
 
         @fragments.commercial.pageSkin()
 


### PR DESCRIPTION
This PR tests moving Omniture calls to the footer of the page, rather than the head.
This is in preparation for moving from two Omniture calls back to one.
We will test this for around 30 mins to check the impact against omniture confidence.

@mkopka @sndrs 
