### PR TITLE
Remove generated content after badge logo

### DIFF
--- a/static/src/stylesheets/module/commercial/_paidfor.scss
+++ b/static/src/stylesheets/module/commercial/_paidfor.scss
@@ -221,6 +221,8 @@
         display: inline-block;
         vertical-align: middle;
         font-size: 0; // remove whitespace on inline-block children
+
+        &::after { content: none; }
     }
 
     .ad-slot.ad-slot--paid-for-badge--front {
@@ -254,7 +256,7 @@
         position: relative;
         // reserve space in-flow for absolutely positioned badge
         // baseline * 3 from the height of the element, plus baseline / 2 for its bottom margin
-        padding-bottom: $gs-baseline * 3.5;
+        padding-bottom: $gs-baseline * 5;
     }
 
     .ad-slot--paid-for-badge {


### PR DESCRIPTION
Minor fix of the [previous one](https://github.com/guardian/frontend/pull/12202)
