### PR TITLE
Header bidding: section should be sent to Rubicon Fastlane as an inventory key

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/PrebidService.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/PrebidService.js
@@ -78,7 +78,9 @@ define([
                 zoneId : 157046,
                 visitor : {geo : 'us'},
                 // Lets us target advert inventory
-                inventory : config.page.section,
+                inventory : {
+                    section : config.page.section
+                },
                 // Lets us report on targeting
                 keyword : config.page.section
             }


### PR DESCRIPTION
It looks like we're not sending the page context up to Rubicon properly in the header-bidding test. This PR should fix that.
