### PR TITLE
Adds a switch for the r2 headers to be passed with the request url.

### DIFF
--- a/admin/app/jobs/R2PagePressJob.scala
+++ b/admin/app/jobs/R2PagePressJob.scala
@@ -6,6 +6,7 @@ import com.amazonaws.services.sqs.model.ReceiveMessageRequest
 import common._
 import conf.Configuration
 import conf.switches.Switches.R2PagePressServiceSwitch
+import conf.switches.Switches.R2HeadersRequiredForPagePressingSwitch
 import org.jsoup.Jsoup
 import pagepresser.{PollsHtmlCleaner, BasicHtmlCleaner}
 import play.api.libs.json.Json
@@ -69,7 +70,10 @@ object R2PagePressJob extends ExecutionContexts with Logging {
       val r2HeaderName = Configuration.r2Press.header.name.getOrElse("")
       val r2HeaderValue = Configuration.r2Press.header.value.getOrElse("")
 
-      WS.url(urlIn).withHeaders((r2HeaderName, r2HeaderValue)).get().map { response =>
+      val wSRequest = if(R2HeadersRequiredForPagePressingSwitch.isSwitchedOn) WS.url(urlIn).withHeaders((r2HeaderName, r2HeaderValue))
+                      else WS.url(urlIn)
+
+      wSRequest.get().map { response =>
         response.status match {
           case 200 => {
             try {

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -340,6 +340,16 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val R2HeadersRequiredForPagePressingSwitch = Switch(
+    "Feature",
+    "r2-headers-page-press-service",
+    "When ON, the R2 page press service will hit the R2 page, when turned off it will hit Dotcom",
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
+
   val EmailInArticleSwitch = Switch(
     "Feature",
     "email-in-article",


### PR DESCRIPTION
Uses a switch to determine if to hit R2 or Dotcom. This is required as we need to repress a few urls to be ready for https but they have been taken down in R2 and we are using the pressed versions. 

This is a bit manual but it's just required for a few examples.
cc @JustinPinner 
