### PR TITLE
Enchilada gallery and liveblog fixes

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -95,17 +95,19 @@
     @if(!gallery.content.shouldHideAdverts && rowNum % adInterval == 0) {
         @adSlots.lift((rowNum / adInterval) - 1).map { adSlot =>
             <li class="gallery2__item gallery2__item--advert">
-                @defining(if(adSlot == "inline1") Option("300,250") else None) { mpuSlotSize =>
-                    @fragments.commercial.standardAd(
-                        adSlot,
-                        Seq("gallery-inline", "dark"),
-                        Map(
-                            "mobile" -> (Seq("1,1", "300,50") ++ mpuSlotSize),
-                            "mobile-landscape" -> (Seq("1,1", "300,50", "320,50") ++ mpuSlotSize),
-                            "tablet" -> Seq("1,1", "300,250")
+                <div class="gallery2__img-container">
+                    @defining(if(adSlot == "inline1") Option("300,250") else None) { mpuSlotSize =>
+                        @fragments.commercial.standardAd(
+                            adSlot,
+                            Seq("gallery-inline", "dark"),
+                            Map(
+                                "mobile" -> (Seq("1,1", "300,50") ++ mpuSlotSize),
+                                "mobile-landscape" -> (Seq("1,1", "300,50", "320,50") ++ mpuSlotSize),
+                                "tablet" -> Seq("1,1", "300,250")
+                            )
                         )
-                    )
-                }
+                    }
+                </div>
             </li>
         }
     }

--- a/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/liveblog-dynamic-adverts.js
@@ -61,7 +61,7 @@ define([
 
     function insertAds(slots) {
         for (var i = 0; i < slots.length && slotCounter < MAX_ADS; i++) {
-            var $adSlot = bonzo(createAdSlot('inline1' + slotCounter++, 'liveblog-inline'));
+            var $adSlot = bonzo(createAdSlot('inline1' + slotCounter++, 'liveblog-inline block'));
             $adSlot.insertAfter(slots[i]);
             dfp.addSlot($adSlot);
         }

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -148,12 +148,23 @@ $mobile-max-container-width: gs-span(8);
         width: 300px;
     }
 
+    // Hide 'advertisement' label for gu style
     .ad-slot__label {
         display: none;
     }
 
-    // Right slot width is exactly the size of the banner so we don't want any margin
+    // Article styles: Right slot width is exactly the size of the banner so we don't want any margin
     &.ad-slot--right {
         margin: 0 auto;
+    }
+
+    // Gallery section styles
+    &.ad-slot--gallery-inline {
+        margin: 0 auto;
+        padding-bottom: 0;
+
+        @include mq(tablet) {
+            width: 300px;
+        }
     }
 }

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -128,14 +128,17 @@ $mobile-max-container-width: gs-span(8);
 .gu-style {
     width: auto;
     border-top: #fedd79 1px solid;
-    margin: 0 $gs-gutter / 2;
+    margin-left: $gs-gutter / 2;
+    margin-right: $gs-gutter / 2;
 
     @include mq(mobileLandscape) {
-        margin: 0 $gs-gutter;
+        margin-left: $gs-gutter;
+        margin-right: $gs-gutter;
     }
 
     @include mq(containerWidestMobile) {
-        margin: 0 auto;
+        margin-left: auto;
+        margin-right: auto;
         width: $mobile-max-container-width;
     }
 
@@ -155,12 +158,16 @@ $mobile-max-container-width: gs-span(8);
 
     // Article styles: Right slot width is exactly the size of the banner so we don't want any margin
     &.ad-slot--right {
-        margin: 0 auto;
+        margin-left: auto;
+        margin-right: auto;
     }
 
-    // Gallery section styles
-    &.ad-slot--gallery-inline {
-        margin: 0 auto;
+    // Gallery & Liveblog sections styles
+    &.ad-slot--gallery-inline,
+    &.ad-slot--liveblog-inline {
+        margin-left: auto;
+        margin-right: auto;
+        padding-top: 0;
         padding-bottom: 0;
 
         @include mq(tablet) {

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comlabel.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comlabel.scss
@@ -1,4 +1,6 @@
 .gu-comlabel {
+    color: colour(neutral-1);
+    
     .gu-comlabel__btn {
         @include f-textSans;
         @include font-size(14, 10);


### PR DESCRIPTION
# Awesome changes to enchilada format
## What does this change?

Positions and margins of enchilada format across different sections of the website
## What is the value of this and can you measure success?

Looks amazing. It has more smooth integration with the content.
## Screenshots

Gallery:
<img width="802" alt="screen shot 2016-02-24 at 14 33 13" src="https://cloud.githubusercontent.com/assets/2579465/13290853/60537034-db0d-11e5-8495-1241c99c16fa.png">
<img width="421" alt="screen shot 2016-02-24 at 14 35 34" src="https://cloud.githubusercontent.com/assets/2579465/13290854/605722b0-db0d-11e5-8d61-41928856f979.png">

Liveblog:
<img width="872" alt="screen shot 2016-02-24 at 14 53 02" src="https://cloud.githubusercontent.com/assets/2579465/13290862/69dd7370-db0d-11e5-93fa-165eca073231.png">
<img width="680" alt="screen shot 2016-02-24 at 14 53 25" src="https://cloud.githubusercontent.com/assets/2579465/13290863/69df8692-db0d-11e5-80f1-1d232a2a15cd.png">
