### PR TITLE
Making story packages in AMP have an absolute url instead of a relative one

### DIFF
--- a/common/app/views/fragments/amp/storyPackageAmp.scala.html
+++ b/common/app/views/fragments/amp/storyPackageAmp.scala.html
@@ -3,6 +3,7 @@
 @import model.pressed.CuratedContent
 @import views.support.ContentOldAgeDescriber
 @import views.support.TrailCssClasses
+@import conf.Configuration.site.host
 
 <div class="fc-container__inner">
     <div class="fc-container__header__title">
@@ -50,6 +51,6 @@
                 </time>
             </aside>
         </div>
-        <a href="@content.header.url" class="fc-item__link">@content.header.headline</a>
+        <a href="@{host}/@content.header.url" class="fc-item__link">@content.header.headline</a>
     </div>
 }


### PR DESCRIPTION
# Absolute vs Relative
## What does this change?

Makes sure that links on story packages on amp takes us to www.theguardian.com!
## Does this affect other platforms - Amp, Apps, etc?

Only affects Amp
## Request for comment

@stephanfowler 
