### PR TITLE
Facia press sends status update to a stream

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -374,6 +374,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   object faciatool {
     lazy val frontPressCronQueue = configuration.getStringProperty("frontpress.sqs.cron_queue_url")
     lazy val frontPressToolQueue = configuration.getStringProperty("frontpress.sqs.tool_queue_url")
+    lazy val frontPressStatusNotificationStream = configuration.getStringProperty("frontpress.kinesis.status_notification_stream")
 
     lazy val configBeforePressTimeout: Int = 1000
 

--- a/common/app/conf/switches/FaciaSwitches.scala
+++ b/common/app/conf/switches/FaciaSwitches.scala
@@ -51,4 +51,13 @@ trait FaciaSwitches {
     exposeClientSide = false
   )
 
+  val FaciaPressStatusNotifications = Switch(
+    "Facia",
+    "facia-press-status-notifications",
+    "If this is switched off, facia press will not send status notification on kinesis",
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
 }

--- a/facia-press/app/frontpress/StatusNotification.scala
+++ b/facia-press/app/frontpress/StatusNotification.scala
@@ -59,7 +59,7 @@ object StatusNotification {
           new PutRecordRequest()
             .withStreamName(streamName)
             .withPartitionKey(partitionKey)
-            .withData(ByteBuffer.wrap(Json.toJson(message).toString.getBytes)),
+            .withData(ByteBuffer.wrap(Json.toJson(message).toString.getBytes("UTF-8"))),
           KinesisLoggingAsyncHandler)
       case None => Logger.info("Kinesis status notification not configured.")
     }

--- a/facia-press/app/frontpress/StatusNotification.scala
+++ b/facia-press/app/frontpress/StatusNotification.scala
@@ -1,0 +1,67 @@
+package frontpress
+
+import java.nio.ByteBuffer
+
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
+import com.amazonaws.services.kinesis.model.{PutRecordRequest, PutRecordResult}
+import com.gu.facia.api.ApiError
+import conf.Configuration
+import play.api.Logger
+import play.api.libs.json.Json
+
+
+object StatusNotificationMessage {
+  implicit val jsonFormat = Json.format[StatusNotificationMessage]
+}
+case class StatusNotificationMessage(
+  status: String,
+  front: String,
+  isLive: Boolean
+)
+
+object StatusNotification {
+  lazy val partitionKey: String = "facia-tool-updates"
+
+  object KinesisLoggingAsyncHandler extends AsyncHandler[PutRecordRequest, PutRecordResult] {
+    def onError(exception: Exception) {
+      Logger.error(s"Kinesis PutRecord request error: ${exception.getMessage}}")}
+    def onSuccess(request: PutRecordRequest, result: PutRecordResult) {
+      Logger.info(s"Kinesis status notification sent to stream:${request.getStreamName}")}
+  }
+
+  lazy val client: AmazonKinesisAsyncClient = {
+    val c = new AmazonKinesisAsyncClient(Configuration.aws.mandatoryCredentials)
+    c.setRegion(Region.getRegion(Regions.fromName(Configuration.aws.region)))
+    c
+  }
+
+
+  def notifyFailedJob(front: String, isLive: Boolean, reason: ApiError) = {
+    putMessage(StatusNotificationMessage(
+      status = s"Error: ${reason.cause} ${reason.message}",
+      front = front,
+      isLive = isLive
+    ))}
+
+  def notifyCompleteJob(front: String, isLive: Boolean) = {
+    putMessage(StatusNotificationMessage(
+      status = "ok",
+      front = front,
+      isLive = isLive
+    ))}
+
+  def putMessage(message: StatusNotificationMessage): Unit = {
+    Configuration.faciatool.frontPressStatusNotificationStream match {
+      case Some(streamName) =>
+        client.putRecordAsync(
+          new PutRecordRequest()
+            .withStreamName(streamName)
+            .withPartitionKey(partitionKey)
+            .withData(ByteBuffer.wrap(Json.toJson(message).toString.getBytes)),
+          KinesisLoggingAsyncHandler)
+      case None => Logger.info("Kinesis status notification not configured.")
+    }
+  }
+}

--- a/facia-press/app/frontpress/StatusNotification.scala
+++ b/facia-press/app/frontpress/StatusNotification.scala
@@ -19,7 +19,8 @@ object StatusNotificationMessage {
 case class StatusNotificationMessage(
   status: String,
   front: String,
-  isLive: Boolean
+  isLive: Boolean,
+  message: Option[String]
 )
 
 object StatusNotification {
@@ -41,16 +42,18 @@ object StatusNotification {
 
   def notifyFailedJob(front: String, isLive: Boolean, reason: ApiError) = {
     putMessage(StatusNotificationMessage(
-      status = s"Error: ${reason.cause} ${reason.message}",
+      status = "error",
       front = front,
-      isLive = isLive
+      isLive = isLive,
+      message = Some(s"${reason.cause} ${reason.message}")
     ))}
 
   def notifyCompleteJob(front: String, isLive: Boolean) = {
     putMessage(StatusNotificationMessage(
       status = "ok",
       front = front,
-      isLive = isLive
+      isLive = isLive,
+      message = None
     ))}
 
   def putMessage(message: StatusNotificationMessage): Unit = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val identityLibVersion = "3.51"
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
-  val awsVersion = "1.10.37"
+  val awsVersion = "1.10.60"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.3.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val identityLibVersion = "3.51"
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
-  val awsVersion = "1.10.60"
+  val awsVersion = "1.10.37"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.3.5"

--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -125,7 +125,11 @@ object Frontend extends Build with Prototypes {
     RoutesKeys.routesImport += "org.joda.time.LocalDate"
   )
 
-  val faciaPress = application("facia-press").dependsOn(commonWithTests)
+  val faciaPress = application("facia-press").dependsOn(commonWithTests).settings(
+    libraryDependencies ++= Seq(
+      awsKinesis
+    )
+  )
 
   val identity = application("identity").dependsOn(commonWithTests).aggregate(common).settings(
     libraryDependencies ++= Seq(


### PR DESCRIPTION
# My Awesome Pull Request
## What does this change?

Facia press sends status updates on a kinesis stream every time it presses a front, either successfully or not
## What is the value of this and can you measure success?

We can create all sort of services that consume this information, e.g. be notified of errors or burst cache of front pages
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

Json received by a lambda consuming the stream
![screen shot 2016-03-11 at 14 01 07](https://cloud.githubusercontent.com/assets/680284/13703992/636ab3be-e791-11e5-8ebe-2319ab853e83.png)
## Request for comment

@janua how do you like it?
@johnduffell this requires a cloudformation change to create a kinesis stream, but in the meantime we can merge it, it'll just do nothing until we configure a stream
