### PR TITLE
don't preroll on advertisement features

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -372,7 +372,9 @@ define([
 
     function init() {
         // The `hasMultipleVideosInPage` flag is temporary until the #10034 will be fixed
-        var shouldPreroll = commercialFeatures.videoPreRolls && !config.page.hasMultipleVideosInPage;
+        var shouldPreroll = commercialFeatures.videoPreRolls &&
+            !config.page.hasMultipleVideosInPage &&
+            !config.page.isAdvertisementFeature;
 
         if (config.switches.enhancedMediaPlayer) {
             if (shouldPreroll) {


### PR DESCRIPTION
# No prerol on ad features
## What does this change?

Stops preroll adverts on video that is already sponsored. e.g. [this](http://www.theguardian.com/netflix-love/video/2016/feb/19/isy-sutties-real-dating-disaster-the-cats-tale-video) (at the moment they've just turned off ads, not showing the sponsors badge).
## What is the value of this and can you measure success?

Less ads on valuable content.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@rich-nguyen @Calanthe @akash1810 
