### PR TITLE
Prioritise master images during trail image picking

### DIFF
--- a/IMAGES.md
+++ b/IMAGES.md
@@ -3,7 +3,7 @@
 ## How are trail pictures picked in Frontend?
 
 Use the rules below like a filter to narrow down the content api response into a list of candidate images.
-From the candidate images, choose the largest 5:3 image, or simply the largest one if a 5:3 wasn't found.
+From the candidate images, choose the master 5:3 image, or simply the largest 5:3 if a master wasn't found.
 
 ### Default rules
 1. Use the trail pic (known in content api as 'image element with thumbnail relation'), if it contains an image with width >= 460.

--- a/common/app/model/trails.scala
+++ b/common/app/model/trails.scala
@@ -35,7 +35,7 @@ object Trail {
       }
 
       // If there isn't a 5:3 image, no ImageMedia object will be created.
-      val largestTrailImage = filteredTrailImages.sortBy(-_.width).headOption.map { bestImage =>
+      lazy val largestTrailImage = filteredTrailImages.sortBy(-_.width).headOption.map { bestImage =>
         ImageMedia.make(List(bestImage))
       }
 


### PR DESCRIPTION
This ensures that we pick master images for trail images, I think that's the main issue causing  https://github.com/guardian/frontend/issues/12214
