### PR TITLE
Outbrain: Use same codes across all editions for the low-rel slot

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
@@ -26,26 +26,9 @@ define([
         },
 
         merchandising: {
-            UK: {
-                mobile:  { code: 'MB_10' },
-                desktop: { code: 'AR_28' },
-                tablet:  { code: 'MB_11' }
-            },
-            US: {
-                mobile:  { code: 'CRMB_55' },
-                desktop: { code: 'CR_13' },
-                tablet:  { code: 'CRMB_56' }
-            },
-            AU: {
-                mobile:  { code: 'CRMB_57' },
-                desktop: { code: 'CR_14' },
-                tablet:  { code: 'CRMB_58' }
-            },
-            INT: {
-                mobile:  { code: 'CRMB_59' },
-                desktop: { code: 'CR_15' },
-                tablet:  { code: 'CRMB_60' }
-            }
+            mobile:  { code: 'MB_10' },
+            desktop: { code: 'AR_28' },
+            tablet:  { code: 'MB_11' }
         }
     };
 
@@ -53,7 +36,7 @@ define([
         if (!(data.slot in outbrainCodes) || data.slot === 'defaults') {
             return outbrainCodes.defaults[getSection(data.section)][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
         } else {
-            return outbrainCodes.merchandising[data.edition][data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
+            return outbrainCodes.merchandising[data.breakpoint === 'wide' ? 'desktop' : data.breakpoint];
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -55,7 +55,6 @@ define([
         widgetCodes = getCode({
             slot: slot,
             section: config.page.section,
-            edition: config.page.edition,
             breakpoint: breakpoint
         });
         widgetHtml = build(widgetCodes, breakpoint);

--- a/static/test/javascripts/spec/common/commercial/third-party-tags/outbrain.spec.js
+++ b/static/test/javascripts/spec/common/commercial/third-party-tags/outbrain.spec.js
@@ -337,8 +337,7 @@ define([
                 config.page.edition = 'AU';
 
                 sut.load('merchandising').then(function () {
-                    expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('CR_14');
-                    expect($('.OUTBRAIN', $fixtureContainer).last().data('widgetId')).toEqual('CR_14');
+                    expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('AR_28');
                     done();
                 });
             });
@@ -350,7 +349,6 @@ define([
 
                 sut.load('merchandising').then(function () {
                     expect($('.OUTBRAIN', $fixtureContainer).first().data('widgetId')).toEqual('MB_11');
-                    expect($('.OUTBRAIN', $fixtureContainer).last().data('widgetId')).toEqual('MB_11');
                     done();
                 });
             });


### PR DESCRIPTION
Despite having sent us four sets of codes, one for each edition, OB now wants us to use only one. Let's save a few bytes then!

cc @JonNorman 
