### PR TITLE
Override media tones in paid content styles

### DIFF
--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -191,7 +191,7 @@
         background-color: unset;
     }
 
-    // Tone overrides
+    // Media tone overrides
 
     &.tonal--tone-media .tonal__standfirst a {
         color: colour(news-default);

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -191,8 +191,6 @@
         background-color: unset;
     }
 
-    // Media tone overrides
-
     &.tonal--tone-media .tonal__standfirst a {
         color: colour(news-default);
     }

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -191,4 +191,17 @@
         background-color: unset;
     }
 
+    // Tone overrides
+
+    &.tonal--tone-media .tonal__standfirst a {
+        color: colour(news-default);
+    }
+
+    &.tonal--tone-media .tonal__standfirst {
+        .bullet:before,
+        ul>li:before {
+            background-color: colour(neutral-1);
+        }
+    }
+
 }


### PR DESCRIPTION
# Turn white links black on paid-content media pages
## What does this change?

On a paid-content page page like http://www.theguardian.com/netflix-love/video/2016/feb/19/isy-sutties-real-dating-disaster-the-cats-tale-video, several elements use the `tone-media` styles that assume a dark background, and appear white. This gives them poor contrast in the paid-content theme.
## Screenshots

_Before:_
![image](https://cloud.githubusercontent.com/assets/3148617/13260097/03857282-da52-11e5-814a-81eaf310801f.png)

_After:_
![image](https://cloud.githubusercontent.com/assets/3148617/13260110/1216f992-da52-11e5-83e7-34ed73c2e4b6.png)
## Request for comment

I've fixed this by adding an override for the tonal styles in paid-content mode. Long term, though, we might need a better solution - perhaps we should create a separate `tone-paidfor` style, and use that for styling paidfor articles rather than `paid-content--advertisement-feature`. This might be a bit of refactor, though.
