### PR TITLE
Added in childrens book filter, removed during previous merge

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -125,6 +125,7 @@ define([
         if (commercialFeatures.outbrain &&
             !config.page.isFront &&
             !config.page.isPreview &&
+            config.page.section !== 'childrens-books-site' &&
             identityPolicy()
         ) {
             // if there is no merch component, load the outbrain widget right away

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/plista.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/plista.js
@@ -38,6 +38,7 @@ define([
         return commercialFeatures.outbrain &&
                 !config.page.isFront &&
                 !config.page.isPreview &&
+                config.page.section !== 'childrens-books-site' &&
                 identityPolicy();
     }
 


### PR DESCRIPTION
# My Awesome Pull Request
## What does this change?

Adds a filter to not show Outbrain when the content is tagged as 'childrens-book-site'. This was previously in place but was taken out during a [mega-merge](https://github.com/guardian/frontend/commit/4f25e301ff7c39c8e4ebf76296cc312383e8da56).
## What is the value of this and can you measure success?

This will correct the current and undesired behaviour of showing Outbrain on these pages.
## Does this affect other platforms - Amp, Apps, etc?

Nope.
## Screenshots
## Request for comment

-- @regiskuckaertz who worked on this before.

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
Yep.
