### PR TITLE
set up userzoom email survery for mobile

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -90,7 +90,7 @@ trait ABTestSwitches {
     "ab-userzoom-survey-message--mobile-v3",
     "Segment the userzoom data-team survey",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 2, 7),
+    sellByDate = new LocalDate(2016, 2, 8),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -84,4 +84,13 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 2, 11),
     exposeClientSide = true
   )
+
+  val UserzoomSurveyMessageMobileV3 = Switch(
+    "A/B Tests",
+    "ab-userzoom-survey-message--mobile-v3",
+    "Segment the userzoom data-team survey",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 2, 7),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -14,6 +14,7 @@ define([
     'common/modules/experiments/tests/prebid-performance',
     'common/modules/experiments/tests/liveblog-toast',
     'common/modules/experiments/tests/userzoom-survey-message-v3',
+    'common/modules/experiments/tests/userzoom-survey-message-mobile-v3',
     'lodash/arrays/flatten',
     'lodash/collections/forEach',
     'lodash/objects/keys',
@@ -39,6 +40,7 @@ define([
     PrebidPerformance,
     LiveblogToast,
     UserzoomSurveyMessageV3,
+    UserzoomSurveyMessageMobileV3,
     flatten,
     forEach,
     keys,
@@ -59,7 +61,8 @@ define([
         new RtrtEmailFormArticlePromo(),
         new PrebidPerformance(),
         new LiveblogToast(),
-        new UserzoomSurveyMessageV3()
+        new UserzoomSurveyMessageV3(),
+        new UserzoomSurveyMessageMobileV3()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-mobile-v3.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-mobile-v3.js
@@ -68,7 +68,6 @@ define([
                 arrowWhiteRight: svgs('arrowWhiteRight')
             },
             createMessage = function () {
-                console.log("Create message");
                 new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
                 userPrefs.set('survey-message-seen', true);
             };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-mobile-v3.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/userzoom-survey-message-mobile-v3.js
@@ -1,0 +1,87 @@
+define([
+    'common/utils/$',
+    'bean',
+    'bonzo',
+    'fastdom',
+    'common/utils/config',
+    'lodash/utilities/noop',
+    'common/views/svgs',
+    'common/utils/template',
+    'common/modules/ui/message',
+    'text!common/views/survey-message.html',
+    'common/utils/detect',
+    'common/modules/user-prefs',
+    'common/utils/cookies'
+], function (
+    $,
+    bean,
+    bonzo,
+    fastdom,
+    config,
+    noop,
+    svgs,
+    template,
+    Message,
+    messageTemplate,
+    detect,
+    userPrefs,
+    cookies
+) {
+    return function () {
+        this.id = 'UserzoomSurveyMessageMobileV3';
+        this.start = '2016-02-02';
+        this.expiry = '2016-02-07';
+        this.author = 'Nathaniel Bennett';
+        this.description = 'Segment the userzoom data-team survey for mobile';
+        this.audience = 0.3;
+        this.audienceOffset = 0.0;
+        this.successMeasure = 'Gain qualitative feedback via a survey';
+        this.audienceCriteria = '30% of UK visitors to article page, on mobile, that haven\'t seen the message previously';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        var browserId = cookies.get('bwid') || false;
+
+        this.canRun = function () {
+
+            var inUKEdition = config.page.edition && config.page.edition === 'UK',
+                notPreviouslySeen = !userPrefs.get('survey-message-seen'),
+                onAnArticlePage = config && config.page && config.page.isContent,
+                isMobile = detect.isBreakpoint({max: 'mobile'});
+
+            return inUKEdition && notPreviouslySeen && onAnArticlePage && isMobile && browserId;
+        };
+
+        var messageId = 'survey',
+            messageOptions = {
+                siteMessageLinkName: 'userzoom-survey | message | email sign-up',
+                siteMessageCloseBtn: 'hide',
+                cssModifierClass: 'alt'
+            },
+            messageTemplateOptions = {
+                linkHref: 'https://s.userzoom.com/p/MSBDMTBTMjY2/' + browserId,
+                linkText: 'Open Survey',
+                linkName: 'survey sign-up button',
+                messageTextHeadline: 'Tell us about what you love (or don\'t) about the Guardian',
+                messageTextWide: 'Complete a quick survey (5 minutes max) and help us make the site better',
+                messageTextNarrow: 'Complete a quick survey (5 minutes max) and help us make the site better',
+                arrowWhiteRight: svgs('arrowWhiteRight')
+            },
+            createMessage = function () {
+                console.log("Create message");
+                new Message(messageId, messageOptions).show(template(messageTemplate, messageTemplateOptions));
+                userPrefs.set('survey-message-seen', true);
+            };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: noop
+            },
+            {
+                id: 'survey-shown',
+                test: createMessage
+            }
+        ];
+    };
+});


### PR DESCRIPTION
Run a userzoom survery for the data team for mobile users, following on from this test: https://github.com/guardian/frontend/pull/11631 which is running for desktop users. This test has an audience of 30% and runs until Sunday coming. 

@gtrufitt . This look OK to you?
