### PR TITLE
Fix TeamCity error (use make install)

### DIFF
--- a/dev/teamcity/dist-npm-tc
+++ b/dev/teamcity/dist-npm-tc
@@ -4,8 +4,7 @@ set -o xtrace
 set -o nounset
 set -o errexit
 
-echo "Npm installation."
-npm prune
-npm install
+echo "Install dependencies"
+make install
 
 ./grunt-tc clean


### PR DESCRIPTION
[Builds are failing](http://teamcity.gu-web.net:8111/viewLog.html?buildId=6696&buildTypeId=dotcom_pullrequests&tab=buildLog#_focus=2191) with the following error:

```
[11:35:10][Step 2/3] Running "shell:makeDeploysRadiator" (shell) task
[11:35:11][Step 2/3] 
[11:35:11][Step 2/3] > @ build /home/ubuntu/buildAgent/work/2225eda885912a28/static/src/deploys-radiator
[11:35:11][Step 2/3] > jspm bundle-sfx app/main target/main.js && cp app/main.css target/main.css
[11:35:11][Step 2/3] 
[11:35:11][Step 2/3] sh: 1: jspm: not found
```

I believe this is related to the change in #12058, which moved the `npm install` for the Deploys Radiator into `make install` which isn't currently run in TeamCity. Presumably a recent clean must have removed the node module for good.

This pull request proposes we replace `npm prune/install` with `make install` in the TeamCity install script.

I'll see if this PR succeeds and merge it if so.

@sndrs @jbreckmckye @uplne @NataliaLKB 
