### PR TITLE
Force schema.org/NewsArticle for all amplified articles

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -13,7 +13,7 @@
             @if(article.commercial.isAdvertisementFeature){content--advertisement-feature}
             @if(article.tags.isFeature && article.elements.hasShowcaseMainElement){has-feature-showcase-element}
             @if(article.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn){paid-content--advertisement-feature}"
-            itemscope itemtype="@article.metadata.schemaType" role="main">
+            itemscope itemtype="@if(amp && ForceSchemaOrgTypeForAmpArticlesSwitch.isSwitchedOn){http://schema.org/NewsArticle} else {@article.metadata.schemaType}" role="main"> @*Feb 2015: Google does only support NewsArticle in their amp carrousel. To remove once Google starts supporting other schema like schema.org/Review*@
             <meta itemprop="mainEntityOfPage" content="@LinkTo(article.metadata.url)">
             <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
                 <meta itemprop="name" content="The Guardian">

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -366,4 +366,14 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2016, 3, 1), //Tuesday
     exposeClientSide = true
   )
+
+  // Owner: Dotcom reach
+  val ForceSchemaOrgTypeForAmpArticlesSwitch = Switch(
+    "Feature",
+    "force-schema-org-type-for-amp-articles",
+    "When ON, all amplified articles have schema.org type set to 'NewsArticle' (which is the only type Google search carousel supports as of Feb 2015)",
+    safeState = On,
+    sellByDate = new LocalDate(2016, 4, 5), //Tuesday
+    exposeClientSide = false
+  )
 }


### PR DESCRIPTION
Google search carousel doesn't support other schema type at the moment
This commit forces reviews to be NewsArticles (only amp'ed page though)
A feature switch has also be added to force us to reevaluate this
workaround on a regular basis
