### PR TITLE
Invalidate all identity csrf cookies

### DIFF
--- a/identity/app/controllers/SignoutController.scala
+++ b/identity/app/controllers/SignoutController.scala
@@ -43,9 +43,10 @@ class SignoutController @Inject()(returnUrlVerifier: ReturnUrlVerifier,
       DiscardingCookie("gu_paying_member", "/", Some(conf.id.domain), secure = false)
       )
 
-    val cookiesToDiscard = 
+    val cookiesToDiscard =
       DiscardingCookie("GU_U", "/", Some(conf.id.domain), secure = false) ::
       DiscardingCookie("SC_GU_U", "/", Some(conf.id.domain), secure = true) ::
+      DiscardingCookie("GU_ID_CSRF", "/", Some(conf.id.domain), secure = true) ::
       adfreeCookies
 
     NoCache(Found(

--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -58,7 +58,7 @@ play {
   filters {
 
     csrf {
-      cookie.name=GU_CSRF
+      cookie.name=GU_ID_CSRF
       cookie.secure=true
       sign.tokens=true
     }


### PR DESCRIPTION
Due to the application secret being rotated users are experiencing issues accessing pages that check csrf cookies. Existing cookies are not currently removed on sign out and existing cookies signed with the old secret are resulting in 500s. This updates the sign out action to discard the csrf cookie and renames the cookie to effectively remove it for all users.
