### PR TITLE
Revert "Revert "Editionalising onward journeys on amp""

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -181,6 +181,10 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       .map(_.trim).toSeq).getOrElse(Nil)
   }
 
+  object amp {
+    lazy val url = configuration.getStringProperty("amp.url").getOrElse("")
+  }
+
   object id {
     lazy val url = configuration.getStringProperty("id.url").getOrElse("")
     lazy val apiRoot = configuration.getStringProperty("id.apiRoot").getOrElse("")

--- a/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
+++ b/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
@@ -51,7 +51,7 @@
                                 </time>
                             </aside>
                         </div>
-                        <a href="{{url}}" class="fc-item__link">{{headline}}</a>
+                        <a href="@{Configuration.site.host}{{url}}" class="fc-item__link">{{headline}}</a>
                     </div>
                 {{/content}}
             </div>

--- a/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
+++ b/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
@@ -2,7 +2,7 @@
 @import conf.Configuration
 
 @* must be served by localhost, not thegulocal *@
-<amp-list layout="fixed-height" height="188" src="@Configuration.ajax.url/@path" class="onward-list">
+<amp-list layout="fixed-height" height="188" src="@Configuration.amp.url/@path" class="onward-list">
     <template type="amp-mustache">
         {{#showContent}}
             <div class="fc-container__inner">

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -75,9 +75,9 @@
             @fragments.amp.outbrain(page)
 
             @fragments.amp.onwardTemplateAmp("most-read-mf2.json")
-            @fragments.amp.onwardTemplateAmp("container-mf2/1/0/international.json")
-            @fragments.amp.onwardTemplateAmp("container-mf2/1/1/international.json")
-            @fragments.amp.onwardTemplateAmp("container-mf2/1/2/international.json")
+            @fragments.amp.onwardTemplateAmp(s"container-mf2/1/0/${page.metadata.section}.json")
+            @fragments.amp.onwardTemplateAmp(s"container-mf2/1/1/${page.metadata.section}.json")
+            @fragments.amp.onwardTemplateAmp(s"container-mf2/1/2/${page.metadata.section}.json")
 
             <amp-font
                 layout="nodisplay"

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -23,6 +23,8 @@ ajax.cors.origin=http://m.code.dev-theguardian.com,https://profile.code.dev-theg
 
 oas.siteId.host=m.code.dev-theguardian.com
 
+amp.url=https://amp.code.dev-theguardian.com
+
 # ID
 id.url=https://profile.code.dev-theguardian.com
 id.apiRoot=https://idapi.code.dev-theguardian.com

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -21,6 +21,8 @@ ajax.url=https://api.nextgen.guardianapps.co.uk
 # no spaces
 ajax.cors.origin=http://www.theguardian.com,https://www.theguardian.com,https://profile.theguardian.com,https://composer.gutools.co.uk,https://composer.release.dev-gutools.co.uk,https://composer.code.dev-gutools.co.uk,http://preview.gutools.co.uk,https://preview.gutools.co.uk
 
+amp.url=https://amp.theguardian.com
+
 # ID
 id.url=https://profile.theguardian.com
 id.apiRoot=https://idapi.theguardian.com

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -98,7 +98,6 @@ GET            /most-read-facebook.json                                         
 GET            /most-read-twitter.json                                                                                           controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "twitter")
 GET            /most-read.json                                                                                                   controllers.MostPopularController.render(path = "")
 GET            /most-read/*path.json                                                                                             controllers.MostPopularController.render(path)
-GET            /most-read-mf2.json                                                                                               controllers.MostPopularController.renderPopularMicroformat2()
 GET            /most-read-geo.json                                                                                               controllers.MostPopularController.renderPopularGeo()
 GET            /most-read-day.json                                                                                               controllers.MostPopularController.renderPopularDay(countryCode)
 
@@ -106,7 +105,6 @@ GET            /top-stories.json                                                
 GET            /top-stories/trails.json                                                                                          controllers.TopStoriesController.renderTrails()
 GET            /related/*path.json                                                                                               controllers.RelatedController.render(path)
 GET            /related/*path                                                                                                    controllers.RelatedController.renderHtml(path)
-GET            /related-mf2/*path.json                                                                                           controllers.RelatedController.renderMf2(path)
 GET            /popular-in-tag/*tag.json                                                                                         controllers.PopularInTag.render(tag)
 
 GET            /preference/edition/:edition                                                                                      controllers.ChangeEditionController.render(edition)
@@ -318,9 +316,13 @@ GET            /commercial/magento/token                                        
 GET            /commercial/magento/resource                                                                                      controllers.commercial.magento.ApiSandbox.getResource(t: String)
 GET            /commercial/magento/books                                                                                         controllers.commercial.magento.ApiSandbox.getBooks(t: String)
 
+# AMP
+GET            /most-read-mf2.json                                                                                               controllers.MostPopularController.renderPopularMicroformat2()
+GET            /related-mf2/*path.json                                                                                           controllers.RelatedController.renderMf2(path)
+GET            /container-mf2/:num/:offset/:section.json                                                                         controllers.FaciaController.renderSomeFrontContainersMf2(num, offset, section)
+GET            /series/mf2/*path.json                                                                                            controllers.SeriesController.renderMf2SeriesStories(path)
 
 # Onward journeys
-GET            /series/mf2/*path.json                                                                                            controllers.SeriesController.renderMf2SeriesStories(path)
 GET            /series/*path.json                                                                                                controllers.SeriesController.renderSeriesStories(path)
 
 # Applications (must come before wildcard)
@@ -372,7 +374,6 @@ GET            /$path<(uk|au|us|international)(/(culture|sport|commentisfree|bus
 GET            /*path/lite.json                                                                                                  controllers.FaciaController.renderFrontJsonLite(path)
 GET            /*path/deduped.json                                                                                               controllers.DedupedController.getDedupedForPath(path)
 GET            /container/*path/some/:num/:offset/:containerNameToFilter/:edition.json                                           controllers.FaciaController.renderSomeFrontContainers(path, num, offset, containerNameToFilter, edition)
-GET            /container-mf2/:num/:offset/*path.json                                                                            controllers.FaciaController.renderSomeFrontContainersMf2(num, offset, path)
 GET            /container/use-layout/*id.json                                                                                    controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
 GET            /container/*id.json                                                                                               controllers.FaciaController.renderContainerJson(id)
 GET            /most-relevant-container/*path.json                                                                               controllers.FaciaController.renderMostRelevantContainerJson(path)

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -93,10 +93,13 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
     }
   }
 
-  def renderSomeFrontContainersMf2(rawNum: String, rawOffset: String, path: String) = MemcachedAction { implicit request =>
-    def getEditionFromString(edition: String) = Edition.all.find(_.id.toLowerCase() == "int").getOrElse(Edition.all.head)
+  def renderSomeFrontContainersMf2(rawNum: String, rawOffset: String, section: String) = MemcachedAction { implicit request =>
+    val edition = Edition(request)
+    // TODO: This list also exists in the JS for fronts on articles a/b test. Pending a decision on that, this should go in the jsconfig, or be removed
+    val sectionsToLoad = List("commentisfree", "sport", "football", "fashion", "lifeandstyle", "education", "culture", "business", "technology", "politics", "environment", "travel", "film", "media", "money", "society", "science", "music", "books", "stage", "cities", "tv-and-radio", "artanddesign", "global-development")
+    val id = if (sectionsToLoad.contains(section)) section else edition.id.toLowerCase()
 
-    def returnContainers(num: Int, offset: Int) = getSomeCollections(Editionalise(path, getEditionFromString("international")), num, offset, "none").map { collections =>
+    def returnContainers(num: Int, offset: Int) = getSomeCollections(Editionalise(id, edition), num, offset, "none").map { collections =>
       Cached(60) {
         JsonComponent(
           "items" -> JsArray(collections.getOrElse(List()).map(getCollection))

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -20,7 +20,6 @@ GET        /external/eyeblaster/addineyeV2.html                                 
 GET        /collection/*id/rss                                                      controllers.FaciaController.renderCollectionRss(id)
 GET        /container/use-layout/*id.json                                           controllers.FaciaController.renderContainerJsonWithFrontsLayout(id)
 GET        /container/*path/some/:num/:offset/:containerNameToFilter/:edition.json  controllers.FaciaController.renderSomeFrontContainers(path, num, offset, containerNameToFilter, edition)
-GET        /container-mf2/:num/:offset/*path.json                                   controllers.FaciaController.renderSomeFrontContainersMf2(num, offset, path)
 GET        /container/*id.json                                                      controllers.FaciaController.renderContainerJson(id)
 GET        /most-relevant-container/*path.json                                      controllers.FaciaController.renderMostRelevantContainerJson(path)
 
@@ -33,3 +32,6 @@ GET        /*path/deduped.json                                                  
 GET        /*path.json                                                              controllers.FaciaController.renderFrontJson(path)
 GET        /                                                                        controllers.FaciaController.rootEditionRedirect()
 GET        /*path                                                                   controllers.FaciaController.renderFront(path)
+
+# AMP
+GET        /container-mf2/:num/:offset/:section.json                                controllers.FaciaController.renderSomeFrontContainersMf2(num, offset, section)

--- a/onward/conf/routes
+++ b/onward/conf/routes
@@ -26,7 +26,6 @@ GET        /most-read-facebook.json                   controllers.MostViewedSoci
 GET        /most-read-twitter.json                    controllers.MostViewedSocialController.renderMostViewed(socialContext: String = "twitter")
 GET        /most-read.json                            controllers.MostPopularController.render(path = "")
 GET        /most-read/*path.json                      controllers.MostPopularController.render(path)
-GET        /most-read-mf2.json                        controllers.MostPopularController.renderPopularMicroformat2()
 GET        /most-read-geo.json                        controllers.MostPopularController.renderPopularGeo()
 GET        /most-read-day.json                        controllers.MostPopularController.renderPopularDay(countryCode)
 
@@ -55,14 +54,12 @@ GET        /embed/card/*path                          controllers.RichLinkContro
 # For tests
 GET        /most-read/*path                           controllers.MostPopularController.renderHtml(path)
 GET        /related/*path                             controllers.RelatedController.renderHtml(path)
-GET        /related-mf2/*path.json                    controllers.RelatedController.renderMf2(path)
 GET        /top-stories                               controllers.TopStoriesController.renderTopStoriesHtml()
 GET        /gallery/most-viewed                       controllers.MostViewedGalleryController.renderMostViewedHtml()
 
 # Experimental
 GET        /cards/opengraph/*path.json                controllers.CardController.opengraph(path)
 GET        /tagged.json                               controllers.TaggedContentController.renderJson(tag: String)
-GET        /series/mf2/*path.json                     controllers.SeriesController.renderMf2SeriesStories(path)
 GET        /series/*path.json                         controllers.SeriesController.renderSeriesStories(path)
 
 # Business data
@@ -71,3 +68,8 @@ GET        /business-data/stocks.json                 controllers.StocksControll
 # User tech feedback
 GET        /info/tech-feedback                        controllers.TechFeedbackController.techFeedback(path = "")
 GET        /info/tech-feedback/*path                  controllers.TechFeedbackController.techFeedback(path)
+
+# AMP
+GET        /most-read-mf2.json                        controllers.MostPopularController.renderPopularMicroformat2()
+GET        /related-mf2/*path.json                    controllers.RelatedController.renderMf2(path)
+GET        /series/mf2/*path.json                     controllers.SeriesController.renderMf2SeriesStories(path)


### PR DESCRIPTION
Reverts guardian/frontend#11769

This was tested on CODE (Friday night) and all looked good. However because I don't want an unexpected bug to pop up over the weekend, I have reverted. 

This should be good to deploy on Monday morning.

cc @stephanfowler 
