### PR TITLE
Credentials on Amp List

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -185,6 +185,8 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     private lazy val scheme = configuration.getStringProperty("amp.scheme").getOrElse("")
     lazy val host = configuration.getStringProperty("amp.host").getOrElse("")
     lazy val baseUrl = scheme + host
+    lazy val corsOrigins: Seq[String] = configuration.getStringProperty("amp.cors.origin").map(_.split(",")
+      .map(_.trim).toSeq).getOrElse(Nil)
   }
 
   object id {

--- a/common/app/conf/Filters.scala
+++ b/common/app/conf/Filters.scala
@@ -70,14 +70,7 @@ object SurrogateKeyFilter extends Filter with ExecutionContexts {
 object AmpFilter extends Filter with ExecutionContexts with implicits.Requests {
   override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
     if (request.isAmp) {
-      val domain = request.headers.get("Origin") match {
-        case None => {
-          "https://" + request.domain
-        }
-        case Some(requestOrigin) => {
-          requestOrigin
-        }
-      }
+      val domain = request.headers.get("Origin").getOrElse("https://" + request.domain)
       val exposeAmpHeader = "Access-Control-Expose-Headers" -> "AMP-Access-Control-Allow-Source-Origin"
       val ampHeader = "AMP-Access-Control-Allow-Source-Origin" -> Configuration.amp.corsOrigins.find(_ == domain).getOrElse("*")
 

--- a/common/app/model/Cors.scala
+++ b/common/app/model/Cors.scala
@@ -1,24 +1,27 @@
 package model
 
+import conf.Configuration.{amp, ajax}
 import play.api.mvc.{RequestHeader, Results}
 import play.api.mvc.Result
-import conf.Configuration.ajax.corsOrigins
 
-object Cors extends Results {
+object Cors extends Results with implicits.Requests {
 
   private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
 
   def apply(result: Result, allowedMethods: Option[String] = None)(implicit request: RequestHeader): Result = {
 
     val responseHeaders = (defaultAllowHeaders ++ request.headers.get("Access-Control-Request-Headers").toList) mkString ","
+    val corsOrigins = if(request.isAmp) amp.corsOrigins else ajax.corsOrigins
 
     request.headers.get("Origin") match {
       case None => result
       case Some(requestOrigin) => {
+        val allowedOrigin = corsOrigins.find(_ == requestOrigin).getOrElse("*")
         val headers = allowedMethods.map("Access-Control-Allow-Methods" -> _).toList ++ List(
-          "Access-Control-Allow-Origin" -> corsOrigins.find(_ == requestOrigin).getOrElse("*"),
+          "Access-Control-Allow-Origin" -> allowedOrigin,
           "Access-Control-Allow-Headers" -> responseHeaders,
           "Access-Control-Allow-Credentials" -> "true")
+
         result.withHeaders(headers: _*)
       }
     }

--- a/common/app/views/fragments/amp/storyPackageAmp.scala.html
+++ b/common/app/views/fragments/amp/storyPackageAmp.scala.html
@@ -51,6 +51,6 @@
                 </time>
             </aside>
         </div>
-        <a href="@{host}/@content.header.url" class="fc-item__link">@content.header.headline</a>
+        <a href="@{host}@content.header.url" class="fc-item__link">@content.header.headline</a>
     </div>
 }

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -25,6 +25,7 @@ oas.siteId.host=m.code.dev-theguardian.com
 
 amp.host=amp.code.dev-theguardian.com
 amp.scheme=https://
+amp.cors.origin=https://m.code.dev-theguardian.com,https://amp.code.dev-theguardian.com, https://cdn.ampproject.org
 
 # ID
 id.url=https://profile.code.dev-theguardian.com

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -17,6 +17,8 @@ frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 #ajax.url=//localhost:9000
 ajax.cors.origin=http://m.random.com,http://127.0.0.1:9000,http://www.random.com,http://m.thegulocal.com,https://profile.thegulocal.com,http://localhost:9000
 
+amp.cors.origin=http://127.0.0.1:9000,https://www.random.com,https://m.thegulocal.com.https://www.thegulocal.com,https://profile.thegulocal.com,http://localhost:9000,https://3e245a8f.ngrok.io
+
 # ID
 id.url=https://profile.thegulocal.com
 id.apiRoot=https://idapi.thegulocal.com

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -17,7 +17,7 @@ frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 #ajax.url=//localhost:9000
 ajax.cors.origin=http://m.random.com,http://127.0.0.1:9000,http://www.random.com,http://m.thegulocal.com,https://profile.thegulocal.com,http://localhost:9000
 
-amp.cors.origin=http://127.0.0.1:9000,https://www.random.com,https://m.thegulocal.com.https://www.thegulocal.com,https://profile.thegulocal.com,http://localhost:9000,https://3e245a8f.ngrok.io
+amp.cors.origin=http://127.0.0.1:9000,https://amp.random.com,https://m.thegulocal.com,http://localhost:9000,https://amp.int.gnl
 
 # ID
 id.url=https://profile.thegulocal.com

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -23,6 +23,7 @@ ajax.cors.origin=http://www.theguardian.com,https://www.theguardian.com,https://
 
 amp.host=amp.theguardian.com
 amp.scheme=https://
+amp.cors.origin=https://www.theguardian.com,https://amp.theguardian.com, https://cdn.ampproject.org
 
 # ID
 id.url=https://profile.theguardian.com


### PR DESCRIPTION
# Credentials on Amp List

Take Two. First attempt here: https://github.com/guardian/frontend/pull/12022 (which I had to revert)
## What does this change?
- Adds amp specific response headers 
## This PR should fix:
- https://github.com/guardian/frontend/issues/12053
- Cookies should be sent with a request (cookie based editionalisation perhaps? :open_mouth: )
## Does this affect other platforms - Amp, Apps, etc?

This should only affect AMP
## Request for comment

@TBonnin can you take a look? Happy to discuss this with you :). Would really like to get your feedback
