### PR TITLE
Article - recommendation discovery - Fix name to match convention set-up

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/article-related-content-display-as-recommendation.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/article-related-content-display-as-recommendation.js
@@ -3,7 +3,7 @@ define([
 ], function (config) {
 
     return function () {
-        this.id = 'RelatedContentDisplayAsRecommendation';
+        this.id = 'ArticleRelatedContentDisplayAsRecommendation';
         this.start = '2016-03-07';
         this.expiry = '2016-03-16';
         this.author = 'Mariot Chauvin';

--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -70,7 +70,7 @@ define([
         } else if (fetchRelated) {
 
 
-            if (ab.isInVariant('RelatedContentDisplayAsRecommendation', 'people-who-read-this-also-read-title')) {
+            if (ab.isInVariant('ArticleRelatedContentDisplayAsRecommendation', 'people-who-read-this-also-read-title')) {
                 var relatedContentSection = document.getElementById('related-content');
                 if (relatedContentSection) {
                     fastdom.write(function () {


### PR DESCRIPTION
This is a fix necessary for A/B switching working client side, see https://github.com/guardian/frontend/pull/12197
