### PR TITLE
Remove unused traits which should fix the flaky test build.

### DIFF
--- a/common/test/layout/WidthsByBreakpointTest.scala
+++ b/common/test/layout/WidthsByBreakpointTest.scala
@@ -5,7 +5,7 @@ import org.scalatest._
 import org.scalatest.concurrent.Eventually
 import test.SingleServerSuite
 
-class WidthsByBreakpointTest extends FreeSpec with ShouldMatchers with Eventually with SingleServerSuite {
+class WidthsByBreakpointTest extends FreeSpec with ShouldMatchers {
   "ContentWidths" - {
     "getWidthsFromContentElement" - {
       "inline" - {


### PR DESCRIPTION
`WidthsByBreakpointTest` fails in Teamcity on 
`
sbt.ForkMain$ForkError: org.jboss.netty.channel.ChannelException: Failed to bind to: /0.0.0.0:19001
`

This test looks to be a unit test so doesn't need an app server, I've removed it and it ran locally fine. Hopefully the PR will build in Teamcity too.
