### PR TITLE
Enable batch redirects

### DIFF
--- a/admin/app/controllers/RedirectController.scala
+++ b/admin/app/controllers/RedirectController.scala
@@ -1,5 +1,7 @@
 package controllers.admin
 
+import java.io.File
+
 import play.api.mvc.Controller
 import common.Logging
 import play.api.data._
@@ -28,6 +30,59 @@ object RedirectController  extends Controller with Logging {
     }
 
     SeeOther(routes.RedirectController.redirect().url)
+  }
+
+  def redirectBatchPost() = AuthActions.AuthActionTest { implicit request =>
+
+    val body = request.body
+    val uploadedFile = body.asMultipartFormData.flatMap { files =>
+      files.file("urlfile").map { theFile =>
+        val rnd = Math.random().toString.replace(".","")
+        val tmpName = s"/tmp/$rnd${theFile.filename}"
+        val tmpFile = new File(tmpName)
+        theFile.ref.moveTo(tmpFile)
+        tmpFile
+      }
+    }
+    val msgs = if(uploadedFile.nonEmpty) {
+      val results = uploadedFile.map(file => {
+        try {
+          redirectFile(file)
+        } catch {
+          case e: Exception => List(s"Error processing ${file.getName} - ${e.getMessage}")
+        }
+      })
+      List(s"File uploaded as ${uploadedFile.map(_.getName).getOrElse("")}") ::: results.getOrElse(List.empty)
+    } else {
+      List("File was not uploaded")
+    }
+
+    Ok(views.html.redirects(redirectForm, fileMsgs = msgs))
+
+  }
+
+  private def redirectFile(file: File): List[String] = {
+    val source = scala.io.Source.fromFile(file)
+    try {
+      source.getLines().map { line =>
+        if (line.nonEmpty) {
+          val fromAndTo = line.split("\t")
+          val from = fromAndTo(0)
+          val to = fromAndTo(1)
+          try {
+            Redirects.set(from, to)
+            s"$from -> $to"
+          } catch {
+            case e: Exception => s"Error processing $line: ${e.getMessage}"
+          }
+        } else {
+          "* empty input line *"
+        }
+      }.toList
+    } finally {
+      source.close()
+      file.delete()
+    }
   }
 
 }

