### PR TITLE
Adblock detect tidy

### DIFF
--- a/common/app/templates/inlineJS/blocking/config.scala.js
+++ b/common/app/templates/inlineJS/blocking/config.scala.js
@@ -20,6 +20,7 @@ window.guardian = {
     css: {
         loaded: false
     },
+    adBlockers: {},
     config: @JavaScript(templates.js.javaScriptConfig(page).body)
 };
 

--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -1,6 +1,5 @@
 try {
     ((document, window) => {
-        window.guardian.adBlockers = {};
         var ad = document.createElement('div');
         ad.style.position = 'absolute';
         ad.style.left = '-9999px';

--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -19,7 +19,7 @@ try {
 
                 // Only tells us if FF ABP is installed - not whether it is active
                 var adMozBinding = adStyles.getPropertyValue('-moz-binding');
-                window.guardian.adBlockers.ffAdblockPlus = adMozBinding && adMozBinding.match('elemhidehit') !== null;
+                window.guardian.adBlockers.ffAdblockPlus = !!adMozBinding && adMozBinding.match('elemhidehit') !== null;
 
                 try {
                     window.guardian.adBlockers.onDetect(window.guardian.adBlockers);


### PR DESCRIPTION
- fix `guardian.adBlockers` race condition (sporadic `onDetect` is undefined error)
- coerce FF adblock detection into a boolean
