### PR TITLE
Updating krux tag to Guardian Amp

### DIFF
--- a/facia/public/amp_remote.html
+++ b/facia/public/amp_remote.html
@@ -22,7 +22,7 @@
         function loadKrux() {
             var krux = document.createElement('script');
             krux.setAttribute("class", "kxct");
-            krux.setAttribute("data-id", "JVZiE3vn");
+            krux.setAttribute("data-id", "KS_cfybw");
             krux.setAttribute("data-timing", "async");
             krux.setAttribute("data-version", "1.9");
             krux.setAttribute("type", "text/javascript");
@@ -32,7 +32,7 @@
             "var k=document.createElement('script');k.type='text/javascript';k.async=true; " +
             "var m,src=(m=location.href.match(/\bkxsrc=([^&]+)/))&&decodeURIComponent(m[1]); " +
             "k.src = /^https?:\\/\\/([a-z0-9_\\-\\.]+\\.)?krxd\\.net(:\\d{1,5})?\\//i.test(src) ? src : src === 'disable' ? '' : " +
-            "(location.protocol==='https:'?'https:':'http:')+'//cdn.krxd.net/controltag?confid=JVZiE3vn' ; " +
+            "(location.protocol==='https:'?'https:':'http:')+'//cdn.krxd.net/controltag?confid=KS_cfybw' ; " +
             "var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(k,s); }());";
 
             document.body.appendChild(krux);


### PR DESCRIPTION
We have created a new Guardian Amp krux tag. This PR uses that for amp, instead of Nextgen one. 

@stephanfowler @blackyjnz 
