### PR TITLE
Fixed inline image for videos in commercial containers

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -45,8 +45,12 @@
                                                     <li class="lineitem l-row__item l-row__item--span-1">
                                                         <div class="rich-link tone-paidfor--item">
                                                             <div class="rich-link__container">
-                                                                @for(InlineImage(images) <- contentCard.displayElement) {
-                                                                    @itemImage(images)
+                                                                @for(displayElement <- contentCard.displayElement) {
+                                                                    @displayElement match {
+                                                                        case InlineVideo(videoElement, _, _, _) => { @itemImage(videoElement.images) }
+                                                                        case InlineImage(images) => { @itemImage(images) }
+                                                                        case _ => { }
+                                                                    }
                                                                 }
                                                             <div class="rich-link__header">
                                                             @title(contentCard.header, 0, container.index)


### PR DESCRIPTION
## What does this change?

Items in commercial containers are not pulling in images for videos:
![picture 1](https://cloud.githubusercontent.com/assets/629976/13668271/a8c36dc2-e6b3-11e5-8dd8-efaba4b26da8.png)

Now it does:
![picture 2](https://cloud.githubusercontent.com/assets/629976/13668289/c1e2f6ec-e6b3-11e5-8da6-feca89531590.png)

@kelvin-chappell 
