### PR TITLE
Add a min-width to the engaged reader banner button

### DIFF
--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -150,6 +150,7 @@
     @include mq(tablet) {
         display: table-cell;
         vertical-align: middle;
+        min-width: 85px;
         margin-top: 0;
     }
 }

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -150,7 +150,7 @@
     @include mq(tablet) {
         display: table-cell;
         vertical-align: middle;
-        min-width: 85px;
+        min-width: $gs-column-width * 2;
         margin-top: 0;
     }
 }


### PR DESCRIPTION
before

![image](https://cloud.githubusercontent.com/assets/1388226/13009068/28a3f840-d192-11e5-8099-8710986ed74d.png)

after

![image](https://cloud.githubusercontent.com/assets/1388226/13009129/8f8dcea0-d192-11e5-9ab3-28b1b9d74e52.png)

necessary as the text is the only clickable part of the button
