### PR TITLE
Fix the min-height on author block

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -407,7 +407,7 @@
     }
 
     @include mq(leftCol) {
-        min-height: gs-height(1) $gs-baseline;
+        min-height: gs-height(1) + $gs-baseline;
         padding-top: $gs-baseline/6;
         padding-bottom: $gs-baseline;
         margin-bottom: 0;


### PR DESCRIPTION
Went awry in https://github.com/guardian/frontend/pull/11430

Before: 
![screen shot 2016-01-22 at 10 09 31](https://cloud.githubusercontent.com/assets/2236852/12507857/5518499c-c0f0-11e5-8320-da19ed0c45da.png)

After:
![screen shot 2016-01-22 at 10 09 25](https://cloud.githubusercontent.com/assets/2236852/12507858/577b5d50-c0f0-11e5-9afd-84464c05acb5.png)
