### PR TITLE
Updating name and wording on email formerly known as 'Best of Cif' to 'Best of Guardian Opinion'

### DIFF
--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -38,7 +38,7 @@ object ListIds {
   val guardianTodayUs = 1493
   val guardianTodayAu = 1506
 
-  val theBestOfCiF = 2313
+  val theBestOfOpinion = 2313
   val theFiver = 218
   val mediaBriefing = 217
   val greenLight = 28
@@ -74,7 +74,7 @@ object ListIds {
   val UsElection = 3599
 
   val allWithoutTrigger: List[Int] = List(
-    theBestOfCiF,
+    theBestOfOpinion,
     theFiver,
     mediaBriefing,
     greenLight,

--- a/identity/app/model/EmailSubscriptions.scala
+++ b/identity/app/model/EmailSubscriptions.scala
@@ -56,10 +56,10 @@ object EmailSubscriptions {
       subscribedTo = subscribedListIds.exists{ x => x == "2635" }
     ),
     EmailSubscription(
-      "Best of Comment is free - Australia",
+      "Best of Guardian Opinion - Australia",
       "comment",
-      "Cartoons from Guardian Australia's resident Walkley-winning cartoonist",
-      "An evening selection of the best reads on Comment is free in Australia",
+      "An evening selection of the best reads from Guardian Opinion in Australia",
+      "An evening selection of the best reads from Guardian Opinion in Australia",
       "Daily",
       "2976",
       11,
@@ -187,10 +187,10 @@ object EmailSubscriptions {
       subscribedTo = subscribedListIds.exists{ x => x == "1493" }
     ),
     EmailSubscription(
-      "The best of CiF",
+      "The best of Guardian Opinion",
       "news",
-      "The best of Comment is free",
-      "Comment is free's daily email newsletter with the most shared comment, analysis and editorial articles from the last 24 hours — sign up to read, share and join the debate on the Guardian's most popular opinion pieces every lunchtime.",
+      "Opinion's daily email newsletter",
+      "Guardian Opinion's daily email newsletter with the most shared opinion, analysis and editorial articles from the last 24 hours — sign up to read, share and join the debate every lunchtime.",
       "Weekday lunchtime",
       "2313",
       10,


### PR DESCRIPTION
This changes the name of the "Best of Cif" email signup to "Best of Guardian Opinion"
Descriptions have also been updated.

In addition  email signup name of "Best of Comment is Free - Australia" - has been changed to "Best of Guardian Opinion" and description updated.
