### PR TITLE
Using remote instead of remote-3 for custom domain serving on amp

### DIFF
--- a/amp/remote.html
+++ b/amp/remote.html
@@ -5,7 +5,7 @@
     <script>
         (function() {
             var v = location.search.substr(1);
-            if (!(/^\d+$/.test(v))) return;
+            if (!(/^\d+(-canary)?$/.test(v))) return;
             var u = 'https://3p.ampproject.net/'+encodeURIComponent(v)+'/f.js';
             document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
         })();
@@ -13,10 +13,7 @@
 </head>
 <body style="margin:0">
 <div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;">
-    <script>draw3p(function(config, done){
-        config.targeting.at = 'tom5';
-        done(config);
-    })</script>
+    <script>draw3p()</script>
 </div>
 <script>if (window.docEndCallback) window.docEndCallback()</script>
 </body>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -10,7 +10,7 @@
     <head>
         @* "utf-8" meta tag needs to be first according to AMP spec *@
         <meta charset="utf-8">
-        <meta name="amp-3p-iframe-src" content="https://static.theguardian.com/amp/remote-3.html">
+        <meta name="amp-3p-iframe-src" content="https://static.theguardian.com/amp/remote.html">
 
         @fragments.metaData(page, true)
         <title>@views.support.Title(page)</title>


### PR DESCRIPTION
The code added in `remote-3.html` is currently breaking other iframes in AMP pages. For example, `amp-twitter` is not working right now.

Lets go back to the basic version recommeded by the AMP team over the weekend, and then on Monday come up with a revised solution for krux.

cc @kenlim @stephanfowler 
