### PR TITLE
just get the beacon out for the British COuncil

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -239,4 +239,13 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
+  val BritishCouncilBeacon = Switch(
+    "Commercial",
+    "british-council-beacon",
+    "British Council's beacon",
+    safeState = On,
+    sellByDate = new LocalDate(2016, 8, 1),
+    exposeClientSide = false
+  )
+
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -243,7 +243,7 @@ trait CommercialSwitches {
     "Commercial",
     "british-council-beacon",
     "British Council's beacon",
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2016, 8, 1),
     exposeClientSide = false
   )

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -4,6 +4,7 @@
 @import views.support.{OmnitureAnalyticsData, OmnitureAnalyticsAccount}
 @import conf.Static
 @import conf.switches.Switches.NonBlockingOmniture
+@import conf.switches.Switches.BritishCouncilBeacon
 @import common.InlineJs
 
 @if(NonBlockingOmniture.isSwitchedOn) {
@@ -55,3 +56,8 @@
 </noscript>
 
 <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
+
+@if(BritishCouncilBeacon.isSwitchedOn && page.metadata.url.contains("british-council-partner-zone")) {
+    <img alt="DCSIMG" id="DCSIMG" width="1" height="1"
+    src="http://statse.webtrendslive.com/dcsozkqgb00000sh0y1unaabw_9e3r/njs.gif?dcssip=www.guardian.co.uk&amp;dcsuri=/british-council-partner-zone&amp;WT.dl=0&amp;WT.es=www.guardian.co.uk/british-council-partner-zone&amp;WT.sp=Guardian_British_Council_Zone&amp;WT.js=No&amp;WT.tv=BC.nojs.1"/>
+}


### PR DESCRIPTION
## What does this change?

Adds a required beacon by the British Council to their Partner Zone pages
## What is the value of this and can you measure success?

When the client stop complaining
## Does this affect other platforms - Amp, Apps, etc?

Nope. 
## Request for comment
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_

We tried to get this out using KRux, but that's not working right now. This is a quick hack
