### PR TITLE
Remove the nextgen profile from the AWSCredentialsProviderChain

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -423,7 +423,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
         new EnvironmentVariableCredentialsProvider(),
         new SystemPropertiesCredentialsProvider(),
         new ProfileCredentialsProvider("frontend"),
-        new ProfileCredentialsProvider("nextgen"),
         new InstanceProfileCredentialsProvider
       )
 


### PR DESCRIPTION
Will switch this over on monday as there could be unforeseen consequences.

@rich-nguyen 
