### PR TITLE
explicitly set vjs control bar position

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -207,6 +207,8 @@ $ima-controls-height: 70px;
 }
 
 .vjs-control-bar {
+    position: relative;
+
     .gu-media--video & {
         position: absolute;
         bottom: $gs-baseline*-5;


### PR DESCRIPTION
# Make audio player work
## What does this change?

Makes the audio player work by explicitly making the control bar positioned, allowing it to overlay some tracking DOM elements before (which are `absolute`). This is FF / IE only.
## What is the value of this and can you measure success?

People can listen to audio again.
## Request for comment

@Calanthe @rich-nguyen  @paperboyo.
