### PR TITLE
Enable HTTPS on crosswords

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -28,7 +28,7 @@ trait LinkTo extends Logging {
   /**
     * email is here to allow secure POSTs from the footer signup form
     */
-  val httpsEnabledSections: Seq[String] = Seq("info", "email", "science")
+  val httpsEnabledSections: Seq[String] = Seq("info", "email", "science", "crosswords")
 
   def apply(html: Html)(implicit request: RequestHeader): String = this(html.toString(), Edition(request))
   def apply(link: String)(implicit request: RequestHeader): String = this(link, Edition(request))


### PR DESCRIPTION
See also https://github.com/guardian/fastly-edge-cache/pull/550
