### PR TITLE
only autoplay on liveblogs & articles

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -36,7 +36,7 @@ trait ABTestSwitches {
     "ab-article-video-autoplay",
     "Autoplay embedded videos in article",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 3, 21),
+    sellByDate = new LocalDate(2016, 3, 22),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -326,7 +326,9 @@ define([
                         resolve();
                     }
 
-                    if (abVideoAutoplay.variant === 'autoplay') {
+                    var contentType = config.page.contentType;
+                    var isArticleOrLiveBlog = contentType === 'Article' || contentType === 'LiveBlog';
+                    if (abVideoAutoplay.variant === 'autoplay' && isArticleOrLiveBlog) {
                         // Annoyingly we pass the `parentNode` as the video is absolutely positioned.
                         var parentNode = player.el().parentNode;
                         var firstAutoplay = true;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/article-video-autoplay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/article-video-autoplay.js
@@ -1,7 +1,6 @@
 define([
-    'common/utils/config',
     'common/utils/detect'
-], function (config, detect) {
+], function (detect) {
 
     return function () {
         this.id = 'ArticleVideoAutoplay';
@@ -18,9 +17,7 @@ define([
 
         this.canRun = function () {
             var bp = detect.getBreakpoint();
-            var ct = config.page.contentType;
-
-            return !(bp === 'mobile' || bp === 'mobileLandscape') && (ct === 'Article' || ct === 'LiveBlog');
+            return !(bp === 'mobile' || bp === 'mobileLandscape');
         };
 
         this.variants = [{

--- a/static/src/javascripts/projects/common/modules/experiments/tests/article-video-autoplay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/article-video-autoplay.js
@@ -4,8 +4,8 @@ define([
 
     return function () {
         this.id = 'ArticleVideoAutoplay';
-        this.start = '2016-03-07';
-        this.expiry = '2016-03-21';
+        this.start = '2016-03-08';
+        this.expiry = '2016-03-22';
         this.author = 'James Gorrie';
         this.description = 'Autoplay embedded videos on article pages';
         this.audience = .2;


### PR DESCRIPTION
# Video autoplay

Turns out I didn't really understand how the framework runs, `canRun` I thought was whether to run the test, but is actually can the person be put into the test. This stops people, who are in the test, have the autoplay code run on Video pages and fronts. 
## What does this change?

:arrow_up:
## Request for comment

@johnduffell & @akash1810 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
