### PR TITLE
Email sign-up: Single click for signed-in users

### DIFF
--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -27,7 +27,7 @@
                 <input class="email-sub__text-input js-email-sub__text-input" type="email" name="email" id="@inputId" required />
                 <input class="js-email-sub__listid-input" type="hidden" name="listId" value="@listId" />
             </div>
-            <button type="submit" class="email-sub__submit-input button button--tertiary button--large">@submitText</button>
+            <button type="submit" class="email-sub__submit-input js-email-sub__submit-input button button--tertiary button--large">@fragments.inlineSvg("envelope", "icon", Seq("email-sub__submit-input__icon"))@submitText</button>
             <small class="email-sub__small js-email-sub__small">@smallText</small>
         </div>
     </form>

--- a/common/app/views/fragments/email/signup/emailSignUp.scala.html
+++ b/common/app/views/fragments/email/signup/emailSignUp.scala.html
@@ -23,11 +23,11 @@
     <form action="@LinkTo("/email")" method="post" id="@formId" class="@formClass" data-email-form-type="@componentClass" data-email-list-id="@listId">
         <div class="email-sub__form-wrapper">
             <div class="email-sub__inline-label js-email-sub__inline-label">
-                <label class="email-sub__label js-email-sub__label" for="@inputId">@fragments.inlineSvg("envelope", "icon", Seq("email-sub__label__icon"))@labelText</label>
+                <label class="email-sub__label js-email-sub__label" for="@inputId">@fragments.inlineSvg("envelope", "icon", Seq("label__icon"))@labelText</label>
                 <input class="email-sub__text-input js-email-sub__text-input" type="email" name="email" id="@inputId" required />
                 <input class="js-email-sub__listid-input" type="hidden" name="listId" value="@listId" />
             </div>
