### PR TITLE
Harmonise padding in paidfor band

### DIFF
--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -111,7 +111,7 @@
     }
 
     .paidfor-branding {
-        padding: $gs-baseline / 2 $gs-gutter / 2;
+        padding: ($gs-baseline / 2) 0 ($gs-baseline / 2) ($gs-gutter / 2);
 
         svg {
             height: 24px;
@@ -123,4 +123,6 @@
 .paidfor-band__inner {
     display: flex;
     justify-content: space-between;
+    box-sizing: border-box;
+    @include content-gutter();
 }


### PR DESCRIPTION
Before:
![picture 3](https://cloud.githubusercontent.com/assets/629976/12613485/fd97bbd4-c4f1-11e5-9338-daf5f5fe3d93.png)

After:
![picture 4](https://cloud.githubusercontent.com/assets/629976/12613488/010a1348-c4f2-11e5-8180-22567c7eb3bd.png)

I know this is not the place nor the time, but it's sad that paddings are not the same on fronts/content pages.
