### PR TITLE
make multimedia URIs non-secure

### DIFF
--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -82,7 +82,11 @@ object VideoAsset {
     VideoAsset(
       fields = Helpers.assetFieldsToMap(asset),
       mimeType = asset.mimeType,
-      url = asset.typeData.flatMap(_.secureFile).orElse(asset.file) )
+      url = asset.typeData.flatMap {
+        // FIXME: Remove this once the multimedia.guardianapis are available over https
+        case asset if !asset.secureFile.exists(s => s.startsWith("https://multimedia.guardianapis.com")) => asset.secureFile
+        case _ => None
+      }.orElse(asset.file) )
   }
 }
 


### PR DESCRIPTION
## What does this change?

A simple wedge to not use https URIs on the multimedia domain as something went wrong with the dang certificates.

We will be removing this once the certs are setup again.
## What is the value of this and can you measure success?

Videos on that domain will start working again.
## Does this affect other platforms - Amp, Apps, etc?

No

@rich-nguyen 
