### PR TITLE
Sponsored CAPI component restyling

### DIFF
--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -36,18 +36,6 @@
                     <span class='u-h'>Guardian Labs</span>
                 </a>
             </div>
-
-            <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">
-                <div class="ad-slot--paid-for-badge__inner">
-                    <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel:</h3>
-                    <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
-                        @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
-                    </a>
-                    @for(aboutLinkUrl <- optCapiAbout) {
-                        <a href="@optClickMacro@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
-                    }
-                </div>
-            </div>
             <div class="commercial__body">
                 <div class="lineitems">
                     <div class="lineitem lineitem--dfp-single">
@@ -76,6 +64,14 @@
                                 </a>
                             }
                         </div>
+                    </div>
+                </div>
+                <div class="ad-slot--adbadge ad-slot--paid-for-badge">
+                    <div class="ad-slot--paid-for-badge__inner">
+                        <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel:</h3>
+                        <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
+                            @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
+                        </a>
                     </div>
                 </div>
             </div>

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -1,8 +1,87 @@
 @(item: model.ContentType, optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optCapiButtonText: Option[String], optCapiReadMoreUrl: Option[String], optCapiReadMoreText: Option[String], optSponsorType: Option[String], optSponsorLabel: Option[String], optClickMacro: Option[String], optOmnitureId: Option[String])(implicit request: RequestHeader)
 
 @import conf.switches.Switches.NewCommercialContent
+@import views.html.fragments.inlineSvg
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
+    @if(NewCommercialContent.isSwitchedOn) {
+    <div class="commercial commercial--dfp-single paid-content--advertisement-feature commercial--tone-paidfor" data-link-name="merchandising | capi | single @optOmnitureId">
+        <div class="commercial__inner">
+            <div class="commercial__header commercial--paidfor">
+                <div class="paidfor-meta">
+                    <span class="paidfor-meta__label">Paid Content</span>
+                    <div class="paidfor-label paidfor-meta__more has-popup">
+                        <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--capi-component">About @inlineSvg("arrow-down", "icon")</button>
+                        <div class="popup is-off paidfor-popup paidfor-popup--capi-component">
+                            <h3 class="paidfor-popup__title">Paid stories are paid for and approved by an advertiser and created by the Guardian Labs commercial editorial team</h3>
+                            <a class="paidfor-popup__link" href="@LinkTo("/info/2014/sep/23/paid-for-content")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+                        </div>
+                    </div>
+                </div>
+                <h3 class="commercial__title">
+                    @optCapiLink.map { linkUrl =>
+                        <a href="@optClickMacro@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                    }.getOrElse {
+                        <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
+                    }
+                </h3>
+                <a class="commercial__cta"
+                    @if(Edition(request).id == "AU") {
+                        href="@LinkTo("/guardian-labs-australia")"
+                    } else {
+                        href="@LinkTo("/guardian-labs")"
+                    }
+                    >
+                    @inlineSvg("glabs-logo", "logo")
+                    <span class='u-h'>Guardian Labs</span>
+                </a>
+            </div>
+
+            <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">
+                <div class="ad-slot--paid-for-badge__inner">
+                    <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel:</h3>
+                    <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
+                        @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
+                    </a>
+                    @for(aboutLinkUrl <- optCapiAbout) {
+                        <a href="@optClickMacro@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
+                    }
+                </div>
+            </div>
+            <div class="commercial__body">
+                <div class="lineitems">
+                    <div class="lineitem lineitem--dfp-single">
+                        <div class="lineitem--dfp-single__offer">
+                            <a href="@optClickMacro@item.metadata.webUrl" data-link-name="merchandising-capi-single-v@{version}_@{date}-@item.metadata.webTitle">
+                                @item.trail.trailPicture.map { trailPictureContainer =>
+                                    @Item300.bestFor(trailPictureContainer).map{ url => <img src="@url" alt="" class="lineitem__image" /> }
+                                }
+                                <h4 class="fc-item__title lineitem__title">@item.metadata.webTitle</h4>
+                                @item.fields.trailText.map { trailText =>
+                                    <p class="fc-item__standfirst lineitem__desc">@Html(trailText)</p>
+                                }
+                                @for(buttonText <- optCapiButtonText) {
+                                    <a href="@optClickMacro@item.metadata.webUrl" class="lineitem__cta button button--tertiary button--small">
+                                        @buttonText
+                                        @fragments.inlineSvg("arrow-right", "icon", List("i-right", "i-arrow-black"))
+                                    </a>
+                                }
+                            </a>
+                        </div>
+                        <div class="lineitem--dfp-single__cta hide-on-mobile">
+                            @for(moreButton <- optCapiReadMoreText) {
+                                <a href="@optClickMacro@for(moreUrl <- optCapiReadMoreUrl) {@moreUrl}" class="commercial__cta button button--primary button--large" data-link-name="merchandising-single-more">
+                                    @moreButton
+                                    @fragments.inlineSvg("arrow-right", "icon", List("i-right"))
+                                </a>
+                            }
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    } else {
     <section class="@RenderClasses(
             Map(
                 "paid-content--advertisement-feature" -> NewCommercialContent.isSwitchedOn
@@ -63,4 +142,5 @@
             </div>
         </div>
     </section>
+    }
 }

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -13,7 +13,7 @@
                     <div class="paidfor-label paidfor-meta__more has-popup">
                         <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--capi-component">About @inlineSvg("arrow-down", "icon")</button>
                         <div class="popup is-off paidfor-popup paidfor-popup--capi-component">
