### PR TITLE
Sticky ad: only transition when the ad has actually increased in height

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/newSticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newSticky.js
@@ -195,10 +195,14 @@ define([
                         });
                     case 'NEW_AD_HEIGHT':
                         var scrollIsAtTop = previousState.scrollCoords[1] === 0;
+                        var previousAdHeight = previousState.adHeight;
+                        var adHeight = action.adHeight;
+                        var diff = adHeight - previousAdHeight;
+                        var adHeightHasIncreased = diff > 0;
                         return assign({}, previousState, {
-                            shouldTransition: scrollIsAtTop,
-                            adHeight: action.adHeight,
-                            previousAdHeight: previousState.adHeight
+                            shouldTransition: adHeightHasIncreased && scrollIsAtTop,
+                            adHeight: adHeight,
+                            previousAdHeight: previousAdHeight
                         });
                     case 'AD_BANNER_TRANSITION_END':
                         return assign({}, previousState, {


### PR DESCRIPTION
The logic in https://github.com/guardian/frontend/pull/11876 was wrong.

/cc @NataliaLKB 
