### PR TITLE
extending outbrain-on-amp for a month

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -235,7 +235,7 @@ trait CommercialSwitches {
     "outbrain-on-amp",
     "Show an Outbrain component on amp pages",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 3, 2),
+    sellByDate = new LocalDate(2016, 4, 5),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
Outbrain on AMP is now live; whilst it is assessed we want to keep it switchable (the switch expires tonight).
