### PR TITLE
Editing route to contain edition 

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -327,7 +327,8 @@ GET            /commercial/magento/books                                        
 # AMP
 GET            /most-read-mf2.json                                                                                               controllers.MostPopularController.renderPopularMicroformat2()
 GET            /related-mf2/*path.json                                                                                           controllers.RelatedController.renderMf2(path)
-GET            /container-mf2/:num/:offset/:section.json                                                                         controllers.FaciaController.renderSomeFrontContainersMf2(num, offset, section)
+GET            /container-mf2/:num/:offset/:section.json                                                                         controllers.FaciaController.frontContainersMf2EditionRedirect(num, offset, section)
+GET            /container-mf2/:num/:offset/:section/:edition.json                                                                controllers.FaciaController.renderSomeFrontContainersMf2(num, offset, section, edition)
 GET            /series-mf2/*path.json                                                                                            controllers.SeriesController.renderMf2SeriesStories(path)
 
 # Onward journeys

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -93,7 +93,8 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
     }
   }
 
-  def renderSomeFrontContainersMf2(rawNum: String, rawOffset: String, section: String) = MemcachedAction { implicit request =>
+  def frontContainersMf2EditionRedirect(rawNum: String, rawOffset: String, section: String) = renderSomeFrontContainersMf2(rawNum, rawOffset, section, edition = "")
+  def renderSomeFrontContainersMf2(rawNum: String, rawOffset: String, section: String, edition: String) = MemcachedAction { implicit request =>
     val edition = Edition(request)
     // TODO: This list also exists in the JS for fronts on articles a/b test. Pending a decision on that, this should go in the jsconfig, or be removed
     val sectionsToLoad = List("commentisfree", "sport", "football", "fashion", "lifeandstyle", "education", "culture", "business", "technology", "politics", "environment", "travel", "film", "media", "money", "society", "science", "music", "books", "stage", "cities", "tv-and-radio", "artanddesign", "global-development")

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -24,7 +24,8 @@ GET        /container/*id.json                                                  
 GET        /most-relevant-container/*path.json                                      controllers.FaciaController.renderMostRelevantContainerJson(path)
 
 # AMP
-GET        /container-mf2/:num/:offset/:section.json                                controllers.FaciaController.renderSomeFrontContainersMf2(num, offset, section)
+GET        /container-mf2/:num/:offset/:section.json                                controllers.FaciaController.frontContainersMf2EditionRedirect(num, offset, section)
+GET        /container-mf2/:num/:offset/:section/:edition.json                       controllers.FaciaController.renderSomeFrontContainersMf2(num, offset, section, edition)
 
 # Editionalised pages
 GET        /*path/show-more/*id.json                                                controllers.FaciaController.renderShowMore(path, id)


### PR DESCRIPTION
Will go with a corresponding fastly change.

Like how we do it with `/`, we need to separate the cache into editions for this route. 
