### PR TITLE
A match report is not necessary to have a minute by minute liveblog

### DIFF
--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -95,7 +95,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
 
     getResponse(LiveContentApi.search(Edition(request))
       .section("football")
-      .tag("tone/matchreports|football/series/squad-sheets|football/series/match-previews|football/series/saturday-clockwatch")
+      .tag("tone/minutebyminute|tone/matchreports|football/series/squad-sheets|football/series/match-previews|football/series/saturday-clockwatch")
       .fromDate(matchDate.minusDays(2).toDateTimeAtStartOfDay)
       .toDate(matchDate.plusDays(2).toDateTimeAtStartOfDay)
       .reference(s"pa-football-team/${theMatch.homeTeam.id},pa-football-team/${theMatch.awayTeam.id}")

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -148,8 +148,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
         c.matchReport && !c.minByMin && !c.preview
     }
     val minByMin = related.find { c =>
-      c.trail.webPublicationDate.withZone(DateTimeZone.forID("Europe/London")).toLocalDate == matchDate &&
-        c.matchReport && c.minByMin && !c.preview
+      c.trail.webPublicationDate.withZone(DateTimeZone.forID("Europe/London")).toLocalDate == matchDate && c.minByMin && !c.preview
     }
     val preview = related.find { c =>
       c.trail.webPublicationDate.withZone(DateTimeZone.forID("Europe/London")) <= matchDate.toDateTimeAtStartOfDay &&


### PR DESCRIPTION
This is currently preventing link from the football live match pages to go to the match minutes by minutes.
