### PR TITLE
Override story-package styles on paid-for fronts

### DIFF
--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -19,7 +19,10 @@
     .fc-item__link:visited,
     .fc-item__standfirst,
     .item__link:visited,
-    .item__link:visited .item__title {
+    .item__link:visited .item__title,
+    // Story-package overrides
+    .fc-container--story-package .fc-item__standfirst,
+    .fc-container--story-package .fc-item__link:visited {
         color: colour(neutral-2-contrasted);
     }
 
@@ -135,6 +138,11 @@
         .fc-item__link:visited {
             color: colour(neutral-1);
         }
+    }
+
+    // Override story-package hover colours
+    .fc-container--story-package .fc-item .u-faux-block-link--hover {
+        background-color: colour(neutral-6);
     }
 
     .headline-list__item:before {


### PR DESCRIPTION
This continues the [fix](https://github.com/guardian/frontend/pull/11734) from this morning. We still have hard-to-read text on live, because of hover styles:

![image](https://cloud.githubusercontent.com/assets/3148617/12643786/388d77a0-c5b6-11e5-98e8-86aab77ceb13.png)

There's also still poor contrast in the non-hover state with the standfirst:

![image](https://cloud.githubusercontent.com/assets/3148617/12643836/84cc97b8-c5b6-11e5-8b6a-a5af3a2d07f3.png)

This PR applies overrides for the story-package styles on fc-containers. I'd like to take a look at stopping the Scala from adding the story-package class full stop, so we can remove all the overrides entirely, but that might take a little while as I don't know Scala well.

Fix screenshot, hover state:
![image](https://cloud.githubusercontent.com/assets/3148617/12643825/741cebc0-c5b6-11e5-91cf-61bd29762e20.png)

Fix screenshot, non-hover state:
![image](https://cloud.githubusercontent.com/assets/3148617/12643844/948e470a-c5b6-11e5-8f5f-89d45d2e54fd.png)
