### PR TITLE
Push back aws-credentials-switchover switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -10,7 +10,7 @@ trait FeatureSwitches {
     "aws-credentials-switchover",
     "Switch to remind us to remove the 'nextgen' profile from the default AWS credentials provider chain",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 2, 2), //Tuesday
+    sellByDate = new LocalDate(2016, 2, 5), //Friday
     exposeClientSide = false
   )
 


### PR DESCRIPTION
Push this back to Friday next week as not all accounts have been sorted out yet to be ready for Tuesday. (And I'm off Monday!)

@rich-nguyen 
