### PR TITLE
Add logos and formatting to paid imageContent pages

### DIFF
--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -1,12 +1,29 @@
 @(page: ImageContentPage)(implicit request: RequestHeader)
+@import common.Edition
+@import conf.switches.Switches.NewCommercialContent
 @import layout.ContentWidths.ImageContentMedia
+@import views.support.RenderClasses
 
 @defining(page.image) { image =>
 
 <div class="l-side-margins l-side-margins--media">
-    <article class="content content--media content--image tonal tonal--tone-media" itemprop="mainContentOfPage" itemscope itemtype="@image.metadata.schemaType" role="main">
+    <article
+        class="@RenderClasses(Map(
+            "content--advertisement-feature" -> image.commercial.isAdvertisementFeature,
+            "content--sponsored" -> image.commercial.isSponsored(Some(Edition(request))),
+            "content--foundation-supported" -> image.commercial.isFoundationSupported,
+            "paid-content--advertisement-feature" -> (image.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn)
+        ), "content content--media content--image tonal tonal--tone-media")"
+        itemprop="mainContentOfPage"
+        itemscope
+        itemtype="@image.metadata.schemaType"
+        role="main">
 
-        @fragments.headTonal(image)
+        @if(image.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn) {
+            @fragments.guBand()
+        }
+
+        @fragments.headTonal(image, showBadge = true)
 
         <div class="content__main tonal__main tonal__main--tone-media">
             <div class="gs-container">


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/1722550/12643651/5a957f24-c5b5-11e5-8692-76ba7e9755e1.png)

Now:

![image](https://cloud.githubusercontent.com/assets/1722550/12643656/68e048ca-c5b5-11e5-9cf8-4b89661555fb.png)

/cc @JonNorman @Calanthe 
