### PR TITLE
This adds ipod device type and devices on iOS7 to is Older Device

### DIFF
--- a/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
+++ b/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
@@ -46,7 +46,7 @@
     // Old here means iOS 3-6.
     // For usage stats see http://david-smith.org/iosversionstats/
     function isOlderIOSDevice() {
-        return /.*(iPhone|iPad; CPU) OS ([3456])_\d+.*/.test(navigator.userAgent);
+        return /.*(iPhone|iPad|iPod; CPU) OS ([34567])_\d+.*/.test(navigator.userAgent);
     };
 
     function isIpad() {

--- a/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
+++ b/common/app/templates/inlineJS/blocking/shouldEnhance.scala.js
@@ -43,7 +43,7 @@
     };
 
     // If this is an older iOS, we assume it's an older device (they stop being upgradeable at some point).
-    // Old here means iOS 3-6.
+    // Old here means iOS 3-7.
     // For usage stats see http://david-smith.org/iosversionstats/
     function isOlderIOSDevice() {
         return /.*(iPhone|iPad|iPod; CPU) OS ([34567])_\d+.*/.test(navigator.userAgent);


### PR DESCRIPTION
Since mobile aggregator got switched off we have had a bunch of users on older devices trying to access the web and crashing. Many cant even access the content page with the link to switch to core.
This change incorporates iPods into our old device checks.
It also adds iOS7 into the older device bin
