### PR TITLE
Insert ads in liveblogs at the correct location

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -78,8 +78,6 @@ define([
             new Promise(function (resolve) {
                 var loadedCount = 0;
                 bean.on(body, 'load', notLoaded, function onImgLoaded(e) {
-                    var idx = notLoaded.indexOf(e.currentTarget);
-                    if (idx === -1) return;
                     loadedCount += 1;
                     if (loadedCount === notLoaded.length) {
                         bean.off(body, 'load', onImgLoaded);

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -77,7 +77,7 @@ define([
             Promise.resolve(true) :
             new Promise(function (resolve) {
                 var loadedCount = 0;
-                bean.on(body, 'load', notLoaded, function onImgLoaded(e) {
+                bean.on(body, 'load', notLoaded, function onImgLoaded() {
                     loadedCount += 1;
                     if (loadedCount === notLoaded.length) {
                         bean.off(body, 'load', onImgLoaded);
@@ -89,9 +89,7 @@ define([
     }
 
     function onRichLinksUpgraded(body) {
-        var unloaded = qwery('.element-rich-link--not-upgraded', body);
-
-        return unloaded.length === 0 ?
+        return qwery('.element-rich-link--not-upgraded', body).length === 0 ?
             Promise.resolve(true) :
             new Promise(function (resolve) {
                 mediator.once('rich-link:loaded', resolve);

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -118,11 +118,11 @@ define([
     }
 
     function _enforceRules(slots, rules, bodyTop, bodyHeight) {
-        var filtered;
+        var filtered = Promise.resolve(true);
 
         // enforce absoluteMinAbove rule
         if (rules.absoluteMinAbove > 0) {
-            filtered = Promise.resolve(filter(slots, function (slot) {
+            filtered = filtered.then(filter(slots, function (slot) {
                 return bodyTop + slot.top >= rules.absoluteMinAbove;
             }));
         }

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -75,7 +75,7 @@ define([
                 [new Promise(expire)].concat(
                     map(notLoaded, function (img) {
                         return new Promise(function (resolve) {
-                            bean.on(img, 'load', resolve);
+                            bean.one(img, 'load', resolve);
                         });
                     })
                 )

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -114,6 +114,7 @@ define([
 
     function _mapElementToDimensions(el) {
         return {
+            absoluteTop: el.getBoundingClientRect().top + window.pageYOffset,
             top: el.offsetTop,
             bottom: el.offsetTop + el.offsetHeight,
             element: el

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -118,7 +118,7 @@ define([
     }
 
     function _enforceRules(slots, rules, bodyTop, bodyHeight) {
-        var filtered = Promise.resolve(true);
+        var filtered = Promise.resolve(slots);
 
         // enforce absoluteMinAbove rule
         if (rules.absoluteMinAbove > 0) {

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -26,6 +26,10 @@ define([
     forOwn,
     curry
 ) {
+    // maximum time (in ms) to wait for images to be loaded and rich links
+    // to be upgraded
+    var LOADING_TIMEOUT = 5000;
+
     // find spaces in articles for inserting ads and other inline content
     // minAbove and minBelow are measured in px from the top of the paragraph element being tested
     var defaultRules = { // these are written for adverts
@@ -61,7 +65,7 @@ define([
     };
 
     function expire(resolve) {
-        window.setTimeout(resolve, 5000);
+        window.setTimeout(resolve, LOADING_TIMEOUT);
     }
 
     function onImagesLoaded(body) {

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -98,8 +98,8 @@ define([
 
     // test one element vs another for the given rules
     function _testElem(rules, elem, other) {
-        var isMinAbove = elem.top - other.bottom >= rules.minAbove,
-            isMinBelow = other.top - elem.top >= rules.minBelow;
+        var isMinAbove = elem.top - other.bottom >= rules.minAbove;
+        var isMinBelow = other.top - elem.top >= rules.minBelow;
 
         return isMinAbove || isMinBelow;
     }
@@ -130,8 +130,8 @@ define([
         // enforce minAbove and minBelow rules
         filtered = filtered.then(function (slots) {
             return filter(slots, function (slot) {
-                var farEnoughFromTopOfBody = slot.top >= rules.minAbove,
-                    farEnoughFromBottomOfBody = slot.top + rules.minBelow <= bodyHeight;
+                var farEnoughFromTopOfBody = slot.top >= rules.minAbove;
+                var farEnoughFromBottomOfBody = slot.top + rules.minBelow <= bodyHeight;
                 return farEnoughFromTopOfBody && farEnoughFromBottomOfBody;
             });
         });

--- a/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
@@ -69,13 +69,7 @@ define([
     function fill(rules) {
         return spaceFiller.fillSpace(rules, insertAds)
             .then(function (result) {
-                if (slotCounter === MAX_ADS) {
-                    result = false;
-                }
-                return result;
-            })
-            .then(function (result) {
-                if (result) {
+                if (result && slotCounter < MAX_ADS) {
                     firstSlot = document.querySelector(rules.bodySelector + ' > .ad-slot').previousSibling;
                     startListening();
                 } else {

--- a/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
@@ -61,7 +61,7 @@ define([
     function insertAds(slots) {
         for (var i = 0; i < slots.length && slotCounter < MAX_ADS; i++) {
             var $adSlot = bonzo(createAdSlot('inline1' + slotCounter++, 'liveblog-inline'));
-            $adSlot.insertBefore(slots[i]);
+            $adSlot.insertAfter(slots[i]);
             dfp.addSlot($adSlot);
         }
     }

--- a/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
@@ -62,7 +62,7 @@ define([
         for (var i = 0; i < slots.length && slotCounter < MAX_ADS; i++) {
             var $slot = bonzo(slots[i]);
             var $adSlot = bonzo(createAdSlot('inline1' + slotCounter++, 'liveblog-inline'));
-            $slot.after($adSlot);
+            $slot.before($adSlot);
             dfp.addSlot($adSlot);
         }
     }

--- a/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
@@ -60,9 +60,8 @@ define([
 
     function insertAds(slots) {
         for (var i = 0; i < slots.length && slotCounter < MAX_ADS; i++) {
-            var $slot = bonzo(slots[i]);
             var $adSlot = bonzo(createAdSlot('inline1' + slotCounter++, 'liveblog-inline'));
-            $slot.before($adSlot);
+            $adSlot.insertBefore(slots[i]);
             dfp.addSlot($adSlot);
         }
     }

--- a/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
@@ -37,15 +37,14 @@ define([
             slotSelector: ' > .block',
             fromBottom: update,
             startAt: update ? firstSlot : null,
+            absoluteMinAbove: update ? 0 : (windowHeight * OFFSET),
             minAbove: 0,
             minBelow: 0,
             filter: filterSlot
         };
 
         function filterSlot(slot, index) {
-            if (!prevSlot &&
-                (update || (slot.absoluteTop >= windowHeight * OFFSET))
-            ) {
+            if (index === 0) {
                 prevSlot = slot;
                 prevIndex = index;
                 return !update;

--- a/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
@@ -37,13 +37,15 @@ define([
             slotSelector: ' > .block',
             fromBottom: update,
             startAt: update ? firstSlot : null,
-            minAbove: update ? 0 : windowHeight * OFFSET,
+            minAbove: 0,
             minBelow: 0,
             filter: filterSlot
         };
 
         function filterSlot(slot, index) {
-            if (index === 0) {
+            if (!prevSlot &&
+                (update || (slot.absoluteTop >= windowHeight * OFFSET))
+            ) {
                 prevSlot = slot;
                 prevIndex = index;
                 return !update;


### PR DESCRIPTION
The computation of the position at which the first dynamic ad should be inserted was off because all the coordinates are relative to the top of the `.js-liveblog-body`. The only way to get around this was to add a new spacefinder rule that will reject every slot that is located in a certain range from the top of the page. This is done via the `absoluteMinAbove` rule.

Additionally, I refactored the code to remove useless variables and function calls as well as reduce the footprint of code running inside animation frames.

/cc @michaelwmcnamara @uplne @jbreckmckye @Calanthe 
