### PR TITLE
Try out a lighter adblocking technique

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/detectAdblock.scala.js
@@ -3,8 +3,10 @@ try {
         window.guardian.adBlockers = {};
         var ad = document.createElement('div');
         ad.style.position = 'absolute';
-        ad.style.left = '-9999px';
+        ad.style.left = '0';
+        ad.style.top = '0';
         ad.style.height = '10px';
+        ad.style.zIndex = '-1';
         ad.innerHTML = '&nbsp;';
         ad.setAttribute('class', 'ad_unit');
 

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -8,6 +8,7 @@
 define([
     'common/utils/mediator',
     'common/utils/$',
+    'common/modules/user-prefs',
     'lodash/arrays/last',
     'lodash/arrays/findIndex',
     'lodash/objects/defaults',
@@ -19,10 +20,12 @@ define([
     'lodash/collections/pluck',
     'lodash/arrays/initial',
     'lodash/arrays/rest',
+    'lodash/functions/memoize',
     'Promise'
 ], function (
     mediator,
     $,
+    userPrefs,
     last,
     findIndex,
     defaults,
@@ -34,6 +37,7 @@ define([
     pluck,
     initial,
     rest,
+    memoize,
     Promise
 ) {
 
@@ -405,38 +409,58 @@ define([
     // this is soon - it's not worth refactoring them when they're off soon
     //
     // ** don't forget to remove them from the return object too **
-    function adblockInUseSync() {
-        if (!detect.cachedAdblockInUse) {
-            var sacrificialAd = createSacrificialAd(),
-                contentBlocked = isHidden(sacrificialAd);
-            sacrificialAd.remove();
-            detect.cachedAdblockInUse = contentBlocked;
-            return contentBlocked;
-        }
+    var adblockInUseSync, getFirefoxAdblockPlusInstalledSync, createSacrificialAd;
+    if (userPrefs.get('lighter-adblock')) {
+        adblockInUseSync = memoize(function () {
+            return createSacrificialAd().css('display') === 'none';
+        });
 
-        return detect.cachedAdblockInUse;
+        /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
+        getFirefoxAdblockPlusInstalledSync = memoize(function () {
+            var adUnitMozBinding = createSacrificialAd().css('-moz-binding');
+            return !!adUnitMozBinding && adUnitMozBinding.match('elemhidehit') !== null;
+        });
 
-        function isHidden(bonzoElement) {
-            return bonzoElement.css('display') === 'none';
-        }
+        createSacrificialAd = memoize(function () {
+            var sacrificialAd = $.create('<div class="ad_unit" style="position: absolute; height: 10px; top: 0; left: 0; z-index: -1;">&nbsp;</div>');
+            sacrificialAd.appendTo(document.body);
+            return sacrificialAd;
+        });
+    } else {
+        adblockInUseSync = function () {
+            if (!detect.cachedAdblockInUse) {
+                var sacrificialAd = createSacrificialAd(),
+                    contentBlocked = isHidden(sacrificialAd);
+                sacrificialAd.remove();
+                detect.cachedAdblockInUse = contentBlocked;
+                return contentBlocked;
+            }
+
+            return detect.cachedAdblockInUse;
+
+            function isHidden(bonzoElement) {
+                return bonzoElement.css('display') === 'none';
+            }
+        };
+
+        /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
+        getFirefoxAdblockPlusInstalledSync = function () {
+            var sacrificialAd = createSacrificialAd();
+            var adUnitMozBinding = sacrificialAd.css('-moz-binding');
+            if (adUnitMozBinding) {
+                return adUnitMozBinding.match('elemhidehit') !== null;
+            } else {
+                return false;
+            }
+        };
+
+        createSacrificialAd = function () {
+            var sacrificialAd = $.create('<div class="ad_unit" style="position: absolute; left: -9999px; height: 10px">&nbsp;</div>');
+            sacrificialAd.appendTo(document.body);
+            return sacrificialAd;
+        };
     }
 
-    /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
-    function getFirefoxAdblockPlusInstalledSync() {
-        var sacrificialAd = createSacrificialAd();
-        var adUnitMozBinding = sacrificialAd.css('-moz-binding');
-        if (adUnitMozBinding) {
-            return adUnitMozBinding.match('elemhidehit') !== null;
-        } else {
-            return false;
-        }
-    }
-
-    function createSacrificialAd() {
-        var sacrificialAd = $.create('<div class="ad_unit" style="position: absolute; left: -9999px; height: 10px">&nbsp;</div>');
-        sacrificialAd.appendTo(document.body);
-        return sacrificialAd;
-    }
     // end sync adblock detection
 
     var getAdBlockers = new Promise(function (resolve) {

--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -409,58 +409,21 @@ define([
     // this is soon - it's not worth refactoring them when they're off soon
     //
     // ** don't forget to remove them from the return object too **
-    var adblockInUseSync, getFirefoxAdblockPlusInstalledSync, createSacrificialAd;
-    if (userPrefs.get('lighter-adblock')) {
-        adblockInUseSync = memoize(function () {
-            return createSacrificialAd().css('display') === 'none';
-        });
+    var adblockInUseSync = memoize(function () {
+        return createSacrificialAd().css('display') === 'none';
+    });
 
-        /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
-        getFirefoxAdblockPlusInstalledSync = memoize(function () {
-            var adUnitMozBinding = createSacrificialAd().css('-moz-binding');
-            return !!adUnitMozBinding && adUnitMozBinding.match('elemhidehit') !== null;
-        });
+    /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
+    var getFirefoxAdblockPlusInstalledSync = memoize(function () {
+        var adUnitMozBinding = createSacrificialAd().css('-moz-binding');
+        return !!adUnitMozBinding && adUnitMozBinding.match('elemhidehit') !== null;
+    });
 
-        createSacrificialAd = memoize(function () {
-            var sacrificialAd = $.create('<div class="ad_unit" style="position: absolute; height: 10px; top: 0; left: 0; z-index: -1;">&nbsp;</div>');
-            sacrificialAd.appendTo(document.body);
-            return sacrificialAd;
-        });
-    } else {
-        adblockInUseSync = function () {
-            if (!detect.cachedAdblockInUse) {
-                var sacrificialAd = createSacrificialAd(),
-                    contentBlocked = isHidden(sacrificialAd);
-                sacrificialAd.remove();
-                detect.cachedAdblockInUse = contentBlocked;
-                return contentBlocked;
-            }
-
-            return detect.cachedAdblockInUse;
-
-            function isHidden(bonzoElement) {
-                return bonzoElement.css('display') === 'none';
-            }
-        };
-
-        /** Includes Firefox Adblock Plus users who whitelist the Guardian domain */
-        getFirefoxAdblockPlusInstalledSync = function () {
-            var sacrificialAd = createSacrificialAd();
-            var adUnitMozBinding = sacrificialAd.css('-moz-binding');
-            if (adUnitMozBinding) {
-                return adUnitMozBinding.match('elemhidehit') !== null;
-            } else {
-                return false;
-            }
-        };
-
-        createSacrificialAd = function () {
-            var sacrificialAd = $.create('<div class="ad_unit" style="position: absolute; left: -9999px; height: 10px">&nbsp;</div>');
-            sacrificialAd.appendTo(document.body);
-            return sacrificialAd;
-        };
-    }
-
+    var createSacrificialAd = memoize(function () {
+        var sacrificialAd = $.create('<div class="ad_unit" style="position: absolute; height: 10px; top: 0; left: 0; z-index: -1;">&nbsp;</div>');
+        sacrificialAd.appendTo(document.body);
+        return sacrificialAd;
+    });
     // end sync adblock detection
 
     var getAdBlockers = new Promise(function (resolve) {


### PR DESCRIPTION
this basically uses the same method as the current one, but only ads the element once, and on the main viewport canvas.

before, it was actually adding the element 5 times:

![screen shot 2016-02-19 at 13 09 22](https://cloud.githubusercontent.com/assets/867233/13176453/4bf44ffc-d70a-11e5-83c8-fc8ad7033f54.png)

and `9999px` off screen.

this may have no effect, but i'm hopeful it may help iPad crashes

cc @jbreckmckye @regiskuckaertz 
