### PR TITLE
Fix invisible text on sponsored fronts

### DIFF
--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -117,6 +117,11 @@
         border-top: 0;
     }
 
+    .fc-container--story-package .tone-news--item.fc-item {
+        // This is to override an !important background colour in story-package items
+        background-color: colour(paid-article-subheader) !important;
+    }
+
     .tone-media--item {
         .u-faux-block-link--hover {
             background-color: colour(neutral-6);


### PR DESCRIPTION
Sponsored content fronts inherit styles from the existing facia containers. Some containers with the `--story-package` type have a dark background colour set with `!important` [[story-package.scss:69](https://github.com/guardian/frontend/blob/master/static/src/stylesheets/inline/story-package.scss#L69)]. This makes the dark copy on the sponsored items effectively invisible:

![image](https://cloud.githubusercontent.com/assets/3148617/12625389/7cf832e4-c52b-11e5-8232-d6d05ed10d15.png)

This is a production issue, and fairly high-priority. For the moment I've resolved the issue by shadowing the !important selector in the sponsored styles rather than trying to unpick the original code and see if its specificity hacks can be removed. This `important` is scoped within a check for the new paid content theme, so it should at least stay relatively contained.
