### PR TITLE
Add image missing metadata (height and width)

### DIFF
--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -41,6 +41,8 @@
 
         @if(amp) {
             <meta itemprop="url" content="@ImgSrc.getFallbackUrl(picture)">
+            <meta itemprop="width" content="@ImgSrc.getFallbackAsset(picture).fold(0)(_.width)">
+            <meta itemprop="height" content="@ImgSrc.getFallbackAsset(picture).fold(0)(_.height)">
         }
 
         @lightbox{


### PR DESCRIPTION
Image metadata height and width are required for amp pages
![screen shot 2016-02-10 at 15 34 10](https://cloud.githubusercontent.com/assets/233326/12951737/9e6a3e78-d00b-11e5-86f7-d9ea0699cf09.png)

@NataliaLKB 
