### PR TITLE
Live Blog pagination styling and toast z-index

### DIFF
--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -15,9 +15,9 @@
                 href="/@{article.content.metadata.id}@newest.suffix"
                 title="Go to page @newest.pageNumber"
             }
-            class="liveblog-navigation__link link-navigation__link--secondary link-navigation__link--secondary--newer @if(pagination.newest.isEmpty) { liveblog-navigation__link--disabled }"
+            class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--newer @if(pagination.newest.isEmpty) { liveblog-navigation__link--disabled }"
             data-link-name="newest page">
-                @fragments.inlineSvg("arrow-left-double", "icon", List("link-navigation__link--secondary--newer__icon"))
+                @fragments.inlineSvg("arrow-left-double", "icon", List("liveblog-navigation__link--secondary--newer__icon"))
                 Newest
             </a>
 
@@ -45,10 +45,10 @@
                 href="/@{article.content.metadata.id}@oldest.suffix"
                 title="Go to page @oldest.pageNumber"
             }
-            class="liveblog-navigation__link link-navigation__link--secondary link-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"
+            class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"
             data-link-name="oldest page">
                 Oldest
-                @fragments.inlineSvg("arrow-right-double", "icon", List("link-navigation__link--secondary--older__icon"))
+                @fragments.inlineSvg("arrow-right-double", "icon", List("liveblog-navigation__link--secondary--older__icon"))
             </a>
         </div>
     </div>

--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -45,7 +45,7 @@
                 href="/@{article.content.metadata.id}@oldest.suffix"
                 title="Go to page @oldest.pageNumber"
             }
-            class="liveblog-navigation__link link-navigation__link--secondary liveblog-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"
+            class="liveblog-navigation__link link-navigation__link--secondary link-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"
             data-link-name="oldest page">
                 Oldest
                 @fragments.inlineSvg("arrow-right-double", "icon", List("link-navigation__link--secondary--older__icon"))
@@ -53,4 +53,3 @@
         </div>
     </div>
 }
-

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -487,6 +487,7 @@ $block-padding-right: $gs-gutter;
 .dropdown--key-events,
 .dropdown--live-feed {
     border-top: 0;
+    margin-top: $gs-baseline;
 
     $content-gutter: $gs-gutter / 2;
 
@@ -582,7 +583,7 @@ $timeline-width: 15px;
 }
 
 .toast__container {
-    z-index: 900;
+    z-index: $zindex-content;
     padding-bottom: $gs-baseline;
     text-align: center;
     transition: transform .3s ease-in-out;
@@ -621,6 +622,7 @@ $timeline-width: 15px;
     box-sizing: border-box;
     overflow: hidden;
     border: 0;
+    margin-right: 0;
     max-width: 300px; // somewhat arbitrary, just need a max-width to animate from
     position: relative;
 
@@ -676,8 +678,8 @@ $timeline-width: 15px;
 }
 
 .toast__space-reserver {
-    padding-bottom: $gs-baseline;
     height: $gs-baseline*3; // was 0, for testing
+    margin-bottom: -$gs-baseline*3;
     display: none;
 
     .toast-enabled & {
@@ -941,4 +943,3 @@ $timeline-width: 15px;
         }
     }
 }
-

--- a/static/src/stylesheets/module/content/live-blog/navigation.scss
+++ b/static/src/stylesheets/module/content/live-blog/navigation.scss
@@ -40,20 +40,21 @@
 .liveblog-navigation__link {
     display: inline-block;
     position: relative;
-    color: #ffffff;
-    background: colour(guardian-brand);
+    color: colour(neutral-1);
+    background: transparent;
+    border: 1px solid colour(neutral-4);
     height: $gs-baseline * 3;
     line-height: 38px;
     font-weight: bold;
     vertical-align: middle;
 
     &:hover {
-        background: colour(guardian-brand-dark);
+        border-color: colour(neutral-2);
         text-decoration: none;
     }
 
     svg {
-        fill: #ffffff;
+        fill: colour(neutral-2);
         position: absolute;
     }
 
@@ -67,23 +68,18 @@
     border-radius: 100%;
 
     svg {
-        top: 7px;
-        width: 22px;
-        height: 22px;
+        top: 10px;
+        width: 16px;
+        height: 16px;
     }
 
     .inline-chevron-right svg{
-        right: 6px;
+        right: 9px;
     }
 
     .inline-arrow-left svg{
-        left: 6px;
+        left: 9px;
     }
-}
-
-.liveblog-navigation__link--primary--disabled,
-.liveblog-navigation__link--primary--disabled:hover {
-    background: colour(neutral-6);
 }
 
 .link-navigation__link--secondary {
@@ -125,30 +121,21 @@
     .link-navigation__link--secondary {
         width: $gs-baseline * 3;
         padding: 0;
-
-        svg {
-            top: 9px;
-            width: 18px;
-            height: 18px;
-        }
-
-        &--newer svg {
-            left: 8px;
-        }
-
-        &--older svg {
-            right: 8px;
-        }
     }
 }
 
 .liveblog-navigation__link--disabled {
     cursor: default;
-    background: colour(neutral-6);
+    color: colour(neutral-5);
+    border-color: colour(neutral-6);
+
+    svg {
+        fill: colour(neutral-5);
+    }
 
     &:hover,
     &:active  {
-        color: #ffffff;
-        background: colour(neutral-6);
+        color: colour(neutral-5);
+        border-color: colour(neutral-6);
     }
 }

