### PR TITLE
Load Outbrain in place of the low-pri merch component

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -265,4 +265,13 @@ trait CommercialSwitches {
     sellByDate = new LocalDate(2016, 3, 1),
     exposeClientSide = true
   )
+
+  val OutbrainReplacesMerch = Switch(
+    "Commercial",
+    "outbrain-replaces-merch",
+    "In case the low-priority merchandising component is empty, an Outbrain widget is loaded in its place",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 2, 12),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -273,6 +273,7 @@ trait CommercialSwitches {
     safeState = Off,
     sellByDate = new LocalDate(2016, 2, 12),
     exposeClientSide = true
+  )
 
   val OutbrainOnAmp = Switch(
     "Commercial",

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -22,7 +22,7 @@
     } {
         <div class="fc-container fc-container--commercial-high">@fragments.commercial.commercialComponentHigh()</div>
     } {
-        <div class="fc-container fc-container--commercial">@fragments.commercial.commercialComponent()</div>
+        <div class="fc-container fc-container--commercial js-container--commercial">@fragments.commercial.commercialComponent()</div>
     } {
         @fragments.outbrainPlaceholder()
     }

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
@@ -30,7 +30,8 @@ define([
                 sliceAdverts : false,
                 popularContentMPU : false,
                 videoPreRolls : false,
-                frontCommercialComponents : false
+                frontCommercialComponents : false,
+                outbrain: false
             };
         }
     };
