### PR TITLE
Changing font urls to one with the correct mime type

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -1,7 +1,8 @@
+http://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-off/original/GuardianTextEgyptianWeb/GuardianTextEgyptianWeb-Regular.woff
 @@font-face {
     font-family: "Guardian Egyptian Web";
-    src: url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-cleartype/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.eot");
-    src: url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-cleartype/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.eot?#iefix") format("embedded-opentype"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-cleartype/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.woff2") format("woff2"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-cleartype/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.woff") format("woff"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-cleartype/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.ttf") format("truetype"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-cleartype/kerning-on/latin1/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.svg#GuardianEgyptianWeb-Regular") format("svg");
+    src: url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-off/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.eot");
+    src: url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-off/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.eot?#iefix") format("embedded-opentype"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-off/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.woff2") format("woff2"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-off/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.woff") format("woff"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-off/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.ttf") format("truetype"), url("https://pasteup.guim.co.uk/fonts/1.0.0/hinting-off/kerning-off/original/GuardianEgyptianWeb/GuardianEgyptianWeb-Regular.svg#GuardianEgyptianWeb-Regular") format("svg");
     font-weight: 400;
     font-style: normal;
     font-stretch: normal


### PR DESCRIPTION
Currently the fonts we are requesting in AMP have the wrong Content-Type. Changing the url to this one fixes this issue, but I am unsure if it is the correct font. 

@zeftilldeath, can you check to see if this is correct?
