### PR TITLE
Switch h2 rules for sign-up positioning

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -104,7 +104,7 @@ define([
                 fromBottom: true,
                 selectors: {
                     ' .element-rich-link': {minAbove: 100, minBelow: 100},
-                    ' > h2': {minAbove: 0, minBelow: 200},
+                    ' > h2': {minAbove: 200, minBelow: 0},
                     ' > *:not(p):not(h2):not(blockquote)': {minAbove: 35, minBelow: 200},
                     ' .ad-slot': {minAbove: 150, minBelow: 200}
                 }


### PR DESCRIPTION
# I got some numbers wrong
## What does this change?

It makes sure the email sign-up has 200px space _below_ an h2, instead of above so that we don't get the sign-up form immediately after the heading.
## What is the value of this and can you measure success?

It is a bugfix to avoid bad flow of articles.
