### PR TITLE
The Minute: Update twitter loading to prevent fastdom error

### DIFF
--- a/article/app/views/fragments/minuteBody.scala.html
+++ b/article/app/views/fragments/minuteBody.scala.html
@@ -24,7 +24,7 @@
 
                     <div class="js-article__container article__container--minute-article" data-component="body">
 
-                        <div class="u-cf from-content-api" itemprop="{articleBody}">
+                        <div class="js-article__body--minute-article u-cf from-content-api" itemprop="{articleBody}">
                         <div class="gs-container gs-container--minute-article">
                         @BodyCleaner(article, article.fields.body, amp = false)
                         </div>

--- a/static/src/javascripts/projects/common/modules/article/twitter.js
+++ b/static/src/javascripts/projects/common/modules/article/twitter.js
@@ -21,7 +21,7 @@ define([
     mediator,
     debounce
 ) {
-    var body = qwery('.js-liveblog-body, .js-article__body');
+    var body = qwery('.js-liveblog-body, .js-article__body, .js-article__body--minute-article');
 
     function bootstrap() {
         mediator.on('window:throttledScroll', debounce(enhanceTweets, 200));


### PR DESCRIPTION
I had to remove `js-article_body` (as per liveblog approach, where needed we will add the new class `js-article__body--minute-article`) but this broke twitter. Re-adding the minute-article specific body class fixes this.
