### PR TITLE
Removed NewCommercialContent switch

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -1,6 +1,5 @@
 @(gallery: model.Gallery, related: model.RelatedContent, index: Int)(implicit request: RequestHeader)
 @import common.{Edition, LinkTo}
-@import conf.switches.Switches._
 @import layout.ContentWidths.GalleryMedia
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{ImgSrc, RenderClasses}
@@ -9,17 +8,17 @@
 
     <article id="article" class="@RenderClasses(
             Map("content--advertisement-feature" -> gallery.commercial.isAdvertisementFeature,
-                "paid-content--advertisement-feature" -> (NewCommercialContent.isSwitchedOn && gallery.commercial.isAdvertisementFeature)
+                "paid-content--advertisement-feature" -> gallery.commercial.isAdvertisementFeature
             ),
             "content", "content--media", "content--gallery", "tonal", s"tonal--${toneClass(gallery)}"
         )"
         itemscope itemtype="@gallery.metadata.schemaType" role="main">
 
-        @if(gallery.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn){
+        @if(gallery.commercial.isAdvertisementFeature){
             @fragments.guBand()
         }
 
-        @fragments.headTonal(gallery, gallery.commercial.isSponsored(Some(Edition(request))) || gallery.commercial.isFoundationSupported || (gallery.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn))
+        @fragments.headTonal(gallery, gallery.commercial.isSponsored(Some(Edition(request))) || gallery.commercial.isFoundationSupported || gallery.commercial.isAdvertisementFeature)
 
         <div class="content__main tonal__main tonal__main--@toneClass(gallery)">
             <div class="gs-container">
@@ -39,7 +38,7 @@
     </article>
 
     @if(gallery.content.showInRelated &&
-        !(gallery.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn) ) {
+        !gallery.commercial.isAdvertisementFeature ) {
         <div class="gallery__most-popular facia-container fc-container--media hide-on-childrens-books-site">
             <div class="js-gallery-most-popular tonal--@toneClass(gallery)">
                 <div class="fc-container">

--- a/applications/app/views/fragments/imageContentBody.scala.html
+++ b/applications/app/views/fragments/imageContentBody.scala.html
@@ -1,6 +1,5 @@
 @(page: ImageContentPage)(implicit request: RequestHeader)
 @import common.Edition
-@import conf.switches.Switches.NewCommercialContent
 @import layout.ContentWidths.ImageContentMedia
 @import views.support.RenderClasses
 
@@ -9,17 +8,16 @@
 <div class="l-side-margins l-side-margins--media">
     <article
         class="@RenderClasses(Map(
-            "content--advertisement-feature" -> image.commercial.isAdvertisementFeature,
+            "content--advertisement-feature paid-content--advertisement-feature" -> image.commercial.isAdvertisementFeature,
             "content--sponsored" -> image.commercial.isSponsored(Some(Edition(request))),
-            "content--foundation-supported" -> image.commercial.isFoundationSupported,
-            "paid-content--advertisement-feature" -> (image.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn)
+            "content--foundation-supported" -> image.commercial.isFoundationSupported
         ), "content content--media content--image tonal tonal--tone-media")"
         itemprop="mainContentOfPage"
         itemscope
         itemtype="@image.metadata.schemaType"
         role="main">
 
-        @if(image.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn) {
+        @if(image.commercial.isAdvertisementFeature) {
             @fragments.guBand()
         }
 

--- a/applications/app/views/fragments/indexBody.scala.html
+++ b/applications/app/views/fragments/indexBody.scala.html
@@ -1,6 +1,5 @@
 @(index: services.IndexPage)(implicit request: RequestHeader)
 @import common.{Edition, PagePaths}
-@import conf.switches.Switches
 @import model.FrontProperties.empty
 @import services.IndexPage
 @import views.html.fragments.containers.facia_cards.{container, containerScaffold}
@@ -22,9 +21,7 @@
                     index.commercial.isAdvertisementFeature ||
                     index.commercial.isFoundationSupported
                 ),
-                "fc-container--advertisement-feature" -> index.commercial.isAdvertisementFeature,
-                "paid-content--advertisement-feature" ->
-                    (Switches.NewCommercialContent.isSwitchedOn && index.commercial.isAdvertisementFeature)
+                "fc-container--advertisement-feature paid-content--advertisement-feature" -> index.commercial.isAdvertisementFeature
             ), "u-cf index-page"
         )"
         data-link-name="Front | @request.path"
@@ -36,7 +33,7 @@
         }
         role="main">
 
