### PR TITLE
Added inline merchandise test back into the default Commercial model

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -44,7 +44,7 @@ object Commercial {
       isAdvertisementFeature = false,
       hasMultipleSponsors = false,
       hasMultipleFeatureAdvertisers = false,
-      hasInlineMerchandise = false
+      hasInlineMerchandise = DfpAgent.hasInlineMerchandise(tags.tags)
     )
   }
 


### PR DESCRIPTION
Inline merchandising components are not showing up anymore, because they're hidden by default _unless_ the page is sponsored.

/cc @kelvin-chappell 
