### PR TITLE
Fixed the case where we get a Bonzo object

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -78,7 +78,7 @@ define([
             this.type   = this.params.type;
             // remove type from params
             delete this.params.type;
-            this.adSlot    = adSlot;
+            this.adSlot    = adSlot.length ? adSlot[0] : adSlot;
             this.components = {
                 bestbuy:        buildComponentUrl('money/bestbuys', this.params),
                 book:           buildComponentUrl('books/book', merge({}, this.params, { t: config.page.isbn || this.params.isbn })),


### PR DESCRIPTION
In dfp-api, the constructor if given a Bonzo object, while everywhere else it's getting a DOM element.
