### PR TITLE
Fix profile avatars

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
@@ -1,8 +1,9 @@
 define([
     'common/utils/$',
     'bonzo',
-    'common/modules/avatar/api'
-], function ($, bonzo, avatarApi) {
+    'common/modules/avatar/api',
+    'common/utils/config'
+], function ($, bonzo, avatarApi, config) {
 
     function init() {
         $('.user-avatar').each(avatarify);
@@ -12,7 +13,13 @@ define([
         var container = bonzo(el),
             updating = bonzo(bonzo.create('<div class="is-updating"></div>')),
             avatar = bonzo(bonzo.create('<img class="user-avatar__image" alt="" />')),
-            userId = container.data('userid');
+            userId = container.data('userid'),
+            ownAvatar = userId === parseInt(config.user.id);
+
+        var updateCleanup = function () {
+            updating.remove();
+            avatar.appendTo(container);
+        };
 
         container
             .removeClass('is-hidden');
@@ -21,16 +28,20 @@ define([
             .css('display', 'block')
             .appendTo(container);
 
-        avatarApi.getActive()
-            .then(function (response) {
-                avatar.attr('src', response.data.avatarUrl);
-                updating.remove();
-                avatar.appendTo(container);
-            }, function () {
-                avatar.attr('src', avatarApi.deterministicUrl(userId));
-                updating.remove();
-                avatar.appendTo(container);
-            });
+        if (ownAvatar) {
+            avatarApi.getActive()
+                .then(function (response) {
+                    avatar.attr('src', response.data.avatarUrl);
+                }, function () {
+                    avatar.attr('src', avatarApi.deterministicUrl(userId));
+                })
+                .always(function () {
+                    updateCleanup();
+                });
+        } else {
+            avatar.attr('src', avatarApi.deterministicUrl(userId));
+            updateCleanup();
+        }
     }
 
     return {init: init, avatarify: avatarify};

--- a/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
+++ b/static/src/javascripts/projects/common/modules/discussion/user-avatars.js
@@ -13,8 +13,9 @@ define([
         var container = bonzo(el),
             updating = bonzo(bonzo.create('<div class="is-updating"></div>')),
             avatar = bonzo(bonzo.create('<img class="user-avatar__image" alt="" />')),
-            userId = container.data('userid'),
-            ownAvatar = userId === parseInt(config.user.id);
+            avatarUserId = container.data('userid'),
+            userId = config.user ? parseInt(config.user.id) : null,
+            ownAvatar = avatarUserId === userId;
 
         var updateCleanup = function () {
             updating.remove();
@@ -33,13 +34,13 @@ define([
                 .then(function (response) {
                     avatar.attr('src', response.data.avatarUrl);
                 }, function () {
-                    avatar.attr('src', avatarApi.deterministicUrl(userId));
+                    avatar.attr('src', avatarApi.deterministicUrl(avatarUserId));
                 })
                 .always(function () {
                     updateCleanup();
                 });
         } else {
-            avatar.attr('src', avatarApi.deterministicUrl(userId));
+            avatar.attr('src', avatarApi.deterministicUrl(avatarUserId));
             updateCleanup();
         }
     }


### PR DESCRIPTION
At the moment, when viewing another user's profile page, a user sees _their own_ avatar. E.g. see:

https://profile.theguardian.com/user/id/1678506

This bug was introduced as part of: https://github.com/guardian/frontend/pull/11780

This commit fixes this bug.
