### PR TITLE
Amp tweaks

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -16,7 +16,6 @@
     font-stretch: normal;
 }
 .guardian-egyptian-loaded .content__headline,
-.guardian-egyptian-loaded .element-rich-link--not-upgraded a,
 .guardian-egyptian-loaded .content__labels,
 .guardian-egyptian-loaded .element-pullquote,
 .guardian-egyptian-loaded .tonal__standfirst,
@@ -35,8 +34,11 @@
 .guardian-egyptian-loaded .fc-item__header,
 .guardian-egyptian-loaded .fc-container__header__title,
 .guardian-egyptian-loaded .control__info,
+.guardian-egyptian-loaded .element-rich-link--not-upgraded a,
 .guardian-egyptian-loaded .element-pullquote footer,
-.guardian-egyptian-loaded .signposting__item a {
+.guardian-egyptian-loaded .signposting__item a,
+.guardian-egyptian-loaded .from-content-api h2,
+.guardian-egyptian-loaded .from-content-api .block-elements h2 {
     font-family: "Guardian Egyptian Web", Georgia, serif;
     font-weight: 500;
 }

--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -38,7 +38,8 @@
 .guardian-egyptian-loaded .element-pullquote footer,
 .guardian-egyptian-loaded .signposting__item a,
 .guardian-egyptian-loaded .from-content-api h2,
-.guardian-egyptian-loaded .from-content-api .block-elements h2 {
+.guardian-egyptian-loaded .from-content-api .block-elements h2,
+.guardian-egyptian-loaded .from-content-api p strong {
     font-family: "Guardian Egyptian Web", Georgia, serif;
     font-weight: 500;
 }

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -193,7 +193,7 @@
         color: #005689;
     }
 
-    .from-content-api h2, .from-content-api .block-elements h2, .from-content-api p strong {
+    .from-content-api p strong {
         letter-spacing: -0.02em;
     }
 

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -193,10 +193,6 @@
         color: #005689;
     }
 
-    .from-content-api p strong {
-        letter-spacing: -0.02em;
-    }
-
     @* Dropcap styling *@
     .drop-cap__inner {
         float: left;

--- a/common/app/views/fragments/amp/stylesheets/social.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/social.scala.html
@@ -45,6 +45,7 @@
 
 .meta__extras {
     padding: 0.375rem 0;
+    clear: both;
 }
 
 .submeta hr, .meta__extras {


### PR DESCRIPTION
Firstly a small fix to prevent this from happening:
![screen shot 2016-02-24 at 11 08 05](https://cloud.githubusercontent.com/assets/14570016/13323979/b8e50746-dbd3-11e5-9d13-70fcca0b3be5.png)

Then typography, The bold weight of Georgia is **SO FAT**, that it warrants using the medium cut of Egyptian Web we have available as a replacement. Examples of why:

![dustbag](https://cloud.githubusercontent.com/assets/14570016/13324052/ff0bb58a-dbd3-11e5-92e8-cfadc46b8a1b.png)

CC @NataliaLKB 
