### PR TITLE
Use secureFile for images and audio and embedded media

### DIFF
--- a/applications/test/GalleryTemplateTest.scala
+++ b/applications/test/GalleryTemplateTest.scala
@@ -32,7 +32,7 @@ import scala.collection.JavaConversions._
     import browser._
     $("meta[name='twitter:card']").getAttributes("content").head should be ("gallery")
     $("meta[name='twitter:title']").getAttributes("content").head should be ("Southbank Centre's Sounds Venezuela festival - in pictures")
-    $("meta[name='twitter:image3:src']").getAttributes("content").head should startWith ("http://")
+    $("meta[name='twitter:image3:src']").getAttributes("content").head should startWith ("https://")
     $("meta[name='twitter:image3:src']").getAttributes("content").head should include ("/Bassoons-in-the-Symphony--003.jpg")
   }
 

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -37,7 +37,7 @@ object ImageAsset {
       fields = Helpers.assetFieldsToMap(asset),
       mediaType = asset.`type`.name,
       mimeType = asset.mimeType,
-      url = asset.file )
+      url = asset.typeData.flatMap(_.secureFile).orElse(asset.file) )
   }
 }
 
@@ -115,7 +115,7 @@ object AudioAsset {
     AudioAsset(
       fields = Helpers.assetFieldsToMap(asset),
       mimeType = asset.mimeType,
-      url = asset.file )
+      url = asset.typeData.flatMap(_.secureFile).orElse(asset.file) )
   }
 }
 
@@ -133,7 +133,7 @@ object EmbedAsset {
   def make(asset: Asset): EmbedAsset = {
     EmbedAsset(
       fields = Helpers.assetFieldsToMap(asset),
-      url = asset.file )
+      url = asset.typeData.flatMap(_.secureFile).orElse(asset.file) )
   }
 }
 


### PR DESCRIPTION
Videos are now using SecureFile field if available. Audio, Images and other embedded media should do the same

cc @rich-nguyen 
