### PR TITLE
Changing amp logo to be `/`, and not editionalise

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -49,7 +49,7 @@
             @* this is for testing only *@
             @defining("""bowie""".r) { hasHeader =>
                 <header class="main-header @if(hasHeader.findFirstIn(page.metadata.id).nonEmpty) {variant-kicker}">
-                    <a href="@LinkTo{/}" class="logo-wrapper" name="top">
+                    <a href="@Configuration.site.host/" class="logo-wrapper" name="top">
                         @fragments.inlineSvg("guardian-logo-160", "logo")
                     </a>
                         @if(hasHeader.findFirstIn(page.metadata.id).nonEmpty) {


### PR DESCRIPTION
LinkedTo editionalises, which is great, but unfortunately not useful for AMP. The link to the home page our article pages in the amp carousal are being cached with an edition.

To prevent this, lets not use LinkedTo :)
