### PR TITLE
Use front type to determine rendering of paid containers

### DIFF
--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -8,6 +8,7 @@ import conf.Configuration.commercial.showMpuInAllContainersPageId
 import contentapi.Paths
 import model.facia.PressedCollection
 import play.api.libs.json.{JsBoolean, JsString, JsValue}
+import services.ConfigAgent
 
 import scala.language.postfixOps
 
@@ -104,9 +105,12 @@ case class PressedPage (
     }
   }
   val navSection: String = metadata.section
+
   val keywordIds: Seq[String] = frontKeywordIds(id)
 
-   def sponsorshipType: Option[String] = {
+  lazy val frontPriority: Option[FrontPriority] = ConfigAgent.getFrontPriorityFromConfig(id)
+
+  def sponsorshipType: Option[String] = {
     if (isSponsored(None)) {
       Option("sponsoredfeatures")
     } else if (isAdvertisementFeature) {

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -1,6 +1,7 @@
 package services
 
 import akka.util.Timeout
+import com.gu.facia.api.models.{CommercialPriority, EditorialPriority, FrontPriority, TrainingPriority}
 import com.gu.facia.client.models.{ConfigJson => Config, FrontJson => Front}
 import common._
 import conf.Configuration
@@ -94,6 +95,18 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
       title  = frontOption.flatMap(_.title).filter(_.nonEmpty),
       description  = frontOption.flatMap(_.description).filter(_.nonEmpty)
     )
+  }
+
+  def getFrontPriorityFromConfig(pageId: String): Option[FrontPriority] = {
+    configAgent.get() flatMap {
+      _.fronts.get(pageId) map {
+        _.priority match {
+          case Some("commercial") => CommercialPriority
+          case Some("training") => TrainingPriority
+          case _ => EditorialPriority
+        }
+      }
+    }
   }
 
   def fetchFrontProperties(id: String): FrontProperties = {

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,10 +1,25 @@
-@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties = model.FrontProperties.empty, isPaidContent: Boolean = false)(implicit request: RequestHeader)
+@import com.gu.facia.api.models.FrontPriority
+@(containerDefinition: layout.FaciaContainer,
+  frontProperties: model.FrontProperties = model.FrontProperties.empty,
+  isPaidContent: Boolean = false,
+  frontPriority: Option[FrontPriority] = None
+)(implicit request: RequestHeader)
+
 @import common.dfp.{Keyword, Series}
 @import conf.switches.Switches
 @import layout.MetaDataHeader
-@import slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList}
+@import slices.{CommercialContainerType, Dynamic, Fixed, MostPopular, NavList, NavMediaList, SingleCampaign}
 @import views.html.fragments.containers.facia_cards.{commercialContainer, containerMetaData, mostPopularContainer, navListContainer, navMediaListContainer, standardContainer}
-@import views.support.{GetClasses, RenderClasses}
+@import views.support.{Commercial, GetClasses, RenderClasses}
+
+@renderCommercialContainer(containerType: CommercialContainerType) = {
+    <div class="@RenderClasses(
+        Map("fc-container__inner--full-span fc-container__inner--paidfor" -> Switches.NewCommercialContent.isSwitchedOn),
+        "fc-container__inner"
+    )">
+    @commercialContainer(containerType, containerDefinition, frontProperties)
+    </div>
+}
 
 @defining((containerDefinition.displayName, containerDefinition.faciaComponentName)) { case (title, componentName) =>
     @containerDefinition.customHeader.map {
@@ -44,6 +59,10 @@
 
             @containerDefinition.container match {
 
+                case Fixed(definition) if Commercial.container.shouldRenderAsCommercialContainer(frontPriority, containerDefinition) => {
+                    @renderCommercialContainer(SingleCampaign(definition))
+                }
+
                 case _: Dynamic | _: Fixed => {
                     <div class="fc-container__inner">
                         @standardContainer(containerDefinition, frontProperties)
@@ -69,12 +88,7 @@
                 }
 
                 case slices.Commercial(container) => {
-                    <div class="@RenderClasses(
-                        Map("fc-container__inner--full-span fc-container__inner--paidfor" -> Switches.NewCommercialContent.isSwitchedOn),
-                        "fc-container__inner"
-                    )">
-                        @commercialContainer(container, containerDefinition, frontProperties)
-                    </div>
+                    @renderCommercialContainer(container)
                 }
             }
         </section>

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -1,8 +1,10 @@
 package views.support
 
+import com.gu.facia.api.models.{EditorialPriority, FrontPriority}
 import common.Edition
 import common.dfp.AdSize.{leaderboardSize, responsiveSize}
 import common.dfp._
+import conf.switches.Switches
 import conf.switches.Switches._
 import layout.{ColumnAndCards, ContentCard, FaciaContainer}
 import model.pressed.{CollectionConfig, PressedContent}
@@ -80,6 +82,13 @@ object Commercial {
   }
 
   object container {
+
+    def shouldRenderAsCommercialContainer(frontPriority: Option[FrontPriority], container: FaciaContainer): Boolean = {
+      Switches.NewCommercialContent.isSwitchedOn &&
+      Switches.PaidContainerUpdate.isSwitchedOn &&
+      frontPriority.contains(EditorialPriority) &&
+      container.commercialOptions.isAdvertisementFeature
+    }
 
     def mkSponsorDataAttributes(config: CollectionConfig): Option[SponsorDataAttributes] = {
       DfpAgent.findContainerCapiTagIdAndDfpTag(config) map { tagData =>

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -1,7 +1,7 @@
 @(faciaPage: model.PressedPage)(implicit request: RequestHeader)
 @import common.Edition
-@import views.support.RenderClasses
 @import conf.switches.Switches._
+@import views.support.RenderClasses
 
 @defining((faciaPage.isSponsored(Some(Edition(request))),
         faciaPage.isAdvertisementFeature,
@@ -32,7 +32,12 @@
                     @fragments.basher(faciaPage.id)
 
                     @collections.map { containerDefinition =>
-                        @fragments.containers.facia_cards.container(containerDefinition, faciaPage.frontProperties, faciaPage.isAdvertisementFeature)
+                        @fragments.containers.facia_cards.container(
+                            containerDefinition,
+                            faciaPage.frontProperties,
+                            faciaPage.isAdvertisementFeature,
+                            faciaPage.frontPriority
+                        )
                     }
 
                     @defining(layout.Front.makeLinkedData(faciaPage.metadata.url, collections)) { linkedData =>


### PR DESCRIPTION
We only want paid containers to have the new styling if they appear on editorial fronts.
This change uses the `ConfigAgent` to determine the type of front the container is on.

/cc @janua  
