### PR TITLE
Show dismiss button only for merchandising components

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -448,8 +448,7 @@ define([
         idleFastdom.write(function () {
             if (shouldRenderLabel($adSlot)) {
                 $adSlot.prepend('<div class="ad-slot__label" data-test-id="ad-slot-label">Advertisement</div>');
-            } else if (ab.isInVariant('CommercialComponentsDismiss', 'dismiss') 
-                    && contains(['dfp-ad--merchandising', 'dfp-ad--merchandising-high', 'dfp-ad--im'], $adSlot.attr('id'))) {
+            } else if (ab.isInVariant('CommercialComponentsDismiss', 'dismiss') && contains(['dfp-ad--merchandising', 'dfp-ad--merchandising-high', 'dfp-ad--im'], $adSlot.attr('id'))) {
                 var survey = new SurveySimple();
                 var crossIcon = svgs('crossIcon');
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -448,8 +448,8 @@ define([
         idleFastdom.write(function () {
             if (shouldRenderLabel($adSlot)) {
                 $adSlot.prepend('<div class="ad-slot__label" data-test-id="ad-slot-label">Advertisement</div>');
-            } else if (ab.isInVariant('CommercialComponentsDismiss', 'dismiss')
-                    && ($adSlot.attr('data-link-name').match(/\bmerchandising\b/) || $adSlot.attr('id').match(/\bmerchandising\b/))) {
+            } else if (ab.isInVariant('CommercialComponentsDismiss', 'dismiss') 
+                    && contains(['dfp-ad--merchandising', 'dfp-ad--merchandising-high', 'dfp-ad--im'], $adSlot.attr('id'))) {
                 var survey = new SurveySimple();
                 var crossIcon = svgs('crossIcon');
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -448,7 +448,8 @@ define([
         idleFastdom.write(function () {
             if (shouldRenderLabel($adSlot)) {
                 $adSlot.prepend('<div class="ad-slot__label" data-test-id="ad-slot-label">Advertisement</div>');
-            } else if (ab.isInVariant('CommercialComponentsDismiss', 'dismiss')) {
+            } else if (ab.isInVariant('CommercialComponentsDismiss', 'dismiss')
+                    && ($adSlot.attr('data-link-name').match(/\bmerchandising\b/) || $adSlot.attr('id').match(/\bmerchandising\b/))) {
                 var survey = new SurveySimple();
                 var crossIcon = svgs('crossIcon');
 


### PR DESCRIPTION
I had to do some additional checks to make sure that dismiss button is only next to merchandising components.

And there are two attributes telling us that:
1. id
2. data-link-name for article inline components

@regiskuckaertz 
