### PR TITLE
Add a try catch to Rubicon listener in new sticky ad test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/remove-sticky-nav.js
@@ -7,8 +7,8 @@ define([
         this.expiry = '2016-3-1';
         this.author = 'Josh Holder';
         this.description = '0% AB test for removing the sticky nav';
-        this.audience = 0.0;
-        this.audienceOffset = 0.0;
+        this.audience = 0.5;
+        this.audienceOffset = 0.5;
         this.successMeasure = '';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';

--- a/static/src/javascripts/projects/common/modules/navigation/newSticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newSticky.js
@@ -56,17 +56,25 @@ define([
 
                 var newRubiconAdHeightPromise = new Promise(function (resolve) {
                     window.addEventListener('message', function (event) {
-                        var data = JSON.parse(event.data);
-                        var $iframe = getAdIframe();
-                        var isRubiconAdEvent = data.type === 'set-ad-height';
-                        var isEventForTopAdBanner = isRubiconAdEvent && data.value.id === $iframe[0].id;
+                        var data;
 
-                        if (isRubiconAdEvent && isEventForTopAdBanner) {
-                            fastdom.read(function () {
-                                var padding = parseInt($adBannerInner.css('padding-top'))
-                                    + parseInt($adBannerInner.css('padding-bottom'));
-                                resolve(parseInt(data.value.height) + padding);
-                            });
+                        // other DFP events get caught by this listener, but if they're not json we don't want to parse them or use them
+                        try {
+                            data = JSON.parse(event.data);
+                        } catch(e) {}
+
+                        if(data) {
+                            var $iframe = getAdIframe();
+                            var isRubiconAdEvent = data.type === 'set-ad-height';
+                            var isEventForTopAdBanner = isRubiconAdEvent && data.value.id === $iframe[0].id;
+
+                            if (isRubiconAdEvent && isEventForTopAdBanner) {
+                                fastdom.read(function () {
+                                    var padding = parseInt($adBannerInner.css('padding-top'))
+                                        + parseInt($adBannerInner.css('padding-bottom'));
+                                    resolve(parseInt(data.value.height) + padding);
+                                });
+                            }
                         }
                     });
                 });

--- a/static/src/javascripts/projects/common/modules/navigation/newSticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newSticky.js
@@ -59,9 +59,11 @@ define([
                         var data;
 
                         // other DFP events get caught by this listener, but if they're not json we don't want to parse them or use them
+                        /* eslint-disable no-empty */
                         try {
                             data = JSON.parse(event.data);
                         } catch (e) {}
+                        /* eslint-enable no-empty */
 
                         if (data) {
                             var $iframe = getAdIframe();

--- a/static/src/javascripts/projects/common/modules/navigation/newSticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newSticky.js
@@ -61,9 +61,9 @@ define([
                         // other DFP events get caught by this listener, but if they're not json we don't want to parse them or use them
                         try {
                             data = JSON.parse(event.data);
-                        } catch(e) {}
+                        } catch (e) {}
 
-                        if(data) {
+                        if (data) {
                             var $iframe = getAdIframe();
                             var isRubiconAdEvent = data.type === 'set-ad-height';
                             var isEventForTopAdBanner = isRubiconAdEvent && data.value.id === $iframe[0].id;


### PR DESCRIPTION
Adds a try catch to Rubicon listener in new sticky ad test to prevent errors when non-json DFP events are caught by this listener.

@OliverJAsh, is this what you meant?