-            <button type="submit" class="email-sub__submit-input js-email-sub__submit-input button button--tertiary button--large">@fragments.inlineSvg("envelope", "icon", Seq("email-sub__submit-input__icon"))@submitText</button>
+            <button type="submit" class="email-sub__submit-input js-email-sub__submit-input button button--tertiary button--large">@fragments.inlineSvg("envelope", "icon", Seq("submit-input__icon"))@submitText</button>
             <small class="email-sub__small js-email-sub__small">@smallText</small>
         </div>
     </form>

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -15,7 +15,7 @@ define([
     'text!common/views/email/iframe.html',
     'common/utils/template',
     'common/modules/article/space-filler',
-    'common/modules/analytics/omniture'
+    'common/modules/analytics/omniture',
     'common/utils/robust'
 ], function (
     $,
@@ -34,7 +34,7 @@ define([
     iframeTemplate,
     template,
     spaceFiller,
-    omniture
+    omniture,
     robust
 ) {
 
@@ -153,6 +153,9 @@ define([
                 if (listConfig.insertMethod && listConfig.insertMethod()) {
                     fastdom.write(function () {
                         listConfig.insertMethod()($iframeEl);
+
+                        omniture.trackLinkImmediate('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
+                        emailInserted = true;
                     });
                 } else {
                     spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -196,7 +196,11 @@ define([
         init: function () {
             if (!emailInserted) {
                 // Get the user's current subscriptions
-                Id.getUserEmailSignUps().then(buildUserSubscriptions);
+                Id.getUserEmailSignUps()
+                    .then(buildUserSubscriptions)
+                    .catch(function (error) {
+                        robust.log('c-email', error);
+                    });
             }
         }
     };

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -8,7 +8,7 @@ define([
     'common/utils/detect',
     'lodash/collections/contains',
     'lodash/arrays/intersection',
-    'lodash/collections/pluck',
+    'lodash/collections/map',
     'common/utils/config',
     'lodash/collections/every',
     'lodash/collections/find',
@@ -27,7 +27,7 @@ define([
     detect,
     contains,
     intersection,
-    pluck,
+    map,
     config,
     every,
     find,
@@ -130,7 +130,7 @@ define([
         },
         buildUserSubscriptions = function (response) {
             if (response && response.status !== 'error' && response.result && response.result.subscriptions) {
-                userListSubscriptions = pluck(response.result.subscriptions, 'listId');
+                userListSubscriptions = map(response.result.subscriptions, 'listId');
             }
 
             // Get the first list that is allowed on this page

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -150,7 +150,6 @@ define([
                 bean.on(iframe, 'load', function () {
                     email.init(iframe);
                 });
-
                 if (listConfig.insertMethod && listConfig.insertMethod()) {
                     fastdom.write(function () {
                         listConfig.insertMethod()($iframeEl);
@@ -160,15 +159,12 @@ define([
                     });
                 } else {
                     spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {
-                        var figureEmbed = bonzo.create('<figure class="element element-embed element--supporting">'),
-                            $wrappedEmailEl = $(figureEmbed).append($iframeEl);
-
-                        $wrappedEmailEl.insertBefore(paras[0]);
-
+                        $iframeEl.insertBefore(paras[0]);
                         omniture.trackLinkImmediate('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
                         emailInserted = true;
                     });
                 }
+
             }
         },
         canRunHelpers = {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -199,7 +199,7 @@ define([
 
     return {
         init: function () {
-            if (!emailInserted) {
+            if (!emailInserted && !config.page.isFront) {
                 // Get the user's current subscriptions
                 Id.getUserEmailSignUps()
                     .then(buildUserSubscriptions)

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -150,6 +150,7 @@ define([
                 bean.on(iframe, 'load', function () {
                     email.init(iframe);
                 });
+
                 if (listConfig.insertMethod && listConfig.insertMethod()) {
                     fastdom.write(function () {
                         listConfig.insertMethod()($iframeEl);
@@ -159,12 +160,15 @@ define([
                     });
                 } else {
                     spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {
-                        $iframeEl.insertBefore(paras[0]);
+                        var figureEmbed = bonzo.create('<figure class="element element-embed element--supporting">'),
+                            $wrappedEmailEl = $(figureEmbed).append($iframeEl);
+
+                        $wrappedEmailEl.insertBefore(paras[0]);
+
                         omniture.trackLinkImmediate('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
                         emailInserted = true;
                     });
                 }
-
             }
         },
         canRunHelpers = {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -16,6 +16,7 @@ define([
     'common/utils/template',
     'common/modules/article/space-filler',
     'common/modules/analytics/omniture'
+    'common/utils/robust'
 ], function (
     $,
     bean,
@@ -34,6 +35,7 @@ define([
     template,
     spaceFiller,
     omniture
+    robust
 ) {
 
     var listConfigs = {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -176,7 +176,6 @@ define([
 
                 return !pageIsBlacklisted &&
                         urlRegex.test(document.referrer) &&
-                        !Id.isUserLoggedIn() &&
                         !(browser === 'MSIE' && contains(['7','8','9'], version + ''));
             }
         };

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -199,20 +199,13 @@ define([
                     formSuccessHeadline = (opts && opts.formSuccessHeadline) || formData.formSuccessHeadline,
                     formSuccessDesc = (opts && opts.formSuccessDesc) || formData.formSuccessDesc,
                     removeComforter = (opts && opts.removeComforter) || formData.removeComforter || false,
-                    formModClass = (opts && opts.formModClass) || formData.formModClass || false,
-                    userFromId;
+                    formModClass = (opts && opts.formModClass) || formData.formModClass || false;
 
-                userFromId = Id.getUserFromApi(function(userResponse){
-                        return userResponse;
-                    });
+                Id.getUserFromApi(function (userFromId) {
+                    ui.updateFormForLoggedIn(userFromId, el)
+                });
 
                 fastdom.write(function () {
-                    if (userFromId && userFromId.primaryEmailAddress) {
-                        $('.js-email-sub__inline-label', el).addClass('email-sub__inline-label--is-hidden');
-                        $('.js-email-sub__submit-input', el).addClass('email-sub__submit-input--solo');
-                        $('.js-email-sub__text-input', el).val(userFromId.primaryEmailAddress);
-                    }
-
                     if (formTitle) {
                         $('.js-email-sub__heading', el).text(formTitle);
                     }
@@ -238,6 +231,15 @@ define([
                     customSuccessDesc: formSuccessDesc
                 });
 
+            },
+            updateFormForLoggedIn: function (userFromId, el) {
+                if (userFromId && userFromId.primaryEmailAddress) {
+                    fastdom.write(function () {
+                        $('.js-email-sub__inline-label', el).addClass('email-sub__inline-label--is-hidden');
+                        $('.js-email-sub__submit-input', el).addClass('email-sub__submit-input--solo');
+                        $('.js-email-sub__text-input', el).val(userFromId.primaryEmailAddress);
+                    });
+                }
             },
             setTone: function ($el) {
                 if ($el.hasClass('js-email-sub--article')) {

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -14,7 +14,8 @@ define([
     'common/views/svgs',
     'text!common/views/email/submissionResponse.html',
     'common/utils/robust',
-    'common/utils/detect'
+    'common/utils/detect',
+    'common/modules/identity/api'
 ], function (
     formInlineLabels,
     bean,
@@ -31,7 +32,8 @@ define([
     svgs,
     successHtml,
     robust,
-    detect
+    detect,
+    Id
 ) {
     var omniture;
 
@@ -94,7 +96,8 @@ define([
 
                 formSubmission.bindSubmit($formEl, {
                     formType: $formEl.data('email-form-type'),
-                    listId: $formEl.data('email-list-id')
+                    listId: $formEl.data('email-list-id'),
+                    signedIn: (Id.isUserLoggedIn()) ? 'user signed-in' : 'user not signed-in'
                 });
 
                 // If we're in an iframe, we should check whether we need to add a title and description
@@ -146,7 +149,7 @@ define([
                         state.submitting = true;
 
                         return getOmniture().then(function (omniture) {
-                            omniture.trackLinkImmediate('rtrt | email form inline | ' + analytics.formType + ' | ' + analytics.listId + ' | subscribe clicked');
+                            omniture.trackLinkImmediate('rtrt | email form inline | ' + analytics.formType + ' | ' + analytics.listId + ' | ' + analytics.signedIn + ' | subscribe clicked');
 
                             return ajax({
                                 url: url,
@@ -157,12 +160,12 @@ define([
                                 }
                             })
                             .then(function () {
-                                omniture.trackLinkImmediate('rtrt | email form inline | ' + analytics.formType + ' | ' + analytics.listId + ' | subscribe successful');
+                                omniture.trackLinkImmediate('rtrt | email form inline | ' + analytics.formType + ' | ' + analytics.listId + ' | ' + analytics.signedIn + ' | subscribe successful');
                             })
                             .then(handleSubmit(true, $form))
                             .catch(function (error) {
                                 robust.log('c-email', error);
-                                omniture.trackLinkImmediate('rtrt | email form inline | ' + analytics.formType + ' | ' + analytics.listId + ' | error');
+                                omniture.trackLinkImmediate('rtrt | email form inline | ' + analytics.formType + ' | ' + analytics.listId + ' | ' + analytics.signedIn + ' | error');
                                 handleSubmit(false, $form)();
                             });
                         });
@@ -196,9 +199,20 @@ define([
                     formSuccessHeadline = (opts && opts.formSuccessHeadline) || formData.formSuccessHeadline,
                     formSuccessDesc = (opts && opts.formSuccessDesc) || formData.formSuccessDesc,
                     removeComforter = (opts && opts.removeComforter) || formData.removeComforter || false,
-                    formModClass = (opts && opts.formModClass) || formData.formModClass || false;
+                    formModClass = (opts && opts.formModClass) || formData.formModClass || false,
+                    userFromId;
+
+                userFromId = Id.getUserFromApi(function(userResponse){
+                        return userResponse;
+                    });
 
                 fastdom.write(function () {
+                    if (userFromId && userFromId.primaryEmailAddress) {
+                        $('.js-email-sub__inline-label', el).addClass('email-sub__inline-label--is-hidden');
+                        $('.js-email-sub__submit-input', el).addClass('email-sub__submit-input--solo');
+                        $('.js-email-sub__text-input', el).val(userFromId.primaryEmailAddress);
+                    }
+
                     if (formTitle) {
                         $('.js-email-sub__heading', el).text(formTitle);
                     }

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -202,7 +202,7 @@ define([
                     formModClass = (opts && opts.formModClass) || formData.formModClass || false;
 
                 Id.getUserFromApi(function (userFromId) {
-                    ui.updateFormForLoggedIn(userFromId, el)
+                    ui.updateFormForLoggedIn(userFromId, el);
                 });
 
                 fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/identity/api.js
+++ b/static/src/javascripts/projects/common/modules/identity/api.js
@@ -6,7 +6,8 @@ define([
     'common/utils/cookies',
     'common/utils/mediator',
     'common/utils/storage',
-    'common/modules/asyncCallMerger'
+    'common/modules/asyncCallMerger',
+    'Promise'
 ], function (
     ajax,
     utilAtob,
@@ -14,7 +15,8 @@ define([
     cookies,
     mediator,
     storage,
-    asyncCallMerger
+    asyncCallMerger,
+    Promise
 ) {
 
     /**
@@ -213,6 +215,21 @@ define([
             });
 
         return request;
+    };
+
+    Id.getUserEmailSignUps = function () {
+        if (Id.getUserFromCookie()) {
+            var endpoint = '/useremails/' + Id.getUserFromCookie().id,
+                request = ajax({
+                    url: Id.idApiRoot + endpoint,
+                    type: 'jsonp',
+                    crossOrigin: true
+                });
+
+            return request;
+        }
+
+        return Promise.resolve(null);
     };
 
     Id.sendValidationEmail = function () {

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -98,6 +98,7 @@
 }
 
 .email-sub__submit-input--solo {
+
     .email-sub__submit-input__icon {
         display: inline-block;
         margin-right: $gs-gutter / 4;

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -57,8 +57,8 @@
     display: none;
 }
 
-.email-sub__submit-input__icon,
-.email-sub__label__icon {
+.submit-input__icon,
+.label__icon {
     display: none; // Hidden by default
 
     svg {
@@ -67,11 +67,11 @@
     }
 }
 
-.email-sub__submit-input__icon svg {
+.submit-input__icon svg {
     fill: $form-primary-colour;
 }
 
-.email-sub__label__icon svg {
+.label__icon svg {
     fill: $form-label-colour;
     opacity: .65;
 }
@@ -99,7 +99,7 @@
 
 .email-sub__submit-input--solo {
 
-    .email-sub__submit-input__icon {
+    .submit-input__icon {
         display: inline-block;
         margin-right: $gs-gutter / 4;
     }
@@ -251,7 +251,7 @@
 
 .email-sub__form--article,
 .email-sub__form--plain {
-    .email-sub__label__icon {
+    .label__icon {
         display: inline-block;
         margin-right: $gs-gutter / 4;
     }

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -53,15 +53,27 @@
     }
 }
 
+.email-sub__inline-label--is-hidden {
+    display: none;
+}
+
+.email-sub__submit-input__icon,
 .email-sub__label__icon {
     display: none; // Hidden by default
 
     svg {
-        fill: $form-label-colour;
-        opacity: .65;
         width: 1.143em;
         height: .857em;
     }
+}
+
+.email-sub__submit-input__icon svg {
+    fill: $form-primary-colour;
+}
+
+.email-sub__label__icon svg {
+    fill: $form-label-colour;
+    opacity: .65;
 }
 
 .email-sub__text-input {
@@ -82,6 +94,14 @@
     &:active {
         border-color: $form-primary-colour;
         cursor: pointer;
+    }
+}
+
+.email-sub__submit-input--solo {
+
+    .email-sub__submit-input__icon {
+        display: inline-block;
+        margin-right: $gs-gutter / 4;
     }
 }
 
@@ -165,6 +185,7 @@
     }
 
     .email-sub__small {
+        clear: left;
         color: $form-primary-colour;
         @include fs-textSans(1, $size-only: true);
     }
@@ -219,6 +240,12 @@
 
     .email-sub__message__description {
         color: guss-colour(neutral-1, $pasteup-palette);
+    }
+
+    @include mq($until: tablet) {
+        .email-sub__small {
+            clear: left;
+        }
     }
 }
 

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -98,7 +98,6 @@
 }
 
 .email-sub__submit-input--solo {
-
     .email-sub__submit-input__icon {
         display: inline-block;
         margin-right: $gs-gutter / 4;

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -76,10 +76,6 @@ body {
             padding-left: $gs-gutter / 2;
         }
     }
-
-    .email-sub__form--article .email-sub__submit-input--solo {
-        width: auto;
-    }
 }
 
 // It's a fixed layout so only at this width do we want to apply these styles

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -76,6 +76,10 @@ body {
             padding-left: $gs-gutter / 2;
         }
     }
+
+    .email-sub__form--article .email-sub__submit-input--solo {
+        width: auto;
+    }
 }
 
 // It's a fixed layout so only at this width do we want to apply these styles

--- a/static/src/stylesheets/module/email/_iframe.scss
+++ b/static/src/stylesheets/module/email/_iframe.scss
@@ -62,6 +62,12 @@ body {
             margin-right: 0;
             width: 38%;
         }
+
+        // Solo submit button - for logged in users where we remove the input
+        // because we know the email address already
+        .email-sub__submit-input--solo {
+            border-radius: 1000px;
+        }
     }
 
     .email-sub__form--footer,


### PR DESCRIPTION
Looking to get this in Monday morning.
## What does this change?

This removes the email input for signed in users so that they are able to click the sign up button with no friction. It also checks whether the user has already signed up so they are not shown sign-up forms for emails they already get. Right thing, right time, mate.
## What is the value of this and can you measure success?

This change:
- Improves the user experience of signing up for signed-in users, single click, minimal friction
- Allows us to ensure that signed in users  that are signing-up are tied to one email address, allowing management in email preference correctly
- I have added the state of the user (signed in / out) to the omniture hit to ensure that we can segment the differences between these sign ups
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots
### Signed Out Article

![not signed in article](https://cloud.githubusercontent.com/assets/638051/13359293/53f9a714-dcab-11e5-8ed7-7fe743cd68e9.gif)
### Signed In Article

![signed in article](https://cloud.githubusercontent.com/assets/638051/13359295/53fcab80-dcab-11e5-9a62-79895f0b4143.gif)
### Signed Out Footer

![not signed in footer](https://cloud.githubusercontent.com/assets/638051/13359294/53faf830-dcab-11e5-939f-96b3c17bf65f.gif)
### Signed In Footer

![signed in footer](https://cloud.githubusercontent.com/assets/638051/13359296/53fe04d0-dcab-11e5-86e3-e80b3b62cf2f.gif)
## Request for comment
- @NathanielBennett - Can you look at the ID stuff I've added as you've worked with it before
- @crifmulholland - Checkity check, the chinese chicken.
- @desbo @OliverJAsh - Scan of the JS to see if I've made any sillies or not handled errors anywhere you can see
- @superfrank For reference, I'm going to be doing more on the compact version after this is in, so lets chat then 
