### PR TITLE
Revert sticky ad transform

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -34,73 +34,65 @@
                 @if(showAdverts) {
                     @fragments.commercial.topBanner(page.metadata, edition)
                 }
+
+                @fragments.header(page)
+
+                @if(adBelowNav) {
+                    @fragments.commercial.topBannerBelowNav()
+                }
+
+                @if(showAdverts) {
+                    @fragments.commercial.topBannerMobile(page.metadata, edition)
+                }
+
+                <div id="maincontent" tabindex="0"></div>
+            } else {
+                @fragments.header(page)
             }
         }
 
-        <div id="page">
+        @if(BreakingNewsSwitch.isSwitchedOn) {
+            <div class="js-breaking-news-placeholder breaking-news breaking-news--hidden breaking-news--fade-in"
+            data-link-name="breaking news"
+            data-component="breaking-news"></div>
+        }
 
-            @fragments.header(page)
+        @body
 
-            @if(!(page.metadata.hasHeader && getContent(page).exists(_.tags.isArticle))) {
-                @if(!mvt.CMTopBannerPosition.isParticipating) {
+        @**********************
+         24x7 support training
 
-                    @if(adBelowNav) {
-                        @fragments.commercial.topBannerBelowNav()
-                    }
+         We intentionally modified the displayed section on this specific article.
+         This is a failure that trainees have to diagnose in frontend.
+        ************************@
+        @if(request.path == "/info/2015/mar/11/-removed-article") {
+            <script type="text/javascript">
+                document.querySelectorAll('[data-link-name="article section"]')[0].textContent = "Culture"
+                @***
+                 The following is a misdirection to let people think damned CAPI is causing the issue
+                ***@
+                console.log("Error connecting to content API to retrieve section: 503")
+                console.log("Defaulting to Culture")
+            </script>
+        }
 
-                    @if(showAdverts) {
-                        @fragments.commercial.topBannerMobile(page.metadata, edition)
-                    }
-                }
-            }
+        @fragments.footer(page)
 
-            <!-- Used for skipping to content -->
-            <div id="maincontent" tabindex="0"></div>
+        @if(NonBlockingOmniture.isSwitchedOn) {
 
-            @if(BreakingNewsSwitch.isSwitchedOn) {
-                <div class="js-breaking-news-placeholder breaking-news breaking-news--hidden breaking-news--fade-in"
-                data-link-name="breaking news"
-                data-component="breaking-news"></div>
-            }
+            @fragments.inlineJSNonBlocking()
 
-            @body
+            @fragments.analytics(page)
 
-            @**********************
-             24x7 support training
+        } else {
 
-             We intentionally modified the displayed section on this specific article.
-             This is a failure that trainees have to diagnose in frontend.
-            ************************@
-            @if(request.path == "/info/2015/mar/11/-removed-article") {
-                <script type="text/javascript">
-                    document.querySelectorAll('[data-link-name="article section"]')[0].textContent = "Culture"
-                    @***
-                     The following is a misdirection to let people think damned CAPI is causing the issue
-                    ***@
-                    console.log("Error connecting to content API to retrieve section: 503")
-                    console.log("Defaulting to Culture")
-                </script>
-            }
+            @fragments.analytics(page)
 
-            @fragments.footer(page)
+            @fragments.inlineJSNonBlocking()
 
-            @if(NonBlockingOmniture.isSwitchedOn) {
+        }
 
-                @fragments.inlineJSNonBlocking()
-
-                @fragments.analytics(page)
-
-            } else {
-
-                @fragments.analytics(page)
-
-                @fragments.inlineJSNonBlocking()
-
-            }
-
-            @fragments.commercial.pageSkin()
-
-        </div>
+        @fragments.commercial.pageSkin()
 
     </body>
     </html>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -38,9 +38,12 @@
         }
 
         <div id="page">
