### PR TITLE
Fixing liveblog ads css

### DIFF
--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -8,7 +8,7 @@
 @import model.liveblog.{LiveBlogDate}
 
 @blocks.map { block =>
-    <div id="block-@block.id" class="block@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
+    <div id="block-@block.id" class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
         <p class="block-time published-time">
             <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
             @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -165,13 +165,10 @@ $mobile-max-container-width: gs-span(8);
     // Gallery & Liveblog sections styles
     &.ad-slot--gallery-inline,
     &.ad-slot--liveblog-inline {
+        width: 100%;
         margin-left: auto;
         margin-right: auto;
         padding-top: 0;
         padding-bottom: 0;
-
-        @include mq(tablet) {
-            width: 300px;
-        }
     }
 }

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -149,13 +149,17 @@ $block-padding-right: $gs-gutter;
    ========================================================================== */
 .block {
     @include clearfix;
+
     margin-bottom: $gs-baseline;
+    position: relative;
+}
+
+.block--content {
     padding-top: $gs-baseline/2;
     padding-bottom: $gs-baseline;
     background-color: #ffffff;
     border-top: 1px solid colour(neutral-3);
     border-bottom: 1px solid colour(neutral-6);
-    position: relative;
 }
 
 .block.is-key-event,


### PR DESCRIPTION
Some fixes to liveblog ads which I accidentally introduced yesterday.

New state:
<img width="837" alt="screen shot 2016-02-25 at 12 09 53" src="https://cloud.githubusercontent.com/assets/2579465/13319440/8c109c90-dbb9-11e5-86c4-cf188b55bcd1.png">
![screen shot 2016-02-25 at 12 15 27](https://cloud.githubusercontent.com/assets/2579465/13319441/8c112480-dbb9-11e5-8f5e-c24eb464ae72.png)

Still looks good on gallery:
![screen shot 2016-02-25 at 12 11 42](https://cloud.githubusercontent.com/assets/2579465/13319447/96940fda-dbb9-11e5-9aad-ea4cb67f9fe7.png)
![screen shot 2016-02-25 at 12 18 23](https://cloud.githubusercontent.com/assets/2579465/13319478/cc9aa116-dbb9-11e5-8741-281fbca0bcff.png)

CC @regiskuckaertz 
