### PR TITLE
Add logging to help understand PA errors

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -188,7 +188,12 @@ object PaMetrics {
     "AP api returned error"
   )
 
-  val all: Seq[FrontendMetric] = Seq(PaApiHttpTimingMetric, PaApiHttpOkMetric, PaApiHttpErrorMetric)
+  object PaApiErrorsMetric extends CountMetric(
+    "pa-content-errors",
+    "AP api returned errors in content"
+  )
+
+  val all: Seq[FrontendMetric] = Seq(PaApiHttpTimingMetric, PaApiHttpOkMetric, PaApiHttpErrorMetric, PaApiErrorsMetric)
 }
 
 object DiscussionMetrics {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -47,7 +47,7 @@ object Dependencies {
   val mockito = "org.mockito" % "mockito-all" % "1.9.5" % Test
   val nScalaTime = "com.github.nscala-time" %% "nscala-time" % "1.2.0"
   val openCsv = "net.sf.opencsv" % "opencsv" % "2.3"
-  val paClient = "com.gu" %% "pa-client" % "5.0.1-NG"
+  val paClient = "com.gu" %% "pa-client" % "6.0.0"
   val playGoogleAuth = "com.gu" %% "play-googleauth" % "0.3.3"
   val quartzScheduler = "org.quartz-scheduler" % "quartz" % "2.2.1"
   val rome = "rome" % "rome" % "1.0"

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -57,6 +57,7 @@ trait Prototypes {
       Resolver.typesafeRepo("releases"),
       Resolver.sonatypeRepo("releases"),
       "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases",
+      "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Spy" at "https://files.couchbase.com/maven2/"
     ),
 

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -4,7 +4,7 @@ import common.PaMetrics._
 import common._
 import feed.Competitions
 import model.{TeamMap, LiveBlogAgent}
-import pa.{Http, PaClient}
+import pa.{PaClientErrorsException, Http, PaClient}
 import play.api.GlobalSettings
 import play.api.libs.ws.WS
 import scala.concurrent.Future
@@ -106,6 +106,14 @@ object FootballClient extends PaClient with Http with Logging with ExecutionCont
   override def GET(urlString: String): Future[pa.Response] = {
     _http.GET(urlString)
   }
+
+  def logErrors[T]: PartialFunction[Throwable, T] = {
+    case e: PaClientErrorsException =>
+      log.error(s"Football Client errors: ${e.getMessage}")
+      PaApiErrorsMetric.increment()
+      throw e
+  }
+
 }
 
 object HealthCheck extends AllGoodHealthcheckController(

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -62,7 +62,7 @@ object MatchController extends Controller with Football with Requests with Loggi
 
   private def render(maybeMatch: Option[FootballMatch]) = Action.async { implicit request =>
     val response = maybeMatch map { theMatch =>
-      val lineup: Future[LineUp] = FootballClient.lineUp(theMatch.id)
+      val lineup: Future[LineUp] = FootballClient.lineUp(theMatch.id).recover(FootballClient.logErrors)
       val page: Future[MatchPage] = lineup map { MatchPage(theMatch, _) }
 
       page map { page =>

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -75,7 +75,9 @@ object MoreOnMatchController extends Controller with Football with Requests with
 
     val maybeResponse: Option[Future[Result]] = maybeMatch map { theMatch =>
       loadMoreOn(request, theMatch) map {
-        case Nil => JsonNotFound()
+        case Nil =>
+          log.info(s"Cannot load more for match id: ${theMatch.id}")
+          JsonNotFound()
         case related => JsonComponent(
           "nav" -> football.views.html.fragments.matchNav(populateNavModel(theMatch, related filter {
             hasExactlyTwoTeams

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -144,7 +144,7 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
           case _ =>
         }
       }
-    })
+    }).recover(FootballClient.logErrors)
   }
 
   //one http call updates all competitions

--- a/sport/app/football/feed/agent.scala
+++ b/sport/app/football/feed/agent.scala
@@ -15,6 +15,7 @@ trait Lineups extends ExecutionContexts with Logging {
     val awayTeam = m.awayTeam.copy(name = TeamName(m.awayTeam))
     LineUp(homeTeam, awayTeam, m.homeTeamPossession)
   }
+    .recover(FootballClient.logErrors)
 }
 
 trait LiveMatches extends ExecutionContexts with Logging {
@@ -31,6 +32,7 @@ trait LiveMatches extends ExecutionContexts with Logging {
     // we have checked above that the competition does exist for these matches
     matchesWithCleanedTeams.groupBy(_.competition.head.id)
   }
+    .recover(FootballClient.logErrors)
 }
 
 trait LeagueTables extends ExecutionContexts with Logging {
@@ -42,6 +44,7 @@ trait LeagueTables extends ExecutionContexts with Logging {
         t.copy(team = team)
       }
     }
+      .recover(FootballClient.logErrors)
   }
 }
 
@@ -55,6 +58,7 @@ trait Fixtures extends ExecutionContexts with Logging {
         f.copy(homeTeam = homeTeam, awayTeam = awayTeam)
       }
     }
+      .recover(FootballClient.logErrors)
   }
 }
 
@@ -70,6 +74,7 @@ trait Results extends ExecutionContexts with Logging with implicits.Collections 
         r.copy(homeTeam = homeTeam, awayTeam = awayTeam)
       }
     }
+      .recover(FootballClient.logErrors)
   }
 }
 


### PR DESCRIPTION
## What does this change?

Add logging and metric to better understand why Football scores sometimes don't update, especially if/when PA API returns errors in xml reponses
## What is the value of this and can you measure success?

Next time the PA API stops returning up-to-date data, we will be able to see the type of errors they return and communicate them to their customer support
The new metric will also allow us to assess how often those errors happen. Until now we have been relying on readers or football desk to report this issue
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@rich-nguyen @JustinPinner 
