### PR TITLE
Sticky MPU fix on the advertisement feature pages

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ads/sticky-mpu.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ads/sticky-mpu.js
@@ -26,7 +26,9 @@ define([
             return fastdom.write(function () {
                 $adSlot.parent().css('height', (articleBodyOffset + mpuHeight) + 'px');
             }).then(function () {
-                return new Sticky($adSlot[0]).init();
+                //if there is a sticky 'paid by' band move the sticky mpu down so it will be always visible
+                var options = config.page.isAdvertisementFeature ? {top: 43} : {};
+                return new Sticky($adSlot[0], options).init();
             });
         });
     }

--- a/static/src/javascripts/projects/common/modules/ui/sticky.js
+++ b/static/src/javascripts/projects/common/modules/ui/sticky.js
@@ -63,6 +63,7 @@ define([
             message = 'fixed';
         } else {
             stick = false;
+            css = { top: 0 };
             message = 'unfixed';
         }
 


### PR DESCRIPTION
## What does this change?

This PR fixes the sticky MPU on the advertisement feature pages (with 'Paid by' band).
## What is the value of this and can you measure success?

The sticky MPU is fully visible.
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

before:
![screen shot 2016-03-03 at 17 52 38](https://cloud.githubusercontent.com/assets/489567/13503478/7d1020e0-e167-11e5-8235-caba0360b045.png)

after:
![screen shot 2016-03-03 at 17 52 46](https://cloud.githubusercontent.com/assets/489567/13503483/8438870e-e167-11e5-8008-bcf3a6d1c217.png)
## Request for comment

This requires proper testing because the `sticky.js` module is used by liveblog's toast as well.
@OliverJAsh 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
