### PR TITLE
Remove redundant ipad split features switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -241,15 +241,6 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
-  val SplitOlderIPadsSwitch = Switch(
-    "Feature",
-    "ipad-split-capabilities",
-    "If switched on then this gives older ipads the stripped down front but full articles",
-    safeState = On,
-    sellByDate = new LocalDate(2016, 2, 1),
-    exposeClientSide = false
-  )
-
   val FootballFeedRecorderSwitch = Switch(
     "Feature",
     "football-feed-recorder",

--- a/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
+++ b/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
@@ -1,5 +1,4 @@
 @(item: model.MetaData)(implicit request: RequestHeader)
-@import conf.switches.Switches._
 
 // Determine whether we want to run the enhanced app or not.
 // It can come either from a preference in localStorage (see `enhancedKey`)


### PR DESCRIPTION
As discussed with @michaelwmcnamara - this switch isn't used any more.

cc @sndrs @OliverJAsh 
