### PR TITLE
Don't use space-finder for G-today AU

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -44,8 +44,10 @@ define([
                 successHeadline: 'Thank you for signing up to the Guardian US Campaign minute',
                 successDescription: 'We will send you the biggest political story lines of the day',
                 modClass: 'post-article',
-                insertMethod: function ($iframeEl) {
-                    $iframeEl.insertAfter('.js-article__container');
+                insertMethod: function () {
+                    return function ($iframeEl) {
+                        $iframeEl.insertAfter('.js-article__container');
+                    }
                 }
             },
             theFilmToday: {
@@ -89,7 +91,19 @@ define([
                 description: 'Sign up to The Guardian Today daily email and get the biggest headlines each morning.',
                 successHeadline: 'Thank you for signing up to the Guardian Today',
                 successDescription: 'We will send you our picks of the most important headlines tomorrow morning.',
-                modClass: 'end-article'
+                modClass: 'end-article',
+                insertMethod: function () {
+                    switch (config.page.edition) {
+                        case 'AU':
+                            // In AU Edition, we want to place the article at the bottom of the body
+                            // and not use space-finder
+                            return function ($iframeEl) {
+                                $iframeEl.appendTo('.js-article__body');
+                            };
+                        default:
+                            return false;
+                    }
+                }
             }
         },
         emailInserted = false,
@@ -123,10 +137,9 @@ define([
                 bean.on(iframe, 'load', function () {
                     email.init(iframe);
                 });
-
-                if (listConfig.insertMethod) {
+                if (listConfig.insertMethod && listConfig.insertMethod()) {
                     fastdom.write(function () {
-                        listConfig.insertMethod($iframeEl);
+                        listConfig.insertMethod()($iframeEl);
                     });
                 } else {
                     spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -47,7 +47,7 @@ define([
                 insertMethod: function () {
                     return function ($iframeEl) {
                         $iframeEl.insertAfter('.js-article__container');
-                    }
+                    };
                 }
             },
             theFilmToday: {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -93,15 +93,14 @@ define([
                 successDescription: 'We will send you our picks of the most important headlines tomorrow morning.',
                 modClass: 'end-article',
                 insertMethod: function () {
-                    switch (config.page.edition) {
-                        case 'AU':
-                            // In AU Edition, we want to place the article at the bottom of the body
-                            // and not use space-finder
-                            return function ($iframeEl) {
-                                $iframeEl.appendTo('.js-article__body');
-                            };
-                        default:
-                            return false;
+                    if (config.page.edition === 'AU') {
+                        // In AU Edition, we want to place the article at the bottom of the body
+                        // and not use space-finder
+                        return function ($iframeEl) {
+                            $iframeEl.appendTo('.js-article__body');
+                        };
+                    } else {
+                        return false;
                     }
                 }
             }


### PR DESCRIPTION
## What does this change?

The method of insertion for The Guardian Today in Australia will now use a basic insert to the bottom of the article, instead of using space-finder.
## What is the value of this and can you measure success?

This was a request from Aus editorial, so keeps them happy but also gives us a comparison to be able to measure sign-ups when the form is bottom of article vs mid-article.
## Does this affect other platforms - Amp, Apps, etc?

Nope.
## Request for comment

@crifmulholland