+
+            @fragments.header(page)
+
             @if(!(page.metadata.hasHeader && getContent(page).exists(_.tags.isArticle))) {
-                @fragments.header(page)
                 @if(!mvt.CMTopBannerPosition.isParticipating) {
+
                     @if(adBelowNav) {
                         @fragments.commercial.topBannerBelowNav()
                     }

--- a/static/src/javascripts/projects/common/modules/commercial/sticky-ad-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/sticky-ad-banner.js
@@ -106,11 +106,11 @@ define([
         var transitionTimingFunction = 'cubic-bezier(0, 0, 0, .985)';
         var transitionDuration = '1s';
 
-        els.$page.css({
+        els.$header.css({
             'transition': state.shouldTransition
-                ? ['transform', transitionDuration, transitionTimingFunction].join(' ')
+                ? ['margin-top', transitionDuration, transitionTimingFunction].join(' ')
                 : '',
-            'transform': 'translateY(' + state.adHeight + 'px)'
+            'margin-top': state.adHeight
         });
 
         var pageYOffset = state.scrollCoords[1];
@@ -198,7 +198,7 @@ define([
                 $document: $(document.body),
                 $adBanner: $adBanner,
                 $adBannerInner: $adBannerInner,
-                $page: $('#page'),
+                $header: $header,
                 window: window
             };
             var update = function () {

--- a/static/src/stylesheets/base/_base.scss
+++ b/static/src/stylesheets/base/_base.scss
@@ -19,7 +19,8 @@ body {
 
 
 @if $old-ie == false {
-    #page {
+    html,
+    body {
         overflow-x: hidden;
     }
 }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -75,6 +75,8 @@
     .sticky-ad-banner & {
         z-index: 1022;
         width: 100%;
+        transform: translateZ(0);
+        will-change: transform;
         position: relative;
     }
 

--- a/static/test/javascripts/spec/common/commercial/sticky-ad-banner.spec.js
+++ b/static/test/javascripts/spec/common/commercial/sticky-ad-banner.spec.js
@@ -12,7 +12,7 @@ define([
             id: 'sticky-ad-banner-test',
             fixtures: [
                 '<div class="ad-banner"><div class="ad-banner-inner"></div></div>' +
-                '<div class="page"><div class="header"></div></div>'
+                '<div class="header"></div>'
             ]
         };
 
@@ -25,7 +25,6 @@ define([
                 $adBanner: $('.ad-banner'),
                 $adBannerInner: $('.ad-banner-inner'),
                 $header: $('.header'),
-                $page: $('.page'),
                 // We can't scroll the Phantom window for some reason, so
                 // we mock window instead
                 window: { scrollTo: sinon.spy() }
@@ -48,7 +47,7 @@ define([
 
             expect(elements.$adBanner.css('position')).toEqual('fixed');
             expect(elements.$adBanner.css('height')).toEqual(state.adHeight + 'px');
-            expect(elements.$page.css('transform')).toEqual('translateY(' + state.adHeight + 'px)');
+            expect(elements.$header.css('margin-top')).toEqual(state.adHeight + 'px');
         });
 
         it('when the user has scrolled past the sticky (fixed) zone, it should begin pushing the ad banner up', function () {
@@ -79,7 +78,7 @@ define([
                 // Stop the ad from overflowing while we transition
                 expect(elements.$adBanner.css('overflow')).toEqual('hidden');
                 expect(elements.$adBanner.css('transition')).toEqual('height 1s cubic-bezier(0, 0, 0, .985)');
-                expect(elements.$page.css('transition')).toEqual('transform 1s cubic-bezier(0, 0, 0, .985)');
+                expect(elements.$header.css('transition')).toEqual('margin-top 1s cubic-bezier(0, 0, 0, .985)');
 
                 expect(elements.window.scrollTo.callCount).toEqual(0);
             });


### PR DESCRIPTION
Reverts #12140 and then #11988 because it breaks `position: fixed` elements inside of the transformed element, much to our surprise! More info about this at http://stackoverflow.com/questions/15194313/webkit-css-transform3d-position-fixed-issue

/cc @regiskuckaertz @tijanamiletic 
