### PR TITLE
Make sponsored about text unconditional

### DIFF
--- a/static/src/javascripts/projects/common/views/commercial/creatives/logo-sponsored.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/logo-sponsored.html
@@ -3,7 +3,5 @@
     <a href="<%=clickMacro%><%=logoUrl%>" class="ad-slot--paid-for-badge__link">
         <img class="ad-slot--paid-for-badge__logo" src="<%=logoImage%>" />
     </a>
-    <% if (!guardian.config.switches.newCommercialContent) { %>
-        <a href="<%=clickMacro%><%=infoUrl%>" class="ad-slot--paid-for-badge__help">About this content</a>
-    <% } %>
+    <a href="<%=clickMacro%><%=infoUrl%>" class="ad-slot--paid-for-badge__help">About this content</a>
 </div>


### PR DESCRIPTION
This link should always appear on sponsored content, as opposed to paid content.
