### PR TITLE
Exclude edge browser from woff2 selection

### DIFF
--- a/common/app/templates/inlineJS/blocking/loadFonts.scala.js
+++ b/common/app/templates/inlineJS/blocking/loadFonts.scala.js
@@ -70,7 +70,7 @@ do you have fonts in localStorage?
 
                         // some browsers (e.g. FF40) support WOFF2 but not window.FontFace,
                         // so fall back to known support
-                        if (!/edge\/([0-9]+)/.test(ua)) { // don't let edge tell you it's chrome when it's not
+                        if (!/edge\/([0-9]+)/.test(ua.toLowerCase())) { // don't let edge tell you it's chrome when it's not
                             const browser = /(chrome|firefox)\/([0-9]+)/.exec(ua.toLowerCase());
                             const supportsWoff2 = {
                                 'chrome': 36,


### PR DESCRIPTION
It looks like there has been some UA capitalisation since my last attempt to exclude Edge browser from woff2, #10395. This should address a regression of issue #9992, which was fixed for a short period of time.

I've checked on browserstack, and this seems to work. Prod, however is another matter.
