### PR TITLE
Sponsored audio articles have layout bugs

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -24,7 +24,6 @@
         }
 
         @fragments.headTonal(media)
-
         <div class="content__main tonal__main tonal__main--@toneClass(media)">
             <div class="gs-container">
                 <div class="content__main-column content__main-column--media content__main-column--@mediaType">
@@ -92,14 +91,14 @@
                         </div>
 
                         <div class="content__main-column__body" data-component="body">
-                            <div class="tonal__standfirst">
                                 @media match {
                                     case v: Video => {
-                                        @fragments.standfirst(v)
+                                        <div class="tonal__standfirst">
+                                            @fragments.standfirst(v)
+                                        </div>
                                     }
                                     case _ => { }
                                 }
-                            </div>
 
                             @fragments.contentMeta(media)
 

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -1,6 +1,5 @@
 @(item: model.ContentType)(implicit request: RequestHeader)
 
-@* live with empty standfirst as it is used to hook things into the page with javascript *@
 <div class="content__standfirst" data-link-name="standfirst" data-component="standfirst">
     @item.fields.trailText.map{ t =>
 

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -79,7 +79,7 @@
 
     // increase height if we have sponsorship logos
     &.paid-content--advertisement-feature .content__main-column--audio {
-        min-height: 325px;
+        min-height: $gs-row-height * 9;
     }
 }
 .content__headline:before {

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -70,9 +70,17 @@
         }
     }
 }
-// if it's audio and there's body text, we display an advert
-.content--has-body .content__main-column--audio {
-    min-height: 274px;
+
+.content--has-body {
+    // if it's audio and there's body text, we display an advert
+    .content__main-column--audio {
+        min-height: 274px;
+    }
+
+    // increase height if we have sponsorship logos
+    &.paid-content--advertisement-feature .content__main-column--audio {
+        min-height: 325px;
+    }
 }
 .content__headline:before {
     .content--media--audio & {


### PR DESCRIPTION
This is a fix to sponsored audio articles. 

![image](https://cloud.githubusercontent.com/assets/3148617/12585299/5bd3b09a-c443-11e5-9e84-11b13ea16685.png)

It comprises two changes:
1. An empty standfirst created a large empty space between the media player and the paragraph below,
2. When the large space was removed, the 'Save for Later' button was cut off. This is because that cell is absolutely positioned, and the container uses a min-height to reserve space for it.

_After:_
![image](https://cloud.githubusercontent.com/assets/3148617/12585141/9a388104-c442-11e5-9dba-a3e77be293b0.png)

I've changed three things:
1. We now only insert the standfirst on the mediaBody is it's actually needed.
2. I've removed an old comment which suggested that we needed to inject an empty standfirst for the sake of scripting; I couldn't find any evidence of this by grepping scripts (*.js, *scala.js) for 'standfirst'.
3. I've bumped up the min-height of the audio content container when the sidebar has a sponsorship logo to show.
