### PR TITLE
Revert "Set amp-list credentials mode to 'include' so cookies are sent with the xhr request"

### DIFF
--- a/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
+++ b/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
@@ -2,7 +2,7 @@
 @import conf.Configuration
 
 @* must be served by localhost, not thegulocal *@
-<amp-list layout="fixed-height" height="184" src="@Configuration.amp.baseUrl/@path" credentials="include" class="onward-list">
+<amp-list layout="fixed-height" height="184" src="@Configuration.amp.baseUrl/@path" class="onward-list">
     <template type="amp-mustache">
         {{#showContent}}
             <div class="fc-container__inner">


### PR DESCRIPTION
Reverts guardian/frontend#12022

cc @TBonnin 
