### PR TITLE
Vary membership adblock message by edition

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -33,39 +33,46 @@ define([
 ) {
     function showAdblockMessage() {
         var adblockLink = 'https://membership.theguardian.com/supporter',
-            message = sample([
-                {
-                    id: 'monthly',
-                    messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter from just £5 per month',
+            messages = {
+                UK: {
+                    campaign: 'ADB_UK',
+                    messageText: [
+                        'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way?',
+                        'Become a Supporter for less than £1 per week'
+                    ].join(' '),
                     linkText: 'Find out more'
                 },
-                {
-                    id: 'annual',
-                    messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter for just £50 per a year',
+                US: {
+                    campaign: 'ADB_US',
+                    messageText: [
+                        'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way?',
+                        'Become a Supporter for less than $1 per week'
+                    ].join(' '),
                     linkText: 'Find out more'
                 },
-                {
-                    id: 'weekly',
-                    messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way? Become a Supporter for less than £1 per week',
+                INT: {
+                    campaign: 'ADB_INT',
+                    messageText: [
+                        'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way?',
+                        'Become a Supporter for less than $1/€1 per week'
+                    ].join(' '),
                     linkText: 'Find out more'
-                },
-                {
-                    id: 'no-price',
-                    messageText: 'We notice you\'re using an ad-blocker. Perhaps you\'ll support us another way?',
-                    linkText: 'Become a supporter today'
                 }
-            ]);
+            },
+            message = messages[config.page.edition];
 
-        new Message('adblock-message', {
-            pinOnHide: false,
-            siteMessageLinkName: 'adblock message variant ' + message.id,
-            siteMessageCloseBtn: 'hide'
-        }).show(template(messageTemplate, {
-            linkHref: adblockLink + '?INTCMP=adb-mv-' + message.id,
-            messageText: message.messageText,
-            linkText: message.linkText,
-            arrowWhiteRight: svgs('arrowWhiteRight')
-        }));
+        if (message) {
+            new Message('adblock-message', {
+                pinOnHide: false,
+                siteMessageLinkName: 'adblock',
+                siteMessageCloseBtn: 'hide'
+            }).show(template(messageTemplate, {
+                linkHref: adblockLink + '?INTCMP=' + message.campaign,
+                messageText: message.messageText,
+                linkText: message.linkText,
+                arrowWhiteRight: svgs('arrowWhiteRight')
+            }));
+        }
     }
 
     function showAdblockBanner() {

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -150,7 +150,7 @@
     @include mq(tablet) {
         display: table-cell;
         vertical-align: middle;
-        min-width: $gs-column-width * 2;
+        min-width: 135px;
         margin-top: 0;
     }
 }


### PR DESCRIPTION
## What does this change?

We were running a test involving four variations of the ad block message. Based on [these results](https://docs.google.com/spreadsheets/d/1dZER-_FK_LaJ2Q4rSX-Dt0COzDoP7lSDDF2m5hr5YkE/edit?ts=56e6deb8#gid=0) the weekly price variant has the best Supporter conversion rate so we're going with that. At the same time, we need to put in international variations by edition since we now have custom landing pages and also custom banners at the top of the page in local currency.

Also increases min width on the button area of the banner to fix a styling issue where the button appears empty between the tablet and desktop breakpoints. 
## What is the value of this and can you measure success?

Value is not to confuse users by potentially giving them a price in their local currency at the top of the page, but in pounds at the bottom
## Does this affect other platforms - Amp, Apps, etc?

Just web
## Screenshots
### Fix for mismatched currencies
#### before

![picture 177](https://cloud.githubusercontent.com/assets/5122968/13753225/0565b572-ea0a-11e5-80ca-1241775b2d27.png)
#### after

![picture 178](https://cloud.githubusercontent.com/assets/5122968/13753228/07e5f5a0-ea0a-11e5-93be-0944475a2348.png)
### CSS bug fix:
#### before

![picture 173](https://cloud.githubusercontent.com/assets/5122968/13752795/51637d6c-ea08-11e5-82a6-36d6aae37f5e.png)
#### after

![picture 174](https://cloud.githubusercontent.com/assets/5122968/13752797/57ac0d06-ea08-11e5-8250-15ae50ce2310.png)
## Request for comment

@jbreckmckye 
