### PR TITLE
Update conditions for showing paid containers in new style

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -127,7 +127,7 @@ object ContainerCommercialOptions {
 
         ContainerCommercialOptions(
           isSponsored = dfpTag.paidForType == Sponsored,
-          isAdvertisementFeature = dfpTag.paidForType == AdvertisementFeature,
+          isPaidContainer = dfpTag.paidForType == AdvertisementFeature,
           isFoundationSupported = dfpTag.paidForType == FoundationFunded,
           sponsor = dfpTag.lineItems.headOption flatMap (_.sponsor),
           sponsorshipTag,
@@ -144,7 +144,7 @@ object ContainerCommercialOptions {
 
   val empty = ContainerCommercialOptions(
     isSponsored = false,
-    isAdvertisementFeature = false,
+    isPaidContainer = false,
     isFoundationSupported = false,
     sponsor = None,
     sponsorshipTag = None,
@@ -157,14 +157,14 @@ object ContainerCommercialOptions {
 
 case class ContainerCommercialOptions(
   isSponsored: Boolean,
-  isAdvertisementFeature: Boolean,
+  isPaidContainer: Boolean,
   isFoundationSupported: Boolean,
   sponsor: Option[String],
   sponsorshipTag: Option[SponsorshipTag],
   sponsorshipType: Option[String],
   omitMPU: Boolean
 ) {
-  val isPaidFor = isSponsored || isAdvertisementFeature || isFoundationSupported
+  val isPaidFor = isSponsored || isPaidContainer || isFoundationSupported
 }
 
 object FaciaContainer {

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -8,7 +8,6 @@ import conf.Configuration.commercial.showMpuInAllContainersPageId
 import contentapi.Paths
 import model.facia.PressedCollection
 import play.api.libs.json.{JsBoolean, JsString, JsValue}
-import services.ConfigAgent
 
 import scala.language.postfixOps
 
@@ -107,8 +106,6 @@ case class PressedPage (
   val navSection: String = metadata.section
 
   val keywordIds: Seq[String] = frontKeywordIds(id)
-
-  lazy val frontPriority: Option[FrontPriority] = ConfigAgent.getFrontPriorityFromConfig(id)
 
   def sponsorshipType: Option[String] = {
     if (isSponsored(None)) {

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -1,9 +1,6 @@
-@import com.gu.facia.api.models.FrontPriority
 @(containerDefinition: layout.FaciaContainer,
   frontProperties: model.FrontProperties = model.FrontProperties.empty,
-  isPaidFront: Boolean = false,
-  frontPriority: Option[FrontPriority] = None
-)(implicit request: RequestHeader)
+  isPaidFront: Boolean = false)(implicit request: RequestHeader)
 
 @import common.dfp.{Keyword, Series}
 @import layout.MetaDataHeader
@@ -55,7 +52,7 @@
 
             @containerDefinition.container match {
 
-                case Fixed(definition) if Commercial.container.shouldRenderAsCommercialContainer(frontPriority, containerDefinition) => {
+                case Fixed(definition) if Commercial.container.shouldRenderAsCommercialContainer(isPaidFront, containerDefinition) => {
                     @renderCommercialContainer(SingleCampaign(definition))
                 }
 

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -1,6 +1,5 @@
 package views.support
 
-import com.gu.facia.api.models.{EditorialPriority, FrontPriority}
 import common.Edition
 import common.dfp.AdSize.{leaderboardSize, responsiveSize}
 import common.dfp._
@@ -82,9 +81,8 @@ object Commercial {
 
   object container {
 
-    def shouldRenderAsCommercialContainer(frontPriority: Option[FrontPriority], container: FaciaContainer): Boolean = {
-      frontPriority.contains(EditorialPriority) &&
-      container.commercialOptions.isAdvertisementFeature
+    def shouldRenderAsCommercialContainer(isPaidFront: Boolean, container: FaciaContainer): Boolean = {
+      !isPaidFront && container.commercialOptions.isAdvertisementFeature
     }
 
     private def contentCards(container: FaciaContainer): Seq[Option[ContentCard]] = {

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -82,7 +82,7 @@ object Commercial {
   object container {
 
     def shouldRenderAsCommercialContainer(isPaidFront: Boolean, container: FaciaContainer): Boolean = {
-      !isPaidFront && container.commercialOptions.isAdvertisementFeature
+      !isPaidFront && container.commercialOptions.isPaidContainer
     }
 
     private def contentCards(container: FaciaContainer): Seq[Option[ContentCard]] = {

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -33,8 +33,7 @@
                         @fragments.containers.facia_cards.container(
                             containerDefinition,
                             faciaPage.frontProperties,
-                            faciaPage.isAdvertisementFeature,
-                            faciaPage.frontPriority
+                            faciaPage.isAdvertisementFeature
                         )
                     }
 


### PR DESCRIPTION
## What does this change?

Paid containers have correct styling on commercial fronts.

The key change is https://github.com/guardian/frontend/compare/kc-paid-containers?expand=1#diff-572795cc410ad8b9f41bbbac4921547eR84
and the rest is just refactoring.
## What is the value of this and can you measure success?

Paid containers now appear consistently everywhere and the business rules make sense.
## Screenshots

You've seen this one before:
![image](https://cloud.githubusercontent.com/assets/1722550/13430393/c93c779a-dfbc-11e5-8473-f86b12017958.png)

/cc @JonNorman 
