### PR TITLE
Amp multiple tweaks

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -43,3 +43,7 @@
     font-family: "Guardian Egyptian Web", Georgia, serif;
     font-weight: 500;
 }
+
+b, strong {
+    font-weight: 500;
+}

--- a/common/app/views/fragments/amp/stylesheets/header.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/header.scala.html
@@ -6,8 +6,8 @@
 
 .main-header .logo-wrapper {
     position: absolute;
-    top: 3px;
     right: 20px;
+    padding-top: 3px;
     width: inherit;
     text-align: right;
 }

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -185,6 +185,7 @@
     .submeta {
         border-top: 0.0625rem dotted #dfdfdf;
         padding: 6px 0 12px;
+        clear: both;
     }
 
     .u-underline {

--- a/common/app/views/fragments/amp/stylesheets/tones.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/tones.scala.html
@@ -44,7 +44,7 @@
 }
 
 .tonal--tone-review .tonal__standfirst,
-.tone-review {
+.fc-item.tone-review {
     background-color: #7d7569;
 }
 


### PR DESCRIPTION
More AMP tweaks.

Review tone in OJs now showing correctly. 

Changed `top` to `padding` on the logo wrapper so when a user hits back to top they go to the top, not 3px off.

Prevented forced bold version of Egyptian showing when `<strong>` tags are wrapped within h2s etc. 

Added a clear to the comments/meta section.
