### PR TITLE
Redisplay uk supporter banner with colours

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -33,7 +33,9 @@ define([
     var messages = {
         UK: {
             campaign:      'MEMBERSHIP_SUPPORTER_BANNER_UK',
-            code:          'membership-message-uk',
+            // increment the number at the end of the code to redisplay banners
+            // to everyone who has previously closed them
+            code:          'membership-message-uk-1',
             minVisited:    10,
             data: {
                 messageText: [
@@ -66,6 +68,15 @@ define([
         }
     };
 
+    var colours = {
+     // 0: 'purple',
+        1: 'vibrant-blue',
+        2: 'yellow',
+        3: 'teal',
+        4: 'orange',
+        5: 'light-blue'
+    };
+
     function checkWeCanShowMessage(message) {
         return commercialFeatures.async.membershipMessages.then(function (canShow) {
             return canShow && message.minVisited <= (storage.local.get('gu.alreadyVisited') || 0);
@@ -78,12 +89,19 @@ define([
 
     function show(edition, message) {
         var data = defaults({ linkHref: formatEndpointUrl(edition, message) }, message.data, defaultData);
+        // Rotate through six different colours on successive page views
+        var colour = storage.local.get('gu.alreadyVisited') % 6;
+        var cssModifierClass = 'membership-message';
+
+        if (colour) {
+            cssModifierClass += ('-' + colours[colour]);
+        }
 
         return new Message(message.code, {
             pinOnHide: false,
             siteMessageLinkName: 'membership message',
             siteMessageCloseBtn: 'hide',
-            cssModifierClass: 'membership-message'
+            cssModifierClass: cssModifierClass
         }).show(template(messageTemplate, data));
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -69,7 +69,6 @@ define([
     };
 
     var colours = {
-     // 0: 'purple',
         1: 'vibrant-blue',
         2: 'yellow',
         3: 'teal',

--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -39,10 +39,10 @@ define([
             minVisited:    10,
             data: {
                 messageText: [
-                    'Thank you for reading the Guardian.',
-                    'Help keep our journalism fearless and independent by becoming a Supporter for just £5 a month.'
+                    'Support Guardian journalism and our coverage of critical, under-reported stories from around the world.',
+                    'Become a Supporter for just £49 per year.'
                 ].join(' '),
-                linkText: 'Join'
+                linkText: 'Find out more'
             }
         },
         US: {

--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -70,10 +70,10 @@ define([
 
     var colours = {
         1: 'vibrant-blue',
-        2: 'yellow',
-        3: 'teal',
-        4: 'orange',
-        5: 'light-blue'
+        2: 'orange',
+        3: 'light-blue',
+        4: 'deep-purple',
+        5: 'teal'
     };
 
     function checkWeCanShowMessage(message) {
@@ -92,6 +92,7 @@ define([
         var colour = storage.local.get('gu.alreadyVisited') % 6;
         var cssModifierClass = 'membership-message';
 
+        // 0 leaves it as the default colour set by the base class
         if (colour) {
             cssModifierClass += ('-' + colours[colour]);
         }

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -462,6 +462,27 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 .site-message--membership-message {
     background: colour(membership-default);
 }
+.site-message--membership-message-yellow {
+    background: #fff200;
+    color: #333;
+}
+.site-message--membership-message-orange {
+    background: #ffbb00;
+    color: #333;
+}
+.site-message--membership-message-vibrant-blue {
+    background: #4bc6df;
+    color: #333;
+}
+.site-message--membership-message-light-blue {
+    background: #aad8f1;
+    color: #333;
+}
+.site-message--membership-message-teal {
+    background: #69d1ca;
+    color: #333;
+}
+
 
 
 

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -458,29 +458,40 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 /**
  * Membership messages
  */
+@mixin site-message-dark-text {
+    &,
+    .site-message__actions,
+    .site-message__actions__item,
+    path,
+    button,
+    a {
+        color: #333333;
+        fill: #333333;
+        border-color: #333333;
+    }
+}
 .site-message--adblock-message,
 .site-message--membership-message {
     background: colour(membership-default);
 }
-.site-message--membership-message-yellow {
-    background: #fff200;
-    color: #333333;
+.site-message--membership-message-deep-purple {
+    background: #7d0068;
 }
 .site-message--membership-message-orange {
     background: #ffbb00;
-    color: #333333;
+    @include site-message-dark-text;
 }
 .site-message--membership-message-vibrant-blue {
     background: #4bc6df;
-    color: #333333;
+    @include site-message-dark-text;
 }
 .site-message--membership-message-light-blue {
     background: #aad8f1;
-    color: #333333;
+    @include site-message-dark-text;
 }
 .site-message--membership-message-teal {
     background: #69d1ca;
-    color: #333333;
+    @include site-message-dark-text;
 }
 
 

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -464,23 +464,23 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 }
 .site-message--membership-message-yellow {
     background: #fff200;
-    color: #333;
+    color: #333333;
 }
 .site-message--membership-message-orange {
     background: #ffbb00;
-    color: #333;
+    color: #333333;
 }
 .site-message--membership-message-vibrant-blue {
     background: #4bc6df;
-    color: #333;
+    color: #333333;
 }
 .site-message--membership-message-light-blue {
     background: #aad8f1;
-    color: #333;
+    color: #333333;
 }
 .site-message--membership-message-teal {
     background: #69d1ca;
-    color: #333;
+    color: #333333;
 }
 
 

--- a/static/test/javascripts/spec/common/commercial/membership-messages.spec.js
+++ b/static/test/javascripts/spec/common/commercial/membership-messages.spec.js
@@ -59,6 +59,8 @@ define([
             membershipMessages.init().then(function () {
                 var message = document.querySelector('.js-site-message');
                 expect(message).not.toBeNull();
+                expect(message.className).toContain('membership-message');
+                expect(message.className).not.toContain('is-hidden');
             }).then(done);
         }
 
@@ -66,6 +68,14 @@ define([
             membershipMessages.init().then(function () {
                 var message = document.querySelector('.js-site-message');
                 expect(message).toBeNull();
+            }).then(done);
+        }
+
+        function expectMessageNotToBeVisible(done) {
+            membershipMessages.init().then(function () {
+                var message = document.querySelector('.js-site-message');
+                expect(message.className).toContain('is-hidden');
+                expect(message.className).not.toContain('membership-message');
             }).then(done);
         }
 
@@ -131,7 +141,7 @@ define([
 
                     config.page = { edition: edition };
 
-                    expectMessageNotToBeShown(done);
+                    expectMessageNotToBeVisible(done);
                 });
             });
         });

--- a/static/test/javascripts/spec/common/commercial/membership-messages.spec.js
+++ b/static/test/javascripts/spec/common/commercial/membership-messages.spec.js
@@ -57,14 +57,14 @@ define([
 
         function expectMessageToBeShown(done) {
             membershipMessages.init().then(function () {
-                var message = document.querySelector('.js-site-message.site-message--membership-message');
+                var message = document.querySelector('.js-site-message');
                 expect(message).not.toBeNull();
             }).then(done);
         }
 
         function expectMessageNotToBeShown(done) {
             membershipMessages.init().then(function () {
-                var message = document.querySelector('.js-site-message.site-message--membership-message');
+                var message = document.querySelector('.js-site-message');
                 expect(message).toBeNull();
             }).then(done);
         }


### PR DESCRIPTION
## What does this change?
- Redisplays the UK supporter banner to everyone who has previously closed it (by changing the message id).
- Tweaks the copy on that banner.
- Provides some new colours for the banner and rotates through them on successive page views.

https://trello.com/c/AuLCGUN5/399-update-copy-and-colours-on-engaged-reader-banner-and-display-it-to-readers-in-the-uk
## What is the value of this and can you measure success?

The aim is to drive Supporter signup. Success would be an increase in signups associated with the MEMBERSHIP_SUPPORTER_BANNER_UK code.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![picture 185](https://cloud.githubusercontent.com/assets/5122968/13755903/481f33f6-ea15-11e5-859f-773c1d07278d.png)
![picture 184](https://cloud.githubusercontent.com/assets/5122968/13755907/4822c34a-ea15-11e5-998a-70912e69d8c1.png)
![picture 183](https://cloud.githubusercontent.com/assets/5122968/13755908/48235594-ea15-11e5-9771-5f31b58af63e.png)
![picture 182](https://cloud.githubusercontent.com/assets/5122968/13755905/4821cfb2-ea15-11e5-9a5f-dde097a36ab8.png)
![picture 180](https://cloud.githubusercontent.com/assets/5122968/13755906/48229712-ea15-11e5-9581-954f3c4bce47.png)
![picture 179](https://cloud.githubusercontent.com/assets/5122968/13755904/481ff048-ea15-11e5-80dd-b734a904c384.png)
