### PR TITLE
only run autoplay video on Article and Liveblogs

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/article-video-autoplay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/article-video-autoplay.js
@@ -1,6 +1,7 @@
 define([
+    'common/utils/config',
     'common/utils/detect'
-], function (detect) {
+], function (config, detect) {
 
     return function () {
         this.id = 'ArticleVideoAutoplay';
@@ -17,7 +18,9 @@ define([
 
         this.canRun = function () {
             var bp = detect.getBreakpoint();
-            return !(bp === 'mobile' || bp === 'mobileLandscape');
+            var ct = config.page.contentType;
+
+            return !(bp === 'mobile' || bp === 'mobileLandscape') && (ct === 'Article' || ct === 'LiveBlog');
         };
 
         this.variants = [{


### PR DESCRIPTION
# Refine people to run video autoplay test
## What does this change?

Only run video autoplay test on video / liveblog pages.
This was having a strange affect on video pages.
## Request for comment

@johnduffell, @akash1810 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
