### PR TITLE
Use cAPI blocks instead of flexible-content-body-parser

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -5,7 +5,6 @@ import java.net.URL
 import com.gu.contentapi.client.model.{v1 => contentapi}
 import com.gu.facia.api.{utils => fapiutils}
 import com.gu.facia.client.models.TrailMetaData
-import com.gu.util.liveblogs.{Parser => LiveBlogParser}
 import common._
 import common.dfp.DfpAgent
 import conf.Configuration
@@ -470,8 +469,7 @@ final case class Article (
   lazy val hasKeyEvents: Boolean = soupedBody.body().select(".is-key-event").nonEmpty
 
   lazy val isSport: Boolean = tags.tags.exists(_.id == "sport/sport")
-  //@deprecated("use content.fields.blocks", "")
-  lazy val blocks = LiveBlogParser.parse(fields.body)
+  lazy val blocks = content.fields.blocks
   lazy val mostRecentBlock: Option[String] = blocks.headOption.map(_.id)
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,8 +32,6 @@ object Dependencies {
   val exactTargetClient = "com.gu" %% "exact-target-client" % "2.24"
   val faciaFapiScalaClient = "com.gu" %% "fapi-client" % "0.68"
   val faciaScalaClient = "com.gu" %% "facia-json" % "0.68"
-  val flexibleContentBlockToText = "com.gu" %% "flexible-content-block-to-text" % "0.4"
-  val flexibleContentBodyParser = "com.gu" %% "flexible-content-body-parser" % "0.6"
   val googleSheetsApi = "com.google.gdata" % "core" % "1.47.1"
   val guardianConfiguration = "com.gu" %% "configuration" % "4.1"
   val guice = "com.google.inject" % "guice" % "3.0"

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -26,8 +26,6 @@ object Frontend extends Build with Prototypes {
       contentApiClient,
       faciaScalaClient,
       filters,
-      flexibleContentBlockToText,
-      flexibleContentBodyParser,
       googleSheetsApi,
       guardianConfiguration,
       jacksonCore,


### PR DESCRIPTION
We're currently using https://github.com/guardian/flexible-content-body-parser to parse CAPI responses into blocks, but CAPI gives us the blocks directly so there's no need for the parser. This removes the only use of it.

@rich-nguyen 
