### PR TITLE
Add email article module moving AB test functionality perm

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -348,4 +348,13 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = false
   )
+
+  val EmailInArticleSwitch = Switch(
+    "Feature",
+    "email-in-article",
+    "When ON, the email sign-up form will show on articles matching the email lists utilising the email module",
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -353,7 +353,9 @@ define([
                 email.init();
 
                 // Initalise email insertion into articles
-                emailArticle.init();
+                if (config.switches.emailInArticle){
+                    emailArticle.init();
+                }
 
                 // Initalise email forms in iframes
                 forEach(document.getElementsByClassName('js-email-sub__iframe'), function (el) {

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -353,7 +353,7 @@ define([
                 email.init();
 
                 // Initalise email insertion into articles
-                if (config.switches.emailInArticle){
+                if (config.switches.emailInArticle) {
                     emailArticle.init();
                 }
 

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -53,6 +53,7 @@ define([
     'common/modules/save-for-later',
     'common/modules/commercial/membership-messages',
     'common/modules/email/email',
+    'common/modules/email/email-article',
     'text!common/views/international-message.html',
     'bootstraps/enhanced/identity-common',
     'lodash/collections/forEach'
@@ -109,6 +110,7 @@ define([
     SaveForLater,
     membershipMessages,
     email,
+    emailArticle,
     internationalMessage,
     identity,
     forEach) {
@@ -347,7 +349,11 @@ define([
             },
 
             initEmail: function () {
+                // Initalise email embedded in page
                 email.init();
+
+                // Initalise email insertion into articles
+                emailArticle.init();
 
                 // Initalise email forms in iframes
                 forEach(document.getElementsByClassName('js-email-sub__iframe'), function (el) {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -51,14 +51,15 @@ define([
         },
         addListToPage = function (listConfig) {
             if (listConfig) {
-                var iframe = bonzo.create(template(iframeTemplate, listConfig))[0];
+                var iframe = bonzo.create(template(iframeTemplate, listConfig))[0],
+                    $iframeEl = $(iframe);
 
                 bean.on(iframe, 'load', function () {
                     email.init(iframe);
                 });
 
                 fastdom.write(function () {
-                    $(iframe).appendTo($articleBody);
+                    $iframeEl.appendTo($articleBody);
                 });
 
                 emailInserted = true;

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -28,7 +28,7 @@ define([
             nhs: {
                 listId: '3573',
                 canRun: 'nhs',
-                campaignCode: 'inArticleNhs',
+                campaignCode: 'NHS_in_article',
                 headline: 'Interested in the NHS?',
                 description: 'Sign up to email updates related to the Guardian\'s coverage of the NHS, including daily updates as the project develops',
                 successHeadline: 'Thank you for signing up to our NHS email updates',

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -56,6 +56,8 @@ define([
                 fastdom.write(function () {
                     $(iframe).appendTo($articleBody);
                 });
+
+                emailInserted = true;
             }
         },
         canRunGlobal = {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -9,7 +9,9 @@ define([
     'lodash/collections/contains',
     'common/utils/config',
     'lodash/collections/every',
-    'lodash/collections/find'
+    'lodash/collections/find',
+    'text!common/views/email/iframe.html',
+    'common/utils/template'
 ], function (
     $,
     bean,
@@ -21,7 +23,9 @@ define([
     contains,
     config,
     every,
-    find
+    find,
+    iframeTemplate,
+    template
 ) {
 
     var listConfigs = {
@@ -47,7 +51,7 @@ define([
         },
         addListToPage = function (listConfig) {
             if (listConfig) {
-                var iframe = bonzo.create('<iframe src="/email/form/article/' + listConfig.listId + '" height="218px" data-form-title="' + listConfig.headline + '" data-form-description="' + listConfig.description + '" data-form-campaign-code="' + listConfig.campaignCode + '" scrolling="no" seamless frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"' + ' data-form-success-headline="' + listConfig.successHeadline + '" data-form-success-desc="' + listConfig.successDescription + '"></iframe>')[0];
+                var iframe = bonzo.create(template(iframeTemplate, listConfig))[0];
 
                 bean.on(iframe, 'load', function () {
                     email.init(iframe);

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -29,10 +29,10 @@ define([
                 listId: '3573',
                 canRun: 'nhs',
                 campaignCode: '',
-                headline: 'NHS',
-                description: 'This is the NHS',
-                successHeadline: '',
-                successDescription: ''
+                headline: 'Interested in the NHS?',
+                description: 'Sign up to email updates related to the Guardian\'s coverage of the NHS, including daily updates as the project develops',
+                successHeadline: 'Thank you for signing up to our NHS email updates',
+                successDescription: 'You\'ll receive daily updates in your inbox'
             }
         },
         $articleBody,

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -1,0 +1,100 @@
+define([
+    'common/utils/$',
+    'bean',
+    'bonzo',
+    'common/modules/identity/api',
+    'fastdom',
+    'common/modules/email/email',
+    'common/utils/detect',
+    'lodash/collections/contains',
+    'common/utils/config',
+    'lodash/collections/every',
+    'lodash/collections/find'
+], function (
+    $,
+    bean,
+    bonzo,
+    Id,
+    fastdom,
+    email,
+    detect,
+    contains,
+    config,
+    every,
+    find
+) {
+
+    var listConfigs = {
+            nhs: {
+                listId: '3573',
+                canRun: 'nhs',
+                campaignCode: '',
+                headline: 'NHS',
+                description: 'This is the NHS',
+                successHeadline: '',
+                successDescription: ''
+            }
+        },
+        $articleBody,
+        emailInserted = false,
+        isParagraph = function ($el) {
+            return $el.nodeName && $el.nodeName === 'P';
+        },
+        listCanRun = function (listConfig) {
+            if (canRunList[listConfig.canRun]()) {
+                return listConfig;
+            }
+        },
+        addListToPage = function (listConfig) {
+            if (listConfig) {
+                var iframe = bonzo.create('<iframe src="/email/form/article/' + listConfig.listId + '" height="218px" data-form-title="' + listConfig.headline + '" data-form-description="' + listConfig.description + '" data-form-campaign-code="' + listConfig.campaignCode + '" scrolling="no" seamless frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" data-form-success-desc="' + listConfig.successDescription + '"></iframe>')[0];
+
+                bean.on(iframe, 'load', function () {
+                    email.init(iframe);
+                });
+
+                fastdom.write(function () {
+                    $(iframe).appendTo($articleBody);
+                });
+            }
+        },
+        canRunGlobal = {
+            cameFromFronts: function () {
+                var host = window.location.host,
+                    escapedHost = host.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), // Escape anything that will mess up the regex
+                    urlRegex = new RegExp('^https?:\/\/' + escapedHost + '\/(uk\/|us\/|au\/|international\/)?([a-z-])+$', 'gi');
+
+                return urlRegex.test(document.referrer);
+            },
+            allowedUser: function () {
+                var browser = detect.getUserAgent.browser,
+                    version = detect.getUserAgent.version;
+
+                return !(browser === 'MSIE' && contains(['7','8','9'], version + ''))
+                        && !Id.isUserLoggedIn();
+            },
+            allowedArticleStructure: function () {
+                $articleBody = $('.js-article__body');
+
+                var allArticleEls = $('> *', $articleBody),
+                emailAlreadyInArticle = $('js-email-sub__iframe', $articleBody).length > 0,
+                lastFiveElsParas = every([].slice.call(allArticleEls, allArticleEls.length - 5), isParagraph);
+
+                return !emailAlreadyInArticle && lastFiveElsParas;
+            }
+        },
+        canRunList = {
+            nhs: function () {
+                var keywords = config.page.keywords ? config.page.keywords.split(',') : '';
+                return contains(keywords, 'NHS');
+            }
+        };
+
+    return {
+        init: function () {
+            if (!emailInserted && canRunGlobal.cameFromFronts() && canRunGlobal.allowedUser() && canRunGlobal.allowedArticleStructure()) {
+                addListToPage(find(listConfigs, listCanRun));
+            }
+        }
+    };
+});

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -41,7 +41,7 @@ define([
             return $el.nodeName && $el.nodeName === 'P';
         },
         listCanRun = function (listConfig) {
-            if (canRunList[listConfig.canRun]()) {
+            if (listConfig.canRun && canRunList[listConfig.canRun]()) {
                 return listConfig;
             }
         },
@@ -64,11 +64,15 @@ define([
             allowedArticleStructure: function () {
                 $articleBody = $('.js-article__body');
 
-                var allArticleEls = $('> *', $articleBody),
-                emailAlreadyInArticle = $('js-email-sub__iframe', $articleBody).length > 0,
-                lastFiveElsParas = every([].slice.call(allArticleEls, allArticleEls.length - 5), isParagraph);
+                if ($articleBody.length) {
+                    var allArticleEls = $('> *', $articleBody),
+                        emailAlreadyInArticle = $('js-email-sub__iframe', $articleBody).length > 0,
+                        lastFiveElsParas = every([].slice.call(allArticleEls, allArticleEls.length - 5), isParagraph);
 
-                return !emailAlreadyInArticle && lastFiveElsParas;
+                    return !emailAlreadyInArticle && lastFiveElsParas;
+                } else {
+                    return false;
+                }
             }
         },
         canRunList = {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -60,21 +60,7 @@ define([
                 emailInserted = true;
             }
         },
-        canRunGlobal = {
-            cameFromFronts: function () {
-                var host = window.location.host,
-                    escapedHost = host.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), // Escape anything that will mess up the regex
-                    frontsUrl = new RegExp('^https?:\/\/' + escapedHost + '\/(uk\/|us\/|au\/|international\/)?([a-z-])+$', 'gi');
-
-                return frontsUrl.test(document.referrer);
-            },
-            allowedUser: function () {
-                var browser = detect.getUserAgent.browser,
-                    version = detect.getUserAgent.version;
-
-                return !(browser === 'MSIE' && contains(['7','8','9'], version + ''))
-                        && !Id.isUserLoggedIn();
-            },
+        canRunHelpers = {
             allowedArticleStructure: function () {
                 $articleBody = $('.js-article__body');
 
@@ -94,7 +80,7 @@ define([
 
     return {
         init: function () {
-            if (!emailInserted && canRunGlobal.cameFromFronts() && canRunGlobal.allowedUser() && canRunGlobal.allowedArticleStructure()) {
+            if (!emailInserted && canRunHelpers.allowedArticleStructure()) {
                 // Get the first list that is allowed on this page
                 addListToPage(find(listConfigs, listCanRun));
             }

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -47,7 +47,7 @@ define([
         },
         addListToPage = function (listConfig) {
             if (listConfig) {
-                var iframe = bonzo.create('<iframe src="/email/form/article/' + listConfig.listId + '" height="218px" data-form-title="' + listConfig.headline + '" data-form-description="' + listConfig.description + '" data-form-campaign-code="' + listConfig.campaignCode + '" scrolling="no" seamless frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article" data-form-success-desc="' + listConfig.successDescription + '"></iframe>')[0];
+                var iframe = bonzo.create('<iframe src="/email/form/article/' + listConfig.listId + '" height="218px" data-form-title="' + listConfig.headline + '" data-form-description="' + listConfig.description + '" data-form-campaign-code="' + listConfig.campaignCode + '" scrolling="no" seamless frameborder="0" class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"' + ' data-form-success-headline="' + listConfig.successHeadline + '" data-form-success-desc="' + listConfig.successDescription + '"></iframe>')[0];
 
                 bean.on(iframe, 'load', function () {
                     email.init(iframe);

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -62,9 +62,9 @@ define([
             cameFromFronts: function () {
                 var host = window.location.host,
                     escapedHost = host.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), // Escape anything that will mess up the regex
-                    urlRegex = new RegExp('^https?:\/\/' + escapedHost + '\/(uk\/|us\/|au\/|international\/)?([a-z-])+$', 'gi');
+                    frontsUrl = new RegExp('^https?:\/\/' + escapedHost + '\/(uk\/|us\/|au\/|international\/)?([a-z-])+$', 'gi');
 
-                return urlRegex.test(document.referrer);
+                return frontsUrl.test(document.referrer);
             },
             allowedUser: function () {
                 var browser = detect.getUserAgent.browser,
@@ -93,6 +93,7 @@ define([
     return {
         init: function () {
             if (!emailInserted && canRunGlobal.cameFromFronts() && canRunGlobal.allowedUser() && canRunGlobal.allowedArticleStructure()) {
+                // Get the first list that is allowed on this page
                 addListToPage(find(listConfigs, listCanRun));
             }
         }

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -28,7 +28,7 @@ define([
             nhs: {
                 listId: '3573',
                 canRun: 'nhs',
-                campaignCode: '',
+                campaignCode: 'inArticleNhs',
                 headline: 'Interested in the NHS?',
                 description: 'Sign up to email updates related to the Guardian\'s coverage of the NHS, including daily updates as the project develops',
                 successHeadline: 'Thank you for signing up to our NHS email updates',

--- a/static/src/javascripts/projects/common/views/email/iframe.html
+++ b/static/src/javascripts/projects/common/views/email/iframe.html
@@ -1,0 +1,13 @@
+<iframe
+    src="/email/form/article/<%=listId%>"
+    height="218px"
+    data-form-title="<%=headline%>"
+    data-form-description="<%=description%>"
+    data-form-campaign-code="<%=campaignCode%>"
+    data-form-success-headline="<%=successHeadline%>"
+    data-form-success-desc="<%=successDescription%>"
+    scrolling="no"
+    seamless
+    frameborder="0"
+    class="iframed--overflow-hidden email-sub__iframe js-email-sub__iframe js-email-sub__iframe--article"
+></iframe>

--- a/static/src/stylesheets/module/email/_vars.scss
+++ b/static/src/stylesheets/module/email/_vars.scss
@@ -17,5 +17,5 @@ $tones: (
     (media, colour(media-default)),
     (news, colour(news-default)),
     (review, darken(colour(review-background), 10%)),
-    (special-report, colour(news-support-1))
+    (special-report, colour(news-support-6))
 );


### PR DESCRIPTION
This is moving towards removing the email in-article AB test, making the functionality perm, initially by making the NHS email list appear in NHS related articles. When we have a conclusion to the AB test, we'll roll required functionality into this module.
- [x] wrap in switch
- [x] fill in NHS list details
- [x] double-check failsafes 
