### PR TITLE
Fix campaign logos for new sponsored content design

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
@@ -42,7 +42,7 @@ define([
         this.params.arrowRight = svgs('arrowRight', ['i-right']);
         this.params.logoguardian = svgs('logoguardian');
         this.params.marque36iconCreativeMarque = svgs('marque36icon', ['creative__marque']);
-        this.params.logoFeatureLabel = config.switches.newCommercialContent ? 'Paid for by:' : 'Brought to you by:';
+        this.params.logoFeatureLabel = config.switches.newCommercialContent ? 'Paid for by' : 'Brought to you by:';
     };
 
     Template.prototype.create = function () {

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -135,7 +135,7 @@
 
 .commercial--paidfor {
 
-    /* Resets for the A/B test. When (and if) the new design is implemented, the old code
+    /* Resets for new design. When (and if) the new design is committed to, the old code
        will be torn down and these resets should no longer be necessary
     */
 

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -130,6 +130,90 @@
     }
 }
 
+/* Badges
+   ========================================================================== */
+
+.commercial--paidfor {
+
+    /* Resets for the A/B test. When (and if) the new design is implemented, the old code
+       will be torn down and these resets should no longer be necessary
+    */
+
+    .ad-slot--paid-for-badge__help {
+        display: none;
+    }
+
+    .ad-slot--paid-for-badge--front {
+        border: 0;
+        padding: 0;
+        margin: 0;
+    }
+
+    .ad-slot--paid-for-badge .ad-slot--paid-for-badge__link {
+        margin: 0;
+        float: none;
+    }
+
+    .ad-slot--paid-for-badge__link:after {
+        content: none;
+    }
+
+    .ad-slot.ad-slot--paid-for-badge--front {
+        margin: auto;
+        width: auto;
+        min-height: unset;
+    }
+
+    /* Badge layout & logo size constraint */
+
+    .ad-slot--paid-for-badge {
+        text-align: right; // shift inline-block children
+    }
+
+    .ad-slot--paid-for-badge__header {
+        display: inline-block;
+        vertical-align: middle;
+    }
+
+    .ad-slot--paid-for-badge__link {
+        display: inline-block;
+        vertical-align: middle;
+        max-width: $gs-baseline * 6;
+        height: $gs-baseline * 3;
+        font-size: 0; // remove inline-block whitespace
+    }
+
+    .ad-slot--paid-for-badge__logo {
+        max-width: 100%;
+        max-height: 100%;
+        vertical-align: middle;
+        display: inline-block;
+    }
+
+    .ad-slot--paid-for-badge__link:before {
+        content: '';
+        height: 100%;
+        vertical-align: middle;
+        display: inline-block;
+    }
+}
+
+/* Badge layout in multi-campaign components */
+
+.commercial--paidfor-multi {
+
+    .tone-paidfor--item {
+        position: relative;
+        padding-bottom: $gs-baseline * 4; // reserve space in-flow
+    }
+
+    .ad-slot--paid-for-badge {
+        position: absolute;
+        bottom: $gs-baseline / 2;
+        right: $gs-baseline / 2;
+    }
+}
+
 .tone-paidfor--item {
     background: colour(paid-article-subheader);
     flex: 0 1 auto;

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -180,7 +180,7 @@
         vertical-align: middle;
         max-width: $gs-baseline * 6;
         height: $gs-baseline * 3;
-        font-size: 0; // remove inline-block whitespace
+        font-size: 0; // remove whitespace on inline-block children
     }
 
     .ad-slot--paid-for-badge__logo {
@@ -204,7 +204,7 @@
 
     .tone-paidfor--item {
         position: relative;
-        padding-bottom: $gs-baseline * 4; // reserve space in-flow
+        padding-bottom: $gs-baseline * 4; // reserve space in-flow for absolutely positioned badge
     }
 
     .ad-slot--paid-for-badge {

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -161,7 +161,7 @@
     .ad-slot.ad-slot--paid-for-badge--front {
         margin: auto;
         width: auto;
-        min-height: unset;
+        min-height: 0;
     }
 
     /* Badge layout & logo size constraint */


### PR DESCRIPTION
This pull request implements improvements in the layout and appearance of sponsor logos when the new design for paid-for content is enabled. This will go out on Monday.

Screenshots (see the logos in the bottom right of each block):

Container with a single campaign, desktop:
![image](https://cloud.githubusercontent.com/assets/3148617/12518967/bb1cf4b6-c133-11e5-9ffb-2554500da24d.png)

Container with a single campaign, tablet:
![image](https://cloud.githubusercontent.com/assets/3148617/12519024/2224b928-c134-11e5-86e1-eff32932a6f2.png)

Container with a single campaign, mobile:
![image](https://cloud.githubusercontent.com/assets/3148617/12519055/568ea85e-c134-11e5-9eb2-4e8863af3cff.png)

Container with multiple campaigns, desktop:
![image](https://cloud.githubusercontent.com/assets/3148617/12519006/079ca26e-c134-11e5-9482-eae6f6f34c81.png)

Container with multiple campaigns, tablet:
![image](https://cloud.githubusercontent.com/assets/3148617/12519034/306037ba-c134-11e5-9b0a-c7a0b3bfb38b.png)

Container with multiple campaigns, mobile:
![image](https://cloud.githubusercontent.com/assets/3148617/12519060/63b1f3ce-c134-11e5-8a2e-b7f9f62c2260.png)
