### PR TITLE
defer binding of video events to analytics

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -208,14 +208,15 @@ define([
             player.ready(function () {
                 var vol;
 
-                events.bindGlobalEvents(player);
-                events.bindContentEvents(player);
-                if (withPreroll) {
-                    events.bindPrerollEvents(player);
-                }
                 deferToAnalytics(function () {
                     events.initOmnitureTracking(player);
                     events.initOphanTracking(player, mediaId);
+
+                    events.bindGlobalEvents(player);
+                    events.bindContentEvents(player);
+                    if (withPreroll) {
+                        events.bindPrerollEvents(player);
+                    }
                 });
 
                 initLoadingSpinner(player);


### PR DESCRIPTION
# Video analytics
## What does this change?

It seems `bindGlobalEvents` doesn't just bind, but triggers events. Who'd have thunk it.
Tested against what we were fixing last time and that works too.

The reason for not sorting this out properly is the larger discussions about the player.
## What is the value of this and can you measure success?

:dancers: 
## Does this affect other platforms - Amp, Apps, etc?

:hatched_chick: 
## Screenshots

:gun: 
## Request for comment
## @akash1810 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
