### PR TITLE
Restore self help section

### DIFF
--- a/onward/app/views/feedback.scala.html
+++ b/onward/app/views/feedback.scala.html
@@ -19,6 +19,14 @@
                                 <div class="from-content-api" itemprop="articleBody">
                                     <div class="from-content-api">
                                         <p>Thanks for coming to report a technical issue with our web site.</p>
+                                        <h2>Self help</h2>
+                                        <p>If your problem includes the following</p>
+                                        <ul>
+                                            <li>crashing</li>
+                                            <li>reloading</li>
+                                            <li>very slow site access</li>
+                                        </ul>
+                                        <p>please learn about <a href="@LinkTo{/info/2015/sep/22/making-theguardiancom-work-best-for-you}">disabling optional features on our site</a></p>
                                         <h2>Contact us</h2>
                                         <p>Do you need a response?</p>
                                         <p>


### PR DESCRIPTION
Reverts #11106

We removed this to track crashing, but whilst crashing doesn't appear to be so bad, we can better help users by providing the link to the self-help article.

/cc @ScottPainterGNM 
