### PR TITLE
Use complete class name in the test to detect advertising merch components

### DIFF
--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -4,7 +4,7 @@
 @import views.html.fragments.inlineSvg
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
-    @if(NewCommercialContent.isSwitchedOn && optSponsorType.contains("advertisement-feature")) {
+    @if(NewCommercialContent.isSwitchedOn && optSponsorType.contains("fc-container--advertisement-feature")) {
         <div class="commercial commercial--paidfor commercial-dfp-multi commercial--tone-paidfor fc-container--advertisement-feature paid-content--advertisement-feature" data-link-name="merchandising | capi | multiple @optOmnitureId">
             <div class="commercial__inner">
                 <div class="commercial__header">


### PR DESCRIPTION
Fixes [this PR](https://github.com/guardian/frontend/pull/11701)