--- a/admin/app/controllers/RedirectController.scala
+++ b/admin/app/controllers/RedirectController.scala
@@ -67,8 +67,8 @@ object RedirectController  extends Controller with Logging {
       source.getLines().map { line =>
         if (line.nonEmpty) {
           val fromAndTo = line.split("\t")
-          val from = fromAndTo(0)
-          val to = fromAndTo(1)
+          val from = fromAndTo(0).trim
+          val to = fromAndTo(1).trim
           try {
             Redirects.set(from, to)
             s"$from -> $to"

--- a/admin/app/services/Redirects.scala
+++ b/admin/app/services/Redirects.scala
@@ -9,7 +9,7 @@ import play.api.Play
 
 object Redirects {
 
-  private lazy val table = if (Play.isProd) "redirects" else "redirects-DEV"
+  private lazy val table = if (Configuration.environment.isProd) "redirects" else "redirects-DEV"
 
   private lazy val client = {
     val client = new AmazonDynamoDBClient(Configuration.aws.mandatoryCredentials)

--- a/admin/app/views/redirects.scala.html
+++ b/admin/app/views/redirects.scala.html
@@ -1,6 +1,6 @@
-@(form: play.api.data.Form[controllers.admin.PageRedirect])
+@(form: play.api.data.Form[controllers.admin.PageRedirect], urlMsgs: List[String] = List.empty, fileMsgs: List[String] = List.empty)
 
-@admin_main("Redirector", "PROD", isAuthed = true) {
+@admin_main("Redirector", conf.Configuration.environment.stage, isAuthed = true) {
     <ul>
         <li>
             This will <strong>only</strong> add the redirect to Next Gen Web. It will <strong>not</strong> add it to
@@ -44,6 +44,37 @@
                     <input class="btn btn-default" type="submit" value="Submit" />
                 </div>
             </div>
+            @if(urlMsgs.nonEmpty) {
+                <div class="form-group label-warning">
+                    <div id="server-message" class="controls col-sm-offset-1 col-sm-11">
+                    @urlMsgs.mkString
+                    </div>
+                </div>
+            }
+        </fieldset>
+    </form>
+
+    <form action="/redirect-batch-post" method="POST" class="form-horizontal redirect-form" enctype="multipart/form-data">
+        <fieldset>
+            <legend>Redirect a batch of URLs from a tab-separated file (fromUrl\ttoUrl\r\n): </legend>
+            <div class="form-group">
+                <label for="urlfile" class="control-label col-sm-1">File:</label>
+                <div class="col-sm-6">
+                    <input type="file" class="form-control" id="urlfile" name="urlfile" />
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="controls col-sm-offset-1 col-sm-11">
+                    <input class="btn btn-default" type="submit" value="Upload & Redirect" />
+                </div>
+            </div>
+            @if(fileMsgs.nonEmpty) {
+                <div class="form-group label-warning">
+                    <div id="server-message" class="controls col-sm-offset-1 col-sm-11">
+                    @fileMsgs.mkString
+                    </div>
+                </div>
+            }
         </fieldset>
     </form>
 }

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -120,6 +120,7 @@ GET         /deploys-radiator                                                   
 # Redirects
 GET         /redirects                                                                              controllers.admin.RedirectController.redirect()
 POST        /redirect-post                                                                          controllers.admin.RedirectController.redirectPost()
+POST        /redirect-batch-post                                                                    controllers.admin.RedirectController.redirectBatchPost()
 
 # Sport troubleshooter
 GET         /troubleshoot/football                                                                  controllers.admin.SportTroubleshooterController.renderFootballTroubleshooter()

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -7,6 +7,7 @@ import services.{Archive, DynamoDB, Googlebot404Count, Destination}
 import java.net.URLDecoder
 import model.Cached
 import scala.concurrent.Future
+import conf.switches.Switches.ArchiveResolvesR1UrlsInRedirectTableSwitch
 
 object ArchiveController extends Controller with Logging with ExecutionContexts {
 
@@ -53,7 +54,7 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   // Our redirects are 'normalised' Vignette URLs, Ie. path/to/0,<n>,123,<n>.html -> path/to/0,,123,.html
   def normalise(path: String, zeros: String = ""): String = {
     val normalised = path match {
-      case R1ArtifactUrl(path, artifactOrContextId, extension) =>
+      case R1ArtifactUrl(path, artifactOrContextId, extension) if ArchiveResolvesR1UrlsInRedirectTableSwitch.isSwitchedOff =>
         val normalisedUrl = s"www.theguardian.com/$path/0,,$artifactOrContextId,$zeros.html"
         Some(normalisedUrl)
       case ShortUrl(path) =>

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -384,7 +384,7 @@ trait FeatureSwitches {
     "archive-service-resolves-r1-urls",
     "When ON, the archive service can resolve un-normalisd R1 paths from the redirects table.",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 4, 30), //Wednesday
+    sellByDate = new LocalDate(2016, 4, 28), //Thursday
     exposeClientSide = false
   )
 }

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -377,4 +377,14 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2016, 4, 5), //Tuesday
     exposeClientSide = false
   )
+
+  // Owner: Dotcom health (R2/R1 decommissioning)
+  val ArchiveResolvesR1UrlsInRedirectTableSwitch = Switch(
+    "Feature",
+    "archive-service-resolves-r1-urls",
+    "When ON, the archive service can resolve un-normalisd R1 paths from the redirects table.",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 30), //Wednesday
+    exposeClientSide = false
+  )
 }


### PR DESCRIPTION
# Upload a file of from/to URLs into the redirects form
## What does this change?

The admin redirects page can now upload a batch of redirects from a file, instead of just one-by-one manually.
## What is the value of this and can you measure success?

We have approximately 3 million redirects coming our way as a result of shutting down R2. I don't fancy entering those individually through the existing form. Can we measure it? Sure, by watching the Dynamo DB table grow.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

![screen shot 2016-03-10 at 16 06 27](https://cloud.githubusercontent.com/assets/690395/13675584/351bb772-e6da-11e5-8ae3-68a6c2553365.png)
## Request for comment
## cc @jennysivapalan @johnduffell 
