### PR TITLE
Enchilada manual display card - variables

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/gu-style-comcontent.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/gu-style-comcontent.js
@@ -25,25 +25,16 @@ define([
     var GustyleComcontent = function ($adSlot, params) {
         this.$adSlot = $adSlot;
         this.params  = params;
-        this.contentPosition = {
-            bottom: 'gu-display__content-position--bottom',
-            top: 'gu-display__content-position--top'
-        };
-        this.fontSize = {
-            small: 'gu-display__content-size--small',
-            regular: 'gu-display__content-size--regular',
-            big: 'gu-display__content-size--big'
-        };
     };
 
     GustyleComcontent.prototype.create = function () {
         var externalLinkIcon = svgs('externalLink', ['gu-external-icon']),
             templateOptions = {
-                articleContentColor: this.params.articleContentColor === 'white' ? 'gu-display__content-color--bright ' : 'gu-display__content-color--dark',
-                articleContentPosition: this.contentPosition[this.params.articleContentPosition],
-                articleHeaderFontSize: this.fontSize[this.params.articleHeaderFontSize],
-                articleTextFontSize: this.fontSize[this.params.articleTextFontSize],
-                brandLogoPosition: this.params.brandLogoPosition === 'bottom-right' ? 'gu-display__logo-pos--bottom-right' : 'gu-display__logo-pos--top-left',
+                articleContentColor: 'gu-display__content-color--' + this.params.articleContentColor,
+                articleContentPosition: 'gu-display__content-position--' + this.params.articleContentPosition,
+                articleHeaderFontSize: 'gu-display__content-size--' + this.params.articleHeaderFontSize,
+                articleTextFontSize: 'gu-display__content-size--' + this.params.articleTextFontSize,
+                brandLogoPosition: 'gu-display__logo-pos--' + this.params.brandLogoPosition,
                 externalLinkIcon: externalLinkIcon
             };
 

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/gu-style-comcontent.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/gu-style-comcontent.js
@@ -26,24 +26,24 @@ define([
         this.$adSlot = $adSlot;
         this.params  = params;
         this.contentPosition = {
-            bottom: 'bottom: 30px;',
-            top: 'top: 30px;'
+            bottom: 'gu-display__content-position--bottom',
+            top: 'gu-display__content-position--top'
         };
         this.fontSize = {
-            small: 'font-size: 0.9rem; line-height: 0.9rem;',
-            regular: 'font-size: 1.25rem;',
-            big: 'font-size: 1.35rem;'
+            small: 'gu-display__content-size--small',
+            regular: 'gu-display__content-size--regular',
+            big: 'gu-display__content-size--big'
         };
     };
 
     GustyleComcontent.prototype.create = function () {
         var externalLinkIcon = svgs('externalLink', ['gu-external-icon']),
             templateOptions = {
-                articleContentColor: this.params.articleContentColor === 'white' ? 'color: #ffffff;' : 'color: #000000;',
+                articleContentColor: this.params.articleContentColor === 'white' ? 'gu-display__content-color--bright ' : 'gu-display__content-color--dark',
                 articleContentPosition: this.contentPosition[this.params.articleContentPosition],
                 articleHeaderFontSize: this.fontSize[this.params.articleHeaderFontSize],
                 articleTextFontSize: this.fontSize[this.params.articleTextFontSize],
-                brandLogoPosition: this.params.brandLogoPosition === 'bottom-right' ? 'right: 10px; bottom: 10px; left: auto;' : 'left: 10px; top: 0; right: auto;',
+                brandLogoPosition: this.params.brandLogoPosition === 'bottom-right' ? 'gu-display__logo-pos--bottom-right' : 'gu-display__logo-pos--top-left',
                 externalLinkIcon: externalLinkIcon
             };
 

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/gu-style-comcontent.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/gu-style-comcontent.js
@@ -25,12 +25,25 @@ define([
     var GustyleComcontent = function ($adSlot, params) {
         this.$adSlot = $adSlot;
         this.params  = params;
+        this.contentPosition = {
+            bottom: 'bottom: 30px;',
+            top: 'top: 30px;'
+        };
+        this.fontSize = {
+            small: 'font-size: 0.9rem; line-height: 0.9rem;',
+            regular: 'font-size: 1.25rem;',
+            big: 'font-size: 1.35rem;'
+        };
     };
 
     GustyleComcontent.prototype.create = function () {
         var externalLinkIcon = svgs('externalLink', ['gu-external-icon']),
             templateOptions = {
-                clickMacro: this.params.clickMacro,
+                articleContentColor: this.params.articleContentColor === 'white' ? 'color: #ffffff;' : 'color: #000000;',
+                articleContentPosition: this.contentPosition[this.params.articleContentPosition],
+                articleHeaderFontSize: this.fontSize[this.params.articleHeaderFontSize],
+                articleTextFontSize: this.fontSize[this.params.articleTextFontSize],
+                brandLogoPosition: this.params.brandLogoPosition === 'bottom-right' ? 'right: 10px; bottom: 10px; left: auto;' : 'left: 10px; top: 0; right: auto;',
                 externalLinkIcon: externalLinkIcon
             };
 

--- a/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-comcontent.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-comcontent.html
@@ -2,18 +2,18 @@
     <div class="gu-display__image-layer u-responsive-ratio inlined-image">
         <img class="gu-display__image" src="<%=data.articleImage%>">
     </div>
-    <div class="gu-mutable gu-display__content">
-        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link" data-link-name="header text">
-            <h2 class="gu-display__content-title"><%=data.articleHeaderText%></h2>
+    <div class="gu-mutable gu-display__content" style="<%=data.articleContentPosition%>">
+        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link" style="<%=data.articleContentColor%> data-link-name="header text">
+            <h2 class="gu-display__content-title" style="<%=data.articleContentColor%> <%=data.articleHeaderFontSize%>"><%=data.articleHeaderText%></h2>
         </a>
-        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link" data-link-name="text">
-            <p class="gu-display__content-text"><%=data.articleText%></p>
+        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link" style="<%=data.articleContentColor%> data-link-name="text">
+            <p class="gu-display__content-text" style="<%=data.articleContentColor%> <%=data.articleTextFontSize%>"><%=data.articleText%></p>
         </a>
     </div>
     <a href="<%=data.clickMacro%><%=data.callToActionLink%>" class="gu-mutable gu-display__cta gu-display__link button button--tertiary button--medium" data-link-name="call to action">
         <%=data.callToAction%><%=data.externalLinkIcon%>
     </a>
-    <a href="<%=data.brandLink%>" class="gu-mutable gu-display__logo-link" data-link-name="logo">
+    <a href="<%=data.brandLink%>" class="gu-mutable gu-display__logo-link" style="<%=data.brandLogoPosition%>" data-link-name="logo">
         <img class="gu-display__logo" src="<%=data.brandLogo%>" target="_blank">
     </a>
 </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-comcontent.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-comcontent.html
@@ -2,18 +2,18 @@
     <div class="gu-display__image-layer u-responsive-ratio inlined-image">
         <img class="gu-display__image" src="<%=data.articleImage%>">
     </div>
-    <div class="gu-mutable gu-display__content" style="<%=data.articleContentPosition%>">
-        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link" style="<%=data.articleContentColor%> data-link-name="header text">
-            <h2 class="gu-display__content-title" style="<%=data.articleContentColor%> <%=data.articleHeaderFontSize%>"><%=data.articleHeaderText%></h2>
+    <div class="gu-mutable gu-display__content <%=data.articleContentPosition%>">
+        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link <%=data.articleContentColor%>" data-link-name="header text">
+            <h2 class="gu-display__content-title <%=data.articleContentColor%> <%=data.articleHeaderFontSize%>"><%=data.articleHeaderText%></h2>
         </a>
-        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link" style="<%=data.articleContentColor%> data-link-name="text">
-            <p class="gu-display__content-text" style="<%=data.articleContentColor%> <%=data.articleTextFontSize%>"><%=data.articleText%></p>
+        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link <%=data.articleContentColor%>" data-link-name="text">
+            <p class="gu-display__content-text <%=data.articleContentColor%> <%=data.articleTextFontSize%>"><%=data.articleText%></p>
         </a>
     </div>
     <a href="<%=data.clickMacro%><%=data.callToActionLink%>" class="gu-mutable gu-display__cta gu-display__link button button--tertiary button--medium" data-link-name="call to action">
         <%=data.callToAction%><%=data.externalLinkIcon%>
     </a>
-    <a href="<%=data.brandLink%>" class="gu-mutable gu-display__logo-link" style="<%=data.brandLogoPosition%>" data-link-name="logo">
+    <a href="<%=data.brandLink%>" class="gu-mutable gu-display__logo-link <%=data.brandLogoPosition%>" data-link-name="logo">
         <img class="gu-display__logo" src="<%=data.brandLogo%>" target="_blank">
     </a>
 </div>

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -140,8 +140,8 @@
 }
 
 .gu-display__content-size--small {
-    font-size: 0.9rem;
-    line-height: 0.9rem;
+    font-size: .9rem;
+    line-height: .9rem;
 }
 
 .gu-display__content-size--regular {

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -122,6 +122,48 @@
     }
 }
 
+/* values configurable in DFP */
+.gu-display__content-color--bright {
+    color: #ffffff;
+}
+
+.gu-display__content-color--dark {
+    color: #000000;
+}
+
+.gu-display__content-position--bottom {
+    bottom: 30px;
+}
+
+.gu-display__content-position--top {
+    top: 30px;
+}
+
+.gu-display__content-size--small {
+    font-size: 0.9rem;
+    line-height: 0.9rem;
+}
+
+.gu-display__content-size--regular {
+    font-size: 1.25rem;
+}
+
+.gu-display__content-size--big {
+    font-size: 1.35rem;
+}
+
+.gu-display__logo-pos--bottom-right {
+    right: 10px;
+    bottom: 10px;
+    left: auto;
+}
+
+.gu-display__logo-pos--top-left {
+    left: 10px;
+    top: 0;
+    right: auto;
+}
+
 $mobile-max-container-width: gs-span(8);
 @include mq-add-breakpoint(containerWidestMobile, $mobile-max-container-width + $gs-gutter * 2);
 

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -28,7 +28,6 @@
     @extend %gu-style-box;
     bottom: 30px;
     left: 0;
-    width: 100%;
     padding: $gs-gutter/2;
 }
 
@@ -43,6 +42,7 @@
     color: #ffffff;
     text-align: left;
     font-weight: normal;
+    margin-bottom: 5px;
 }
 
 .gu-display__content-text {


### PR DESCRIPTION
Continuation of the https://github.com/guardian/frontend/pull/11984. In DFP you can define now color, logo position, header + text position and header + text font size:

![screen shot 2016-02-17 at 14 50 36](https://cloud.githubusercontent.com/assets/489567/13112907/a0a3dae0-d584-11e5-86c3-2d64c9efb7ba.png)

By changing those variables, author will have more impact on how the ad looks like:
Nike example:
![screen shot 2016-02-17 at 14 30 55](https://cloud.githubusercontent.com/assets/489567/13112969/e33d9d78-d584-11e5-8e33-fa6bc0c549a1.png)

HSBC example:
![screen shot 2016-02-17 at 14 34 11](https://cloud.githubusercontent.com/assets/489567/13112975/edd01db0-d584-11e5-9c5a-a7dac2347d1c.png)
