### PR TITLE
track previous content type

### DIFF
--- a/common/app/templates/inlineJS/blocking/analytics.scala.js
+++ b/common/app/templates/inlineJS/blocking/analytics.scala.js
@@ -61,6 +61,8 @@ try {
         s.prop4     = config.page.keywords || '';
         s.prop8     = config.page.pageCode || '';
         s.prop9     = config.page.contentType || '';
+        // Previous Content type
+        s.prop70    = s.getPreviousValue(s.prop9, "s_prev_ct");
         s.prop10    = config.page.tones || '';
 
         s.prop25    = config.page.blogs || '';


### PR DESCRIPTION
Seems it's available in omniture but we aren't populating it.

[There's other examples in the vendor file, but I assumed that was supplied](https://github.com/guardian/frontend/blob/master/static/public/javascripts/vendor/omniture.js#L89-L90).
