### PR TITLE
clear up console by not running code that we know will fail in dev

### DIFF
--- a/common/app/views/fragments/head.scala.html
+++ b/common/app/views/fragments/head.scala.html
@@ -10,7 +10,9 @@
 @* stylesheet <link>s - get the stylesheets downloading ASAP *@
 @fragments.stylesheets(projectName, getContent(page).exists(_.tags.isCrossword))
 
-<link rel="prefetch" href="@Static("javascripts/app.js")">
+@if(!play.Play.isDev()) {
+    <link rel="prefetch" href="@Static("javascripts/app.js")">
+}
 
 @*
 Protect against ReferenceErrors in IE:

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -124,9 +124,9 @@ define([
             });
         }
 
-        var isDev = window.location.hostname === 'localhost';
-        if ((window.location.protocol === 'https:' || isDev)
-            && config.page.section !== 'identity') {
+        // invert the comments on the following two lines to force service worker registration for local dev
+        // if (true) {
+        if (window.location.protocol === 'https:' && config.page.section !== 'identity') {
             var navigator = window.navigator;
             if (navigator && navigator.serviceWorker) {
                 navigator.serviceWorker.register('/service-worker.js');

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -124,9 +124,8 @@ define([
             });
         }
 
-        // invert the comments on the following two lines to force service worker registration for local dev
-        // if (true) {
-        if (window.location.protocol === 'https:' && config.page.section !== 'identity') {
+        // use a #force-sw hash fragment to force service worker registration for local dev
+        if ((window.location.protocol === 'https:' && config.page.section !== 'identity') || window.location.hash === '#force-sw') {
             var navigator = window.navigator;
             if (navigator && navigator.serviceWorker) {
                 navigator.serviceWorker.register('/service-worker.js');


### PR DESCRIPTION
it's become pretty tricky to find errors in the console in dev.

this prevents code from running that we know cannot succeed in dev, while trying to make it plain how to re-enable it if you're working on it (specifically the service worker)

before:
![screen shot 2016-01-27 at 16 19 41](https://cloud.githubusercontent.com/assets/867233/12619936/22defef0-c512-11e5-8af9-baeaa175b968.png)

after:
![screen shot 2016-01-27 at 16 18 10](https://cloud.githubusercontent.com/assets/867233/12619939/28258d02-c512-11e5-9c72-550e67acb704.png)
