### PR TITLE
Move adblock detection to non-blocking inline JS, and store it on global `guardian` object

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -1,0 +1,24 @@
+try {
+    ((document, window) => {
+        var ad = document.createElement('div');
+        ad.style.position = 'absolute';
+        ad.style.left = '-9999px';
+        ad.style.height = '10px';
+        ad.innerHTML = '&nbsp;';
+        ad.setAttribute('class', 'ad_unit');
+
+        window.requestAnimationFrame(() => {
+            document.body.appendChild(ad);
+
+            window.requestAnimationFrame(() => {
+                var adStyles = window.getComputedStyle(ad);
+                window.guardian.adBlock = {
+                    active: adStyles.getPropertyValue('display') === 'none',
+                    ffAdblockPlusInstalled: adStyles.getPropertyValue('-moz-binding').match('elemhidehit') !== null
+                }
+            })
+        });
+    })(document, window);
+} catch (e) {
+    @if(play.Play.isDev) {throw (e)}
+}

--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -12,9 +12,9 @@ try {
 
             window.requestAnimationFrame(() => {
                 var adStyles = window.getComputedStyle(ad);
-                window.guardian.adBlock = {
-                    active: adStyles.getPropertyValue('display') === 'none',
-                    ffAdblockPlusInstalled: adStyles.getPropertyValue('-moz-binding').match('elemhidehit') !== null
+                window.guardian.adBlockers = {
+                    generic: adStyles.getPropertyValue('display') === 'none',
+                    ffAdblockPlus: adStyles.getPropertyValue('-moz-binding').match('elemhidehit') !== null
                 }
             })
         });

--- a/common/app/views/fragments/inlineJSNonBlocking.scala.html
+++ b/common/app/views/fragments/inlineJSNonBlocking.scala.html
@@ -12,6 +12,7 @@
 <script>
 // non-blocking JS to improve the perceived rendering speed
 @InlineJs(getUserData().body, "getUserData.js")
+@InlineJs(detectAdblock().body, "detectAdblock.js")
 
 @if(IdentityProfileNavigationSwitch.isSwitchedOn) {
     // Insert username in top bar on page load

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -397,30 +397,18 @@ define([
     }
 
     function adblockInUse() {
-        if (!detect.cachedAdblockInUse) {
-            var sacrificialAd = createSacrificialAd(),
-                contentBlocked = isHidden(sacrificialAd);
-            sacrificialAd.remove();
-            detect.cachedAdblockInUse = contentBlocked;
-            return contentBlocked;
+        if (window.guardian.adBlocker) {
+            return window.guardian.adBlocker.generic;
         }
-
-        return detect.cachedAdblockInUse;
-
-        function isHidden(bonzoElement) {
-            return bonzoElement.css('display') === 'none';
-        }
+        return false;
     }
 
     /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
     function getFirefoxAdblockPlusInstalled() {
-        var sacrificialAd = createSacrificialAd();
-        var adUnitMozBinding = sacrificialAd.css('-moz-binding');
-        if (adUnitMozBinding) {
-            return adUnitMozBinding.match('elemhidehit') !== null;
-        } else {
-            return false;
+        if (window.guardian.adBlocker) {
+            return window.guardian.adBlocker.ffAdblockPlus;
         }
+        return false;
     }
 
     function createSacrificialAd() {

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -397,16 +397,16 @@ define([
     }
 
     function adblockInUse() {
-        if (window.guardian.adBlocker) {
-            return window.guardian.adBlocker.generic;
+        if (window.guardian.adBlockers) {
+            return window.guardian.adBlockers.generic;
         }
         return false;
     }
 
     /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
     function getFirefoxAdblockPlusInstalled() {
-        if (window.guardian.adBlocker) {
-            return window.guardian.adBlocker.ffAdblockPlus;
+        if (window.guardian.adBlockers) {
+            return window.guardian.adBlockers.ffAdblockPlus;
         }
         return false;
     }

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -397,18 +397,12 @@ define([
     }
 
     function adblockInUse() {
-        if (window.guardian.adBlockers) {
-            return window.guardian.adBlockers.generic;
-        }
-        return false;
+        return !!window.guardian.adBlockers && window.guardian.adBlockers.generic;
     }
 
     /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
     function getFirefoxAdblockPlusInstalled() {
-        if (window.guardian.adBlockers) {
-            return window.guardian.adBlockers.ffAdblockPlus;
-        }
-        return false;
+        return !!window.guardian.adBlockers && window.guardian.adBlockers.ffAdblockPlus;
     }
 
     function getReferrer() {

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -411,12 +411,6 @@ define([
         return false;
     }
 
-    function createSacrificialAd() {
-        var sacrificialAd = $.create('<div class="ad_unit" style="position: absolute; left: -9999px; height: 10px">&nbsp;</div>');
-        sacrificialAd.appendTo(document.body);
-        return sacrificialAd;
-    }
-
     function getReferrer() {
         return document.referrer || '';
     }


### PR DESCRIPTION
This is more preparation for #11789 (removing omniture topup call)

Move adblock detection code to the bottom of the page, so that it can also be used by the inline omniture call.

has the bonus of only adding one test element.

cc @Calanthe @uplne @jbreckmckye @dominickendrick @regiskuckaertz 
