### PR TITLE
Fix extra padding in top ad slot when the page has a skin

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -221,7 +221,8 @@
             text-align: center;
 
             .ad-slot__label {
-                margin: 0 auto;
+                margin-left: auto;
+                margin-right: auto;
             }
         }
     }


### PR DESCRIPTION
# Before

When the page has a skin, such as it does now on http://www.theguardian.com/uk/culture, there is a bug whereby the top ad has too much padding:

![image](https://cloud.githubusercontent.com/assets/921609/12847655/b6ad70a2-cc0c-11e5-9d8d-c20e8dc76713.png)
# After

![image](https://cloud.githubusercontent.com/assets/921609/12847662/bd7e93d4-cc0c-11e5-9017-04c3ff9ed747.png)
# Why

This is because the `margin-top` no longer needs to be unset since we changed the way padding works in https://github.com/guardian/frontend/pull/11584/files#diff-080ab32aa8365abdced6a7d722b4d6a5R194.

/cc @uplne @Calanthe @jbreckmckye 
