### PR TITLE
Sponsored popup abstract

### DIFF
--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -8,16 +8,7 @@
     <div class="commercial commercial--dfp-single paid-content--advertisement-feature commercial--tone-paidfor" data-link-name="merchandising | capi | single @optOmnitureId">
         <div class="commercial__inner">
             <div class="commercial__header commercial--paidfor">
-                <div class="paidfor-meta">
-                    <span class="paidfor-meta__label">Paid content</span>
-                    <div class="paidfor-label paidfor-meta__more has-popup">
-                        <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--capi-component">About @inlineSvg("arrow-down", "icon")</button>
-                        <div class="popup is-off paidfor-popup paidfor-popup--capi-component">
-                            <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
-                            <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
-                        </div>
-                    </div>
-                </div>
+                @fragments.commercial.paidForMeta()
                 <h3 class="commercial__title">
                     @optCapiLink.map { linkUrl =>
                         <a href="@optClickMacro@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -8,16 +8,7 @@
         <div class="commercial commercial--paidfor commercial-dfp-multi commercial--tone-paidfor fc-container--advertisement-feature paid-content--advertisement-feature" data-link-name="merchandising | capi | multiple @optOmnitureId">
             <div class="commercial__inner">
                 <div class="commercial__header">
-                    <div class="paidfor-meta">
-                        <span class="paidfor-meta__label">Paid content</span>
-                        <div class="paidfor-label paidfor-meta__more has-popup">
-                            <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--capi-component">About @inlineSvg("arrow-down", "icon")</button>
-                            <div class="popup is-off paidfor-popup paidfor-popup--capi-component">
-                                <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
-                                <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
-                            </div>
-                        </div>
-                    </div>
+                    @fragments.commercial.paidForMeta()
                     <h3 class="commercial__title">
                         @optCapiLink.map { linkUrl =>
                             <a href="@optClickMacro@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -189,22 +189,7 @@
                                     @fragments.inlineSvg("glabs-logo-small", "logo")
                                 </a>
                             </div>
-                            <div class="paidfor-meta">
-                                <span class="paidfor-meta__label">Paid content</span>
-                                <div class="paidfor-label paidfor-meta__more has-popup">
-                                    <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--test1">
-                                        About
-                                        @fragments.inlineSvg("arrow-down", "icon")
-                                    </button>
-                                    <div class="popup is-off paidfor-popup paidfor-popup--test1">
-                                        <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
-                                        <a class="paidfor-popup__link" href="#">
-                                            Learn more about Guardian Labs content
-                                            @fragments.inlineSvg("arrow-right", "icon")
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
+                            @fragments.commercial.paidForMeta()
                             <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box">
                                 <h2 class="gu-title">Discover the beauty and culture of Mauritius</h2>
                                 <p class="gu-text">From sandy beaches and tropical forests to colourful festivals and super-fresh seafood.</p>

--- a/common/app/views/fragments/commercial/paidForMeta.scala.html
+++ b/common/app/views/fragments/commercial/paidForMeta.scala.html
@@ -7,7 +7,7 @@
     <div class="paidfor-label paidfor-meta__more has-popup">
         <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--capi-component">About @inlineSvg("arrow-down", "icon")</button>
         <div class="popup is-off paidfor-popup paidfor-popup--capi-component">
-            <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
+            <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team</h3>
             <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
         </div>
     </div>

--- a/common/app/views/fragments/commercial/paidForMeta.scala.html
+++ b/common/app/views/fragments/commercial/paidForMeta.scala.html
@@ -1,0 +1,14 @@
+@()(implicit request: RequestHeader)
+
+@import views.html.fragments.inlineSvg
+
+<div class="paidfor-meta">
+    <span class="paidfor-meta__label">Paid content</span>
+    <div class="paidfor-label paidfor-meta__more has-popup">
+        <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--capi-component">About @inlineSvg("arrow-down", "icon")</button>
+        <div class="popup is-off paidfor-popup paidfor-popup--capi-component">
+            <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
+            <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+        </div>
+    </div>
+</div>

--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -20,16 +20,7 @@
                 <div class="commercial commercial--paidfor commercial--tone-paidfor commercial--paidfor-single">
                     <div class="commercial__inner">
                         <div class="commercial__header">
-                            <div class="paidfor-meta">
-                                <span class="paidfor-meta__label">Paid content</span>
-                                <div class="paidfor-label paidfor-meta__more has-popup">
-                                    <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--@container.dataId">About @inlineSvg("arrow-down", "icon")</button>
-                                    <div class="popup is-off paidfor-popup paidfor-popup--@container.dataId">
-                                        <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
-                                        <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
-                                    </div>
-                                </div>
-                            </div>
+                            @fragments.commercial.paidForMeta()
                             <h3 class="commercial__title">@container.displayName</h3>
                             <a class="commercial__cta"
                                 @if(Edition(request).id == "AU") {
@@ -93,16 +84,7 @@
                 <div class="commercial commercial--paidfor commercial--tone-paidfor commercial--paidfor-multi">
                     <div class="commercial__inner">
                         <div class="commercial__header">
-                            <div class="paidfor-meta">
-                                <span class="paidfor-meta__label">Paid content</span>
-                                <div class="paidfor-label paidfor-meta__more has-popup">
-                                    <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--@container.dataId">About @inlineSvg("arrow-down", "icon")</button>
-                                    <div class="popup is-off paidfor-popup paidfor-popup--@container.dataId">
-                                        <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
-                                        <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
-                                    </div>
-                                </div>
-                            </div>
+                            @fragments.commercial.paidForMeta()
                             <h3 class="commercial__title">@container.displayName</h3>
                             <a class="commercial__cta"
                                 @if(Edition(request).id == "AU") {

--- a/common/app/views/fragments/guBand.scala.html
+++ b/common/app/views/fragments/guBand.scala.html
@@ -3,22 +3,7 @@
 
 <div class="paidfor-band">
     <div class="gs-container paidfor-band__inner">
-        <div class="paidfor-meta">
-            <span class="paidfor-meta__label">Paid content</span>
-            <div class="paidfor-label paidfor-meta__more has-popup">
-                <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="paidfor-popup--sticky">
-                    About
-                    @fragments.inlineSvg("arrow-down", "icon")
-                </button>
-                <div class="popup is-off paidfor-popup paidfor-popup--sticky">
-                    <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
-                    <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">
-                        Learn more about Guardian Labs content
-                        @fragments.inlineSvg("arrow-right", "icon")
-                    </a>
-                </div>
-            </div>
-        </div>
+        @fragments.commercial.paidForMeta()
         <a class="paidfor-branding"
             @if(Edition(request).id == "AU") {
                 href="@LinkTo("/guardian-labs-australia")"

--- a/static/src/javascripts/projects/common/views/commercial/creatives/paidfor-content.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/paidfor-content.html
@@ -10,7 +10,7 @@
                 About <%=icon%>
             </button>
             <div class="popup is-off paidfor-popup paidfor-popup--<%=dataAttr%>">
-                <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and created by the Guardian Labs team</h3>
+                <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team</h3>
                 <a class="paidfor-popup__link" href="https://www.theguardian.com/info/2014/sep/23/paid-for-content" data-link-name="popup link">
                     Learn more about Guardian Labs content
                     <%=infoLinkIcon%>


### PR DESCRIPTION
Created fragment for paid for content meta block so we don't need to edit it in multiple places.
- I did the requested change to replace 'created' with 'produced'

![screen shot 2016-01-29 at 13 56 03](https://cloud.githubusercontent.com/assets/2579465/12677244/70df2430-c68f-11e5-94a0-f8a8a88a6312.png)

CC @kelvin-chappell @jbreckmckye @Calanthe 
