### PR TITLE
stop mobile chrome jumping on immersives

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -664,6 +664,7 @@
             height: 100vh;
             min-height: 520px;
             max-height: 800px;
+            transition: height 999s; // remove when fixed: https://bugs.chromium.org/p/chromium/issues/detail?id=428132
         }
 
         .content__header {

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -664,7 +664,7 @@
             height: 100vh;
             min-height: 520px;
             max-height: 800px;
-            transition: height 999s; // remove when fixed: https://bugs.chromium.org/p/chromium/issues/detail?id=428132
+            transition: height 999999s; // remove when fixed: https://bugs.chromium.org/p/chromium/issues/detail?id=428132
         }
 
         .content__header {


### PR DESCRIPTION
Current situation - as the address bar switches in and out the vh changes and causes everything to resize.  This is really annoying.
![jumping](https://cloud.githubusercontent.com/assets/7304387/13599768/c7b5b8cc-e51c-11e5-8195-7fa1ab8df660.gif)
With a long transition (hack), you can't really notice it moving
![still](https://cloud.githubusercontent.com/assets/7304387/13599932/ae77e294-e51d-11e5-9b77-841833a02c34.gif)
This only affects chrome apparently, and once [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=428132) is resolved in stable chrome, we can take this out again - although their fix may involve it being hidden behind the url bar.
@sammorrisdesign does that seem sensible? @NataliaLKB 
