### PR TITLE
Don't show last payment information if you're cancelling friend membership

### DIFF
--- a/identity/app/views/fragments/profile/membershipForm/cancelled.scala.html
+++ b/identity/app/views/fragments/profile/membershipForm/cancelled.scala.html
@@ -6,8 +6,10 @@
         membership section won't be available in your profile.
     </p>
     <p>
-        Your final subscription payment was taken on
-        <strong><span class="js-mem-current-period-start"></span></strong>. Please note, you won't be able to
-        amend your package again until this change has been processed.
+        <span class="js-mem-current-period-start-container is-hidden">
+            Your final subscription payment was taken on
+            <strong><span class="js-mem-current-period-start"></span></strong>.
+        </span>
+        Please note, you won't be able to amend your package again until this change has been processed.
     </p>
 </div>

--- a/static/src/javascripts/projects/membership/membership-tab.js
+++ b/static/src/javascripts/projects/membership/membership-tab.js
@@ -14,6 +14,8 @@ define([
         PACKAGE_CURRENT_RENEWAL_DATE = '.js-mem-current-renewal-date',
         PACKAGE_CURRENT_PERIOD_END = '.js-mem-current-period-end',
         PACKAGE_CURRENT_PERIOD_START = '.js-mem-current-period-start',
+        PACKAGE_CURRENT_PERIOD_START_CONTAINER = '.js-mem-current-period-start-container',
+
         PACKAGE_NEXT_PAYMENT_CONTAINER = '.js-mem-next-payment-container',
         TRIAL_INFO_CONTAINER = '.js-mem-only-for-trials',
         PACKAGE_NEXT_PAYMENT_DATE = '.js-mem-next-payment-date',
@@ -70,7 +72,6 @@ define([
             $(CHANGE_TIER_CARD_LAST4).text(userDetails.subscription.card.last4);
         }
 
-        $(PACKAGE_CURRENT_PERIOD_START).text(formatters.formatDate(userDetails.subscription.start));
         $(PACKAGE_CURRENT_PERIOD_END).text(formatters.formatDate(userDetails.subscription.end));
         $(PACKAGE_CURRENT_RENEWAL_DATE).text(formatters.formatDate(userDetails.subscription.renewalDate));
 
@@ -94,6 +95,11 @@ define([
         // update card details
         if (userDetails.subscription.card) {
             stripeForm.updateCard(userDetails.subscription.card);
+        }
+
+        if (userDetails.subscription.start) {
+            $(PACKAGE_CURRENT_PERIOD_START).text(formatters.formatDate(userDetails.subscription.start));
+            $(PACKAGE_CURRENT_PERIOD_START_CONTAINER).removeClass(IS_HIDDEN_CLASSNAME);
         }
 
         // user has cancelled


### PR DESCRIPTION
Currently it says "your last subscription payment was taken on `<sign up date>` which is a bit surprising if you're on a free membership
