### PR TITLE
Show cutouts on special reports

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -89,7 +89,7 @@ final case class Content(
   }
 
   lazy val hasTonalHeaderByline: Boolean = {
-    (cardStyle == Comment || cardStyle == Editorial || cardStyle == SpecialReport) &&
+    (cardStyle == Comment || cardStyle == Editorial || (cardStyle == SpecialReport && tags.isComment)) &&
       hasSingleContributor &&
       metadata.contentType != GuardianContentTypes.ImageContent
   }

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -89,7 +89,7 @@ final case class Content(
   }
 
   lazy val hasTonalHeaderByline: Boolean = {
-    (cardStyle == Comment || cardStyle == Editorial) &&
+    (cardStyle == Comment || cardStyle == Editorial || cardStyle == SpecialReport) &&
       hasSingleContributor &&
       metadata.contentType != GuardianContentTypes.ImageContent
   }


### PR DESCRIPTION
## comment piece

before:
![screen shot 2016-02-05 at 16 41 43](https://cloud.githubusercontent.com/assets/867233/12852737/68f26676-cc28-11e5-8580-f0448bb4e6ac.png)

after:
![screen shot 2016-02-05 at 16 40 55](https://cloud.githubusercontent.com/assets/867233/12852726/616ca7fe-cc28-11e5-9b60-7299122585c1.png)
## non-comment piece

before and after:
![screen shot 2016-02-05 at 16 48 48](https://cloud.githubusercontent.com/assets/867233/12852760/88c6f638-cc28-11e5-988b-6188ef0fc8e4.png)

cc @sammorrisdesign @rich-nguyen 
