### PR TITLE
Add test logback configurations

### DIFF
--- a/admin-jobs/test/resources/logback-test.xml
+++ b/admin-jobs/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-admin-jobs</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/admin/test/resources/logback-test.xml
+++ b/admin/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-admin</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/applications/test/resources/logback-test.xml
+++ b/applications/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-applications</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/archive/test/resources/logback-test.xml
+++ b/archive/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-archive</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/article/test/resources/logback-test.xml
+++ b/article/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-article</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/commercial/test/resources/logback-test.xml
+++ b/commercial/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-commercial</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/diagnostics/test/resources/logback-test.xml
+++ b/diagnostics/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-diagnostics</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/discussion/test/resources/logback-test.xml
+++ b/discussion/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-discussion</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/facia/test/resources/logback-test.xml
+++ b/facia/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-facia</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/identity/test/resources/logback-test.xml
+++ b/identity/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-identity</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/onward/test/resources/logback-test.xml
+++ b/onward/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-onward</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/preview/test/resources/logback-test.xml
+++ b/preview/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-preview</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>

--- a/sport/test/resources/logback-test.xml
+++ b/sport/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<configuration>
+
+    <contextName>frontend-sport</contextName>
+
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/frontend-test.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/frontend-test.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{15}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
This tidies up the scalatest logging on your machine and teamcity. So no more of this:
![screen shot 2016-02-04 at 15 52 45](https://cloud.githubusercontent.com/assets/4549425/12820516/4cf7cdf2-cb57-11e5-86d8-7a636ed63160.png)
