### PR TITLE
Added support for media plus special-report tones (save for later)

### DIFF
--- a/static/src/stylesheets/module/_save-for-later.scss
+++ b/static/src/stylesheets/module/_save-for-later.scss
@@ -67,7 +67,24 @@ $sfl-button-height: 30px;
 @include sfl-button-toned(media, colour(media-default), colour(media-background));
 @include sfl-button-toned(news);
 @include sfl-button-toned(review, colour(review-background));
-@include sfl-button-toned(special-report, colour(news-support-1), colour(news-support-6));
+
+// Specific fix for pages that are special-report & media
+.content--media.tonal--tone-special-report {
+    .save-for-later__button {
+        color: colour(news-support-1);
+        .inline-icon {
+            fill: colour(news-support-1);
+            border-color: colour(news-support-1);
+            background-color: colour(news-support-6);
+        }
+        &:hover {
+            .inline-icon {
+                fill: colour(news-support-6);
+                background-color: colour(news-support-1);
+            }
+        }
+    }
+}
 
 // button labels per state
 .save-for-later__label {


### PR DESCRIPTION
#11661

The usual method was leaving special report pages that wern't videos or galleries looking wrong too. So had to create seperate css for the combination of media AND special-report.

Erstwhile (on Fargo)
![screen shot 2016-02-05 at 10 36 49](https://cloud.githubusercontent.com/assets/14570016/12844035/dccfa7cc-cbf4-11e5-845b-78bb1dadc1ec.png)

Thereafter
![screen shot 2016-02-05 at 10 36 45](https://cloud.githubusercontent.com/assets/14570016/12844034/dcce78f2-cbf4-11e5-8611-086d1bd79aad.png)
