### PR TITLE
Fix paid containers on paid fronts

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,20 +1,10 @@
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties = model.FrontProperties.empty, isPaidContent: Boolean = false)(implicit request: RequestHeader)
-
 @import common.dfp.{Keyword, Series}
 @import conf.switches.Switches
 @import layout.MetaDataHeader
-@import slices.{CommercialContainerType, Dynamic, Fixed, MostPopular, NavList, NavMediaList, SingleCampaign}
+@import slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList}
 @import views.html.fragments.containers.facia_cards.{commercialContainer, containerMetaData, mostPopularContainer, navListContainer, navMediaListContainer, standardContainer}
 @import views.support.{GetClasses, RenderClasses}
-
-@renderCommercialContainer(containerType: CommercialContainerType) = {
-    <div class="@RenderClasses(
-        Map("fc-container__inner--full-span fc-container__inner--paidfor" -> Switches.NewCommercialContent.isSwitchedOn),
-        "fc-container__inner"
-    )">
-    @commercialContainer(containerType, containerDefinition, frontProperties)
-    </div>
-}
 
 @defining((containerDefinition.displayName, containerDefinition.faciaComponentName)) { case (title, componentName) =>
     @containerDefinition.customHeader.map {
@@ -54,14 +44,6 @@
 
             @containerDefinition.container match {
 
-                case Fixed(definition) if containerDefinition.commercialOptions.isAdvertisementFeature => {
-                    @*
-                    This is a workaround until existing paid content containers
-                    are converted to commercial/single-campaign container types.
-                    *@
-                    @renderCommercialContainer(SingleCampaign(definition))
-                }
-
                 case _: Dynamic | _: Fixed => {
                     <div class="fc-container__inner">
                         @standardContainer(containerDefinition, frontProperties)
@@ -87,7 +69,12 @@
                 }
 
                 case slices.Commercial(container) => {
-                    @renderCommercialContainer(container)
+                    <div class="@RenderClasses(
+                        Map("fc-container__inner--full-span fc-container__inner--paidfor" -> Switches.NewCommercialContent.isSwitchedOn),
+                        "fc-container__inner"
+                    )">
+                        @commercialContainer(container, containerDefinition, frontProperties)
+                    </div>
                 }
             }
         </section>

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -1,8 +1,8 @@
 package views.support
 
-import model.pressed.{Audio, Gallery, Video}
 import conf.switches.Switches.SaveForLaterSwitch
 import layout._
+import model.pressed.{Audio, Gallery, Video}
 import slices.{Dynamic, DynamicSlowMPU}
 
 object GetClasses {
@@ -103,7 +103,6 @@ object GetClasses {
       ("fc-container--has-show-more", hasDesktopShowMore),
       ("js-container--first", isFirst),
       ("fc-container--sponsored", commercialOptions.isSponsored),
-      ("fc-container--advertisement-feature", commercialOptions.isAdvertisementFeature),
       ("fc-container--foundation-supported", commercialOptions.isFoundationSupported),
       ("fc-container--lazy-load", lazyLoad),
       ("js-container--lazy-load", lazyLoad),


### PR DESCRIPTION
They should no longer look like paid containers.

This is just a revert of https://github.com/guardian/frontend/pull/11775 and a removal of the _fc-container--advertisement-feature_ class from containers so that they blend in on paid fronts.

Before:
![image](https://cloud.githubusercontent.com/assets/1722550/12785123/d27ad9e0-ca82-11e5-9a02-75bfb3b8ea92.png)

Now:
![image](https://cloud.githubusercontent.com/assets/1722550/12785130/db73aa18-ca82-11e5-848d-c423898e0fa9.png)

/cc @Calanthe @jbreckmckye 
