### PR TITLE
AMP: don't show related content if `showInRelatedContent` is `false`

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -65,7 +65,9 @@
                         @fragments.amp.onwardTemplateAmp("series-mf2/" + tag.id + ".json")
                     }
                 }
-                @if(!content.item.content.hasStoryPackage && content.item.tags.series.isEmpty){
+                @if(content.item.content.showInRelated
+                    && !content.item.content.hasStoryPackage
+                    && content.item.tags.series.isEmpty){
                     @fragments.amp.onwardTemplateAmp("related-mf2/" + page.metadata.id + ".json")
                 }
             }


### PR DESCRIPTION
# My Awesome Pull Request
## What does this change?

On AMP page, related content container (Onward journey below the article) is not shown if `showInRelatedContent` is `false`
Fix: https://github.com/guardian/frontend/issues/12024
## Request for comment

@NataliaLKB 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
