### PR TITLE
Fix comments in Firefox (workaround browser bug)

### DIFF
--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -90,6 +90,13 @@ self.addEventListener('install', function (event) {
     event.waitUntil(updateCache());
 });
 
+var needCredentialsWorkaround = function (url) {
+    var whitelist = ['https://discussion.code.dev-theguardian.com/discussion-api'];
+    return whitelist.some(function (entry) {
+        return new RegExp('^' + entry).test(url);
+    });
+};
+
 this.addEventListener('fetch', function (event) {
     var request = event.request;
 
@@ -124,7 +131,9 @@ this.addEventListener('fetch', function (event) {
         event.respondWith(
             caches.match(request)
                 .then(function (response) {
-                    return response || fetch(request);
+                    // Workaround Firefox bug which drops cookies
+                    // https://github.com/guardian/frontend/issues/12012
+                    return response || fetch(request, needCredentialsWorkaround(request.url) ? { credentials: 'include' } : {});
                 })
         );
     }


### PR DESCRIPTION
For full detail on the issue, see #12012, which this fixes.

I had two options to workaround this browser bug.
1. use CORS instead of JSONP, as the bug only effects JS requests, not XHRs
2. specify that credentials should be included to override browser behaviour, suggested by Ben Kelly from Firefox

I went with 2 because the discussion API doesn't support CORS for GET requests which include credentials. /cc @nicl 