-                            <h3 class="paidfor-popup__title">Paid stories are paid for and approved by an advertiser and created by the Guardian Labs commercial editorial team</h3>
+                            <h3 class="paidfor-popup__title">Paid stories are paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
                             <a class="paidfor-popup__link" href="@LinkTo("/info/2014/sep/23/paid-for-content")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
                         </div>
                     </div>

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -68,7 +68,7 @@
                 </div>
                 <div class="ad-slot--adbadge ad-slot--paid-for-badge">
                     <div class="ad-slot--paid-for-badge__inner">
-                        <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel:</h3>
+                        <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel</h3>
                         <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
                             @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
                         </a>

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -14,7 +14,7 @@
                         <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--capi-component">About @inlineSvg("arrow-down", "icon")</button>
                         <div class="popup is-off paidfor-popup paidfor-popup--capi-component">
                             <h3 class="paidfor-popup__title">Paid stories are paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
-                            <a class="paidfor-popup__link" href="@LinkTo("/info/2014/sep/23/paid-for-content")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+                            <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
                         </div>
                     </div>
                 </div>

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -1,37 +1,42 @@
 @(items: Seq[model.ContentType], optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optClickMacro: Option[String], optOmnitureId: Option[String], optCapiAdFeature: Option[String], optSponsorType: Option[String], optSponsorLabel: Option[String])(implicit request: RequestHeader)
 
 @import conf.switches.Switches.NewCommercialContent
