### PR TITLE
Use new avatar subdomain

### DIFF
--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -61,7 +61,7 @@ guardian.page.externalEmbedHost=https://embed.theguardian.com
 guardian.page.weatherapiurl=/weatherapi/city
 guardian.page.locationapiurl=/weatherapi/locations?query=
 guardian.page.forecastsapiurl=/weatherapi/forecast
-guardian.page.avatarApiUrl=https://avatar.code.dev-guardianapis.com
+guardian.page.avatarApiUrl=https://avatar.code.dev-theguardian.com
 guardian.page.userAttributesApiUrl=https://members-data-api.theguardian.com/user-attributes
 
 # Beacon

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -62,6 +62,7 @@ guardian.page.weatherapiurl=/weatherapi/city
 guardian.page.locationapiurl=/weatherapi/locations?query=
 guardian.page.forecastsapiurl=/weatherapi/forecast
 guardian.page.avatarApiUrl=https://avatar.code.dev-theguardian.com
+guardian.page.avatarImagesUrl=https://avatar.guimcode.co.uk
 guardian.page.userAttributesApiUrl=https://members-data-api.theguardian.com/user-attributes
 
 # Beacon

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -56,6 +56,7 @@ guardian.page.weatherapiurl=/weatherapi/city
 guardian.page.locationapiurl=/weatherapi/locations?query=
 guardian.page.forecastsapiurl=/weatherapi/forecast
 guardian.page.avatarApiUrl=https://avatar.code.dev-theguardian.com
+guardian.page.avatarImagesUrl=https://avatar.guimcode.co.uk
 guardian.page.userAttributesApiUrl=https://members-data-api.theguardian.com/user-attributes
 
 memcached.host=127.0.0.1:11211

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -55,7 +55,7 @@ guardian.page.externalEmbedHost=/assets/
 guardian.page.weatherapiurl=/weatherapi/city
 guardian.page.locationapiurl=/weatherapi/locations?query=
 guardian.page.forecastsapiurl=/weatherapi/forecast
-guardian.page.avatarApiUrl=https://avatar.code.dev-guardianapis.com
+guardian.page.avatarApiUrl=https://avatar.code.dev-theguardian.com
 guardian.page.userAttributesApiUrl=https://members-data-api.theguardian.com/user-attributes
 
 memcached.host=127.0.0.1:11211

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -46,6 +46,7 @@ guardian.page.fbAppId=202314643182694
 guardian.page.idApiJsClientToken=frontend-dev-js-client-token
 guardian.page.dfpAccountId=59666047
 guardian.page.dfpAdUnitRoot=theguardian.com
+guardian.page.avatarApiUrl=https://avatar.code.dev-theguardian.com
 
 aws.region=eu-west-1
 

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -59,6 +59,7 @@ guardian.page.weatherapiurl=/weatherapi/city
 guardian.page.locationapiurl=/weatherapi/locations?query=
 guardian.page.forecastsapiurl=/weatherapi/forecast
 guardian.page.avatarApiUrl=https://avatar.theguardian.com
+guardian.page.avatarImagesUrl=https://avatar.guim.co.uk
 guardian.page.userAttributesApiUrl=https://members-data-api.theguardian.com/user-attributes
 
 # Beacon

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -58,7 +58,7 @@ guardian.page.externalEmbedHost=https://embed.theguardian.com
 guardian.page.weatherapiurl=/weatherapi/city
 guardian.page.locationapiurl=/weatherapi/locations?query=
 guardian.page.forecastsapiurl=/weatherapi/forecast
-guardian.page.avatarApiUrl=https://avatar.guardianapis.com
+guardian.page.avatarApiUrl=https://avatar.theguardian.com
 guardian.page.userAttributesApiUrl=https://members-data-api.theguardian.com/user-attributes
 
 # Beacon

