### PR TITLE
Some juicy css specificity overrides

### DIFF
--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -35,6 +35,7 @@
     color: #ffffff;
 }
 
+.content--immersive .from-content-api .gu-display__content-title,
 .gu-display__content-title {
     @include f-headlineSans;
     @include font-size(20, 20);
@@ -85,6 +86,7 @@
     color: #ffffff;
 }
 
+.content--immersive .from-content-api .gu-display__content-color--dark,
 .gu-display__content-color--dark {
     color: #000000;
 }


### PR DESCRIPTION
I am not enjoying this PR. All this madness is to fix this:

<img width="381" alt="screen shot 2016-02-24 at 17 40 31" src="https://cloud.githubusercontent.com/assets/2579465/13315750/996239f4-dba4-11e5-94c4-2152a94360f1.png">

And it happens because of this:
<img width="308" alt="screen shot 2016-02-24 at 17 40 44" src="https://cloud.githubusercontent.com/assets/2579465/13315758/a535bec2-dba4-11e5-9cb1-462663ed4132.png">
