### PR TITLE
Unhide paid content "About" popup when sticky

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -15,11 +15,11 @@ define([
     var isNewCommercialContent = config.switches.newCommercialContent && config.page.isAdvertisementFeature;
     var paidforBandHeight;
 
-    function initPFBand() {
+    function initPFBand(element) {
         paidforBandHeight = 0;
         if (isNewCommercialContent) {
             var paidforBand = document.querySelector('.paidfor-band');
-            if (paidforBand) {
+            if (paidforBand && paidforBand !== element) {
                 fastdom.read(function () {
                     paidforBandHeight = paidforBand.offsetHeight;
                 });
@@ -41,7 +41,7 @@ define([
 
     Sticky.prototype.init = function init() {
         if (paidforBandHeight === undefined) {
-            initPFBand();
+            initPFBand(this.element);
         }
         mediator.on('window:throttledScroll', this.updatePosition.bind(this));
         // kick off an initial position update

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -15,7 +15,7 @@ define([
     var isNewCommercialContent = config.switches.newCommercialContent && config.page.isAdvertisementFeature;
     var paidforBandHeight;
 
-    function initPFBand(element) {
+    function initPaidForBand(element) {
         paidforBandHeight = 0;
         if (isNewCommercialContent) {
             var paidforBand = document.querySelector('.paidfor-band');
@@ -41,7 +41,7 @@ define([
 
     Sticky.prototype.init = function init() {
         if (paidforBandHeight === undefined) {
-            initPFBand(this.element);
+            initPaidForBand(this.element);
         }
         mediator.on('window:throttledScroll', this.updatePosition.bind(this));
         // kick off an initial position update

--- a/static/src/stylesheets/base/_state.scss
+++ b/static/src/stylesheets/base/_state.scss
@@ -71,7 +71,6 @@
 }
 
 .is-sticky {
-    overflow: hidden;
     position: fixed;
     top: 0;
 }


### PR DESCRIPTION
In paid content, when the user scrolls so that the band becomes sticky, the popup will be hidden because of a `position: overflow`:
![picture 1](https://cloud.githubusercontent.com/assets/629976/13180836/0ca8b028-d722-11e5-972a-4f9725951add.png)

Also, when deciding whether an element becomes sticky or not, the script takes into account the height of the band if it is present—this behaviour should be disabled if the band is itself the element.
