### PR TITLE
Fix redirect loop on tag pages ending with /email

### DIFF
--- a/common/app/common/ModelOrResult.scala
+++ b/common/app/common/ModelOrResult.scala
@@ -29,9 +29,8 @@ private object ItemOrRedirect extends ItemResponses with Logging {
   }
 
   private def redirectArticle[T](item: T, response: ItemResponse, request: RequestHeader): Either[T, Result] = {
-
     canonicalPath(response) match {
-      case Some(canonicalPath) if canonicalPath != request.pathWithoutModifiers && !(request.isJson || request.isRss) =>
+      case Some(canonicalPath) if canonicalPath != request.pathWithoutModifiers && !(request.isModified) =>
         Right(Found(canonicalPath + paramString(request)))
       case _ => Left(item)
     }

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -26,6 +26,8 @@ trait Requests {
 
     lazy val isEmail: Boolean = r.path.endsWith(EMAIL_SUFFIX)
 
+    lazy val isModified = isJson || isRss || isEmail
+
     lazy val pathWithoutModifiers: String =
       if (isEmail) r.path.stripSuffix(EMAIL_SUFFIX)
       else         r.path.stripSuffix("/all")


### PR DESCRIPTION
Currently there's a redirect loop on `technology/email` caused by `ModelOrResult` not treating a path ending in `/email` as modified, and returning a 302 to the same thing.

I've added `/email` to the check so that if we're on `technology/email` the item gets returned (and the index page rendered) rather than the 302. 