@@ -161,6 +162,7 @@ define([
         this.frontCommercialComponents = enabled;
         this.thirdPartyTags = enabled;
         this.badges = enabled;
+        this.outbrain = true;
     }
 
     function getPolicySwitches() {

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
@@ -147,6 +147,9 @@ define([
         if (!config.switches.sponsored) {
             switches.badges = false;
         }
+        if (!config.switches.outbrain) {
+            switches.outbrain = false;
+        }
 
         return switches;
     };
@@ -162,7 +165,7 @@ define([
         this.frontCommercialComponents = enabled;
         this.thirdPartyTags = enabled;
         this.badges = enabled;
-        this.outbrain = true;
+        this.outbrain = enabled;
     }
 
     function getPolicySwitches() {

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
@@ -120,7 +120,10 @@ define([
 
     policies.nonFrontPages = function () {
         if (!config.page.isFront) {
-            return {frontCommercialComponents : false};
+            return {
+                frontCommercialComponents : false,
+                outbrain: false
+            };
         }
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
@@ -38,7 +38,7 @@ define(function () {
     };
 
     function getCode(data) {
-        if (data.slot === 'outbrain') {
+        if (!data.slot in outbrainCodes || data.slot === 'outbrain') {
             return outbrainCodes.outbrain[data.section][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
         } else {
             return outbrainCodes.merchandising[data.edition][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
@@ -1,0 +1,49 @@
+define(function () {
+    var outbrainCodes = {
+        outbrain: {
+            1: {
+                mobile:  { code: 'MB_4' },
+                desktop: { image: 'AR_12', text: 'AR_14' },
+                tablet:  { image: 'MB_6', text: 'MB_8' }
+            },
+            2: {
+                mobile:  { code: 'MB_5' },
+                desktop: { image: 'AR_13', text: 'AR_15' },
+                tablet:  { image: 'MB_7', text: 'MB_9' }
+            }
+        },
+
+        merchandising: {
+            UK: {
+                mobile:  { code: 'MB_10' },
+                desktop: { code: 'AR_28' },
+                tablet:  { code: 'MB_11' }
+            },
+            US: {
+                mobile:  { code: 'CRMB_55' },
+                desktop: { code: 'CR_13' },
+                tablet:  { code: 'CRMB_56' }
+            },
+            AU: {
+                mobile:  { code: 'CRMB_57' },
+                desktop: { code: 'CR_14' },
+                tablet:  { code: 'CRMB_58' }
+            },
+            INT: {
+                mobile:  { code: 'CRMB_59' },
+                desktop: { code: 'CR_15' },
+                tablet:  { code: 'CRMB_60' }
+            }
+        }
+    };
+
+    function getCode(data) {
+        if (data.slot === 'outbrain') {
+            return outbrainCodes.outbrain[data.section][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
+        } else {
+            return outbrainCodes.merchandising[data.edition][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
+        }
+    }
+
+    return getCode;
+})

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
@@ -1,4 +1,6 @@
-define(function () {
+define([
+    'common/modules/commercial/third-party-tags/outbrain-sections'
+], function (getSection) {
     var outbrainCodes = {
         outbrain: {
             1: {
@@ -39,7 +41,7 @@ define(function () {
 
     function getCode(data) {
         if (!(data.slot in outbrainCodes) || data.slot === 'outbrain') {
-            return outbrainCodes.outbrain[data.section][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
+            return outbrainCodes.outbrain[getSection(data.section)][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
         } else {
             return outbrainCodes.merchandising[data.edition][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
         }

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
@@ -1,14 +1,24 @@
 define([
     'common/modules/commercial/third-party-tags/outbrain-sections'
 ], function (getSection) {
+    /* These codes are given to us directly by Outbrain. They will eventually
+       be sent back to them via a data- attribute, in order for them to return
+       contextually-relevant links. The codes differ whether on a smartphone,
+       tablet or desktop. Also, except on mobile, we will request two sets of
+       links from Outbrain, hence the two codes in some contexts.
+       Currently, there are two categories of codes:
+       1. defaults: these are the codes used by default for the Outbrain widget
+       2. merchandising: these are the codes when the widget replaces the low-
+        priority merchandising component
+    */
     var outbrainCodes = {
-        outbrain: {
-            1: {
+        defaults: {
+            news: {
                 mobile:  { code: 'MB_4' },
                 desktop: { image: 'AR_12', text: 'AR_14' },
                 tablet:  { image: 'MB_6', text: 'MB_8' }
             },
-            2: {
+            defaults: {
                 mobile:  { code: 'MB_5' },
                 desktop: { image: 'AR_13', text: 'AR_15' },
                 tablet:  { image: 'MB_7', text: 'MB_9' }
@@ -40,7 +50,7 @@ define([
     };
 
     function getCode(data) {
-        if (!(data.slot in outbrainCodes) || data.slot === 'outbrain') {
+        if (!(data.slot in outbrainCodes) || data.slot === 'defaults') {
             return outbrainCodes.outbrain[getSection(data.section)][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
         } else {
             return outbrainCodes.merchandising[data.edition][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
@@ -1,14 +1,24 @@
 define([
     'common/modules/commercial/third-party-tags/outbrain-sections'
 ], function (getSection) {
+    /* These codes are given to us directly by Outbrain. They will eventually
+       be sent back to them via a data- attribute, in order for them to return
+       contextually-relevant links. The codes differ whether on a smartphone,
+       tablet or desktop. Also, except on mobile, we will request two sets of
+       links from Outbrain, hence the two codes in some contexts.
+       Currently, there are two categories of codes:
+       1. defaults: these are the codes used by default for the Outbrain widget
+       2. merchandising: these are the codes when the widget replaces the low-
+        priority merchandising component
+    */
     var outbrainCodes = {
-        outbrain: {
-            1: {
+        defaults: {
+            news: {
                 mobile:  { code: 'MB_4' },
                 desktop: { image: 'AR_12', text: 'AR_14' },
                 tablet:  { image: 'MB_6', text: 'MB_8' }
             },
-            2: {
+            defaults: {
                 mobile:  { code: 'MB_5' },
                 desktop: { image: 'AR_13', text: 'AR_15' },
                 tablet:  { image: 'MB_7', text: 'MB_9' }
@@ -40,8 +50,8 @@ define([
     };
 
     function getCode(data) {
-        if (!(data.slot in outbrainCodes) || data.slot === 'outbrain') {
-            return outbrainCodes.outbrain[getSection(data.section)][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
+        if (!(data.slot in outbrainCodes) || data.slot === 'defaults') {
+            return outbrainCodes.defaults[getSection(data.section)][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
         } else {
             return outbrainCodes.merchandising[data.edition][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
         }

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
@@ -38,7 +38,7 @@ define(function () {
     };
 
     function getCode(data) {
-        if (!data.slot in outbrainCodes || data.slot === 'outbrain') {
+        if (!(data.slot in outbrainCodes) || data.slot === 'outbrain') {
             return outbrainCodes.outbrain[data.section][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
         } else {
             return outbrainCodes.merchandising[data.edition][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
@@ -46,4 +46,4 @@ define(function () {
     }
 
     return getCode;
-})
+});

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-sections.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-sections.js
@@ -1,4 +1,4 @@
-define(function() {
+define(function () {
     var sections = ['politics', 'world', 'business', 'commentisfree'];
 
     function getSection(section) {

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-sections.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-sections.js
@@ -1,0 +1,10 @@
+define(function() {
+    var sections = ['politics', 'world', 'business', 'commentisfree'];
+
+    function getSection(section) {
+        section = section.toLowerCase();
+        return /news/.test(section) || sections.indexOf(section) !== -1 ? 1 : 2;
+    }
+
+    return getSection;
+});

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-sections.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-sections.js
@@ -3,7 +3,7 @@ define(function () {
 
     function getSection(section) {
         section = section.toLowerCase();
-        return /news/.test(section) || sections.indexOf(section) !== -1 ? 1 : 2;
+        return /news/.test(section) || sections.indexOf(section) !== -1 ? 'news' : 'defaults';
     }
 
     return getSection;

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -46,12 +46,11 @@ define([
     }
 
     function load(target) {
-        var slot          = target in selectors ? target : 'outbrain',
-            $outbrain     = $(selectors.outbrain.widget),
-            $container    = $(selectors.outbrain.container, $outbrain[0]),
-            breakpoint    = detect.getBreakpoint(),
-            widgetCodes,
-            widgetHtml;
+        var slot          = target in selectors ? target : 'defaults';
+        var $outbrain     = $(selectors.outbrain.widget);
+        var $container    = $(selectors.outbrain.container, $outbrain[0]);
+        var breakpoint    = detect.getBreakpoint();
+        var widgetCodes, widgetHtml;
 
         widgetCodes = getCode({
             slot: slot,
@@ -87,17 +86,17 @@ define([
         return new Promise(function (resolve, reject) {
             var onAdLoaded = function (event) {
                 if (event.slot.getSlotElementId() === id) {
-                    off();
+                    unlisten();
                     resolve(!event.isEmpty);
                 }
             };
 
             var onAllAdsLoaded = function () {
-                off();
+                unlisten();
                 reject(new Error('Unable to load Outbrain widget: slot ' + id + ' was never loaded'));
             };
 
-            function off() {
+            function unlisten() {
                 mediator.off('modules:commercial:dfp:rendered', onAdLoaded);
                 mediator.off('modules:commercial:dfp:alladsrendered', onAllAdsLoaded);
             }

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -140,7 +140,7 @@ define([
                 // location right away
                 return Promise.all([
                     isHiResLoaded,
-                    isHiResLoaded ? trackAd('dfp-ad--merchandising') : false
+                    isHiResLoaded && config.switches.outbrainReplacesMerch ? trackAd('dfp-ad--merchandising') : true
                 ]);
             }).then(function (args) {
                 var isHiResLoaded = args[0];

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -30,7 +30,7 @@ define([
             container: '.js-outbrain-container'
         },
         merchandising: {
-            widget: '.fc-container--commercial',
+            widget: '.js-container--commercial',
             container: '.js-outbrain-container'
         }
     };

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -27,13 +27,19 @@ define([
     var outbrainTpl = template(outbrainStr);
 
     var selectors = {
-        outbrain: { widget: '.js-outbrain', container: '.js-outbrain-container' },
-        merchandising: { widget: '#dfp-ad--merchandising', container: '#dfp-ad--merchandising' }
+        outbrain: {
+            widget: '.js-outbrain',
+            container: '.js-outbrain-container'
+        },
+        merchandising: {
+            widget: '.fc-container--commercial',
+            container: '.js-outbrain-container'
+        }
     };
 
     function build(codes, breakpoint) {
         var html = outbrainTpl({ widgetCode: codes.code || codes.image });
-        if (breakpoint !== 'mobile') {
+        if (breakpoint !== 'mobile' ) {
             html += outbrainTpl({ widgetCode: codes.code || codes.text });
         }
         return html;
@@ -41,8 +47,8 @@ define([
 
     function load(target) {
         var slot          = target in selectors ? target : 'outbrain',
-            $outbrain     = $(selectors[slot].widget),
-            $container    = $(selectors[slot].container),
+            $outbrain     = $(selectors.outbrain.widget),
+            $container    = $(selectors.outbrain.container, $outbrain[0]),
             breakpoint    = detect.getBreakpoint(),
             widgetCodes,
             widgetHtml;
@@ -54,12 +60,15 @@ define([
             breakpoint: breakpoint
         });
         widgetHtml = build(widgetCodes, breakpoint);
-        $container.append(widgetHtml);
-        module.tracking(widgetCodes.code || widgetCodes.image);
-        require(['js!' + outbrainUrl], function () {
-            fastdom.write(function () {
-                $outbrain.css('display', 'block');
-            });
+        return fastdom.write(function () {
+            if (slot !== 'outbrain') {
+                $(selectors[slot].widget).replaceWith($outbrain[0]);
+            }
+            $container.append(widgetHtml);
+            $outbrain.css('display', 'block');
+        }).then(function () {
+            module.tracking(widgetCodes.code || widgetCodes.image);
+            require(['js!' + outbrainUrl]);
         });
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -7,6 +7,7 @@ define([
     'common/utils/mediator',
     'common/utils/template',
     'common/modules/identity/api',
+    'common/modules/commercial/commercial-features',
     'common/modules/commercial/third-party-tags/outbrain-codes',
     'text!common/views/commercial/outbrain.html'
 ], function (
@@ -18,6 +19,7 @@ define([
     mediator,
     template,
     identity,
+    commercialFeatures,
     getCode,
     outbrainStr
 ) {
@@ -121,11 +123,11 @@ define([
     }
 
     function init() {
-        if (config.switches.outbrain
-            && !config.page.isFront
-            && !config.page.isPreview
-            && config.page.section !== 'childrens-books-site'
-            && identityPolicy()
+        if (config.switches.outbrain &&
+            !config.page.isFront &&
+            !config.page.isPreview &&
+            commercialFeatures.outbrain &&
+            identityPolicy()
         ) {
             // if there is no merch component, load the outbrain widget right away
             if (loadInstantly()) {

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -39,7 +39,7 @@ define([
 
     function build(codes, breakpoint) {
         var html = outbrainTpl({ widgetCode: codes.code || codes.image });
-        if (breakpoint !== 'mobile' ) {
+        if (breakpoint !== 'mobile') {
             html += outbrainTpl({ widgetCode: codes.code || codes.text });
         }
         return html;

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -123,7 +123,6 @@ define([
 
     function init() {
         if (commercialFeatures.outbrain &&
-            !config.page.isFront &&
             !config.page.isPreview &&
             identityPolicy()
         ) {

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -8,7 +8,6 @@ define([
     'common/utils/template',
     'common/modules/identity/api',
     'common/modules/commercial/third-party-tags/outbrain-codes',
-    'common/modules/commercial/third-party-tags/outbrain-sections',
     'text!common/views/commercial/outbrain.html'
 ], function (
     Promise,
@@ -20,7 +19,6 @@ define([
     template,
     identity,
     getCode,
-    getSection,
     outbrainStr
 ) {
     var outbrainUrl = '//widgets.outbrain.com/outbrain.js';
@@ -55,7 +53,7 @@ define([
 
         widgetCodes = getCode({
             slot: slot,
-            section: getSection(config.page.section),
+            section: config.page.section,
             edition: config.page.edition,
             breakpoint: breakpoint
         });

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -42,7 +42,7 @@ define([
     }
 
     function load(target) {
-        var slot          = target || 'outbrain',
+        var slot          = target in selectors ? target : 'outbrain',
             $outbrain     = $(selectors[slot].widget),
             $container    = $(selectors[slot].container),
             breakpoint    = detect.getBreakpoint(),

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -46,12 +46,11 @@ define([
     }
 
     function load(target) {
-        var slot          = target in selectors ? target : 'outbrain',
-            $outbrain     = $(selectors.outbrain.widget),
-            $container    = $(selectors.outbrain.container, $outbrain[0]),
-            breakpoint    = detect.getBreakpoint(),
-            widgetCodes,
-            widgetHtml;
+        var slot          = target in selectors ? target : 'defaults';
+        var $outbrain     = $(selectors.outbrain.widget);
+        var $container    = $(selectors.outbrain.container, $outbrain[0]);
+        var breakpoint    = detect.getBreakpoint();
+        var widgetCodes, widgetHtml;
 
         widgetCodes = getCode({
             slot: slot,
@@ -61,7 +60,7 @@ define([
         });
         widgetHtml = build(widgetCodes, breakpoint);
         return fastdom.write(function () {
-            if (slot !== 'outbrain') {
+            if (slot !== 'defaults') {
                 $(selectors[slot].widget).replaceWith($outbrain[0]);
             }
             $container.append(widgetHtml);
@@ -87,17 +86,17 @@ define([
         return new Promise(function (resolve, reject) {
             var onAdLoaded = function (event) {
                 if (event.slot.getSlotElementId() === id) {
-                    off();
+                    unlisten();
                     resolve(!event.isEmpty);
                 }
             };
 
             var onAllAdsLoaded = function () {
-                off();
+                unlisten();
                 reject(new Error('Unable to load Outbrain widget: slot ' + id + ' was never loaded'));
             };
 
-            function off() {
+            function unlisten() {
                 mediator.off('modules:commercial:dfp:rendered', onAdLoaded);
                 mediator.off('modules:commercial:dfp:alladsrendered', onAllAdsLoaded);
             }
@@ -123,10 +122,9 @@ define([
     }
 
     function init() {
-        if (config.switches.outbrain &&
+        if (commercialFeatures.outbrain &&
             !config.page.isFront &&
             !config.page.isPreview &&
-            commercialFeatures.outbrain &&
             identityPolicy()
         ) {
             // if there is no merch component, load the outbrain widget right away

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -9,8 +9,7 @@ define([
     'common/modules/identity/api',
     'common/modules/commercial/third-party-tags/outbrain-codes',
     'common/modules/commercial/third-party-tags/outbrain-sections',
-    'text!common/views/commercial/outbrain.html',
-    'lodash/collections/map'
+    'text!common/views/commercial/outbrain.html'
 ], function (
     Promise,
     fastdom,
@@ -22,8 +21,7 @@ define([
     identity,
     getCode,
     getSection,
-    outbrainStr,
-    map
+    outbrainStr
 ) {
     var outbrainUrl = '//widgets.outbrain.com/outbrain.js';
     var outbrainTpl = template(outbrainStr);
@@ -35,7 +33,7 @@ define([
 
     function build(codes, breakpoint) {
         var html = outbrainTpl({ widgetCode: codes.code || codes.image });
-        if (breakpoint !== "mobile") {
+        if (breakpoint !== 'mobile') {
             html += outbrainTpl({ widgetCode: codes.code || codes.text });
         }
         return html;

--- a/static/test/javascripts/spec/common/commercial/commercial-feature-policies.spec.js
+++ b/static/test/javascripts/spec/common/commercial/commercial-feature-policies.spec.js
@@ -46,7 +46,8 @@ define([
                 sliceAdverts : false,
                 popularContentMPU : false,
                 videoPreRolls : false,
-                frontCommercialComponents : false
+                frontCommercialComponents : false,
+                outbrain : false
             };
 
             it('hides features on a sensitive page', function () {

--- a/static/test/javascripts/spec/common/commercial/third-party-tags/outbrain.spec.js
+++ b/static/test/javascripts/spec/common/commercial/third-party-tags/outbrain.spec.js
@@ -1,6 +1,6 @@
-define('ophan/ng', [], function() { return { record: function() {} }});
-define('js', [], function() { return function() {} });
-define('js!//widgets.outbrain.com/outbrain.js', [], function() { return function() {} });
+define('ophan/ng', [], function () { return { record: function () {} }; });
+define('js', [], function () { return function () {}; });
+define('js!//widgets.outbrain.com/outbrain.js', [], function () { return function () {}; });
 define([
     'fastdom',
     'helpers/injector',
@@ -172,12 +172,12 @@ define([
                 eventStubLo.isEmpty = true;
 
                 var oldEmit = mediator.emit;
-                mediator.emit = function(eventName, data) {
-                    return new Promise(function(resolve) {
+                mediator.emit = function (eventName, data) {
+                    return new Promise(function (resolve) {
                         oldEmit.call(mediator, eventName, data);
                         resolve();
                     });
-                }
+                };
 
                 sut.init().then(function () {
                     expect(sut.load).toHaveBeenCalledWith('merchandising');

--- a/static/test/javascripts/spec/common/commercial/third-party-tags/outbrain.spec.js
+++ b/static/test/javascripts/spec/common/commercial/third-party-tags/outbrain.spec.js
@@ -54,7 +54,6 @@ define([
                 config.page = {
                     section: 'uk-news',
                     isPreview: false,
-                    isFront: false,
                     commentable: true,
                     edition: 'UK'
                 };
@@ -122,15 +121,6 @@ define([
 
             it('should not load when isPreview', function (done) {
                 config.page.isPreview = true;
-
-                sut.init().then(function () {
-                    expect(sut.load).not.toHaveBeenCalled();
-                    done();
-                });
-            });
-
-            it('should not load when on network front', function (done) {
-                config.page.isFront = true;
 
                 sut.init().then(function () {
                     expect(sut.load).not.toHaveBeenCalled();

--- a/static/test/javascripts/spec/common/commercial/third-party-tags/outbrain.spec.js
+++ b/static/test/javascripts/spec/common/commercial/third-party-tags/outbrain.spec.js
@@ -170,6 +170,7 @@ define([
             it('should load in the low-priority merch component', function (done) {
                 eventStub.isEmpty = false;
                 eventStubLo.isEmpty = true;
+                config.switches.outbrainReplacesMerch = true;
 
                 var oldEmit = mediator.emit;
                 mediator.emit = function (eventName, data) {
@@ -227,9 +228,7 @@ define([
                 };
                 config.page.section = 'uk-news';
 
-                sut.load();
-
-                fastdom.defer(function () {
+                sut.load().then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('AR_12');
                     expect($('.OUTBRAIN', $fixtureContainer).last().data('widgetId')).toEqual('AR_14');
                     done();
@@ -242,9 +241,7 @@ define([
                 };
                 config.page.section = 'football';
 
-                sut.load();
-
-                fastdom.defer(function () {
+                sut.load().then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('AR_13');
                     expect($('.OUTBRAIN', $fixtureContainer).last().data('widgetId')).toEqual('AR_15');
                     done();
@@ -257,9 +254,7 @@ define([
                 };
                 config.page.section = 'football';
 
-                sut.load();
-
-                fastdom.defer(function () {
+                sut.load().then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('AR_13');
                     expect($('.OUTBRAIN', $fixtureContainer).last().data('widgetId')).toEqual('AR_15');
                     done();
@@ -272,9 +267,7 @@ define([
                 };
                 config.page.section = 'uk-news';
 
-                sut.load();
-
-                fastdom.defer(function () {
+                sut.load().then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('MB_6');
                     expect($('.OUTBRAIN', $fixtureContainer).last().data('widgetId')).toEqual('MB_8');
                     done();
@@ -287,9 +280,7 @@ define([
                 };
                 config.page.section = 'football';
 
-                sut.load();
-
-                fastdom.defer(function () {
+                sut.load().then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('MB_7');
                     expect($('.OUTBRAIN', $fixtureContainer).last().data('widgetId')).toEqual('MB_9');
                     done();
@@ -302,9 +293,7 @@ define([
                 };
                 config.page.section = 'uk-news';
 
-                sut.load();
-
-                fastdom.defer(function () {
+                sut.load().then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('MB_4');
                     done();
                 });
@@ -316,9 +305,7 @@ define([
                 };
                 config.page.section = 'football';
 
-                sut.load();
-
-                fastdom.defer(function () {
+                sut.load().then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('MB_5');
                     done();
                 });
@@ -330,9 +317,7 @@ define([
                 };
                 config.page.edition = 'AU';
 
-                sut.load('merchandising');
-
-                fastdom.defer(function () {
+                sut.load('merchandising').then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('CR_14');
                     expect($('.OUTBRAIN', $fixtureContainer).last().data('widgetId')).toEqual('CR_14');
                     done();
@@ -344,9 +329,7 @@ define([
                     return 'tablet';
                 };
 
-                sut.load('merchandising');
-
-                fastdom.defer(function () {
+                sut.load('merchandising').then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('MB_11');
                     expect($('.OUTBRAIN', $fixtureContainer).last().data('widgetId')).toEqual('MB_11');
                     done();
@@ -358,18 +341,14 @@ define([
                     return 'mobile';
                 };
 
-                sut.load('merchandising');
-
-                fastdom.defer(function () {
+                sut.load('merchandising').then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('MB_10');
                     done();
                 });
             });
 
             it('should require outbrain javascript', function (done) {
-                sut.load();
-
-                fastdom.defer(function () {
+                sut.load().then(function () {
                     var url = requireStub.args[1][0][0];
                     expect(url).toBe('js!//widgets.outbrain.com/outbrain.js');
                     done();
@@ -389,9 +368,7 @@ define([
 
                 spyOn(sut, 'tracking');
 
-                sut.load();
-
-                fastdom.defer(function () {
+                sut.load().then(function () {
                     expect(sut.tracking).toHaveBeenCalledWith('AR_13');
                     done();
                 });


### PR DESCRIPTION
These are the new rules for when and how Outbrain should be displayed, across all editions, under the same condition (i.e. not a front, not on children's book site, anonymous user or article w/o comments)
1. if the visitor has an ad blocker: same as before, otherwise
2. if the high priority merchandising component is empty: same as before, otherwise
3. if the high priority merchandising component is not empty _and_ the low priority is empty: move the outbrain widget down to where the low-pri component should have appeared and load it from there

The latter case uses new codes given by Outbrain, and this is not looking too good right now:
![picture 1](https://cloud.githubusercontent.com/assets/629976/12679704/797a1e66-c69d-11e5-9c3f-bf7a82b480b4.png)

Thus, point **3** is hidden behind a switch until they can fix this.
