### PR TITLE
Supporter banner for international edition

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -22,7 +22,8 @@ define([
 
     var membershipEndpoints = {
         UK:   'https://membership.theguardian.com/supporter',
-        US:   'https://membership.theguardian.com/us/supporter'
+        US:   'https://membership.theguardian.com/us/supporter',
+        INT:   'https://membership.theguardian.com/supporter'
     };
 
     var defaultData = {
@@ -50,6 +51,18 @@ define([
                 messageText: 'Support open, independent journalism. Become a Supporter for just $4.99 per month',
                 linkText: 'Find out more'
             }
+        },
+        INT: {
+            campaign:      'MEMBERSHIP_SUPPORTER_BANNER_INT',
+            code:          'membership-message-int',
+            minVisited:    10,
+            data: {
+                messageText: [
+                    'Support Guardian journalism and our coverage of critical, under-reported stories from around the world.',
+                    'Become a Supporter for just $49/€49 per year.'
+                ].join(' '),
+                linkText: 'Find out more'
+            }
         }
     };
 
@@ -64,24 +77,38 @@ define([
     }
 
     function show(edition, message) {
-        var originalMessage;
-
         var data = defaults({ linkHref: formatEndpointUrl(edition, message) }, message.data, defaultData);
 
-        originalMessage = new Message(message.code);
+        // Four cases (for a given edition, say UK):
+        // (a) has never closed any membership banner
+        // (b) has closed only 'membership-message-uk'
+        // (c) has closed only 'membership-message-uk-redisplayed'
+        //     (can't occur for US)
+        // (d) has closed both 'membership-messaged-uk' and 'membership-message-uk-redisplayed'
 
-        // Allow tracking to distinguish banners that have been re-displayed
-        // after closing from those that have only been displayed once.
-        if (originalMessage.hasSeen()) {
-            message.code += '-redisplayed';
-            message.campaign += '_REDISPLAYED';
-            message.data.linkHref = formatEndpointUrl(edition, message);
-        }
+        // once I make this change, what will the behaviour be?
+        // (a) =>
+        //   current => they see banner. closed once, it will reappear. closed again, it will not.
+        //   new     => they see banner. closed once, it will not reappear.
+        // (b) =>
+        //   current => they see banner (r). closed once, it will reappear.
+        //   new     => they will not see banner (since they've already closed it)
+        // (c) PROBLEMATIC =>
+        //   current => they do not see banner.
+        //   new     => they see banner. closed once, it will not reappear.
+        // (d) =>
+        //   current => they do not see banner.
+        //   new     => they do not see banner.
+
+        // Switching between editions, no history is preserved
+        // (e.g. if I've closed the banner only on the UK edition,
+        //       I will see it on the US & International editions)
 
         return new Message(message.code, {
             pinOnHide: false,
             siteMessageLinkName: 'membership message',
-            siteMessageCloseBtn: 'hide'
+            siteMessageCloseBtn: 'hide',
+            cssModifierClass: 'membership-message'
         }).show(template(messageTemplate, data));
     }
 
@@ -98,6 +125,7 @@ define([
     }
 
     return {
-        init: init
+        init: init,
+        messages: messages
     };
 });

--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -79,31 +79,6 @@ define([
     function show(edition, message) {
         var data = defaults({ linkHref: formatEndpointUrl(edition, message) }, message.data, defaultData);
 
-        // Four cases (for a given edition, say UK):
-        // (a) has never closed any membership banner
-        // (b) has closed only 'membership-message-uk'
-        // (c) has closed only 'membership-message-uk-redisplayed'
-        //     (can't occur for US)
-        // (d) has closed both 'membership-messaged-uk' and 'membership-message-uk-redisplayed'
-
-        // once I make this change, what will the behaviour be?
-        // (a) =>
-        //   current => they see banner. closed once, it will reappear. closed again, it will not.
-        //   new     => they see banner. closed once, it will not reappear.
-        // (b) =>
-        //   current => they see banner (r). closed once, it will reappear.
-        //   new     => they will not see banner (since they've already closed it)
-        // (c) PROBLEMATIC =>
-        //   current => they do not see banner.
-        //   new     => they see banner. closed once, it will not reappear.
-        // (d) =>
-        //   current => they do not see banner.
-        //   new     => they do not see banner.
-
-        // Switching between editions, no history is preserved
-        // (e.g. if I've closed the banner only on the UK edition,
-        //       I will see it on the US & International editions)
-
         return new Message(message.code, {
             pinOnHide: false,
             siteMessageLinkName: 'membership message',

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -459,11 +459,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
  * Membership messages
  */
 .site-message--adblock-message,
-.site-message--membership-message,
-.site-message--membership-message-uk,
-.site-message--membership-message-uk-redisplayed,
-.site-message--membership-message-us,
-.site-message--membership-message-us-redisplayed {
+.site-message--membership-message {
     background: colour(membership-default);
 }
 

--- a/static/test/javascripts/spec/common/commercial/membership-messages.spec.js
+++ b/static/test/javascripts/spec/common/commercial/membership-messages.spec.js
@@ -3,17 +3,21 @@ define([
     'fastdom',
     'qwery',
     'common/utils/$',
+    'common/modules/user-prefs',
     'helpers/fixtures',
     'helpers/injector',
-    'Promise'
+    'Promise',
+    'common/modules/ui/message'
 ], function (
     bonzo,
     fastdom,
     qwery,
     $,
+    userPrefs,
     fixtures,
     Injector,
-    Promise
+    Promise,
+    Message
 ) {
     var commercialFeatures, membershipMessages,
         showMembershipMessages, alreadyVisited, storage, config;
@@ -51,6 +55,20 @@ define([
             });
         });
 
+        function expectMessageToBeShown(done) {
+            membershipMessages.init().then(function () {
+                var message = document.querySelector('.js-site-message.site-message--membership-message');
+                expect(message).not.toBeNull();
+            }).then(done);
+        }
+
+        function expectMessageNotToBeShown(done) {
+            membershipMessages.init().then(function () {
+                var message = document.querySelector('.js-site-message.site-message--membership-message');
+                expect(message).toBeNull();
+            }).then(done);
+        }
+
         describe('If user already member', function () {
             beforeEach(function (done) {
                 showMembershipMessages = commercialFeatures.async.membershipMessages;
@@ -65,12 +83,7 @@ define([
                 storage.local.set('gu.alreadyVisited', alreadyVisited);
             });
 
-            it('should not show any messages even to engaged readers', function (done) {
-                membershipMessages.init().then(function () {
-                    var message = document.querySelector('.js-site-message.site-message--banner');
-                    expect(message).toBeNull();
-                }).then(done);
-            });
+            it('should not show any messages even to engaged readers', expectMessageNotToBeShown);
         });
 
         describe('If user not member', function () {
@@ -79,6 +92,7 @@ define([
                 alreadyVisited = storage.local.get('gu.alreadyVisited');
                 commercialFeatures.async.membershipMessages = Promise.resolve(true);
                 fixtures.render(conf);
+                storage.local.set('gu.alreadyVisited', 10);
                 done();
             });
 
@@ -91,22 +105,33 @@ define([
             describe('of the UK edition', function () {
                 it('should show a message to engaged readers', function (done) {
                     config.page = { edition: 'UK' };
-                    storage.local.set('gu.alreadyVisited', 10);
-                    membershipMessages.init().then(function () {
-                        var message = document.querySelector('.js-site-message.site-message--membership-message-uk');
-                        expect(message).not.toBeNull();
-                    }).then(done);
+                    expectMessageToBeShown(done);
                 });
             });
 
             describe('of the US edition', function () {
                 it('should show a message to engaged readers', function (done) {
                     config.page = { edition: 'US' };
-                    storage.local.set('gu.alreadyVisited', 10);
-                    membershipMessages.init().then(function () {
-                        var message = document.querySelector('.js-site-message.site-message--membership-message-us');
-                        expect(message).not.toBeNull();
-                    }).then(done);
+                    expectMessageToBeShown(done);
+                });
+            });
+
+            describe('of the International edition', function () {
+                it('should show a message to engaged readers', function (done) {
+                    config.page = { edition: 'INT' };
+                    expectMessageToBeShown(done);
+                });
+            });
+
+            describe('but has already closed a message', function () {
+                it('should not redisplay that message', function (done) {
+                    var edition = 'UK';
+                    var message = new Message(membershipMessages.messages[edition].code);
+                    message.acknowledge();
+
+                    config.page = { edition: edition };
+
+                    expectMessageNotToBeShown(done);
                 });
             });
         });


### PR DESCRIPTION
## What does this change?

This displays a membership "engaged reader" banner (encouraging people with more than 10 page views to become a Supporter) to readers of the International edition, since on we now have local landing pages for [Europe](https://membership.theguardian.com/eu/supporter) and the [Rest Of The World](https://membership.theguardian.com/int/supporter) and a geolocated redirect [here](https://membership.theguardian.com/supporter).

It also fixes a bug that was introduced in #11166 (specifically, [here](https://github.com/guardian/frontend/blob/975b4a9ee3c1ae8c5023d22307ff8a3b06179f56/static/src/javascripts/projects/common/modules/commercial/membership-messages.js#L76-L80)). This caused a banner closed by the user to immediately redisplay on the next page load. (When closed a second time, it was gone for good.) This was based on a misinterpretation of #11065, where I changed the id of the message to redisplay to everyone who had closed it before that point in time (but _not_ to display to everyone twice). I've added a unit test to make sure this doesn't happen again.

To avoid irritating our users I thought a bit about how my change here would affect the possible states a user could be in at this point. There are four cases (for a given edition, say UK):
##### 1.) has never closed any membership banner

**currently:** they see banner. closed once, it will reappear. closed again, it will not.
**after this change:** they see banner. closed once, it will not reappear.
##### 2.) has closed only `membership-message-uk`

**currently:** they see banner. closed once, it will reappear.
**after this change:** they will not see banner (since they've already closed it)
##### 3.) has closed only `membership-message-uk-redisplayed`

**currently:** they do not see banner.
**after this change:** they will see the banner. closed once, it will not reappear.
##### 4.) has closed both `membership-messaged-uk` and `membership-message-uk-redisplayed`

**currently:** they do not see banner.
**after this change:** they do not see banner.

Case (3) is the only problematic one, but will only affect people who closed the banner once between  #11065 and #11166. And once the banner appears again, closing it once more will keep it closed. So I think it's acceptable.
## What is the value of this and can you measure success?

Value is to drive international readers towards their appropriate localised supporter page in the hopes that they will sign up. Success will be measured based on signup rates for the MEMBERSHIP_SUPPORTER_BANNER_INT campaign code.
## Does this affect other platforms - Amp, Apps, etc?

Just web
## Screenshots

![picture 165](https://cloud.githubusercontent.com/assets/5122968/13669766/835dc47e-e6bd-11e5-852d-3eeb23860ad5.png)
## Request for comment

@regiskuckaertz 
