### PR TITLE
Toast bug fix: prevent overlapping elements above

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -131,10 +131,8 @@ define([
                     var updateText = (count > 1) ? ' new updates' : ' new update';
                     $toastButton.removeClass('toast__button--closed').addClass('toast__button--open');
                     $toastText.html(count + updateText);
-                    $toastSpaceReserver.addClass('toast__space-reserver--open');
                 } else {
                     $toastButton.removeClass('toast__button--open').removeClass('loading').addClass('toast__button--closed');
-                    $toastSpaceReserver.removeClass('toast__space-reserver--open');
                 }
             });
         };
@@ -199,7 +197,6 @@ define([
         // Cache selectors
         var $liveblogBody = $('.js-liveblog-body');
         var $toastButton = $('.toast__button');
-        var $toastSpaceReserver = $('.toast__space-reserver');
         var $toastText = $('.toast__text', this.$toastButton);
         var toastContainer = qwery('.toast__container')[0];
 

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -587,12 +587,7 @@ $timeline-width: 15px;
     padding-bottom: $gs-baseline;
     text-align: center;
     transition: transform .3s ease-in-out;
-    transform: translateY((-1) * $gs-baseline * 5);
     width: 100%;
-
-    .toast__space-reserver--open & {
-        transform: translateY(0);
-    }
 
     @include mq(desktop) {
         width: gs-span(8);


### PR DESCRIPTION
Toast currently overlaps previous elements, e.g. the Witness button:

Turns out this bit of CSS is no longer necessary…

![image](https://cloud.githubusercontent.com/assets/921609/13706288/62409ade-e79c-11e5-917a-bbc492e227c1.png)

/cc @johnduffell 
