### PR TITLE
Add election 2016 to the US nav bar

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -46,6 +46,7 @@ trait Navigation {
   val world = SectionLink("world", "world", "World", "/world")
   val uk = SectionLink("uk-news", "UK", "UK News", "/uk-news")
   val us = SectionLink("us-news", "US", "US News", "/us-news")
+  val usElection2016 = SectionLink("us-elections-2016", "election 2016", "Election 2016", "/us-news/us-elections-2016")
   val politics = SectionLink("politics", "politics", "Politics", "/politics")
   val technology = SectionLink("technology", "tech", "Technology", "/technology")
   val environment = SectionLink("environment", "environment", "Environment", "/environment")

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -58,6 +58,7 @@ object Us extends Edition(
   override val navigation: Seq[NavItem] = {
     Seq(
       NavItem(home),
+      NavItem(usElection2016),
       NavItem(us),
       NavItem(world, worldLocalNav),
       NavItem(opinion),
@@ -79,6 +80,7 @@ object Us extends Edition(
 
   override def briefNav: Seq[NavItem] = Seq(
     NavItem(home),
+    NavItem(usElection2016),
     NavItem(us),
     NavItem(world, worldLocalNav),
     NavItem(opinion),

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -92,7 +92,6 @@ object Us extends Edition(
     NavItem(fashion),
     NavItem(business, Seq(markets, companies)),
     NavItem(travel, Seq(usaTravel, europetravel, uktravel)),
-    NavItem(environment, environmentLocalNav),
-    NavItem(science)
+    NavItem(environment, environmentLocalNav)
   )
 }


### PR DESCRIPTION
As requested by the US office:

<img width="1161" alt="screen shot 2016-01-26 at 18 07 13" src="https://cloud.githubusercontent.com/assets/944375/12589897/0cd15d0c-c458-11e5-89e1-4b27438ec200.png">
