### PR TITLE
Fix for snap cards on fronts

### DIFF
--- a/static/src/javascripts/projects/facia/modules/ui/snaps.js
+++ b/static/src/javascripts/projects/facia/modules/ui/snaps.js
@@ -55,7 +55,8 @@ define([
         // Second, init non-inlined embeds.
         var snaps = toArray($('.js-snappable.js-snap'))
                 .filter(function (el) {
-                    var isInlinedSnap = el.hasClass('facia-snap-embed'),
+
+                    var isInlinedSnap = $(el).hasClass('facia-snap-embed'),
                         snapType = el.getAttribute('data-snap-type');
                     return !isInlinedSnap && snapType && clientProcessedTypes.indexOf(snapType) > -1;
                 })


### PR DESCRIPTION
Non-inlined snap cards were not executing the enhancement step because of this.
