### PR TITLE
Extending to banner position test extra month

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -22,7 +22,7 @@ object CMTopBannerPosition extends TestDefinition(
   List(Variant1),
   "cm-top-banner-position",
   "Test viewability and revenue changes when top banner is moved below first container on fronts and removed from articles",
-  new LocalDate(2016, 2, 25)
+  new LocalDate(2016, 3, 31)
 )
 
 object ActiveTests extends Tests {


### PR DESCRIPTION
We have sufficient data for this test and it seems that odds are against this amazing feature. However the user experience gain is great so I would like to wait for product owner (on holiday) to go through data one more time and possibly setup some process so it won't be lost in the abyss of the past.
