### PR TITLE
Removed disabling Outbrain on non-front pages (duh)

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
@@ -121,8 +121,7 @@ define([
     policies.nonFrontPages = function () {
         if (!config.page.isFront) {
             return {
-                frontCommercialComponents : false,
-                outbrain: false
+                frontCommercialComponents : false
             };
         }
     };

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -123,6 +123,7 @@ define([
 
     function init() {
         if (commercialFeatures.outbrain &&
+            !config.page.isFront &&
             !config.page.isPreview &&
             identityPolicy()
         ) {


### PR DESCRIPTION
Fixes an issue with [this PR](https://github.com/guardian/frontend/pull/11758) where Outbrain would not appear on article pages because of a wrong guard condition
