### PR TITLE
Removes unused div container for plista/outbrain

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -603,28 +603,5 @@ import collection.JavaConversions._
       }
     }
 
-    scenario("Outbrain") {
-
-      Given("I am on an article")
-      OutbrainSwitch.switchOn()
-      goTo("/society/2014/oct/15/lord-freud-unreserved-apology-comment-disabled-people-mimimu-wage") {
-        browser =>
-          import browser._
-          Then("Then the Outbrain placeholder should be rendered")
-          var outbrainPlaceholder = $(".js-outbrain")
-          outbrainPlaceholder.length should be(1)
-      }
-
-      Given("I am on a live blog")
-      goTo("/politics/blog/live/2014/oct/15/cameron-and-miliband-at-pmqs-politics-live-blog") {
-        browser =>
-          import browser._
-          Then("Then the Outbrain placeholder should not be rendered")
-          $(".js-outbrain").isEmpty should be(true)
-
-      }
-
-    }
-
   }
 }

--- a/common/app/views/fragments/externalContentPlaceholder.scala.html
+++ b/common/app/views/fragments/externalContentPlaceholder.scala.html
@@ -1,8 +1,3 @@
 @()
-	<div class="fc-container fc-container--outbrain hide-on-childrens-books-site js-outbrain">
-    	<div class="fc-container__inner js-outbrain-container"></div>
-    </div>
-
-    <div class="fc-container fc-container--plista hide-on-childrens-books-site js-plista">
-        <div class="fc-container__inner js-plista-container"></div>
+	<div class="js-external-content-widget-anchor">
     </div>

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -41,20 +41,20 @@ define([
     function loadExternalContentWidget() {
 
         var externalTpl = template(externalContentContainerStr);
-        var documentAnchorId = '.js-external-content-widget-anchor';
+        var documentAnchorClass = '.js-external-content-widget-anchor';
 
         function renderWidgetContainer(widgetType) {
-            $(documentAnchorId).append(externalTpl({widgetType: widgetType}));
+            $(documentAnchorClass).append(externalTpl({widgetType: widgetType}));
         }
 
         if (config.switches.plistaForOutbrainAu && config.page.edition.toLowerCase() === 'au') {
             fastdom.write(function () {
                 renderWidgetContainer('plista');
-            }).then(plista.init());
+            }).then(plista.init);
         } else {
             fastdom.write(function () {
                 renderWidgetContainer('outbrain');
-            }).then(outbrain.init());
+            }).then(outbrain.init);
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -2,6 +2,7 @@
  * A regionalised container for all the commercial tags.
  */
 define([
+    'common/utils/$',
     'Promise',
     'common/utils/config',
     'common/utils/detect',
@@ -14,8 +15,12 @@ define([
     'common/modules/commercial/third-party-tags/krux',
     'common/modules/identity/api',
     'common/modules/commercial/third-party-tags/outbrain',
-    'common/modules/commercial/third-party-tags/plista'
+    'common/modules/commercial/third-party-tags/plista',
+    'text!common/views/commercial/external-content.html',
+    'common/utils/fastdom-promise',
+    'common/utils/template'
 ], function (
+    $,
     Promise,
     config,
     detect,
@@ -28,13 +33,28 @@ define([
     krux,
     identity,
     outbrain,
-    plista) {
+    plista,
+    externalContentContainerStr,
+    fastdom,
+    template) {
 
     function loadExternalContentWidget() {
+
+        var externalTpl = template(externalContentContainerStr);
+        var documentAnchorId = '.js-external-content-widget-anchor';
+
+        function renderWidgetContainer(widgetType) {
+            $(documentAnchorId).append(externalTpl({widgetType: widgetType}));
+        }
+
         if (config.switches.plistaForOutbrainAu && config.page.edition.toLowerCase() === 'au') {
-            plista.init();
+            fastdom.write(function () {
+                renderWidgetContainer('plista');
+            }).then(plista.init());
         } else {
-            outbrain.init();
+            fastdom.write(function () {
+                renderWidgetContainer('outbrain');
+            }).then(outbrain.init());
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -2,11 +2,13 @@
  * A regionalised container for all the commercial tags.
  */
 define([
-    'common/utils/$',
     'Promise',
+    'common/utils/$',
     'common/utils/config',
     'common/utils/detect',
     'common/utils/mediator',
+    'common/utils/fastdom-promise',
+    'common/utils/template',
     'common/modules/commercial/commercial-features',
     'common/modules/commercial/third-party-tags/audience-science-gateway',
     'common/modules/commercial/third-party-tags/audience-science-pql',
@@ -16,15 +18,15 @@ define([
     'common/modules/identity/api',
     'common/modules/commercial/third-party-tags/outbrain',
     'common/modules/commercial/third-party-tags/plista',
-    'text!common/views/commercial/external-content.html',
-    'common/utils/fastdom-promise',
-    'common/utils/template'
+    'text!common/views/commercial/external-content.html'
 ], function (
-    $,
     Promise,
+    $,
     config,
     detect,
     mediator,
+    fastdom,
+    template,
     commercialFeatures,
     audienceScienceGateway,
     audienceSciencePql,
@@ -34,9 +36,8 @@ define([
     identity,
     outbrain,
     plista,
-    externalContentContainerStr,
-    fastdom,
-    template) {
+    externalContentContainerStr
+    ) {
 
     function loadExternalContentWidget() {
 

--- a/static/src/javascripts/projects/common/views/commercial/external-content.html
+++ b/static/src/javascripts/projects/common/views/commercial/external-content.html
@@ -1,0 +1,3 @@
+<div class="fc-container fc-container--<%=widgetType%> hide-on-childrens-books-site js-<%=widgetType%>">
+    <div class="fc-container__inner js-<%=widgetType%>-container"></div>
+</div>


### PR DESCRIPTION
**Issue**
Only one of Plista and Outbrain widgets will be served on the page. The original Scala HTML template contained two container divs - one for each widget. As a result, there would be an empty container being rendered regardless of which widget is being served.

**Fix**
The widget container div is now rendered immediately prior to the initialisation of the respective Plista/Outbrain widget, thus only one div is being rendered.

**Screenies**
_before:_
![image](https://cloud.githubusercontent.com/assets/1821099/12814784/981e1a5c-cb39-11e5-9123-c579cec27065.png)

_after:_
![image](https://cloud.githubusercontent.com/assets/1821099/12814781/8f7cec16-cb39-11e5-8b6f-9cfc719e33e6.png)
