### PR TITLE
Added 'networkFrontID' to each Edition to enable reliable identification of network fronts

### DIFF
--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -13,6 +13,7 @@ abstract class Edition(
     val timezone: DateTimeZone,
     val locale: Locale,
     val homePagePath: String,
+    val networkFrontId: String,
     val editionalisedSections: Seq[String] = Seq(
       "", // network front
       "business",

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -12,7 +12,6 @@ abstract class Edition(
     val displayName: String,
     val timezone: DateTimeZone,
     val locale: Locale,
-    val homePagePath: String,
     val networkFrontId: String,
     val editionalisedSections: Seq[String] = Seq(
       "", // network front
@@ -27,8 +26,9 @@ abstract class Edition(
       "environment",
       "film"
     )
-  ) extends Navigation {
 
+  ) extends Navigation {
+  val homePagePath: String = s"/$networkFrontId"
   def navigation: Seq[NavItem]
   def briefNav: Seq[NavItem]
 

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -17,7 +17,6 @@ object Au extends Edition(
   displayName = "Australia edition",
   DateTimeZone.forID("Australia/Sydney"),
   locale = Locale.forLanguageTag("en-au"),
-  homePagePath = "/au",
   networkFrontId = "au"
 ) with QueryDefaults {
 

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -17,7 +17,8 @@ object Au extends Edition(
   displayName = "Australia edition",
   DateTimeZone.forID("Australia/Sydney"),
   locale = Locale.forLanguageTag("en-au"),
-  homePagePath = "/au"
+  homePagePath = "/au",
+  networkFrontId = "au"
 ) with QueryDefaults {
 
   implicit val AU = Au

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -11,7 +11,6 @@ object International extends Edition(
   displayName = "International",
   timezone = DateTimeZone.forID("Europe/London"),
   locale = Locale.forLanguageTag("en"),
-  homePagePath = "/international",
   networkFrontId = "international",
   editionalisedSections = Seq("") // only the home page
 ){

--- a/common/app/common/editions/International.scala
+++ b/common/app/common/editions/International.scala
@@ -12,6 +12,7 @@ object International extends Edition(
   timezone = DateTimeZone.forID("Europe/London"),
   locale = Locale.forLanguageTag("en"),
   homePagePath = "/international",
+  networkFrontId = "international",
   editionalisedSections = Seq("") // only the home page
 ){
 

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -11,7 +11,8 @@ object Uk extends Edition(
   displayName = "UK edition",
   timezone = DateTimeZone.forID("Europe/London"),
   locale = Locale.forLanguageTag("en-gb"),
-  homePagePath = "/uk"
+  homePagePath = "/uk",
+  networkFrontId = "uk"
 ){
 
   implicit val UK = Uk

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -11,7 +11,6 @@ object Uk extends Edition(
   displayName = "UK edition",
   timezone = DateTimeZone.forID("Europe/London"),
   locale = Locale.forLanguageTag("en-gb"),
-  homePagePath = "/uk",
   networkFrontId = "uk"
 ){
 

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -14,7 +14,8 @@ object Us extends Edition(
   displayName = "US edition",
   timezone = DateTimeZone.forID("America/New_York"),
   locale = Locale.forLanguageTag("en-us"),
-  homePagePath = "/us"
+  homePagePath = "/us",
+  networkFrontId = "us"
 ) with QueryDefaults {
 
   implicit val US = Us

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -14,7 +14,6 @@ object Us extends Edition(
   displayName = "US edition",
   timezone = DateTimeZone.forID("America/New_York"),
   locale = Locale.forLanguageTag("en-us"),
-  homePagePath = "/us",
   networkFrontId = "us"
 ) with QueryDefaults {
 

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -19,7 +19,7 @@ object PressedPage {
     def optionalMapEntry(key:String, o: Option[String]): Map[String, String] =
       o.map(value => Map(key -> value)).getOrElse(Map())
 
-    val isNetworkFront: Boolean = Edition.all.exists(_.networkFrontId.toLowerCase == id)
+    val isNetworkFront: Boolean = Edition.all.exists(_.networkFrontId == id)
     val showMpuInAllContainers: Boolean = showMpuInAllContainersPageId contains id
     val keywordIds: Seq[String] = frontKeywordIds(id)
     val contentType = if (isNetworkFront) GuardianContentTypes.NetworkFront else GuardianContentTypes.Section

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -19,7 +19,7 @@ object PressedPage {
     def optionalMapEntry(key:String, o: Option[String]): Map[String, String] =
       o.map(value => Map(key -> value)).getOrElse(Map())
 
-    val isNetworkFront: Boolean = Edition.all.exists(_.id.toLowerCase == id)
+    val isNetworkFront: Boolean = Edition.all.exists(_.networkFrontId.toLowerCase == id)
     val showMpuInAllContainers: Boolean = showMpuInAllContainersPageId contains id
     val keywordIds: Seq[String] = frontKeywordIds(id)
     val contentType = if (isNetworkFront) GuardianContentTypes.NetworkFront else GuardianContentTypes.Section


### PR DESCRIPTION
As described on the [Trello card](https://trello.com/c/G9TdopQq), the International front was being classed as a section rather than a network-front when making ad calls (**ct** parameter) as well as omniture calls (**c9** parameter).

This has now been fixed.
