### PR TITLE
Recommendation button for 'more replies' comments should not be disabled

### DIFF
--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -46,10 +46,10 @@ object CommentsController extends DiscussionController with ExecutionContexts {
         Cached(60) {
           if (request.isJson)
             JsonComponent(
-              "html" -> views.html.fragments.comment(comment).toString
+              "html" -> views.html.fragments.comment(comment, comment.discussion.isClosedForRecommendation).toString
             )
           else
-            Ok(views.html.fragments.comment(comment))
+            Ok(views.html.fragments.comment(comment, comment.discussion.isClosedForRecommendation))
         }
     }
   }


### PR DESCRIPTION
Comments loaded via the 'Load X more replies' always had their
recommendation button disabled.
Chrome seems to dispatch the click event anyway, even when the button is
disabled. That would explain why the recommendation feature for those
comments was still working on Chrome
On the other hand, Firefox doesn't seem to dispatch the click event when
button is disabled
Read more at https://code.google.com/p/chromium/issues/detail?id=243199
