### PR TITLE
AB test: Update userzoom survey audience & message

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -67,12 +67,12 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val UserzoomSurveyMessageV2 = Switch(
+  val UserzoomSurveyMessageV3 = Switch(
     "A/B Tests",
-    "ab-userzoom-survey-message-v2",
+    "ab-userzoom-survey-message-v3",
     "Segment the userzoom data-team survey",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 2, 4),
+    sellByDate = new LocalDate(2016, 2, 11),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -12,7 +12,7 @@ define([
     'common/modules/experiments/tests/rtrt-email-form-article-promo',
     'common/modules/experiments/tests/prebid-performance',
     'common/modules/experiments/tests/liveblog-toast',
-    'common/modules/experiments/tests/userzoom-survey-message-v2',
+    'common/modules/experiments/tests/userzoom-survey-message-v3',
     'lodash/arrays/flatten',
     'lodash/collections/forEach',
     'lodash/objects/keys',
@@ -36,7 +36,7 @@ define([
     RtrtEmailFormArticlePromo,
     PrebidPerformance,
     LiveblogToast,
-    UserzoomSurveyMessageV2,
+    UserzoomSurveyMessageV3,
     flatten,
     forEach,
     keys,
@@ -55,7 +55,7 @@ define([
         new RtrtEmailFormArticlePromo(),
         new PrebidPerformance(),
         new LiveblogToast(),
-        new UserzoomSurveyMessageV2()
+        new UserzoomSurveyMessageV3()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-v3.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-v3.js
@@ -65,9 +65,9 @@ define([
                 linkHref: 'https://s.userzoom.com/p/MSBDMTBTMjYy/' + browserId,
                 linkText: 'Open Survey',
                 linkName: 'survey sign-up button',
-                messageTextHeadline: 'Tell us about your experience using the Guardian site',
-                messageTextWide: 'Complete a quick survey (5 minutes max) and get involved in the development of the site',
-                messageTextNarrow: 'Complete a quick survey (5 minutes max) and get involved in the development of the site',
+                messageTextHeadline: 'Tell us about what you love (or don\'t) about the Guardian',
+                messageTextWide: 'Complete a quick survey (5 minutes max) and help us make the site better',
+                messageTextNarrow: 'Complete a quick survey (5 minutes max) and help us make the site better',
                 arrowWhiteRight: svgs('arrowWhiteRight')
             },
             createMessage = function () {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-v3.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-v3.js
@@ -28,15 +28,15 @@ define([
     cookies
 ) {
     return function () {
-        this.id = 'UserzoomSurveyMessageV2';
+        this.id = 'UserzoomSurveyMessageV3';
         this.start = '2016-01-20';
-        this.expiry = '2016-02-04';
+        this.expiry = '2016-02-11';
         this.author = 'Gareth Trufitt';
         this.description = 'Segment the userzoom data-team survey';
-        this.audience = 0.04;
-        this.audienceOffset = 0.02;
+        this.audience = 0.2;
+        this.audienceOffset = 0.7;
         this.successMeasure = 'Gain qualitative feedback via a survey';
-        this.audienceCriteria = '2% of UK visitors to article page, on desktop, that haven\'t seen the message previously';
+        this.audienceCriteria = '10% of UK visitors to article page, on desktop, that haven\'t seen the message previously';
         this.dataLinkNames = '';
         this.idealOutcome = '';
 


### PR DESCRIPTION
Update AB test name to ensure `notintest` is reset, localstorage will still be checked for users that have seen the message.
