### PR TITLE
AMP: Only show Outbrain when shouldHideAdverts is false

### DIFF
--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -69,7 +69,10 @@
                     @fragments.amp.onwardTemplateAmp("related-mf2/" + page.metadata.id + ".json")
                 }
 
-                @fragments.amp.outbrain(page)
+                @if(!content.shouldHideAdverts) {
+                    @fragments.amp.outbrain(page)
+                }
+
                 @* Show top container for section front only if current page belongs to one of the following sections *@
                 @* Otherwise show top container for network front *@
                 @* TODO: This list also exists in the JS for fronts on articles a/b test. Pending a decision on that, this should go in the jsconfig, or be removed*@


### PR DESCRIPTION
## What does this change?

Relates to #12026 - Outbrain is currently served on AMP regardless of `shouldHideAdverts`.
This is inconsistent with desktop/regular articles; this astoundingly complex change remedies this.
## What is the value of this and can you measure success?

value: consistency with the desktop/regular articles
measure: self-evident
## Does this affect other platforms - Amp, Apps, etc?

Only AMP
## Request for comment

-- @michaelwmcnamara - I believe that there are still questions around what the behaviour should be for some of the CAPI flags e.g. `legallySensitive`/`sensitive` and how they should be handled, but this at least harmonises the behaviour of Outbrain across both platforms.
