### PR TITLE
Fix localStorage check in breaking news

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/breaking-news.js
+++ b/static/src/javascripts/projects/common/modules/onward/breaking-news.js
@@ -64,7 +64,7 @@ define([
         var page = config.page,
             hiddenIds = storage.local.get(storageKeyHidden) || {};
 
-        if (!page || hiddenIds[page.pageId] === true || !storage.isAvailable) { return; }
+        if (!page || hiddenIds[page.pageId] === true || !storage.local.isAvailable()) { return; }
 
         ajax({
             url: breakingNewsSource,


### PR DESCRIPTION
The old value was always `undefined` so the rest of the function was never being called.
