### PR TITLE
Changing number of minimum related content items for amp

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -182,13 +182,8 @@
     }
 
     .logo-wrapper {
-        display: block;
-        padding: 0.5rem;
-    }
-
-    .logo-wrapper svg {
-        display: block;
-        margin: 0 auto;
+        float: right;
+        margin: 0.1875rem 0.625rem 0.34rem 0;
     }
 
     .from-content-api h2, .from-content-api .block-elements h2, .from-content-api p strong {

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -54,7 +54,7 @@ object RelatedController extends Controller with Related with Containers with Lo
       "items" -> JsArray(Seq(
         Json.obj(
           "displayName" -> "related content",
-          "showContent" -> (relatedTrails.length == 4),
+          "showContent" -> (!relatedTrails.isEmpty),
           "content" -> relatedTrails.map( collection => isCuratedContent(collection.faciaContent))
         )
       ))


### PR DESCRIPTION
Like theguardian.com, we will show related content, even if there are less than 4 numbers.
