### PR TITLE
Replace article structure with space-filler

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -13,7 +13,8 @@ define([
     'lodash/collections/find',
     'text!common/views/email/iframe.html',
     'common/utils/template',
-    'common/modules/article/space-filler'
+    'common/modules/article/space-filler',
+    'common/modules/analytics/omniture'
 ], function (
     $,
     bean,
@@ -29,7 +30,8 @@ define([
     find,
     iframeTemplate,
     template,
-    spaceFiller
+    spaceFiller,
+    omniture
 ) {
 
     var listConfigs = {
@@ -129,6 +131,7 @@ define([
                 } else {
                     spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {
                         $iframeEl.insertBefore(paras[0]);
+                        omniture.trackLinkImmediate('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
                         emailInserted = true;
                     });
                 }

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -102,7 +102,7 @@ define([
                 fromBottom: true,
                 selectors: {
                     ' .element-rich-link': {minAbove: 100, minBelow: 100},
-                    ' > h2': {minAbove: 20, minBelow: 200},
+                    ' > h2': {minAbove: 0, minBelow: 200},
                     ' > *:not(p):not(h2):not(blockquote)': {minAbove: 35, minBelow: 200},
                     ' .ad-slot': {minAbove: 150, minBelow: 200}
                 }

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -12,7 +12,8 @@ define([
     'lodash/collections/every',
     'lodash/collections/find',
     'text!common/views/email/iframe.html',
-    'common/utils/template'
+    'common/utils/template',
+    'common/modules/article/space-filler'
 ], function (
     $,
     bean,
@@ -27,7 +28,8 @@ define([
     every,
     find,
     iframeTemplate,
-    template
+    template,
+    spaceFiller
 ) {
 
     var listConfigs = {
@@ -40,8 +42,9 @@ define([
                 successHeadline: 'Thank you for signing up to the Guardian US Campaign minute',
                 successDescription: 'We will send you the biggest political story lines of the day',
                 modClass: 'post-article',
-                insertMethod: 'insertAfter',
-                insertSelector: '.js-article__container'
+                insertMethod: function ($iframeEl) {
+                    $iframeEl.insertAfter('.js-article__container');
+                }
             },
             theFilmToday: {
                 listId: '1950',
@@ -87,11 +90,23 @@ define([
                 modClass: 'end-article'
             }
         },
-        $articleBody,
         emailInserted = false,
         keywords = config.page.keywords ? config.page.keywords.split(',') : '',
-        isParagraph = function ($el) {
-            return $el.nodeName && $el.nodeName === 'P';
+        getSpacefinderRules = function () {
+            return {
+                bodySelector: '.js-article__body',
+                slotSelector: ' > p',
+                minAbove: 200,
+                minBelow: 150,
+                clearContentMeta: 50,
+                fromBottom: true,
+                selectors: {
+                    ' .element-rich-link': {minAbove: 100, minBelow: 100},
+                    ' > h2': {minAbove: 20, minBelow: 200},
+                    ' > *:not(p):not(h2):not(blockquote)': {minAbove: 35, minBelow: 200},
+                    ' .ad-slot': {minAbove: 150, minBelow: 200}
+                }
+            };
         },
         listCanRun = function (listConfig) {
             if (listConfig.canRun && canRunList[listConfig.canRun]()) {
@@ -101,34 +116,26 @@ define([
         addListToPage = function (listConfig) {
             if (listConfig) {
                 var iframe = bonzo.create(template(iframeTemplate, listConfig))[0],
-                    $iframeEl = $(iframe),
-                    $insertEl = $(listConfig.insertSelector);
+                    $iframeEl = $(iframe);
 
                 bean.on(iframe, 'load', function () {
                     email.init(iframe);
                 });
 
-                fastdom.write(function () {
-                    $iframeEl[listConfig.insertMethod || 'appendTo']($insertEl && $insertEl.length > 0 ? $insertEl : $articleBody);
-                });
+                if (listConfig.insertMethod) {
+                    fastdom.write(function () {
+                        listConfig.insertMethod($iframeEl);
+                    });
+                } else {
+                    spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {
+                        $iframeEl.insertBefore(paras[0]);
+                        emailInserted = true;
+                    });
+                }
 
-                emailInserted = true;
             }
         },
         canRunHelpers = {
-            allowedArticleStructure: function () {
-                $articleBody = $('.js-article__body');
-
-                if ($articleBody.length) {
-                    var allArticleEls = $('> *', $articleBody),
-                        emailAlreadyInArticle = $('js-email-sub__iframe', $articleBody).length > 0,
-                        lastFiveElsParas = every([].slice.call(allArticleEls, allArticleEls.length - 5), isParagraph);
-
-                    return !emailAlreadyInArticle && lastFiveElsParas;
-                } else {
-                    return false;
-                }
-            },
             keywordExists: function (keyword) {
                 // Compare page keywords with passed in array
                 return !!intersection(keywords, keyword).length;
@@ -139,10 +146,10 @@ define([
                 return config.page.isMinuteArticle && canRunHelpers.keywordExists(['US elections 2016']);
             },
             theFilmToday: function () {
-                return config.page.section === 'film' && canRunHelpers.allowedArticleStructure();
+                return config.page.section === 'film';
             },
             theFiver: function () {
-                return canRunHelpers.keywordExists(['Football']) && canRunHelpers.allowedArticleStructure();
+                return canRunHelpers.keywordExists(['Football']);
             },
             theGuardianToday: function () {
                 var host = window.location.host,
@@ -153,7 +160,6 @@ define([
                     pageIsBlacklisted = canRunHelpers.keywordExists(['US elections 2016', 'Football']) || config.page.section === 'film';
 
                 return !pageIsBlacklisted &&
-                        canRunHelpers.allowedArticleStructure() &&
                         urlRegex.test(document.referrer) &&
                         !Id.isUserLoggedIn() &&
                         !(browser === 'MSIE' && contains(['7','8','9'], version + ''));


### PR DESCRIPTION
## What does this change?

This replaces my 'are the last 5 elements paragraphs' rudimentary check with the super-powered spacefinder check via space-filler for the in-article email sign-up insertion.
## What is the value of this and can you measure success?

It's less likely to cause clashes and no longer breaks certain contracts.
## Request for comment

@crifmulholland on the rules, @jbreckmckye because you're spacefinderman
