### PR TITLE
Remove Egyptian from paid content fronts

### DIFF
--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -38,7 +38,8 @@
     .fc-item__standfirst,
     .fc-item--list-compact,
     .item__title,
-    .linkslist__action {
+    .linkslist__action,
+    .fc-sublink__title {
         @include f-headlineSans;
     }
 


### PR DESCRIPTION
Containers on paid content fronts use the Egyptian font for sublinks, when everything on those pages should be styled with Guardian sans:

![image](https://cloud.githubusercontent.com/assets/3148617/12613120/72fca5e0-c4ef-11e5-94a5-2ee4c83a7bd7.png)

This dangerous and complicated pull request uses something named "CSS" to change the "font" of the "text".

![image](https://cloud.githubusercontent.com/assets/3148617/12613175/ce618a0e-c4ef-11e5-8307-69aa53bbdedb.png)

@regiskuckaertz 
