### PR TITLE
AMP badge styling

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -70,6 +70,7 @@
         border-bottom: 0.0625rem dotted #dfdfdf;
         position: relative;
         z-index: 1;
+        overflow: hidden;
     }
 
     .content__headline {
@@ -81,6 +82,17 @@
         padding-top: 0.125rem;
         padding-bottom: 1.5rem;
         margin: 0;
+    }
+
+    .badge-slot {
+        float: left;
+        width: 2.0625rem;
+        margin-top: 0.125rem;
+        margin-right: 0.3125rem;
+    }
+
+    .badge-slot__img {
+        width: 100%;
     }
 
     @@media (min-width: 30rem) {


### PR DESCRIPTION
Added styling to prevent this:

![screen shot 2016-02-01 at 15 18 21](https://cloud.githubusercontent.com/assets/14570016/12721323/28c9bc18-c8f7-11e5-946a-89dadf3c4158.png)
