### PR TITLE
Remove old sticky code

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -121,18 +121,6 @@
 .top-banner-ad-container--responsive {
     min-height: ($gs-row-height * 7) + 16;
 }
-.top-banner-ad-container--reveal iframe {
-    transform: translateZ(0);
-    transition: height 1s cubic-bezier(0, 0, 0, .985);
-    min-height: 90px;
-
-    // overwrite if in the new sticky ad AB test
-    .sticky-ad-banner & {
-        transition: none;
-        transform: none;
-        min-height: auto;
-    }
-}
 .top-banner-ad-container--above-nav {
     @include mq(tablet) {
         .js-on & {


### PR DESCRIPTION
I have a feeling this will fix #12072.

It appears that the iframe is transitioning before the `render` functions run due to this CSS.

/cc @regiskuckaertz 
