### PR TITLE
Use DAPI webUrl for permalink URL 

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -243,7 +243,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val apiTimeout = configuration.getMandatoryStringProperty("discussion.apiTimeout")
     lazy val apiClientHeader = configuration.getMandatoryStringProperty("discussion.apiClientHeader")
     lazy val d2Uid = configuration.getMandatoryStringProperty("discussion.d2Uid")
-    lazy val url = configuration.getMandatoryStringProperty("discussion.url")
   }
 
   object witness {

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -30,7 +30,6 @@ id.membership.stripePublicToken=pk_test_Qm3CGRdrV4WfGYCpm0sftR0f
 discussion.apiRoot=https://discussion-secure.code.dev-guardianapis.com/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
-discussion.url=http://discussion.code.dev-theguardian.com
 discussion.d2Uid=zHoBy6HNKsk
 
 # Witness

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -28,7 +28,6 @@ id.oauth.url=https://oauth.thegulocal.com
 discussion.apiRoot=https://discussion-secure.code.dev-guardianapis.com/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen-dev
-discussion.url=http://discussion.code.dev-theguardian.com
 discussion.d2Uid=zHoBy6HNKsk
 
 # Witness

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -32,7 +32,6 @@ id.membership.stripePublicToken=pk_live_2O6zPMHXNs2AGea4bAmq5R7Z
 discussion.apiRoot=https://discussion.guardianapis.com/discussion-api
 discussion.apiTimeout=2000
 discussion.apiClientHeader=nextgen
-discussion.url=http://discussion.theguardian.com
 discussion.d2Uid=zHoBy6HNKsk
 
 # Witness

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -14,7 +14,6 @@ import model.NoCache
 import play.api.Play.current
 import play.api.data.validation._
 
-
 import scala.util.control.NonFatal
 
 object CommentsController extends DiscussionController with ExecutionContexts {

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -14,6 +14,7 @@ import model.NoCache
 import play.api.Play.current
 import play.api.data.validation._
 
+
 import scala.util.control.NonFatal
 
 object CommentsController extends DiscussionController with ExecutionContexts {
@@ -78,9 +79,12 @@ object CommentsController extends DiscussionController with ExecutionContexts {
   val reportAbuseThankYouPage = SimplePage(MetaData.make("/reportAbuseThankYou", "Discussion", "Report Abuse Thank You", "GFE: Report Abuse Thank You"))
 
 
-  def reportAbuseThankYou(commentId: Int) = Action { implicit request =>
-
-    Cached(60) { Ok(views.html.discussionComments.reportCommentThankYou(commentId, reportAbuseThankYouPage)) }
+  def reportAbuseThankYou(commentId: Int) = Action.async { implicit request =>
+    discussionApi.commentFor(commentId).map { comment =>
+      Cached(60) {
+        Ok(views.html.discussionComments.reportCommentThankYou(comment.webUrl, reportAbuseThankYouPage))
+      }
+    }
   }
 
   def abuseReportToMap(abuseReport: DiscussionAbuseReport): Map[String, Seq[String]] = {

--- a/discussion/app/views/discussionComments/reportCommentThankYou.scala.html
+++ b/discussion/app/views/discussionComments/reportCommentThankYou.scala.html
@@ -1,6 +1,6 @@
 @import _root_.model.SimplePage
 @import conf.Configuration
-@(commentId: Int, page: SimplePage)(implicit request: RequestHeader)
+@(webUrl: String, page: SimplePage)(implicit request: RequestHeader)
 @main(page) { } {
 
 
@@ -22,7 +22,7 @@
         <div class="content__main tonal__main tonal__main--tone-news">
             <div class="gs-container">
                 <div class="content__main-column">
-                 Thank you for your report. <a href="@Configuration.discussion.url/comment-permalink/@commentId">Return to comment</a>
+                 Thank you for your report. <a href="@webUrl">Return to comment</a>
                 </div>
             </div>
         </div>

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -43,7 +43,7 @@
                     </a>
                 }
                 <div class="d-comment__timestamp">
-                    <a href="@Configuration.discussion.url/comment-permalink/@comment.id" class="d-comment__timestamp block-time">
+                    <a href="@comment.webUrl" class="d-comment__timestamp block-time">
                         <time class="js-timestamp" itemprop="dateCreated"
                             datetime="@comment.date.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")"
                             data-timestamp="@comment.date.getMillis" data-relativeformat="med"
@@ -100,7 +100,7 @@
                 </div>
                 @if(!comment.isBlocked){
                     <div class="d-comment__actions d-comment__actions--left modern-visible">
-                        <a class="d-comment__action d-comment__action--reply" href="https://profile.theguardian.com/signin?returnUrl=@Configuration.discussion.url/comment-permalink/@comment.id"
+                        <a class="d-comment__action d-comment__action--reply" href="https://profile.theguardian.com/signin?returnUrl=@comment.webUrl"
                                 data-link-name="reply to comment" data-comment-id="@comment.id" role="button">
                             @fragments.inlineSvg("reply", "icon", List("blue"))
                             Reply

--- a/discussion/app/views/fragments/topComment.scala.html
+++ b/discussion/app/views/fragments/topComment.scala.html
@@ -22,7 +22,7 @@ itemscope itemtype="http://schema.org/Comment">
             )
         </div>
 
-        <a class="d-top-comment__link js-jump-to-comment" href="@Configuration.discussion.url/comment-permalink/@comment.id" data-comment-id="@comment.id">
+        <a class="d-top-comment__link js-jump-to-comment" href="@comment.webUrl" data-comment-id="@comment.id">
             Jump to comment
         </a>
     </div>
@@ -49,7 +49,7 @@ itemscope itemtype="http://schema.org/Comment">
             </span>
 
             <div class="d-comment__timestamp">
-                <a href="@Configuration.discussion.url/comment-permalink/@comment.id" class="d-comment__timestamp">
+                <a href="@comment.webUrl" class="d-comment__timestamp">
                     <time class="js-timestamp" itemprop="dateCreated" datetime="@comment.date.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")"
                     data-timestamp="@comment.date.getMillis" data-relativeformat="med" title="Permalink to this comment">
                     @Format(comment.date, "d MMM y HH:mm")

--- a/discussion/app/views/profileActivity/discussions.scala.html
+++ b/discussion/app/views/profileActivity/discussions.scala.html
@@ -21,7 +21,7 @@
                                   itemprop="datePublished"
                                   datetime="@c.date.toString("yyyy-MM-dd'T'HH:mm:ss'Z'")"
                                   data-timestamp="@c.date.getMillis">
-                                <a class="disc-comment__permalink" href="@Configuration.discussion.url/comment-permalink/@c.id" itemprop="url" data-link-name="Discussion permalink">@c.date.toString("d MMM y HH:mm")</a>
+                                <a class="disc-comment__permalink" href="@c.webUrl" itemprop="url" data-link-name="Discussion permalink">@c.date.toString("d MMM y HH:mm")</a>
                             </time>
                         </div>
 


### PR DESCRIPTION
Previously comment permalinks were built using a host value from `Configuration` e.g. `@Configuration.discussion.url/comment-permalink/@comment.id` however, we provide this URL in the DAPI response as `webUrl` so this PR changes frontend to read `webUrl` in all instances.

This means we can remove the config value `Configuration.discussion.url` which was the old Discussion D2 microapp and allow us to update the `webUrl` in future without having to modify Frontend.

CC @guardian/discussion @johnduffell 
