### PR TITLE
Separate jobs feed reading and parsing switches

### DIFF
--- a/commercial/app/commercial/feeds/FeedMetaData.scala
+++ b/commercial/app/commercial/feeds/FeedMetaData.scala
@@ -31,7 +31,7 @@ case class JobsFeedMetaData(urlTemplate: String) extends FeedMetaData {
     urlTemplate replace("yyyy-MM-dd", feedDate)
   }
 
-  val switch = Switches.JobFeedSwitch
+  val switch = Switches.JobFeedReadSwitch
   override val responseEncoding = utf8
 }
 

--- a/commercial/app/model/commercial/jobs/JobsFeed.scala
+++ b/commercial/app/model/commercial/jobs/JobsFeed.scala
@@ -10,6 +10,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 import scala.xml.{Elem, XML}
+import conf.switches.Switches.JobParseSwitch
 
 object JobsFeed extends ExecutionContexts with Logging {
 
@@ -20,7 +21,7 @@ object JobsFeed extends ExecutionContexts with Logging {
   } yield Job(jobXml)
 
   def parsedJobs(feedMetaData: FeedMetaData, feedContent: => Option[String]): Future[ParsedFeed[Job]] = {
-    feedMetaData.switch.isGuaranteedSwitchedOn flatMap { switchedOn =>
+    JobParseSwitch.isGuaranteedSwitchedOn flatMap { switchedOn =>
       if (switchedOn) {
         val start = currentTimeMillis
         feedContent map { body =>
@@ -30,7 +31,7 @@ object JobsFeed extends ExecutionContexts with Logging {
           Future.failed(MissingFeedException(feedMetaData.name))
         }
       } else {
-        Future.failed(SwitchOffException(feedMetaData.switch.name))
+        Future.failed(SwitchOffException(JobParseSwitch.name))
       }
     } recoverWith {
       case NonFatal(e) => Future.failed(e)

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -131,9 +131,18 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
-  val JobFeedSwitch = Switch(
+  val JobFeedReadSwitch = Switch(
     "Commercial",
-    "gu-jobs",
+    "gu-jobs-feed-read",
+    "If this switch is on, cached jobs feed will be updated from external source.",
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
+  val JobParseSwitch = Switch(
+    "Commercial",
+    "gu-jobs-parse",
     "If this switch is on, commercial components will be fed by job feed.",
     safeState = Off,
     sellByDate = never,


### PR DESCRIPTION
## What does this change?

Separate switches for reading jobs from external source, and parsing job instances for the merchandising component.
## What is the value of this and can you measure success?

We can stop trying to read a known broken feed without bringing down the component.
## Does this affect other platforms - Amp, Apps, etc?

Don't think other platforms will be affected.

/cc @kenlim 
