### PR TITLE
Fix for #11967 - Footer font

### DIFF
--- a/static/src/stylesheets/layout/_footer.scss
+++ b/static/src/stylesheets/layout/_footer.scss
@@ -94,8 +94,8 @@ $c-primary-footer-background-side-bar: mix($c-primary-footer-background, #ffffff
 
 .colophon__list {
     @include clearfix();
-    @include fs-bodyHeading(1);
-    @include f-headlineSans();
+    @include fs-bodyHeading(1, true);
+    @include f-textSans();
     list-style: none;
     margin: 0;
 


### PR DESCRIPTION
# Footer Font
## What does this change?

Bugfix for the footer font issue raised by @paperboyo in #11967 
## Screenshots
### Before

![image](https://cloud.githubusercontent.com/assets/638051/13179289/29110230-d71b-11e5-98e3-e420c6c7e49c.png)
### After

![image](https://cloud.githubusercontent.com/assets/638051/13179250/f862b41c-d71a-11e5-9c1c-97934e82bd2b.png)
## Notify

@superfrank 
