### PR TITLE
Align items with the grid

### DIFF
--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -31,9 +31,6 @@
 
     .commercial__body {
         padding-top: $gs-gutter / 2;
-        max-width: none;
-        padding-left: $gs-gutter / 2;
-        padding-right: $gs-gutter / 2;
     }
 
     .rich-link__standfirst {
@@ -154,6 +151,11 @@
         margin-right: $gs-gutter;
     }
 
+    .fc-slice {
+        margin: 0 -10px;
+        width: auto;
+    }
+
     .fc-item__kicker {
         &:after {
             color: colour(neutral-2);
@@ -195,13 +197,6 @@
 
 /* Badges
    ========================================================================== */
-
-.commercial--paidfor {
-    .ad-slot--paid-for-badge {
-        padding-left: $gs-gutter / 2;
-        padding-right: $gs-gutter / 2;
-    }
-}
 
 .commercial--paidfor,
 .commercial--dfp-single {


### PR DESCRIPTION
## What does this change?

Items in paid containers were not aligned according to the grid:
![picture 1](https://cloud.githubusercontent.com/assets/629976/13434138/b89796f8-dfcc-11e5-8608-11ca632bd8d9.png)

Into this:
![picture 6](https://cloud.githubusercontent.com/assets/629976/13434204/e266c882-dfcc-11e5-8d9b-466fe2479332.png)

@jbreckmckye @uplne this is fairly urgent so it cannot wait our refactoring.