-        @if(Switches.NewCommercialContent.isSwitchedOn && index.commercial.isAdvertisementFeature) {
+        @if(index.commercial.isAdvertisementFeature) {
             @fragments.guBand()
         }
 

--- a/applications/app/views/fragments/interactiveBody.scala.html
+++ b/applications/app/views/fragments/interactiveBody.scala.html
@@ -1,8 +1,6 @@
 @(page: InteractivePage)(implicit request: RequestHeader)
 @import common.Edition
 @import views.support.TrailCssClasses.toneClass
-@import conf.switches.Switches.NewCommercialContent
-
 @body(page.interactive, page.item.content.isImmersive)
 
 @bodyRaw(interactive: model.Interactive) = {
@@ -20,13 +18,13 @@
                     "content--advertisement-feature" -> interactive.commercial.isAdvertisementFeature,
                     "content--sponsored" -> interactive.commercial.isSponsored(Some(Edition(request))),
                     "content--foundation-supported" -> interactive.commercial.isFoundationSupported,
-                    "paid-content--advertisement-feature" -> (interactive.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn)
+                    "paid-content--advertisement-feature" -> interactive.commercial.isAdvertisementFeature
                 ),
                 "content", "content--interactive", "tonal", s"tonal--${toneClass(interactive)}"
             )"
             itemscope itemtype="@interactive.metadata.schemaType" role="main">
 
-            @if(interactive.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn){
+            @if(interactive.commercial.isAdvertisementFeature){
                 @fragments.guBand()
             }
 
@@ -63,7 +61,7 @@
 
     @if(isImmersive) {
         <div class="@RenderClasses(Map(
-                    "paid-content--advertisement-feature" -> (interactive.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn)
+                    "paid-content--advertisement-feature" -> interactive.commercial.isAdvertisementFeature
                 ))">
                 @interactive.figureEl.map(HtmlFormat.raw(_))
         </div>

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -4,22 +4,19 @@
 @import model.{Audio, AudioPlayer, Video, VideoPlayer}
 @import views.support.{Video640, SeoOptimisedContentImage, StripHtmlTags}
 @import views.support.TrailCssClasses.toneClass
-@import conf.switches.Switches._
-
 @defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }){ case (media, mediaType) =>
 <div class="l-side-margins l-side-margins--media">
 
     <article id="article" class="@RenderClasses(
             Map(
                 "content--has-body" -> media.fields.body.nonEmpty,
-                "content--advertisement-feature" -> page.media.commercial.isAdvertisementFeature,
-                "paid-content--advertisement-feature" -> (NewCommercialContent.isSwitchedOn && page.media.commercial.isAdvertisementFeature)
+                "content--advertisement-feature paid-content--advertisement-feature" -> page.media.commercial.isAdvertisementFeature
             ),
             "content", "content--media", s"content--media--$mediaType", "tonal", s"tonal--${toneClass(media)}"
         )"
         itemscope itemtype="@media.metadata.schemaType" role="main">
 
