### PR TITLE
Email template: Font-size and spacing adjustments

### DIFF
--- a/common/app/views/fragments/email/stylesheets/main.scala.html
+++ b/common/app/views/fragments/email/stylesheets/main.scala.html
@@ -27,19 +27,18 @@
         margin-bottom: 20px;
     }
 
-    h2, h3 {
-        font-size: 24px;
-        line-height: 28px;
-    }
-
     h2 {
         font-weight: bold;
+        font-size: 24px;
+        line-height: 28px;
         margin-bottom: 5px;
         margin-top: 20px;
     }
 
     h3 {
         font-weight: normal;
+        font-size: 18px;
+        line-height: 28px;
     }
 
     p {

--- a/common/app/views/fragments/email/stylesheets/main.scala.html
+++ b/common/app/views/fragments/email/stylesheets/main.scala.html
@@ -28,13 +28,14 @@
     }
 
     h2, h3 {
-        font-size: 18px;
+        font-size: 24px;
         line-height: 28px;
     }
 
     h2 {
         font-weight: bold;
         margin-bottom: 5px;
+        margin-top: 20px;
     }
 
     h3 {


### PR DESCRIPTION
## What does this change?

Increases the sub-heading font-sizes and adds some breathing room above heading.
## Screenshots
### Before

![image](https://cloud.githubusercontent.com/assets/638051/13466548/4b0f6090-e092-11e5-8394-5d6e75bb4c44.png)
### After

![image](https://cloud.githubusercontent.com/assets/638051/13466555/549e81c2-e092-11e5-99ae-f32a57a8b2b7.png)
### Before

![image](https://cloud.githubusercontent.com/assets/638051/13466597/85ce66b8-e092-11e5-840e-9c1ba2639352.png)
### After

![image](https://cloud.githubusercontent.com/assets/638051/13466644/cc1310ce-e092-11e5-8645-23894630a484.png)
