### PR TITLE
Refactored breakout iframe using promises

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -40,8 +40,8 @@ define([
             return type;
         }
 
-        $breakoutEl = $('.breakout__html', iFrameBody);
-        if ($breakoutEl.length) {
+        $breakoutEl = $('.breakout__html, .breakout__script', iFrameBody);
+        if ($breakoutEl.hasClass('breakout__html')) {
             fastdom.write(function () {
                 $iFrame.hide();
                 $breakoutEl.detach();
@@ -52,28 +52,25 @@ define([
                     $responsiveAds.addClass('ad--responsive--open');
                 });
             });
-        } else {
-            $breakoutEl = $('.breakout__script', iFrameBody);
-            if ($breakoutEl.length) {
-                fastdom.write(function () {
-                    $iFrame.hide();
-                }).then(function () {
-                    var breakoutContent = $breakoutEl.html();
-                    if ($breakoutEl.attr('type') === 'application/json') {
-                        var creativeConfig = JSON.parse(breakoutContent);
-                        if (creativeConfig.name === 'fluid250-v4' || creativeConfig.name === 'fluid250-v3') {
-                            creativeConfig.name = 'fluid250';
-                        }
-                        require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
-                            new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
-                        });
-                        type = creativeConfig.params.adType || '';
-                    } else {
-                        // evil, but we own the returning js snippet
-                        eval(breakoutContent);
+        } else if ($breakoutEl.hasClass('breakout__script')) {
+            fastdom.write(function () {
+                $iFrame.hide();
+            }).then(function () {
+                var breakoutContent = $breakoutEl.html();
+                if ($breakoutEl.attr('type') === 'application/json') {
+                    var creativeConfig = JSON.parse(breakoutContent);
+                    if (creativeConfig.name === 'fluid250-v4' || creativeConfig.name === 'fluid250-v3') {
+                        creativeConfig.name = 'fluid250';
                     }
-                });
-            }
+                    require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
+                        new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
+                    });
+                    type = creativeConfig.params.adType || '';
+                } else {
+                    // evil, but we own the returning js snippet
+                    eval(breakoutContent);
+                }
+            });
         }
 
         return type;

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -40,7 +40,8 @@ define([
             return type;
         }
 
-        if (($breakoutEl = $('.breakout__html', iFrameBody)).length) {
+        $breakoutEl = $('.breakout__html', iFrameBody);
+        if ($breakoutEl.length) {
             fastdom.write(function () {
                 $iFrame.hide();
                 $breakoutEl.detach();
@@ -51,25 +52,28 @@ define([
                     $responsiveAds.addClass('ad--responsive--open');
                 });
             });
-        } else if (($breakoutEl = $('.breakout__script', iFrameBody)).length) {
-            fastdom.write(function () {
-                $iFrame.hide();
-            }).then(function () {
-                var breakoutContent = $breakoutEl.html();
-                if ($breakoutEl.attr('type') === 'application/json') {
-                    var creativeConfig = JSON.parse(breakoutContent);
-                    if (creativeConfig.name === 'fluid250-v4' || creativeConfig.name === 'fluid250-v3') {
-                        creativeConfig.name = 'fluid250';
+        } else {
+            $breakoutEl = $('.breakout__script', iFrameBody);
+            if ($breakoutEl.length) {
+                fastdom.write(function () {
+                    $iFrame.hide();
+                }).then(function () {
+                    var breakoutContent = $breakoutEl.html();
+                    if ($breakoutEl.attr('type') === 'application/json') {
+                        var creativeConfig = JSON.parse(breakoutContent);
+                        if (creativeConfig.name === 'fluid250-v4' || creativeConfig.name === 'fluid250-v3') {
+                            creativeConfig.name = 'fluid250';
+                        }
+                        require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
+                            new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
+                        });
+                        type = creativeConfig.params.adType || '';
+                    } else {
+                        // evil, but we own the returning js snippet
+                        eval(breakoutContent);
                     }
-                    require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
-                        new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
-                    });
-                    type = creativeConfig.params.adType || '';
-                } else {
-                    // evil, but we own the returning js snippet
-                    eval(breakoutContent);
-                }
-            });
+                });
+            }
         }
 
         return type;

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -2,19 +2,27 @@ define([
     'bonzo',
     'common/utils/$',
     'common/utils/config',
-    'common/utils/fastdom-idle',
-    'lodash/collections/forEach'
+    'common/utils/fastdom-promise',
+
+    'common/modules/commercial/creatives/commercial-component',
+    'common/modules/commercial/creatives/gu-style-comcontent',
+    'common/modules/commercial/creatives/expandable',
+    'common/modules/commercial/creatives/expandable-v2',
+    'common/modules/commercial/creatives/expandable-v3',
+    'common/modules/commercial/creatives/expandable-video',
+    'common/modules/commercial/creatives/expandable-video-v2',
+    'common/modules/commercial/creatives/fluid250',
+    'common/modules/commercial/creatives/fluid250GoogleAndroid',
+    'common/modules/commercial/creatives/foundation-funded-logo',
+    'common/modules/commercial/creatives/scrollable-mpu',
+    'common/modules/commercial/creatives/scrollable-mpu-v2',
+    'common/modules/commercial/creatives/template'
 ], function (
     bonzo,
     $,
     config,
-    idleFastdom,
-    forEach
+    fastdom
 ) {
-    var breakoutClasses = [
-        'breakout__html',
-        'breakout__script'
-    ];
 
     /**
      * Allows ad content to break out of their iframes. The ad's content must have one of the above breakoutClasses.
@@ -22,57 +30,45 @@ define([
      */
     function breakoutIFrame(iFrame, $slot) {
         /*eslint-disable no-eval*/
-        var shouldRemoveIFrame = false,
-            $iFrame            = bonzo(iFrame),
-            iFrameBody         = iFrame.contentDocument.body,
-            $iFrameParent      = $iFrame.parent(),
-            type               = {};
+        var $iFrame            = bonzo(iFrame);
+        var $iFrameParent      = bonzo(iFrame.parentNode);
+        var iFrameBody         = iFrame.contentDocument.body;
+        var type               = {};
+        var $breakoutEl;
 
-        if (iFrameBody) {
-            forEach(breakoutClasses, function (breakoutClass) {
-                $('.' + breakoutClass, iFrameBody).each(function (breakoutEl) {
-                    var creativeConfig,
-                        $breakoutEl     = bonzo(breakoutEl),
-                        breakoutContent = $breakoutEl.html();
+        if (!iFrameBody) {
+            return type;
+        }
 
-                    if (breakoutClass === 'breakout__script') {
-                        // new way of passing data from DFP
-                        if ($breakoutEl.attr('type') === 'application/json') {
-                            creativeConfig = JSON.parse(breakoutContent);
-                            if (creativeConfig.name === 'fluid250-v4' || creativeConfig.name === 'fluid250-v3') {
-                                creativeConfig.name = 'fluid250';
-                            }
-                            require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
-                                new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
-                            });
-                        } else {
-                            // evil, but we own the returning js snippet
-                            eval(breakoutContent);
-                        }
-
-                        type = creativeConfig.params.adType || '';
-
-                    } else {
-                        idleFastdom.write(function () {
-                            $iFrameParent.append(breakoutContent);
-                            $breakoutEl.remove();
-                        });
-
-                        $('.ad--responsive', $iFrameParent[0]).each(function (responsiveAd) {
-                            window.setTimeout(function () {
-                                idleFastdom.write(function () {
-                                    bonzo(responsiveAd).addClass('ad--responsive--open');
-                                });
-                            }, 50);
-                        });
-                    }
-                    shouldRemoveIFrame = true;
+        if (($breakoutEl = $('.breakout__html', iFrameBody)).length) {
+            fastdom.write(function () {
+                $iFrame.hide();
+                $breakoutEl.detach();
+                $iFrameParent.append($breakoutEl.html());
+            }).then(function () {
+                var $responsiveAds = $('.ad--responsive', $iFrameParent[0]);
+                fastdom.write(function () {
+                    $responsiveAds.addClass('ad--responsive--open');
                 });
             });
-        }
-        if (shouldRemoveIFrame) {
-            idleFastdom.write(function () {
+        } else if (($breakoutEl = $('.breakout__script', iFrameBody)).length) {
+            fastdom.write(function () {
                 $iFrame.hide();
+            }).then(function () {
+                var breakoutContent = $breakoutEl.html();
+                if ($breakoutEl.attr('type') === 'application/json') {
+                    var creativeConfig = JSON.parse(breakoutContent);
+                    if (creativeConfig.name === 'fluid250-v4' || creativeConfig.name === 'fluid250-v3') {
+                        creativeConfig.name = 'fluid250';
+                    }
+                    require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
+                        new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
+                    });
+                    type = creativeConfig.params.adType || '';
+                } else {
+                    // evil, but we own the returning js snippet
+                    eval(breakoutContent);
+                }
             });
         }
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -45,7 +45,7 @@ define([
             fastdom.write(function () {
                 $iFrame.hide();
                 $breakoutEl.detach();
-                $iFrameParent.append($breakoutEl.html());
+                $iFrameParent.append($breakoutEl[0].children);
             }).then(function () {
                 var $responsiveAds = $('.ad--responsive', $iFrameParent[0]);
                 fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -45,21 +45,7 @@ define([
     'lodash/collections/find',
     'lodash/arrays/last',
     'lodash/arrays/intersection',
-    'lodash/arrays/initial',
-
-    'common/modules/commercial/creatives/commercial-component',
-    'common/modules/commercial/creatives/gu-style-comcontent',
-    'common/modules/commercial/creatives/expandable',
-    'common/modules/commercial/creatives/expandable-v2',
-    'common/modules/commercial/creatives/expandable-v3',
-    'common/modules/commercial/creatives/expandable-video',
-    'common/modules/commercial/creatives/expandable-video-v2',
-    'common/modules/commercial/creatives/fluid250',
-    'common/modules/commercial/creatives/fluid250GoogleAndroid',
-    'common/modules/commercial/creatives/foundation-funded-logo',
-    'common/modules/commercial/creatives/scrollable-mpu',
-    'common/modules/commercial/creatives/scrollable-mpu-v2',
-    'common/modules/commercial/creatives/template'
+    'lodash/arrays/initial'
 ], function (
     bean,
     bonzo,


### PR DESCRIPTION
## What does this change?

This fixes the "jump" that is happening in Firefox (and sometimes Safari) in the top slot, when the component is a breakout script. It is caused by the iframe taking up space until it is hidden, which happens only after its content has been added to the DOM. When the iframe is hidden first, the jump does not happen anymore.

I also cleaned up the code a little and moved all the creatives in `breakout-iframe` where they are called (unless @jbreckmckye there was a reason not to... if yes let me know, happy to revert it)
## Screenshots

![picture 1](https://cloud.githubusercontent.com/assets/629976/13260017/a1a5127a-da51-11e5-9b1f-437f2e805a29.png)
