### PR TITLE
Add HSTS CDN test endpoint

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -42,6 +42,9 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
         case SectionSpecialIndex(section, _)  => Cached(300)(Redirect(s"${LinkTo(section)}/all", 301))
         case NewspaperPage(paper, date, book)       =>  Cached(300)(Redirect(s"${LinkTo(paper)}/$book/$date/all", 301))
 
+          // edge cache test
+        case "automated-test/strict-transport-security" => Cached(300)(Ok("<h1>test</h1>").withHeaders("Strict-Transport-Security" -> "max-age=0"))
+
         case _ =>
           log404(request)
           // short cache time as we might just be waiting for the content api to index

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -43,7 +43,7 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
         case NewspaperPage(paper, date, book)       =>  Cached(300)(Redirect(s"${LinkTo(paper)}/$book/$date/all", 301))
 
           // edge cache test
-        case "automated-test/strict-transport-security" => Cached(300)(Ok("<h1>test</h1>").withHeaders("Strict-Transport-Security" -> "max-age=0"))
+        case "automated-test/strict-transport-security" => Cached(300)(Ok("<h1>test</h1>").withHeaders("Strict-Transport-Security" -> "max-age=0", "X-Test-Response" -> "true"))
 
         case _ =>
           log404(request)


### PR DESCRIPTION
I want to have a test that the cdn won't let through any HSTS header.  However we need to have an endpoint that will return it so we know it's gone.  This is that endpoint.
