### PR TITLE
Use async adblock for membership messages

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -23,7 +23,7 @@ try {
                 window.guardian.adBlockers.ffAdblockPlus = adMozBinding && adMozBinding.match('elemhidehit') !== null;
 
                 try {
-                    window.guardian.adBlockers.onDetect();
+                    window.guardian.adBlockers.onDetect(window.guardian.adBlockers);
                 } catch(e) {}
             })
         });

--- a/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-feature-policies.js
@@ -68,16 +68,15 @@ define([
         }
     };
 
-    policies.membershipMessages = function () {
-        if (!detect.adblockInUseSync() &&
-            detect.getBreakpoint() !== 'mobile' &&
-            config.page.contentType === 'Article' &&
-            !userFeatures.isPayingMember()
-        ) {
-            return {
-                membershipMessages : true
-            };
-        }
+    policies.checkWeCanShowMembershipMessages = function () {
+        return {
+            checkWeCanShowMembershipMessages: detect.adblockInUse.then(function (adblockInUse) {
+                return !adblockInUse &&
+                    detect.getBreakpoint() !== 'mobile' &&
+                    config.page.contentType === 'Article' &&
+                    !userFeatures.isPayingMember();
+            })
+        };
     };
 
     policies.identityPages = function () {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -53,11 +53,10 @@ define([
         }
     };
 
-    function canShow(message) {
-        return (
-            commercialFeatures.membershipMessages &&
-            message.minVisited <= (storage.local.get('gu.alreadyVisited') || 0)
-        );
+    function checkWeCanShowMessage(message) {
+        return commercialFeatures.checkWeCanShowMembershipMessages.then(function (canShow) {
+            return canShow && message.minVisited <= (storage.local.get('gu.alreadyVisited') || 0);
+        })
     }
 
     function formatEndpointUrl(edition, message) {
@@ -88,9 +87,16 @@ define([
 
     function init() {
         var message = messages[config.page.edition];
-        if (message && canShow(message)) {
-            show(config.page.edition, message);
+        if (message) {
+            return checkWeCanShowMessage(message).then(function (weCanShowMessage) {
+                if (weCanShowMessage) {
+                    return show(config.page.edition, message);
+                } else {
+                    return false;
+                }
+            });
         }
+        return Promise.reject();
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -56,7 +56,7 @@ define([
     function checkWeCanShowMessage(message) {
         return commercialFeatures.checkWeCanShowMembershipMessages.then(function (canShow) {
             return canShow && message.minVisited <= (storage.local.get('gu.alreadyVisited') || 0);
-        })
+        });
     }
 
     function formatEndpointUrl(edition, message) {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -90,13 +90,11 @@ define([
         if (message) {
             return checkWeCanShowMessage(message).then(function (weCanShowMessage) {
                 if (weCanShowMessage) {
-                    return show(config.page.edition, message);
-                } else {
-                    return false;
+                    show(config.page.edition, message);
                 }
             });
         }
-        return Promise.reject();
+        return Promise.resolve();
     }
 
     return {

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -445,7 +445,7 @@ define([
             resolve(window.guardian.adBlockers);
         } else {
             // Push a listener for when the JS loads
-            window.guardian.adBlockers.onDetect = resolve.bind(this, window.guardian.adBlockers);
+            window.guardian.adBlockers.onDetect = resolve;
         }
     });
 

--- a/static/test/javascripts/setup.js
+++ b/static/test/javascripts/setup.js
@@ -35,7 +35,8 @@ window.guardian = {
             commercial: {}
         }
     },
-    css: {}
+    css: {},
+    adBlockers: {}
 };
 
 // Omniture variables expected on the page

--- a/static/test/javascripts/spec/common/commercial/membership-messages.spec.js
+++ b/static/test/javascripts/spec/common/commercial/membership-messages.spec.js
@@ -65,10 +65,11 @@ define([
                 storage.local.set('gu.alreadyVisited', alreadyVisited);
             });
 
-            it('should not show any messages even to engaged readers', function () {
-                membershipMessages.init();
-                var message = document.querySelector('.js-site-message.site-message--banner');
-                expect(message).toBeNull();
+            it('should not show any messages even to engaged readers', function (done) {
+                membershipMessages.init().then(function () {
+                    var message = document.querySelector('.js-site-message.site-message--banner');
+                    expect(message).toBeNull();
+                }).then(done);
             });
         });
 
@@ -88,24 +89,24 @@ define([
             });
 
             describe('of the UK edition', function () {
-                it('should show a message to engaged readers', function () {
+                it('should show a message to engaged readers', function (done) {
                     config.page = { edition: 'UK' };
                     storage.local.set('gu.alreadyVisited', 10);
                     membershipMessages.init().then(function () {
                         var message = document.querySelector('.js-site-message.site-message--membership-message-uk');
                         expect(message).not.toBeNull();
-                    });
+                    }).then(done);
                 });
             });
 
             describe('of the US edition', function () {
-                it('should show a message to engaged readers', function () {
+                it('should show a message to engaged readers', function (done) {
                     config.page = { edition: 'US' };
                     storage.local.set('gu.alreadyVisited', 10);
                     membershipMessages.init().then(function () {
                         var message = document.querySelector('.js-site-message.site-message--membership-message-us');
                         expect(message).not.toBeNull();
-                    });
+                    }).then(done);
                 });
             });
         });

--- a/static/test/javascripts/spec/common/commercial/membership-messages.spec.js
+++ b/static/test/javascripts/spec/common/commercial/membership-messages.spec.js
@@ -54,13 +54,8 @@ define([
         describe('If user already member', function () {
             beforeEach(function (done) {
                 showMembershipMessages = commercialFeatures.checkWeCanShowMembershipMessages;
+                commercialFeatures.checkWeCanShowMembershipMessages = Promise.resolve(false);
                 alreadyVisited = storage.local.get('gu.alreadyVisited');
-                window.guardian.adBlockers.onDetect = new Promise(function (resolve) {
-                    resolve({
-                        generic: false,
-                        ffAdblockPlus: false
-                    });
-                });
                 storage.local.set('gu.alreadyVisited', 10);
                 done();
             });
@@ -81,12 +76,7 @@ define([
             beforeEach(function (done) {
                 showMembershipMessages = commercialFeatures.checkWeCanShowMembershipMessages;
                 alreadyVisited = storage.local.get('gu.alreadyVisited');
-                window.guardian.adBlockers.onDetect = new Promise(function (resolve) {
-                    resolve({
-                        generic: true,
-                        ffAdblockPlus: true
-                    });
-                });
+                commercialFeatures.checkWeCanShowMembershipMessages = Promise.resolve(true);
                 fixtures.render(conf);
                 done();
             });


### PR DESCRIPTION
First part of using async adblock detection, for #11789 and following #11970. Also cleans up following https://github.com/guardian/frontend/pull/11970#discussion_r52889127.

@jbreckmckye @regiskuckaertz @OliverJAsh you might want to check the tests in particular...
