### PR TITLE
Article - recommendation discovery - fix access through bonzo

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/related.js
+++ b/static/src/javascripts/projects/common/modules/onward/related.js
@@ -95,7 +95,7 @@ define([
                             var relatedContentSection = document.getElementById('related-content');
                             if (relatedContentSection) {
                                 fastdom.write(function () {
-                                    $('.fc-container__header__title', relatedContentSection).textContent = 'people who have read this also read';
+                                    $('.fc-container__header__title', relatedContentSection)[0].textContent = 'people who have read this also read';
                                 });
                             }
                         }


### PR DESCRIPTION
`bonzo` unlike chrome builtin `$` [returns an array](https://github.com/ded/bonzo#bonzodomelement--arraylikedomelementcollection.) I have been able to test this locally so should be the latest fix of #12197
