### PR TITLE
Increase Userzoom AB test to 0.5% from 0

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -58,12 +58,12 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val UserzoomSurveyMessage = Switch(
+  val UserzoomSurveyMessageV2 = Switch(
     "A/B Tests",
-    "ab-userzoom-survey-message",
-    "(Initial 0%) Segment the userzoom data-team survey",
+    "ab-userzoom-survey-message-v2",
+    "Segment the userzoom data-team survey",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 1, 28),
+    sellByDate = new LocalDate(2016, 2, 4),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -11,7 +11,7 @@ define([
     'common/modules/experiments/tests/identity-sign-in-v2',
     'common/modules/experiments/tests/rtrt-email-form-article-promo',
     'common/modules/experiments/tests/prebid-performance',
-    'common/modules/experiments/tests/userzoom-survey-message',
+    'common/modules/experiments/tests/userzoom-survey-message-v2',
     'lodash/arrays/flatten',
     'lodash/collections/forEach',
     'lodash/objects/keys',
@@ -34,7 +34,7 @@ define([
     IdentitySignInV2,
     RtrtEmailFormArticlePromo,
     PrebidPerformance,
-    UserzoomSurveyMessage,
+    UserzoomSurveyMessageV2,
     flatten,
     forEach,
     keys,
@@ -52,7 +52,7 @@ define([
         new IdentitySignInV2(),
         new RtrtEmailFormArticlePromo(),
         new PrebidPerformance(),
-        new UserzoomSurveyMessage()
+        new UserzoomSurveyMessageV2()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-v2.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-v2.js
@@ -35,7 +35,7 @@ define([
         this.description = 'Segment the userzoom data-team survey';
         this.audience = 1;
         this.audienceOffset = 0;
-        this.successMeasure = 'Increase email sign-up numbers';
+        this.successMeasure = 'Gain qualitative feedback via a survey';
         this.audienceCriteria = '0.5% of UK visitors to article page, on desktop, that haven\'t seen the message previously';
         this.dataLinkNames = '';
         this.idealOutcome = '';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-v2.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-v2.js
@@ -28,15 +28,15 @@ define([
     cookies
 ) {
     return function () {
-        this.id = 'UserzoomSurveyMessage';
+        this.id = 'UserzoomSurveyMessageV2';
         this.start = '2016-01-20';
-        this.expiry = '2016-01-28';
+        this.expiry = '2016-02-04';
         this.author = 'Gareth Trufitt';
-        this.description = '(Initial 0%) Segment the userzoom data-team survey';
+        this.description = 'Segment the userzoom data-team survey';
         this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Increase email sign-up numbers';
-        this.audienceCriteria = '1% of UK visitors to article page, that haven\'t seen the message previously';
+        this.audienceCriteria = '0.5% of UK visitors to article page, on desktop, that haven\'t seen the message previously';
         this.dataLinkNames = '';
         this.idealOutcome = '';
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message.js
@@ -33,7 +33,7 @@ define([
         this.expiry = '2016-01-28';
         this.author = 'Gareth Trufitt';
         this.description = '(Initial 0%) Segment the userzoom data-team survey';
-        this.audience = 0;
+        this.audience = 1;
         this.audienceOffset = 0;
         this.successMeasure = 'Increase email sign-up numbers';
         this.audienceCriteria = '1% of UK visitors to article page, that haven\'t seen the message previously';


### PR DESCRIPTION
No new functionality, just renaming to reset the `notintest` people.
