### PR TITLE
Enchilada margins at the right article position

### DIFF
--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -143,4 +143,9 @@ $mobile-max-container-width: gs-span(8);
     @include mq(desktop) {
         width: 300px;
     }
+
+    // Right slot width is exactly the size of the banner so we don't want any margin
+    &.ad-slot--right {
+        margin: 0 auto;
+    }
 }


### PR DESCRIPTION
# Fix: Enchilada margins at the right article position
## What does this change?

Styling issue.
## What is the value of this and can you measure success?

Looks better.
## Screenshots

Before:
![screen shot 2016-02-23 at 17 16 50](https://cloud.githubusercontent.com/assets/2579465/13260158/3a27ced4-da52-11e5-9cff-7f03c8b29a00.png)

After:
![screen shot 2016-02-23 at 17 20 22](https://cloud.githubusercontent.com/assets/2579465/13260165/3ef9b18e-da52-11e5-89d6-77d642dbab99.png)
