### PR TITLE
use ab util methods to determine if we should run autoplay tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -36,7 +36,7 @@ trait ABTestSwitches {
     "ab-article-video-autoplay",
     "Autoplay embedded videos in article",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 3, 22),
+    sellByDate = new LocalDate(2016, 3, 23),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -50,7 +50,7 @@ define([
     ab
 ) {
     // For the A/B test
-    var abVideoAutoplay = ab.getParticipations().ArticleVideoAutoplay;
+    var abVideoAutoplay = ab.testCanBeRun('ArticleVideoAutoplay');
     function elementIsInView(el, offset) {
         var viewportHeight = window.innerHeight;
         var rect = el.getBoundingClientRect();
@@ -326,9 +326,7 @@ define([
                         resolve();
                     }
 
-                    var contentType = config.page.contentType;
-                    var isArticleOrLiveBlog = contentType === 'Article' || contentType === 'LiveBlog';
-                    if (abVideoAutoplay.variant === 'autoplay' && isArticleOrLiveBlog) {
+                    if (ab.isInVariant('ArticleVideoAutoplay', 'autoplay')) {
                         // Annoyingly we pass the `parentNode` as the video is absolutely positioned.
                         var parentNode = player.el().parentNode;
                         var firstAutoplay = true;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/article-video-autoplay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/article-video-autoplay.js
@@ -1,11 +1,12 @@
 define([
+    'common/utils/config',
     'common/utils/detect'
-], function (detect) {
+], function (config, detect) {
 
     return function () {
         this.id = 'ArticleVideoAutoplay';
-        this.start = '2016-03-08';
-        this.expiry = '2016-03-22';
+        this.start = '2016-03-09';
+        this.expiry = '2016-03-23';
         this.author = 'James Gorrie';
         this.description = 'Autoplay embedded videos on article pages';
         this.audience = .2;
@@ -17,7 +18,8 @@ define([
 
         this.canRun = function () {
             var bp = detect.getBreakpoint();
-            return !(bp === 'mobile' || bp === 'mobileLandscape');
+            var ct = config.page.contentType;
+            return !(bp === 'mobile' || bp === 'mobileLandscape') && (ct === 'Article' || ct === 'LiveBlog');
         };
 
         this.variants = [{


### PR DESCRIPTION
# Use A/B util to autoplay videos

Using the actual util functions to do this to make sure we aren't running tests when we shouldn't etc as per @johnduffell's [suggestion](https://github.com/guardian/frontend/pull/12186#discussion_r55348671)
## What is the value of this and can you measure success?

Makes things work more accurately
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@akash1810 @ScottPainterGNM 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
