### PR TITLE
Restore standfirsts to paid content pages

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -690,9 +690,13 @@
     }
 
     .tonal__standfirst {
-        background-color: colour(paid-article-subheader);
+        background-color: transparent;
         padding: $gs-baseline 0 $gs-baseline*2;
         min-height: $gs-baseline*8;
+
+        .content__standfirst {
+            color: colour(neutral-1);
+        }
     }
 
     .ad-slot__label,
@@ -740,7 +744,7 @@
 
         &.content--media--audio,
         &.content--media--video {
-            .tonal__standfirst {
+            .content__head .tonal__standfirst {
                 display: none;
             }
         }

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -40,14 +40,6 @@
         }
     }
 
-    &.paid-content--advertisement-feature {
-        .content__main-column--video {
-            @include mq(desktop) {
-                min-height: 0;
-            }
-        }
-    }
-
     .content__secondary-column--media {
         @include mq($until: desktop) {
             display: block;


### PR DESCRIPTION
Standfirsts were previously hidden by CSS. This change restores them and styles them appropriately for the new design.

_Before:_
![image](https://cloud.githubusercontent.com/assets/3148617/12581085/56f3f65a-c42c-11e5-88e5-0912e0db8ae8.png)

_After:_
![image](https://cloud.githubusercontent.com/assets/3148617/12581090/64050712-c42c-11e5-9379-a576a647870d.png)

This change comprises
1. Removing Steve's fix to [remove space underneath videos](https://github.com/guardian/frontend/pull/11681), as it's no longer necessary
2. Modifying the CSS that hides standfirsts in the new design to only hide header standfirsts
3. Styling the body standfirst in accordance with the rest of the page

@regiskuckaertz @uplne
