### PR TITLE
Use switch for rendering of merch containers

### DIFF
--- a/commercial/app/controllers/commercial/BookOffersController.scala
+++ b/commercial/app/controllers/commercial/BookOffersController.scala
@@ -63,7 +63,11 @@ object BookOffersController
             case Some("prominent") =>
               jsonFormat.result(views.html.books.booksProminent(someBooks, omnitureId, clickMacro))
             case _ =>
-              jsonFormat.result(views.html.books.booksStandard(someBooks, omnitureId, clickMacro))
+              if (conf.switches.Switches.v2BooksTemplate.isSwitchedOn) {
+                jsonFormat.result(views.html.books.booksStandardV2(someBooks, omnitureId, clickMacro))
+              } else {
+                jsonFormat.result(views.html.books.booksStandard(someBooks, omnitureId, clickMacro))
+              }
           }
         }
     }

--- a/commercial/app/controllers/commercial/ContentApiOffersController.scala
+++ b/commercial/app/controllers/commercial/ContentApiOffersController.scala
@@ -66,9 +66,65 @@ object ContentApiOffersController extends Controller with ExecutionContexts with
       case Nil => NoCache(format.nilResult)
       case contents => Cached(componentMaxAge) {
         if (isMulti) {
-          format.result(views.html.contentapi.items(contents, optLogo, optCapiTitle, optCapiLink, optCapiAbout, optClickMacro, optOmnitureId, optCapiAdFeature, optSponsorType, optSponsorLabel))
+          if(conf.switches.Switches.v2CapiMultipleTemplate.isSwitchedOn) {
+            format.result(views.html.contentapi.itemsV2(
+              contents,
+              optLogo,
+              optCapiTitle,
+              optCapiLink,
+              optCapiAbout,
+              optClickMacro,
+              optOmnitureId,
+              optCapiAdFeature,
+              optSponsorType,
+              optSponsorLabel)
+            )
+          } else {
+            format.result(views.html.contentapi.items(
+              contents,
+              optLogo,
+              optCapiTitle,
+              optCapiLink,
+              optCapiAbout,
+              optClickMacro,
+              optOmnitureId,
+              optCapiAdFeature,
+              optSponsorType,
+              optSponsorLabel)
+            )
+          }
         } else {
-          format.result(views.html.contentapi.item(contents.head, optLogo, optCapiTitle, optCapiLink, optCapiAbout, optCapiButtonText, optCapiReadMoreUrl, optCapiReadMoreText, optSponsorType, optSponsorLabel, optClickMacro, optOmnitureId))
+          if(conf.switches.Switches.v2CapiSingleTemplate.isSwitchedOn) {
+            format.result(views.html.contentapi.itemV2(
+              contents.head,
+              optLogo,
+              optCapiTitle,
+              optCapiLink,
+              optCapiAbout,
+              optCapiButtonText,
+              optCapiReadMoreUrl,
+              optCapiReadMoreText,
+              optSponsorType,
+              optSponsorLabel,
+              optClickMacro,
+              optOmnitureId)
+            )
+          } else {
+            format.result(views.html.contentapi.item(
+              contents.head,
+              optLogo,
+              optCapiTitle,
+              optCapiLink,
+              optCapiAbout,
+              optCapiButtonText,
+              optCapiReadMoreUrl,
+              optCapiReadMoreText,
+              optSponsorType,
+              optSponsorLabel,
+              optClickMacro,
+              optOmnitureId)
+            )
+          }
         }
       }
     }

--- a/commercial/app/controllers/commercial/JobAds.scala
+++ b/commercial/app/controllers/commercial/JobAds.scala
@@ -1,9 +1,10 @@
 package controllers.commercial
 
-import model.commercial.jobs.{Job, JobsAgent}
-import model.{NoCache, Cached}
+import model.commercial.jobs.JobsAgent
+import model.{Cached, NoCache}
 import performance.MemcachedAction
 import play.api.mvc._
+
 import scala.concurrent.Future
 
 object JobAds extends Controller with implicits.Requests {
@@ -18,7 +19,11 @@ object JobAds extends Controller with implicits.Requests {
           val clickMacro = request.getParameter("clickMacro")
           val omnitureId = request.getParameter("omnitureId")
 
-          jsonFormat.result(views.html.jobs.jobs(jobs.take(2), omnitureId, clickMacro))
+          if(conf.switches.Switches.v2JobsTemplate.isSwitchedOn) {
+            jsonFormat.result(views.html.jobs.jobsV2(jobs.take(2), omnitureId, clickMacro))
+          } else {
+            jsonFormat.result(views.html.jobs.jobs(jobs.take(2), omnitureId, clickMacro))
+          }
         }
       }
     }

