### PR TITLE
validate email input (report abuse non-ajax)

### DIFF
--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -23,7 +23,7 @@ object CommentsController extends DiscussionController with ExecutionContexts {
       "categoryId" -> Forms.number.verifying(ReportAbuseFormValidation.validCategoryConstraint),
       "commentId" -> Forms.number,
       "reason" -> optional(Forms.text.verifying("Reason must be 250 characters or fewer", input => Constraints.maxLength(250)(input) == Valid)),
-      "email" -> optional(Forms.text.verifying("Please enter a valid email address", input => Constraints.emailAddress == Valid))
+      "email" -> optional(Forms.text.verifying("Please enter a valid email address", input => Constraints.emailAddress(input) == Valid))
     )(DiscussionAbuseReport.apply)(DiscussionAbuseReport.unapply)
   )
 


### PR DESCRIPTION
I forgot to validate the email input before, so this comparison wasn't working previously.
CC @guardian/discussion 
