### PR TITLE
Any facia item with an image may be snappable

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -10,7 +10,7 @@
 
 @import Function.const
 
-<div class="@GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(!isList && !item.hasInlineSnapHtml) {js-snappable}"
+<div class="@GetClasses.forItem(item, isFirstContainer) @item.cardTypes.classes @if(item.hasImage && !item.hasInlineSnapHtml) {js-snappable}"
     @if(item.discussionSettings.isCommentable) {
         @item.discussionSettings.discussionId.map { id =>
         data-discussion-id="@id"


### PR DESCRIPTION
This allows containers which have items that were considered listed (part of a list) to perform their snap upgrade. Space may be limited, but the agreement is to let the snap embed choose it's own height; the container grows as needed.
### before

![screen shot 2016-02-05 at 13 43 33](https://cloud.githubusercontent.com/assets/4549425/12847934/9b154cbe-cc0e-11e5-90c7-2c95e5a3a693.png)
### after

![screen shot 2016-02-05 at 13 43 49](https://cloud.githubusercontent.com/assets/4549425/12847945/a60c00d6-cc0e-11e5-9df9-79ae71cfc66a.png)
