### PR TITLE
Fixing error where amp header needs to be equal to our amp domain

### DIFF
--- a/common/app/conf/Filters.scala
+++ b/common/app/conf/Filters.scala
@@ -72,7 +72,7 @@ object AmpFilter extends Filter with ExecutionContexts with implicits.Requests {
     if (request.isAmp) {
       val domain = request.headers.get("Origin").getOrElse("https://" + request.domain)
       val exposeAmpHeader = "Access-Control-Expose-Headers" -> "AMP-Access-Control-Allow-Source-Origin"
-      val ampHeader = "AMP-Access-Control-Allow-Source-Origin" -> Configuration.amp.corsOrigins.find(_ == domain).getOrElse("*")
+      val ampHeader = "AMP-Access-Control-Allow-Source-Origin" -> Configuration.amp.baseUrl
 
       nextFilter(request).map(_.withHeaders(exposeAmpHeader, ampHeader))
     } else {


### PR DESCRIPTION
This is a fix for something in prod, so merging straight away. It will only affect AMP.

Bug:
![image](https://cloud.githubusercontent.com/assets/8774970/13602426/8b0adad0-e52e-11e5-8bb7-e091d8e97065.png)
