### PR TITLE
Article - Recommendation discovery - People who read this also read - baseline

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -49,4 +49,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABRelatedContentDisplayAsRecommendation = Switch(
+    "A/B Tests",
+    "ab-article-related-content-display-as-recommendation",
+    "Display related content as people who read this also read",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 3, 16),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -10,6 +10,7 @@ define([
     'common/modules/experiments/tests/identity-register-membership-standfirst',
     'common/modules/experiments/tests/article-video-autoplay',
     'common/modules/experiments/tests/next-in-series',
+    'common/modules/experiments/tests/article-related-content-display-as-recommendation',
     'lodash/arrays/flatten',
     'lodash/collections/forEach',
     'lodash/objects/keys',
@@ -31,6 +32,7 @@ define([
     IdentityRegisterMembershipStandfirst,
     ArticleVideoAutoplay,
     NextInSeries,
+    RelatedContentDisplayAsRecommendation,
     flatten,
     forEach,
     keys,
@@ -47,7 +49,8 @@ define([
         new FrontsOnArticles2(),
         new IdentityRegisterMembershipStandfirst(),
         new ArticleVideoAutoplay(),
-        new NextInSeries()
+        new NextInSeries(),
+        new RelatedContentDisplayAsRecommendation()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/article-related-content-display-as-recommendation.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/article-related-content-display-as-recommendation.js
@@ -1,0 +1,33 @@
+define([
+    'common/utils/config'
+], function (config) {
+
+    return function () {
+        this.id = 'RelatedContentDisplayAsRecommendation';
+        this.start = '2016-03-07';
+        this.expiry = '2016-03-16';
+        this.author = 'Mariot Chauvin';
+        this.description = 'Display related content as people who read this also read';
+        this.audience = .35;
+        this.audienceOffset = .3;
+        this.successMeasure = 'Component clicks per article view, attention time following the click through, page views per visit, articles per visit, Minutes spent reading articles per visit, and visits within last 7 days.';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'not any change as this is measure our baseline';
+
+        this.canRun = function () {
+            var ct = config.page.contentType;
+            return ct === 'Article';
+        };
+
+        this.variants = [{
+            id: 'control',
+            test: function () {}
+        }, {
+            id: 'people-who-read-this-also-read-title',
+            test: function () {}
+        }];
+
+    };
+
+});

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -1,6 +1,7 @@
 define([
     'bonzo',
     'qwery',
+    'fastdom',
     'common/utils/$',
     'common/utils/config',
     'common/utils/mediator',
@@ -13,6 +14,7 @@ define([
 ], function (
     bonzo,
     qwery,
+    fastdom,
     $,
     config,
     mediator,
@@ -66,6 +68,17 @@ define([
                 showCount: false
             }).init();
         } else if (fetchRelated) {
+
+
+            if (ab.isInVariant('RelatedContentDisplayAsRecommendation', 'people-who-read-this-also-read-title')) {
+                var relatedContentSection = document.getElementById('related-content');
+                if (relatedContentSection) {
+                    fastdom.write(function () {
+                        $('.fc-container__header__title', relatedContentSection).textContent = 'people who have read this also read';
+                    });
+                }
+            }
+
             container = document.body.querySelector('.js-related');
 
             if (container) {


### PR DESCRIPTION
### Recommendation discovery

Recommendations are widely used as a mechanism to encourage a customer to buy more products / a reader to consume more content. We currently we do not provide recommendations to our readers so we have created a small team ( @MahanaC @cb372 @LATaylor-guardian @thomaska @cb372 ) that will spend 4 weeks to test a series of hypotheses to understand which recommendations improve onward journeys for our readers.
#### Objectives
- Our primary aim is to prove that content recommendation using a collaborative filtering algorithm can increase the number of articles viewed and increase the time spent per visit.
- Our secondary aim is to understand whether providing effective recommendations can encourage loyalty - increasing the number of visits per week.
#### Recommendation UI

For the discovery we are going to replace/override the related content component. The user interface will not differ, only the content inside this section and the title presented to the user will be different
#### First test - People who read this also read

Our first test will be around recommending content based on what other users have read.
#### Associated changes

The changes add a new A/B test that only change the title from `related content` to `people who read this also read`.  The content is not modified. The results will serve as our baseline to measure success when the content will come from recommendation engine and not related content.
