### PR TITLE
Moving AB test tracking to first omniture call

### DIFF
--- a/common/app/templates/inlineJS/blocking/analytics.scala.js
+++ b/common/app/templates/inlineJS/blocking/analytics.scala.js
@@ -130,6 +130,48 @@ try {
         s.prop20    = tpA[2] + ':' + tpA[1];
         s.eVar20    = 'D=c20';
 
+        var participationsKey = 'gu.ab.participations';
+        var abTestsParticipations;
+
+        try {
+            var participations = window.localStorage.getItem(participationsKey);
+
+            abTestsParticipations = makeOmnitureABTag(participations);
+
+            s.eVar51    = abTestsParticipations;
+            s.list1     = abTestsParticipations;
+
+            // This is set globally so we can check if the use ab test participations change once the ab test runs.
+            // If it does, we fire a second tracking call in modules/analytics/omniture.js
+            guardian.config.abTestsParticipations = abTestsParticipations;
+        } catch (e) { }
+
+        function makeOmnitureABTag(currentParticipations) {
+            var participations = JSON.parse(currentParticipations);
+            var tag = [];
+
+            for (var key in participations.value) {
+                if (participations != null && hasOwnProperty.call(participations.value, key)){
+                    tag.push(['AB', key, participations.value[key].variant].join(' | '));
+                }
+            }
+
+            for (var key in config.tests) {
+                if (config.tests != null && hasOwnProperty.call(config.tests, key)){
+                    if (key.toLowerCase().match(/^cm/)) {
+                        tag.push(['AB', key, 'variant'].join(' | '));
+                    }
+                    //only collect serverside tests the user is participating in
+                    if(!!config.tests[key]){
+                        tag.push('AB | ' + key + ' | inTest');
+                    }
+                }
+            };
+
+            return tag.join(',');
+        }
+
+
         @*
           eVar1 contains today's date
           in the Omniture backend it only ever holds the first

--- a/common/app/templates/inlineJS/blocking/analytics.scala.js
+++ b/common/app/templates/inlineJS/blocking/analytics.scala.js
@@ -131,12 +131,11 @@ try {
         s.eVar20    = 'D=c20';
 
         var participationsKey = 'gu.ab.participations';
-        var abTestsParticipations;
 
         try {
             var participations = window.localStorage.getItem(participationsKey);
 
-            abTestsParticipations = makeOmnitureABTag(participations);
+            var abTestsParticipations = makeOmnitureABTag(participations);
 
             s.eVar51    = abTestsParticipations;
             s.list1     = abTestsParticipations;
@@ -151,20 +150,16 @@ try {
             var tag = [];
 
             for (var key in participations.value) {
-                if (participations != null && hasOwnProperty.call(participations.value, key)){
-                    tag.push(['AB', key, participations.value[key].variant].join(' | '));
-                }
+                tag.push(['AB', key, participations.value[key].variant].join(' | '));
             }
 
             for (var key in config.tests) {
-                if (config.tests != null && hasOwnProperty.call(config.tests, key)){
-                    if (key.toLowerCase().match(/^cm/)) {
-                        tag.push(['AB', key, 'variant'].join(' | '));
-                    }
-                    //only collect serverside tests the user is participating in
-                    if(!!config.tests[key]){
-                        tag.push('AB | ' + key + ' | inTest');
-                    }
+                if (key.toLowerCase().match(/^cm/)) {
+                    tag.push(['AB', key, 'variant'].join(' | '));
+                }
+                //only collect serverside tests the user is participating in
+                if(!!config.tests[key]){
+                    tag.push('AB | ' + key + ' | inTest');
                 }
             };
 

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -132,18 +132,17 @@ define([
         });
     };
 
-    Omniture.prototype.shouldPopulateMvtPageProperties = function (mvt) {
-        // This checks if the user has been alocated or removed to any tests after the
-        // ab testing has loaded. If they have we fire the tracking event.
-        return mvt !== config.abTestsParticipations;
+    Omniture.prototype.shouldPopulateMvtPageProperties = function (mvtTag) {
+        // This checks if the user test alocation has changed once ab test framework has loaded.
+        return mvtTag !== config.abTestsParticipations;
     };
 
     Omniture.prototype.go = function () {
-        var mvt = ab.makeOmnitureTag();
+        var mvtTag = ab.makeOmnitureTag();
 
-        if (this.shouldPopulateMvtPageProperties(mvt)) {
-            this.s.eVar51    = mvt;
-            this.s.list1     = mvt; // allows us to 'unstack' the AB test names (allows longer names)
+        if (this.shouldPopulateMvtPageProperties(mvtTag)) {
+            this.s.eVar51 = mvtTag;
+            this.s.list1 = mvtTag; // allows us to 'unstack' the AB test names (allows longer names)
             this.s.linkTrackVars = standardProps;
             this.s.linkTrackEvents = 'None';
 

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -132,27 +132,21 @@ define([
         });
     };
 
-    Omniture.prototype.shouldPopulateMvtPageProperties = function () {
-        //get the users current ab status
-        var mvt = ab.makeOmnitureTag();
-        var previousMvt = config.abTestsParticipations;
-
+    Omniture.prototype.shouldPopulateMvtPageProperties = function (mvt) {
         // This checks if the user has been alocated or removed to any tests after the
         // ab testing has loaded. If they have we fire the tracking event.
-        var testStatusUpdated = mvt != previousMvt;
+        return mvt !== config.abTestsParticipations;
+    };
 
-        if (testStatusUpdated) {
+    Omniture.prototype.go = function () {
+        var mvt = ab.makeOmnitureTag();
+
+        if (this.shouldPopulateMvtPageProperties(mvt)) {
             this.s.eVar51    = mvt;
             this.s.list1     = mvt; // allows us to 'unstack' the AB test names (allows longer names)
             this.s.linkTrackVars = standardProps;
             this.s.linkTrackEvents = 'None';
-        }
 
-        return testStatusUpdated;
-    };
-
-    Omniture.prototype.go = function () {
-        if (this.shouldPopulateMvtPageProperties()) {
             this.logView();
             mediator.emit('analytics:ready');
         }

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -132,8 +132,8 @@ define([
         });
     };
 
-    Omniture.prototype.populateMvtPageProperties = function () {
-        //check the users current ab status
+    Omniture.prototype.shouldPopulateMvtPageProperties = function () {
+        //get the users current ab status
         var mvt = ab.makeOmnitureTag();
         var previousMvt = config.abTestsParticipations;
 
@@ -152,7 +152,7 @@ define([
     };
 
     Omniture.prototype.go = function () {
-        if (this.populateMvtPageProperties()) {
+        if (this.shouldPopulateMvtPageProperties()) {
             this.logView();
             mediator.emit('analytics:ready');
         }


### PR DESCRIPTION
This PR:
- Adds you previous page ab test participations into the current page omniture tracking
- Fires a second Omniture call if you are added or removed from a test
- Does not fire a second call if your test allocation does not change

Depends on  #11789
## QA
- [ ] With no current test, if I'm not allocated to any new test, a 2nd tracking call shouldn't be fired
- [ ] With some current tests, if I'm not allocated to any new test, a 2nd tracking call shouldn't be fired
- [ ] With no current tests, if I am allocated to any new test, a 2nd tracking call should fire
- [ ] With some current tests, if I am allocated to any new test, a 2nd tracking call should fire
- [ ] With some current tests, if I am removed from a test, a second tracking call should fire
