### PR TITLE
R2 pressing - ensure https version of file is available

### DIFF
--- a/admin/app/pagepresser/HtmlCleaner.scala
+++ b/admin/app/pagepresser/HtmlCleaner.scala
@@ -11,6 +11,11 @@ import scala.io.Source
 abstract class HtmlCleaner extends Logging {
   def canClean(document: Document): Boolean
   def clean(document: Document): Document
+
+  def replaceLinks(document: Document): Document = {
+    val newDocumentString = document.html().replaceAll("http:", "https:")
+    Jsoup.parse(newDocumentString)
+  }
 }
 
 object BasicHtmlCleaner extends HtmlCleaner {

--- a/admin/test/pagepresser/HtmlCleanerTest.scala
+++ b/admin/test/pagepresser/HtmlCleanerTest.scala
@@ -46,4 +46,13 @@ import scala.io.Source
     actualResult.html().replace(" ", "") should be(expectedDoc.html().replace(" ", ""))
   }
 
+  it should "change links from http to https" in {
+    val html = "<html><head><link rel=\"stylesheet\" type=\"text/css\" href=\"http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/print.css\" media=\"print\" class=\"contrast\"/></head><body> some text </body></html>"
+    val expectedDoc = Jsoup.parse("<html><head><link rel=\"stylesheet\" type=\"text/css\" href=\"https://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/print.css\" media=\"print\" class=\"contrast\"/></head><body> some text </body></html>")
+
+    val actualResult = BasicHtmlCleaner.replaceLinks(Jsoup.parse(html))
+    actualResult.html().replace(" ", "") should be(expectedDoc.html().replace(" ", ""))
+
+  }
+
 }

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
       "www.theguardian.com/books/reviews/travel/foo" -> "http://www.theguardian.com/books/reviews/travel/foo"
     )
     tests foreach {
-      case (key, value) => controllers.ArchiveController.normalise(key) should be (value)
+      case (key, value) => controllers.ArchiveController.normalise(key, isSecure = false) should be (value)
     }
   }
 
@@ -23,7 +23,7 @@ import scala.concurrent.Future
   it should "return a normalised r1 path with suffixed zeros" in {
     val path = "www.theguardian.com/books/reviews/travel/0,,343395,.html"
     val expectedPath = "http://www.theguardian.com/books/reviews/travel/0,,343395,00.html"
-    controllers.ArchiveController.normalise(path , zeros = "00") should be (expectedPath)
+    controllers.ArchiveController.normalise(path , isSecure = false, zeros = "00") should be (expectedPath)
   }
 
   it should "return a normalised short url path" in {
@@ -32,8 +32,13 @@ import scala.concurrent.Future
       "www.theguardian.com/p/dfas" -> "http://www.theguardian.com/p/dfas"
     )
     tests foreach {
-      case (key, value) => controllers.ArchiveController.normalise(key) should be (value)
+      case (key, value) => controllers.ArchiveController.normalise(key, isSecure = false) should be (value)
     }
+  }
+
+  it should "return the secure path if request is secure and it is non R2 or short url path" in {
+    controllers.ArchiveController.normalise("www.theguardian.com/info/developer-blog/2012/oct/30/miso-dataset-new-release-features", isSecure = true) should be ("https://www.theguardian.com/info/developer-blog/2012/oct/30/miso-dataset-new-release-features")
+    controllers.ArchiveController.normalise("www.theguardian.com/info/developer-blog/2012/oct/30/miso-dataset-new-release-features", isSecure = false) should be ("http://www.theguardian.com/info/developer-blog/2012/oct/30/miso-dataset-new-release-features")
   }
 
   it should "not decode encoded urls" in {


### PR DESCRIPTION
Some content cannot be migrated from R2 to Flex content so we need to press them. Some of these pages are in sections that have moved to https and so will currently not be served out of the archive.

The plan:
- In R2 pressing (Admin), along with a press of the original R2 page we will press a "secure" version of page. This secure version updates all links on the page source to https. This generally looks okay as it's mainly assets which has a secure version too.
- We will have two rows in the DynamoDb for a path one for http and one for https. The http will point to `path` whereas https will point to `path.secure`.
- In Archive if the request is on https fetch the secure version of the or non https the non-secure version. There is no fallback if secure version does not exist so we need to repress every R2 page to ensure this will work in the future.

cc @JustinPinner 
