### PR TITLE
Darken captions on new paid-for design

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -675,6 +675,10 @@
     &.content--interactive,
     &.tonal--tone-media {
         background-color: colour(paid-article);
+
+        .caption {
+            color: colour(neutral-1);
+        }
     }
 
     &.content {


### PR DESCRIPTION
Captions on media pages with the new paid-for design are hard to read against the dark background. This straightforward pull request changes this -

![image](https://cloud.githubusercontent.com/assets/3148617/12650538/1a4c78d4-c5db-11e5-8b20-e4ea0f78bfbb.png)

to this -

![image](https://cloud.githubusercontent.com/assets/3148617/12650547/23e7b64c-c5db-11e5-807a-27c298bdd03e.png)
