### PR TITLE
Send immersives into email template

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -122,10 +122,10 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
 
     case article: ArticlePage =>
       val htmlResponse = () => {
-        if (article.article.isImmersive) views.html.articleImmersive(article)
-        else if (request.isAmp)          views.html.articleAMP(article)
-        else if (request.isEmail)        views.html.articleEmail(article)
-        else                             views.html.article(article)
+        if (request.isEmail) views.html.articleEmail(article)
+        else if (article.article.isImmersive) views.html.articleImmersive(article)
+        else if (request.isAmp) views.html.articleAMP(article)
+        else views.html.article(article)
       }
 
       val jsonResponse = () => views.html.fragments.articleBody(article)

--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -32,9 +32,11 @@
                 case TextBlockElement(Some(html)) => {
                     @paddedRow(Html(html))
                 }
+
                 case EmbedBlockElement(Some(html), _, _) => {
-                    @fullRow(Html(html))
+                    @*fullRow(Html(html))*@
                 }
+
                 case ImageBlockElement(media, data, showCredit) => {
                     @EmailArticleImage.bestFor(media).map { url =>
 


### PR DESCRIPTION
Slightly change the `ArticleController` logic so that immersives go through to the email template as well as regular articles. Also never render embeds in emails since no email client will show them.
