### PR TITLE
Hide low-relevance Outbrain widget behind a switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -247,4 +247,13 @@ trait CommercialSwitches {
     sellByDate = new LocalDate(2016, 3, 2),
     exposeClientSide = false
   )
+
+  val OutbrainLowRel = Switch(
+    "Commercial",
+    "outbrain-low-rel",
+    "Show Outbrain in the low relevance slot in place of the merchandising component",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 3, 31),
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -140,7 +140,7 @@ define([
                 // location right away
                 return Promise.all([
                     isHiResLoaded,
-                    isHiResLoaded ? trackAd('dfp-ad--merchandising') : true
+                    isHiResLoaded && config.switches.outbrainLowRel ? trackAd('dfp-ad--merchandising') : true
                 ]);
             }).then(function (args) {
                 var isHiResLoaded = args[0];

--- a/static/test/javascripts/spec/common/commercial/third-party-tags/outbrain.spec.js
+++ b/static/test/javascripts/spec/common/commercial/third-party-tags/outbrain.spec.js
@@ -51,6 +51,7 @@ define([
                 commercialFeatures = arguments[6];
 
                 config.switches.outbrain = true;
+                config.switches.outbrainLowRel = true;
                 config.page = {
                     section: 'uk-news',
                     isPreview: false,


### PR DESCRIPTION
## What does this change?

Outbrain hasn't fully tested the new widget, as it's not displaying correctly in the Australian edition:
![unnamed](https://cloud.githubusercontent.com/assets/629976/13284482/6b48c78a-daec-11e5-995c-430a13db2a04.png)

I just hid it behind a switch so that they can test on CODE and verify that everything is working as expected.

/cc @JonNorman 
