### PR TITLE
Use the same S3 client for facia collections/config

### DIFF
--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -12,6 +12,7 @@ import common._
 import conf.switches.Switches.FaciaInlineEmbeds
 import conf.{Configuration, LiveContentApi}
 import contentapi.{CircuitBreakingContentApiClient, QueryDefaults}
+import fronts.FrontsApi
 import model._
 import model.facia.PressedCollection
 import model.pressed._
@@ -38,13 +39,11 @@ private case class ContentApiClientWithTarget(override val apiKey: String, overr
 
 object LiveFapiFrontPress extends FapiFrontPress {
   val apiKey: String = Configuration.contentApi.key.getOrElse("facia-press")
-  val stage: String = Configuration.facia.stage.toUpperCase
-  val bucket: String = Configuration.aws.bucket
   val targetUrl: String = Configuration.contentApi.contentApiLiveHost
 
   override implicit val capiClient: GuardianContentClient = new ContentApiClientWithTarget(apiKey, targetUrl)
-  private val amazonS3Client = new AmazonS3Client()
-  implicit val apiClient: ApiClient = ApiClient(bucket, stage, AmazonSdkS3Client(amazonS3Client))
+
+  implicit val apiClient: ApiClient = FrontsApi.amazonClient
 
   def pressByPathId(path: String): Future[Unit] =
     getPressedFrontForPath(path)


### PR DESCRIPTION
in facia press we have a job to get the facia config from the s3 bucket and put it in an agent.  We also have the actual presser that goes to get the collections from the same bucket and return the pressed json.

These were using separate clients but the latter one was just using the default credentials.  This meant it didn't work if you were using the frontend credentials, only if you had default credentials with access.

This updates them to use the same client, which seems to work.

@rich-nguyen thanks for helping understand this problem! @janua @piuccio fyi/any comments?
@NataliaLKB 
