### PR TITLE
Expose server side test definitions to the client

### DIFF
--- a/common/app/templates/inlineJS/blocking/analytics.scala.js
+++ b/common/app/templates/inlineJS/blocking/analytics.scala.js
@@ -149,12 +149,12 @@ try {
                 tag.push(['AB', key, participations.value[key].variant].join(' | '));
             }
 
-            for (var key in config.tests) {
+            for (var key in config.tests.participations) {
                 if (key.toLowerCase().match(/^cm/)) {
                     tag.push(['AB', key, 'variant'].join(' | '));
                 }
                 //only collect serverside tests the user is participating in
-                if(!!config.tests[key]){
+                if(!!config.tests.participations[key]){
                     tag.push('AB | ' + key + ' | inTest');
                 }
             };

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -10,7 +10,7 @@
         "switches" : { @{JavaScript(conf.switches.Switches.all.filter(_.exposeClientSide).map{ switch =>
             s""""${CamelCase.fromHyphenated(switch.name)}":${switch.isSwitchedOn}"""}.mkString(","))}
         },
-        "tests": { @JavaScript(mvt.ActiveTests.getJavascriptConfig) },
+        "tests": @JavaScript(mvt.ActiveTests.getJavascriptConfig),
         "modules": { },
         "stylesheets": {
             "fonts": {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -82,7 +82,7 @@ define([
                 }
             });
 
-            forIn(keys(config.tests), function (n) {
+            forIn(keys(config.tests.participations), function (n) {
                 if (n.toLowerCase().match(/^cm/)) {
                     abParams.push(n);
                 }

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -73,7 +73,7 @@ define([
 
             return Promise.all(chain(adSlices).slice(0, maxAdsToShow).and(map, function ($adSlice, index) {
                     // When we are inside the AB test we are adding inline1 manually so index needs to start from 2.
-                    var inlineIndexOffset = (config.tests.cmTopBannerPosition) ? 2 : 1;
+                    var inlineIndexOffset = (config.tests.participations.cmTopBannerPosition) ? 2 : 1;
 
                     var adName        = 'inline' + (index + inlineIndexOffset),
                         $mobileAdSlot = bonzo(createAdSlot(adName, 'container-inline'))

--- a/static/src/javascripts/projects/common/modules/commercial/top-banner-below-container.js
+++ b/static/src/javascripts/projects/common/modules/commercial/top-banner-below-container.js
@@ -14,8 +14,8 @@ define([
 
     function init() {
         // If you are not at front you can enjoy refreshing adfree experience
-        if (typeof config.tests.cmTopBannerPosition === 'undefined'
-            || !config.tests.cmTopBannerPosition
+        if (typeof config.tests.participations.cmTopBannerPosition === 'undefined'
+            || !config.tests.participations.cmTopBannerPosition
             || !config.page.isFront) {
 
             return false;

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -144,7 +144,7 @@ define([
             }
         });
 
-        forEach(keys(config.tests), function (k) {
+        forEach(keys(config.tests.participations), function (k) {
             if (k.toLowerCase().match(/^cm/)) {
                 tag.push(['AB', k, 'variant'].join(' | '));
             }
@@ -231,7 +231,7 @@ define([
 
     // These kinds of tests are both server and client side.
     function getServerSideTests() {
-        return chain(config.tests)
+        return chain(config.tests.participations)
             .and(pick, function (participating) { return !!participating; })
             .and(keys)
             .value();

--- a/static/src/javascripts/projects/common/modules/navigation/sticky.js
+++ b/static/src/javascripts/projects/common/modules/navigation/sticky.js
@@ -45,7 +45,7 @@ define([
         this.isMobile = contains(this.breakpoint, 'mobile');
         this.isTablet = contains(this.breakpoint, 'tablet');
         this.isAppleCampaign = config.page.hasBelowTopNavSlot;
-        this.inTopBannerAbTest = config.tests && config.tests.cmTopBannerPosition;
+        this.inTopBannerAbTest = config.tests && config.tests.participations && config.tests.participations.cmTopBannerPosition;
         this.noTopBanner = !commercialFeatures.topBannerAd || adblockMsg.noAdblockMsg() || this.inTopBannerAbTest;
         this.isProfilePage = config.page.section === 'identity';
 

--- a/static/test/javascripts/setup.js
+++ b/static/test/javascripts/setup.js
@@ -33,7 +33,8 @@ window.guardian = {
         page: { },
         images: {
             commercial: {}
-        }
+        },
+        tests: {}
     },
     css: {}
 };

--- a/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
@@ -43,7 +43,9 @@ define([
                     pageId: 'uk/commentisfree'
                 };
                 config.tests = {
-                    cmTopBannerPosition: false
+                    participations: {
+                        cmTopBannerPosition: false
+                    }
                 };
 
                 detect.getBreakpoint = function () {
@@ -76,7 +78,7 @@ define([
         });
 
         it('should create a maximum of 4 advert slots inside topBannerPosition AB test', function (done) {
-            config.tests.cmTopBannerPosition = false;
+            config.tests.participations.cmTopBannerPosition = false;
 
             sliceAdverts.init();
 

--- a/static/test/javascripts/spec/common/experiments/ab.spec.js
+++ b/static/test/javascripts/spec/common/experiments/ab.spec.js
@@ -27,7 +27,7 @@ define([
                     abDummyTest2: true
                 };
 
-                config.tests = [];
+                config.tests = { participations: [] };
 
                 // a list of ab-tests that can be used in the spec's
                 test = {


### PR DESCRIPTION
`window.guardian.config.tests` is currently a map of participations: `Map[TestId, Boolean]`.

I want to add support for server-side tests to the [A/B Tests Chrome extension](https://chrome.google.com/webstore/detail/ab-tests/nehbenedinjacnhlkjbdneedibcagmno). By exposing information about these tests to the client, I will be able to expose it in the extension, like so:

![image](https://cloud.githubusercontent.com/assets/921609/12924081/4dba56b8-cf50-11e5-86b7-fbb5324f763f.png)

This proposes changing `window.guardian.config.tests` to an interface with two keys: `participations` (same as before) and `definitions`. For example:

![image](https://cloud.githubusercontent.com/assets/921609/12924114/7a47e394-cf50-11e5-97df-5975ef363872.png)
