### PR TITLE
The Campaign Minute. Version 1, desktop styling

### DIFF
--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -46,22 +46,37 @@
         <div class="content__head--mobile">
             <div class="content__wrapper content__wrapper--headline">
                 <div class="gs-container">
+                @if(!article.isUSMinute) {
                     @article.content.blogOrSeriesTag.map { series =>
-                    <h3 class="content__series-label">
-                        <a class="content__series-label__link" href="@LinkTo {/@series.id}">@series.name</a>
-                    </h3>
+                        <h3 class="content__series-label">
+                            <a class="content__series-label__link" href="@LinkTo {/@series.id}">@series.name</a>
+                        </h3>
                     }
+                }
                     <h1 class="content__headline">@Html(article.trail.headline)</h1>
+
+                    @if(article.isUSMinute) {
+
+                        @if(!article.trail.shouldHidePublicationDate) {
+                            @fragments.meta.dateline(article.trail.webPublicationDate, article.fields.lastModified, article.content.hasBeenModified, article.tags.isLiveBlog, article.fields.isLive, article.tags.isUSMinuteSeries)
+                        }
+
+                        @if(article.fields.standfirst.isDefined) {
+                            @fragments.standfirst(article)
+                        }
+                    }
                 </div>
             </div>
         </div>
 
-        <div class="content__wrapper content__wrapper--standfirst">
-            <div class="gs-container">
+        @if(!article.isUSMinute) {
+            <div class="content__wrapper content__wrapper--standfirst">
+                <div class="gs-container">
                 @if(article.fields.standfirst.isDefined) {
                     @fragments.standfirst(article)
                 }
+                </div>
             </div>
-        </div>
+        }
     </div>
 </header>

--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -6,7 +6,8 @@
 @import layout._
 
 <header class="content__head content__head--immersive content__head--desktop tonal__head tonal__head--@toneClass(article)
-               @if(article.fields.main.nonEmpty) { is-fixed-height }">
+@if(article.fields.main.nonEmpty) { is-fixed-height }
+@if(article.isUSMinute) { content__head--minute-article}">
     <div class="content__logo-container">
         <a class="gs-container" href="@LinkTo{/}">
             @fragments.inlineSvg("guardian-logo-160", "logo", Seq("content__logo"))

--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -5,7 +5,7 @@
 @import views.support.ImgSrc
 @import layout._
 
-<header class="content__head content__head--desktop tonal__head tonal__head--@toneClass(article)
+<header class="content__head content__head--immersive content__head--desktop tonal__head tonal__head--@toneClass(article)
                @if(article.fields.main.nonEmpty) { is-fixed-height }">
     <div class="content__logo-container">
         <a class="gs-container" href="@LinkTo{/}">

--- a/article/app/views/fragments/minuteBody.scala.html
+++ b/article/app/views/fragments/minuteBody.scala.html
@@ -20,23 +20,21 @@
             @fragments.headerImmersive(article)
 
             <div class="content__main content__main--minute-article tonal__main tonal__main--@toneClass(article)">
-                <div class="gs-container">
-                    <div class="content__main-column content__main-column--minutearticle">
+                <div class="content__main-column content__main-column--minute-article">
 
-                        <div class="js-article__container" data-component="body">
+                    <div class="js-article__container" data-component="body">
 
-                            <div class="u-cf from-content-api" itemprop="{articleBody}">
-                            @BodyCleaner(article, article.fields.body, amp = false)
-                            </div>
+                        <div class="u-cf from-content-api" itemprop="{articleBody}">
+                        @BodyCleaner(article, article.fields.body, amp = false)
                         </div>
-
-                        @fragments.submeta(article)
-
-                        <div class="after-article js-after-article"></div>
-
-                        <div class="js-bottom-marker"></div>
-
                     </div>
+
+                    @fragments.submeta(article)
+
+                    <div class="after-article js-after-article"></div>
+
+                    <div class="js-bottom-marker"></div>
+
                 </div>
             </div>
         </article>

