### PR TITLE
Add fallback image metadata to amp article if no images

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -70,6 +70,17 @@
                         <div class="content__article-body from-content-api js-article__body" itemprop="@bodyType(model)"
                             data-test-id="article-review-body">
                             @BodyCleaner(article, article.fields.body, amp = amp)
+
+                            @* A value for the image field is required for AMP article
+                            WORKAROUND: if the article doesn't contain any image we insert the metadata of the fallback logo,
+                            so the amp page passes validation but no image is visible by the user *@
+                            @if(amp && article.content.elements.images.isEmpty) {
+                                <div itemprop="image" itemscope itemtype="http://schema.org/ImageObject">
+                                    <meta itemprop="url" content="https://assets.guim.co.uk/images/2170b16eb045a34f8c79761b203627b4/fallback-logo.png">
+                                    <meta itemprop="width" content="1200">
+                                    <meta itemprop="height" content="630">
+                                </div>
+                            }
                         </div>
 
                         @fragments.witnessCallToAction(article.content)


### PR DESCRIPTION
A value for the image field is required for AMP articles
https://developers.google.com/structured-data/rich-snippets/articles
which is a kind of ridiculous requirement for a webpage. :(
In order to please (trick?) the validator we are adding an invisible
image metadata (fallback logo) if the article content has no images
