### PR TITLE
Using amp.theguardian.com as domain for amphtml link

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -18,6 +18,7 @@ import scala.collection.JavaConversions._
 trait LinkTo extends Logging {
 
   lazy val host = Configuration.site.host
+  lazy val ampUrl = Configuration.amp.url
 
   private val ProdURL = "^http://www.theguardian.com/.*$".r
   private val GuardianUrl = "^(http://www.theguardian.com)?(/.*)?$".r
@@ -49,18 +50,20 @@ trait LinkTo extends Logging {
     case RssPath(path, format) =>
       ProcessedUrl(urlFor(path, edition) + format)
     case AmpPath(path, format) =>
-      ProcessedUrl(urlFor(path, edition, secure = true) + format)
+      ProcessedUrl(urlFor(path, edition, secure = true, isAmp = true) + format)
     case GuardianUrl(_, path) =>
       ProcessedUrl(urlFor(path, edition))
     case otherUrl =>
       ProcessedUrl(otherUrl, true)
   }
 
-  private def urlFor(path: String, edition: Edition, secure: Boolean = false): String = {
+  private def urlFor(path: String, edition: Edition, secure: Boolean = false, isAmp: Boolean = false): String = {
     val pathString = Option(path).getOrElse("")
     val id = if (pathString.startsWith("/")) pathString.substring(1) else pathString
     val editionalisedPath = Editionalise(clean(id), edition)
-    val url = s"$host/$editionalisedPath"
+
+    val url = if (isAmp) s"$ampUrl/$editionalisedPath" else s"$host/$editionalisedPath"
+
     url match {
       case ProdURL() if (isHttpsEnabled(editionalisedPath) || secure) =>  url.replace("http://", "https://")
       case _ => url

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -22,6 +22,10 @@ class LinkToTest extends FlatSpec with Matchers with implicits.FakeRequests {
     override lazy val host = "http://www.theguardian.com"
   }
 
+  object AmpLinkTo extends LinkTo {
+    override lazy val ampUrl = "https://amp.theguardian.com"
+  }
+
   "LinkTo" should "leave 'other' urls unchanged" in {
     val otherUrl = "http://somewhere.com/foo/bar.html?age=7#TOP"
     TestLinkTo(otherUrl, edition) should be (otherUrl)
@@ -68,7 +72,7 @@ class LinkToTest extends FlatSpec with Matchers with implicits.FakeRequests {
   }
 
   it should "be https to amp" in {
-    TheGuardianLinkTo("/law/2015/oct/08/jeremy-corbyn-rejects-formal-privy-council-induction-by-queen/amp", edition) should be ("https://www.theguardian.com/law/2015/oct/08/jeremy-corbyn-rejects-formal-privy-council-induction-by-queen/amp")
+    AmpLinkTo("/law/2015/oct/08/jeremy-corbyn-rejects-formal-privy-council-induction-by-queen/amp", edition) should be ("https://amp.theguardian.com/law/2015/oct/08/jeremy-corbyn-rejects-formal-privy-council-induction-by-queen/amp")
   }
 
   it should "correctly editionalise the International front" in {


### PR DESCRIPTION
:zap: 
