### PR TITLE
Tighten spacing on paid-for-content logos

### DIFF
--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -21,7 +21,7 @@
 
     .rich-link__standfirst {
         @include fs-textSans(4);
-        padding: $gs-baseline/3  $gs-gutter/2 $gs-baseline/3 $gs-gutter/4;
+        padding: $gs-baseline/3 $gs-gutter/2 $gs-baseline/3 $gs-gutter/4;
     }
 
     .fc-item__image-container {

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -21,6 +21,7 @@
 
     .rich-link__standfirst {
         @include fs-textSans(4);
+        padding: $gs-baseline/3  $gs-gutter/2 $gs-baseline/3 $gs-gutter/4;
     }
 
     .fc-item__image-container {
@@ -204,7 +205,9 @@
 
     .tone-paidfor--item {
         position: relative;
-        padding-bottom: $gs-baseline * 4; // reserve space in-flow for absolutely positioned badge
+        // reserve space in-flow for absolutely positioned badge
+        // baseline * 3 from the height of the element, plus baseline / 2 for its bottom margin
+        padding-bottom: $gs-baseline * 3.5;
     }
 
     .ad-slot--paid-for-badge {


### PR DESCRIPTION
This pull request concerns the spacing of the logos at the bottom of paid-for-content elements on multi-campaign containers. It brings them closer up to the text:

![image](https://cloud.githubusercontent.com/assets/3148617/12551561/4c29334e-c363-11e5-8663-32e4045103c5.png)

This PR entails
- rationalizing the space we carve out for the absolutely positioned elements
- explicitly shadowing the spacing on rich-link__standfirsts in the commercial content redesign
