### PR TITLE
adds support for embeds/links from s3-uploader

### DIFF
--- a/admin/app/controllers/cache/ImageDecacheController.scala
+++ b/admin/app/controllers/cache/ImageDecacheController.scala
@@ -24,7 +24,7 @@ object ImageDecacheController extends Controller with Logging with AuthLogging w
   case object Cleared extends MessageType
   case object Error extends MessageType
 
-  private val iGuim = """i.guim.co.uk/img/(static|media)(/.*)""".r
+  private val iGuim = """i.guim.co.uk/img/(static|media|uploads)(/.*)""".r
   private val Origin = """(static|media).guim.co.uk/.*""".r
 
   def renderImageDecacheForm() = AuthActions.AuthActionTest { request =>

--- a/admin/app/controllers/cache/ImageServices.scala
+++ b/admin/app/controllers/cache/ImageServices.scala
@@ -19,7 +19,8 @@ object ImageServices extends ExecutionContexts {
 
   private val fastlyOriginCdns = Map(
     "static.guim.co.uk" -> "5qHts5Ev0rFxzm1DhCkmyA",
-    "media.guim.co.uk" -> "1NLDlK1ywahkZzRZrmWIYw"
+    "media.guim.co.uk" -> "1NLDlK1ywahkZzRZrmWIYw",
+    "uploads.guim.co.uk" -> "2TmfkSoyUoNo8aFNe6Htjs"
   )
 
   // clear both the origin CDN and i.guim.co.uk
@@ -28,7 +29,8 @@ object ImageServices extends ExecutionContexts {
 
   private val imgixBackends = Map(
     "static.guim.co.uk" -> "static-guim.imgix.net",
-    "media.guim.co.uk" -> "media-guim.imgix.net"
+    "media.guim.co.uk" -> "media-guim.imgix.net",
+    "uploads.guim.co.uk" -> "uploads-guim.imgix.net"
   )
   private def imgixBackendFor(host: String): String = imgixBackends(host)
 

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -211,6 +211,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     object backends {
       lazy val mediaToken: String = configuration.getMandatoryStringProperty("images.media.token")
       lazy val staticToken: String = configuration.getMandatoryStringProperty("images.static.token")
+      lazy val uploadsToken: String = configuration.getMandatoryStringProperty("images.uploads.token")
     }
   }
 

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -96,7 +96,8 @@ object ImgSrc extends Logging {
   private lazy val hostPrefixMapping: Map[String, HostMapping] = Map(
     "static.guim.co.uk" -> HostMapping("static", Configuration.images.backends.staticToken),
     "static-secure.guim.co.uk" -> HostMapping("static", Configuration.images.backends.staticToken),
-    "media.guim.co.uk" -> HostMapping("media", Configuration.images.backends.mediaToken)
+    "media.guim.co.uk" -> HostMapping("media", Configuration.images.backends.mediaToken),
+    "uploads.guim.co.uk" -> HostMapping("uploads", Configuration.images.backends.uploadsToken)
   )
 
   def tokenFor(host:String): Option[String] = hostPrefixMapping.get(host).map(_.token)

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -55,10 +55,6 @@ commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
 commercial.travel_url=http://www.guardianholidayoffers.co.uk
 
-images.media.token=not-a-real-token
-images.static.token=not-a-real-token
-images.uploads.token=not-a-real-token
-
 # Headlines AB Test
 headlines.spreadsheet=1aGUa-Prxre5ul4nDc-7b31TOIyHaprCsmy6jkKevGL8
 

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -57,6 +57,7 @@ commercial.travel_url=http://www.guardianholidayoffers.co.uk
 
 images.media.token=not-a-real-token
 images.static.token=not-a-real-token
+images.uploads.token=not-a-real-token
 
 # Headlines AB Test
 headlines.spreadsheet=1aGUa-Prxre5ul4nDc-7b31TOIyHaprCsmy6jkKevGL8

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -49,6 +49,32 @@ class ImgSrcTest extends FlatSpec with Matchers with OneAppPerSuite {
 
   val mediaImage = ImageMedia.apply(Seq(mediaImageAsset))
 
+  val s3UploadJpgImageAsset = ImageAsset.make(Asset(
+    AssetType.Image,
+    Some("image/jpeg"),
+    Some("https://uploads.guim.co.uk/2016/02/10/Screen_Shot_2016-02-09_at_17.50.09.jpeg"),
+    None
+  ), 1)
+
+  val s3UploadJpgImage = ImageMedia.apply(Seq(s3UploadJpgImageAsset))
+
+  val s3UploadPNGImageAsset = ImageAsset.make(Asset(
+    AssetType.Image,
+    Some("image/png"),
+    Some("https://uploads.guim.co.uk/2016/02/04/gu.png"),
+    None
+  ), 1)
+
+  val s3UploadPNGImage = ImageMedia.apply(Seq(s3UploadPNGImageAsset))
+
+  val s3UploadGifImageAsset = ImageAsset.make(Asset(
+    AssetType.Image,
+    Some("image/gif"),
+    Some("https://uploads.guim.co.uk/2016/02/04/meep.gif"),
+    None
+  ), 1)
+
+  val s3UploadGifImage = ImageMedia.apply(Seq(s3UploadGifImageAsset))
 
   "ImgSrc" should "convert the URL of a static image to the resizing endpoint with a /static prefix" in {
     ImageServerSwitch.switchOn()
@@ -87,5 +113,20 @@ class ImgSrcTest extends FlatSpec with Matchers with OneAppPerSuite {
     ImageServerSwitch.switchOn()
     val someoneElsesImage = ImageMedia(Seq(ImageAsset.make(asset.copy(file = Some("http://foo.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.gif")),0)))
     Item700.bestFor(someoneElsesImage) should be (Some("http://foo.co.uk/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.gif"))
+  }
+
+  it should "convert the URL of a jpeg s3 upload to the resizing endpoint with a /uploads prefix" in {
+    ImageServerSwitch.switchOn()
+    Item700.bestFor(s3UploadJpgImage) should be (Some(s"$imageHost/img/uploads/2016/02/10/Screen_Shot_2016-02-09_at_17.50.09.jpeg?w=700&q=85&auto=format&sharp=10&s=ee0643ec4ff438e30b05b070628c704e"))
+  }
+
+  it should "convert the URL of a png s3 upload to the resizing endpoint with a /uploads prefix" in {
+    ImageServerSwitch.switchOn()
+    Item700.bestFor(s3UploadPNGImage) should be (Some(s"$imageHost/img/uploads/2016/02/04/gu.png?w=700&q=85&auto=format&sharp=10&s=c19a854dc0df6dd7919adae79abb2fde"))
+  }
+
+  it should "not convert the URL of a gif s3 upload (we do not support animated GIF)" in {
+    ImageServerSwitch.switchOn()
+    Item700.bestFor(s3UploadGifImage) should be (Some(s"https://uploads.guim.co.uk/2016/02/04/meep.gif"))
   }
 }

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -117,12 +117,12 @@ class ImgSrcTest extends FlatSpec with Matchers with OneAppPerSuite {
 
   it should "convert the URL of a jpeg s3 upload to the resizing endpoint with a /uploads prefix" in {
     ImageServerSwitch.switchOn()
-    Item700.bestFor(s3UploadJpgImage) should be (Some(s"$imageHost/img/uploads/2016/02/10/Screen_Shot_2016-02-09_at_17.50.09.jpeg?w=700&q=85&auto=format&sharp=10&s=ee0643ec4ff438e30b05b070628c704e"))
+    Item700.bestFor(s3UploadJpgImage) should be (Some(s"$imageHost/img/uploads/2016/02/10/Screen_Shot_2016-02-09_at_17.50.09.jpeg?w=700&q=85&auto=format&sharp=10&s=0b99c35bdef4f7797872058898771443"))
   }
 
   it should "convert the URL of a png s3 upload to the resizing endpoint with a /uploads prefix" in {
     ImageServerSwitch.switchOn()
-    Item700.bestFor(s3UploadPNGImage) should be (Some(s"$imageHost/img/uploads/2016/02/04/gu.png?w=700&q=85&auto=format&sharp=10&s=c19a854dc0df6dd7919adae79abb2fde"))
+    Item700.bestFor(s3UploadPNGImage) should be (Some(s"$imageHost/img/uploads/2016/02/04/gu.png?w=700&q=85&auto=format&sharp=10&s=a7334eb719aae4f07c6a4c32e9d005d5"))
   }
 
   it should "not convert the URL of a gif s3 upload (we do not support animated GIF)" in {


### PR DESCRIPTION
S3-Uploader is a replacement for the R2 dependant batch uploader. You upload a file and are given a fastly backed URL to it. This file can then be added to any article. If the file is a gif, jpeg or png it will be embedded else it will be linked.

This PR adds `uploads.guim.co.uk` to `fastlyOriginCdns` so that images can be served through imigix.

Requires https://github.com/guardian/fastly-image-service/pull/5.
