### PR TITLE
Add series name to series emails without a custom header

### DIFF
--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -12,6 +12,15 @@
         </a>
     }
 
+    @if(!article.hasCustomEmailBanner) {
+        @article.content.seriesName.map { seriesName =>
+            @paddedRow {
+                <h3 class="text--brand">@seriesName</h3>
+                <hr class="rule--compact" />
+            }
+        }
+    }
+
     @paddedRow {
         <h1>@article.trail.headline</h1>
     }

--- a/article/app/views/fragments/emailArticleBody.scala.html
+++ b/article/app/views/fragments/emailArticleBody.scala.html
@@ -12,12 +12,10 @@
         </a>
     }
 
-    @if(!article.hasCustomEmailBanner) {
-        @article.content.seriesName.map { seriesName =>
-            @paddedRow {
-                <h3 class="text--brand">@seriesName</h3>
-                <hr class="rule--compact" />
-            }
+    @article.fallbackSeriesText.map { seriesName =>
+        @paddedRow {
+            <h3 class="text--brand">@seriesName</h3>
+            <hr class="rule--compact" />
         }
     }
 

--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -59,8 +59,6 @@ object EmailAddons {
 
     val fallbackSeriesText = if (email.isEmpty) c.content.seriesName else None
 
-    val hasCustomEmailBanner: Boolean = email.exists(_.banner.nonEmpty)
-
     lazy val banner = {
       val banner = email map (_.banner) getOrElse defaultBanner
       Static(s"images/email/banners/$banner").path

--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -57,6 +57,8 @@ object EmailAddons {
   implicit class EmailContentType(c: ContentType) {
     val email = allEmails.find(_.test(c))
 
+    val fallbackSeriesText = if (email.isEmpty) c.content.seriesName else None
+
     val hasCustomEmailBanner: Boolean = email.exists(_.banner.nonEmpty)
 
     lazy val banner = {

--- a/common/app/model/EmailAddons.scala
+++ b/common/app/model/EmailAddons.scala
@@ -57,6 +57,8 @@ object EmailAddons {
   implicit class EmailContentType(c: ContentType) {
     val email = allEmails.find(_.test(c))
 
+    val hasCustomEmailBanner: Boolean = email.exists(_.banner.nonEmpty)
+
     lazy val banner = {
       val banner = email map (_.banner) getOrElse defaultBanner
       Static(s"images/email/banners/$banner").path

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -152,6 +152,11 @@ final case class Content(
     tags.blogs.find{tag => tag.id != "commentisfree/commentisfree"}.orElse(tags.series.headOption)
   }
 
+  val seriesName: Option[String] = tags.series.filterNot{ _.id == "commentisfree/commentisfree"} match {
+    case allTags@(mainSeries :: _) => Some(mainSeries.name)
+    case _ => None
+  }
+
   lazy val linkCounts = LinkTo.countLinks(fields.body) + fields.standfirst.map(LinkTo.countLinks).getOrElse(LinkCounts.None)
 
   lazy val hasMultipleVideosInPage: Boolean = mainVideoCanonicalPath match {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -152,10 +152,7 @@ final case class Content(
     tags.blogs.find{tag => tag.id != "commentisfree/commentisfree"}.orElse(tags.series.headOption)
   }
 
-  val seriesName: Option[String] = tags.series.filterNot{ _.id == "commentisfree/commentisfree"} match {
-    case allTags@(mainSeries :: _) => Some(mainSeries.name)
-    case _ => None
-  }
+  val seriesName: Option[String] = tags.series.filterNot(_.id == "commentisfree/commentisfree").headOption.map(_.name)
 
   lazy val linkCounts = LinkTo.countLinks(fields.body) + fields.standfirst.map(LinkTo.countLinks).getOrElse(LinkCounts.None)
 

--- a/common/app/views/fragments/email/stylesheets/main.scala.html
+++ b/common/app/views/fragments/email/stylesheets/main.scala.html
@@ -71,6 +71,10 @@
         margin-bottom: -4px;
     }
 
+    hr.rule--compact {
+        margin-top: 5px;
+    }
+
     .author a {
         text-decoration: none;
         color: #005689 !important;
@@ -141,5 +145,9 @@
         clear: none;
         margin: 0 auto;
         padding: 20% 0;
+    }
+
+    .text--brand {
+        color: #005689;
     }
 </style>


### PR DESCRIPTION
## What does this change?

Adds the series name to emails without a custom header.
## Screenshots
### Series, no custom header.

![image](https://cloud.githubusercontent.com/assets/638051/13499683/4a6a58aa-e157-11e5-90b2-5c84085a957f.png)
### Series, custom header

![image](https://cloud.githubusercontent.com/assets/638051/13499769/896f05dc-e157-11e5-9461-c72ba27129b2.png)
### Not a series

![image](https://cloud.githubusercontent.com/assets/638051/13499690/4ff79a26-e157-11e5-898b-50f847d620bc.png)
