### PR TITLE
Adding test for ab tracking in second call

### DIFF
--- a/common/app/templates/inlineJS/blocking/analytics.scala.js
+++ b/common/app/templates/inlineJS/blocking/analytics.scala.js
@@ -130,6 +130,38 @@ try {
         s.prop20    = tpA[2] + ':' + tpA[1];
         s.eVar20    = 'D=c20';
 
+        try {
+            var participationsKey = 'gu.ab.participations';
+            var participations = window.localStorage.getItem(participationsKey);
+
+            var abTestsParticipations = makeOmnitureABTag(participations);
+
+            // This is set globally so we can check if the use ab test participations change once the ab test runs.
+            // If it does, we fire a second tracking call in modules/analytics/omniture.js
+            guardian.config.abTestsParticipations = abTestsParticipations;
+        } catch (e) { }
+
+        function makeOmnitureABTag(currentParticipations) {
+            var participations = JSON.parse(currentParticipations);
+            var tag = [];
+
+            for (var key in participations.value) {
+                tag.push(['AB', key, participations.value[key].variant].join(' | '));
+            }
+
+            for (var key in config.tests) {
+                if (key.toLowerCase().match(/^cm/)) {
+                    tag.push(['AB', key, 'variant'].join(' | '));
+                }
+                //only collect serverside tests the user is participating in
+                if(!!config.tests[key]){
+                    tag.push('AB | ' + key + ' | inTest');
+                }
+            };
+
+            return tag.join(',');
+        }
+
         @*
           eVar1 contains today's date
           in the Omniture backend it only ever holds the first

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -150,7 +150,7 @@ define([
         //This is for testing moving ab testing to first omniture call.
         var inTest = this.shouldPopulateMvtPageProperties(mvt);
         var testCall = 'AB | firedSecondCall | ' + inTest;
-        mvt = (mvt ? [mvt, testCall].join(',') : testCall);
+        mvt = mvt.split(',').concat(testCall).join(',');
 
         this.s.prop31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
         this.s.eVar31    = id.getUserFromCookie() ? 'registered user' : 'guest user';

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -132,6 +132,11 @@ define([
         });
     };
 
+    Omniture.prototype.shouldPopulateMvtPageProperties = function (mvtTag) {
+        // This checks if the user test alocation has changed once ab test framework has loaded.
+        return mvtTag !== config.abTestsParticipations;
+    };
+
     Omniture.prototype.populatePageProperties = function () {
         var d,
             /* Retrieve navigation interaction data */
@@ -142,6 +147,10 @@ define([
             this.s.prop2 = 'GUID:' + id.getUserFromCookie().id;
             this.s.eVar2 = 'GUID:' + id.getUserFromCookie().id;
         }
+        //This is for testing moving ab testing to first omniture call.
+        var inTest = this.shouldPopulateMvtPageProperties(mvt);
+        var testCall = 'AB | firedSecondCall | ' + inTest;
+        mvt = (mvt ? [mvt, testCall].join(',') : testCall);
 
         this.s.prop31    = id.getUserFromCookie() ? 'registered user' : 'guest user';
         this.s.eVar31    = id.getUserFromCookie() ? 'registered user' : 'guest user';


### PR DESCRIPTION
This tracks if a users ab status changes between page views. 
This is passed to omniture along with the current ab test asssignments