+@import views.html.fragments.inlineSvg
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
-    <section class="@RenderClasses(
-            Map(
-                "paid-content--advertisement-feature" -> NewCommercialContent.isSwitchedOn
-            ),
-            "fc-container", "fc-container--paid-for", "fc-container--special", "fc-container--merchandising", "commercial-dfp-multi", optSponsorType.getOrElse("")
-        )" data-link-name="merchandising | capi | multiple @optOmnitureId">
-        <div class="fc-container__inner">
-            <div class="fc-container__header">
-                <h2 class="fc-container__header__title">
-                    @optCapiLink.map { linkUrl =>
-                        <a href="@optClickMacro@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
-                    }.getOrElse {
-                        <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
-                    }
-                </h2>
-            </div>
-            <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">
-                <div class="ad-slot--paid-for-badge__inner">
-                    <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel:</h3>
-                    <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
-                        @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
+    @if(NewCommercialContent.isSwitchedOn) {
+        <div class="commercial commercial--paidfor commercial-dfp-multi commercial--tone-paidfor fc-container--advertisement-feature paid-content--advertisement-feature">
+            <div class="commercial__inner">
+                <div class="commercial__header">
+                    <div class="paidfor-meta">
+                        <span class="paidfor-meta__label">Paid Content</span>
+                        <div class="paidfor-label paidfor-meta__more has-popup">
+                            <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--capi-component">About @inlineSvg("arrow-down", "icon")</button>
+                            <div class="popup is-off paidfor-popup paidfor-popup--capi-component">
+                                <h3 class="paidfor-popup__title">Paid stories are paid for and approved by an advertiser and created by the Guardian Labs commercial editorial team</h3>
+                                <a class="paidfor-popup__link" href="@LinkTo("/info/2014/sep/23/paid-for-content")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+                            </div>
+                        </div>
+                    </div>
+                    <h3 class="commercial__title">
+                        @optCapiLink.map { linkUrl =>
+                            <a href="@optClickMacro@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                        }.getOrElse {
+                            <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
+                        }
+                    </h3>
+                    <a class="commercial__cta"
+                        @if(Edition(request).id == "AU") {
+                            href="@LinkTo("/guardian-labs-australia")"
+                        } else {
+                            href="@LinkTo("/guardian-labs")"
+                        }
+                        >
+                        @inlineSvg("glabs-logo", "logo")
+                        <span class='u-h'>Guardian Labs</span>
                     </a>
-                    @for(aboutLinkUrl <- optCapiAbout) {
-                        <a href="@optClickMacro@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
-                    }
                 </div>
-            </div>
-            <div class="fc-container__body">
-                <div class="fc-slice-wrapper">
+                <div class="commercial__body">
                     <ul class="u-unstyled l-row l-row--cols-4 l-row--layout-m fc-slice">
                         @for(item <- items) {
                             <li class="fc-slice__item l-row__item l-row__item--span-1">
@@ -79,7 +84,85 @@
                 </div>
             </div>
         </div>
-    </section>
+    } else {
+        <section class="@RenderClasses(
+                Map(
+                    "paid-content--advertisement-feature" -> NewCommercialContent.isSwitchedOn
+                ),
+                "fc-container", "fc-container--paid-for", "fc-container--special", "fc-container--merchandising", "commercial-dfp-multi", optSponsorType.getOrElse("")
+            )" data-link-name="merchandising | capi | multiple @optOmnitureId">
+            <div class="fc-container__inner">
+                <div class="fc-container__header">
+                    <h2 class="fc-container__header__title">
+                        @optCapiLink.map { linkUrl =>
+                            <a href="@optClickMacro@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
+                        }.getOrElse {
+                            <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
+                        }
+                    </h2>
+                </div>
+                <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">
+                    <div class="ad-slot--paid-for-badge__inner">
+                        <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel:</h3>
+                        <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
+                            @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
+                        </a>
+                        @for(aboutLinkUrl <- optCapiAbout) {
+                            <a href="@optClickMacro@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
+                        }
+                    </div>
+                </div>
+                <div class="fc-container__body">
+                    <div class="fc-slice-wrapper">
+                        <ul class="u-unstyled l-row l-row--cols-4 l-row--layout-m fc-slice">
+                            @for(item <- items) {
+                                <li class="fc-slice__item l-row__item l-row__item--span-1">
+                                    <div class="fc-item fc-item--has-image fc-item--has-metadata @item match {
+                                            case _: Video => { fc-item--video }
+                                            case _: Audio => { fc-item--audio }
+                                            case _: Gallery => { fc-item--gallery }
+                                            case _ => { }
+                                        } @item match {
+                                            case _: Video | _: Audio | _: Gallery => { tone-media--item }
+                                            case _ => { tone-news--item }
+                                        }">
+                                        <div class="fc-item__container">
+                                            @item.trail.trailPicture.map { trailPictureContainer =>
+                                                @fragments.items.elements.facia_cards.itemImage(trailPictureContainer, true)
+                                            }
+                                            <div class="fc-item__content">
+                                                <div class="fc-item__header">
+                                                    <h2 class="fc-item__title">
+                                                        @insertItemMediaIcon(item)
+                                                        @item.metadata.webTitle
+                                                    </h2>
+                                                </div>
+                                                <div class="fc-item__meta">
+                                                    <time
+                                                        class="fc-item__timestamp js-item__timestamp"
+                                                        datetime="@item.trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
+                                                        data-timestamp="@item.trail.webPublicationDate.getMillis"
+                                                        data-relativeformat="short">
+                                                        <span class="timestamp__text">
+                                                            <span class="u-h">Published: </span>
+                                                            @Format(item.trail.webPublicationDate, "d MMM y")
+                                                        </span>
+                                                    </time>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <a href="@optClickMacro@item.metadata.webUrl" class="u-faux-block-link__overlay" data-link-name="merchandising-capi-v@{version}_@{date}-@item.metadata.webTitle" tabindex="-1">
+                                            @item.metadata.webTitle
+                                        </a>
+                                    </div>
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+    }
 }
 
 @insertItemMediaIcon(item : model.ContentType) = @{

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -14,7 +14,7 @@
                             <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--capi-component">About @inlineSvg("arrow-down", "icon")</button>
                             <div class="popup is-off paidfor-popup paidfor-popup--capi-component">
                                 <h3 class="paidfor-popup__title">Paid stories are paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
-                                <a class="paidfor-popup__link" href="@LinkTo("/info/2014/sep/23/paid-for-content")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+                                <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
                             </div>
                         </div>
                     </div>

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -83,7 +83,7 @@
                     </ul>
                     <div class="ad-slot--adbadge ad-slot--paid-for-badge">
                         <div class="ad-slot--paid-for-badge__inner">
-                            <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel:</h3>
+                            <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel</h3>
                             <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
                                 @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
                             </a>

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -81,6 +81,14 @@
                             </li>
                         }
                     </ul>
