### PR TITLE
make liveblog timeline use permalinks

### DIFF
--- a/article/app/liveblog/LiveBlogPageModel.scala
+++ b/article/app/liveblog/LiveBlogPageModel.scala
@@ -13,7 +13,7 @@ object LiveBlogPageModel {
 
     endedPages.sliding(3).toList.map {
       case List(later, curr, earlier) =>
-        LiveBlogPageModel(curr.page, main, later.self, earlier.self, curr.self)
+        LiveBlogPageModel(curr.page, blocks, later.self, earlier.self, curr.self)
     }.find(hasRequestedBlock)
   }
 

--- a/article/app/views/liveblog/keyEvents.scala.html
+++ b/article/app/views/liveblog/keyEvents.scala.html
@@ -3,7 +3,7 @@
 
 @keyEvents.map { keyEvent =>
     <li class="timeline__item">
-        <a class="timeline__link" href="@id#block-@keyEvent.id" data-event-id="block-@keyEvent.id">
+        <a class="timeline__link" href="@id?page=with:block-@keyEvent.id#block-@keyEvent.id" data-event-id="block-@keyEvent.id">
             <span class="timeline__date">@views.html.liveblog.dateBlock(keyEvent.time)</span><span class="timeline__title u-underline">@keyEvent.title</span>
         </a>
     </li>

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -59,6 +59,15 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val LiveBlogTransitionSwitch = Switch(
+    "Feature",
+    "liveblog-transition",
+    "Fix up liveblog scroll transitions in liveblog.js to work with pagination",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 3, 2),
+    exposeClientSide = true
+  )
+
   val GeoMostPopular = Switch(
     "Feature",
     "geo-most-popular",

--- a/static/src/javascripts/bootstraps/enhanced/liveblog.js
+++ b/static/src/javascripts/bootstraps/enhanced/liveblog.js
@@ -81,7 +81,7 @@ define([
             }
         });
 
-        if (timeline) {
+        if (timeline && config.switches.liveblogTransition) {
             bean.on(timeline, 'click', '.timeline__link', function (e) {
                 mediator.emit('module:liveblog:showkeyevents', true);
                 $('.dropdown--live-feed').addClass('dropdown--active');


### PR DESCRIPTION
at the moment the timeline (key events panel) uses anchor links and only populates from the first page.

This PR changes it to pull the events from all pages, and uses the block permalink to find it.  This does have the side effect of making the page refresh, but it should allow the page size to be made a lot smaller if desired.

A bit more work is needed to make the smooth scroller work if the block is actually on the current page - this would involve altering the data-block-id to only be present if the block is on the current page (server side logic) and then the client side smooth scroller could only capture the event if the data-block-id is defined. I have added a switch to remind us to do that when I'm available.

@stephanfowler @OliverJAsh I don't think I should ship it today, feel free to close for the time being if you can't get it out
