### PR TITLE
Align paid-for containers with fronts grids

### DIFF
--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -28,7 +28,8 @@
                     </a>
                 </div>
                 <div class="commercial__body">
-                    <ul class="u-unstyled l-row l-row--cols-4 l-row--layout-m fc-slice">
+                    <div class="fc-slice-wrapper">
+                        <ul class="u-unstyled l-row l-row--cols-4 l-row--layout-m fc-slice">
                         @for(item <- items) {
                             <li class="fc-slice__item l-row__item l-row__item--span-1">
                                 <div class="fc-item fc-item--has-image fc-item--has-metadata @item match {
@@ -72,6 +73,7 @@
                             </li>
                         }
                     </ul>
+                    </div>
                     <div class="ad-slot--adbadge ad-slot--paid-for-badge">
                         <div class="ad-slot--paid-for-badge__inner">
                             <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel</h3>

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -22,9 +22,6 @@
 
     .commercial__body {
         padding-top: $gs-gutter / 2;
-        max-width: none;
-        padding-left: $gs-gutter / 2;
-        padding-right: $gs-gutter / 2;
     }
 
     .rich-link__standfirst {


### PR DESCRIPTION
This pull request changes the layout of paid-for containers on fronts from this -

![image](https://cloud.githubusercontent.com/assets/3148617/12757282/537d5bda-c9cf-11e5-8564-fac265887855.png)
![image](https://cloud.githubusercontent.com/assets/3148617/12757291/5ca5d8cc-c9cf-11e5-8319-14a32cc1fcaf.png)

to this -

![image](https://cloud.githubusercontent.com/assets/3148617/12757326/78971c8a-c9cf-11e5-824c-0af5a2bb9e62.png)
![image](https://cloud.githubusercontent.com/assets/3148617/12757339/836e5f2e-c9cf-11e5-808e-dee02776d981.png)

Turns out we were using `fc-slice` without an `fc-slice-wrapper`. This also means we can remove an earlier fix for the widths of `commercial__body' elements.
