### PR TITLE
Add logic to check bottom of article email sign-up checks previous els

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -130,6 +130,9 @@ define([
         emailInserted = false,
         userListSubscriptions = [],
         keywords = config.page.keywords ? config.page.keywords.split(',') : '',
+        isParagraph = function ($el) {
+            return $el.nodeName && $el.nodeName === 'P';
+        },
         getSpacefinderRules = function () {
             return {
                 bodySelector: '.js-article__body',
@@ -215,6 +218,16 @@ define([
                 return canRunHelpers.keywordExists(['US elections 2016', 'Football']) ||
                         config.page.section === 'film' ||
                         config.page.seriesId === 'world/series/guardian-morning-briefing';
+            },
+            allowedArticleStructure: function () {
+                var $articleBody = $('.js-article__body');
+
+                if ($articleBody.length) {
+                    var allArticleEls = $('> *', $articleBody);
+                    return every([].slice.call(allArticleEls, allArticleEls.length - 3), isParagraph);
+                } else {
+                    return false;
+                }
             }
         },
         canRunList = {
@@ -225,18 +238,23 @@ define([
                 return config.page.section === 'film';
             },
             theFiver: function () {
-                return canRunHelpers.keywordExists(['Football']);
+                return canRunHelpers.keywordExists(['Football']) &&
+                        canRunHelpers.allowedArticleStructure();
             },
             morningMailUkSeries: function () {
-                return config.page.seriesId === 'world/series/guardian-morning-briefing';
+                return config.page.seriesId === 'world/series/guardian-morning-briefing' &&
+                        canRunHelpers.allowedArticleStructure();
             },
             morningMailUk: function () {
                 return (config.page.edition === 'UK' || config.page.edition === 'INT') &&
                         !canRunHelpers.pageHasBlanketBlacklist() &&
-                        canRunHelpers.userReferredFromFront();
+                        canRunHelpers.userReferredFromFront() &&
+                        canRunHelpers.allowedArticleStructure();
             },
             theGuardianToday: function () {
-                return !canRunHelpers.pageHasBlanketBlacklist() && canRunHelpers.userReferredFromFront();
+                return !canRunHelpers.pageHasBlanketBlacklist() &&
+                        canRunHelpers.userReferredFromFront() &&
+                        canRunHelpers.allowedArticleStructure();
             }
         };
 


### PR DESCRIPTION
## What does this change?

This adds back in the article structure check to make sure we are not ramming
## Screenshots

Prevents this beautiful sight:

![image](https://cloud.githubusercontent.com/assets/638051/13575595/a2994946-e481-11e5-8086-573d1df31d68.png)
## Request for comment

Thanks @OliverJAsh :100: 
