### PR TITLE
Extend FixedTopAboveNavAdSlotSwitch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -226,7 +226,7 @@ trait CommercialSwitches {
     "fixed-top-above-nav",
     "Fixes size of top-above-nav ad slot on fronts.",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 3, 16),
+    sellByDate = new LocalDate(2016, 4, 13),
     exposeClientSide = false
   )
 


### PR DESCRIPTION
Experiment is probably going to continue.
If it doesn't we'll remove the switch altogether next month.
