### PR TITLE
Discussion - add specific error messages

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -73,8 +73,8 @@ CommentBox.prototype.errorMessages = {
     USER_BANNED: 'Commenting has been disabled for this account (<a href="/community-faqs#321a">why?</a>).',
     DISCUSSION_CLOSED: 'Sorry your comment can not be published as the discussion is now closed for comments.',
     COMMENT_RATE_LIMIT_EXCEEDED: 'You can only post one comment every minute. Please try again in a moment.',
-    INVALID_PROTOCOL: 'Sorry your comment can not be published as it was not sent over a secure channel. Please report us this issue',
-    AUTH_COOKIE_INVALID: 'Sorry your comment can not be published as your authenciation cookie seems invalid. Please try to sign in before posting again.',
+    INVALID_PROTOCOL: 'Sorry your comment can not be published as it was not sent over a secure channel. Please report us this issue using the technical issue link in the page footer.',
+    AUTH_COOKIE_INVALID: 'Sorry, your comment was not published as you are no longer signed in. Please sign in and try again.',
     'READ-ONLY-MODE': 'Sorry your comment can not currently be published as commenting is undergoing maintenance but will be back shortly. Please try again in a moment.',
     /* Custom error codes */
     API_CORS_BLOCKED: /*CORS blocked by HTTP/1.0 proxy*/'Could not post due to your internet settings, which might be controlled by your provider. Please contact your administrator or disable any proxy servers or VPNs and try again.',

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -67,11 +67,17 @@ CommentBox.prototype.classes = {};
  * @override
  */
 CommentBox.prototype.errorMessages = {
+    /* Discussion API error codes - See DAPI exceptions and associated error messages  */
     EMPTY_COMMENT_BODY: 'Please write a comment.',
     COMMENT_TOO_LONG: 'Your comment must be fewer than 5000 characters long.',
-    HTTP_420: 'You can only post one comment every minute. Please try again in a moment.',
-    HTTP_0: /*CORS blocked by HTTP/1.0 proxy*/'Could not post due to your internet settings, which might be controlled by your provider. Please contact your administrator or disable any proxy servers or VPNs and try again.',
     USER_BANNED: 'Commenting has been disabled for this account (<a href="/community-faqs#321a">why?</a>).',
+    DISCUSSION_CLOSED: 'Sorry your comment can not be published as the discussion is now closed for comments.',
+    COMMENT_RATE_LIMIT_EXCEEDED: 'You can only post one comment every minute. Please try again in a moment.',
+    INVALID_PROTOCOL: 'Sorry your comment can not be published as it was not sent over a secure channel. Please report us this issue',
+    AUTH_COOKIE_INVALID: 'Sorry your comment can not be published as your authenciation cookie seems invalid. Please try to sign in before posting again.',
+    'READ-ONLY-MODE': 'Sorry your comment can not currently be published as commenting is undergoing maintenance but will be back shortly. Please try again in a moment.',
+    /* Custom error codes */
+    API_CORS_BLOCKED: /*CORS blocked by HTTP/1.0 proxy*/'Could not post due to your internet settings, which might be controlled by your provider. Please contact your administrator or disable any proxy servers or VPNs and try again.',
     API_ERROR: 'Sorry, there was a problem posting your comment.  Please try another browser or network connection.  Reference code ',
     EMAIL_VERIFIED: '<span class="d-comment-box__error-meta">Sent. Please check your email to verify ' +
         ' your email address' + '. Once verified post your comment.</span>',
@@ -252,7 +258,7 @@ CommentBox.prototype.postComment = function(e) {
  */
 CommentBox.prototype.error = function(type, message) {
 
-    if (type === 'HTTP_0') {
+    if (type === 'API_CORS_BLOCKED') {
         beacon.counts('comment-http-proxy-error', 'comment-error');
     } else {
         beacon.counts('comment-error');
@@ -298,8 +304,8 @@ CommentBox.prototype.fail = function(xhr) {
 
     this.setFormState();
 
-    if (this.errorMessages['HTTP_' + xhr.status]) {
-        this.error('HTTP_' + xhr.status);
+    if (xhr.status == 0) {
+        this.error('API_CORS_BLOCKED');
     } else if (this.errorMessages[response.errorCode]) {
         this.error(response.errorCode);
     } else {

--- a/static/test/javascripts/fixtures/discussion/api-post-comment-error-discussion-closed.js
+++ b/static/test/javascripts/fixtures/discussion/api-post-comment-error-discussion-closed.js
@@ -1,0 +1,3 @@
+define(function () {
+    return '{"status":"error", "statusCode": 409, "message":"Discussion closed", "errorCode": "DISCUSSION_CLOSED"}';
+});

--- a/static/test/javascripts/fixtures/discussion/api-post-comment-error-read-only-mode.js
+++ b/static/test/javascripts/fixtures/discussion/api-post-comment-error-read-only-mode.js
@@ -1,0 +1,3 @@
+define(function () {
+    return '{"status":"error", "statusCode": 503, "message":"Commenting is undergoing maintenance but will be back again shortly.", "errorCode": "READ-ONLY-MODE"}';
+});

--- a/static/test/javascripts/spec/common/discussion/comment-box.spec.js
+++ b/static/test/javascripts/spec/common/discussion/comment-box.spec.js
@@ -5,6 +5,8 @@ define([
     'fixtures/discussion/discussion',
     'fixtures/discussion/comment-valid',
     'fixtures/discussion/api-post-comment-valid',
+    'fixtures/discussion/api-post-comment-error-discussion-closed',
+    'fixtures/discussion/api-post-comment-error-read-only-mode',
     'common/modules/discussion/comment-box'
 ], function (
     Id,
@@ -13,6 +15,8 @@ define([
     discussionJson,
     validCommentText,
     apiPostValidCommentResp,
+    apiPostValidCommentButDiscussionClosed,
+    apiPostValidCommentButReadOnlyMode,
     CommentBox
 ) {
     describe('Comment box', function () {
@@ -176,6 +180,24 @@ define([
                 };
 
                 bean.fire(commentBox.elem, 'submit');
+                expect(commentBox.getElem('error')).not.toBeUndefined();
+            });
+
+            it('should error on discussion closed', function () {
+                expect(commentBox.getElem('error')).toBeUndefined();
+                commentBox.getElem('body').value = validCommentText;
+                server.respondWith('POST', /.*/, [409, { 'Content-Type': 'text/html', 'Content-Length': apiPostValidCommentButDiscussionClosed.length }, apiPostValidCommentButDiscussionClosed]);
+                bean.fire(commentBox.elem, 'submit');
+                server.respond();
+                expect(commentBox.getElem('error')).not.toBeUndefined();
+            });
+
+            it('should error on read only mode', function () {
+                expect(commentBox.getElem('error')).toBeUndefined();
+                commentBox.getElem('body').value = validCommentText;
+                server.respondWith('POST', /.*/, [503, { 'Content-Type': 'text/html', 'Content-Length': apiPostValidCommentButReadOnlyMode.length }, apiPostValidCommentButReadOnlyMode]);
+                bean.fire(commentBox.elem, 'submit');
+                server.respond();
                 expect(commentBox.getElem('error')).not.toBeUndefined();
             });
 


### PR DESCRIPTION
## Discussion - add specific error messages

Between the time a user start writing a comment and the comment is posted the discussion could be closed. In that case the current user experience display a generic error message:

![ce33e9ae-398f-47d7-9154-ce5004fa2be7](https://cloud.githubusercontent.com/assets/615085/13494686/b3bfed34-e13d-11e5-94ee-89eb9185fa6c.png)

The same could happens if a discussion api maintenance work is started.

The associated changes handle those errors with a specific error messages explaining to the user why the comment could not be published. Error modes are defined in [discussion api code](https://github.com/guardian/discussion-api/blob/master/discussion-api/src/main/scala/com.gu.discussion.api/api/ApiRequestException.scala).
