### PR TITLE
Updated copy for the membership supporter banner for the US edition.

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -47,7 +47,7 @@ define([
             code:          'membership-message-us',
             minVisited:    10,
             data: {
-                messageText: 'Support open, independent journalism. Become a Supporter from just $5 per month',
+                messageText: 'Support open, independent journalism. Become a Supporter for just $4.99 per month',
                 linkText: 'Find out more'
             }
         }


### PR DESCRIPTION
The engaged reader banner appears on the US edition homepage for logged out customers. Its copy is slightly wrong, and this change corrects that, as per https://trello.com/c/F4RsgETQ/354-copy-change-in-front-end-engaged-user-banner-served-in-the-us