+                    <div class="ad-slot--adbadge ad-slot--paid-for-badge">
+                        <div class="ad-slot--paid-for-badge__inner">
+                            <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel:</h3>
+                            <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
+                                @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
+                            </a>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -13,7 +13,7 @@
                         <div class="paidfor-label paidfor-meta__more has-popup">
                             <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--capi-component">About @inlineSvg("arrow-down", "icon")</button>
                             <div class="popup is-off paidfor-popup paidfor-popup--capi-component">
-                                <h3 class="paidfor-popup__title">Paid stories are paid for and approved by an advertiser and created by the Guardian Labs commercial editorial team</h3>
+                                <h3 class="paidfor-popup__title">Paid stories are paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
                                 <a class="paidfor-popup__link" href="@LinkTo("/info/2014/sep/23/paid-for-content")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
                             </div>
                         </div>

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -5,7 +5,7 @@
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
     @if(NewCommercialContent.isSwitchedOn) {
-        <div class="commercial commercial--paidfor commercial-dfp-multi commercial--tone-paidfor fc-container--advertisement-feature paid-content--advertisement-feature">
+        <div class="commercial commercial--paidfor commercial-dfp-multi commercial--tone-paidfor fc-container--advertisement-feature paid-content--advertisement-feature" data-link-name="merchandising | capi | multiple @optOmnitureId">
             <div class="commercial__inner">
                 <div class="commercial__header">
                     <div class="paidfor-meta">

--- a/static/src/stylesheets/module/commercial/_dfp.scss
+++ b/static/src/stylesheets/module/commercial/_dfp.scss
@@ -37,7 +37,7 @@
     .lineitem--dfp-single__cta {
         box-sizing: border-box;
         margin-left: $gs-gutter/2;
-        border-left: 1px solid colour(neutral-4);
+        border-left: 1px solid colour(paid-article-subheader);
         padding-left: $gs-gutter/2;
         float: left;
         position: absolute;

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -133,7 +133,8 @@
 /* Badges
    ========================================================================== */
 
-.commercial--paidfor {
+.commercial--paidfor,
+.commercial--dfp-single {
 
     /* Resets for new design. When (and if) the new design is committed to, the old code
        will be torn down and these resets should no longer be necessary

--- a/static/src/stylesheets/module/commercial/_tones.scss
+++ b/static/src/stylesheets/module/commercial/_tones.scss
@@ -154,9 +154,3 @@
     guss-colour(paidfor-background, $frontend-palette),
     $backgroundColour: #ebebeb
 );
-
-.commercial--tone-paidfor {
-    .commercial__inner {
-        background: #f5f5f5;
-    }
-}


### PR DESCRIPTION
After:
![screen shot 2016-01-25 at 10 56 58](https://cloud.githubusercontent.com/assets/2579465/12549257/ede3eaae-c353-11e5-89d4-7fd38bcd28ce.png)

It is behind the switch so till the switch is off it looks like old CAPI component.
It uses @jbreckmckye amazing work on badges position so it works like a magic. I just needed to add '.commercial--dfp-single' into the equation.

TODO: after launch we will have to do massive clean up of redundant code which is behind the switch

CC @jbreckmckye @regiskuckaertz 
