### PR TITLE
Fix paid containers logo size

### DIFF
--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -242,7 +242,7 @@
 
     .ad-slot--paid-for-badge__logo {
         max-width: none;
-        max-height: $gs-baseline * 8;
+        max-height: $gs-baseline * 5;
     }
 }
 

--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -215,13 +215,12 @@
         margin: 0;
     }
 
-    .ad-slot--paid-for-badge .ad-slot--paid-for-badge__link {
+    .ad-slot--paid-for-badge__link {
         margin: 0;
         float: none;
-    }
-
-    .ad-slot--paid-for-badge__link:after {
-        content: none;
+        display: inline-block;
+        vertical-align: middle;
+        font-size: 0; // remove whitespace on inline-block children
     }
 
     .ad-slot.ad-slot--paid-for-badge--front {
@@ -241,26 +240,9 @@
         vertical-align: middle;
     }
 
-    .ad-slot--paid-for-badge__link {
-        display: inline-block;
-        vertical-align: middle;
-        max-width: $gs-baseline * 6;
-        height: $gs-baseline * 3;
-        font-size: 0; // remove whitespace on inline-block children
-    }
-
     .ad-slot--paid-for-badge__logo {
-        max-width: 100%;
-        max-height: 100%;
-        vertical-align: middle;
-        display: inline-block;
-    }
-
-    .ad-slot--paid-for-badge__link:before {
-        content: '';
-        height: 100%;
-        vertical-align: middle;
-        display: inline-block;
+        max-width: none;
+        max-height: $gs-baseline * 8;
     }
 }
 


### PR DESCRIPTION
Logos in commercial containers are currently capped at 140x90px. Since most of them are horizontal, the `max-width` triggers first and results in logos that are unreadable.

![picture 1](https://cloud.githubusercontent.com/assets/629976/13605610/53b4d722-e540-11e5-8646-6585d0964742.png)

It turns out that the width limit makes no sense, at least in this instance—there's plenty of room. The problem is vertical space, because the logo will ultimately create a huge negative space below container items that is likely to draw attention away from the content.

As a first step to a better solution, we'll cap the height at 60px. Next is getting all people involved in setting up these components to ask brands for a horizontal version of their logo.
