### PR TITLE
Update Rubicon Fastlane request parameters

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/PrebidService.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/PrebidService.js
@@ -16,7 +16,7 @@ define([
 ) {
     var PREBID_TIMEOUT = 2000;
 
-    return function PrebidService(pageTargeting) {
+    return function PrebidService() {
         // We create a stub interface to use while Prebid.js is loading, passing commands it will run when it
         // finally arrives, before it replaces the stub with itself.
         window.pbjs = {que: []};
@@ -33,8 +33,6 @@ define([
         // This allows us to re-use ad units on refresh
         var adUnits = {};
 
-        var targetingKeywords = pageTargeting.k.toString();
-
         this.loadAdvert = function loadAdvert(advert) {
             return advertQueue.add(function () {
                 return runAuction(advert);
@@ -44,7 +42,7 @@ define([
         function runAuction(advert) {
             var adSlotId = advert.adSlotId;
             var isNewAdvert = !adUnits[adSlotId];
-            adUnits[adSlotId] =  adUnits[adSlotId] || new PrebidAdUnit(advert, targetingKeywords);
+            adUnits[adSlotId] =  adUnits[adSlotId] || new PrebidAdUnit(advert);
 
             return new Promise(function (resolve, reject) {
                 pbjs.que.push(function () {
@@ -69,7 +67,7 @@ define([
         }
     };
 
-    function PrebidAdUnit(advert, targetingKeywords) {
+    function PrebidAdUnit(advert) {
         this.code = advert.adSlotId;
         this.sizes = getAllValidSlotSizes(advert);
         this.bids = [{
@@ -79,7 +77,7 @@ define([
                 siteId : 37668,
                 zoneId : 157046,
                 visitor : {geo : 'us'},
-                keywords : targetingKeywords
+                inventory : config.page.section
             }
         }];
     }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/PrebidService.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/PrebidService.js
@@ -77,7 +77,10 @@ define([
                 siteId : 37668,
                 zoneId : 157046,
                 visitor : {geo : 'us'},
-                inventory : config.page.section
+                // Lets us target advert inventory
+                inventory : config.page.section,
+                // Lets us report on targeting
+                keyword : config.page.section
             }
         }];
     }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -178,8 +178,8 @@ define([
         }));
     }
 
-    function setPageTargeting(pageTargeting) {
-        forOwn(pageTargeting, function (value, key) {
+    function setPageTargeting() {
+        forOwn(buildPageTargeting(), function (value, key) {
             googletag.pubads().setTargeting(key, value);
         });
     }
@@ -312,10 +312,8 @@ define([
             require(['js!googletag.js']);
         }
 
-        var pageTargeting = buildPageTargeting();
-
         if (prebidEnabled) {
-            prebidService = new PrebidService(pageTargeting);
+            prebidService = new PrebidService();
         }
 
         window.googletag.cmd.push = raven.wrap({ deep: true }, window.googletag.cmd.push);
@@ -324,9 +322,7 @@ define([
             renderStartTime = new Date().getTime();
         });
         window.googletag.cmd.push(setListeners);
-        window.googletag.cmd.push(function () {
-            setPageTargeting(pageTargeting);
-        });
+        window.googletag.cmd.push(setPageTargeting);
         window.googletag.cmd.push(defineAdverts);
 
         if (shouldLazyLoad()) {


### PR DESCRIPTION
Rather than sending page keywords and Krux segments, we're going to send Rubicon just the page section, and allow them to fish audience data out of the cookies sent up to rubiconproject.

This means we don't have to give the prebidService pageTargeting data any longer, and allows us to call buildPageTargeting in the way we used to, directly in setPageTargeting.
