### PR TITLE
Add US Election Badging to Liveblogs

### DIFF
--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -8,6 +8,7 @@
 @import views.html.fragments.items.facia_cards.item
 @import views.support.TrailCssClasses.toneClass
 @import common.Edition
+@import conf.switches.Switches._
 
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
 <div class="l-side-margins">
@@ -17,7 +18,8 @@
 
         <meta itemprop="url" content="@LinkTo(article.metadata.url)">
 
-        <header class="content__head tonal__head tonal__head--@toneClass(article)">
+        <header class="content__head tonal__head tonal__head--@toneClass(article)
+                        @if(USElectionSwitch.isSwitchedOn && article.content.tags.tags.exists(_.id == "us-news/us-elections-2016")) { content__head--us-election }">
             @* UPPER HEADER *@
             <div class="content__header tonal__header u-cf">
                 <div class="gs-container">

--- a/static/src/stylesheets/module/content/_badging.scss
+++ b/static/src/stylesheets/module/content/_badging.scss
@@ -29,7 +29,7 @@
    ========================================================================== */
 .content__head--us-election {
     .content__header .gs-container {
-        background-image: url("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/1/29/1454085451546/uselectionliveblogon.jpg");
+        background-image: url('http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/1/29/1454085451546/uselectionliveblogon.jpg');
         background-position: right bottom;
         background-repeat: no-repeat;
         background-size: gs-span(4);

--- a/static/src/stylesheets/module/content/_badging.scss
+++ b/static/src/stylesheets/module/content/_badging.scss
@@ -29,7 +29,7 @@
    ========================================================================== */
 .content__head--us-election {
     .content__header .gs-container {
-        background-image: url('http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/1/29/1454085451546/uselectionliveblogon.jpg');
+        background-image: url('http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454325391071/uselectionliveblogon.jpg');
         background-position: right bottom;
         background-repeat: no-repeat;
         background-size: gs-span(4);
@@ -53,4 +53,8 @@
             background-size: gs-span(6);
         }
     }
+}
+
+.tonal__head--tone-dead .content__header .gs-container {
+    background-image: url('http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454325390553/uselectionliveblogoff.jpg');
 }

--- a/static/src/stylesheets/module/content/_badging.scss
+++ b/static/src/stylesheets/module/content/_badging.scss
@@ -1,3 +1,5 @@
+/* US Elections Tag Badge
+   ========================================================================== */
 .badge-slot--us-election {
     width: 33px;
     margin-top: 2px;
@@ -20,5 +22,35 @@
     .content__section-label,
     .content__series-label {
         float: none;
+    }
+}
+
+/* US Election Liveblog Image
+   ========================================================================== */
+.content__head--us-election {
+    .content__header .gs-container {
+        background-image: url("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/1/29/1454085451546/uselectionliveblogon.jpg");
+        background-position: right bottom;
+        background-repeat: no-repeat;
+        background-size: gs-span(4);
+        padding-bottom: gs-height(2) + $gs-baseline * 2;
+
+        @include mq(tablet) {
+            padding-bottom: gs-height(3);
+            background-size: gs-span(5);
+        }
+
+        @include mq(desktop) {
+            padding-bottom: gs-height(4);
+        }
+
+        @include mq(leftCol) {
+            padding-bottom: gs-height(3);
+        }
+
+        @include mq(wide) {
+            padding-bottom: gs-height(2) + $gs-baseline * 2;
+            background-size: gs-span(6);
+        }
     }
 }


### PR DESCRIPTION
A way to promote the personalities in the US Election coverage.

Mobile:
<img width="396" alt="screen shot 2016-02-01 at 11 19 21" src="https://cloud.githubusercontent.com/assets/1607666/12716049/c5efed40-c8d5-11e5-8e71-ed9f38dd3db9.png">

Desktop:
<img width="1375" alt="screen shot 2016-02-01 at 11 19 14" src="https://cloud.githubusercontent.com/assets/1607666/12716050/c5f1c624-c8d5-11e5-82ea-2324aab0dec6.png">

For when the live blog has closed...
<img width="642" alt="screen shot 2016-02-01 at 11 19 40" src="https://cloud.githubusercontent.com/assets/1607666/12716048/c5d9b660-c8d5-11e5-8dcd-375ae05713bc.png">