--- a/commercial/app/controllers/commercial/Multi.scala
+++ b/commercial/app/controllers/commercial/Multi.scala
@@ -103,7 +103,11 @@ object Multi
       val content = contents.flatten
       if (requestedContent.nonEmpty && content.size == requestedContent.size) {
         Cached(componentMaxAge) {
-          jsonFormat.result(views.html.multi(content, omnitureId))
+          if(conf.switches.Switches.v2BlendedTemplate.isSwitchedOn) {
+            jsonFormat.result(views.html.multiV2(content, omnitureId))
+          } else {
+            jsonFormat.result(views.html.multi(content, omnitureId))
+          }
         }
       } else {
         NoCache(jsonFormat.nilResult)

--- a/commercial/app/controllers/commercial/SoulmatesController.scala
+++ b/commercial/app/controllers/commercial/SoulmatesController.scala
@@ -34,7 +34,14 @@ object SoulmatesController extends Controller with implicits.Requests {
   }
 
   def renderSoulmates(groupName: String): Action[AnyContent] = Action { implicit request =>
-    result(groupName, views.html.soulmates.soulmates(_, _, _))
+    val soulmates = {
+      if(conf.switches.Switches.v2SoulmatesTemplate.isSwitchedOn) {
+        views.html.soulmates.soulmatesV2(_, _, _)
+      } else {
+        views.html.soulmates.soulmates(_, _, _)
+      }
+    }
+    result(groupName, soulmates)
   }
 
   def renderSoulmatesTest(groupName: String): Action[AnyContent] = Action { implicit request =>

--- a/commercial/app/controllers/commercial/TravelOffers.scala
+++ b/commercial/app/controllers/commercial/TravelOffers.scala
@@ -1,24 +1,33 @@
 package controllers.commercial
 
-import model.commercial.travel.{TravelOffer, TravelOffersAgent}
-import model.{NoCache, Cached}
+import model.commercial.travel.TravelOffersAgent
+import model.{Cached, NoCache}
 import performance.MemcachedAction
 import play.api.mvc._
+
 import scala.concurrent.Future
 
 object TravelOffers extends Controller with implicits.Requests {
 
   def renderTravel = MemcachedAction { implicit request =>
     Future.successful {
-      (TravelOffersAgent.specificTravelOffers(specificIds) ++ TravelOffersAgent.offersTargetedAt(segment)).distinct match {
+      val travelOffers = (TravelOffersAgent.specificTravelOffers(specificIds) ++
+                      TravelOffersAgent.offersTargetedAt(segment)).distinct
+      travelOffers match {
         case Nil => NoCache(jsonFormat.nilResult)
         case offers => Cached(componentMaxAge) {
           val clickMacro = request.getParameter("clickMacro")
           val omnitureId = request.getParameter("omnitureId")
 
           request.getParameter("layout") match {
-            case Some("prominent") => jsonFormat.result(views.html.travel.travelProminent(offers.take(4), omnitureId, clickMacro))
-            case _ => jsonFormat.result(views.html.travel.travelStandard(offers.take(4), omnitureId, clickMacro))
+            case Some("prominent") =>
+              jsonFormat.result(views.html.travel.travelProminent(offers.take(4), omnitureId, clickMacro))
+            case _ =>
+              if (conf.switches.Switches.v2TravelTemplate.isSwitchedOn) {
+                jsonFormat.result(views.html.travel.travelStandardV2(offers.take(4), omnitureId, clickMacro))
+              } else {
+                jsonFormat.result(views.html.travel.travelStandard(offers.take(4), omnitureId, clickMacro))
+              }
           }
         }
       }

--- a/commercial/app/views/books/booksStandardV2.scala.html
+++ b/commercial/app/views/books/booksStandardV2.scala.html
@@ -1,0 +1,3 @@
+@(books: Seq[model.commercial.books.Book],
+  omnitureId: Option[String],
+  clickMacro: Option[String])(implicit request: RequestHeader)

--- a/commercial/app/views/contentapi/itemV2.scala.html
+++ b/commercial/app/views/contentapi/itemV2.scala.html
@@ -1,0 +1,12 @@
+@(item: model.ContentType,
+  optLogo: Option[String],
+  optCapiTitle: Option[String],
+  optCapiLink: Option[String],
+  optCapiAbout: Option[String],
+  optCapiButtonText: Option[String],
+  optCapiReadMoreUrl: Option[String],
+  optCapiReadMoreText: Option[String],
+  optSponsorType: Option[String],
+  optSponsorLabel: Option[String],
+  optClickMacro: Option[String],
+  optOmnitureId: Option[String])(implicit request: RequestHeader)

--- a/commercial/app/views/contentapi/itemsV2.scala.html
+++ b/commercial/app/views/contentapi/itemsV2.scala.html
@@ -1,0 +1,10 @@
+@(items: Seq[model.ContentType],
+  optLogo: Option[String],
+  optCapiTitle: Option[String],
+  optCapiLink: Option[String],
+  optCapiAbout: Option[String],
+  optClickMacro: Option[String],
+  optOmnitureId: Option[String],
+  optCapiAdFeature: Option[String],
+  optSponsorType: Option[String],
+  optSponsorLabel: Option[String])(implicit request: RequestHeader)

--- a/commercial/app/views/jobs/jobsV2.scala.html
+++ b/commercial/app/views/jobs/jobsV2.scala.html
@@ -1,0 +1,3 @@
+@(jobs: Seq[model.commercial.jobs.Job],
+  omnitureId: Option[String],
+  clickMacro: Option[String])(implicit request: RequestHeader)

--- a/commercial/app/views/masterClasses/masterclassesV2.scala.html
+++ b/commercial/app/views/masterClasses/masterclassesV2.scala.html
@@ -1,0 +1,3 @@
+@(events: Seq[model.commercial.masterclasses.MasterClass],
+  omnitureId: Option[String],
+  clickMacro: Option[String])(implicit request: RequestHeader)

--- a/commercial/app/views/multiV2.scala.html
+++ b/commercial/app/views/multiV2.scala.html
@@ -1,0 +1,1 @@
+@(components: Seq[Html], omnitureId: Option[String])(implicit request: RequestHeader)

--- a/commercial/app/views/soulmates/soulmatesV2.scala.html
+++ b/commercial/app/views/soulmates/soulmatesV2.scala.html
@@ -1,0 +1,3 @@
+@(members: Seq[model.commercial.soulmates.Member],
+  omnitureId: Option[String],
+  clickMacro: Option[String])(implicit request: RequestHeader)

--- a/commercial/app/views/travel/travelStandardV2.scala.html
+++ b/commercial/app/views/travel/travelStandardV2.scala.html
@@ -1,0 +1,3 @@
+@(offers: Seq[model.commercial.travel.TravelOffer],
+  omnitureId: Option[String],
+  clickMacro: Option[String])(implicit request: RequestHeader)

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -248,4 +248,93 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
+  val v2JobsTemplate = Switch(
+    "Commercial",
+    "v2-jobs-template",
+    "Jobs component using template v2",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
+
+  val v2MasterclassesTemplate = Switch(
+    "Commercial",
+    "v2-masterclasses-template",
+    "Masterclasses component using template v2",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
+
+  val v2BooksTemplate = Switch(
+    "Commercial",
+    "v2-books-template",
+    "Books component using template v2",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
+
+  val v2TravelTemplate = Switch(
+    "Commercial",
+    "v2-travel-template",
+    "Travel component using template v2",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
+
+  val v2SoulmatesTemplate = Switch(
+    "Commercial",
+    "v2-soulmates-template",
+    "Soulmates component using template v2",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
+
+  val v2BlendedTemplate = Switch(
+    "Commercial",
+    "v2-blended-template",
+    "Blended component using template v2",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
+
+  val v2ManualSingleTemplate = Switch(
+    "Commercial",
+    "v2-manual-single-template",
+    "Manual single component using template v2",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
+
+  val v2ManualMultipleTemplate = Switch(
+    "Commercial",
+    "v2-manual-multiple-template",
+    "Manual multiple component using template v2",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
+
+  val v2CapiSingleTemplate = Switch(
+    "Commercial",
+    "v2-capi-single-template",
+    "Capi single component using template v2",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
+
+  val v2CapiMultipleTemplate = Switch(
+    "Commercial",
+    "v2-capi-multiple-template",
+    "Capi multiple component using template v2",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
 }


### PR DESCRIPTION
This enables new container templates to be switched on so that we can deploy new templates without switching them on in Prod.

/cc @regiskuckaertz 
