### PR TITLE
Sticky ad: use throttled scroll

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/newSticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newSticky.js
@@ -156,7 +156,7 @@ define([
     };
 
     var setupDispatchers = function (dispatch) {
-        window.addEventListener('scroll', function () {
+        mediator.on('window:throttledScroll', function () {
             getScrollCoords().then(function (scrollCoords) {
                 dispatch({ type: 'SCROLL', scrollCoords: scrollCoords });
             });


### PR DESCRIPTION
Previously we were queueing the animation frame every time the scroll event happened. `throttledScroll` optimises the scroll event so that we only queue an animation frame once the previous animation frame has finished, thus we remove redundant JS execution.

There is no perceived difference in performance.
