### PR TITLE
Increase log line exceptions to improve diagnosing of issues

### DIFF
--- a/admin-jobs/conf/application-logger.xml
+++ b/admin-jobs/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/admin/conf/application-logger.xml
+++ b/admin/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/applications/conf/application-logger.xml
+++ b/applications/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/archive/conf/application-logger.xml
+++ b/archive/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/article/conf/application-logger.xml
+++ b/article/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/commercial/conf/application-logger.xml
+++ b/commercial/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/dev-build/conf/application-logger.xml
+++ b/dev-build/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/diagnostics/conf/application-logger.xml
+++ b/diagnostics/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/discussion/conf/application-logger.xml
+++ b/discussion/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/facia-press/conf/application-logger.xml
+++ b/facia-press/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/identity/conf/application-logger.xml
+++ b/identity/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/image/conf/application-logger.xml
+++ b/image/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/preview/conf/application-logger.xml
+++ b/preview/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/router/conf/application-logger.xml
+++ b/router/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/rss/conf/application-logger.xml
+++ b/rss/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/sport/conf/application-logger.xml
+++ b/sport/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 

--- a/training-preview/conf/application-logger.xml
+++ b/training-preview/conf/application-logger.xml
@@ -11,7 +11,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Following @gklopper example https://github.com/guardian/frontend/pull/11718/files  I've increased the number of log lines reported in exceptions from 3 to 15 across the board.

Admin seemed to never have a limit but I've made it consistent with other applications.
