### PR TITLE
Stop FF ABP detection throwing exceptions outside Firefox

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -17,10 +17,14 @@ try {
             window.requestAnimationFrame(() => {
                 var adStyles = window.getComputedStyle(ad);
                 window.guardian.adBlockers.generic = adStyles.getPropertyValue('display') === 'none';
-                window.guardian.adBlockers.ffAdblockPlus = adStyles.getPropertyValue('-moz-binding').match('elemhidehit') !== null;
+
+                // Only tells us if FF ABP is installed - not whether it is active
+                var adMozBinding = adStyles.getPropertyValue('-moz-binding');
+                window.guardian.adBlockers.ffAdblockPlus = adMozBinding && adMozBinding.match('elemhidehit') !== null;
+
                 try {
                     window.guardian.adBlockers.onDetect();
-                } catch(e) {};
+                } catch(e) {}
             })
         });
     })(document, window);


### PR DESCRIPTION
The adblock detection script throws exceptions outside of Firefox:

![image](https://cloud.githubusercontent.com/assets/3148617/13078801/fceab96c-d4b8-11e5-88c9-25cd8634179e.png)

This line is the culprit:
![image](https://cloud.githubusercontent.com/assets/3148617/13078825/13f9a050-d4b9-11e5-8493-d22d66c3a404.png)
_If the element does not have a mozBinding, we try and call .match on a null_

This pull request squashes the bug:
![image](https://cloud.githubusercontent.com/assets/3148617/13078853/3dc0fa6e-d4b9-11e5-9fd8-21aa36aa3695.png)

@sndrs @gtrufitt 
