### PR TITLE
Enable plista switchin production environment

### DIFF
--- a/admin/app/views/switchboardPlista.scala.html
+++ b/admin/app/views/switchboardPlista.scala.html
@@ -18,8 +18,8 @@
                 <div class="checkbox">
                     <label @if(Switch.expiry(switch).expiresSoon) { class="Expiring expiry-days-@Switch.expiry(switch).daysToExpiry"}>
                     <strong>@switch.name</strong><span> - @switch.description @if(Switch.expiry(switch).expiresSoon) {There are <strong> @Switch.expiry(switch).daysToExpiry</strong> days left.} <br /></span>
-                    <input id="switch-@switch.name" name="@switch.name" type="radio" value = "on" @if(env == "prod") {disabled="disabled"} @if(switch.isSwitchedOn) { checked="checked" } style="margin-right: 3px"/>on
-                    <input id="switch-@switch.name" name="@switch.name" type="radio" value = "off" @if(env == "prod") {disabled="disabled"} @if(!switch.isSwitchedOn) { checked="checked" } style="margin-right: 3px"/>off
+                    <input id="switch-@switch.name" name="@switch.name" type="radio" value = "on" @if(switch.isSwitchedOn) { checked="checked" } style="margin-right: 3px"/>on
+                    <input id="switch-@switch.name" name="@switch.name" type="radio" value = "off" @if(!switch.isSwitchedOn) { checked="checked" } style="margin-right: 3px"/>off
                     </label>
                 </div>
             </div>

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -35,7 +35,7 @@ trait FeatureSwitches {
   val PlistaForOutbrainAU = Switch(
     "Feature",
     "plista-for-outbrain-au",
-    "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition. For CODE environment only.",
+    "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition.",
     safeState = Off,
     sellByDate = new LocalDate(2016, 4, 6),
     exposeClientSide = true
@@ -377,7 +377,7 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2016, 4, 5), //Tuesday
     exposeClientSide = false
   )
-  
+
   // Owner: Dotcom loyalty
   val EmailInArticleGtodaySwitch = Switch(
     "Feature",


### PR DESCRIPTION
Currently the switch on the [Plista-specific switchboard](https://frontend.gutools.co.uk/dev/switchboard-plista) is disabled in DEV. We are now ready to go live with it - this change enables the switch to be turned off/on in DEV.

**/cc** @kelvin-chappell
