### PR TITLE
Do not load Foresee survey JS on profile pages

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/foresee-survey.js
+++ b/static/src/javascripts/projects/common/modules/analytics/foresee-survey.js
@@ -15,12 +15,13 @@ define([
     function load() {
 
         var isNetworkFront = config.page.contentType === 'Network Front',
+            isProfilePage = config.page.contentType === 'userid',
             sampleRate = detect.isBreakpoint({max: 'mobile'}) ? 0.008 : 0.006, // 0.8% mobile and 0.6% rest
             sample = Math.random() <= sampleRate,
             hasForcedOptIn = /forceForesee/.test(location.hash);
 
         // the Foresee code is large, we only want to load it in when necessary.
-        if (!Cookie.get('GU_TEST') && !isNetworkFront && (window.openForeseeWhenReady || sample || hasForcedOptIn)) {
+        if (!Cookie.get('GU_TEST') && !isNetworkFront && !isProfilePage && (window.openForeseeWhenReady || sample || hasForcedOptIn)) {
             openForesee();
         }
 


### PR DESCRIPTION
# Do not load Foresee survey JS on profile pages
## What does this change?

This change excludes the profile pages (https://profile.theguardian.com) from triggering the Foresee survey JS.

Currently, when Foresee is triggered, it will try to load `/assets/javascripts/vendor/foresee/20150703/foresee-surveydef.js?build=10` from the same domain.

In the case of the profile pages, that means `https://profile.theguardian.com/assets/javascripts/vendor/foresee/20150703/foresee-surveydef.js?build=10`, which is not accessible (all assets for the profile pages are on `https://assets.guim.co.uk`).

When browsers try to load the asset directly from `https://profile.theguardian.com`, it causes a 500 error, which has lead to a constant stream of alerts in our monitoring.

This can be reproduced by hitting `https://profile.theguardian.com/account/edit#forceForesee` whilst logged in (see screenshot further down).

Similarly to how the existing code checked to see if

```
config.page.contentType === 'Network Front'
```

an additional check for

```
config.page.contentType === 'userid'
```

is done and evaluated.

The `contentType` for Identity Frontend is [set here](https://github.com/guardian/frontend/blob/master/identity/app/model/IdentityPage.scala#L14).
## What is the value of this and can you measure success?

Reduce the number of non-critical 500 errors for Identity Frontend to below our pre-determined threshold.

At the moment this makes it hard to rely on our monitoring for Identity Frontend to distinguish actual issues affecting users.
## Does this affect other platforms - Amp, Apps, etc?

Only web.
## Screenshots

<img width="1277" alt="screen shot 2016-03-10 at 11 41 12" src="https://cloud.githubusercontent.com/assets/164991/13668428/af0a1572-e6b4-11e5-8973-f961fcacc527.png">
## Request for comment
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
