### PR TITLE
Selection sharing z-index fix

### DIFF
--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -196,6 +196,7 @@ category: Common
     opacity: 0;
     visibility: hidden;
     transition: opacity .15s ease;
+    z-index: 2;
 
     .social__item {
         padding: 0 $gs-gutter / 10;

--- a/static/src/stylesheets/module/_social.scss
+++ b/static/src/stylesheets/module/_social.scss
@@ -196,7 +196,7 @@ category: Common
     opacity: 0;
     visibility: hidden;
     transition: opacity .15s ease;
-    z-index: 2;
+    z-index: $zindex-content;
 
     .social__item {
         padding: 0 $gs-gutter / 10;


### PR DESCRIPTION
Selection sharing was showing behind showcased images. Thanks @paperboyo for spotting.

![screen shot 2016-01-26 at 14 30 57](https://cloud.githubusercontent.com/assets/14570016/12583234/92d7943a-c439-11e5-892b-6d455a96048a.png)
