### PR TITLE
Fix toast bug: send correct block ID

### DIFF
--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -75,7 +75,7 @@
                         <div class="js-article__container" data-component="body">
                             @* Remove LiveFilter and the fragment once Toast comes out of AB test status *@
                             @fragments.liveFilter(article.fields.isLive)
-                            <div class="js-liveblog-body u-cf from-content-api js-blog-blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="@article.mostRecentBlock" data-test-id="live-blog-blocks"
+                            <div class="js-liveblog-body u-cf from-content-api js-blog-blocks @if(article.fields.isLive) {live-blog}" data-test-id="live-blog-blocks"
                                 itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
                                 <div class="toast__space-reserver">
                                     <div id="toast__tofix" class="toast__container">

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -75,7 +75,7 @@
                         <div class="js-article__container" data-component="body">
                             @* Remove LiveFilter and the fragment once Toast comes out of AB test status *@
                             @fragments.liveFilter(article.fields.isLive)
-                            <div class="js-liveblog-body u-cf from-content-api js-blog-blocks @if(article.fields.isLive) {live-blog}" data-test-id="live-blog-blocks"
+                            <div class="js-liveblog-body u-cf from-content-api js-blog-blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="@article.mostRecentBlock" data-test-id="live-blog-blocks"
                                 itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
                                 <div class="toast__space-reserver">
                                     <div id="toast__tofix" class="toast__container">

--- a/static/src/javascripts/projects/common/modules/ui/newAutoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/newAutoupdate.js
@@ -203,7 +203,7 @@ define([
         var $toastText = $('.toast__text', this.$toastButton);
         var toastContainer = qwery('.toast__container')[0];
 
-        latestBlockId = $liveblogBody.data('most-recent-block');
+        latestBlockId = 'block-' + $liveblogBody.data('most-recent-block');
 
         new NotificationCounter().init();
         new Sticky(toastContainer, { top: options.toastOffsetTop, emitMessage: true, containInParent: false }).init();

--- a/static/src/javascripts/projects/common/modules/ui/newAutoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/newAutoupdate.js
@@ -139,6 +139,10 @@ define([
             });
         };
 
+        var getLatestBlockId = function () {
+            return $('.block').first().attr('id');
+        };
+
         var injectNewBlocks = function () {
             if (!updating && newBlocks) {
                 updating = true;
@@ -161,7 +165,7 @@ define([
 
                     mediator.emit('modules:autoupdate:updates', elementsToAdd.length);
 
-                    latestBlockId = $('.block').first().attr('id');
+                    latestBlockId = getLatestBlockId();
 
                     newBlocks = '';
 
@@ -203,7 +207,7 @@ define([
         var $toastText = $('.toast__text', this.$toastButton);
         var toastContainer = qwery('.toast__container')[0];
 
-        latestBlockId = $liveblogBody.data('most-recent-block');
+        latestBlockId = getLatestBlockId();
 
         new NotificationCounter().init();
         new Sticky(toastContainer, { top: options.toastOffsetTop, emitMessage: true, containInParent: false }).init();

--- a/static/src/javascripts/projects/common/modules/ui/newAutoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/newAutoupdate.js
@@ -139,10 +139,6 @@ define([
             });
         };
 
-        var getLatestBlockId = function () {
-            return $('.block').first().attr('id');
-        };
-
         var injectNewBlocks = function () {
             if (!updating && newBlocks) {
                 updating = true;
@@ -165,7 +161,7 @@ define([
 
                     mediator.emit('modules:autoupdate:updates', elementsToAdd.length);
 
-                    latestBlockId = getLatestBlockId();
+                    latestBlockId = $('.block').first().attr('id');
 
                     newBlocks = '';
 
@@ -207,7 +203,7 @@ define([
         var $toastText = $('.toast__text', this.$toastButton);
         var toastContainer = qwery('.toast__container')[0];
 
-        latestBlockId = getLatestBlockId();
+        latestBlockId = $liveblogBody.data('most-recent-block');
 
         new NotificationCounter().init();
         new Sticky(toastContainer, { top: options.toastOffsetTop, emitMessage: true, containInParent: false }).init();


### PR DESCRIPTION
# Steps to reproduce
1. Go to a live liveblog with Toast enabled (currently disabled in PROD)
2. Wait ~30 seconds
# Expected

Toast will appear if there are updates, with the correct number of updates displayed.
# Actual

Toast appears with a large number of updates (all blocks!).
# Comments

This is because we are requesting new updates in the format of `<liveblogUrl>.json?lastUpdate=<blockId>&isLivePage=true`, when we should be querying updates in the format of `<liveblogUrl>.json?lastUpdate=block-<blockId>&isLivePage=true`. Note the missing prefix on the block ID.

This was happening because the `data-most-recent-block` attribute only contained the block ID without the `block-` prefix.

I have changed this so that we always query the DOM to find the latest block, whose ID always contains the `block-` prefix.
# Screenshots

![image](https://cloud.githubusercontent.com/assets/921609/13260583/0943c974-da54-11e5-99ad-bad2a616fc48.png)

/cc @Jholder112233 
