### PR TITLE
Refactor full-height into state and renderer funcs

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/full-height.js
+++ b/static/src/javascripts/projects/common/modules/ui/full-height.js
@@ -15,43 +15,47 @@ define([
     // changes as the url bar slides in and out
     // http://code.google.com/p/chromium/issues/detail?id=428132
 
-    var heightSet = false,
-        ready = function () {
-            mediator.on('window:resize', debounce(function () {
-                if (heightSet && detect.getBreakpoint() !== 'mobile') {
-                    // If the height has been set and we're not on mobile
-                    stickHeight(true);
-                } else if (detect.getBreakpoint() === 'mobile') {
-                    // If we are on mobile, we need to just set the new height
-                    stickHeight();
-                }
-            }, 200));
-
-            if (detect.getBreakpoint() === 'mobile') {
-                // We only want to initially set the height if we are on mobile
-                stickHeight();
+    var renderBlock = function (state) {
+        return fastdomPromise.write(function () {
+            state.$el.css('height', '');
+        }).then(function () {
+            if (state.isMobile) {
+                return fastdomPromise.read(function () {
+                    return state.$el.height();
+                }).then(function (height) {
+                    return fastdomPromise.write(function () {
+                        state.$el.css('height', height);
+                    });
+                });
             }
-        },
-        stickHeight = function (setHeightToAuto) {
+        });
+    };
 
-            // This simply sticks the height of 100vh elements to the initial viewport height
-            // which means there will be a gap once the url bar goes away,
-            // but this is fine for the current use case
+    var render = function (state) {
+        state.elements.each(function (element) {
+            renderBlock({ $el: $(element), isMobile: state.isMobile });
+        });
+    };
 
-            $('.js-is-fixed-height').each(function (el) {
-                var $el = $(el),
-                    elHeight;
+    var getState = function () {
+        return fastdomPromise.read(function () {
+            var elements = $('.js-is-fixed-height');
+            return { elements: elements, isMobile: detect.getBreakpoint() === 'mobile' };
+        });
+    };
 
-                fastdomPromise.read(function () {
-                    elHeight = (setHeightToAuto) ? '' : $el.height();
-                }).then(fastdomPromise.write(function () {
-                    $el.css('height', elHeight);
-                    heightSet = true;
-                }));
-            });
-        };
+    var onViewportChange = function () {
+        getState().then(render);
+    };
+
+    var init = function () {
+        mediator.on('window:resize', debounce(onViewportChange, 200));
+        mediator.on('window:orientationchange', onViewportChange);
+        onViewportChange();
+    };
+
 
     return {
-        init: ready
+        init: init
     };
 });


### PR DESCRIPTION
This is a refactor and bugfix for the 100vh fixed height images to use the separation of state and render pattern. It also fixed a bug with reseting the height on orientationchange as this doesn't fire resize event.

cc/ @OliverJAsh 
