### PR TITLE
Fix edition-deriving code for top mobile ad slot

### DIFF
--- a/common/app/common/dfp/AdSlotAgent.scala
+++ b/common/app/common/dfp/AdSlotAgent.scala
@@ -9,7 +9,7 @@ import conf.Configuration.commercial.dfpAdUnitRoot
 
 trait AdSlotAgent {
 
-  protected val isProd: Boolean
+  protected def isProd: Boolean
 
   protected def lineItemsBySlot: Map[AdSlot, Seq[GuLineItem]]
 
@@ -41,8 +41,8 @@ trait AdSlotAgent {
       creativeSizes.contains(leaderboardSize) || creativeSizes.contains(responsiveSize)
     }
 
-    def deriveEditionFromGeotargeting(lineItem: GuLineItem): Option[Edition] = {
-      lineItem.targeting.geoTargetsIncluded.headOption flatMap {
+    def deriveEditionFromGeotargeting(lineItem: GuLineItem): Seq[Edition] = {
+      lineItem.targeting.geoTargetsIncluded flatMap {
         case GeoTarget(_, _, "COUNTRY", "United Kingdom") => Some(Uk)
         case GeoTarget(_, _, "COUNTRY", "United States") => Some(Us)
         case GeoTarget(_, _, "COUNTRY", "Australia") => Some(Au)


### PR DESCRIPTION
 So that it uses all geotargets to derive edition rather than just the first one.

/cc @regiskuckaertz 
