### PR TITLE
Added fallback when blended component would not find any item by id

### DIFF
--- a/commercial/app/controllers/commercial/Multi.scala
+++ b/commercial/app/controllers/commercial/Multi.scala
@@ -33,7 +33,9 @@ object Multi
     val eventualContent = componentsAndSpecificIds map {
       case ("jobs", jobId) if jobId.nonEmpty =>
         Future.successful {
-          JobsAgent.specificJobs(Seq(jobId)).headOption map {
+          JobsAgent.specificJobs(Seq(jobId)).headOption orElse {
+            JobsAgent.jobsTargetedAt(segment).headOption
+          } map {
             views.html.jobs.jobFragment(_, clickMacro)
           }
         }
@@ -45,8 +47,10 @@ object Multi
         }
       case ("books", isbn) if isbn.nonEmpty =>
         BestsellersAgent.getSpecificBooks(Seq(isbn)) map { books =>
-          books.headOption map { book =>
-            views.html.books.bookFragment(book, clickMacro)
+          books.headOption orElse {
+            BestsellersAgent.bestsellersTargetedAt(segment).headOption
+          } map {
+            views.html.books.bookFragment(_, clickMacro)
           }
         }
       case ("books", _) =>
@@ -57,7 +61,9 @@ object Multi
         }
       case ("travel", travelId) if travelId.nonEmpty =>
         Future.successful {
-          TravelOffersAgent.specificTravelOffers(Seq(travelId)).headOption map {
+          TravelOffersAgent.specificTravelOffers(Seq(travelId)).headOption orElse {
+            TravelOffersAgent.offersTargetedAt(segment).headOption
+          } map {
             views.html.travel.travelFragment(_, clickMacro)
           }
         }
@@ -69,7 +75,9 @@ object Multi
         }
       case ("masterclasses", eventBriteId) if eventBriteId.nonEmpty =>
         Future.successful {
-          MasterClassAgent.specificClasses(Seq(eventBriteId)).headOption map {
+          MasterClassAgent.specificClasses(Seq(eventBriteId)).headOption orElse {
+            MasterClassAgent.masterclassesTargetedAt(segment).headOption
+          } map {
             views.html.masterClasses.masterClassFragment(_, clickMacro)
           }
         }


### PR DESCRIPTION
## What does this change?

The blended component template in DFP allows the merch team to specify an item for each component, via its ID. Except that if this ID leads to nothing, the whole component fails to display.
## What is the value of this and can you measure success?

This change makes sure the component falls back to fetching a targeted item.

cc @kelvin-chappell 
