### PR TITLE
Fix broken About button in commercial components

### DIFF
--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -645,7 +645,9 @@
                                 omnitureId: '[%OmnitureID%]'
                             });
 
-                            commercialComponent.postLoadEvents['capi@if(component("type") == "single"){Single}'] = function () {
+                            var oldFn = commercialComponent.postLoadEvents['capi@if(component("type") == "single"){Single}'];
+                            commercialComponent.postLoadEvents['capi@if(component("type") == "single"){Single}'] = function (el) {
+                                oldFn.call(commercialComponent, el);
                                 $capiType.removeClass('lazyloaded');
                             };
                             commercialComponent.create();

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -645,9 +645,10 @@
                                 omnitureId: '[%OmnitureID%]'
                             });
 
-                            var oldFn = commercialComponent.postLoadEvents['capi@if(component("type") == "single"){Single}'];
-                            commercialComponent.postLoadEvents['capi@if(component("type") == "single"){Single}'] = function (el) {
-                                oldFn.call(commercialComponent, el);
+                            var callbackName = 'capi@if(component("type") == "single"){Single}';
+                            var originalPostLoadEvents = commercialComponent.postLoadEvents[callbackName];
+                            commercialComponent.postLoadEvents[callbackName] = function (el) {
+                                originalPostLoadEvents && originalPostLoadEvents.call(commercialComponent, el);
                                 $capiType.removeClass('lazyloaded');
                             };
                             commercialComponent.create();

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -110,29 +110,27 @@ define([
     };
 
     CommercialComponent.prototype.create = function () {
-        return new Promise(function (resolve) {
-            new LazyLoad({
-                url: this.components[this.type],
-                container: this.adSlot,
-                beforeInsert: function (html) {
-                    // Currently we are replacing the OmnitureToken with nothing. This will change once
-                    // commercial components have properly been setup in the lovely mess that is Omniture!
-                    return html ? html.replace(/%OASToken%/g, this.params.clickMacro).replace(/%OmnitureToken%/g, '') : html;
-                }.bind(this),
-                success: function () {
-                    if (this.postLoadEvents[this.type]) {
-                        this.postLoadEvents[this.type](this.adSlot);
-                    }
+        new LazyLoad({
+            url: this.components[this.type],
+            container: this.adSlot,
+            beforeInsert: function (html) {
+                // Currently we are replacing the OmnitureToken with nothing. This will change once
+                // commercial components have properly been setup in the lovely mess that is Omniture!
+                return html ? html.replace(/%OASToken%/g, this.params.clickMacro).replace(/%OmnitureToken%/g, '') : html;
+            }.bind(this),
+            success: function () {
+                if (this.postLoadEvents[this.type]) {
+                    this.postLoadEvents[this.type](this.adSlot);
+                }
 
-                    mediator.emit('modules:commercial:creatives:commercial-component:loaded');
-                }.bind(this),
-                error: function () {
-                    bonzo(this.adSlot).hide();
-                }.bind(this)
-            }).load();
+                mediator.emit('modules:commercial:creatives:commercial-component:loaded');
+            }.bind(this),
+            error: function () {
+                bonzo(this.adSlot).hide();
+            }.bind(this)
+        }).load();
 
-            resolve(this);
-        }.bind(this));
+        return this;
     };
 
     return CommercialComponent;

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -95,16 +95,18 @@ define([
             };
         };
 
+    function createToggle(el) {
+        if (el.querySelector('.popup__toggle')) {
+            new Toggles(el).init();
+        }
+    }
+
     CommercialComponent.prototype.postLoadEvents = {
         bestbuy: function (el) {
             new Tabs().init(el);
         },
-        capi: function (el) {
-            new Toggles(el).init();
-        },
-        capiSingle: function (el) {
-            new Toggles(el).init();
-        }
+        capi: createToggle,
+        capiSingle: createToggle
     };
 
     CommercialComponent.prototype.create = function () {

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
@@ -5,6 +5,7 @@ define([
     'common/utils/template',
     'common/utils/fastdom-promise',
     'common/views/svgs',
+    'common/modules/ui/toggles',
     'common/modules/commercial/creatives/template-preprocessor',
 
     // require templates, so they're bundled up as part of the build
@@ -23,8 +24,15 @@ define([
     template,
     fastdom,
     svgs,
+    Toggles,
     templatePreprocessor
 ) {
+    function createToggle(el) {
+        if (el.querySelector('.popup__toggle')) {
+            new Toggles(el).init();
+        }
+    }
+
     /**
      * Create simple templated creatives
      *
@@ -50,6 +58,11 @@ define([
         this.params.logoFeatureLabel = config.switches.newCommercialContent ? 'Paid for by' : 'Brought to you by:';
     };
 
+    Template.prototype.postLoadEvents = {
+        'manual-single': createToggle,
+        'manual-multiple': createToggle
+    };
+
     Template.prototype.create = function () {
         return new Promise(function (resolve) {
             require(['text!common/views/commercial/creatives/' + this.params.creative + '.html'], function (creativeTpl) {
@@ -61,7 +74,11 @@ define([
                 var $ad = $.create(creativeHtml);
 
                 resolve(fastdom.write(function () {
-                    return $ad.appendTo(this.$adSlot);
+                    $ad.appendTo(this.$adSlot);
+                    if (this.postLoadEvents[this.params.creative]) {
+                        this.postLoadEvents[this.params.creative]($ad[0]);
+                    }
+                    return $ad;
                 }, this));
             }.bind(this));
         }.bind(this));


### PR DESCRIPTION
The initial call to `Toggles` does not account for lazy loaded components, thus we must call it again in case there's a popup in the content returned from `/commercial`

@jbreckmckye @uplne 
