### PR TITLE
GLabs links to Australia

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -104,7 +104,16 @@
                                 </div>
                             </div>
                             <h3 class="commercial__title">@container.displayName</h3>
-                            <a class="commercial__cta" href="@LinkTo("/guardian-labs")">@inlineSvg("glabs-logo", "logo")</a>
+                            <a class="commercial__cta"
+                                @if(Edition(request).id == "AU") {
+                                    href="@LinkTo("/guardian-labs-australia")"
+                                } else {
+                                    href="@LinkTo("/guardian-labs")"
+                                    }
+                            >
+                                @inlineSvg("glabs-logo", "logo")
+                                <span class='u-h'>Guardian Labs</span>
+                            </a>
                         </div>
                         <div class="commercial__body">
                             <ul class="lineitems l-row l-row--cols-4">


### PR DESCRIPTION
The GLabs logo should point to the GLabs Australia pages when the user is reading the Australian edition (or as I prefer to call it, "upside-down mode"). This link was missed from a previous PR.
