### PR TITLE
Dont show any onward journey's on amp if in section children's books

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -2,7 +2,6 @@
 
 @import common.{AnalyticsHost, LinkTo, CanonicalLink}
 @import conf.Configuration
-@import model.Page
 @import views.support.OmnitureAnalyticsData
 
 <!doctype html>
@@ -55,40 +54,42 @@
                 </div>
             }
 
-
-            @Page.getContentPage(page).map { content =>
-                @if(content.item.content.hasStoryPackage) {
+            @if(content.metadata.section != "childrens-books-site") {
+                @if(content.hasStoryPackage) {
                     @fragments.amp.storyPackageAmp(related)
                 }
-                @if(content.item.tags.series.nonEmpty) {
-                    @content.item.tags.series.map { tag =>
+                @if(content.tags.series.nonEmpty) {
+                    @content.tags.series.map { tag =>
                         @fragments.amp.onwardTemplateAmp("series-mf2/" + tag.id + ".json")
                     }
                 }
-                @if(content.item.content.showInRelated
-                    && !content.item.content.hasStoryPackage
-                    && content.item.tags.series.isEmpty){
+                @if(content.showInRelated
+                    && !content.hasStoryPackage
+                    && content.tags.series.isEmpty) {
                     @fragments.amp.onwardTemplateAmp("related-mf2/" + page.metadata.id + ".json")
                 }
-            }
 
-            @fragments.amp.outbrain(page)
+                @fragments.amp.outbrain(page)
+                @* Show top container for section front only if current page belongs to one of the following sections *@
+                @* Otherwise show top container for network front *@
+                @* TODO: This list also exists in the JS for fronts on articles a/b test. Pending a decision on that, this should go in the jsconfig, or be removed*@
 
-            @* Show top container for section front only if current page belongs to one of the following sections *@
-            @* Otherwise show top container for network front *@
-            @*TODO: This list also exists in the JS for fronts on articles a/b test. Pending a decision on that, this should go in the jsconfig, or be removed*@
-            @whitelistedSections = @{List("commentisfree", "sport", "football", "fashion", "lifeandstyle",
-                "education", "culture", "business", "technology", "politics", "environment", "travel",
-                "film", "media", "money", "society", "science", "music", "books", "stage", "cities",
-                "tv-and-radio", "artanddesign", "global-development")}
-            @isWhitelistedSection = @{whitelistedSections.contains(page.metadata.section)}
-            @if(isWhitelistedSection) {
-                @fragments.amp.onwardTemplateAmp(s"container/count/1/offset/0/section/${page.metadata.section}/mf2.json")
-            } else {
-                @fragments.amp.onwardTemplateAmp(s"container/count/1/offset/0/mf2.json")
+                @defining({
+                    val whitelistedSections = List("commentisfree", "sport", "football", "fashion", "lifeandstyle",
+                                    "education", "culture", "business", "technology", "politics", "environment", "travel",
+                                    "film", "media", "money", "society", "science", "music", "books", "stage", "cities",
+                                    "tv-and-radio", "artanddesign", "global-development")
+                    whitelistedSections.contains(page.metadata.section)
+                }) { isWhitelistedSection =>
+                    @if(isWhitelistedSection) {
+                        @fragments.amp.onwardTemplateAmp(s"container/count/1/offset/0/section/${page.metadata.section}/mf2.json")
+                    } else {
+                        @fragments.amp.onwardTemplateAmp(s"container/count/1/offset/0/mf2.json")
+                    }
+                    @fragments.amp.onwardTemplateAmp("most-read-mf2.json")
+                    @fragments.amp.onwardTemplateAmp(s"container/count/3/offset/${if(isWhitelistedSection) 0 else 1}/mf2.json")
+                }
             }
-            @fragments.amp.onwardTemplateAmp("most-read-mf2.json")
-            @fragments.amp.onwardTemplateAmp(s"container/count/3/offset/${if(isWhitelistedSection) 0 else 1}/mf2.json")
 
             <amp-font
                 layout="nodisplay"


### PR DESCRIPTION
## What does this change?

We should not be showing any onward journey's on the Children's Books site. This is because it is possible that not child appropriate content may show in most popular, headlines, or other onward containers.

I have also refactored slightly to remove a redundant import
## Does this affect other platforms?

This only effects AMP :zap: 
## Request for comment

please can i have a comment :smile: 
