### PR TITLE
Determine branded container logo from first card

### DIFF
--- a/applications/app/views/all.scala.html
+++ b/applications/app/views/all.scala.html
@@ -1,24 +1,21 @@
 @(index: services.IndexPage, nav: PreviousAndNext)(implicit request: RequestHeader)
 
+@import layout.{ContainerDisplayConfig, ContainerLayout}
 @import model.pressed.CollectionConfig
 @import views.support.PreviousAndNext
-@import layout.{ContainerLayout, ContainerDisplayConfig}
 
 @main(index.page, projectName = Option("facia")){  }{
 <div class="l-side-margins">
     <div data-link-name="Front" role="main" class="fc-container">
         @fragments.containers.index(
-            index.faciaTrails,
+            index,
             ContainerLayout.singletonFromContainerDefinition(
                 slices.TagContainers.allTagPageSlices(index.trails.length),
                 ContainerDisplayConfig.empty,
                 index.faciaTrails
             ),
             0,
-            index.date,
-            index.page.metadata,
-            nav,
-            index.tzOverride
+            nav
         )(request, CollectionConfig.empty)
     </div>
 </div>

--- a/common/app/common/dfp/PaidForTagAgent.scala
+++ b/common/app/common/dfp/PaidForTagAgent.scala
@@ -1,11 +1,7 @@
 package common.dfp
 
-import java.net.URLDecoder
-
 import common.Edition
 import model.Tag
-import model.`package`.frontKeywordIds
-import model.pressed.CollectionConfig
 
 trait PaidForTagAgent {
 
@@ -118,29 +114,6 @@ trait PaidForTagAgent {
   def isFoundationSupported(capiTagId: String,
                             maybeSectionId: Option[String]): Boolean = {
     isPaidFor(capiTagId, maybeSectionId, maybeEdition = None, FoundationFunded)
-  }
-
-  def findContainerCapiTagIdAndDfpTag(config: CollectionConfig):
-  Option[CapiTagIdAndDfpTag] = {
-
-    def containerCapiTagIds(config: CollectionConfig): Seq[String] = {
-      val stopWords = Set("newest", "order-by", "published", "search", "tag", "use-date")
-
-      config.apiQuery map { encodedQuery =>
-        def negativeClause(token: String): Boolean = token.startsWith("-")
-        val query = URLDecoder.decode(encodedQuery, "utf-8")
-        val tokens = query.split( """\?|&|=|\(|\)|\||\,""")
-        (tokens filterNot negativeClause filterNot stopWords.contains flatMap frontKeywordIds).toSeq
-      } getOrElse Nil
-    }
-
-    val candidateCapiTagIds = containerCapiTagIds(config)
-    for (capiTagId <- candidateCapiTagIds) {
-      for (dfpTag <- findWinningDfpTag(currentPaidForTags, capiTagId, None, None)) {
-        return Some(CapiTagIdAndDfpTag(capiTagId, dfpTag))
-      }
-    }
-    None
   }
 
   def sponsorshipTag(capiTags: Seq[Tag], maybeSectionId: Option[String]): Option[Tag] = {

--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -99,34 +99,6 @@ case class CollectionEssentials(
 )
 
 object ContainerCommercialOptions {
-  def fromConfig(config: CollectionConfig) = {
-    DfpAgent.findContainerCapiTagIdAndDfpTag(config) map { tagData =>
-      val capiTagId = tagData.capiTagId
-      val dfpTag = tagData.dfpTag
-
-      val sponsor = {
-        def tagTypeAndIdMatch(): Boolean = {
-          (dfpTag.tagType == Series && capiTagId.contains("/series/")) ||
-          (dfpTag.tagType == Keyword && capiTagId.matches("(\\w+)/\\1"))
-        }
-        if (tagTypeAndIdMatch()) {
-          dfpTag.lineItems.headOption flatMap (_.sponsor)
-        } else {
-          None
-        }
-      }
-
-      ContainerCommercialOptions(
-        isSponsored = dfpTag.paidForType == Sponsored,
-        isAdvertisementFeature = dfpTag.paidForType == AdvertisementFeature,
-        isFoundationSupported = dfpTag.paidForType == FoundationFunded,
-        sponsor,
-        sponsorshipTag = Some(SponsorshipTag(dfpTag.tagType, capiTagId)),
-        sponsorshipType = Some(dfpTag.paidForType.name),
-        omitMPU = false
-      )
-    } getOrElse empty
-  }
 
   def fromCollection(collection: CollectionEssentials): ContainerCommercialOptions = {
 
@@ -242,27 +214,26 @@ object FaciaContainer {
     omitMPU: Boolean = false
   ): FaciaContainer = FaciaContainer(
     index,
-    config.id,
-    config.config.displayName orElse collectionEssentials.displayName,
-    config.config.href orElse collectionEssentials.href,
+    dataId = config.id,
+    displayName = config.config.displayName orElse collectionEssentials.displayName,
+    href = config.config.href orElse collectionEssentials.href,
     componentId,
     container,
     collectionEssentials,
     containerLayout,
-    config.config.showDateHeader,
-    config.config.showLatestUpdate,
-    // popular containers should never be sponsored
-    container match {
+    showDateHeader = config.config.showDateHeader,
+    showLatestUpdate = config.config.showLatestUpdate,
+    commercialOptions = container match {
+      // popular containers should never be sponsored
       case MostPopular => ContainerCommercialOptions.mostPopular(omitMPU)
-      case Commercial(SingleCampaign(_)) => ContainerCommercialOptions.fromCollection(collectionEssentials)
       case Commercial(MultiCampaign(_)) => ContainerCommercialOptions.empty
-      case _ => ContainerCommercialOptions.fromConfig(config.config)
+      case _ => ContainerCommercialOptions.fromCollection(collectionEssentials)
     },
-    config.config.description.map(DescriptionMetaHeader),
-    None,
+    customHeader = config.config.description.map(DescriptionMetaHeader),
+    customClasses = None,
     hideToggle = false,
     showTimestamps = false,
-    None,
+    dateLinkPath = None,
     useShowMore = true,
     hasShowMoreEnabled = !config.config.hideShowMore
   )

--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -1,14 +1,14 @@
 package model
 
-import common.{NavItem, SectionLink, Pagination}
+import common.{NavItem, Pagination, SectionLink}
 import model.content._
 import model.facia.PressedCollection
 import model.liveblog.{BlockAttributes, BodyBlock}
-import quiz._
+import model.pressed._
 import org.joda.time.DateTime
-import play.api.libs.json._
 import play.api.libs.functional.syntax._
-import pressed._
+import play.api.libs.json._
+import quiz._
 
 object ElementsFormat {
 
@@ -221,6 +221,7 @@ object ContentTypeFormat {
 
   private case class JsonCommercial(
     isInappropriateForSponsorship: Boolean,
+    sponsor: Option[String],
     sponsorshipTag: Option[Tag],
     isFoundationSupported: Boolean,
     isAdvertisementFeature: Boolean,
@@ -259,6 +260,7 @@ object ContentTypeFormat {
        val sharelinks = ShareLinks.apply(tags, fields, metadata)
        val commercial = Commercial.apply(tags, metadata,
         jsonCommercial.isInappropriateForSponsorship,
+        jsonCommercial.sponsor,
         jsonCommercial.sponsorshipTag,
         jsonCommercial.isFoundationSupported,
         jsonCommercial.isAdvertisementFeature,
@@ -333,6 +335,7 @@ object ContentTypeFormat {
         ),
         JsonCommercial.apply(
           content.commercial.isInappropriateForSponsorship,
+          content.commercial.sponsor,
           content.commercial.sponsorshipTag,
           content.commercial.isFoundationSupported,
           content.commercial.isAdvertisementFeature,

--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -1,10 +1,9 @@
 @(containerType: slices.CommercialContainerType, container: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
 @import common.{Edition, LinkTo}
-@import conf.switches.Switches
 @import layout.{ColumnAndCards, ContentCard, FaciaCardAndIndex}
 @import model.InlineImage
 @import slices.{MultiCampaign, SingleCampaign}
-@import views.html.fragments.containers.facia_cards.{showMore, showMoreButton, standardContainer}
+@import views.html.fragments.containers.facia_cards.{showMore, showMoreButton}
 @import views.html.fragments.inlineSvg
 @import views.html.fragments.items.elements.facia_cards.{itemImage, title}
 @import views.support.{Commercial, RemoveOuterParaHtml, RenderClasses}
@@ -37,7 +36,7 @@
                         <div class="commercial__body">
                             @for(layout <- container.containerLayout) {
                                 @for(slice <- layout.slices) {
-                                    <ul class="lineitems l-row l-row--cols-@math.min(Commercial.container.numberOfItems(container), 4)">
+                                    <ul class="lineitems l-row l-row--cols-@math.min(Commercial.container.numberOfContentCards(container), 4)">
                                     @for(ColumnAndCards(_, cards) <- slice.columns) {
                                         @for(FaciaCardAndIndex(_, card, hideUpTo) <- cards) {
                                             @card match {
@@ -106,7 +105,7 @@
                             </a>
                         </div>
                         <div class="commercial__body">
-                            @defining(Commercial.containerCard.mkCardsWithSponsorDataAttributes(container, 4)) { items =>
+                            @defining(Commercial.container.mkCardsWithBrandedContentDataAttributes(container, 4)) { items =>
                                 <ul class="lineitems l-row l-row--cols-@math.min(items.length, 4)">
                                     @*
                                     Taking first 4 cards as a temporary fix until container can show a 'more' CTA

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,16 +1,15 @@
 @import com.gu.facia.api.models.FrontPriority
 @(containerDefinition: layout.FaciaContainer,
   frontProperties: model.FrontProperties = model.FrontProperties.empty,
-  isPaidContent: Boolean = false,
+  isPaidFront: Boolean = false,
   frontPriority: Option[FrontPriority] = None
 )(implicit request: RequestHeader)
 
 @import common.dfp.{Keyword, Series}
-@import conf.switches.Switches
 @import layout.MetaDataHeader
 @import slices.{CommercialContainerType, Dynamic, Fixed, MostPopular, NavList, NavMediaList, SingleCampaign}
 @import views.html.fragments.containers.facia_cards.{commercialContainer, containerMetaData, mostPopularContainer, navListContainer, navMediaListContainer, standardContainer}
-@import views.support.{Commercial, GetClasses, RenderClasses}
+@import views.support.{Commercial, GetClasses}
 
 @renderCommercialContainer(containerType: CommercialContainerType) = {
     <div class="fc-container__inner--full-span fc-container__inner--paidfor fc-container__inner">
@@ -26,8 +25,8 @@
         case _ => {}
     }
 
-    @(containerDefinition.container, isPaidContent) match {
-        case (MostPopular, true) => {}
+    @containerDefinition.container match {
+        case _: MostPopular if isPaidFront => {}
         case _ => {
         <section id="@componentName"
         class="@GetClasses.forContainerDefinition(containerDefinition)"

--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -2,19 +2,20 @@
 
 @import common.LinkTo
 @import views.html.fragments.containers.facia_cards.{date, slice}
-@import views.support.Commercial.container
-@import views.support.{GetClasses, PreviousAndNext}
+@import views.support.{BrandedContentDataAttributes, GetClasses, PreviousAndNext}
 
 @* TODO Consolidate this with the master container template to get rid of repetition *@
 
 @defining(page.webTitle) { case (webTitle) =>
     <section class="@GetClasses.forTagContainer(webTitle.nonEmpty)"
         data-link-name="all index"
-        @for(sponsorData <- container.mkSponsorDataAttributes(config)) {
-            @for(sponsor <- sponsorData.sponsor) { data-sponsor="@sponsor" }
-            @for(seriesId <- sponsorData.seriesId) { data-keywords="@seriesId" }
-            @for(keywordId <- sponsorData.keywordId) { data-keywords="@keywordId" }
-            @for(sponsorshipType <- sponsorData.sponsorshipType) { data-sponsorship="@sponsorshipType" }
+        @for(firstTrail <- trails.headOption) {
+            @for(sponsorData <- BrandedContentDataAttributes(firstTrail)) {
+                @for(sponsor <- sponsorData.sponsor) { data-sponsor="@sponsor" }
+                @for(seriesId <- sponsorData.seriesId) { data-keywords="@seriesId" }
+                @for(keywordId <- sponsorData.keywordId) { data-keywords="@keywordId" }
+                @for(sponsorshipType <- sponsorData.sponsorshipType) { data-sponsorship="@sponsorshipType" }
+            }
         }
         data-component="all index">
         <div class="fc-container__inner">

--- a/common/app/views/fragments/containers/index.scala.html
+++ b/common/app/views/fragments/containers/index.scala.html
@@ -1,28 +1,24 @@
-@(trails: Seq[model.pressed.PressedContent], containerLayout: layout.ContainerLayout, containerIndex: Int, actualDate: org.joda.time.DateTime, page: model.MetaData, nav: PreviousAndNext, tzOverride: Option[org.joda.time.DateTimeZone] = None)(implicit request: RequestHeader, config: model.pressed.CollectionConfig)
-
+@(indexPage: services.IndexPage,
+  containerLayout: layout.ContainerLayout,
+  containerIndex: Int,
+  nav: PreviousAndNext)(implicit request: RequestHeader, config: model.pressed.CollectionConfig)
 @import common.LinkTo
 @import views.html.fragments.containers.facia_cards.{date, slice}
-@import views.support.{BrandedContentDataAttributes, GetClasses, PreviousAndNext}
+@import views.support.{GetClasses, PreviousAndNext}
 
-@* TODO Consolidate this with the master container template to get rid of repetition *@
-
-@defining(page.webTitle) { case (webTitle) =>
+@defining(indexPage.page.metadata.webTitle) { case (webTitle) =>
     <section class="@GetClasses.forTagContainer(webTitle.nonEmpty)"
         data-link-name="all index"
-        @for(firstTrail <- trails.headOption) {
-            @for(sponsorData <- BrandedContentDataAttributes(firstTrail)) {
-                @for(sponsor <- sponsorData.sponsor) { data-sponsor="@sponsor" }
-                @for(seriesId <- sponsorData.seriesId) { data-keywords="@seriesId" }
-                @for(keywordId <- sponsorData.keywordId) { data-keywords="@keywordId" }
-                @for(sponsorshipType <- sponsorData.sponsorshipType) { data-sponsorship="@sponsorshipType" }
-            }
-        }
+        @for(sponsor <- indexPage.commercial.sponsor) { data-sponsor="@sponsor" }
+        @for(seriesId <- indexPage.commercial.seriesId) { data-keywords="@seriesId" }
+        @for(keywordId <- indexPage.commercial.keywordId) { data-keywords="@keywordId" }
+        @for(sponsorshipType <- indexPage.commercial.sponsorshipType) { data-sponsorship="@sponsorshipType" }
         data-component="all index">
         <div class="fc-container__inner">
             <div class="fc-container__header js-container__header">
                 <div class="fc-container__header__title">
                     <span class="u-text-hyphenate">@Html(webTitle)</span>
-                    @date(actualDate, tzOverride)
+                    @date(indexPage.date, indexPage.tzOverride)
                 </div>
             </div>
             <div class="fc-container__body fc-container--rolled-up-hide">
@@ -38,6 +34,6 @@
                 }
             </div>
         </div>
-        @fragments.trendingTopics(trails, page.id)
+        @fragments.trendingTopics(indexPage.faciaTrails, indexPage.page.metadata.id)
     </section>
 }

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -6,7 +6,7 @@ import common.dfp.AdSize.{leaderboardSize, responsiveSize}
 import common.dfp._
 import conf.switches.Switches._
 import layout.{ColumnAndCards, ContentCard, FaciaContainer}
-import model.pressed.{CollectionConfig, PressedContent}
+import model.pressed.PressedContent
 import model.{ContentType, MetaData, Page, Tag}
 
 object Commercial {
@@ -87,42 +87,8 @@ object Commercial {
       container.commercialOptions.isAdvertisementFeature
     }
 
-    def mkSponsorDataAttributes(config: CollectionConfig): Option[SponsorDataAttributes] = {
-      DfpAgent.findContainerCapiTagIdAndDfpTag(config) map { tagData =>
-        val capiTagId = tagData.capiTagId
-        val dfpTag = tagData.dfpTag
-        def tagId(tagType: TagType) = if (dfpTag.tagType == tagType) Some(capiTagId) else None
-        SponsorDataAttributes(
-          sponsor = dfpTag.lineItems.headOption flatMap (_.sponsor),
-          sponsorshipType = dfpTag.paidForType.name,
-          seriesId = tagId(Series),
-          keywordId = tagId(Keyword)
-        )
-      }
-    }
-
-    def numberOfItems(container: FaciaContainer): Int = container.containerLayout.map {
-      _.slices.flatMap {
-        _.columns.flatMap { case ColumnAndCards(_, cards) =>
-          cards.flatMap {
-            _.item match {
-                case card: ContentCard => Some(card)
-                case _ => None
-            }
-          }
-        }
-      }.length
-    }.getOrElse(0)
-  }
-
-  object containerCard {
-
-    def mkCardsWithSponsorDataAttributes(
-      container: FaciaContainer,
-      maxCardCount: Int
-    ): Seq[CardWithSponsorDataAttributes] = {
-
-      val contentCards = container.containerLayout map {
+    private def contentCards(container: FaciaContainer): Seq[Option[ContentCard]] = {
+      container.containerLayout map {
         _.slices flatMap {
           _.columns flatMap { case ColumnAndCards(_, cards) =>
             cards map {
@@ -134,62 +100,68 @@ object Commercial {
           }
         }
       } getOrElse Nil
+    }
 
+    def numberOfContentCards(container: FaciaContainer): Int = contentCards(container).flatten.size
+
+    def mkCardsWithBrandedContentDataAttributes(container: FaciaContainer, maxCardCount: Int):
+    Seq[CardWithBrandedContentDataAttributes] = {
       val cardsAndContents: Seq[ContentCardAndItsContent] = {
-        val allCardsAndContents = contentCards zip container.collectionEssentials.items flatMap {
+        val allCardsAndContents = contentCards(container) zip container.collectionEssentials.items flatMap {
           case (None, _) => None
           case (Some(card), content) => Some(ContentCardAndItsContent(card, content))
         }
         allCardsAndContents take maxCardCount
       }
-
-      cardsAndContents map (CardWithSponsorDataAttributes(_))
+      cardsAndContents map (CardWithBrandedContentDataAttributes(_))
     }
   }
 }
 
 case class ContentCardAndItsContent(card: ContentCard, content: PressedContent)
 
-case class SponsorDataAttributes(
+case class BrandedContentDataAttributes(
   sponsor: Option[String],
   sponsorshipType: String,
   seriesId: Option[String],
   keywordId: Option[String]
 )
 
-case class CardWithSponsorDataAttributes(card: ContentCard, sponsorData: Option[SponsorDataAttributes])
+object BrandedContentDataAttributes {
 
-object CardWithSponsorDataAttributes {
+  def apply(content: PressedContent): Option[BrandedContentDataAttributes] = {
 
-  def apply(cardAndContent: ContentCardAndItsContent): CardWithSponsorDataAttributes = {
-
-    def sponsorDataAttributes(item: PressedContent): Option[SponsorDataAttributes] = {
-
-      def sponsoredTagPair(content: ContentType): Option[CapiTagAndDfpTag] = {
-        DfpAgent.winningTagPair(
-          capiTags = content.tags.tags,
-          sectionId = Some(content.metadata.section),
-          edition = None
-        )
-      }
-
-      def mkFromSponsoredTagPair(tagProps: CapiTagAndDfpTag): SponsorDataAttributes = {
-        val capiTag = tagProps.capiTag
-        val dfpTag = tagProps.dfpTag
-
-        def tagId(p: Tag => Boolean): Option[String] = if (p(capiTag)) Some(capiTag.id) else None
-
-        SponsorDataAttributes(
-          sponsor = dfpTag.lineItems.headOption flatMap (_.sponsor),
-          sponsorshipType = dfpTag.paidForType.name,
-          seriesId = tagId(_.isSeries),
-          keywordId = tagId(_.isKeyword)
-        )
-      }
-
-      item.properties.maybeContent flatMap (sponsoredTagPair(_) map mkFromSponsoredTagPair)
+    def sponsoredTagPair(content: ContentType): Option[CapiTagAndDfpTag] = {
+      DfpAgent.winningTagPair(
+        capiTags = content.tags.tags,
+        sectionId = Some(content.metadata.section),
+        edition = None
+      )
     }
 
-    CardWithSponsorDataAttributes(cardAndContent.card, sponsorDataAttributes(cardAndContent.content))
+    def mkFromSponsoredTagPair(tagProps: CapiTagAndDfpTag): BrandedContentDataAttributes = {
+      val capiTag = tagProps.capiTag
+      val dfpTag = tagProps.dfpTag
+
+      def tagId(p: Tag => Boolean): Option[String] = if (p(capiTag)) Some(capiTag.id) else None
+
+      BrandedContentDataAttributes(
+        sponsor = dfpTag.lineItems.headOption flatMap (_.sponsor),
+        sponsorshipType = dfpTag.paidForType.name,
+        seriesId = tagId(_.isSeries),
+        keywordId = tagId(_.isKeyword)
+      )
+    }
+
+    content.properties.maybeContent flatMap (sponsoredTagPair(_) map mkFromSponsoredTagPair)
+  }
+}
+
+case class CardWithBrandedContentDataAttributes(card: ContentCard, sponsorData: Option[BrandedContentDataAttributes])
+
+object CardWithBrandedContentDataAttributes {
+
+  def apply(cardAndContent: ContentCardAndItsContent): CardWithBrandedContentDataAttributes = {
+    CardWithBrandedContentDataAttributes(cardAndContent.card, BrandedContentDataAttributes(cardAndContent.content))
   }
 }

--- a/common/test/common/dfp/PaidForTagAgentTest.scala
+++ b/common/test/common/dfp/PaidForTagAgentTest.scala
@@ -1,14 +1,10 @@
 package common.dfp
 
 import com.gu.contentapi.client.model.v1.{Tag => ApiTag, TagType => ApiTagType}
-import com.gu.facia.api.{models => fapi}
-import com.gu.facia.client.models.CollectionConfigJson
 import common.Edition.defaultEdition
 import common.editions.Us
 import model.Tag
-import model.pressed.CollectionConfig
 import org.joda.time.DateTime
-import org.scalatest.Inspectors._
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Random
@@ -152,26 +148,6 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
 
     override protected def tagToAdvertisementFeatureSponsorsMap: Map[String, Set[String]] = Map
       .empty
-
-    private def isPaidFor(config: CollectionConfig, paidForType: PaidForType): Boolean = {
-      findContainerCapiTagIdAndDfpTag(config) exists (_.dfpTag.paidForType == paidForType)
-    }
-
-    def isSponsored(config: CollectionConfig): Boolean = {
-      isPaidFor(config, Sponsored)
-    }
-
-    def isAdvertisementFeature(config: CollectionConfig): Boolean = {
-      isPaidFor(config, AdvertisementFeature)
-    }
-
-    def isFoundationSupported(config: CollectionConfig): Boolean = {
-      isPaidFor(config, FoundationFunded)
-    }
-  }
-
-  private def apiQuery(apiQuery: String) = {
-    CollectionConfig.make(fapi.CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(apiQuery = Some(apiQuery))))
   }
 
   "isAdvertisementFeature" should "be true for an advertisement feature" in {
@@ -200,101 +176,6 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
       toSeries("best-awards/best-awards")
     )
     TestPaidForTagAgent.isAdvertisementFeature(tags, maybeSectionId = None) should be(false)
-  }
-
-  it should "be true for an advertisement feature container" in {
-
-    val apiQueries = Seq(
-      "search?tag=books%2Ffilm&section=money",
-      "search?tag=environment%2Fblog%7Cfilm%2Ffilm%2Fguardian-environment-blogs%7Cenvironment" +
-        "%2Fgeorgemonbiot%7Cenvironment%2Fdamian-carrington-blog%7books%2Ffilm",
-      "search?tag=film%2Ffilm&section=sport&page-size=50",
-      "search?tag=books%2Ffilm&section=culture%7Cmusic%7Cgruel%7Cbooks%7Cartanddesign%7Cstage" +
-        "%7Ctv-and-radio",
-      "search?tag=(tone%2Fanalysis%2C(world%2Fusa%7Cfilm%2Ffilm))%7C(tone%2Fcomment%2C" +
-        "(world%2Fusa%7Cbusiness%2Fus-personal-finance))&section=business",
-      "search?tag=business/financial-sector|business/manufacturing-sector|business/luxury-goods" +
-        "-sector|business" +
-        "/fooddrinks|business/theairlineindustry|business/automotive-industry|business/banking" +
-        "|business/construction" +
-        "|filmo/gruel|business/healthcare|business/insurance|business/mining|business" +
-        "/musicindustry|business" +
-        "/pharmaceuticals-industry|business/realestate|business/retail|business/technology|film" +
-        "/film|business" +
-        "/tobacco-industry|business/travelleisure|business/utilities|business/services-sector",
-      "film?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "search?tag=world/mongolia|world/afghanistan|books/film|world/bangladesh|world/bhutan|world" +
-        "/burma|world" +
-        "/kazakhstan|world/kyrgyzstan|world/india|world/maldives|world/nepal|world/pakistan|world" +
-        "/srilanka|world" +
-        "/tajikistan|world/turkmenistan|world/uzbekistan|world/brunei|world/cambodia|world/china" +
-        "|world/indonesia|world" +
-        "/japan|world/laos|world/mongolia|world/malaysia|world/north-korea|world/philippines" +
-        "|world/singapore|world" +
-        "/south-korea|world/taiwan|world/thailand|world/vietnam|world/timor-leste|world/tibet",
-      "books/film",
-      "books/film?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "film?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "books/film?edition=au",
-      "film"
-    )
-
-    forEvery(apiQueries) { q =>
-      TestPaidForTagAgent.isAdvertisementFeature(apiQuery(q)) should be(true)
-    }
-  }
-
-  it should "be true for a partner zone container" in {
-
-    val apiQueries = Seq("media-network/adobe-partner-zone")
-
-    forEvery(apiQueries) { q =>
-      TestPaidForTagAgent.isAdvertisementFeature(apiQuery(q)) should be(true)
-    }
-  }
-
-  it should "be false for a non advertisement feature container" in {
-
-    val apiQueries = Seq(
-      "search?tag=type%2Fvideo&section=money",
-      "search?tag=environment%2Fblog%7Cenvironment%2Fseries%2Fguardian-environment-blogs" +
-        "%7Cenvironment" +
-        "%2Fgeorgemonbiot%7Cenvironment%2Fdamian-carrington-blog%7Cenvironment%2Fbike-blog",
-      "search?tag=type%2Fgallery&section=sport&page-size=50",
-      "search?tag=tone%2Freviews&section=culture%7Cmusic%7Cculture%7Cbooks%7Cartanddesign%7Cstage" +
-        "%7Ctv-and-radio",
-      "search?tag=(tone%2Fanalysis%2C(world%2Fusa%7Cbusiness%2Fus-personal-finance))%7C" +
-        "(tone%2Fcomment%2C" +
-        "(world%2Fusa%7Cbusiness%2Fus-personal-finance))&section=business",
-      "search?tag=business/financial-sector|business/manufacturing-sector|business/luxury-goods" +
-        "-sector|business" +
-        "/fooddrinks|business/theairlineindustry|business/automotive-industry|business/banking" +
-        "|business/construction" +
-        "|film/film-industry|business/healthcare|business/insurance|business/mining|business" +
-        "/musicindustry|business" +
-        "/pharmaceuticals-industry|business/realestate|business/retail|business/technology" +
-        "|business/telecoms|business" +
-        "/tobacco-industry|business/travelleisure|business/utilities|business/services-sector",
-      "technology?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "search?tag=world/mongolia|world/afghanistan|world/azerbaijan|world/bangladesh|world/bhutan" +
-        "|world/burma|world" +
-        "/kazakhstan|world/kyrgyzstan|world/india|world/maldives|world/nepal|world/pakistan|world" +
-        "/srilanka|world" +
-        "/tajikistan|world/turkmenistan|world/uzbekistan|world/brunei|world/cambodia|world/china" +
-        "|world/indonesia|world" +
-        "/japan|world/laos|world/mongolia|world/malaysia|world/north-korea|world/philippines" +
-        "|world/singapore|world" +
-        "/south-korea|world/taiwan|world/thailand|world/vietnam|world/timor-leste|world/tibet",
-      "news/special",
-      "uk/money?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "au?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "sport/motorsports?edition=au",
-      "environment"
-    )
-
-    forEvery(apiQueries) { q =>
-      TestPaidForTagAgent.isAdvertisementFeature(apiQuery(q)) should be(false)
-    }
   }
 
   it should "be true for front of an ad feature section with a multi-part section name" in {
@@ -423,97 +304,6 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
     TestPaidForTagAgent.isSponsored(tags, maybeSectionId = None) should be(false)
   }
 
-  it should "be true for a sponsored container" in {
-
-    val apiQueries = Seq(
-      "search?tag=books%2Fmedia&section=money",
-      "search?tag=environment%2Fblog%7Cmedia%2Fmedia%2Fguardian-environment-blogs%7Cenvironment" +
-        "%2Fgeorgemonbiot%7Cenvironment%2Fdamian-carrington-blog%7books%2Fmedia",
-      "search?tag=media%2Fmedia&section=sport&page-size=50",
-      "search?tag=books%2Fgruel&section=culture%7Cmedia%7Cmusic%7Cbooks%7Cartanddesign%7Cstage" +
-        "%7Ctv-and-radio",
-      "search?tag=(tone%2Fanalysis%2C(world%2Fusa%7Cmedia%2Fmedia))%7C(tone%2Fcomment%2C" +
-        "(world%2Fusa%7Cbusiness%2Fus-personal-finance))&section=business",
-      "search?tag=business/financial-sector|business/manufacturing-sector|business/luxury-goods" +
-        "-sector|business" +
-        "/fooddrinks|business/theairlineindustry|business/automotive-industry|business/banking" +
-        "|business/construction" +
-        "|mediao/gruel|business/healthcare|business/insurance|business/mining|business" +
-        "/musicindustry|business" +
-        "/pharmaceuticals-industry|business/realestate|business/retail|business/technology|media" +
-        "/media|business" +
-        "/tobacco-industry|business/travelleisure|business/utilities|business/services-sector",
-      "media?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "search?tag=world/mongolia|world/afghanistan|books/media|world/bangladesh|world/bhutan" +
-        "|world/burma|world" +
-        "/kazakhstan|world/kyrgyzstan|world/india|world/maldives|world/nepal|world/pakistan|world" +
-        "/srilanka|world" +
-        "/tajikistan|world/turkmenistan|world/uzbekistan|world/brunei|world/cambodia|world/china" +
-        "|world/indonesia|world" +
-        "/japan|world/laos|world/mongolia|world/malaysia|world/north-korea|world/philippines" +
-        "|world/singapore|world" +
-        "/south-korea|world/taiwan|world/thailand|world/vietnam|world/timor-leste|world/tibet",
-      "books/media",
-      "books/media?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "media?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "books/media?edition=au",
-      "media"
-    )
-
-    forEvery(apiQueries) { q =>
-      TestPaidForTagAgent.isSponsored(apiQuery(q)) should be(true)
-    }
-  }
-
-  it should "be false for a non sponsored container" in {
-
-    val apiQueries = Seq(
-      "search?tag=type%2Fvideo&section=money",
-      "search?tag=environment%2Fblog%7Cenvironment%2Fseries%2Fguardian-environment-blogs" +
-        "%7Cenvironment" +
-        "%2Fgeorgemonbiot%7Cenvironment%2Fdamian-carrington-blog%7Cenvironment%2Fbike-blog",
-      "search?tag=type%2Fgallery&section=sport&page-size=50",
-      "search?tag=tone%2Freviews&section=culture%7Cmusic%7Cculture%7Cbooks%7Cartanddesign%7Cstage" +
-        "%7Ctv-and-radio",
-      "search?tag=(tone%2Fanalysis%2C(world%2Fusa%7Cbusiness%2Fus-personal-finance))%7C" +
-        "(tone%2Fcomment%2C" +
-        "(world%2Fusa%7Cbusiness%2Fus-personal-finance))&section=business",
-      "search?tag=business/financial-sector|business/manufacturing-sector|business/luxury-goods" +
-        "-sector|business" +
-        "/fooddrinks|business/theairlineindustry|business/automotive-industry|business/banking" +
-        "|business/construction" +
-        "|film/film-industry|business/healthcare|business/insurance|business/mining|business" +
-        "/musicindustry|business" +
-        "/pharmaceuticals-industry|business/realestate|business/retail|business/technology" +
-        "|business/telecoms|business" +
-        "/tobacco-industry|business/travelleisure|business/utilities|business/services-sector",
-      "technology?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "search?tag=world/mongolia|world/afghanistan|world/azerbaijan|world/bangladesh|world/bhutan" +
-        "|world/burma|world" +
-        "/kazakhstan|world/kyrgyzstan|world/india|world/maldives|world/nepal|world/pakistan|world" +
-        "/srilanka|world" +
-        "/tajikistan|world/turkmenistan|world/uzbekistan|world/brunei|world/cambodia|world/china" +
-        "|world/indonesia|world" +
-        "/japan|world/laos|world/mongolia|world/malaysia|world/north-korea|world/philippines" +
-        "|world/singapore|world" +
-        "/south-korea|world/taiwan|world/thailand|world/vietnam|world/timor-leste|world/tibet",
-      "news/special",
-      "uk/money?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "au?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true",
-      "sport/motorsports?edition=au",
-      "environment"
-    )
-
-    forEvery(apiQueries) { q =>
-      TestPaidForTagAgent.isSponsored(apiQuery(q)) should be(false)
-    }
-  }
-
-  it should "be false for a container built from a query with a negative clause" in {
-    val q = "search?tag=sport/rugby-union,-sport/sixnations"
-    TestPaidForTagAgent.isSponsored(apiQuery(q)) should be(false)
-  }
-
   "isFoundationSupported" should "be true for a foundation-supported page" in {
     TestPaidForTagAgent.isFoundationSupported("global-development/global-development",
       maybeSectionId = None
@@ -524,26 +314,6 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
     TestPaidForTagAgent.isFoundationSupported("guffaw",
       maybeSectionId = None
     ) should be(false)
-  }
-
-  it should "be true for a container with multiple foundation-targeted keywords" in {
-    val q =
-      "search?tag=global-development/series/womens-rights-and-gender-equality-in-focus|" +
-        "(world/gender,global-development/global-development)"
-    TestPaidForTagAgent.isFoundationSupported(apiQuery(q)) should be(true)
-  }
-
-  it should "be true for a container with multiple foundation-targeted series and keywords" in {
-    val q =
-      "search?tag=global-development/series/womens-rights-and-gender-equality-in-focus|" +
-        "(world/gender,global-development/global-development,modern-day-slavery-in-focus)"
-    TestPaidForTagAgent.isFoundationSupported(apiQuery(q)) should be(true)
-  }
-
-  it should "be true for a container with a single foundation-targeted keyword or series" in {
-    val q =
-      "search?tag=global-development/series/womens-rights-and-gender-equality-in-focus"
-    TestPaidForTagAgent.isFoundationSupported(apiQuery(q)) should be(true)
   }
 
   "getSponsor" should "have some value for a sponsored tag with a specified sponsor" in {


### PR DESCRIPTION
## What does this change?

The logos on sponsored/paid/foundation-funded containers were determined by parsing the capi query that builds the container.  This change uses the metadata of the first card in the container to determine the logo instead.
## What is the value of this and can you measure success?
- We're ready to replace ad-server served logos with capi-served logos.
- Targeting is more accurate.
- A branded container can be built with a mixture of manual and automated content as long as the first card targets the correct logo.

/cc @JonNorman 