--- a/article/app/views/fragments/minuteBody.scala.html
+++ b/article/app/views/fragments/minuteBody.scala.html
@@ -7,7 +7,7 @@
 @defining(model.article) {  article =>
     <div class="l-side-margins">
         <article id="article" data-test-id="article-root"
-        class="content content--article content--immersive tonal tonal--@toneClass(article) section-@article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
+        class="content content--article content--minute-article tonal tonal--@toneClass(article) section-@article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
             @if(article.commercial.isAdvertisementFeature){content--advertisement-feature}
             @if(article.tags.isFeature && article.elements.hasShowcaseMainElement){has-feature-showcase-element}"
         itemscope itemtype="@article.metadata.schemaType" role="main">
@@ -19,7 +19,7 @@
 
             @fragments.headerImmersive(article)
 
-            <div class="content__main tonal__main tonal__main--@toneClass(article)">
+            <div class="content__main content__main--minute-article tonal__main tonal__main--@toneClass(article)">
                 <div class="gs-container">
                     <div class="content__main-column content__main-column--minutearticle">
 

--- a/article/app/views/fragments/minuteBody.scala.html
+++ b/article/app/views/fragments/minuteBody.scala.html
@@ -22,7 +22,7 @@
             <div class="content__main content__main--minute-article tonal__main tonal__main--@toneClass(article)">
                 <div class="content__main-column content__main-column--minute-article">
 
-                    <div class="js-article__container" data-component="body">
+                    <div class="js-article__container article__container--minute-article" data-component="body">
 
                         <div class="u-cf from-content-api" itemprop="{articleBody}">
                         @BodyCleaner(article, article.fields.body, amp = false)

--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -199,7 +199,12 @@ object ContentWidths {
   }
 
   object MinuteMedia extends ContentRelation {
-    override val inline = BodyMedia.inline
+    override val inline = WidthsByBreakpoint(
+      mobile = Some(95.vw),
+      tablet = Some(300.px),
+      desktop = Some(380.px),
+      leftCol = Some(460.px),
+      wide = Some(540.px))
 
     override val thumbnail = WidthsByBreakpoint(
       mobile = Some(95.vw))

--- a/common/app/views/fragments/meta/dateline.scala.html
+++ b/common/app/views/fragments/meta/dateline.scala.html
@@ -1,15 +1,19 @@
-@(webPublicationDate: org.joda.time.DateTime, lastModified: org.joda.time.DateTime, hasBeenModified: Boolean, isLiveBlog: Boolean = false, isLive: Boolean = false)(implicit request: RequestHeader)
+@(webPublicationDate: org.joda.time.DateTime, lastModified: org.joda.time.DateTime, hasBeenModified: Boolean, isLiveBlog: Boolean = false, isLive: Boolean = false, isMinute: Boolean = false)(implicit request: RequestHeader)
 @import views.support.AuFriendlyFormat
 
 <p class="content__dateline" aria-hidden="true">
     <time itemprop="datePublished" datetime='@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@webPublicationDate.getMillis" class="content__dateline-wpd js-wpd">
-        @Format(webPublicationDate, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(webPublicationDate)</span>
+        @if(isMinute) {
+            <span class="content__dateline-time">@Format(webPublicationDate, "EEEE dd MMM, yyyy")</span>
+        } else {
+            @Format(webPublicationDate, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(webPublicationDate)</span>
+        }
     </time>
     @if(isLiveBlog) {
         <meta itemprop="coverageStartTime" content="@Format(webPublicationDate, "yyyy-MM-dd'T'HH:mm:ssZ")">
     }
-    @if(hasBeenModified) {
+    @if(hasBeenModified && !isMinute) {
         <time itemprop="dateModified" datetime='@Format(lastModified, "yyyy-MM-dd'T'HH:mm:ssZ")'
         data-timestamp="@lastModified.getMillis" class="content__dateline-lm js-lm u-h">
             Last modified on @Format(lastModified, "EEEE d MMMM y") <span class="content__dateline-time">@AuFriendlyFormat(lastModified)</span>

--- a/common/app/views/support/MinuteCleaner.scala
+++ b/common/app/views/support/MinuteCleaner.scala
@@ -27,7 +27,12 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
   /**
     * Classes to strip from block children.
     */
-  val strippable = Seq("element--thumbnail")
+  val strippable = Seq(
+    "element--thumbnail",
+    "caption--img",
+    "fig--narrow-caption",
+    "fig--has-shares"
+  )
 
   override def clean(document: Document): Document = {
     if (article.isUSMinute) {
@@ -37,15 +42,12 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
         val elementTitle = block.getElementsByClass("block-title")
         val blockElementDiv = block.getElementsByClass("block-elements")
 
+        // Add classes
         block.addClass("block--minute-article")
-        block.removeClass("block")
-        block.getElementsByClass("block-share").remove()
+        block.getElementsByClass("caption--img").addClass("caption--image__minute-article")
 
-        // Re-order Elements
-        elementImage.remove()
-        elementTitle.remove()
-        blockElementDiv.after(elementImage.toString)
-        blockElementDiv.prepend(elementTitle.toString)
+        // Remove Classes
+        block.removeClass("block")
 
         ParentClasses.foldLeft(Set(): Set[String]) { case (classes, (childClass, parentClass)) =>
           if (allElements.exists(_.hasClass(childClass))) classes + parentClass
@@ -53,6 +55,15 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
         } foreach(block.addClass)
 
         allElements.foreach(el => strippable.foreach(el.removeClass))
+
+        // Re-order Elements
+        elementImage.remove()
+        elementTitle.remove()
+        blockElementDiv.after(elementImage.toString)
+        blockElementDiv.prepend(elementTitle.toString)
+
+        // Remove Elements
+        block.getElementsByClass("block-share").remove()
       }
     }
 

--- a/common/app/views/support/MinuteCleaner.scala
+++ b/common/app/views/support/MinuteCleaner.scala
@@ -17,7 +17,7 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
     */
   val ParentClasses = Map(
     "element-video" -> "block--embed block--video",
-    "element-twitter" -> "block--embed block--tweet",
+    "element-tweet" -> "block--embed block--tweet",
     "block-title" -> "has-title",
     "quoted" -> "block--quote",
     "element--inline" -> "background-image",

--- a/common/app/views/support/MinuteCleaner.scala
+++ b/common/app/views/support/MinuteCleaner.scala
@@ -64,6 +64,7 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
 
         // Remove Elements
         block.getElementsByClass("block-share").remove()
+        block.getElementsByClass("inline-expand-image").remove()
       }
     }
 

--- a/common/app/views/support/MinuteCleaner.scala
+++ b/common/app/views/support/MinuteCleaner.scala
@@ -43,6 +43,9 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
         block.addClass("block--minute-article")
         block.getElementsByClass("caption--img").addClass("caption--image__minute-article")
 
+        // Add alternative layout on alternate rows
+        if (block.elementSiblingIndex() % 2 == 1) block.addClass("block--minute-article--alt-layout")
+
         // Remove Classes
         block.removeClass("block")
 

--- a/common/app/views/support/MinuteCleaner.scala
+++ b/common/app/views/support/MinuteCleaner.scala
@@ -38,9 +38,6 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
     if (article.isUSMinute) {
       document.getElementsByClass("block").foreach { block =>
         val allElements = block.getAllElements
-        val elementImage = block.getElementsByClass("element-image")
-        val elementTitle = block.getElementsByClass("block-title")
-        val blockElementDiv = block.getElementsByClass("block-elements")
 
         // Add classes
         block.addClass("block--minute-article")
@@ -59,10 +56,10 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
         allElements.foreach(el => strippable.foreach(el.removeClass))
 
         // Re-order Elements
-        elementImage.remove()
-        elementTitle.remove()
-        blockElementDiv.after(elementImage.toString)
-        blockElementDiv.prepend(elementTitle.toString)
+        block.getElementsByClass("block-elements").headOption.map { outer =>
+          block.getElementsByClass("block-title").headOption.map(t => outer.insertChildren(0, Seq(t)))
+          outer.getElementsByClass("element-image").headOption.map(outer.after)
+        }
 
         // Remove Elements
         block.getElementsByClass("block-share").remove()

--- a/common/app/views/support/MinuteCleaner.scala
+++ b/common/app/views/support/MinuteCleaner.scala
@@ -33,9 +33,19 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
     if (article.isUSMinute) {
       document.getElementsByClass("block").foreach { block =>
         val allElements = block.getAllElements
+        val elementImage = block.getElementsByClass("element-image")
+        val elementTitle = block.getElementsByClass("block-title")
+        val blockElementDiv = block.getElementsByClass("block-elements")
+
         block.addClass("block--minute-article")
         block.removeClass("block")
         block.getElementsByClass("block-share").remove()
+
+        // Re-order Elements
+        elementImage.remove()
+        elementTitle.remove()
+        blockElementDiv.after(elementImage.toString)
+        blockElementDiv.prepend(elementTitle.toString)
 
         ParentClasses.foldLeft(Set(): Set[String]) { case (classes, (childClass, parentClass)) =>
           if (allElements.exists(_.hasClass(childClass))) classes + parentClass

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -22,42 +22,6 @@
         background-color: rgba(0, 0, 0, .5);
     }
 
-    .content__logo-container {
-        position: relative;
-        z-index: 10;
-
-        @include mq($until: desktop) {
-            background-color: lighten(colour(neutral-1), 15%);
-            padding-bottom: $gs-baseline / 2;
-        }
-
-        .gs-container {
-            overflow: auto;
-            display: block;
-
-            @include mq(desktop) {
-                overflow: visible;
-            }
-        }
-    }
-
-    .content__logo {
-        display: block;
-        float: right;
-        width: gs-span(2) + $gs-gutter;
-        height: auto;
-        margin-top: $gs-baseline / 2;
-
-        svg {
-            width: 100%;
-            height: auto;
-
-            path {
-                fill: #ffffff;
-            }
-        }
-    }
-
     .content__series-label,
     .content__headline,
     .content__standfirst {
@@ -170,64 +134,6 @@
     }
 
     .is-fixed-height {
-        &.content__head--desktop {
-            height: 100vh;
-            max-height: 800px;
-        }
-
-        .content__header {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-        }
-
-        @include mq($until: desktop) {
-            .content__head--mobile {
-                position: relative;
-                display: table-cell;
-                vertical-align: bottom;
-                background-position: center center;
-                background-size: cover;
-            }
-
-            &.content__head--desktop {
-                background-image: none !important;
-            }
-
-            .content__header {
-                display: table;
-                width: 100%;
-                height: 100%;
-            }
-
-            .content__wrapper--standfirst {
-                display: table-row-group;
-                height: 1px;
-            }
-        }
-
-        @include mq(desktop) {
-            &.content__head--desktop {
-                position: relative;
-                background-position: center center;
-                background-size: cover;
-                max-height: initial;
-            }
-
-            .content__head--mobile {
-                background-image: none !important;
-            }
-        }
-
-        .content__logo-container {
-            background-color: transparent;
-            padding-bottom: 0;
-
-            .gs-container {
-                overflow: visible;
-            }
-        }
 
         .content__headline {
             @include fs-headline(7, true);
@@ -653,7 +559,7 @@
             }
         }
 
-        + .section-rule {
+        .section-rule {
             display: none;
         }
     }
@@ -710,6 +616,107 @@
 
         @include mq(wide) {
             margin-right: -(gs-span(5) + $gs-gutter);
+        }
+    }
+}
+
+.content__head--immersive {
+    position: relative;
+
+    .content__logo-container {
+        position: relative;
+        z-index: 10;
+
+        @include mq($until: desktop) {
+            background-color: lighten(colour(neutral-1), 15%);
+            padding-bottom: $gs-baseline / 2;
+        }
+
+        .gs-container {
+            overflow: auto;
+            display: block;
+
+            @include mq(desktop) {
+                overflow: visible;
+            }
+        }
+    }
+
+    .content__logo {
+        display: block;
+        float: right;
+        width: gs-span(2) + $gs-gutter;
+        height: auto;
+        margin-top: $gs-baseline / 2;
+
+        svg {
+            width: 100%;
+            height: auto;
+
+            path {
+                fill: #ffffff;
+            }
+        }
+    }
+
+    &.is-fixed-height {
+        &.content__head--desktop {
+            height: 100vh;
+            max-height: 800px;
+        }
+
+        .content__header {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+        }
+
+        @include mq($until: desktop) {
+            .content__head--mobile {
+                position: relative;
+                display: table-cell;
+                vertical-align: bottom;
+                background-position: center center;
+                background-size: cover;
+            }
+
+            &.content__head--desktop {
+                background-image: none !important;
+            }
+
+            .content__header {
+                display: table;
+                width: 100%;
+                height: 100%;
+            }
+
+            .content__wrapper--standfirst {
+                display: table-row-group;
+                height: 1px;
+            }
+        }
+
+        @include mq(desktop) {
+            &.content__head--desktop {
+                position: relative;
+                background-position: center center;
+                background-size: cover;
+                max-height: initial;
+            }
+
+            .content__head--mobile {
+                background-image: none !important;
+            }
+        }
+
+        .content__logo-container {
+            background-color: transparent;
+            padding-bottom: 0;
+
+            .gs-container {
+                overflow: visible;
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -68,22 +68,6 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
     @include mq($from: tablet) {
         border-top: 0 none;
         padding-left: $gs-baseline*1.5;
-
-        &:after {
-            background-color: $us-minute-highlight-colour;
-            content: '';
-            height: $gs-baseline*3;
-            position: absolute;
-            right: 0;
-            top: 0;
-            width: gs-span(7);
-        }
-    }
-
-    @include mq($from: wide) {
-        &:after {
-            width: gs-span(10);
-        }
     }
 
     /* ==========================================================================
@@ -97,6 +81,16 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
     @include mq($from: tablet) {
         margin: $gs-baseline/2 0 0 $minute-layout-margin-nudge;
         max-width: gs-span(8);
+
+        &:after {
+            background-color: $us-minute-highlight-colour;
+            content: '';
+            height: $gs-baseline*3;
+            position: absolute;
+            right: 0;
+            top: 0;
+            width: gs-span(7);
+        }
 
         .block-elements {
             box-sizing: border-box;
@@ -142,6 +136,10 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
     @include mq($from: wide) {
         margin-left: $minute-layout-margin-nudge + gs-span(1);
+
+        &:after {
+            width: gs-span(10);
+        }
 
         .block-elements {
             width: gs-span(5);

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -11,20 +11,41 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
 .content__head--minute-article {
 
-    &:after {
-        content: '';
-        display: block;
-        background-color: rgba(0, 0, 0, .4);
-        height: 100%;
-        width: 100%;
+    .content__head--mobile, 
+    .content__head--desktop {
+
+        &:before {
+            content: '';
+            display: block;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, .4);
+            background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 50%, #000000 100%);
+            width: 100%;
+        }
+
+    }
+
+    .content__wrapper {
+        
+        max-width: gs-span(8);
+        @include mq(leftCol) {
+            margin-left: gs-span(1) + $gs-gutter;
+        }
     }
 
     .content__headline {
+        @include fs-headline(9);
         color: #ffffff;
-        @include f-headline;
-        font-size: 70px;
-        line-height: 74px;
         font-weight: 200;
+        line-height: 1;
+        padding-top: $gs-baseline / 2;
+        padding-bottom: 1.5rem;
+
+        @include mq(desktop) {
+            font-size: 4rem;
+        }
     }
 
     .content__dateline {
@@ -36,6 +57,7 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
     .content__standfirst {
         @include fs-header(2);
         color: $minute-headline-colour;
+        padding-bottom: gs-span(2);
     }
 }
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -57,6 +57,10 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
     background-color: $us-minute-main-colour;
 }
 
+/* ==========================================================================
+   Layout
+   ========================================================================== */
+
 .block--minute-article {
     background-color: $us-minute-main-colour;
     border-top: 4px solid $us-minute-highlight-colour;
@@ -67,12 +71,8 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
     @include mq($from: tablet) {
         border-top: 0 none;
-        padding-left: $gs-baseline*1.5;
+        padding-left: $gs-gutter*1.5;
     }
-
-    /* ==========================================================================
-       Layout
-       ========================================================================== */
 
     .block-elements {
         padding: 0 $gs-gutter;
@@ -84,7 +84,7 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
     }
 
     @include mq($from: tablet) {
-        margin: $gs-baseline/2 0 0 $minute-layout-margin-nudge;
+        margin: 0 auto;
         max-width: gs-span(8);
 
         &:after {
@@ -130,6 +130,8 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
     @include mq($from: desktop) {
         max-width: gs-span(11);
+        margin: $gs-baseline/2 0 0 $minute-layout-margin-nudge;
+        padding-left: 0;
 
         &:after {
             width: gs-span(9);
@@ -191,10 +193,37 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
             width: gs-span(7);
         }
     }
+}
 
-    /* ==========================================================================
-       Content Overrides
-       ========================================================================== */
+// Alternative Layout
+.block--minute-article--alt-layout {
+
+    @include mq($from: leftCol) {
+        margin-left: $minute-layout-margin-nudge + gs-span(1);
+    }
+
+    @include mq($from: wide) {
+        margin-left: $minute-layout-margin-nudge + gs-span(2);
+    }
+
+    &:after {
+        left: 0;
+        right: auto;
+    }
+
+    .block-elements {
+        float: left;
+    }
+
+    figure.element-image {
+        float: right;
+    }
+}
+
+/* ==========================================================================
+   Content Overrides
+   ========================================================================== */
+.block--minute-article {
 
     // Standard elements
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -245,13 +245,17 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
     }
 
     .caption--image__minute-article {
-        background-color: rgba(0, 0, 0, .4);
+        background-color: rgba(12, 87, 135, .5);
         box-sizing: border-box;
         bottom: 0;
         color: $us-minute-contrast-colour;
-        padding: $gs-baseline $gs-gutter;
+        padding: $gs-baseline/2 $gs-gutter/2;
         position: absolute;
         width: 100%;
+
+        @include mq($from: leftCol) {
+            padding: $gs-baseline $gs-gutter;
+        }
     }
 
     figcaption.caption--image__minute-article {

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -78,6 +78,11 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
         padding: 0 $gs-gutter;
     }
 
+    .quoted__contents {
+        @include fs-headline(1);
+        font-style: normal;
+    }
+
     @include mq($from: tablet) {
         margin: $gs-baseline/2 0 0 $minute-layout-margin-nudge;
         max-width: gs-span(8);
@@ -105,6 +110,23 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
             position: relative;
             width: gs-span(4);
         }
+
+        // Quote Template
+        &.block--quote {
+
+            &:after {
+                left: gs-span(7);
+                right: auto;
+            }
+
+            .block-elements {
+                width: gs-span(7);
+            }
+
+            .quoted__contents {
+                @include fs-headline(6, true);
+            }
+        }
     }
 
     @include mq($from: desktop) {
@@ -118,6 +140,23 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
         figure.element-image {
             width: gs-span(5);
+        }
+
+        // Quote Template
+        &.block--quote {
+
+            &:after {
+                left: gs-span(2);
+                right: auto;
+            }
+
+            .block-elements {
+                width: gs-span(10);
+            }
+
+            .quoted__contents {
+                @include fs-headline(6, true);
+            }
         }
     }
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -5,7 +5,6 @@ $minute-headline-colour: #ffffff;
 
 .content--minute-article {
     border-top: 0 none;
-    background-color: $us-minute-main-colour;
 
     .content__headline {
         color: #ffffff;
@@ -26,14 +25,12 @@ $minute-headline-colour: #ffffff;
     }
 }
 
-.content__main--minute-article {
-
-}
-
 .content__main-column--minute-article {
     margin: 0 auto;
     max-width: none;
     width: 100%;
+.article__container--minute-article {
+    background-color: $us-minute-main-colour;
 }
 
 .block--minute-article {

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -2,7 +2,11 @@ $us-minute-highlight-colour: #eb1e25;
 $us-minute-main-colour: #104f75;
 $us-minute-contrast-color: #ffffff;
 
-.content__main-column--minutearticle {
+.content--minute-article {
+    border-top: 0 none;
+}
+
+.content__main-column--minute-article {
     margin: 0 auto;
 }
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -72,18 +72,18 @@ $minute-headline-colour: #ffffff;
 
     @include mq($from: tablet) {
         margin: $gs-baseline/2 0 0 $minute-layout-margin-nudge;
-        max-width: gs-span(11);
+        max-width: gs-span(8);
 
         .block-elements {
             box-sizing: border-box;
             float: right;
-            padding: $gs-baseline*2.5 $gs-gutter 0;
-            width: gs-span(6);
+            padding: $gs-baseline*2.5 0 0 $gs-gutter;
+            width: gs-span(4);
         }
 
         .article__img-container {
             display: block;
-            width: gs-span(5);
+            width: gs-span(4);
         }
 
         figure.element-image {
@@ -102,6 +102,24 @@ $minute-headline-colour: #ffffff;
             position: absolute;
             bottom: 0;
             right: 0;
+            width: gs-span(4)-$gs-gutter*2;
+        }
+    }
+
+    @include mq($from: desktop) {
+        max-width: gs-span(11);
+
+        .block-elements {
+            width: gs-span(6);
+            padding-left: 0;
+            padding-right: $gs-gutter;
+        }
+
+        .article__img-container {
+            width: gs-span(5);
+        }
+
+        .caption--img {
             width: gs-span(6)-$gs-gutter;
         }
     }

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -7,6 +7,17 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
 .content--minute-article {
     border-top: 0 none;
+}
+
+.content__head--minute-article {
+
+    &:after {
+        content: '';
+        display: block;
+        background-color: rgba(0, 0, 0, .4);
+        height: 100%;
+        width: 100%;
+    }
 
     .content__headline {
         color: #ffffff;

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -115,7 +115,6 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
         &.block--quote {
 
             &:after {
-                left: gs-span(7);
                 right: auto;
             }
 
@@ -131,6 +130,10 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
     @include mq($from: desktop) {
         max-width: gs-span(11);
+
+        &:after {
+            width: gs-span(9);
+        }
 
         .block-elements {
             width: gs-span(6);
@@ -163,6 +166,10 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
     @include mq($from: leftCol) {
         max-width: gs-span(12);
 
+        &:after {
+            width: gs-span(9);
+        }
+
         .block-elements {
             width: gs-span(6);
             padding-right: gs-span(1) + $gs-gutter;
@@ -175,10 +182,6 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
     @include mq($from: wide) {
         margin-left: $minute-layout-margin-nudge + gs-span(1);
-
-        &:after {
-            width: gs-span(10);
-        }
 
         .block-elements {
             width: gs-span(5);

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -40,8 +40,57 @@ $minute-headline-colour: #ffffff;
     background-color: $us-minute-main-colour;
     border-top: 4px solid $us-minute-highlight-colour;
     color: $us-minute-contrast-color;
-    padding: $gs-baseline/2 $gs-gutter/2;
     margin-bottom: $gs-baseline/2;
+    overflow: hidden;
+    position: relative;
+
+    @include mq($from: tablet) {
+        border-top: 0 none;
+        padding-top: $gs-baseline*1.5;
+
+        &:after {
+            background-color: $us-minute-highlight-colour;
+            content: '';
+            height: $gs-baseline*3;
+            position: absolute;
+            right: 0;
+            top: 0;
+            width: gs-span(10);
+        }
+    }
+
+    /* ==========================================================================
+       Layout
+       ========================================================================== */
+
+    @include mq($from: wide) {
+        margin: $gs-baseline/2 auto;
+        max-width: gs-span(12) - $gs-gutter*2;
+
+        .block-elements {
+            box-sizing: border-box;
+            float: right;
+            padding: $gs-baseline*4 gs-span(1) 0 $gs-gutter;
+            width: gs-span(5);
+        }
+
+        .article__img-container {
+            display: block;
+            width: gs-span(7) - $gs-gutter;
+        }
+
+        figure.element-image {
+            margin-top: 0;
+        }
+
+        .caption--img {
+            position: absolute;
+            padding-right: gs-span(1);
+            bottom: 0;
+            right: 0;
+            width: gs-span(4);
+        }
+    }
 
     /* ==========================================================================
        Content Overrides

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -151,7 +151,7 @@ $minute-headline-colour: #ffffff;
     }
 
     .caption--image__minute-article {
-        background-color: rgba(0,0,0,0.4);
+        background-color: rgba(0, 0, 0, .4);
         box-sizing: border-box;
         bottom: 0;
         color: $us-minute-contrast-colour;
@@ -160,7 +160,7 @@ $minute-headline-colour: #ffffff;
         width: 100%;
     }
 
-    figcaption.caption--image__minute-article{
+    figcaption.caption--image__minute-article {
         max-width: none;
     }
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -29,9 +29,16 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
     .content__wrapper {
         
-        max-width: gs-span(8);
-        @include mq(leftCol) {
-            margin-left: gs-span(1) + $gs-gutter;
+        margin: 0 auto;
+        width: 100%;
+
+        @include mq(desktop) {
+            max-width: gs-span(6);
+            margin-left: $minute-layout-margin-nudge - $gs-gutter;
+        }
+
+        @include mq(wide) {
+            margin-left: $minute-layout-margin-nudge + gs-span(1) - $gs-gutter;
         }
     }
 
@@ -57,7 +64,8 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
     .content__standfirst {
         @include fs-header(2);
         color: $minute-headline-colour;
-        padding-bottom: gs-span(2);
+        padding-bottom: $gs-baseline;
+
     }
 }
 
@@ -109,12 +117,18 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
     }
 
     .block-elements {
-        padding: 0 $gs-gutter;
+        padding: 0 $gs-gutter/2;
     }
 
     .quoted__contents {
         @include fs-headline(1);
         font-style: normal;
+    }
+    @include mq($from: mobileLandscape) {
+        .block-elements {
+            padding-left: $gs-gutter;
+            padding-right: $gs-gutter;
+        }
     }
 
     @include mq($from: tablet) {

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -3,6 +3,8 @@ $us-minute-main-colour: #104f75;
 $us-minute-contrast-colour: #ffffff;
 $minute-headline-colour: #ffffff;
 
+$minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
+
 .content--minute-article {
     border-top: 0 none;
 
@@ -29,6 +31,28 @@ $minute-headline-colour: #ffffff;
     margin: 0 auto;
     max-width: none;
     width: 100%;
+
+    .submeta {
+        @include mq($from: tablet) {
+            margin-left: $minute-layout-margin-nudge;
+            width: gs-span(8);
+        }
+
+        @include mq($from: desktop) {
+            width: gs-span(11);
+        }
+
+        @include mq($from: leftCol) {
+            width: gs-span(12);
+        }
+
+        @include mq($from: wide) {
+            margin-left: $minute-layout-margin-nudge + gs-span(1);
+        }
+
+    }
+}
+
 .article__container--minute-article {
     background-color: $us-minute-main-colour;
 }
@@ -37,13 +61,13 @@ $minute-headline-colour: #ffffff;
     background-color: $us-minute-main-colour;
     border-top: 4px solid $us-minute-highlight-colour;
     color: $us-minute-contrast-colour;
-    margin-bottom: $gs-baseline/2;
     overflow: hidden;
+    padding: $gs-baseline 0;
     position: relative;
 
     @include mq($from: tablet) {
         border-top: 0 none;
-        padding-top: $gs-baseline*1.5;
+        padding-left: $gs-baseline*1.5;
 
         &:after {
             background-color: $us-minute-highlight-colour;
@@ -65,7 +89,10 @@ $minute-headline-colour: #ffffff;
     /* ==========================================================================
        Layout
        ========================================================================== */
-    $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
+
+    .block-elements {
+        padding: 0 $gs-gutter;
+    }
 
     @include mq($from: tablet) {
         margin: $gs-baseline/2 0 0 $minute-layout-margin-nudge;

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -1,9 +1,28 @@
 $us-minute-highlight-colour: #eb1e25;
 $us-minute-main-colour: #104f75;
 $us-minute-contrast-color: #ffffff;
+$minute-headline-colour: #ffffff;
 
 .content--minute-article {
     border-top: 0 none;
+
+    .content__headline {
+        color: #ffffff;
+        @include f-headline;
+        font-size: 70px;
+        line-height: 74px;
+        font-weight: 200;
+    }
+
+    .content__dateline {
+        @include fs-header(2);
+        color: $us-minute-highlight-colour;
+    }
+
+    .content__standfirst {
+        @include fs-header(2);
+        color: $minute-headline-colour;
+    }
 }
 
 .content__main-column--minute-article {

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -112,11 +112,6 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
         padding: 0 $gs-gutter;
     }
 
-    .quoted__contents {
-        @include fs-headline(1);
-        font-style: normal;
-    }
-
     @include mq($from: tablet) {
         margin: 0 auto;
         max-width: gs-span(8);
@@ -144,22 +139,6 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
             position: relative;
             width: gs-span(4);
         }
-
-        // Quote Template
-        &.block--quote {
-
-            &:after {
-                right: auto;
-            }
-
-            .block-elements {
-                width: gs-span(7);
-            }
-
-            .quoted__contents {
-                @include fs-headline(6, true);
-            }
-        }
     }
 
     @include mq($from: desktop) {
@@ -179,23 +158,6 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
         figure.element-image {
             width: gs-span(5);
-        }
-
-        // Quote Template
-        &.block--quote {
-
-            &:after {
-                left: gs-span(2);
-                right: auto;
-            }
-
-            .block-elements {
-                width: gs-span(10);
-            }
-
-            .quoted__contents {
-                @include fs-headline(6, true);
-            }
         }
     }
 
@@ -251,6 +213,56 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
     figure.element-image {
         float: right;
+    }
+}
+
+/* ==========================================================================
+   Block Content Styles & Layout
+   ========================================================================== */
+
+// Quote Layout
+
+.block--minute-article.block--quote {
+
+    .quoted__contents {
+        @include fs-headline(1);
+        font-style: normal;
+    }
+
+    @include mq($from: tablet) {
+        &:after {
+            right: auto;
+        }
+
+        .block-elements {
+            width: gs-span(7);
+        }
+
+        .quoted__contents {
+            @include fs-headline(6, true);
+        }
+    }
+
+    @include mq($from: desktop) {
+        &:after {
+            left: gs-span(2);
+        }
+
+        .block-elements {
+            width: gs-span(10);
+        }
+
+        .quoted__contents {
+            @include fs-headline(6, true);
+        }
+    }
+}
+
+.block--minute-article--alt-layout.block--quote {
+    @include mq($from: tablet) {
+        &:after {
+            left: 0;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -257,7 +257,12 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 /* ==========================================================================
    Content Overrides
    ========================================================================== */
+
 .block--minute-article {
+
+    .updated-time {
+        display: none;
+    }
 
     // Standard elements
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -5,6 +5,7 @@ $minute-headline-colour: #ffffff;
 
 .content--minute-article {
     border-top: 0 none;
+    background-color: $us-minute-main-colour;
 
     .content__headline {
         color: #ffffff;
@@ -25,8 +26,14 @@ $minute-headline-colour: #ffffff;
     }
 }
 
+.content__main--minute-article {
+
+}
+
 .content__main-column--minute-article {
     margin: 0 auto;
+    max-width: none;
+    width: 100%;
 }
 
 .block--minute-article {

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -53,8 +53,14 @@ $minute-headline-colour: #ffffff;
             content: '';
             height: $gs-baseline*3;
             position: absolute;
-            right: 0;
+            right: $gs-gutter;
             top: 0;
+            width: gs-span(7);
+        }
+    }
+
+    @include mq($from: wide) {
+        &:after {
             width: gs-span(10);
         }
     }
@@ -62,33 +68,76 @@ $minute-headline-colour: #ffffff;
     /* ==========================================================================
        Layout
        ========================================================================== */
+    $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
-    @include mq($from: wide) {
-        margin: $gs-baseline/2 auto;
-        max-width: gs-span(12) - $gs-gutter*2;
+    @include mq($from: tablet) {
+        margin: $gs-baseline/2 0 0 $minute-layout-margin-nudge;
+        max-width: gs-span(11);
 
         .block-elements {
             box-sizing: border-box;
             float: right;
-            padding: $gs-baseline*4 gs-span(1) 0 $gs-gutter;
-            width: gs-span(5);
+            padding: $gs-baseline*2.5 $gs-gutter 0;
+            width: gs-span(6);
         }
 
         .article__img-container {
             display: block;
-            width: gs-span(7) - $gs-gutter;
+            width: gs-span(5);
         }
 
         figure.element-image {
             margin-top: 0;
         }
 
+        figure.element.element--thumbnail {
+            margin: 0;
+            width: 100%;
+            float: none;
+            clear: none;
+        }
+
         .caption--img {
+            padding: 0 $gs-gutter;
             position: absolute;
-            padding-right: gs-span(1);
             bottom: 0;
             right: 0;
+            width: gs-span(6)-$gs-gutter;
+        }
+    }
+
+    @include mq($from: leftCol) {
+        max-width: gs-span(12);
+
+        .block-elements {
+            width: gs-span(6);
+            padding-right: gs-span(1) + $gs-gutter;
+        }
+
+        .article__img-container {
+            width: gs-span(6);
+        }
+
+        .caption--img {
+            width: gs-span(5);
+            padding-right: gs-span(1);
+        }
+    }
+
+    @include mq($from: wide) {
+        margin-left: $minute-layout-margin-nudge + gs-span(1);
+
+        .block-elements {
+            width: gs-span(5);
+        }
+
+        .article__img-container {
+            width: gs-span(7);
+        }
+
+        .caption--img {
             width: gs-span(4);
+            padding-left: $gs-gutter;
         }
     }
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -18,6 +18,7 @@ $minute-layout-margin-nudge: gs-span(2)-$gs-gutter;
 
     .content__dateline {
         @include fs-header(2);
+        border-top: 0 none;
         color: $us-minute-highlight-colour;
     }
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -1,6 +1,6 @@
 $us-minute-highlight-colour: #eb1e25;
 $us-minute-main-colour: #104f75;
-$us-minute-contrast-color: #ffffff;
+$us-minute-contrast-colour: #ffffff;
 $minute-headline-colour: #ffffff;
 
 .content--minute-article {
@@ -39,7 +39,7 @@ $minute-headline-colour: #ffffff;
 .block--minute-article {
     background-color: $us-minute-main-colour;
     border-top: 4px solid $us-minute-highlight-colour;
-    color: $us-minute-contrast-color;
+    color: $us-minute-contrast-colour;
     margin-bottom: $gs-baseline/2;
     overflow: hidden;
     position: relative;
@@ -53,7 +53,7 @@ $minute-headline-colour: #ffffff;
             content: '';
             height: $gs-baseline*3;
             position: absolute;
-            right: $gs-gutter;
+            right: 0;
             top: 0;
             width: gs-span(7);
         }
@@ -81,28 +81,11 @@ $minute-headline-colour: #ffffff;
             width: gs-span(4);
         }
 
-        .article__img-container {
-            display: block;
-            width: gs-span(4);
-        }
-
         figure.element-image {
+            display: block;
             margin-top: 0;
-        }
-
-        figure.element.element--thumbnail {
-            margin: 0;
-            width: 100%;
-            float: none;
-            clear: none;
-        }
-
-        .caption--img {
-            padding: 0 $gs-gutter;
-            position: absolute;
-            bottom: 0;
-            right: 0;
-            width: gs-span(4)-$gs-gutter*2;
+            position: relative;
+            width: gs-span(4);
         }
     }
 
@@ -115,12 +98,8 @@ $minute-headline-colour: #ffffff;
             padding-right: $gs-gutter;
         }
 
-        .article__img-container {
+        figure.element-image {
             width: gs-span(5);
-        }
-
-        .caption--img {
-            width: gs-span(6)-$gs-gutter;
         }
     }
 
@@ -132,13 +111,8 @@ $minute-headline-colour: #ffffff;
             padding-right: gs-span(1) + $gs-gutter;
         }
 
-        .article__img-container {
+        figure.element-image {
             width: gs-span(6);
-        }
-
-        .caption--img {
-            width: gs-span(5);
-            padding-right: gs-span(1);
         }
     }
 
@@ -149,13 +123,8 @@ $minute-headline-colour: #ffffff;
             width: gs-span(5);
         }
 
-        .article__img-container {
+        figure.element-image {
             width: gs-span(7);
-        }
-
-        .caption--img {
-            width: gs-span(4);
-            padding-left: $gs-gutter;
         }
     }
 
@@ -167,21 +136,32 @@ $minute-headline-colour: #ffffff;
 
     a,
     .u-fauxlink {
-        color: $us-minute-contrast-color;
+        color: $us-minute-contrast-colour;
     }
 
     // Captions
 
     .caption {
-        color: $us-minute-contrast-color;
-    }
-
-    .caption--img {
-        padding-bottom: 0;
+        color: $us-minute-contrast-colour;
     }
 
     .svg  & .caption--img:before {
-        display: none;
+        @extend %svg-i-camera-white-large;
+        margin-right: 5px;
+    }
+
+    .caption--image__minute-article {
+        background-color: rgba(0,0,0,0.4);
+        box-sizing: border-box;
+        bottom: 0;
+        color: $us-minute-contrast-colour;
+        padding: $gs-baseline $gs-gutter;
+        position: absolute;
+        width: 100%;
+    }
+
+    figcaption.caption--image__minute-article{
+        max-width: none;
     }
 
     // Embeds
@@ -193,10 +173,10 @@ $minute-headline-colour: #ffffff;
     // From content API
 
     .from-content-api & blockquote.quoted {
-        color: $us-minute-contrast-color;
+        color: $us-minute-contrast-colour;
 
         .inline-quote {
-            fill: $us-minute-contrast-color;
+            fill: $us-minute-contrast-colour;
         }
     }
 


### PR DESCRIPTION
The Campaign starts today - this converts the current [mobile-on-desktop](http://www.theguardian.com/us-news/live/2016/jan/28/trump-dumps-debate) styling into nearer to the desktop view. 

![v1_wide_scroll](https://cloud.githubusercontent.com/assets/638051/12717605/dcec3174-c8e0-11e5-8307-1aaf597c8f92.gif)

![v1_breakpoints](https://cloud.githubusercontent.com/assets/638051/12717671/3adf1a9e-c8e1-11e5-8cdd-0f57d84afa3d.gif)

cc/ @superfrank @desbo @crifmulholland 
