### PR TITLE
Only use long share links for liveblog blocks

### DIFF
--- a/applications/test/ShareLinksTest.scala
+++ b/applications/test/ShareLinksTest.scala
@@ -21,13 +21,13 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
 
         pageShares.map(_.text) should be (List("Facebook", "Twitter", "Email", "Pinterest", "LinkedIn", "Google plus", "WhatsApp"))
         pageShares.map(_.href) should be (List(
-          "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_fb&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F4gc8j",
-          "https://twitter.com/intent/tweet?text=Obama%20reaffirms%20his%20support%20for%20Britain%20remaining%20in%20EU%20-%20Politics%20live&url=http%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_tw",
-          "mailto:?subject=Obama%20reaffirms%20his%20support%20for%20Britain%20remaining%20in%20EU%20-%20Politics%20live&body=http%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_link",
-          "http://www.pinterest.com/pin/find/?url=http%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live",
-          "http://www.linkedin.com/shareArticle?mini=true&title=Obama+reaffirms+his+support+for+Britain+remaining+in+EU+-+Politics+live&url=http%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live",
-          "https://plus.google.com/share?url=http%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_gp&amp;hl=en-GB&amp;wwc=1",
-          "whatsapp://send?text=%22Obama%20reaffirms%20his%20support%20for%20Britain%20remaining%20in%20EU%20-%20Politics%20live%22%20http%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_wa"
+          "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsfb&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F4gc8j",
+          "https://twitter.com/intent/tweet?text=Obama%20reaffirms%20his%20support%20for%20Britain%20remaining%20in%20EU%20-%20Politics%20live&url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fstw",
+          "mailto:?subject=Obama%20reaffirms%20his%20support%20for%20Britain%20remaining%20in%20EU%20-%20Politics%20live&body=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsbl",
+          "http://www.pinterest.com/pin/find/?url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j",
+          "http://www.linkedin.com/shareArticle?mini=true&title=Obama+reaffirms+his+support+for+Britain+remaining+in+EU+-+Politics+live&url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j",
+          "https://plus.google.com/share?url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsgp&amp;hl=en-GB&amp;wwc=1",
+          "whatsapp://send?text=%22Obama%20reaffirms%20his%20support%20for%20Britain%20remaining%20in%20EU%20-%20Politics%20live%22%20http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fswa"
         ))
       }
     }
@@ -46,9 +46,9 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
 
         elementShares.map(_.text) should be(List("Facebook", "Twitter", "Pinterest"))
         elementShares.map(_.href) should be(List(
-          "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fwww.theguardian.com%2Fenvironment%2Fgallery%2F2014%2Foct%2F22%2F2014-wildlife-photographer-of-the-year%3FCMP%3Dshare_btn_fb%232&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F42jcb",
-          "https://twitter.com/intent/tweet?text=2014%20Wildlife%20photographer%20of%20the%20Year&url=http%3A%2F%2Fwww.theguardian.com%2Fenvironment%2Fgallery%2F2014%2Foct%2F22%2F2014-wildlife-photographer-of-the-year%3FCMP%3Dshare_btn_tw%232",
-          "http://www.pinterest.com/pin/create/button/?description=2014+Wildlife+photographer+of+the+Year&url=http%3A%2F%2Fwww.theguardian.com%2Fenvironment%2Fgallery%2F2014%2Foct%2F22%2F2014-wildlife-photographer-of-the-year%232&media="
+          "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fsfb%232&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F42jcb",
+          "https://twitter.com/intent/tweet?text=2014%20Wildlife%20photographer%20of%20the%20Year&url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fstw%232",
+          "http://www.pinterest.com/pin/create/button/?description=2014+Wildlife+photographer+of+the+Year&url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%232&media="
         ))
       }
     }

--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -24,14 +24,22 @@ final case class ShareLinks(
 
     def createShareLinkUrl(campaign: Option[String], elementId: Option[String]): String = {
       val campaignParam = campaign.flatMap(ShortCampaignCodes.getFullCampaign(_))
-      val queryParams: Map[String, String] = Map(
-        "page" -> elementId.filter(x => tags.isLiveBlog).map(id => s"with:$id"),
-        "CMP" -> campaignParam
-      )
-        .filter(_._2.isDefined)
-        .map { case (k, v) => (k, v.getOrElse("")) }
+      val url = elementId
+        .flatMap(x => {
+          if (tags.isLiveBlog) {
+            val queryParams: Map[String, String] = Map(
+              "page" -> elementId.filter(x => tags.isLiveBlog).map(id => s"with:$id"),
+              "CMP" -> campaignParam
+            )
+              .filter(_._2.isDefined)
+              .map { case (k, v) => (k, v.getOrElse("")) }
 
-      webLinkUrl.appendQueryParams(queryParams) + elementId.map(id => s"#${id}").getOrElse("")
+            Some(webLinkUrl.appendQueryParams(queryParams))
+          } else None
+        })
+        .getOrElse(campaign.map(campaign => s"$shortLinkUrl/$campaign").getOrElse(shortLinkUrl))
+
+      url + elementId.map(id => s"#${id}").getOrElse("")
     }
 
     lazy val facebook = createShareLinkUrl(Some("sfb"), elementId).urlEncoded


### PR DESCRIPTION
We are reverting to short URLs for all share links but the ones for liveblog blocks, because we didn't mean to change the others in https://github.com/guardian/frontend/pull/11740.
