### PR TITLE
Add shouldHideAdverts check to email sign-up

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -168,7 +168,8 @@ define([
             // Check our lists canRun method and
             // make sure that the user isn't already subscribed to this email and
             // don't show on IE 7,8,9 for now
-            if (listConfig.listName &&
+            if (!config.page.shouldHideAdverts &&
+                listConfig.listName &&
                 canRunList[listConfig.listName]() &&
                 !contains(userListSubscriptions, listConfig.listId) &&
                 !userHasRemoved(listConfig.listId, 'article') &&


### PR DESCRIPTION
## What does this change?

Adds a check for `shouldHideAdverts` config for email sign-up
## What is the value of this and can you measure success?

This prevents us showing the email sign-up promo on sensitive or inappropriate content
