### PR TITLE
Fixing TakeoverEmptyMPUs bug

### DIFF
--- a/common/app/common/dfp/TakeoverWithEmptyMPUs.scala
+++ b/common/app/common/dfp/TakeoverWithEmptyMPUs.scala
@@ -80,7 +80,7 @@ object TakeoverWithEmptyMPUs {
     val takeovers = S3.get(takeoversWithEmptyMPUsKey) map {
       Json.parse(_).as[Seq[TakeoverWithEmptyMPUs]]
     } getOrElse Nil
-    takeovers
+    takeovers filter {t => mustBeAtLeastOneDirectoryDeep(t.url) == Valid}
   }
 
   def fetchSorted(): Seq[TakeoverWithEmptyMPUs] = {

--- a/common/test/common/dfp/TakeoverWithEmptyMPUsTest.scala
+++ b/common/test/common/dfp/TakeoverWithEmptyMPUsTest.scala
@@ -1,0 +1,39 @@
+package common.dfp
+
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import play.api.data.validation.{Invalid, Valid}
+
+class TakeoverWithEmptyMPUsTest extends FlatSpec with Matchers {
+
+  "TakeoverWithEmptyMPUs" should "recognise as valid urls that are at least 1 directory deep" in {
+    TakeoverWithEmptyMPUs.mustBeAtLeastOneDirectoryDeep("http://www.theguardian.com/uk") should equal(Valid)
+  }
+
+  "TakeoverWithEmptyMPUs" should "recognise as valid urls that have multiple directories deep" in {
+    TakeoverWithEmptyMPUs.mustBeAtLeastOneDirectoryDeep("http://www.theguardian.com/abc/def/ghi") should equal(Valid)
+  }
+
+  "TakeoverWithEmptyMPUs" should "recognise as invalid urls that have no path" in {
+    TakeoverWithEmptyMPUs.mustBeAtLeastOneDirectoryDeep("http://www.theguardian.com") should equal(Invalid("Must be at least one directory deep. eg: http://www.theguardian.com/us"))
+  }
+
+  "TakeoverWithEmptyMPUs" should "recognise as invalid urls that have a naked slash path" in {
+    TakeoverWithEmptyMPUs.mustBeAtLeastOneDirectoryDeep("http://www.theguardian.com/") should equal(Invalid("Must be at least one directory deep. eg: http://www.theguardian.com/us"))
+  }
+
+  "TakeoverWithEmptyMPUs" should "recognise as invalid urls that are invalid" in {
+    TakeoverWithEmptyMPUs.mustBeAtLeastOneDirectoryDeep("123") should equal(Invalid("Must be a valid URL. eg: http://www.theguardian.com/us"))
+  }
+
+  "TakeoverWithEmptyMPUs" should "recognise as invalid urls that are empty" in {
+    TakeoverWithEmptyMPUs.mustBeAtLeastOneDirectoryDeep("") should equal(Invalid("Must be a valid URL. eg: http://www.theguardian.com/us"))
+  }
+
+  "TakeoverWithEmptyMPUs" should "recognise as invalid urls that are empty beyond the naked slash" in {
+    TakeoverWithEmptyMPUs.mustBeAtLeastOneDirectoryDeep("http://www.theguardian.com/ ") should equal(Invalid("Must be at least one directory deep. eg: http://www.theguardian.com/us"))
+  }
+
+  "TakeoverWithEmptyMPUs" should "recognise as invalid urls that are empty beyond the root" in {
+    TakeoverWithEmptyMPUs.mustBeAtLeastOneDirectoryDeep("http://www.theguardian.com ") should equal(Invalid("Must be at least one directory deep. eg: http://www.theguardian.com/us"))
+  }
+}


### PR DESCRIPTION
It was previously possible to create an TakeoverEmptyMPU entry that pointed to www.theguardian.com. This broke the app. 

We've implemented a check in the form with better messaging to prevent new entries. 

And we've implemented a filter to stop existing entries from breaking the app. 
