### PR TITLE
Make inline component as wide as the thinnest element on mobile

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -470,13 +470,8 @@
     margin: 5px $gs-gutter $gs-baseline 0;
 
     @include mq($until: mobileLandscape) {
-        width: $gs-gutter * 6.5;
         margin-bottom: $gs-baseline / 2;
         margin-right: $gs-gutter / 2;
-    }
-
-    @include mq(mobileLandscape) {
-        width: gs-span(3);
     }
 }
 .ad-slot--fobadge.ad-slot--im {

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -466,12 +466,17 @@
     }
 }
 .ad-slot--im {
-    box-sizing: border-box;
-    max-width: 50%;
     float: left;
+    margin: 5px $gs-gutter $gs-baseline 0;
+
+    @include mq($until: mobileLandscape) {
+        width: $gs-gutter * 6.5;
+        margin-bottom: $gs-baseline / 2;
+        margin-right: $gs-gutter / 2;
+    }
 
     @include mq(mobileLandscape) {
-        max-width: $left-column-wide + $gs-gutter;
+        width: gs-span(3);
     }
 }
 .ad-slot--fobadge.ad-slot--im {

--- a/static/src/stylesheets/module/commercial/_commercial--v-high.scss
+++ b/static/src/stylesheets/module/commercial/_commercial--v-high.scss
@@ -2,8 +2,6 @@
    Super-high component styling
    ========================================================================== */
 .commercial--v-high {
-    margin-right: $gs-gutter;
-
     .lineitem__image {
         float: none;
         margin-top: (-$gs-baseline/2);
@@ -16,8 +14,6 @@
     }
 
     &.commercial--tone-books {
-        width: gs-span(2);
-
         .lineitem__image {
             max-width: 100%;
             margin: 0;

--- a/static/src/stylesheets/module/commercial/_commercial--v-high.scss
+++ b/static/src/stylesheets/module/commercial/_commercial--v-high.scss
@@ -2,6 +2,14 @@
    Super-high component styling
    ========================================================================== */
 .commercial--v-high {
+    @include mq($until: mobileLandscape) {
+        width: $gs-gutter * 6.5;
+    }
+
+    @include mq(mobileLandscape) {
+        width: gs-span(3);
+    }
+
     .lineitem__image {
         float: none;
         margin-top: (-$gs-baseline/2);
@@ -14,6 +22,10 @@
     }
 
     &.commercial--tone-books {
+        @include mq(mobileLandscape) {
+            width: gs-span(2);
+        }
+
         .lineitem__image {
             max-width: 100%;
             margin: 0;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -33,13 +33,8 @@
         .content__article-body {
             padding-right: gs-span(1) + $gs-gutter;
 
-            .ad-slot {
+            .ad-slot:not(.ad-slot--im) {
                 margin-right: -1 * (gs-span(1) + $gs-gutter);
-            }
-
-            /* Inline merchandising component is on the left so negative margin-right is bad */
-            .ad-slot--im {
-                margin-right: 0;
             }
 
             .gu-media-wrapper {


### PR DESCRIPTION
This PR gives inline components the same width/margins than rich links, so that they take the same space and not more. The only exception is for the inline book component, which keeps a smaller width so that book covers display nicely.

**Before**
![picture 2](https://cloud.githubusercontent.com/assets/629976/12975881/707d9cb0-d0b7-11e5-8c45-4970f372147c.png)

**After**
![picture 1](https://cloud.githubusercontent.com/assets/629976/12975883/76e7e79a-d0b7-11e5-834e-0952d84e9d58.png)
