### PR TITLE
Add the morning briefing series to the blacklist

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -219,7 +219,9 @@ define([
             },
             pageHasBlanketBlacklist: function () {
                 // Prevent the blanket emails from ever showing on certain keywords or sections
-                return canRunHelpers.keywordExists(['US elections 2016', 'Football']) || config.page.section === 'film';
+                return canRunHelpers.keywordExists(['US elections 2016', 'Football']) ||
+                        config.page.section === 'film' ||
+                        config.page.seriesId === 'world/series/guardian-morning-briefing';
             }
         },
         canRunList = {


### PR DESCRIPTION
## What does this change?

Makes sure the non-series version of the morning briefing email sign-up doesn't appear in the series articles.
## What is the value of this and can you measure success?

It has different wording and positioning that fits with the series better.
