### PR TITLE
Removed left padding on Paid content label

### DIFF
--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -106,6 +106,10 @@
         padding: $gs-baseline / 3 $gs-gutter / 2;
     }
 
+    .paidfor-meta__label {
+        padding-left: 0;
+    }
+
     .paidfor-branding {
         padding: $gs-baseline / 2 $gs-gutter / 2;
 


### PR DESCRIPTION
Before:
![picture 1](https://cloud.githubusercontent.com/assets/629976/12559056/c47fe550-c38a-11e5-8d7a-8c61e26278da.png)

After:
![picture 2](https://cloud.githubusercontent.com/assets/629976/12559062/c9242c06-c38a-11e5-9f56-35308f64aced.png)
