### PR TITLE
Quality Dashboard - Total grammar fail fix

### DIFF
--- a/admin/app/views/quality.scala.html
+++ b/admin/app/views/quality.scala.html
@@ -91,7 +91,7 @@
                 }
 
                 function titleFromOmnitureResponse(report) {
-                    return "Top " + report[0].report.elements[0].name + "'s"
+                    return "Top " + report[0].report.elements[0].name + "s"
                 }
 
                 return template;


### PR DESCRIPTION
That apostrophe was incorrectly added to the titles, smallest fix ever.
