### PR TITLE
404 test: next in series

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -13,6 +13,15 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABNextInSeries = Switch(
+    "A/B Tests",
+    "ab-next-in-series",
+    "Show next in series",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 3, 23),
+    exposeClientSide = true
+  )
+
   val ABIdentityRegisterMembershipStandfirst = Switch(
     "A/B Tests",
     "ab-identity-register-membership-standfirst",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -7,6 +7,7 @@ define([
     'common/modules/analytics/mvt-cookie',
     'common/modules/experiments/tests/fronts-on-articles2',
     'common/modules/experiments/tests/identity-register-membership-standfirst',
+    'common/modules/experiments/tests/next-in-series',
     'lodash/arrays/flatten',
     'lodash/collections/forEach',
     'lodash/objects/keys',
@@ -25,6 +26,7 @@ define([
     mvtCookie,
     FrontsOnArticles2,
     IdentityRegisterMembershipStandfirst,
+    NextInSeries,
     flatten,
     forEach,
     keys,
@@ -38,7 +40,8 @@ define([
 
     var TESTS = flatten([
         new FrontsOnArticles2(),
-        new IdentityRegisterMembershipStandfirst()
+        new IdentityRegisterMembershipStandfirst(),
+        new NextInSeries()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/next-in-series.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/next-in-series.js
@@ -1,0 +1,92 @@
+define([
+    'common/utils/$',
+    'lodash/collections/find'
+], function (
+    $,
+    find
+) {
+    var render = function (state) {
+        return '<div class="next-in-series-test">' +
+            '<h3>Coming up next week</h3>' +
+            '<h4>' + state.title + '</h4>' +
+            '<p class="next-in-series-test__teaser">' + state.trail + '</p>' +
+            '<a href="' + state.link + '"' +
+                ' data-link-name="next in series | remind me"' +
+                ' class="button button--large next-in-series-test__remind-me-link">Remind me</a>' +
+        '</div>';
+    };
+
+    var $articleBody = $('.content__article-body');
+
+    var allSeries = [
+        {
+            name: 'Experience',
+            pageId: 'lifeandstyle/2016/mar/04/experience-my-head-was-crushed-by-a-rock-thrown-at-my-car',
+            title: 'I fought off a mountain lion',
+            trail: 'Its ears were slanted in attack position, its teeth yellow splinters buried in black gums',
+            link: 'https://www.surveymonkey.co.uk/r/guardian-experience-remindme'
+        },
+        {
+            name: 'Blind Date',
+            pageId: 'lifeandstyle/2016/mar/05/blind-date-valerio-matt',
+            title: 'Will Charles and Ross hit it off?',
+            trail: 'What was I hoping for? Vin Diesel',
+            link: 'https://www.surveymonkey.co.uk/r/guardian-blinddate-remindme'
+        },
+        {
+            name: 'Alanis',
+            pageId: 'lifeandstyle/2016/mar/04/ask-alanis-morissette-husband-or-son',
+            title: 'Dear Alanis, My friends share my secrets with their partners. What do I do?',
+            trail: 'Suddenly my secrets are not so safe, and it leaves me feeling vulnerable',
+            link: 'https://www.surveymonkey.co.uk/r/guardian-alanis-remindme'
+        },
+        {
+            name: 'What I’m Really Thinking',
+            pageId: 'lifeandstyle/2016/mar/05/what-really-thinking-theme-park-costume-character',
+            title: 'What I’m Really Thinking: the mother of a disabled baby',
+            trail: 'Normal now means a routine of tube feeding, tracheostomy care, physiotherapy, overnight shifts and endless logistics',
+            link: 'https://www.surveymonkey.co.uk/r/guardian-whatimreallythinking-remindme'
+        }
+    ];
+
+    var pageId = window.guardian.config.page.pageId;
+    var series = find(allSeries, function (series) {
+        return series.pageId === pageId;
+    });
+
+    return function () {
+        this.id = 'NextInSeries';
+        this.start = '2016-03-07';
+        this.expiry = '2016-03-30';
+        this.author = 'Oliver Ash';
+        this.description = 'Show next in series';
+        this.audience = 0;
+        this.audienceOffset = 0.3;
+        this.successMeasure = '';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            return true;
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {
+
+                }
+            },
+            {
+                id: 'variant',
+                test: function () {
+                    if (series) {
+                        var el = $.create(render(series));
+                        el.insertAfter($articleBody);
+                    }
+                }
+            }
+        ];
+    };
+});

--- a/static/src/stylesheets/content.scss
+++ b/static/src/stylesheets/content.scss
@@ -147,3 +147,4 @@
 @import 'module/_tag-list';
 @import 'module/_childrens-books-site';
 @import 'module/email/_main';
+@import 'module/content/article-test';

--- a/static/src/stylesheets/module/content/_article-test.scss
+++ b/static/src/stylesheets/module/content/_article-test.scss
@@ -1,0 +1,27 @@
+.next-in-series-test {
+    padding-top: $gs-baseline / 4;
+    padding-bottom: $gs-baseline / 4;
+    border-top: 1px dotted guss-colour(neutral-3, $pasteup-palette);
+
+    h3 {
+        color: colour(neutral-2);
+        @include fs-textSans(5);
+    }
+
+    h4 {
+        @include fs-header(5);
+        margin-bottom: ($gs-baseline / 3) * 2;
+    }
+}
+
+.next-in-series-test__teaser {
+    margin-bottom: $gs-baseline;
+}
+
+.next-in-series-test__remind-me-link {
+    &, a:hover, a:active {
+        background-color: colour(features-support-1) !important;
+        border-color: darken(colour(features-support-1), 5%) !important;
+        color: #ffffff !important;
+    }
+}


### PR DESCRIPTION
I'm working with Andrea to 404 test a “next in series” container at the bottom of 4 different series articles (Experience, Alanis, What I'm Really Thinking, and Blind Date) so we can track interest over the next week. These articles go live tomorrow and Saturday.

Very hacky CSS/JS, but we'll tear it out in a week anyway.

The data is hardcoded and comes directly from editorial.
# Screenshot

![image](https://cloud.githubusercontent.com/assets/921609/13495119/bd6c57fc-e140-11e5-8b7f-0803c926b227.png)
# How will this be tracked?
- clicks on the button
- we will email the next article to people who complete the survey, and track this return journey
