### PR TITLE
Deploys radiator: group commits by commit author username, only show …

### DIFF
--- a/static/src/deploys-radiator/app/model.ts
+++ b/static/src/deploys-radiator/app/model.ts
@@ -91,9 +91,14 @@ export interface GitHubCompareJson {
     commits: Array<GitHubCommitJson>
 }
 
+export interface GitHubNestedAuthorJson {
+    login: string;
+}
+
 export interface GitHubCommitJson {
     html_url: string;
     commit: GitHubNestedCommitJson;
+    author: GitHubNestedAuthorJson;
 }
 
 interface GitHubNestedCommitJson {
@@ -108,6 +113,7 @@ interface GitHubNestedCommitAuthorJson {
 export interface GitHubCommit {
     url: string;
     authorName: string;
+    authorLogin: string;
     message: string;
 }
 


### PR DESCRIPTION
…name

We used to group commits by author name consecutively. Now we just group commits by author name (including non-consecutive commits), and only show the name. This will simplify the interface and stop names from appearing twice.

If your name appears incorrectly on the dashboard, please check `git config --global user.name` and also your GitHub profile username (as this is the user often used for the merge commit).
# After

![image](https://cloud.githubusercontent.com/assets/921609/12786003/f752a488-ca86-11e5-8359-663836a5b91e.png)
