### PR TITLE
make pagination link to the pagination rather than the first block

### DIFF
--- a/article/app/liveblog/LiveBlogPageModel.scala
+++ b/article/app/liveblog/LiveBlogPageModel.scala
@@ -27,7 +27,6 @@ object LiveBlogPageModel {
           allBlocks = blocks,
           currentPage = currentPage,
           pagination = if (pages.length > 1) Some(Pagination(
-            isNewestPage = newestPage.equals(currentPage),
             newest = if (isNewestPage) None else Some(newestPage),
             newer = newerPage,
             oldest = if (oldestPage.equals(currentPage)) None else Some(oldestPage),
@@ -52,10 +51,10 @@ sealed trait PageReference[B] {
   def blocks: Seq[B]
   def suffix: String
   def pageNumber: Int
+  def isArchivePage: Boolean
 }
 
 case class Pagination[B](
-  isNewestPage: Boolean,
   newest: Option[PageReference[B]],
   newer: Option[PageReference[B]],
   oldest: Option[PageReference[B]],
@@ -72,5 +71,9 @@ case class LiveBlogPageModel[B](
 case class FirstPage[B](blocks: Seq[B]) extends PageReference[B] {
   val suffix = ""
   val pageNumber = 1
+  val isArchivePage = false
 }
-case class BlockPage[B](blocks: Seq[B], blockId: String, pageNumber: Int) extends PageReference[B] { val suffix = s"?page=with:block-$blockId#block-$blockId" }
+case class BlockPage[B](blocks: Seq[B], blockId: String, pageNumber: Int) extends PageReference[B] {
+  val suffix = s"?page=with:block-$blockId"
+  val isArchivePage = true
+}

--- a/article/app/views/fragments/liveBlogNavigation.scala.html
+++ b/article/app/views/fragments/liveBlogNavigation.scala.html
@@ -4,7 +4,7 @@
 @(article: Article, pageModel: LiveBlogPageModel[BodyBlock])
 
 @pageModel.pagination.map { pagination =>
-    <div class="liveblog-navigation">
+    <div id="liveblog-navigation" class="liveblog-navigation">
         <div class="liveblog-navigation__detail">
             <!-- div necessary for flexbox -->
             <div><span class="liveblog-navigation__page-number">@pageModel.currentPage.pageNumber</span> of <span class="liveblog-navigation__pages-length">@pagination.numberOfPages</span></div>
@@ -22,7 +22,7 @@
             </a>
 
             <a @pagination.newer.map { newer =>
-                href="/@{article.content.metadata.id}@newer.suffix"
+                href="/@{article.content.metadata.id}@newer.suffix@if(newer.isArchivePage) {#liveblog-navigation} else {}"
                 title="Go to page @newer.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.newer.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
@@ -33,7 +33,7 @@
 
         <div class="liveblog-navigation__older">
             <a @pagination.older.map { older =>
-                href="/@{article.content.metadata.id}@older.suffix"
+                href="/@{article.content.metadata.id}@older.suffix#liveblog-navigation"
                 title="Go to page @older.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--primary @if(pagination.older.isEmpty) { liveblog-navigation__link--disabled liveblog-navigation__link--primary--disabled }"
@@ -42,7 +42,7 @@
             </a>
 
             <a @pagination.oldest.map { oldest =>
-                href="/@{article.content.metadata.id}@oldest.suffix"
+                href="/@{article.content.metadata.id}@oldest.suffix#liveblog-navigation"
                 title="Go to page @oldest.pageNumber"
             }
             class="liveblog-navigation__link liveblog-navigation__link--secondary liveblog-navigation__link--secondary--older @if(pagination.oldest.isEmpty) { liveblog-navigation__link--disabled }"

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -82,9 +82,7 @@
                                 </div>
                             </div>
                             @if(pageModel.currentPage.isArchivePage) {
-                                @pageModel.pagination.map { pagination =>
-                                    @fragments.liveBlogNavigation(article = model.article, pageModel)
-                                }
+                                @fragments.liveBlogNavigation(article = model.article, pageModel)
                             }
                             <div class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="@article.mostRecentBlock" data-test-id="live-blog-blocks"
                                 itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -81,8 +81,8 @@
                                     </button>
                                 </div>
                             </div>
-                            @pageModel.pagination.map { pagination =>
-                                @if(!pagination.isNewestPage) {
+                            @if(pageModel.currentPage.isArchivePage) {
+                                @pageModel.pagination.map { pagination =>
                                     @fragments.liveBlogNavigation(article = model.article, pageModel)
                                 }
                             }

--- a/article/test/liveblog/LiveBlogPageModelTest.scala
+++ b/article/test/liveblog/LiveBlogPageModelTest.scala
@@ -28,7 +28,7 @@ class LiveBlogPageModelTest extends FlatSpec with Matchers {
 
     val expected = blocks.take(2)
     val expectedOldestPage = BlockPage(blocks = blocks.drop(2), blockId = "old 2", pageNumber = 2)
-    val expectedPagination = Some(Pagination(isNewestPage = true, newest = None, newer = None, older = Some(expectedOldestPage), oldest = Some(expectedOldestPage), numberOfPages = 2))
+    val expectedPagination = Some(Pagination(newest = None, newer = None, older = Some(expectedOldestPage), oldest = Some(expectedOldestPage), numberOfPages = 2))
 
     result.map(_.copy(allBlocks = Seq())) should be(Some(LiveBlogPageModel(
       allBlocks = Seq(),
@@ -47,7 +47,7 @@ class LiveBlogPageModelTest extends FlatSpec with Matchers {
 
     val expectedCurrentPage = BlockPage(blocks = blocks.takeRight(2), blockId = "old 2", pageNumber = 2)
     val expectedNewestPage = FirstPage(blocks.take(2))
-    val expectedPagination = Some(Pagination(isNewestPage = false, newest = Some(expectedNewestPage), newer = Some(expectedNewestPage), older = None, oldest = None, numberOfPages = 2))
+    val expectedPagination = Some(Pagination(newest = Some(expectedNewestPage), newer = Some(expectedNewestPage), older = None, oldest = None, numberOfPages = 2))
 
     result.map(_.copy(allBlocks = Seq())) should be(Some(LiveBlogPageModel(
       allBlocks = Seq(),
@@ -66,7 +66,7 @@ class LiveBlogPageModelTest extends FlatSpec with Matchers {
 
     val expectedCurrentPage = BlockPage(blocks = blocks.takeRight(2), blockId = "old 2", pageNumber = 2)
     val expectedNewestPage = FirstPage(blocks.take(2))
-    val expectedPagination = Some(Pagination(isNewestPage = false, newest = Some(expectedNewestPage), newer = Some(expectedNewestPage), older = None, oldest = None, numberOfPages = 2))
+    val expectedPagination = Some(Pagination(newest = Some(expectedNewestPage), newer = Some(expectedNewestPage), older = None, oldest = None, numberOfPages = 2))
 
     result.map(_.copy(allBlocks = Seq())) should be(Some(LiveBlogPageModel(
       allBlocks = Seq(),
@@ -82,7 +82,7 @@ class LiveBlogPageModelTest extends FlatSpec with Matchers {
 
     val expectedCurrentPage = FirstPage(blocks = blocks.take(3))
     val expectedOldestPage = BlockPage(blocks = blocks.drop(3), blockId = "3", pageNumber = 2)
-    val expectedPagination = Some(Pagination(isNewestPage = true, newest = None, newer = None, older = Some(expectedOldestPage), oldest = Some(expectedOldestPage), numberOfPages = 2))
+    val expectedPagination = Some(Pagination(newest = None, newer = None, older = Some(expectedOldestPage), oldest = Some(expectedOldestPage), numberOfPages = 2))
 
     result.map(_.copy(allBlocks = Seq())) should be(Some(LiveBlogPageModel(
       allBlocks = Seq(),
@@ -98,7 +98,7 @@ class LiveBlogPageModelTest extends FlatSpec with Matchers {
 
     val expectedCurrentPage = BlockPage(blocks = blocks.takeRight(2), blockId = "3", pageNumber = 2)
     val expectedNewestPage = FirstPage(blocks.take(3))
-    val expectedPagination = Some(Pagination(isNewestPage = false, newest = Some(expectedNewestPage), newer = Some(expectedNewestPage), older = None, oldest = None, numberOfPages = 2))
+    val expectedPagination = Some(Pagination(newest = Some(expectedNewestPage), newer = Some(expectedNewestPage), older = None, oldest = None, numberOfPages = 2))
 
     result.map(_.copy(allBlocks = Seq())) should be(Some(LiveBlogPageModel(
       allBlocks = Seq(),
@@ -115,7 +115,7 @@ class LiveBlogPageModelTest extends FlatSpec with Matchers {
     val expectedCurrentPage = FirstPage(blocks = blocks.take(2))
     val expectedMiddlePage = BlockPage(blocks = blocks.drop(2).take(2), blockId = "2", pageNumber = 2)
     val expectedOldestPage = BlockPage(blocks = blocks.takeRight(2), blockId = "4", pageNumber = 3)
-    val expectedPagination = Some(Pagination(isNewestPage = true, newest = None, newer = None, older = Some(expectedMiddlePage), oldest = Some(expectedOldestPage), numberOfPages = 3))
+    val expectedPagination = Some(Pagination(newest = None, newer = None, older = Some(expectedMiddlePage), oldest = Some(expectedOldestPage), numberOfPages = 3))
 
     result.map(_.copy(allBlocks = Seq())) should be(Some(LiveBlogPageModel(
       allBlocks = Seq(),
@@ -132,7 +132,7 @@ class LiveBlogPageModelTest extends FlatSpec with Matchers {
     val expectedCurrentPage = BlockPage(blocks = blocks.drop(2).take(2), blockId = "2", pageNumber = 2)
     val expectedFirstPage = FirstPage(blocks = blocks.take(2))
     val expectedOldestPage = BlockPage(blocks = blocks.takeRight(2), blockId = "4", pageNumber = 3)
-    val expectedPagination = Some(Pagination(isNewestPage = false, newest = Some(expectedFirstPage), newer = Some(expectedFirstPage), older = Some(expectedOldestPage), oldest = Some(expectedOldestPage), numberOfPages = 3))
+    val expectedPagination = Some(Pagination(newest = Some(expectedFirstPage), newer = Some(expectedFirstPage), older = Some(expectedOldestPage), oldest = Some(expectedOldestPage), numberOfPages = 3))
 
     result.map(_.copy(allBlocks = Seq())) should be(Some(LiveBlogPageModel(
       allBlocks = Seq(),
@@ -149,7 +149,7 @@ class LiveBlogPageModelTest extends FlatSpec with Matchers {
     val expectedCurrentPage = BlockPage(blocks = blocks.takeRight(2), blockId = "4", pageNumber = 3)
     val expectedFirstPage = FirstPage(blocks = blocks.take(2))
     val expectedMiddlePage = BlockPage(blocks = blocks.drop(2).take(2), blockId = "2", pageNumber = 2)
-    val expectedPagination = Some(Pagination(isNewestPage = false, newest = Some(expectedFirstPage), newer = Some(expectedMiddlePage), older = None, oldest = None, numberOfPages = 3))
+    val expectedPagination = Some(Pagination(newest = Some(expectedFirstPage), newer = Some(expectedMiddlePage), older = None, oldest = None, numberOfPages = 3))
 
     result.map(_.copy(allBlocks = Seq())) should be(Some(LiveBlogPageModel(
       allBlocks = Seq(),


### PR DESCRIPTION
When you use pagination on liveblogs, it will drop you at the pagination controls rather than the first block.  I've also fixed up the metadata in the head to link without the fragments.
When coming back to the first page, the original behaviour of dropping you at the top still applies.
comments welcome, and @OliverJAsh take a look!
