### PR TITLE
Capi paid card styling fixes

### DIFF
--- a/static/src/javascripts/projects/common/views/commercial/creatives/paidfor-content.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/paidfor-content.html
@@ -18,13 +18,13 @@
             </div>
         </div>
     </div>
-    <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box--header" data-link-name="advertisers header">
+    <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box paidfor-box--header" data-link-name="advertisers header">
         <h2 class="gu-title"><%=articleHeaderText%></h2>
     </a>
-    <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box--text" data-link-name="advertisers text">
+    <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box paidfor-box--text" data-link-name="advertisers text">
         <p class="gu-text"><%=articleText%></p>
     </a>
-    <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box--logo" data-link-name="advertisers logo">
+    <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box paidfor-box--logo" data-link-name="advertisers logo">
         <div class="paidfor-brand">
             <span class="paidfor-note">Paid for by:</span>
             <img class="paidfor-logo" src="<%=brandLogo%>" alt="<%=brand%>">

--- a/static/src/javascripts/projects/common/views/commercial/creatives/paidfor-content.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/paidfor-content.html
@@ -18,9 +18,13 @@
             </div>
         </div>
     </div>
-    <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box" data-link-name="advertisers logo">
+    <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box--header" data-link-name="advertisers header">
         <h2 class="gu-title"><%=articleHeaderText%></h2>
+    </a>
+    <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box--text" data-link-name="advertisers text">
         <p class="gu-text"><%=articleText%></p>
+    </a>
+    <a href="<%=clickMacro%><%=articleUrl%>" class="paidfor-box--logo" data-link-name="advertisers logo">
         <div class="paidfor-brand">
             <span class="paidfor-note">Paid for by:</span>
             <img class="paidfor-logo" src="<%=brandLogo%>" alt="<%=brand%>">

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -57,15 +57,32 @@
     }
 }
 
-.paidfor-box {
+.paidfor-box--header,
+.paidfor-box--text,
+.paidfor-box--logo {
     color: inherit;
     display: block;
-    padding: $gs-baseline / 3 $gs-gutter / 4 $gs-baseline;
+    padding: 0 $gs-gutter / 4;
 
     &:hover,
     &:focus {
         text-decoration: none;
     }
+}
+
+.paidfor-box--header {
+    padding-top: $gs-baseline / 3;
+}
+
+.paidfor-box--text {
+    &:hover,
+    &:focus {
+        text-decoration: underline;
+    }
+}
+
+.paidfor-box--logo {
+    padding-bottom: $gs-baseline;
 }
 
 .paidfor-title {

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -57,9 +57,7 @@
     }
 }
 
-.paidfor-box--header,
-.paidfor-box--text,
-.paidfor-box--logo {
+.paidfor-box {
     color: inherit;
     display: block;
     padding: 0 $gs-gutter / 4;

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
@@ -32,8 +32,8 @@
 }
 
 .paidfor-popup__title {
-    font-size: get-font-size(header, 2);
-    line-height: get-line-height(header, 2);
+    font-size: get-font-size(textSans, 3);
+    line-height: get-line-height(textSans, 1);
     margin: 0 0 1em;
 }
 


### PR DESCRIPTION
Small styling fixes for paid card cAPI component:
- The 'About' dropdown text is smaller now (everywhere also on the paid merchandising content and sticky band) 
- Article text link is underlined on hover state

![screen shot 2016-02-08 at 12 55 57](https://cloud.githubusercontent.com/assets/489567/12886104/0277135a-ce63-11e5-97be-0093b54955d1.png)