--- a/static/src/stylesheets/module/content/live-blog/navigation.scss
+++ b/static/src/stylesheets/module/content/live-blog/navigation.scss
@@ -81,7 +81,7 @@
     }
 }
 
-.link-navigation__link--secondary {
+.liveblog-navigation__link--secondary {
     border-radius: 21px;
     padding: 0 $gs-gutter / 2;
 
@@ -92,7 +92,7 @@
     }
 }
 
-.link-navigation__link--secondary--newer {
+.liveblog-navigation__link--secondary--newer {
     margin-right: $gs-gutter / 4;
     padding-left: $gs-gutter * 1.5;
 
@@ -104,7 +104,7 @@
     }
 }
 
-.link-navigation__link--secondary--older {
+.liveblog-navigation__link--secondary--older {
     margin-left: $gs-gutter / 4;
     padding-right: $gs-gutter * 1.5;
 
@@ -117,7 +117,7 @@
 }
 
 @include mq($until: mobileLandscape) {
-    .link-navigation__link--secondary {
+    .liveblog-navigation__link--secondary {
         width: $gs-baseline * 3;
         padding: 0;
     }

--- a/static/src/stylesheets/module/content/live-blog/navigation.scss
+++ b/static/src/stylesheets/module/content/live-blog/navigation.scss
@@ -91,29 +91,29 @@
         height: 14px;
         top: 11px;
     }
+}
 
-    &--newer {
-        margin-right: $gs-gutter / 4;
-        padding-left: $gs-gutter * 1.5;
+.link-navigation__link--secondary--newer {
+    margin-right: $gs-gutter / 4;
+    padding-left: $gs-gutter * 1.5;
 
-        svg {
-            left: $gs-gutter / 2;
-        }
-        @include mq(mobileLandscape) {
-            margin-right: $gs-gutter / 2;
-        }
+    svg {
+        left: $gs-gutter / 2;
     }
+    @include mq(mobileLandscape) {
+        margin-right: $gs-gutter / 2;
+    }
+}
 
-    &--older {
-        margin-left: $gs-gutter / 4;
-        padding-right: $gs-gutter * 1.5;
+.link-navigation__link--secondary--older {
+    margin-left: $gs-gutter / 4;
+    padding-right: $gs-gutter * 1.5;
 
-        svg {
-            right: $gs-gutter / 2;
-        }
-        @include mq(mobileLandscape) {
-            margin-left: $gs-gutter / 2;
-        }
+    svg {
+        right: $gs-gutter / 2;
+    }
+    @include mq(mobileLandscape) {
+        margin-left: $gs-gutter / 2;
     }
 }
 

--- a/static/src/stylesheets/module/content/live-blog/navigation.scss
+++ b/static/src/stylesheets/module/content/live-blog/navigation.scss
@@ -39,11 +39,13 @@
 
 .liveblog-navigation__link {
     display: inline-block;
+    position: relative;
     color: #ffffff;
     background: colour(guardian-brand);
     height: $gs-baseline * 3;
-    line-height: $gs-baseline * 3;
+    line-height: 38px;
     font-weight: bold;
+    vertical-align: middle;
 
     &:hover {
         background: darken(colour(guardian-brand), 10%);
@@ -52,36 +54,30 @@
 
     svg {
         fill: #ffffff;
-        display: block;
-    }
-
-    .inline-icon {
-        vertical-align: middle;
-        display: inline-block;
+        position: absolute;
     }
 
     @include mq($until: mobileLandscape) {
         font-size: 0;
     }
-
 }
 
 .liveblog-navigation__link--primary {
     width: $gs-baseline * 3;
     border-radius: 100%;
-    text-align: center;
 
     svg {
-        width: 21px;
-        height: 21px;
+        top: 7px;
+        width: 22px;
+        height: 22px;
     }
 
-    .inline-chevron-right {
-        margin-right: -1px;
+    .inline-chevron-right svg{
+        right: 6px;
     }
 
-    .inline-arrow-left {
-        margin-left: -1px;
+    .inline-arrow-left svg{
+        left: 6px;
     }
 }
 
@@ -93,17 +89,11 @@
 .link-navigation__link--secondary {
     border-radius: 21px;
     padding: 0 $gs-gutter / 2;
-    position: relative;
-
-    .inline-icon {
-        position: absolute;
-        fill: currentColor;
-        top: $gs-baseline - 1px;
-    }
 
     svg {
-        width: 13px;
-        height: 13px;
+        width: 14px;
+        height: 14px;
+        top: 11px;
     }
 }
 
@@ -111,7 +101,7 @@
     margin-right: $gs-gutter / 4;
     padding-left: $gs-gutter * 1.5;
 
-    .inline-icon {
+    svg {
         left: $gs-gutter / 2;
     }
     @include mq(mobileLandscape) {
@@ -123,7 +113,7 @@
     margin-left: $gs-gutter / 4;
     padding-right: $gs-gutter * 1.5;
 
-    .inline-icon {
+    svg {
         right: $gs-gutter / 2;
     }
     @include mq(mobileLandscape) {
@@ -136,11 +126,8 @@
         width: $gs-baseline * 3;
         padding: 0;
 
-        .inline-icon {
-            top: 10px;
-        }
-
         svg {
+            top: 10px;
             width: 16px;
             height: 16px;
         }
@@ -149,16 +136,11 @@
 
 .liveblog-navigation__link--disabled {
     cursor: default;
-    color: #ffffff;
     background: colour(neutral-6);
 
     &:hover,
     &:active  {
         color: #ffffff;
         background: colour(neutral-6);
-    }
-
-    svg {
-        fill: #ffffff;
     }
 }

--- a/static/src/stylesheets/module/content/live-blog/navigation.scss
+++ b/static/src/stylesheets/module/content/live-blog/navigation.scss
@@ -73,11 +73,11 @@
         height: 16px;
     }
 
-    .inline-chevron-right svg{
+    .inline-chevron-right svg {
         right: 9px;
     }
 
-    .inline-arrow-left svg{
+    .inline-arrow-left svg {
         left: 9px;
     }
 }

--- a/static/src/stylesheets/module/content/live-blog/navigation.scss
+++ b/static/src/stylesheets/module/content/live-blog/navigation.scss
@@ -134,7 +134,7 @@
     }
 
     &:hover,
-    &:active  {
+    &:active {
         color: colour(neutral-5);
         border-color: colour(neutral-6);
     }

--- a/static/src/stylesheets/module/content/live-blog/navigation.scss
+++ b/static/src/stylesheets/module/content/live-blog/navigation.scss
@@ -41,7 +41,6 @@
     display: inline-block;
     position: relative;
     color: colour(neutral-1);
-    background: transparent;
     border: 1px solid colour(neutral-4);
     height: $gs-baseline * 3;
     line-height: 38px;

--- a/static/src/stylesheets/module/content/live-blog/navigation.scss
+++ b/static/src/stylesheets/module/content/live-blog/navigation.scss
@@ -4,10 +4,7 @@
     @include clearfix;
     // If we do support flexbox
     display: flex;
-    @include fs-textSans(2);
-    @include mq(mobileLandscape) {
-        @include fs-textSans(5);
-    }
+    @include fs-textSans(3);
 }
 
 .liveblog-navigation__detail {
@@ -42,10 +39,20 @@
 
 .liveblog-navigation__link {
     display: inline-block;
+    color: #ffffff;
+    background: colour(guardian-brand);
+    height: $gs-baseline * 3;
+    line-height: $gs-baseline * 3;
+    font-weight: bold;
 
-    // Override user-agent styles for <a>
     &:hover {
+        background: darken(colour(guardian-brand), 10%);
         text-decoration: none;
+    }
+
+    svg {
+        fill: #ffffff;
+        display: block;
     }
 
     .inline-icon {
@@ -53,40 +60,45 @@
         display: inline-block;
     }
 
-    svg {
-        display: block;
+    @include mq($until: mobileLandscape) {
+        font-size: 0;
     }
+
 }
 
 .liveblog-navigation__link--primary {
-    padding: $gs-gutter / 2;
-    background: colour(guardian-brand-dark);
+    width: $gs-baseline * 3;
     border-radius: 100%;
-
-    .inline-icon {
-        fill: #ffffff;
-    }
+    text-align: center;
 
     svg {
         width: 21px;
         height: 21px;
     }
+
+    .inline-chevron-right {
+        margin-right: -1px;
+    }
+
+    .inline-arrow-left {
+        margin-left: -1px;
+    }
 }
 
-.liveblog-navigation__link--primary--disabled {
-    background: colour(neutral-5);
+.liveblog-navigation__link--primary--disabled,
+.liveblog-navigation__link--primary--disabled:hover {
+    background: colour(neutral-6);
 }
 
 .link-navigation__link--secondary {
-    // Increase target area
-    padding-top: $gs-gutter / 2;
-    padding-bottom: $gs-gutter / 2;
-    // Override user-agent styles for <a>
-    color: inherit;
-    font-weight: bold;
+    border-radius: 21px;
+    padding: 0 $gs-gutter / 2;
+    position: relative;
 
     .inline-icon {
+        position: absolute;
         fill: currentColor;
+        top: $gs-baseline - 1px;
     }
 
     svg {
@@ -97,27 +109,56 @@
 
 .link-navigation__link--secondary--newer {
     margin-right: $gs-gutter / 4;
+    padding-left: $gs-gutter * 1.5;
+
+    .inline-icon {
+        left: $gs-gutter / 2;
+    }
     @include mq(mobileLandscape) {
         margin-right: $gs-gutter / 2;
     }
 }
 
-.link-navigation__link--secondary--newer__icon {
-    margin-right: $gs-gutter / 4;
-}
-
 .liveblog-navigation__link--secondary--older {
     margin-left: $gs-gutter / 4;
+    padding-right: $gs-gutter * 1.5;
+
+    .inline-icon {
+        right: $gs-gutter / 2;
+    }
     @include mq(mobileLandscape) {
         margin-left: $gs-gutter / 2;
     }
 }
 
-.link-navigation__link--secondary--older__icon {
-    margin-left: $gs-gutter / 4;
+@include mq($until: mobileLandscape) {
+    .link-navigation__link--secondary {
+        width: $gs-baseline * 3;
+        padding: 0;
+
+        .inline-icon {
+            top: 10px;
+        }
+
+        svg {
+            width: 16px;
+            height: 16px;
+        }
+    }
 }
 
 .liveblog-navigation__link--disabled {
     cursor: default;
-    color: colour(neutral-3);
+    color: #ffffff;
+    background: colour(neutral-6);
+
+    &:hover,
+    &:active  {
+        color: #ffffff;
+        background: colour(neutral-6);
+    }
+
+    svg {
+        fill: #ffffff;
+    }
 }

--- a/static/src/stylesheets/module/content/live-blog/navigation.scss
+++ b/static/src/stylesheets/module/content/live-blog/navigation.scss
@@ -48,7 +48,7 @@
     vertical-align: middle;
 
     &:hover {
-        background: darken(colour(guardian-brand), 10%);
+        background: colour(guardian-brand-dark);
         text-decoration: none;
     }
 
@@ -95,29 +95,29 @@
         height: 14px;
         top: 11px;
     }
-}
 
-.link-navigation__link--secondary--newer {
-    margin-right: $gs-gutter / 4;
-    padding-left: $gs-gutter * 1.5;
+    &--newer {
+        margin-right: $gs-gutter / 4;
+        padding-left: $gs-gutter * 1.5;
 
-    svg {
-        left: $gs-gutter / 2;
+        svg {
+            left: $gs-gutter / 2;
+        }
+        @include mq(mobileLandscape) {
+            margin-right: $gs-gutter / 2;
+        }
     }
-    @include mq(mobileLandscape) {
-        margin-right: $gs-gutter / 2;
-    }
-}
 
-.liveblog-navigation__link--secondary--older {
-    margin-left: $gs-gutter / 4;
-    padding-right: $gs-gutter * 1.5;
+    &--older {
+        margin-left: $gs-gutter / 4;
+        padding-right: $gs-gutter * 1.5;
 
-    svg {
-        right: $gs-gutter / 2;
-    }
-    @include mq(mobileLandscape) {
-        margin-left: $gs-gutter / 2;
+        svg {
+            right: $gs-gutter / 2;
+        }
+        @include mq(mobileLandscape) {
+            margin-left: $gs-gutter / 2;
+        }
     }
 }
 
@@ -127,9 +127,17 @@
         padding: 0;
 
         svg {
-            top: 10px;
-            width: 16px;
-            height: 16px;
+            top: 9px;
+            width: 18px;
+            height: 18px;
+        }
+
+        &--newer svg {
+            left: 8px;
+        }
+
+        &--older svg {
+            right: 8px;
         }
     }
 }


### PR DESCRIPTION
Firstly z-index added to toast so it shows over those pesky ads. Also centered a slightly mis-aligned toast.
![screen shot 2016-03-01 at 16 18 06](https://cloud.githubusercontent.com/assets/14570016/13433780/4729d1f8-dfcb-11e5-9017-043c530408f8.png)

Secondly, re-visited the visuals of this beast, to make them more in line with the comments pagination styling.  

![screen shot 2016-03-01 at 12 22 03](https://cloud.githubusercontent.com/assets/14570016/13433739/24e658dc-dfcb-11e5-966d-491510c06f2f.png)

Tiny mobile breakpoint:
![screen shot 2016-03-01 at 16 33 49](https://cloud.githubusercontent.com/assets/14570016/13433820/6d1be608-dfcb-11e5-9f75-45de05819855.png)

Please check the css @OliverJAsh 
