### PR TITLE
Preroll timeout

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -149,7 +149,6 @@ define([
     }
 
     function initPlayer(withPreroll) {
-
         // When possible, use our CDN instead of a third party (zencoder).
         if (config.page.videoJsFlashSwf) {
             videojs.options.flash.swf = config.page.videoJsFlashSwf;
@@ -159,7 +158,7 @@ define([
 
         fastdom.read(function () {
             $('.js-gu-media--enhance').each(function (el) {
-                enhanceVideo(el, false);
+                enhanceVideo(el, false, withPreroll);
             });
         });
 
@@ -169,7 +168,8 @@ define([
         mediator.on('page:media:moreinloaded', initPlayButtons);
     }
 
-    function enhanceVideo(el, autoplay) {
+    function enhanceVideo(el, autoplay, withPreroll) {
+
         var mediaType = el.tagName.toLowerCase(),
             $el = bonzo(el).addClass('vjs vjs-tech-' + videojs.options.techOrder[0]),
             mediaId = $el.attr('data-media-id'),
@@ -248,10 +248,10 @@ define([
                             function () {
                                 events.bindPrerollEvents(player);
                                 player.adSkipCountdown(15);
-
                                 player.ima({
                                     id: mediaId,
-                                    adTagUrl: getAdUrl()
+                                    adTagUrl: getAdUrl(),
+                                    prerollTimeout: 750
                                 });
                                 player.ima.requestAds();
 
@@ -354,8 +354,7 @@ define([
     function initWithRaven(withPreroll) {
         raven.wrap(
             { tags: { feature: 'media' } },
-            initPlayer,
-            [withPreroll]
+            function() { initPlayer(withPreroll) }
         )();
     }
 

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -354,7 +354,7 @@ define([
     function initWithRaven(withPreroll) {
         raven.wrap(
             { tags: { feature: 'media' } },
-            function () { initPlayer(withPreroll) }
+            function () { initPlayer(withPreroll); }
         )();
     }
 

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -354,7 +354,7 @@ define([
     function initWithRaven(withPreroll) {
         raven.wrap(
             { tags: { feature: 'media' } },
-            function() { initPlayer(withPreroll) }
+            function () { initPlayer(withPreroll) }
         )();
     }
 

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -253,9 +253,10 @@ define([
                                     id: mediaId,
                                     adTagUrl: getAdUrl()
                                 });
+                                player.ima.requestAds();
+
                                 // Video analytics event.
                                 player.trigger(events.constructEventName('preroll:request', player));
-                                player.ima.requestAds();
                             }
                         )();
                     } else {


### PR DESCRIPTION
Two changes are made here:
- Moving the inclusion of the Google IMA script to be called further up the chain. The reasons for this are two fold:
  - It's no longer included in a [`NodeList` loop](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/enhanced/media/main.js#L160-L164). This isn't a problem yet as we only run prerolls if there is one video, but might once e remove this hack around a [Google IMA bug](https://github.com/googleads/videojs-ima/issues/116). Once that is fixed this would be really inefficient.
  - the page itself already takes ages to instantiate `videojs` (I'll be looking at this later), and the `ima` script itself is inefficient and take a while to fully instantiate, and prerolls can only happen once that's finished (the main reason for this is it calls in loads of Youtube embed stuff). I have looked for a more efficient IMA plugin, I can't find any.
- We've added a `prerollTimeout` which has it's default set to `100ms`. From what I can tell, most our ads take about `350ms` to load. This stops the video playing, then the advert, then the video, which is currently what happens.

I've chatted to @mkopka about what affect this might have on tracking (the `video:play` won't be triggered first as it is now) but we thought this is a more honest metric, and the data team use all the metrics from a video player (e.g. how many videos were started, prerolled and watched to 25%).
