### PR TITLE
Remove --production flag

### DIFF
--- a/dev/teamcity/dist-npm-tc
+++ b/dev/teamcity/dist-npm-tc
@@ -5,7 +5,7 @@ set -o nounset
 set -o errexit
 
 echo "Npm installation."
-npm prune --production
-npm install --production
+npm prune
+npm install
 
 ./grunt-tc clean


### PR DESCRIPTION
The npm install --production flag keeps installing devDependencies. Removing for quick fix, should take 30-50 seconds off the build
