### PR TITLE
Add email name to footer text

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -3,7 +3,7 @@
 @import views.support.EmailArticleImage
 @import views.support.EmailHelpers._
 @import model.liveblog._
-@import model.EmailAddons.EmailArticle
+@import model.EmailAddons.EmailContentType
 
 @defining(page.article) { article =>
     @fullRow {

--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -2,52 +2,60 @@ package model
 
 import conf.Static
 
-sealed trait EmailContent {
+sealed trait EmailContent extends Product with Serializable {
+  def name: String
   def banner: String
-  def test(a: Article): Boolean
+  def test(c: ContentType): Boolean
 }
 
 case object ArtWeekly extends EmailContent {
+  val name = "Art Weekly"
   val banner = "art-weekly.png"
-  def test(a: Article) = a.content.tags.series.exists(_.id == "artanddesign/series/art-weekly")
+  def test(c: ContentType) = c.tags.series.exists(_.id == "artanddesign/series/art-weekly")
 }
 
 case object GreenLight extends EmailContent {
+  val name = "Green Light"
   val banner = "green-light.png"
-  def test(a: Article) = a.content.tags.series.exists(_.id == "environment/series/green-light")
+  def test(c: ContentType) = c.tags.series.exists(_.id == "environment/series/green-light")
 }
 
 case object MoneyTalks extends EmailContent {
+  val name = "Money Talks"
   val banner = "money-talks.png"
-  def test(a: Article) = a.content.tags.series.exists(_.id == "money/series/money-talks")
+  def test(c: ContentType) = c.tags.series.exists(_.id == "money/series/money-talks")
 }
 
 case object PovertyMatters extends EmailContent {
+  val name = "Poverty Matters"
   val banner = "poverty-matters.png"
-  def test(a: Article) = a.content.tags.blogs.exists(_.id == "global-development/poverty-matters")
+  def test(c: ContentType) = c.tags.blogs.exists(_.id == "global-development/poverty-matters")
 }
 
 case object TheBreakdown extends EmailContent {
+  val name = "The Breakdown"
   val banner = "the-breakdown.png"
-  def test(a: Article) = a.content.tags.series.exists(_.id == "sport/series/breakdown")
+  def test(c: ContentType) = c.tags.series.exists(_.id == "sport/series/breakdown")
 }
 
 case object TheFiver extends EmailContent {
+  val name = "The Fiver"
   val banner = "the-fiver.png"
-  def test(a: Article) = a.content.tags.series.exists(_.id == "football/series/thefiver")
+  def test(c: ContentType) = c.tags.series.exists(_.id == "football/series/thefiver")
 }
 
 case object TheSpin extends EmailContent {
+  val name = "The Spin"
   val banner = "the-spin.png"
-  def test(a: Article) = a.content.tags.series.exists(_.id == "sport/series/thespin")
+  def test(c: ContentType) = c.tags.series.exists(_.id == "sport/series/thespin")
 }
 
 object EmailAddons {
   private val defaultBanner = "generic.png"
   private val allEmails     = Seq(ArtWeekly, GreenLight, MoneyTalks, PovertyMatters, TheBreakdown, TheFiver, TheSpin)
 
-  implicit class EmailArticle(a: Article) {
-    val email = allEmails.find(_.test(a))
+  implicit class EmailContentType(c: ContentType) {
+    val email = allEmails.find(_.test(c))
 
     lazy val banner = {
       val banner = email map (_.banner) getOrElse defaultBanner

--- a/common/app/views/fragments/email/footer.scala.html
+++ b/common/app/views/fragments/email/footer.scala.html
@@ -1,6 +1,7 @@
-@(page: model.Page)(implicit request: RequestHeader)
+@(page: model.ContentPage)(implicit request: RequestHeader)
 
 @import views.support.EmailHelpers._
+@import model.EmailAddons.EmailContentType
 @import common.{CanonicalLink, LinkTo}
 
 @fullRow(Seq("email__links")) {
@@ -8,5 +9,11 @@
 }
 
 @fullRow(Seq("disclaimer")) {
-    <p>You are receiving this email because you are a subscriber to The Fiver. Guardian News & Media Limited - a member of Guardian Media Group PLC. Registered Office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396</p>
+    <p>
+    @page.item.email.map { email =>
+        You are receiving this email because you are a subscriber to @{email.name}.
+    }
+
+    Guardian News & Media Limited - a member of Guardian Media Group PLC. Registered Office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396
+    </p>
 }

--- a/common/app/views/mainEmail.scala.html
+++ b/common/app/views/mainEmail.scala.html
@@ -1,4 +1,4 @@
-@(page: model.Page)(body: Html)(implicit request: RequestHeader)
+@(page: model.ContentPage)(body: Html)(implicit request: RequestHeader)
 
 @import common.{LinkTo, CanonicalLink}
 


### PR DESCRIPTION
With this, if you're looking at an email version of an article, and that article meets the criteria for a particular email, we'll show a bit of text in the footer to explain that you've received it because you follow (for example) The Fiver.
