### PR TITLE
Email sign-up: OB refactor

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -377,7 +377,7 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2016, 4, 5), //Tuesday
     exposeClientSide = false
   )
-  
+
   // Owner: Dotcom loyalty
   val EmailInArticleGtodaySwitch = Switch(
     "Feature",
@@ -387,6 +387,17 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  // Owner: Dotcom loyalty
+  val EmailInArticleOutbrainSwitch = Switch(
+    "Feature",
+    "email-in-article-outbrain",
+    "When ON, we will check whether email sign-up will be shown and, if so, the outbrain non-compliant merchandising widget will be shown",
+    safeState = On,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
 
   // Owner: Dotcom health (R2/R1 decommissioning)
   val ArchiveResolvesR1UrlsInRedirectTableSwitch = Switch(

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain-codes.js
@@ -29,6 +29,12 @@ define([
             mobile:  { code: 'MB_10' },
             desktop: { code: 'AR_28' },
             tablet:  { code: 'MB_11' }
+        },
+
+        email: {
+            mobile:  { code: 'MB_10' },
+            desktop: { code: 'AR_28' },
+            tablet:  { code: 'MB_11' }
         }
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -152,11 +152,13 @@ define([
                         module.load('merchandising');
                     }
                 } else {
-                    if (emailRunChecks.getEmailInserted() && emailRunChecks.getEmailShown() === 'theGuardianToday') {
+                    if (config.switches.emailInArticleOutbrain &&
+                        emailRunChecks.getEmailInserted() &&
+                        emailRunChecks.getEmailShown() === 'theGuardianToday') {
                         // The Guardian today email is already there
                         // so load the merchandising component
                         module.load('merchandising');
-                    } else if (emailRunChecks.allEmailCanRun()) {
+                    } else if (config.switches.emailInArticleOutbrain && emailRunChecks.allEmailCanRun()) {
                         // We need to check the user's email subscriptions
                         // so we don't insert the sign-up if they've already subscribed.
                         // This is an async API request and returns a promise.

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -162,7 +162,7 @@ define([
                         // We need to check the user's email subscriptions
                         // so we don't insert the sign-up if they've already subscribed.
                         // This is an async API request and returns a promise.
-                        emailRunChecks.getUserEmailSubscriptions().then(function() {
+                        emailRunChecks.getUserEmailSubscriptions().then(function () {
                             // Check if the Guardian today list can run, if it can then load
                             // the merchandising (non-compliant) version of Outbrain
                             if (emailRunChecks.listCanRun('theGuardianToday')) {
@@ -170,7 +170,7 @@ define([
                             } else {
                                 module.load();
                             }
-                        })
+                        });
                     } else {
                         module.load();
                     }

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -36,6 +36,10 @@ define([
         merchandising: {
             widget: '.js-container--commercial',
             container: '.js-outbrain-container'
+        },
+        email: {
+            widget: '.js-outbrain',
+            container: '.js-outbrain-container'
         }
     };
 
@@ -123,13 +127,13 @@ define([
     }
 
     function checkEmailSignup() {
-        return new Promise(function(resolve) {
+        return new Promise(function (resolve) {
             if (config.switches.emailInArticleOutbrain &&
                 emailRunChecks.getEmailInserted() &&
                 emailRunChecks.getEmailShown() === 'theGuardianToday') {
                 // The Guardian today email is already there
                 // so load the merchandising component
-                resolve('merchandising');
+                resolve('email');
             } else if (config.switches.emailInArticleOutbrain && emailRunChecks.allEmailCanRun()) {
                 // We need to check the user's email subscriptions
                 // so we don't insert the sign-up if they've already subscribed.
@@ -137,7 +141,7 @@ define([
                 emailRunChecks.getUserEmailSubscriptions().then(function () {
                     // Check if the Guardian today list can run, if it can then load
                     // the merchandising (non-compliant) version of Outbrain
-                    emailRunChecks.listCanRun('theGuardianToday') ? resolve('merchandising') : resolve();
+                    emailRunChecks.listCanRun('theGuardianToday') ? resolve('email') : resolve();
                 });
             } else {
                 resolve();
@@ -154,9 +158,9 @@ define([
         ) {
             // if there is no merch component, load the outbrain widget right away
             if (loadInstantly()) {
-                return checkEmailSignup().then(function(widgetType) {
+                return checkEmailSignup().then(function (widgetType) {
                     widgetType ? module.load(widgetType) : module.load();
-                    return Promise.resolve(true)
+                    return Promise.resolve(true);
                 });
             }
 
@@ -178,9 +182,9 @@ define([
                         module.load('merchandising');
                     }
                 } else {
-                   checkEmailSignup().then(function(widgetType){
-                       widgetType ? module.load(widgetType) : module.load();
-                   });
+                    checkEmailSignup().then(function (widgetType) {
+                        widgetType ? module.load(widgetType) : module.load();
+                    });
                 }
             });
         }

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js
@@ -65,7 +65,7 @@ define([
         });
         widgetHtml = build(widgetCodes, breakpoint);
         return fastdom.write(function () {
-            if (slot !== 'defaults') {
+            if (slot === 'merchandising') {
                 $(selectors[slot].widget).replaceWith($outbrain[0]);
             }
             $container.append(widgetHtml);

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -147,7 +147,7 @@ define([
             if (emailRunChecks.allEmailCanRun()) {
                 // First we need to check the user's email subscriptions
                 // so we don't insert the sign-up if they've already subscribed
-                emailRunChecks.getUserEmailSubscriptions().then(function(){
+                emailRunChecks.getUserEmailSubscriptions().then(function () {
                     // Get the first list that is allowed on this page
                     addListToPage(find(listConfigs, emailRunChecks.listCanRun));
                 }).catch(function (error) {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -127,12 +127,14 @@ define([
 
                         omniture.trackLinkImmediate('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
                         emailRunChecks.setEmailInserted();
+                        emailRunChecks.setEmailShown(listConfig.listName);
                     });
                 } else {
                     spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {
                         $iframeEl.insertBefore(paras[0]);
                         omniture.trackLinkImmediate('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
                         emailRunChecks.setEmailInserted();
+                        emailRunChecks.setEmailShown(listConfig.listName);
                     });
                 }
 

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -2,46 +2,34 @@ define([
     'common/utils/$',
     'bean',
     'bonzo',
-    'common/modules/identity/api',
     'fastdom',
     'common/modules/email/email',
-    'common/utils/detect',
-    'lodash/collections/contains',
-    'lodash/arrays/intersection',
-    'lodash/collections/map',
     'common/utils/config',
-    'lodash/collections/every',
-    'lodash/collections/find',
-    'lodash/collections/some',
     'text!common/views/email/iframe.html',
     'common/utils/template',
     'common/modules/article/space-filler',
     'common/modules/analytics/omniture',
     'common/utils/robust',
-    'common/modules/user-prefs',
-    'common/utils/storage'
+    'common/modules/email/run-checks',
+    'common/utils/page',
+    'common/utils/storage',
+    'lodash/collections/find'
 ], function (
     $,
     bean,
     bonzo,
-    Id,
     fastdom,
     email,
-    detect,
-    contains,
-    intersection,
-    map,
     config,
-    every,
-    find,
-    some,
     iframeTemplate,
     template,
     spaceFiller,
     omniture,
     robust,
-    userPrefs,
-    storage
+    emailRunChecks,
+    page,
+    storage,
+    find
 ) {
 
     var insertBottomOfArticle = function () {
@@ -109,12 +97,6 @@ define([
                 insertMethod: insertBottomOfArticle
             }
         },
-        emailInserted = false,
-        userListSubscriptions = [],
-        keywords = config.page.keywords ? config.page.keywords.split(',') : '',
-        isParagraph = function ($el) {
-            return $el.nodeName && $el.nodeName === 'P';
-        },
         getSpacefinderRules = function () {
             return {
                 bodySelector: '.js-article__body',
@@ -131,37 +113,6 @@ define([
                 }
             };
         },
-        buildUserSubscriptions = function (response) {
-            if (response && response.status !== 'error' && response.result && response.result.subscriptions) {
-                userListSubscriptions = map(response.result.subscriptions, 'listId');
-            }
-
-            // Get the first list that is allowed on this page
-            addListToPage(find(listConfigs, listCanRun));
-        },
-        listCanRun = function (listConfig) {
-            var browser = detect.getUserAgent.browser,
-                version = detect.getUserAgent.version;
-
-            // Check our lists canRun method and
-            // make sure that the user isn't already subscribed to this email and
-            // don't show on IE 7,8,9 for now
-            if (!config.page.shouldHideAdverts &&
-                listConfig.listName &&
-                canRunList[listConfig.listName]() &&
-                !contains(userListSubscriptions, listConfig.listId) &&
-                !userHasRemoved(listConfig.listId, 'article') &&
-                !(browser === 'MSIE' && contains(['7','8','9'], version + ''))) {
-                return listConfig;
-            }
-        },
-        userHasRemoved = function (id, formType) {
-            var currentListPrefs = userPrefs.get('email-sign-up-' + formType);
-            return currentListPrefs && currentListPrefs.indexOf(id) > -1;
-        },
-        userHasSeenThisSession = function () {
-            return storage.session.get('email-sign-up-seen');
-        },
         addListToPage = function (listConfig) {
             if (listConfig) {
                 var iframe = bonzo.create(template(iframeTemplate, listConfig))[0],
@@ -175,86 +126,31 @@ define([
                         listConfig.insertMethod()($iframeEl);
 
                         omniture.trackLinkImmediate('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
-                        emailInserted = true;
+                        emailRunChecks.setEmailInserted();
                     });
                 } else {
                     spaceFiller.fillSpace(getSpacefinderRules(), function (paras) {
                         $iframeEl.insertBefore(paras[0]);
                         omniture.trackLinkImmediate('rtrt | email form inline | article | ' + listConfig.listId + ' | sign-up shown');
-                        emailInserted = true;
+                        emailRunChecks.setEmailInserted();
                     });
                 }
 
                 storage.session.set('email-sign-up-seen', 'true');
             }
-        },
-        canRunHelpers = {
-            keywordExists: function (keyword) {
-                // Compare page keywords with passed in array
-                return !!intersection(keywords, keyword).length;
-            },
-            userReferredFromNetworkFront: function () {
-                // Check whether the referring url ends in the edition
-                var networkFront = ['uk', 'us', 'au', 'international'],
-                    originPathName = document.referrer.split(/\?|#/)[0];
-
-                if (originPathName) {
-                    return some(networkFront, function (frontName) {
-                        return originPathName.substr(originPathName.lastIndexOf('/') + 1) === frontName;
-                    });
-                }
-
-                return false;
-            },
-            pageHasBlanketBlacklist: function () {
-                // Prevent the blanket emails from ever showing on certain keywords or sections
-                return canRunHelpers.keywordExists(['US elections 2016', 'Football']) ||
-                        config.page.section === 'film' ||
-                        config.page.seriesId === 'world/series/guardian-morning-briefing';
-            },
-            allowedArticleStructure: function () {
-                var $articleBody = $('.js-article__body');
-
-                if ($articleBody.length) {
-                    var allArticleEls = $('> *', $articleBody);
-                    return every([].slice.call(allArticleEls, allArticleEls.length - 3), isParagraph);
-                } else {
-                    return false;
-                }
-            }
-        },
-        canRunList = {
-            theCampaignMinute: function () {
-                return config.page.isMinuteArticle && canRunHelpers.keywordExists(['US elections 2016']);
-            },
-            theFilmToday: function () {
-                return config.page.section === 'film';
-            },
-            theFiver: function () {
-                return canRunHelpers.keywordExists(['Football']) &&
-                        canRunHelpers.allowedArticleStructure();
-            },
-            theGuardianToday: function () {
-                return config.switches.emailInArticleGtoday &&
-                        !canRunHelpers.pageHasBlanketBlacklist() &&
-                        canRunHelpers.userReferredFromNetworkFront() &&
-                        canRunHelpers.allowedArticleStructure();
-            }
         };
 
     return {
         init: function () {
-            if (!emailInserted &&
-                !config.page.isFront &&
-                config.switches.emailInArticle &&
-                storage.session.isAvailable &&
-                !userHasSeenThisSession()) {
-                // Get the user's current subscriptions
-                Id.getUserEmailSignUps()
-                    .then(buildUserSubscriptions)
-                    .catch(function (error) {
-                        robust.log('c-email', error);
-                    });
+            if (emailRunChecks.allEmailCanRun()) {
+                // First we need to check the user's email subscriptions
+                // so we don't insert the sign-up if they've already subscribed
+                emailRunChecks.getUserEmailSubscriptions().then(function(){
+                    // Get the first list that is allowed on this page
+                    addListToPage(find(listConfigs, emailRunChecks.listCanRun));
+                }).catch(function (error) {
+                    robust.log('c-email', error);
+                });
             }
         }
     };

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -1,0 +1,153 @@
+define([
+    'common/utils/$',
+    'common/utils/page',
+    'common/utils/config',
+    'common/utils/detect',
+    'common/utils/storage',
+    'common/utils/robust',
+    'lodash/collections/some',
+    'lodash/collections/every',
+    'lodash/collections/map',
+    'lodash/collections/contains',
+    'common/modules/user-prefs',
+    'common/modules/identity/api',
+    'Promise'
+], function (
+    $,
+    page,
+    config,
+    detect,
+    storage,
+    robust,
+    some,
+    every,
+    map,
+    contains,
+    userPrefs,
+    Id,
+    Promise
+) {
+    var emailInserted = false,
+        userListSubsChecked = false,
+        userListSubs = [];
+
+    function pageHasBlanketBlacklist () {
+        // Prevent the blanket emails from ever showing on certain keywords or sections
+        return page.keywordExists(['US elections 2016', 'Football']) ||
+            config.page.section === 'film' ||
+            config.page.seriesId === 'world/series/guardian-morning-briefing';
+    }
+
+    function userHasRemoved (id, formType) {
+        var currentListPrefs = userPrefs.get('email-sign-up-' + formType);
+        return currentListPrefs && currentListPrefs.indexOf(id) > -1;
+    }
+
+    function userHasSeenThisSession () {
+        return !!storage.session.get('email-sign-up-seen');
+    }
+
+    function buildUserSubscriptions (response) {
+        if (response && response.status !== 'error' && response.result && response.result.subscriptions) {
+            userListSubs = map(response.result.subscriptions, 'listId');
+            userListSubsChecked = true;
+        }
+
+        return userListSubs;
+    }
+
+    function userReferredFromNetworkFront () {
+        // Check whether the referring url ends in the edition
+        var networkFront = ['uk', 'us', 'au', 'international'],
+            originPathName = document.referrer.split(/\?|#/)[0];
+
+        if (originPathName) {
+            return some(networkFront, function (frontName) {
+                return originPathName.substr(originPathName.lastIndexOf('/') + 1) === frontName;
+            });
+        }
+
+        return false;
+    }
+
+    function isParagraph ($el) {
+        return $el.nodeName && $el.nodeName === 'P';
+    }
+
+    function allowedArticleStructure () {
+        var $articleBody = $('.js-article__body');
+
+        if ($articleBody.length) {
+            var allArticleEls = $('> *', $articleBody);
+            return every([].slice.call(allArticleEls, allArticleEls.length - 3), isParagraph);
+        } else {
+            return false;
+        }
+    }
+
+    var canRunList = {
+        theCampaignMinute: function () {
+            return config.page.isMinuteArticle && page.keywordExists(['US elections 2016']);
+        },
+        theFilmToday: function () {
+            return config.page.section === 'film';
+        },
+        theFiver: function () {
+            return page.keywordExists(['Football']) && allowedArticleStructure();
+        },
+        theGuardianToday: function () {
+            return config.switches.emailInArticleGtoday &&
+                !pageHasBlanketBlacklist() &&
+                userReferredFromNetworkFront() &&
+                allowedArticleStructure();
+        }
+    };
+
+    // Public
+
+    function setEmailInserted () {
+        emailInserted = true;
+    }
+
+    function allEmailCanRun () {
+        var browser = detect.getUserAgent.browser,
+            version = detect.getUserAgent.version;
+
+        return !config.page.shouldHideAdverts &&
+            !emailInserted &&
+            !config.page.isFront &&
+            config.switches.emailInArticle &&
+            storage.session.isAvailable() &&
+            !userHasSeenThisSession() &&
+            !(browser === 'MSIE' && contains(['7','8','9'], version + ''))
+    }
+
+    function getUserEmailSubscriptions () {
+        if (userListSubsChecked) {
+            return Promise.resolve(userListSubs);
+        } else {
+            return Id.getUserEmailSignUps()
+                .then(buildUserSubscriptions)
+                .catch(function (error) {
+                    robust.log('c-email', error);
+                });
+        }
+    }
+
+    function listCanRun (listConfig) {
+        if (listConfig.listName &&
+            canRunList[listConfig.listName]() &&
+            !contains(userListSubs, listConfig.listId) &&
+            !userHasRemoved(listConfig.listId, 'article')) {
+
+            return listConfig;
+        }
+    }
+
+    return {
+        setEmailInserted: setEmailInserted,
+        allEmailCanRun: allEmailCanRun,
+        getUserEmailSubscriptions: getUserEmailSubscriptions,
+        listCanRun: listCanRun
+    }
+});

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -32,23 +32,23 @@ define([
         userListSubsChecked = false,
         userListSubs = [];
 
-    function pageHasBlanketBlacklist () {
+    function pageHasBlanketBlacklist() {
         // Prevent the blanket emails from ever showing on certain keywords or sections
         return page.keywordExists(['US elections 2016', 'Football']) ||
             config.page.section === 'film' ||
             config.page.seriesId === 'world/series/guardian-morning-briefing';
     }
 
-    function userHasRemoved (id, formType) {
+    function userHasRemoved(id, formType) {
         var currentListPrefs = userPrefs.get('email-sign-up-' + formType);
         return currentListPrefs && currentListPrefs.indexOf(id) > -1;
     }
 
-    function userHasSeenThisSession () {
+    function userHasSeenThisSession() {
         return !!storage.session.get('email-sign-up-seen');
     }
 
-    function buildUserSubscriptions (response) {
+    function buildUserSubscriptions(response) {
         if (response && response.status !== 'error' && response.result && response.result.subscriptions) {
             userListSubs = map(response.result.subscriptions, 'listId');
             userListSubsChecked = true;
@@ -57,7 +57,7 @@ define([
         return userListSubs;
     }
 
-    function userReferredFromNetworkFront () {
+    function userReferredFromNetworkFront() {
         // Check whether the referring url ends in the edition
         var networkFront = ['uk', 'us', 'au', 'international'],
             originPathName = document.referrer.split(/\?|#/)[0];
@@ -71,11 +71,11 @@ define([
         return false;
     }
 
-    function isParagraph ($el) {
+    function isParagraph($el) {
         return $el.nodeName && $el.nodeName === 'P';
     }
 
-    function allowedArticleStructure () {
+    function allowedArticleStructure() {
         var $articleBody = $('.js-article__body');
 
         if ($articleBody.length) {
@@ -106,23 +106,23 @@ define([
 
     // Public
 
-    function setEmailInserted () {
+    function setEmailInserted() {
         emailInserted = true;
     }
 
-    function getEmailInserted () {
+    function getEmailInserted() {
         return emailInserted;
     }
 
-    function setEmailShown (emailName) {
+    function setEmailShown(emailName) {
         emailShown = emailName;
     }
 
-    function getEmailShown () {
+    function getEmailShown() {
         return emailShown;
     }
 
-    function allEmailCanRun () {
+    function allEmailCanRun() {
         var browser = detect.getUserAgent.browser,
             version = detect.getUserAgent.version;
 
@@ -132,10 +132,10 @@ define([
             config.switches.emailInArticle &&
             storage.session.isAvailable() &&
             !userHasSeenThisSession() &&
-            !(browser === 'MSIE' && contains(['7','8','9'], version + ''))
+            !(browser === 'MSIE' && contains(['7','8','9'], version + ''));
     }
 
-    function getUserEmailSubscriptions () {
+    function getUserEmailSubscriptions() {
         if (userListSubsChecked) {
             return Promise.resolve(userListSubs);
         } else {
@@ -147,7 +147,7 @@ define([
         }
     }
 
-    function listCanRun (listConfig) {
+    function listCanRun(listConfig) {
         if (listConfig.listName &&
             canRunList[listConfig.listName]() &&
             !contains(userListSubs, listConfig.listId) &&
@@ -165,5 +165,5 @@ define([
         allEmailCanRun: allEmailCanRun,
         getUserEmailSubscriptions: getUserEmailSubscriptions,
         listCanRun: listCanRun
-    }
+    };
 });

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -28,6 +28,7 @@ define([
     Promise
 ) {
     var emailInserted = false,
+        emailShown,
         userListSubsChecked = false,
         userListSubs = [];
 
@@ -109,6 +110,18 @@ define([
         emailInserted = true;
     }
 
+    function getEmailInserted () {
+        return emailInserted;
+    }
+
+    function setEmailShown (emailName) {
+        emailShown = emailName;
+    }
+
+    function getEmailShown () {
+        return emailShown;
+    }
+
     function allEmailCanRun () {
         var browser = detect.getUserAgent.browser,
             version = detect.getUserAgent.version;
@@ -145,7 +158,10 @@ define([
     }
 
     return {
+        setEmailShown: setEmailShown,
+        getEmailShown: getEmailShown,
         setEmailInserted: setEmailInserted,
+        getEmailInserted: getEmailInserted,
         allEmailCanRun: allEmailCanRun,
         getUserEmailSubscriptions: getUserEmailSubscriptions,
         listCanRun: listCanRun

--- a/static/src/javascripts/projects/common/utils/page.js
+++ b/static/src/javascripts/projects/common/utils/page.js
@@ -70,7 +70,7 @@ define([
         return isit(vis, yes, no, el);
     }
 
-   function keywordExists(keyword) {
+    function keywordExists(keyword) {
         var keywords = config.page.keywords ? config.page.keywords.split(',') : '';
         // Compare page keywords with passed in array
         return !!intersection(keywords, keyword).length;

--- a/static/src/javascripts/projects/common/utils/page.js
+++ b/static/src/javascripts/projects/common/utils/page.js
@@ -2,12 +2,14 @@ define([
     'common/utils/$',
     'common/utils/config',
     'lodash/objects/assign',
-    'lodash/collections/find'
+    'lodash/collections/find',
+    'lodash/arrays/intersection'
 ], function (
     $,
     config,
     assign,
-    find
+    find,
+    intersection
 ) {
 
     function isit(isTrue, yes, no, arg) {
@@ -68,13 +70,20 @@ define([
         return isit(vis, yes, no, el);
     }
 
+   function keywordExists(keyword) {
+        var keywords = config.page.keywords ? config.page.keywords.split(',') : '';
+        // Compare page keywords with passed in array
+        return !!intersection(keywords, keyword).length;
+    }
+
     return {
         isMatch: isMatch,
         isCompetition: isCompetition,
         isClockwatch: isClockwatch,
         isLiveClockwatch: isLiveClockwatch,
         isFootballStatsPage: isFootballStatsPage,
-        belowArticleVisible: belowArticleVisible
+        belowArticleVisible: belowArticleVisible,
+        keywordExists: keywordExists
     };
 
 }); // define


### PR DESCRIPTION
## What does this change?

We need to show the non-compliant (merchandising) OB 'widget' when the email sign-up is shown. To ensure that OB is loaded early as possible in all cases but still check whether email sign-up will show, I have refactored so that we can check if a sign-up form will be shown before showing it, therefore allowing us to insert the correct OB component.
## What is the value of this and can you measure success?

The value of this is to ensure that we are meeting our contract and so they can test the impressions of the widget.
## Request for comment

@regiskuckaertz @jbreckmckye I'm messing with Outbrain so can you guys have a glance please.
