### PR TITLE
Add standfirst to email template

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -14,6 +14,10 @@
         <h1>@article.trail.headline</h1>
     }
 
+    @article.fields.standfirst.map { standfirst =>
+        @paddedRow(Html(standfirst))
+    }
+    
     @fragments.emailMainMedia(article)
 
     @paddedRow(Seq("author")) {


### PR DESCRIPTION
## What does this change?

Adds the standfirst text to emails
## Screenshots

![image](https://cloud.githubusercontent.com/assets/638051/13466211/dfae0fdc-e090-11e5-95ed-a8e994930937.png)

![image](https://cloud.githubusercontent.com/assets/638051/13466164/abbe6924-e090-11e5-80c0-fcf648ee1854.png)

![image](https://cloud.githubusercontent.com/assets/638051/13466199/d20e5f30-e090-11e5-93db-a1dbb34382cb.png)

![image](https://cloud.githubusercontent.com/assets/638051/13466149/9ec5b25e-e090-11e5-9e50-8c92cefa9336.png)
## Request for comment

@crifmulholland - We need to inform the fiver
