### PR TITLE
Fix styling of dropdowns on liveblogs

### DIFF
--- a/static/src/stylesheets/module/_dropdown.scss
+++ b/static/src/stylesheets/module/_dropdown.scss
@@ -23,7 +23,7 @@
     }
 
     .dropdown__button {
-        padding: $gs-baseline/2 0 $gs-baseline*1.5;
+        padding: $gs-baseline/2 0;
         color: colour(neutral-1);
         text-align: left;
 
@@ -35,9 +35,10 @@
 
         .inline-icon {
             background-color: colour(neutral-2);
-            right: 0;
-            position: absolute;
-            max-height: 32px;
+
+            svg {
+                display: block;
+            }
         }
     }
 

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -478,12 +478,11 @@ $block-padding-right: $gs-gutter;
 .dropdown--live-feed {
     border-top: 0;
 
+    $content-gutter: $gs-gutter/2;
+
     @include mq($until: desktop) {
-        margin-right: $gs-gutter*-1;
-        margin-left: $gs-gutter*-1;
-        padding-right: $gs-gutter;
-        padding-left: $gs-gutter;
-        padding-top: $gs-baseline*4;
+        margin-right: ($content-gutter)*-1;
+        margin-left: ($content-gutter)*-1;
     }
 
     .dropdown__button {
@@ -491,10 +490,6 @@ $block-padding-right: $gs-gutter;
             background-color: #ffffff;
             padding-right: $gs-gutter;
             padding-left: $gs-gutter;
-            position: absolute;
-            top: 0;
-            right: 0;
-            left: 0;
         }
 
         @include mq(desktop) {
@@ -522,7 +517,7 @@ $block-padding-right: $gs-gutter;
 
         @include mq($until: desktop) {
             background-color: colour(neutral-8);
-            padding: $gs-baseline 0;
+            padding: $gs-baseline $content-gutter;
         }
 
         @include mq(desktop) {

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -478,11 +478,11 @@ $block-padding-right: $gs-gutter;
 .dropdown--live-feed {
     border-top: 0;
 
-    $content-gutter: $gs-gutter/2;
+    $content-gutter: $gs-gutter / 2;
 
     @include mq($until: desktop) {
-        margin-right: ($content-gutter)*-1;
-        margin-left: ($content-gutter)*-1;
+        margin-right: $content-gutter * -1;
+        margin-left: $content-gutter * -1;
     }
 
     .dropdown__button {


### PR DESCRIPTION
The dropdown buttons currently leak off the side of the page.
# Before

![image](https://cloud.githubusercontent.com/assets/921609/13109110/3dc976ba-d56f-11e5-8e6d-2ec5f7b420bf.png)
# After

![image](https://cloud.githubusercontent.com/assets/921609/13109117/44b9abca-d56f-11e5-937e-6fa66e9f1eed.png)

@jamesgorrie I realise we also use these dropdowns in football somewhere, so that will also need testing, but I can't find a page that demonstrates this. Do you know where I can look?

To do:
- [x] Test football http://www.theguardian.com/football/2016/feb/07/chelsea-manchester-united-premier-league-match-report
