### PR TITLE
Move amp related regexes up in facia routes

### DIFF
--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -16,6 +16,11 @@ GET        /rockabox/rockabox_buster.html                                       
 GET        /external/eyeblaster/addineyeV2.html                                     controllers.Assets.at(path="/public", file="addineyeV2.html")
 GET        /amp/remote.html                                                         controllers.Assets.at(path="/public", file="amp_remote.html")
 
+# AMP
+GET        /container/count/:count/offset/:offset/mf2.json                                      controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "", edition = "")
+GET        /container/count/:count/offset/:offset/section/:section/mf2.json                     controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section, edition = "")
+GET        /container/count/:count/offset/:offset/edition/:edition/mf2.json                     controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "", edition)
+GET        /container/count/:count/offset/:offset/section/:section/edition/:edition/mf2.json    controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section, edition)
 
 #Facia Press
 GET        /collection/*id/rss                                                      controllers.FaciaController.renderCollectionRss(id)
@@ -23,12 +28,6 @@ GET        /container/use-layout/*id.json                                       
 GET        /container/*path/some/:num/:offset/:containerNameToFilter/:edition.json  controllers.FaciaController.renderSomeFrontContainers(path, num, offset, containerNameToFilter, edition)
 GET        /container/*id.json                                                      controllers.FaciaController.renderContainerJson(id)
 GET        /most-relevant-container/*path.json                                      controllers.FaciaController.renderMostRelevantContainerJson(path)
-
-# AMP
-GET        /container/count/:count/offset/:offset/mf2.json                                      controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "", edition = "")
-GET        /container/count/:count/offset/:offset/section/:section/mf2.json                     controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section, edition = "")
-GET        /container/count/:count/offset/:offset/edition/:edition/mf2.json                     controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "", edition)
-GET        /container/count/:count/offset/:offset/section/:section/edition/:edition/mf2.json    controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section, edition)
 
 # Editionalised pages
 GET        /*path/show-more/*id.json                                                controllers.FaciaController.renderShowMore(path, id)


### PR DESCRIPTION
...in order to make sure amp mf2 requests are not wrongfully
catched by the '/container/:id.json' regex
