### PR TITLE
Point GLabs 'About...' CTA to "content funding" page

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -26,7 +26,7 @@
                                     <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--@container.dataId">About @inlineSvg("arrow-down", "icon")</button>
                                     <div class="popup is-off paidfor-popup paidfor-popup--@container.dataId">
                                         <h3 class="paidfor-popup__title">Paid stories are paid for and approved by an advertiser and created by the Guardian Labs commercial editorial team</h3>
-                                        <a class="paidfor-popup__link" href="@LinkTo("/info/2014/sep/23/paid-for-content")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+                                        <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
                                     </div>
                                 </div>
                             </div>
@@ -99,7 +99,7 @@
                                     <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--@container.dataId">About @inlineSvg("arrow-down", "icon")</button>
                                     <div class="popup is-off paidfor-popup paidfor-popup--@container.dataId">
                                         <h3 class="paidfor-popup__title">Paid stories are paid for and approved by an advertiser and created by the Guardian Labs commercial editorial team</h3>
-                                        <a class="paidfor-popup__link" href="@LinkTo("/info/2014/sep/23/paid-for-content")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+                                        <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
                                     </div>
                                 </div>
                             </div>

--- a/common/app/views/fragments/guBand.scala.html
+++ b/common/app/views/fragments/guBand.scala.html
@@ -12,7 +12,7 @@
                 </button>
                 <div class="popup is-off paidfor-popup paidfor-popup--sticky">
                     <h3 class="paidfor-popup__title">Paid stories are paid for and approved by an advertiser and created by the Guardian Labs commercial editorial team</h3>
-                    <a class="paidfor-popup__link" href="@LinkTo("/info/2014/sep/23/paid-for-content")">
+                    <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">
                         Learn more about Guardian Labs content
                         @fragments.inlineSvg("arrow-right", "icon")
                     </a>


### PR DESCRIPTION
This is another change for the upcoming sponsored content redesign. It points the URI of the 'Learn more about...' link to a new page (http://www.theguardian.com/content-funding, which doesn't exist yet).

![image](https://cloud.githubusercontent.com/assets/3148617/12519472/e0b34fa6-c136-11e5-86f3-d74b022653ad.png)

This change only applies to templates used when the NewCommercialContent switch is on.
