### PR TITLE
Fix AJAX error messages

### DIFF
--- a/static/src/javascripts/projects/common/utils/ajax-promise.js
+++ b/static/src/javascripts/projects/common/utils/ajax-promise.js
@@ -8,22 +8,21 @@ define([
     Promise
 ) {
     return function wrappedAjax(params) {
-        var promise = new Promise(function (resolve, reject) {
+        return new Promise(function (resolve, reject) {
             ajax(params)
-            .then(function (value) {
-                resolve(value);
-            })
-            .fail(function (request, text, err) {
-                var statusText = (err && err.statusText) || '';
-                var statusCode = (err && err.status) || '';
-                var errorText = 'Error retrieving data (' + text + ') (Status: ' + statusCode + ') (StatusText: ' + statusText + ')';
+                .then(resolve)
+                .fail(function (res, msg, err) {
+                    if (err) {
+                        return reject(err);
+                    }
 
-                var error = err ? err : new Error(errorText);
+                    if (res && res.status) {
+                        var message = 'AJAX error (' + params.url + '): ' + res.statusText || '' + ' (' + res.status + ')';
+                        return reject(new Error(message));
+                    }
 
-                error.request = request;
-                reject(error);
-            });
+                    reject(new Error('Unknown AJAX error (' + params.url + ')'));
+                });
         });
-        return promise;
     };
 });


### PR DESCRIPTION
The current version treats the third parameter to the error callback as the XHR object when it should be the first one ([source](https://github.com/ded/reqwest/blob/master/src/reqwest.js#L366)). 

Before: 
![screen shot 2016-02-01 at 12 38 54](https://cloud.githubusercontent.com/assets/1064734/12717999/86f65954-c8e3-11e5-8b40-7f5c088eae55.png)

After:
![screen shot 2016-02-01 at 12 38 37](https://cloud.githubusercontent.com/assets/1064734/12718005/8bc99fea-c8e3-11e5-9a82-9887d2883453.png)
