### PR TITLE
Fix logical fallacy to detect wider columns for comments in articles

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/comment-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/comment-adverts.js
@@ -61,7 +61,7 @@ define([
                 idleFastdom.write(function () {
                     $commentMainColumn.addClass('discussion__ad-wrapper');
 
-                    if (!config.page.isLiveBlog || !config.page.isMinuteArticle) {
+                    if (!config.page.isLiveBlog && !config.page.isMinuteArticle) {
                         $commentMainColumn.addClass('discussion__ad-wrapper-wider');
                     }
 


### PR DESCRIPTION
Currently a `.discussion__ad-wrapper-wider` class is added to the container of the comments MPU in all cases except when the page is both a liveblog and a minute article—i.e. always.

Here is what happens:
![picture 1](https://cloud.githubusercontent.com/assets/629976/13045587/1e28b2f2-d3cc-11e5-8d05-6225c601bc60.png)
