### PR TITLE
Make colons in branded content logos consistent

### DIFF
--- a/common/app/views/fragments/commercial/badge.scala.html
+++ b/common/app/views/fragments/commercial/badge.scala.html
@@ -1,7 +1,7 @@
 @(content: model.ContentType)(implicit request: RequestHeader)
 @import common.Edition
 @import conf.switches.Switches.SponsoredSwitch
-@import model.{Video, Audio, Gallery, Interactive, Article}
+@import model.{Article, Audio, Gallery, Interactive, Video}
 
 @defining(content.commercial.isSponsored(Some(Edition(request))),
     content.commercial.isAdvertisementFeature,
@@ -44,16 +44,16 @@
                                 @if(content.commercial.hasMultipleSponsors) {
                                     This content is sponsored.
                                 } else {
-                                    Supported by:
+                                    Supported by
                                 }
                             } else {
                                 @if(isAdFeature) {
-                                    Paid for by:
+                                    Paid for by
                                 } else {
                                     @content.commercial.sponsorshipTag.map { tag =>
-                                        @tag.name is supported by:
+                                        @tag.name is supported by
                                     }.getOrElse {
-                                        Supported by:
+                                        Supported by
                                     }
                                 }
                             }

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/foundation-funded-logo.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/foundation-funded-logo.js
@@ -22,7 +22,7 @@ define([
         this.$adSlot       = $adSlot;
         this.params        = params;
         this.params.header = (!config.page.isFront && config.page.sponsorshipTag) ?
-            config.page.sponsorshipTag + ' is supported by:' : 'Supported by:';
+            config.page.sponsorshipTag + ' is supported by' : 'Supported by';
     };
 
     Template.prototype.create = function () {

--- a/static/src/javascripts/projects/common/views/commercial/creatives/logo-sponsored.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/logo-sponsored.html
@@ -1,5 +1,5 @@
 <div class="ad-slot--paid-for-badge__inner">
-    <h3 class="ad-slot--paid-for-badge__header">Supported by:</h3>
+    <h3 class="ad-slot--paid-for-badge__header">Supported by</h3>
     <a href="<%=clickMacro%><%=logoUrl%>" class="ad-slot--paid-for-badge__link">
         <img class="ad-slot--paid-for-badge__logo" src="<%=logoImage%>" />
     </a>


### PR DESCRIPTION
This is a small fix following on from #12061 
