### PR TITLE
Breakout html for DFP surveys

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -34,7 +34,6 @@ define([
         return new Promise(function (resolve, reject) {
             /*eslint-disable no-eval*/
             var $iFrame = bonzo(iFrame);
-            var $iFrameParent = bonzo(iFrame.parentNode);
             var iFrameBody = iFrame.contentDocument.body;
             var $breakoutEl;
 
@@ -45,16 +44,11 @@ define([
             $breakoutEl = $('.breakout__html, .breakout__script', iFrameBody);
 
             if ($breakoutEl.hasClass('breakout__html')) {
-                fastdom.write(function () {
+                resolve(fastdom.write(function () {
                     $iFrame.hide();
                     $breakoutEl.detach();
-                    $iFrameParent.append($breakoutEl[0].children);
-                }).then(function () {
-                    var $responsiveAds = $('.ad--responsive', $iFrameParent[0]);
-                    resolve(fastdom.write(function () {
-                        $responsiveAds.addClass('ad--responsive--open');
-                    }));
-                });
+                    $slot.append($breakoutEl[0].innerHTML);
+                }));
             } else if ($breakoutEl.hasClass('breakout__script')) {
                 fastdom.write(function () {
                     $iFrame.hide();


### PR DESCRIPTION
## What does this change?

There is a need to have simple polls served by DFP (because it's the best for the geolocation targeting). I use the same method as we used to have for the old merchandising templates, where html snippets where injected directly into ad slots (instead of json type template which are in use now), outside of the iframe.
## What is the value of this and can you measure success?

We will be able to show surveys to the users and save the results in [formstack](https://www.formstack.com/) (service which generates also form templates).
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

![screen shot 2016-03-11 at 17 45 42](https://cloud.githubusercontent.com/assets/489567/13710184/c166889e-e7af-11e5-8495-342c413dd7bd.png)

This will require some additional CSS and JS (validation) work directly in the new DFP template.
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
