### PR TITLE
Week-end refactoring: lazyload

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -28,7 +28,7 @@ define([
     $,
     config,
     mediator,
-    LazyLoad,
+    lazyload,
     Tabs,
     Toggles,
     isArray,
@@ -136,7 +136,7 @@ define([
     };
 
     CommercialComponent.prototype.create = function () {
-        new LazyLoad({
+        lazyload({
             url: this.components[this.type],
             container: this.adSlot,
             success: function () {
@@ -149,7 +149,7 @@ define([
             error: function () {
                 bonzo(this.adSlot).hide();
             }.bind(this)
-        }).load();
+        });
 
         return this;
     };

--- a/static/src/javascripts/projects/common/modules/lazyload.js
+++ b/static/src/javascripts/projects/common/modules/lazyload.js
@@ -7,9 +7,6 @@ define([
     bonzo,
     merge
 ) {
-    function noop() {
-    }
-
     function identity(x) {
         return x;
     }
@@ -28,9 +25,9 @@ define([
             force             - boolean, default false. Reload an already-populated container
         */
         options = merge({
-            success: noop,
-            error:   noop,
-            always:  noop,
+            success: identity,
+            error:   identity,
+            always:  identity,
             beforeInsert: identity,
             force: false
         }, options);

--- a/static/src/javascripts/projects/common/modules/lazyload.js
+++ b/static/src/javascripts/projects/common/modules/lazyload.js
@@ -1,14 +1,20 @@
 define([
     'common/utils/ajax',
     'bonzo',
-    'lodash/objects/assign'
+    'lodash/objects/merge'
 ], function (
     ajax,
     bonzo,
-    assign
+    merge
 ) {
+    function noop() {
+    }
 
-    var LazyLoad = function (options) {
+    function identity(x) {
+        return x;
+    }
+
+    function lazyload(options) {
 
         /*
             Accepts these options:
@@ -21,45 +27,32 @@ define([
             always            - callback function, optional
             force             - boolean, default false. Reload an already-populated container
         */
+        options = merge({
+            success: noop,
+            error:   noop,
+            always:  noop,
+            beforeInsert: identity,
+            force: false
+        }, options);
 
-        var into,
-            defaultOpts = {
-                success: function () {},
-                error:   function () {},
-                always:  function () {},
-                beforeInsert: function (html) { return html; },
-                force: false
-            },
-            opts = assign(defaultOpts, options || {});
-
-        this.load = function () {
-
-            if (opts.url && opts.container) {
-                into = bonzo(opts.container);
-                if (opts.force || !into.hasClass('lazyloaded')) {
-                    return ajax({
-                        url: opts.url,
-                        type: 'json',
-                        crossOrigin: true
-                    }).then(
-                        function (resp) {
-                            into.html(opts.beforeInsert(resp.html));
-                            into.addClass('lazyloaded');
-                            opts.success(resp);
-                        },
-                        function (req) {
-                            opts.error(req);
-                        }
-                    ).always(
-                        function (resp) {
-                            opts.always(resp);
-                        }
-                    );
-                }
+        if (options.url && options.container) {
+            var $container = bonzo(options.container);
+            if (options.force || !$container.hasClass('lazyloaded')) {
+                return ajax({
+                    url: options.url,
+                    type: 'json',
+                    crossOrigin: true
+                })
+                .then(function (resp) {
+                    $container.html(options.beforeInsert(resp.html))
+                        .addClass('lazyloaded');
+                    options.success(resp);
+                })
+                .catch(options.onerror)
+                .always(options.always);
             }
-        };
+        }
+    }
 
-    };
-
-    return LazyLoad;
+    return lazyload;
 });

--- a/static/src/javascripts/projects/common/modules/lazyload.js
+++ b/static/src/javascripts/projects/common/modules/lazyload.js
@@ -45,7 +45,7 @@ define([
                         .addClass('lazyloaded');
                     options.success(resp);
                 })
-                .catch(options.onerror)
+                .catch(options.error)
                 .always(options.always);
             }
         }

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -17,7 +17,7 @@ define([
     config,
     mediator,
     register,
-    LazyLoad,
+    lazyload,
     Expandable,
     ab,
     intersection,
@@ -83,7 +83,7 @@ define([
                     }).join('&');
                 }
 
-                new LazyLoad({
+                lazyload({
                     url: relatedUrl,
                     container: container,
                     success: function () {
@@ -101,7 +101,7 @@ define([
                         bonzo(container).remove();
                         register.error(componentName);
                     }
-                }).load();
+                });
             }
         } else {
             $('.js-related').addClass('u-h');

--- a/static/src/javascripts/projects/common/utils/ajax-promise.js
+++ b/static/src/javascripts/projects/common/utils/ajax-promise.js
@@ -1,10 +1,8 @@
 define([
     'common/utils/ajax',
-    'raven',
     'Promise'
 ], function (
     ajax,
-    raven,
     Promise
 ) {
     return function wrappedAjax(params) {
@@ -13,12 +11,12 @@ define([
                 .then(resolve)
                 .fail(function (res, msg, err) {
                     if (err) {
-                        return reject(err);
+                        reject(err);
                     }
 
                     if (res && res.status) {
                         var message = 'AJAX error (' + params.url + '): ' + res.statusText || '' + ' (' + res.status + ')';
-                        return reject(new Error(message));
+                        reject(new Error(message));
                     }
 
                     reject(new Error('Unknown AJAX error (' + params.url + ')'));

--- a/static/test/javascripts/spec/common/lazy-load.spec.js
+++ b/static/test/javascripts/spec/common/lazy-load.spec.js
@@ -1,4 +1,4 @@
-define(['common/modules/lazyload', 'bonzo'], function (LazyLoad, bonzo) {
+define(['common/modules/lazyload', 'bonzo'], function (lazyload, bonzo) {
     describe('Lazy Load', function () {
 
         var $container = bonzo(bonzo.create('<div id="lazy-load-container"></div>')),
@@ -20,7 +20,7 @@ define(['common/modules/lazyload', 'bonzo'], function (LazyLoad, bonzo) {
         it('should lazy load', function (done) {
             server.respondWith([200, {}, '{ "html": "<span>foo</span>" }']);
 
-            new LazyLoad({
+            lazyload({
                 url: 'fixtures/lazy-load',
                 container: $container[0],
                 success: function () {
@@ -28,7 +28,7 @@ define(['common/modules/lazyload', 'bonzo'], function (LazyLoad, bonzo) {
                     expect($container.html()).toBe('<span>foo</span>');
                     done();
                 }
-            }).load();
+            });
 
         });
 


### PR DESCRIPTION
I suggest that all coding patterns resembling:

```
new Something().init(); // notice there's no assignment here
```

are in fact procedures:

```
doSomething();
```

`lazyload` is one fairly unimportant example, and there are many such examples that could be rewritten in a more idiomatic way.
