### PR TITLE
Extend prebid.js A/B test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -72,7 +72,7 @@ trait ABTestSwitches {
     "ab-prebid-performance",
     "Measure performance impact of running prebid auctions before showing display advertising",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 2, 1),
+    sellByDate = new LocalDate(2016, 2, 8),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/prebid-performance.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/prebid-performance.js
@@ -6,7 +6,7 @@ define([
     return function () {
         this.id = 'PrebidPerformance';
         this.start = '2016-01-15';
-        this.expiry = '2016-01-31';
+        this.expiry = '2016-02-08';
         this.author = 'Jimmy Breck-McKye';
         this.description = 'run prebid.js header-bidding auctions before displaying DFP advertising';
 


### PR DESCRIPTION
This extends the prebid.js performance A/B test for a week. We'll determine how long this test needs to run next week in collaboration with Data Science.

@Calanthe 
