### PR TITLE
Email add killswitch

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -199,7 +199,7 @@ define([
 
     return {
         init: function () {
-            if (!emailInserted && !config.page.isFront) {
+            if (!emailInserted && !config.page.isFront && config.switches.emailInArticle) {
                 // Get the user's current subscriptions
                 Id.getUserEmailSignUps()
                     .then(buildUserSubscriptions)

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -180,7 +180,7 @@
         &:focus,
         &:active {
             background-color: darken(guss-colour(neutral-2, $pasteup-palette), 10%);
-            border: 1px solid darken(guss-colour(neutral-2, $pasteup-palette), 10%);
+            border-color: darken(guss-colour(neutral-2, $pasteup-palette), 10%);
         }
     }
 


### PR DESCRIPTION
## What does this change?

Adds killswitch for in-article email signup insertion (the switch already existed, I just hadn't added the check). It also corrects a minor CSS bug.
## What is the value of this and can you measure success?

To do what switches do best, allow us to shut this down if things go pear shaped.
