### PR TITLE
no more vpaid

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -50,15 +50,6 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val VpaidAdvertsSwitch = Switch(
-    "Commercial",
-    "vpaid-adverts",
-    "Turns on support for vpaid-format adverts on videos.",
-    safeState = Off,
-    sellByDate = never,
-    exposeClientSide = true
-  )
-
   val SponsoredSwitch = Switch(
     "Commercial",
     "sponsored",

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -281,8 +281,7 @@ final case class MetaData (
     ("analyticsName", JsString(analyticsName)),
     ("isFront", JsBoolean(isFront)),
     ("isSurging", JsString(isSurging.mkString(","))),
-    ("videoJsFlashSwf", JsString(conf.Static("flash/components/video-js-swf/video-js.swf").path)),
-    ("videoJsVpaidSwf", JsString(conf.Static("flash/components/video-js-vpaid/video-js.swf").path))
+    ("videoJsFlashSwf", JsString(conf.Static("flash/components/video-js-swf/video-js.swf").path))
   )
 
   def opengraphProperties: Map[String, String] = Map(

--- a/static/public/flash/bower.json
+++ b/static/public/flash/bower.json
@@ -3,8 +3,7 @@
   "version": "0.1.0 ",
   "dependencies": {
     "mediaelement": "~2.16.1",
-    "video-js-swf" : "videojs/video-js-swf#5.0.0-rc1",
-    "video-js-vpaid": "guardian/video-js-vpaid#ce2d0c21603d45d1a00bc6c8d43dfd88532a1b5c"
+    "video-js-swf" : "videojs/video-js-swf#5.0.0-rc1"
   },
   "install": {
     "path": "components",

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -183,14 +183,6 @@ define([
             mouseMoveIdle,
             playerSetupComplete;
 
-        if (config.page.videoJsVpaidSwf && config.switches.vpaidAdverts) {
-
-            // clone the video options and add 'vpaid' to them.
-            techPriority = ['vpaid'].concat(techPriority);
-
-            videojs.options.vpaid = {swf: config.page.videoJsVpaidSwf};
-        }
-
         player = createVideoPlayer(el, {
             techOrder: techPriority,
             controls: true,

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -84,7 +84,6 @@ define([
         var events = {
             end: function () {
                 player.trigger(constructEventName('preroll:end', player));
-                player.removeClass('vjs-ad-playing--vpaid');
                 bindContentEvents(player, true);
             },
             start: function () {
@@ -95,18 +94,11 @@ define([
                     player.one('durationchange', events.start);
                 }
             },
-            vpaidStarted: function () {
-                player.addClass('vjs-ad-playing--vpaid');
-            },
             ready: function () {
                 player.trigger(constructEventName('preroll:ready', player));
 
                 player.one('adstart', events.start);
                 player.one('adend', events.end);
-
-                // Handle custom event to understand when vpaid is playing;
-                // there is a lag between 'adstart' and 'Vpaid::AdStarted'.
-                player.one('Vpaid::AdStarted', events.vpaidStarted);
 
                 if (shouldAutoPlay(player)) {
                     player.play();

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -162,10 +162,6 @@ $ima-controls-height: 70px;
     .vjs-using-native-controls & {
         display: none;
     }
-
-    .vjs-ad-playing--vpaid & {
-        display: none;
-    }
 }
 
 .vjs-loading-spinner {
@@ -622,10 +618,6 @@ $ima-controls-height: 70px;
     .vjs-playing & {
         display: block;
     }
-
-    .vjs-playing.vjs-ad-playing--vpaid & {
-        display: none;
-    }
 }
 
 .vast-skip-button {
@@ -979,8 +971,7 @@ $ima-controls-height: 70px;
 
 /* Tech overrides
    ========================================================================== */
-.vjs-tech-flash,
-.vjs-tech-vpaid {
+.vjs-tech-flash {
     .vjs-poster,
     .vjs-big-play-button,
     .vjs-fullscreen-clickbox,


### PR DESCRIPTION
# Remove VPAID video tech
## What does this change?

Removes references to videojs vpaid as we don't actually have that tech available. 
[The Google Ads IMA plugin should cover this for us](https://github.com/googleads/videojs-ima).
## What is the value of this and can you measure success?

We stop getting the vpaid not supported error
## Does this affect other platforms - Amp, Apps, etc?

Na
## Request for comment

@Calanthe @rich-nguyen 
## 