-        @if(page.media.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn){
+        @if(page.media.commercial.isAdvertisementFeature){
             @fragments.guBand()
         }
 
@@ -118,7 +115,7 @@
 
                 @media match {
                     case v: Video => {
-                        @if(!(page.media.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn)) {
+                        @if(!page.media.commercial.isAdvertisementFeature) {
                             <div class="content__secondary-column content__secondary-column--media content__secondary-column--video hide-on-childrens-books-site"
                             aria-hidden="true">
                                 <div class="js-video-components-container"></div>
@@ -137,7 +134,7 @@
         </div>
     </article>
 
-    @if(mediaType != "video" && (mediaType != "audio" && page.media.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn)) {
+    @if(mediaType != "video" && mediaType != "audio" && page.media.commercial.isAdvertisementFeature) {
         <div class="fc-container fc-container--media">
             <div class="js-media-popular tonal--@toneClass(media)">
                 <div class="fc-container fc-container--popular">

--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -4,7 +4,8 @@
 @import common.LinkTo
 @import views.BodyCleaner
 @import views.support.TrailCssClasses.toneClass
-@import conf.switches.Switches._
+@import conf.switches.Switches.ForceSchemaOrgTypeForAmpArticlesSwitch
+@import views.support.RenderClasses
 
 @*Feb 2015: Google does only support NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/Review*@
 @shouldForceSchemaType = @{amp && ForceSchemaOrgTypeForAmpArticlesSwitch.isSwitchedOn}
@@ -19,11 +20,14 @@
 
     <div class="l-side-margins">
         <article id="article" data-test-id="article-root"
-            class="content content--article tonal tonal--@toneClass(article) section-@article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")
-            @if(article.commercial.isAdvertisementFeature){content--advertisement-feature}
-            @if(article.tags.isFeature && article.elements.hasShowcaseMainElement){has-feature-showcase-element}
-            @if(article.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn){paid-content--advertisement-feature}"
-            itemscope itemtype="@schemaType(model)" role="main">
+
+        class="@RenderClasses(Map(
+            "content--advertisement-feature" -> article.commercial.isAdvertisementFeature,
+            "has-feature-showcase-element" -> (article.tags.isFeature && article.elements.hasShowcaseMainElement),
+            "paid-content--advertisement-feature" -> article.commercial.isAdvertisementFeature
+        ),  "content", "content--article", "tonal", s"tonal--${toneClass(article)}", s"section-${article.trail.sectionName.trim.toLowerCase.replaceAll("""[\s-]+""", "-")}")"
+
+        itemscope itemtype="@schemaType(model)" role="main">
             <meta itemprop="mainEntityOfPage" content="@LinkTo(article.metadata.url)">
             <div itemprop="publisher" itemscope itemtype="https://schema.org/Organization">
                 <meta itemprop="name" content="The Guardian">
@@ -37,11 +41,11 @@
                 }
             </div>
 
-            @if(article.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn){
+            @if(article.commercial.isAdvertisementFeature){
                 @fragments.guBand()
             }
 
-            @fragments.headTonal(article, article.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn)
+            @fragments.headTonal(article, article.commercial.isAdvertisementFeature)
 
             @if(article.tags.isFeature && article.elements.hasShowcaseMainElement) {
                 @fragments.mainMedia(article, amp)

--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -1,13 +1,9 @@
 
 @(page: PageWithStoryPackage)(implicit request: RequestHeader)
-
-@import common.LinkTo
-@import views.BodyCleaner
-@import views.support.TrailCssClasses.toneClass
-@import conf.switches.Switches._
+    @import views.BodyCleaner
 
 @defining(page.article) { article =>
-    @fragments.headTonal(article, article.commercial.isAdvertisementFeature && NewCommercialContent.isSwitchedOn, showMeta = false)
+    @fragments.headTonal(article, article.commercial.isAdvertisementFeature, showMeta = false)
 
     @fragments.emailMainMedia(article)
 

--- a/commercial/app/controllers/commercial/ContentApiOffersController.scala
+++ b/commercial/app/controllers/commercial/ContentApiOffersController.scala
@@ -8,7 +8,6 @@ import play.api.mvc._
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
-import conf.switches.Switches.NewCommercialContent
 
 object ContentApiOffersController extends Controller with ExecutionContexts with implicits.Requests with Logging {
 
@@ -18,15 +17,11 @@ object ContentApiOffersController extends Controller with ExecutionContexts with
     "foundation-supported" -> "fc-container--foundation-supported"
   )
 
-  private val sponsorTypeToLabel = {if (NewCommercialContent.isSwitchedOn) Map(
+  private val sponsorTypeToLabel = Map(
     "sponsored" -> "Supported by",
     "advertisement-feature" -> "Paid for by",
     "foundation-supported" -> "Supported by"
-  ) else {Map(
-    "sponsored" -> "Sponsored by",
-    "advertisement-feature" -> "Brought to you by",
-    "foundation-supported" -> "Supported by"
-  )}}
+  )
 
   private def renderItems(format: Format, isMulti: Boolean) = MemcachedAction { implicit request =>
 

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -1,10 +1,8 @@
 @(item: model.ContentType, optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optCapiButtonText: Option[String], optCapiReadMoreUrl: Option[String], optCapiReadMoreText: Option[String], optSponsorType: Option[String], optSponsorLabel: Option[String], optClickMacro: Option[String], optOmnitureId: Option[String])(implicit request: RequestHeader)
 
-@import conf.switches.Switches.NewCommercialContent
 @import views.html.fragments.inlineSvg
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
-    @if(NewCommercialContent.isSwitchedOn) {
     <div class="commercial commercial--dfp-single paid-content--advertisement-feature commercial--tone-paidfor" data-link-name="merchandising | capi | single @optOmnitureId">
         <div class="commercial__inner">
             <div class="commercial__header commercial--paidfor">
@@ -68,63 +66,4 @@
             </div>
         </div>
     </div>
-    } else {
-    <section class="@RenderClasses(
-            "fc-container", "fc-container--paid-for", "commercial", "commercial--dfp", "fc-container--merchandising", "commercial--dfp-single", optSponsorType.getOrElse("")
-        )" data-link-name="merchandising | capi | single @optOmnitureId">
-        <div class="fc-container__inner">
-            <div class="fc-container__header">
-                <h3 class="fc-container__header__title">
-                    @optCapiLink.map { linkUrl =>
-                        <a href="@optClickMacro@linkUrl" class="fc-container__header__link" data-link-name="header link"><span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span></a>
-                    }.getOrElse {
-                        <span class="u-text-hyphenate">@for(titleText <- optCapiTitle) {@titleText}</span>
-                    }
-                </h3>
-            </div>
-            <div class="ad-slot--adbadge ad-slot--paid-for-badge ad-slot--paid-for-badge--front">
-                <div class="ad-slot--paid-for-badge__inner">
-                    <h3 class="ad-slot--paid-for-badge__header">@optSponsorLabel:</h3>
-                    <a href="@optClickMacro@for(linkUrl <- optCapiLink) {@linkUrl}" class="ad-slot--paid-for-badge__link" data-link-name="logo link">
-                        @for(logoUrl <- optLogo) {<img src="@logoUrl" alt="" class="ad-slot--paid-for-badge__logo" />}
-                    </a>
-                    @for(aboutLinkUrl <- optCapiAbout) {
-                        <a href="@optClickMacro@aboutLinkUrl" class="ad-slot--paid-for-badge__help" data-link-name="about link">About this content</a>
-                    }
-                </div>
-            </div>
-            <div class="fc-container__body">
-                <div class="lineitems">
-                    <div class="lineitem lineitem--dfp-single">
-                        <div class="lineitem--dfp-single__offer">
-                            <a href="@optClickMacro@item.metadata.webUrl" data-link-name="merchandising-capi-single-v@{version}_@{date}-@item.metadata.webTitle">
-                                @item.trail.trailPicture.map { trailPictureContainer =>
-                                    @Item300.bestFor(trailPictureContainer).map{ url => <img src="@url" alt="" class="lineitem__image" /> }
-                                }
-                                <h4 class="fc-item__title lineitem__title">@item.metadata.webTitle</h4>
-                                @item.fields.trailText.map { trailText =>
-                                    <p class="fc-item__standfirst lineitem__desc">@Html(trailText)</p>
-                                }
-                                @for(buttonText <- optCapiButtonText) {
-                                    <a href="@optClickMacro@item.metadata.webUrl" class="lineitem__cta button button--tertiary button--small">
-                                        @buttonText
-                                        @fragments.inlineSvg("arrow-right", "icon", List("i-right", "i-arrow-black"))
-                                    </a>
-                                }
-                            </a>
-                        </div>
-                        <div class="lineitem--dfp-single__cta hide-on-mobile">
-                            @for(moreButton <- optCapiReadMoreText) {
-                                <a href="@optClickMacro@for(moreUrl <- optCapiReadMoreUrl) {@moreUrl}" class="commercial__cta button button--primary button--large" data-link-name="merchandising-single-more">
-                                    @moreButton
-                                    @fragments.inlineSvg("arrow-right", "icon", List("i-right"))
-                                </a>
-                            }
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-    }
 }

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -1,10 +1,8 @@
 @(items: Seq[model.ContentType], optLogo: Option[String], optCapiTitle: Option[String], optCapiLink: Option[String], optCapiAbout: Option[String], optClickMacro: Option[String], optOmnitureId: Option[String], optCapiAdFeature: Option[String], optSponsorType: Option[String], optSponsorLabel: Option[String])(implicit request: RequestHeader)
-
-@import conf.switches.Switches.NewCommercialContent
 @import views.html.fragments.inlineSvg
 
 @defining(("1_0", "2014-08-14")) { case (version, date) =>
-    @if(NewCommercialContent.isSwitchedOn && optSponsorType.contains("fc-container--advertisement-feature")) {
+    @if(optSponsorType.contains("fc-container--advertisement-feature")) {
         <div class="commercial commercial--paidfor commercial-dfp-multi commercial--tone-paidfor fc-container--advertisement-feature paid-content--advertisement-feature" data-link-name="merchandising | capi | multiple @optOmnitureId">
             <div class="commercial__inner">
                 <div class="commercial__header">

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -230,15 +230,6 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val NewCommercialContent = Switch(
-    "Commercial",
-    "new-commercial-content",
-    "New commercial content designs",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 3, 1),
-    exposeClientSide = true
-  )
-
   val OutbrainOnAmp = Switch(
     "Commercial",
     "outbrain-on-amp",

--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -2,7 +2,6 @@
 @import common.Edition
 @import conf.switches.Switches.SponsoredSwitch
 @import model.{Video, Audio, Gallery, Interactive, Article}
-@import conf.switches.Switches.NewCommercialContent
 
 @defining(content.commercial.isSponsored(Some(Edition(request))),
     content.commercial.isAdvertisementFeature,
@@ -49,11 +48,7 @@
                                 }
                             } else {
                                 @if(isAdFeature) {
-                                    @if(NewCommercialContent.isSwitchedOn) {
-                                        Paid for by:
-                                    } else {
-                                        Brought to you by:
-                                    }
+                                    Paid for by:
                                 } else {
                                     @content.commercial.sponsorshipTag.map { tag =>
                                         @tag.name is supported by:

--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -12,87 +12,81 @@
     @containerType match {
 
     case SingleCampaign(_) => {
-        @if(Switches.NewCommercialContent.isSwitchedOn) {
-            <div class="@RenderClasses(Map(
-                            ("fc-show-more--hidden", container.addShowMoreClasses),
-                            ("js-container--fc-show-more", container.addShowMoreClasses),
-                            ("fc-show-more--mobile-only", container.hasMobileOnlyShowMore)
-                        )) fc-container fc-container--commercial fc-container--rolled-up-hide" data-id="@container.dataId">
-                <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component">
-                    <div class="commercial commercial--paidfor commercial--tone-paidfor commercial--paidfor-single">
-                        <div class="commercial__inner">
-                            <div class="commercial__header">
-                                @fragments.commercial.paidForMeta(Some(container.dataId))
-                                <h3 class="commercial__title">@container.displayName</h3>
-                                <a class="commercial__cta"
-                                    @if(Edition(request).id == "AU") {
-                                        href="@LinkTo("/guardian-labs-australia")"
-                                    } else {
-                                        href="@LinkTo("/guardian-labs")"
-                                        }
-                                >
-                                    @inlineSvg("glabs-logo", "logo")
-                                    <span class='u-h'>Guardian Labs</span>
-                                </a>
-                            </div>
-                            <div class="commercial__body">
-                                @for(layout <- container.containerLayout) {
-                                    @for(slice <- layout.slices) {
-                                        <ul class="lineitems l-row l-row--cols-4">
-                                        @for(ColumnAndCards(_, cards) <- slice.columns) {
-                                            @for(FaciaCardAndIndex(_, card, hideUpTo) <- cards) {
-                                                @card match {
-                                                    case contentCard: ContentCard => {
-                                                        <li class="lineitem l-row__item l-row__item--span-1">
-                                                            <div class="rich-link tone-paidfor--item">
-                                                                <div class="rich-link__container">
-                                                                    @for(InlineImage(imageContainer) <- contentCard.displayElement) {
-                                                                        @itemImage(imageContainer.images)
-                                                                    }
-                                                                <div class="rich-link__header">
-                                                                @title(contentCard.header, 0, container.index)
-                                                                </div>
-                                                                <div class="rich-link__standfirst u-cf">@for(text <- contentCard.trailText) {@Html(text)}</div>
-                                                                <a class="rich-link__link u-faux-block-link__overlay" @Html(contentCard.header.url.hrefWithRel)>@RemoveOuterParaHtml(contentCard.header.headline)</a>
-                                                                </div>
+        <div class="@RenderClasses(Map(
+                        ("fc-show-more--hidden", container.addShowMoreClasses),
+                        ("js-container--fc-show-more", container.addShowMoreClasses),
+                        ("fc-show-more--mobile-only", container.hasMobileOnlyShowMore)
+                    )) fc-container fc-container--commercial fc-container--rolled-up-hide" data-id="@container.dataId">
+            <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component">
+                <div class="commercial commercial--paidfor commercial--tone-paidfor commercial--paidfor-single">
+                    <div class="commercial__inner">
+                        <div class="commercial__header">
+                            @fragments.commercial.paidForMeta(Some(container.dataId))
+                            <h3 class="commercial__title">@container.displayName</h3>
+                            <a class="commercial__cta"
+                                @if(Edition(request).id == "AU") {
+                                    href="@LinkTo("/guardian-labs-australia")"
+                                } else {
+                                    href="@LinkTo("/guardian-labs")"
+                                    }
+                            >
+                                @inlineSvg("glabs-logo", "logo")
+                                <span class='u-h'>Guardian Labs</span>
+                            </a>
+                        </div>
+                        <div class="commercial__body">
+                            @for(layout <- container.containerLayout) {
+                                @for(slice <- layout.slices) {
+                                    <ul class="lineitems l-row l-row--cols-4">
+                                    @for(ColumnAndCards(_, cards) <- slice.columns) {
+                                        @for(FaciaCardAndIndex(_, card, hideUpTo) <- cards) {
+                                            @card match {
+                                                case contentCard: ContentCard => {
+                                                    <li class="lineitem l-row__item l-row__item--span-1">
+                                                        <div class="rich-link tone-paidfor--item">
+                                                            <div class="rich-link__container">
+                                                                @for(InlineImage(imageContainer) <- contentCard.displayElement) {
+                                                                    @itemImage(imageContainer.images)
+                                                                }
+                                                            <div class="rich-link__header">
+                                                            @title(contentCard.header, 0, container.index)
                                                             </div>
-                                                        </li>
+                                                            <div class="rich-link__standfirst u-cf">@for(text <- contentCard.trailText) {@Html(text)}</div>
+                                                            <a class="rich-link__link u-faux-block-link__overlay" @Html(contentCard.header.url.hrefWithRel)>@RemoveOuterParaHtml(contentCard.header.headline)</a>
+                                                            </div>
+                                                        </div>
+                                                    </li>
 
-                                                    }
-                                                    case _ => {}
                                                 }
+                                                case _ => {}
                                             }
                                         }
-                                        </ul>
+                                    }
+                                    </ul>
+                                }
+                            }
+                            <div class="commercial__show-mores">
+                                @if(container.hasShowMore && container.hasShowMoreEnabled) {
+                                    @if(container.useShowMore) {
+                                        <div class="js-show-more-placeholder"></div>
+                                        @showMoreButton(container.displayName getOrElse "")
+                                    } else {
+                                        @showMore(
+                                            container.containerLayout.map(_.remainingCards).getOrElse(Nil),
+                                            container.index
+                                        )
                                     }
                                 }
-                                <div class="commercial__show-mores">
-                                    @if(container.hasShowMore && container.hasShowMoreEnabled) {
-                                        @if(container.useShowMore) {
-                                            <div class="js-show-more-placeholder"></div>
-                                            @showMoreButton(container.displayName getOrElse "")
-                                        } else {
-                                            @showMore(
-                                                container.containerLayout.map(_.remainingCards).getOrElse(Nil),
-                                                container.index
-                                            )
-                                        }
-                                    }
-                                    <div class="js-badge-placeholder"></div>
-                                </div>
+                                <div class="js-badge-placeholder"></div>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-        } else {
-            @standardContainer(container, frontProperties)
-        }
+        </div>
     }
 
     case MultiCampaign(_) => {
-        @if(Switches.NewCommercialContent.isSwitchedOn) {
-
         <div class="fc-container fc-container--commercial">
             <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component">
                 <div class="commercial commercial--paidfor commercial--tone-paidfor commercial--paidfor-multi">
@@ -145,11 +139,5 @@
                 </div>
             </div>
         </div>
-
-        } else {
-
-            @standardContainer(container, frontProperties)
-
-        }
     }
 }

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -13,10 +13,7 @@
 @import views.support.{Commercial, GetClasses, RenderClasses}
 
 @renderCommercialContainer(containerType: CommercialContainerType) = {
-    <div class="@RenderClasses(
-        Map("fc-container__inner--full-span fc-container__inner--paidfor" -> Switches.NewCommercialContent.isSwitchedOn),
-        "fc-container__inner"
-    )">
+    <div class="fc-container__inner--full-span fc-container__inner--paidfor fc-container__inner">
     @commercialContainer(containerType, containerDefinition, frontProperties)
     </div>
 }
@@ -29,8 +26,8 @@
         case _ => {}
     }
 
-    @(containerDefinition.container, isPaidContent, Switches.NewCommercialContent.isSwitchedOn) match {
-        case (MostPopular, true, true) => {}
+    @(containerDefinition.container, isPaidContent) match {
+        case (MostPopular, true) => {}
         case _ => {
         <section id="@componentName"
         class="@GetClasses.forContainerDefinition(containerDefinition)"

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -1,6 +1,5 @@
 @(item: model.ContentType, showBadge: Boolean = true, showExtras: Boolean = true)(implicit request: RequestHeader)
 @import conf.switches.Switches.SaveForLaterSwitch
-@import conf.switches.Switches.NewCommercialContent
 @import model._
 @import views.support.ContentOldAgeDescriber
 
@@ -59,7 +58,7 @@
     @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.twitterHandle.nonEmpty)) { content__meta-container--twitter}
     @if(item.tags.contributors.length == 1 && item.tags.contributors.headOption.exists(_.properties.emailAddress.nonEmpty)) { content__meta-container--email}">
 
-    @if(showBadge && (NewCommercialContent.isSwitchedOff || (item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !item.commercial.isAdvertisementFeature)))) {
+    @if(showBadge && (item.tags.isVideo || item.tags.isAudio || (item.tags.isArticle && !item.commercial.isAdvertisementFeature))) {
         @fragments.commercial.badge(item)
     }
 

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -2,7 +2,6 @@
 
 @import views.support.TrailCssClasses.toneClass
 @import views.support.ContributorLinks
-@import conf.switches.Switches._
 
 <header class="content__head tonal__head tonal__head--@toneClass(item)
     @if(item.content.hasTonalHeaderByline && item.tags.hasLargeContributorImage) { content__head--byline-pic}">
@@ -69,7 +68,7 @@
                     </div>
                 }
 
-                @if(showBadge && (NewCommercialContent.isSwitchedOff || !item.commercial.isAdvertisementFeature)) {
+                @if(showBadge && !item.commercial.isAdvertisementFeature) {
                     @fragments.commercial.badge(item)
                 }
 
@@ -81,7 +80,7 @@
         @if(item.fields.standfirst.isDefined) {
             <div class="gs-container">
                 <div class="content__main-column">
-                    @if(showBadge && NewCommercialContent.isSwitchedOn && item.commercial.isAdvertisementFeature) {
+                    @if(showBadge && item.commercial.isAdvertisementFeature) {
                         <div class="content__meta-container js-content-meta js-football-meta u-cf">
                             @fragments.commercial.badge(item)
                         </div>

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -4,7 +4,6 @@ import com.gu.facia.api.models.{EditorialPriority, FrontPriority}
 import common.Edition
 import common.dfp.AdSize.{leaderboardSize, responsiveSize}
 import common.dfp._
-import conf.switches.Switches
 import conf.switches.Switches._
 import layout.{ColumnAndCards, ContentCard, FaciaContainer}
 import model.pressed.{CollectionConfig, PressedContent}
@@ -84,7 +83,6 @@ object Commercial {
   object container {
 
     def shouldRenderAsCommercialContainer(frontPriority: Option[FrontPriority], container: FaciaContainer): Boolean = {
-      Switches.NewCommercialContent.isSwitchedOn &&
       frontPriority.contains(EditorialPriority) &&
       container.commercialOptions.isAdvertisementFeature
     }

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -1,6 +1,5 @@
 @(faciaPage: model.PressedPage)(implicit request: RequestHeader)
 @import common.Edition
-@import conf.switches.Switches._
 @import views.support.RenderClasses
 
 @defining((faciaPage.isSponsored(Some(Edition(request))),
@@ -10,9 +9,8 @@
         <div class="l-side-margins">
             <div class="@RenderClasses(Map(
                 "fc-container--sponsored" -> isSponsored,
-                "fc-container--advertisement-feature" -> isAdFeature,
-                "js-sponsored-front" -> (isSponsored || isAdFeature || isFoundationFunded),
-                "paid-content--advertisement-feature" -> (NewCommercialContent.isSwitchedOn && isAdFeature)
+                "fc-container--advertisement-feature paid-content--advertisement-feature" -> isAdFeature,
+                "js-sponsored-front" -> (isSponsored || isAdFeature || isFoundationFunded)
             ), "facia-page")"
             data-link-name="Front | @request.path"
                 @faciaPage.sponsor.map { sponsor =>
@@ -23,7 +21,7 @@
                 }
             role="main">
 
-            @if(NewCommercialContent.isSwitchedOn && isAdFeature){
+            @if(isAdFeature){
                 @fragments.guBand()
             }
 

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -36,12 +36,9 @@ define([
         ['cm-frontCommercialComponents', frontCommercialComponents.init],
         ['cm-topBannerBelowContainer', topBannerBelowContainer.init],
         ['cm-thirdPartyTags', thirdPartyTags.init],
-        ['cm-badges', badges.init]
+        ['cm-badges', badges.init],
+        ['cm-paidforBand', paidforBand.init]
     ];
-
-    if (config.switches.newCommercialContent) {
-        modules.push(['cm-paidforBand', paidforBand.init]);
-    }
 
     return {
         init: function () {

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -140,7 +140,7 @@ define([
                     && config.page.contentType !== 'Crossword'
                     && !config.page.isImmersive
                     && !config.page.isUsMinute
-                    && (!config.switches.newCommercialContent || !config.page.isAdvertisementFeature)
+                    && !config.page.isAdvertisementFeature
                     && config.page.pageId !== 'offline-page'
                     && !config.page.shouldHideAdverts
                     && config.page.section !== 'childrens-books-site') {

--- a/static/src/javascripts/projects/common/modules/commercial/badges.js
+++ b/static/src/javascripts/projects/common/modules/commercial/badges.js
@@ -28,12 +28,12 @@ define([
     var badgesConfig = {
             sponsoredfeatures: {
                 count:      0,
-                header:     config.switches.newCommercialContent ? 'Supported by:' : 'Sponsored by:',
+                header:     'Supported by:',
                 namePrefix: 'sp'
             },
             'advertisement-features': {
                 count:      0,
-                header:     config.switches.newCommercialContent ? 'Paid for by' : 'Brought to you by:',
+                header:     'Paid for by:',
                 namePrefix: 'ad'
             },
             'foundation-features': {

--- a/static/src/javascripts/projects/common/modules/commercial/badges.js
+++ b/static/src/javascripts/projects/common/modules/commercial/badges.js
@@ -28,17 +28,17 @@ define([
     var badgesConfig = {
             sponsoredfeatures: {
                 count:      0,
-                header:     'Supported by:',
+                header:     'Supported by',
                 namePrefix: 'sp'
             },
             'advertisement-features': {
                 count:      0,
-                header:     'Paid for by:',
+                header:     'Paid for by',
                 namePrefix: 'ad'
             },
             'foundation-features': {
                 count:      0,
-                header:     'Supported by:',
+                header:     'Supported by',
                 namePrefix: 'fo'
             }
         },

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/template.js
@@ -57,7 +57,7 @@ define([
         this.params.arrowRight = svgs('arrowRight', ['i-right']);
         this.params.logoguardian = svgs('logoguardian');
         this.params.marque36iconCreativeMarque = svgs('marque36icon', ['creative__marque']);
-        this.params.logoFeatureLabel = config.switches.newCommercialContent ? 'Paid for by' : 'Brought to you by:';
+        this.params.logoFeatureLabel = 'Paid for by';
     };
 
     Template.prototype.postLoadEvents = {

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -12,12 +12,11 @@ define([
     defaults
 ) {
 
-    var isNewCommercialContent = config.switches.newCommercialContent && config.page.isAdvertisementFeature;
     var paidforBandHeight;
 
     function initPaidForBand(element) {
         paidforBandHeight = 0;
-        if (isNewCommercialContent) {
+        if (config.page.isAdvertisementFeature) {
             var paidforBand = document.querySelector('.paidfor-band');
             if (paidforBand && paidforBand !== element) {
                 fastdom.read(function () {

--- a/static/src/javascripts/projects/common/views/commercial/creatives/logo-ad-feature.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/logo-ad-feature.html
@@ -3,8 +3,4 @@
     <a href="<%=clickMacro%><%=logoUrl%>" class="ad-slot--paid-for-badge__link">
         <img class="ad-slot--paid-for-badge__logo" src="<%=logoImage%>" />
     </a>
-    <% if (!guardian.config.switches.newCommercialContent) { %>
-        <a href="<%=clickMacro%><%=infoUrl%>" class="ad-slot--paid-for-badge__help u-h">About this content</a>
-        <a href="<%=clickMacro%>http://theguardian.com/paid-for-content" class="ad-slot--paid-for-badge__help">About this content</a>
-    <% } %>
 </div>

--- a/static/test/javascripts/spec/common/commercial/badges.spec.js
+++ b/static/test/javascripts/spec/common/commercial/badges.spec.js
@@ -34,15 +34,15 @@ define([
                 var header;
                 switch (sponsorship) {
                     case 'sponsoredfeatures':
-                        header = 'Supported by:';
+                        header = 'Supported by';
                         break;
 
                     case 'advertisement-features':
-                        header = 'Paid for by:';
+                        header = 'Paid for by';
                         break;
 
                     default:
-                        header = 'Supported by:';
+                        header = 'Supported by';
                 }
                 return template(
                     '<div class="ad-slot--paid-for-badge__inner ad-slot__content--placeholder">\n' +

--- a/static/test/javascripts/spec/common/commercial/badges.spec.js
+++ b/static/test/javascripts/spec/common/commercial/badges.spec.js
@@ -34,11 +34,11 @@ define([
                 var header;
                 switch (sponsorship) {
                     case 'sponsoredfeatures':
-                        header = 'Sponsored by:';
+                        header = 'Supported by:';
                         break;
 
                     case 'advertisement-features':
-                        header = 'Brought to you by:';
+                        header = 'Paid for by:';
                         break;
 
                     default:


### PR DESCRIPTION
## What does this change?

The `NewCommercialContent` switch has been removed as it is now to be a permanent change. The switch has been deleted and all the logic that used the switch has been altered accordingly.
## What is the value of this and can you measure success?

value: one less switch to worry about
success: paid content still working on the site
## Request for comment

-- @kelvin-chappell 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
