### PR TITLE
Display ads - changes to style on mobile

### DIFF
--- a/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-comcontent.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-comcontent.html
@@ -1,5 +1,5 @@
 <div class="gu-display" data-link-name="creative | gu style commercial display content">
-    <div class="gu-display__image-layer u-responsive-ratio inlined-image">
+    <div class="gu-display__image-layer inlined-image">
         <img class="gu-display__image" src="<%=data.articleImage%>">
     </div>
     <div class="gu-mutable gu-display__content <%=data.articleContentPosition%>">

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -2,6 +2,10 @@
     padding: $gs-baseline / 2;
 }
 
+.gu-display {
+    position: relative;
+}
+
 .gu-display__image-layer {
     width: 100%;
     height: 100%;
@@ -124,8 +128,11 @@ $mobile-max-container-width: gs-span(8);
 .gu-style {
     width: auto;
     border-top: #fedd79 1px solid;
-    margin-left: $gs-gutter / 2;
-    margin-right: $gs-gutter / 2;
+    margin: 0 $gs-gutter / 2;
+
+    @include mq(mobileLandscape) {
+        margin: 0 $gs-gutter;
+    }
 
     @include mq(containerWidestMobile) {
         margin: 0 auto;

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -122,13 +122,10 @@ $mobile-max-container-width: gs-span(8);
 @include mq-add-breakpoint(containerWidestMobile, $mobile-max-container-width + $gs-gutter * 2);
 
 .gu-style {
+    width: auto;
     border-top: #fedd79 1px solid;
     margin-left: $gs-gutter / 2;
     margin-right: $gs-gutter / 2;
-
-    @include mq(mobile) {
-        margin: 0 auto;
-    }
 
     @include mq(containerWidestMobile) {
         margin: 0 auto;
@@ -142,5 +139,9 @@ $mobile-max-container-width: gs-span(8);
 
     @include mq(desktop) {
         width: 300px;
+    }
+
+    .ad-slot__label {
+        display: none;
     }
 }


### PR DESCRIPTION
# Changes to styles on mobile
## What does this change?

Ad have full width on mobile and the image is taking whole height of the ad slot.
## What is the value of this and can you measure success?

It looks good.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

Before:
<img width="352" alt="screen shot 2016-02-23 at 15 34 58" src="https://cloud.githubusercontent.com/assets/2579465/13256529/f5953522-da42-11e5-8232-a81b690e5524.png">
<img width="316" alt="screen shot 2016-02-23 at 15 35 04" src="https://cloud.githubusercontent.com/assets/2579465/13256530/f595f9bc-da42-11e5-9301-e3bc27447894.png">

After:
![screen shot 2016-02-23 at 15 07 26](https://cloud.githubusercontent.com/assets/2579465/13256494/e23a087c-da42-11e5-9f21-1f6d2b59e0ec.png)
![screen shot 2016-02-23 at 15 07 54](https://cloud.githubusercontent.com/assets/2579465/13256493/e23805e0-da42-11e5-9893-92e114dada5a.png)