--- a/static/src/javascripts/projects/common/modules/avatar/api.js
+++ b/static/src/javascripts/projects/common/modules/avatar/api.js
@@ -7,6 +7,7 @@ define([
 ) {
 
     var apiUrl = config.page.avatarApiUrl + '/v1';
+    var staticUrl = config.page.avatarImagesUrl + '/user';
     var Api = {};
 
     Api.request = function (method, path, data) {
@@ -23,12 +24,20 @@ define([
         return ajax(params);
     };
 
+    // A user's 'active' avatar is only available to signed-in users as it
+    // includes avatars in a pre-mod state.
     Api.getActive = function () {
         return Api.request('GET', '/avatars/user/me/active');
     };
 
     Api.updateAvatar = function (data) {
         return Api.request('POST', '/avatars', data);
+    };
+
+    // The deterministic URL always returns an image. If the user has no avatar,
+    // a default image is returned.
+    Api.deterministicUrl = function (userId) {
+        return staticUrl + '/' + userId;
     };
 
     return Api;

--- a/static/src/javascripts/projects/common/modules/avatar/api.js
+++ b/static/src/javascripts/projects/common/modules/avatar/api.js
@@ -1,0 +1,35 @@
+define([
+    'common/utils/ajax',
+    'common/utils/config'
+], function (
+    ajax,
+    config
+) {
+
+    var apiUrl = config.page.avatarApiUrl + '/v1';
+    var Api = {};
+
+    Api.request = function (method, path, data) {
+        var params = {
+            url: apiUrl + path,
+            type: 'json',
+            data: data || {},
+            processData : false,
+            method: method,
+            crossOrigin: true,
+            withCredentials: true
+        };
+
+        return ajax(params);
+    };
+
+    Api.getActive = function () {
+        return Api.request('GET', '/avatars/user/me/active');
+    };
+
+    Api.updateAvatar = function (data) {
+        return Api.request('POST', '/avatars', data);
+    };
+
+    return Api;
+});

--- a/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
@@ -11,7 +11,8 @@ define([
     function avatarify(el) {
         var container = bonzo(el),
             updating = bonzo(bonzo.create('<div class="is-updating"></div>')),
-            avatar = bonzo(bonzo.create('<img class="user-avatar__image" alt="" />'));
+            avatar = bonzo(bonzo.create('<img class="user-avatar__image" alt="" />')),
+            userId = container.data('userid');
 
         container
             .removeClass('is-hidden');
@@ -23,6 +24,10 @@ define([
         avatarApi.getActive()
             .then(function (response) {
                 avatar.attr('src', response.data.avatarUrl);
+                updating.remove();
+                avatar.appendTo(container);
+            }, function () {
+                avatar.attr('src', avatarApi.deterministicUrl(userId));
                 updating.remove();
                 avatar.appendTo(container);
             });

--- a/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
@@ -1,8 +1,8 @@
 define([
     'common/utils/$',
     'bonzo',
-    'common/modules/discussion/api'
-], function ($, bonzo, discussionApi) {
+    'common/modules/avatar/api'
+], function ($, bonzo, avatarApi) {
 
     function init() {
         $('.user-avatar').each(avatarify);
@@ -11,16 +11,18 @@ define([
     function avatarify(el) {
         var container = bonzo(el),
             updating = bonzo(bonzo.create('<div class="is-updating"></div>')),
-            avatar = bonzo(bonzo.create('<img class="user-avatar__image" alt="" />')),
-            userId = container.data('userid');
+            avatar = bonzo(bonzo.create('<img class="user-avatar__image" alt="" />'));
+
         container
             .removeClass('is-hidden');
+
         updating
             .css('display', 'block')
             .appendTo(container);
-        discussionApi.getUser(userId)
+
+        avatarApi.getActive()
             .then(function (response) {
-                avatar.attr('src', response.userProfile.secureAvatarUrl);
+                avatar.attr('src', response.data.avatarUrl);
                 updating.remove();
                 avatar.appendTo(container);
             });

--- a/static/test/javascripts/spec/common/discussion/comment-box.spec.js
+++ b/static/test/javascripts/spec/common/discussion/comment-box.spec.js
@@ -182,7 +182,7 @@ define([
             it('should send a success message to the user when comment is valid', function (done) {
                 var callback = jasmine.createSpy();
                 commentBox.on('post:success', callback);
-                server.respondWith([200, {}, apiPostValidCommentResp]);
+                server.respondWith('POST', /.*/, apiPostValidCommentResp);
                 commentBox.getElem('body').value = validCommentText;
                 bean.fire(commentBox.elem, 'submit');
 


### PR DESCRIPTION
The Avatar API now lives on avatar.theguardian.com. This means we can use it and stop using the deprecated GU_U cookie for authentication.
