### PR TITLE
Add close button to in-article email sign-up

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -16,7 +16,8 @@ define([
     'common/utils/template',
     'common/modules/article/space-filler',
     'common/modules/analytics/omniture',
-    'common/utils/robust'
+    'common/utils/robust',
+    'common/modules/user-prefs'
 ], function (
     $,
     bean,
@@ -35,7 +36,8 @@ define([
     template,
     spaceFiller,
     omniture,
-    robust
+    robust,
+    userPrefs
 ) {
 
     var listConfigs = {
@@ -138,9 +140,16 @@ define([
         },
         listCanRun = function (listConfig) {
             // Check our lists canRun method and make sure that the user isn't already subscribed to this email
-            if (listConfig.canRun && canRunList[listConfig.canRun]() && !contains(userListSubscriptions, listConfig.listId)) {
+            if (listConfig.canRun &&
+                canRunList[listConfig.canRun]() &&
+                !contains(userListSubscriptions, listConfig.listId) &&
+                !userHasRemoved(listConfig.listId, 'article')) {
                 return listConfig;
             }
+        },
+        userHasRemoved = function (id, formType) {
+            var currentListPrefs = userPrefs.get('email-sign-up-' + formType);
+            return currentListPrefs && currentListPrefs.indexOf(id) > -1;
         },
         addListToPage = function (listConfig) {
             if (listConfig) {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -43,7 +43,7 @@ define([
     var listConfigs = {
             theCampaignMinute: {
                 listId: '3599',
-                canRun: 'theCampaignMinute',
+                listName: 'theCampaignMinute',
                 campaignCode: 'the_minute_footer',
                 headline: 'Enjoying The Minute?',
                 description: 'Sign up and we\'ll send you the Guardian US Campaign Minute, once per day.',
@@ -58,7 +58,7 @@ define([
             },
             theFilmToday: {
                 listId: '1950',
-                canRun: 'theFilmToday',
+                listName: 'theFilmToday',
                 campaignCode: 'film_article_signup',
                 headline: 'Want the best of Film, direct to your inbox?',
                 description: 'Sign up to Film Today and we\'ll deliver to you the latest movie news, blogs, big name interviews, festival coverage, reviews and more.',
@@ -68,7 +68,7 @@ define([
             },
             theFiver: {
                 listId: '218',
-                canRun: 'theFiver',
+                listName: 'theFiver',
                 campaignCode: 'fiver_article_signup',
                 headline: 'Want a football roundup direct to your inbox?',
                 description: 'Sign up to the Fiver, our daily email on the world of football',
@@ -91,7 +91,7 @@ define([
                             return '1506';
                     }
                 }()),
-                canRun: 'theGuardianToday',
+                listName: 'theGuardianToday',
                 campaignCode: 'guardian_today_article_bottom',
                 headline: 'Want stories like this in your inbox?',
                 description: 'Sign up to The Guardian Today daily email and get the biggest headlines each morning.',
@@ -139,9 +139,9 @@ define([
             addListToPage(find(listConfigs, listCanRun));
         },
         listCanRun = function (listConfig) {
-            // Check our lists canRun method and make sure that the user isn't already subscribed to this email
-            if (listConfig.canRun &&
-                canRunList[listConfig.canRun]() &&
+            // Check our lists listName method and make sure that the user isn't already subscribed to this email
+            if (listConfig.listName &&
+                canRunList[listConfig.listName]() &&
                 !contains(userListSubscriptions, listConfig.listId) &&
                 !userHasRemoved(listConfig.listId, 'article')) {
                 return listConfig;

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -1,6 +1,7 @@
 define([
     'common/utils/formInlineLabels',
     'bean',
+    'bonzo',
     'qwery',
     'common/utils/$',
     'common/utils/ajax-promise',
@@ -13,12 +14,16 @@ define([
     'common/utils/template',
     'common/views/svgs',
     'text!common/views/email/submissionResponse.html',
+    'text!common/views/ui/close-button.html',
     'common/utils/robust',
     'common/utils/detect',
-    'common/modules/identity/api'
+    'common/modules/identity/api',
+    'common/modules/user-prefs',
+    'lodash/arrays/uniq'
 ], function (
     formInlineLabels,
     bean,
+    bonzo,
     qwery,
     $,
     ajax,
@@ -31,9 +36,12 @@ define([
     template,
     svgs,
     successHtml,
+    closeHtml,
     robust,
     detect,
-    Id
+    Id,
+    userPrefs,
+    uniq
 ) {
     var omniture;
 
@@ -92,18 +100,19 @@ define([
                 var $el = $(el),
                     freezeHeight = ui.freezeHeight($el, false),
                     freezeHeightReset = ui.freezeHeight($el, true),
-                    $formEl = $('.' + classes.form, el);
+                    $formEl = $('.' + classes.form, el),
+                    analytics = {
+                        formType: $formEl.data('email-form-type'),
+                        listId: $formEl.data('email-list-id'),
+                        signedIn: (Id.isUserLoggedIn()) ? 'user signed-in' : 'user not signed-in'
+                    };
 
-                formSubmission.bindSubmit($formEl, {
-                    formType: $formEl.data('email-form-type'),
-                    listId: $formEl.data('email-list-id'),
-                    signedIn: (Id.isUserLoggedIn()) ? 'user signed-in' : 'user not signed-in'
-                });
+                formSubmission.bindSubmit($formEl, analytics);
 
                 // If we're in an iframe, we should check whether we need to add a title and description
                 // from the data attributes on the iframe (eg: allowing us to set them from composer)
                 if (isIframed) {
-                    ui.updateForm(rootEl, $el);
+                    ui.updateForm(rootEl, $el, analytics);
                     ui.setTone($el);
                 }
 
@@ -114,6 +123,21 @@ define([
                     debounce((isIframed) ? ui.setIframeHeight(rootEl, freezeHeightReset) : freezeHeightReset, 500)
                 );
             });
+        },
+        removeAndRemember = function (e, data) {
+            var $iframe = data[0],
+                analytics = data[1],
+                currentListPrefs = userPrefs.get('email-sign-up-' + analytics.formType) || [];
+
+            currentListPrefs.push(analytics.listId + '');
+            userPrefs.set('email-sign-up-' + analytics.formType, uniq(currentListPrefs));
+
+            $iframe.remove();
+
+            getOmniture().then(function (omniture) {
+                omniture.trackLinkImmediate('rtrt | email form inline | ' + analytics.formType + ' | ' + analytics.listId + ' | ' + analytics.signedIn + ' | form hidden');
+            });
+
         },
         formSubmission = {
             bindSubmit: function ($form, analytics) {
@@ -191,7 +215,7 @@ define([
             }
         },
         ui = {
-            updateForm: function (thisRootEl, el, opts) {
+            updateForm: function (thisRootEl, el, analytics, opts) {
                 var formData = $(thisRootEl).data(),
                     formTitle = (opts && opts.formTitle) || formData.formTitle || false,
                     formDescription = (opts && opts.formDescription) || formData.formDescription || false,
@@ -199,7 +223,8 @@ define([
                     formSuccessHeadline = (opts && opts.formSuccessHeadline) || formData.formSuccessHeadline,
                     formSuccessDesc = (opts && opts.formSuccessDesc) || formData.formSuccessDesc,
                     removeComforter = (opts && opts.removeComforter) || formData.removeComforter || false,
-                    formModClass = (opts && opts.formModClass) || formData.formModClass || false;
+                    formModClass = (opts && opts.formModClass) || formData.formModClass || false,
+                    formCloseButton = (opts && opts.formCloseButton) || formData.formCloseButton || false;
 
                 Id.getUserFromApi(function (userFromId) {
                     ui.updateFormForLoggedIn(userFromId, el);
@@ -220,6 +245,17 @@ define([
 
                     if (formModClass) {
                         $(el).addClass('email-sub--' + formModClass);
+                    }
+
+                    if (formCloseButton) {
+                        var closeButtonTemplate = {
+                            closeIcon: svgs('closeCentralIcon')
+                        },
+                        closeButtonHtml = template(closeHtml, closeButtonTemplate);
+
+                        el.append(closeButtonHtml);
+
+                        bean.on(el[0], 'click', '.js-email-sub--close', removeAndRemember, [thisRootEl, analytics]);
                     }
                 });
 

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -125,14 +125,14 @@ define([
             });
         },
         removeAndRemember = function (e, data) {
-            var $iframe = data[0],
+            var iframe = data[0],
                 analytics = data[1],
                 currentListPrefs = userPrefs.get('email-sign-up-' + analytics.formType) || [];
 
             currentListPrefs.push(analytics.listId + '');
             userPrefs.set('email-sign-up-' + analytics.formType, uniq(currentListPrefs));
 
-            $iframe.remove();
+            $(iframe).remove();
 
             getOmniture().then(function (omniture) {
                 omniture.trackLinkImmediate('rtrt | email form inline | ' + analytics.formType + ' | ' + analytics.listId + ' | ' + analytics.signedIn + ' | form hidden');

--- a/static/src/javascripts/projects/common/views/email/iframe.html
+++ b/static/src/javascripts/projects/common/views/email/iframe.html
@@ -7,6 +7,7 @@
     data-form-success-headline="<%=successHeadline%>"
     data-form-success-desc="<%=successDescription%>"
     data-form-mod-class="<%=modClass%>"
+    data-form-close-button="true"
     scrolling="no"
     seamless
     frameborder="0"

--- a/static/src/javascripts/projects/common/views/ui/close-button.html
+++ b/static/src/javascripts/projects/common/views/ui/close-button.html
@@ -1,6 +1,6 @@
-<button class="email-sub--close js-email-sub--close" data-link-name="hide">
-    <span class="email-sub--hidden">Close</span>
-    <span class="email-sub--close-icon">
+<button class="email-sub__close js-email-sub--close" data-link-name="hide">
+    <span class="email-sub__hidden">Close</span>
+    <span class="email-sub__close-icon">
         <%=closeIcon%>
     </span>
 </button>

--- a/static/src/javascripts/projects/common/views/ui/close-button.html
+++ b/static/src/javascripts/projects/common/views/ui/close-button.html
@@ -1,0 +1,6 @@
+<button class="email-sub--close js-email-sub--close" data-link-name="hide">
+    <span class="email-sub--hidden">Close</span>
+    <span class="email-sub--close-icon">
+        <%=closeIcon%>
+    </span>
+</button>

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -176,12 +176,12 @@
 }
 
 .email-sub--close-icon svg {
-    fill: darken(guss-colour(neutral-2, $pasteup-palette), 10%);
+    fill: darken(colour(neutral-2), 10%);
 
     &:hover,
     &:focus {
         cursor: pointer;
-        fill: guss-colour(neutral-2, $pasteup-palette);
+        fill: colour(neutral-2);
     }
 }
 

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -163,6 +163,28 @@
     @include fs-textSans(1, $size-only: true);
 }
 
+.email-sub--close {
+    background: 0 none;
+    border: 0 none;
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+
+.email-sub--hidden {
+    @include u-h();
+}
+
+.email-sub--close-icon svg {
+    fill: darken(guss-colour(neutral-2, $pasteup-palette), 10%);
+
+    &:hover,
+    &:focus {
+        cursor: pointer;
+        fill: guss-colour(neutral-2, $pasteup-palette);
+    }
+}
+
 /**
 * Modifications
 */

--- a/static/src/stylesheets/module/email/_form.scss
+++ b/static/src/stylesheets/module/email/_form.scss
@@ -163,7 +163,7 @@
     @include fs-textSans(1, $size-only: true);
 }
 
-.email-sub--close {
+.email-sub__close {
     background: 0 none;
     border: 0 none;
     position: absolute;
@@ -171,11 +171,11 @@
     right: 0;
 }
 
-.email-sub--hidden {
+.email-sub__hidden {
     @include u-h();
 }
 
-.email-sub--close-icon svg {
+.email-sub__close-icon svg {
     fill: darken(colour(neutral-2), 10%);
 
     &:hover,

--- a/static/src/stylesheets/module/email/_header.scss
+++ b/static/src/stylesheets/module/email/_header.scss
@@ -34,6 +34,7 @@
 .email-sub__header--article {
     .email-sub__heading {
         color: guss-colour(guardian-brand, $pasteup-palette);
+        padding-right: 40px; // Avoid close icon
     }
 
     .email-sub__description {


### PR DESCRIPTION
## What does this change?

This allows users to remove the email sign-up from in an article. It stores this preference in localstorage so that the user does not see the same email sign-up on the same machine.
## What is the value of this and can you measure success?

This improves the user experience of in-article sign-up forms regardless of the position of this insertion putting the decision to remove in the user's hands (and remembering that decision).
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

![image](https://cloud.githubusercontent.com/assets/638051/13432488/b9275718-dfc5-11e5-8aca-8dd8a591575e.png)
