### PR TITLE
Update top employers URL

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -314,7 +314,7 @@ object Navigation {
       SectionLink("careers", "newsletter", "newsletter", "https://register.theguardian.com/careers"),
       SectionLink("careers", "courses", "courses", "http://jobs.theguardian.com/courses"),
       SectionLink("careers", "jobs", "jobs", "http://jobs.theguardian.com"),
-      SectionLink("careers", "top employers UK", "top employers UK", "/careers/britains-top-employers")
+      SectionLink("careers", "top employers UK", "top employers UK", "/careers/top-employers-uk")
     ),
     "guardian-masterclasses" -> Seq(
       SectionLink("guardian-masterclasses", "guardian masterclasses", "guardian masterclasses", "/guardian-masterclasses"),


### PR DESCRIPTION
From:

`http://www.theguardian.com/careers/britains-top-employers`

To:

`http://www.theguardian.com/careers/top-employers-uk`
