### PR TITLE
Taking out srcset for responsive images on amp, use fallback src instead

### DIFF
--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -85,10 +85,9 @@
 @image(picture: model.ImageMedia, widths: WidthsByBreakpoint, imageOption: Option[ImageAsset], isMain: Boolean) = {
 
 @if(amp) {
+
     @picture.largestImage.map { largestImage =>
         <amp-img src="@ImgSrc.getFallbackUrl(picture)"
-        srcset="@ImgSrc.srcset(picture, widths)"
-        sizes="@widths.sizes"
         layout="responsive"
         width="@largestImage.width"
         height="@largestImage.height"

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -87,7 +87,7 @@
 @if(amp) {
 
     @picture.largestImage.map { largestImage =>
-        <amp-img src="@ImgSrc.getFallbackUrl(picture)"
+        <amp-img src="@ImgSrc.getAmpImageUrl(picture)"
         layout="responsive"
         width="@largestImage.width"
         height="@largestImage.height"

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -171,6 +171,10 @@ object ImgSrc extends Logging {
     }
   }
 
+  def getAmpImageUrl(ImageElement: ImageMedia): Option[String] = {
+      findNearestSrc(ImageElement, Item620)
+  }
+
   def getFallbackAsset(ImageElement: ImageMedia): Option[ImageAsset] = {
     Item300.elementFor(ImageElement)
   }


### PR DESCRIPTION
Fixes both #11944 #11943 

It appears as though srcset for amp-images are not behaving as expected. I propose that for now we just use the fallback source and make a test page after launch for the amp team to look at. I can't find another publisher using srcset to compare their approach.

cc @stephanfowler @michaelwmcnamara 
