### PR TITLE
Fix double breaking-news banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -140,9 +140,10 @@ define([
                     setTimeout(function () {
                         var message = 'breaking news alert shown' + (alertDelay ? '' : ' 2 or more times'), $breakingNewsSpectre;
 
+                        // copy of breaking news banner (with blank content) used inline in the body
+                        // to create space for a pinned alert to be scrolled into
                         $body = $body || bonzo(document.body);
                         $breakingNewsSpectre = bonzo(bonzo.create($breakingNews[0])).addClass('breaking-news--spectre').removeClass('breaking-news--hidden');
-
                         fastdom.write(function () {
                             $body.append($breakingNewsSpectre);
                         });

--- a/static/src/stylesheets/module/onward/_breaking-news.scss
+++ b/static/src/stylesheets/module/onward/_breaking-news.scss
@@ -113,17 +113,11 @@ $breaking-news-close-icon-width: 32px;
     right: 0;
 }
 
-// copy of breaking news element used inline in the body
+// copy of breaking news banner (with blank content) used inline in the body
 // to create space for a pinned alert to be scrolled into
 .breaking-news--spectre {
+    visibility: hidden;
     position: relative;
-    background-color: colour(multimedia-support-4);
-    opacity: 1;
     z-index: 1;
-    box-shadow: none;
     transition: none;
-
-    .breaking-news__items {
-        visibility: hidden;
-    }
 }


### PR DESCRIPTION
**The problem:**
![picture 3](https://cloud.githubusercontent.com/assets/233326/12915512/c03d8f7a-cf23-11e5-8fed-37417811c3e0.png)

**The explanation:**
In order to make sure the breaking-news banner doesn't sit on top of
some footer content at the bottom of the page, we are adding height to the
page, by adding a copy of the news alert inline at the end of the content
which means the scroll height of the page increases by exactly the height of the alert.
In case the breaking news is loaded before the content of the page/footer (likely to happen on interactives since loading might be slow and interactives have no footer), this banner copy would be visible.

**The fix:**
This commit sets `visibility:hidden` to this banner copy (ie: content of the
banner is hidden but the element still takes up space)

cc @sndrs 
