### PR TITLE
Enchilada's advertisement label proper fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -1,5 +1,6 @@
 define([
     'bonzo',
+    'Promise',
     'common/utils/$',
     'common/utils/config',
     'common/utils/fastdom-promise',
@@ -19,6 +20,7 @@ define([
     'common/modules/commercial/creatives/template'
 ], function (
     bonzo,
+    Promise,
     $,
     config,
     fastdom
@@ -29,51 +31,54 @@ define([
      * This can be set on the DFP creative.
      */
     function breakoutIFrame(iFrame, $slot) {
-        /*eslint-disable no-eval*/
-        var $iFrame            = bonzo(iFrame);
-        var $iFrameParent      = bonzo(iFrame.parentNode);
-        var iFrameBody         = iFrame.contentDocument.body;
-        var type               = {};
-        var $breakoutEl;
+        return new Promise(function (resolve, reject) {
+            /*eslint-disable no-eval*/
+            var $iFrame = bonzo(iFrame);
+            var $iFrameParent = bonzo(iFrame.parentNode);
+            var iFrameBody = iFrame.contentDocument.body;
+            var type = '';
+            var $breakoutEl;
 
-        if (!iFrameBody) {
-            return type;
-        }
+            if (!iFrameBody) {
+                reject();
+            }
 
-        $breakoutEl = $('.breakout__html, .breakout__script', iFrameBody);
-        if ($breakoutEl.hasClass('breakout__html')) {
-            fastdom.write(function () {
-                $iFrame.hide();
-                $breakoutEl.detach();
-                $iFrameParent.append($breakoutEl[0].children);
-            }).then(function () {
-                var $responsiveAds = $('.ad--responsive', $iFrameParent[0]);
+            $breakoutEl = $('.breakout__html, .breakout__script', iFrameBody);
+
+            if ($breakoutEl.hasClass('breakout__html')) {
                 fastdom.write(function () {
-                    $responsiveAds.addClass('ad--responsive--open');
+                    $iFrame.hide();
+                    $breakoutEl.detach();
+                    $iFrameParent.append($breakoutEl[0].children);
+                }).then(function () {
+                    var $responsiveAds = $('.ad--responsive', $iFrameParent[0]);
+                    resolve(fastdom.write(function () {
+                        $responsiveAds.addClass('ad--responsive--open');
+                    }));
                 });
-            });
-        } else if ($breakoutEl.hasClass('breakout__script')) {
-            fastdom.write(function () {
-                $iFrame.hide();
-            }).then(function () {
-                var breakoutContent = $breakoutEl.html();
-                if ($breakoutEl.attr('type') === 'application/json') {
-                    var creativeConfig = JSON.parse(breakoutContent);
-                    if (creativeConfig.name === 'fluid250-v4' || creativeConfig.name === 'fluid250-v3') {
-                        creativeConfig.name = 'fluid250';
+            } else if ($breakoutEl.hasClass('breakout__script')) {
+                fastdom.write(function () {
+                    $iFrame.hide();
+                }).then(function () {
+                    var breakoutContent = $breakoutEl.html();
+                    if ($breakoutEl.attr('type') === 'application/json') {
+                        var creativeConfig = JSON.parse(breakoutContent);
+                        if (creativeConfig.name === 'fluid250-v4' || creativeConfig.name === 'fluid250-v3') {
+                            creativeConfig.name = 'fluid250';
+                        }
+                        require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
+                            new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
+                        });
+                        type = creativeConfig.params.adType || '';
+                        resolve(type);
+                    } else {
+                        // evil, but we own the returning js snippet
+                        eval(breakoutContent);
+                        resolve();
                     }
-                    require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
-                        new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
-                    });
-                    type = creativeConfig.params.adType || '';
-                } else {
-                    // evil, but we own the returning js snippet
-                    eval(breakoutContent);
-                }
-            });
-        }
-
-        return type;
+                });
+            }
+        });
     }
 
     return breakoutIFrame;

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -36,7 +36,6 @@ define([
             var $iFrame = bonzo(iFrame);
             var $iFrameParent = bonzo(iFrame.parentNode);
             var iFrameBody = iFrame.contentDocument.body;
-            var type = '';
             var $breakoutEl;
 
             if (!iFrameBody) {
@@ -69,14 +68,15 @@ define([
                         require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
                             new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
                         });
-                        type = creativeConfig.params.adType || '';
-                        resolve(type);
+                        resolve(creativeConfig.params.adType || '');
                     } else {
                         // evil, but we own the returning js snippet
                         eval(breakoutContent);
                         resolve();
                     }
                 });
+            } else {
+                resolve();
             }
         });
     }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -531,10 +531,6 @@ define([
             } else {
                 resolve(breakoutIFrame(iFrame, $adSlot));
             }
-        }).then(function (items) {
-            return find(items, function (adType) {
-                return adType !== '';
-            });
         });
     }
 

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -153,11 +153,6 @@ $mobile-max-container-width: gs-span(8);
         max-width: 300px;
     }
 
-    // Hide 'advertisement' label for gu style
-    .ad-slot__label {
-        display: none;
-    }
-
     // Article styles: Right slot width is exactly the size of the banner so we don't want any margin
     &.ad-slot--right {
         margin-left: auto;


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/frontend/pull/12062/files @uplne fixed the redundant 'Advertisement' label on Enchilada ads by using `display: none`. But that label shouldn't be rendered there at all. The bug was in the `breakout-iframe.js` file, because empty `type` param was returned before asynchronous call ended.
## What is the value of this and can you measure success?

A proper way of solving issue.
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots
## ![screen shot 2016-03-02 at 17 18 41](https://cloud.githubusercontent.com/assets/489567/13468216/96f3cd82-e099-11e5-8978-455a58c1ca78.png)

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
