### PR TITLE
Reduce image weight, welcome hidpi screens

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -136,7 +136,7 @@ import collection.JavaConversions._
 
         And("I should see the image url")
         findFirst("[itemprop='associatedMedia image'] [itemprop=url]").getAttribute("content") should
-          endWith("/img/static/sys-images/Guardian/Pix/pictures/2012/8/6/1344274684805/Gunnerside-village-Swaled-009.jpg?w=300&q=85&auto=format&sharp=10&s=74e8ef24701fb21a730d6f5189ad142d")
+          endWith("/img/static/sys-images/Guardian/Pix/pictures/2012/8/6/1344274684805/Gunnerside-village-Swaled-009.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=5c104f891f729f652c8f50caf5ee2dc6")
 
         And("I should see the image width")
         findFirst("[itemprop='associatedMedia image'] [itemprop=width]").getAttribute("content") should be("460")
@@ -395,7 +395,7 @@ import collection.JavaConversions._
 
         And("video meta thumbnailUrl should be set")
         findFirst("[itemprop='associatedMedia video'] [itemprop=thumbnailUrl]").getAttribute("content") should
-          endWith("img/static/sys-images/Guardian/Pix/audio/video/2014/5/16/1400240928538/Nigel-Farage-LBC-debate-i-014.jpg?w=640&h=360&q=85&auto=format&sharp=10&s=642bf1757bcb095c924d2f3789857019")
+          endWith("img/static/sys-images/Guardian/Pix/audio/video/2014/5/16/1400240928538/Nigel-Farage-LBC-debate-i-014.jpg?w=640&h=360&q=55&auto=format&usm=12&fit=max&s=d113cafb7eb9b6e05e71352c83f0c4bf")
 
         And("video meta uploadDate should be set")
         findFirst("[itemprop='associatedMedia video'] [itemprop=uploadDate]").getAttribute("content") should be("2014-05-16T16:09:34.000+01:00")

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -111,6 +111,9 @@
         @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
         <!--[if IE 9]><video style="display: none;"><![endif]-->
         @widths.breakpoints.map { breakpointWidth =>
+            <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                    sizes="@breakpointWidth.width"
+                    srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true)" />
             <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                     sizes="@breakpointWidth.width"
                     srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture))" />

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -5,6 +5,9 @@
     @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
     <!--[if IE 9]><video style="display: none;"><![endif]-->
     @widths.breakpoints.map { breakpointWidth =>
+        <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                sizes="@breakpointWidth.width"
+                srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true)" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"
                 sizes="@breakpointWidth.width"
                 srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia)" />

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -38,7 +38,7 @@ sealed trait ElementProfile {
 
   // NOTE - if you modify this in any way there is a decent chance that you decache all our images :(
   lazy val resizeString = {
-    val qualityparam = if (hidpi && isPng) {"q=20"} else {"q=55"}
+    val qualityparam = if (hidpi) {"q=20"} else {"q=55"}
     val autoParam = "auto=format"
     val sharpParam = "usm=12"
     val fitParam = "fit=max"

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -44,7 +44,7 @@ sealed trait ElementProfile {
     val fitParam = "fit=max"
     val dprParam = if (hidpi) {
       if (isPng) {
-        "dpr=1.5"
+        "dpr=1.3"
       } else {
         "dpr=2"
       }

--- a/common/test/views/support/ImgSrcTest.scala
+++ b/common/test/views/support/ImgSrcTest.scala
@@ -78,12 +78,12 @@ class ImgSrcTest extends FlatSpec with Matchers with OneAppPerSuite {
 
   "ImgSrc" should "convert the URL of a static image to the resizing endpoint with a /static prefix" in {
     ImageServerSwitch.switchOn()
-      Item700.bestFor(image) should be (Some(s"$imageHost/img/static/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg?w=700&q=85&auto=format&sharp=10&s=70cbadc4c6d3f932fe763721dd8ba5ac"))
+      Item700.bestFor(image) should be (Some(s"$imageHost/img/static/sys-images/Guardian/Pix/pictures/2013/7/5/1373023097878/b6a5a492-cc18-4f30-9809-88467e07ebfa-460x276.jpeg?w=700&q=55&auto=format&usm=12&fit=max&s=1e7d3c46056f162deec921e3c21de647"))
   }
 
   it should "convert the URL of a media service to the resizing endpoint with a /media prefix" in {
     ImageServerSwitch.switchOn()
-      Item700.bestFor(mediaImage) should be (Some(s"$imageHost/img/media/knly7wcp46fuadowlsnitzpawm/437_0_3819_2291/1000.jpg?w=700&q=85&auto=format&sharp=10&s=47061238050fb440cc090b52c2f2354f"))
+      Item700.bestFor(mediaImage) should be (Some(s"$imageHost/img/media/knly7wcp46fuadowlsnitzpawm/437_0_3819_2291/1000.jpg?w=700&q=55&auto=format&usm=12&fit=max&s=278bfb59ec002e4ffe05d4ee548c4135"))
   }
 
   it should "not convert the URL of the image if it is disabled" in {
@@ -94,13 +94,13 @@ class ImgSrcTest extends FlatSpec with Matchers with OneAppPerSuite {
   it should "convert the URL of the image if it is a PNG (original image from static.guim.co.uk domain)" in {
     ImageServerSwitch.switchOn()
     val pngImage = ImageMedia.apply(Seq(ImageAsset.make(asset.copy(file = Some("http://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)))
-    Item700.bestFor(pngImage) should be (Some(s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?w=700&q=85&auto=format&sharp=10&s=454c03a065f89e05748e41457c3bcb32"))
+    Item700.bestFor(pngImage) should be (Some(s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?w=700&q=55&auto=format&usm=12&fit=max&s=e0bbacaf2f991bf660e22d4983b891ca"))
   }
 
   it should "convert the URL of the image if it is a PNG (original image from static-secure.guim.co.uk domain)" in {
     ImageServerSwitch.switchOn()
     val pngImage = ImageMedia.apply(Seq(ImageAsset.make(asset.copy(file = Some("http://static-secure.guim.co.uk/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png")),0)))
-    Item700.bestFor(pngImage) should be (Some(s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?w=700&q=85&auto=format&sharp=10&s=454c03a065f89e05748e41457c3bcb32"))
+    Item700.bestFor(pngImage) should be (Some(s"$imageHost/img/static/sys-images/Guardian/Pix/contributor/2014/10/30/1414675415419/Jessica-Valenti-R.png?w=700&q=55&auto=format&usm=12&fit=max&s=e0bbacaf2f991bf660e22d4983b891ca"))
   }
 
   it should "not convert the URL of the image if it is a GIF (we do not support animated GIF)" in {
@@ -117,12 +117,12 @@ class ImgSrcTest extends FlatSpec with Matchers with OneAppPerSuite {
 
   it should "convert the URL of a jpeg s3 upload to the resizing endpoint with a /uploads prefix" in {
     ImageServerSwitch.switchOn()
-    Item700.bestFor(s3UploadJpgImage) should be (Some(s"$imageHost/img/uploads/2016/02/10/Screen_Shot_2016-02-09_at_17.50.09.jpeg?w=700&q=85&auto=format&sharp=10&s=0b99c35bdef4f7797872058898771443"))
+    Item700.bestFor(s3UploadJpgImage) should be (Some(s"$imageHost/img/uploads/2016/02/10/Screen_Shot_2016-02-09_at_17.50.09.jpeg?w=700&q=55&auto=format&usm=12&fit=max&s=2058cee6d51d04886bdf5d179fa900b0"))
   }
 
   it should "convert the URL of a png s3 upload to the resizing endpoint with a /uploads prefix" in {
     ImageServerSwitch.switchOn()
-    Item700.bestFor(s3UploadPNGImage) should be (Some(s"$imageHost/img/uploads/2016/02/04/gu.png?w=700&q=85&auto=format&sharp=10&s=a7334eb719aae4f07c6a4c32e9d005d5"))
+    Item700.bestFor(s3UploadPNGImage) should be (Some(s"$imageHost/img/uploads/2016/02/04/gu.png?w=700&q=55&auto=format&usm=12&fit=max&s=16cc94b0e0a1c8081cf377da5c14ee51"))
   }
 
   it should "not convert the URL of a gif s3 upload (we do not support animated GIF)" in {


### PR DESCRIPTION
## What does this change?

Updates imgix settings, based on @paperboyo's research:
- reduces quality from  from `q=85` to `q=55`
- adds `fit=max` to prevent upsizing images beyond the original
- changes sharpening to use `usm=12` (no idea, ask @paperboyo!)

It turns out you can drop the `q` enormously if you serve higher resolution images for hidpi screens, so it also:
- reduces quality from `q=85` to `q=20` for JPGs on `@1.25x`\+ screens
- serves `dpr=2` non-PNGs to `@1.25x`\+ screens
- serves `dpr=1.3` PNGs to `@1.25x`\+ screens (PNGs aren't affected by `q`)
## What is the value of this and can you measure success?

Reduces image payload while improving or maintaining quality. The actual saving depends on browser capabilities and the content of the images, but for the current UK network front, desktop breakpoint:

| format | current | `@1.25x`+ | `@1x` |
| --- | --: | --: | --: |
| JPG | 1847kb | 862kb | 754kb |
| WEBP | 572kb | 442kb | 421kb |

As mentioned above, `q` doesn't actually affect PNGs, which we use for cutouts. The affect of serving them `@2x` too is great (Steven Trasher's cutout on a standard item went from 12kb to 45kb). Offering a 1.3 version increases the file size to 19kb while still looking sharper.
## Screenshots (hidpi only)

Non-hidpi look near enough identical. 

Differences in these hidpi screenshots won't really be noticeable on non-hidpi screens…
### before

<img width="482" alt="screen shot 2016-02-24 at 15 05 02" src="https://cloud.githubusercontent.com/assets/867233/13289453/0514bc8c-db08-11e5-8504-96109a4068ca.png">

<img width="535" alt="screen shot 2016-02-24 at 15 06 23" src="https://cloud.githubusercontent.com/assets/867233/13289558/45999264-db08-11e5-8b8e-e4190b625f58.png">
### after

<img width="483" alt="screen shot 2016-02-24 at 15 04 54" src="https://cloud.githubusercontent.com/assets/867233/13289456/0702230e-db08-11e5-8fd2-5adec8cbf182.png">

<img width="530" alt="screen shot 2016-02-24 at 15 06 52" src="https://cloud.githubusercontent.com/assets/867233/13289569/4d7f3d8a-db08-11e5-927f-c3bfcd84a715.png">
## Request for comment

@paperboyo, @jennysivapalan / @rich-nguyen for scala ;)
