### PR TITLE
Expose paid-content flag on clientside

### DIFF
--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -24,10 +24,17 @@ object PressedPage {
     val keywordIds: Seq[String] = frontKeywordIds(id)
     val contentType = if (isNetworkFront) GuardianContentTypes.NetworkFront else GuardianContentTypes.Section
 
+    val isAdvertisementFeature: Boolean = {
+      val adUnitSuffix = AdSuffixHandlingForFronts.extractAdUnitSuffixFrom(id, id)
+      val keywordSponsorship = KeywordSponsorshipHandling(id, adUnitSuffix, keywordIds)
+      keywordSponsorship.isAdvertisementFeature
+    }
+
     val faciaPageMetaData: Map[String, JsValue] = Map(
       "keywords" -> JsString(seoData.webTitle.capitalize),
       "keywordIds" -> JsString(keywordIds.mkString(",")),
-      "contentType" -> JsString(contentType)
+      "contentType" -> JsString(contentType),
+      "isAdvertisementFeature" -> JsBoolean(isAdvertisementFeature)
     ) ++ (if (showMpuInAllContainers) Map("showMpuInAllContainers" -> JsBoolean(true)) else Nil)
 
     val openGraph: Map[String, String] = Map(

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -2,7 +2,7 @@ package model
 
 import com.gu.contentapi.client.model.v1.{Section => ApiSection}
 import common.Pagination
-import play.api.libs.json.{JsString, JsValue}
+import play.api.libs.json.{JsBoolean, JsString, JsValue}
 
 object Section {
   def make(section: ApiSection, pagination: Option[Pagination] = None): Section = {
@@ -18,7 +18,8 @@ object Section {
     val javascriptConfigOverrides: Map[String, JsValue] = Map(
         "keywords" -> JsString(webTitle),
         "keywordIds" -> JsString(keywordIds.mkString(",")),
-        "contentType" -> JsString("Section")
+        "contentType" -> JsString("Section"),
+        "isAdvertisementFeature" -> JsBoolean(keywordSponsorship.isAdvertisementFeature)
       )
 
     val metadata = MetaData (


### PR DESCRIPTION
`guardian.config.page.isAdvertisementFeature`

We will need to do some renaming in the codebase eventually, as ad features are now called paid content.

/cc @uplne 
