### PR TITLE
Remove connection speed detection

### DIFF
--- a/static/src/javascripts/projects/common/utils/detect.js
+++ b/static/src/javascripts/projects/common/utils/detect.js
@@ -111,30 +111,6 @@ define([
         };
     }
 
-    /**
-     * @param performance - Object allows passing in of window.performance, for testing
-     */
-    function getPageSpeed(performance) {
-
-        //https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html#sec-window.performance-attribute
-
-        var startTime,
-            endTime,
-            totalTime,
-            perf = performance || window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
-
-        if (perf && perf.timing) {
-            startTime =  perf.timing.requestStart || perf.timing.fetchStart || perf.timing.navigationStart;
-            endTime = perf.timing.responseEnd;
-
-            if (startTime && endTime) {
-                totalTime = endTime - startTime;
-            }
-        }
-
-        return totalTime;
-    }
-
     function isReload() {
         var perf = window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
         if (!!perf && !!perf.navigation) {
@@ -211,41 +187,6 @@ define([
             version: M[1]
         };
     })();
-
-    function getConnectionSpeed(performance, connection, reportUnknown) {
-
-        connection = connection || navigator.connection || navigator.mozConnection || navigator.webkitConnection || {type: 'unknown'};
-
-        var isMobileNetwork = connection.type === 3 // connection.CELL_2G
-                || connection.type === 4 // connection.CELL_3G
-                || /^[23]g$/.test(connection.type), // string value in new spec
-            loadTime,
-            speed;
-
-        if (isMobileNetwork) {
-            return 'low';
-        }
-
-        loadTime = getPageSpeed(performance);
-
-        // Assume high speed for non supporting browsers
-        speed = 'high';
-        if (reportUnknown) {
-            speed = 'unknown';
-        }
-
-        if (loadTime) {
-            if (loadTime > 1000) { // One second
-                speed = 'medium';
-                if (loadTime > 3000) { // Three seconds
-                    speed = 'low';
-                }
-            }
-        }
-
-        return speed;
-
-    }
 
     function hasTouchScreen() {
         return ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch;
@@ -451,7 +392,6 @@ define([
 
     detect = {
         hasCrossedBreakpoint: hasCrossedBreakpoint,
-        getConnectionSpeed: getConnectionSpeed,
         getVideoFormatSupport: getVideoFormatSupport,
         hasTouchScreen: hasTouchScreen,
         hasPushStateSupport: hasPushStateSupport,
@@ -473,7 +413,6 @@ define([
         initPageVisibility: initPageVisibility,
         pageVisible: pageVisible,
         hasWebSocket: hasWebSocket,
-        getPageSpeed: getPageSpeed,
         breakpoints: breakpoints,
         isEnhanced: isEnhanced,
         adblockInUseSync: adblockInUseSync,

--- a/static/test/javascripts/spec/common/utils/detect.spec.js
+++ b/static/test/javascripts/spec/common/utils/detect.spec.js
@@ -7,46 +7,6 @@ define([
     $,
     detect
 ) {
-    describe('Connection speed', function () {
-
-        it('should default to \'high\' speed', function () {
-            window.performance = null;
-            expect(detect.getConnectionSpeed()).toBe('high');
-        });
-
-        it('should calculate the speed of a slow, medium & fast client request', function () {
-
-            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseEnd: 8000 } })).toBe('low');
-
-            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseEnd: 3000 } })).toBe('medium');
-
-            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseEnd: 750 } })).toBe('high');
-
-        });
-
-        it('should return low if CELL connection can be determined', function () {
-
-            expect(detect.getConnectionSpeed(null, { type: 3})).toBe('low'); // type 3 is CELL_2G
-
-            expect(detect.getConnectionSpeed(null, { type: 4})).toBe('low'); // type 4 is CELL_3G
-
-            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseEnd: 750 } }, { type: 4})).toBe('low');
-
-            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseEnd: 8000 } }, { type: 6})).toBe('low');
-
-            expect(detect.getConnectionSpeed({ timing: { requestStart: 1, responseEnd: 750 } }, { type: 6})).toBe('high');
-
-        });
-
-        it('should return high or unknown if the speed can\'t be determined', function () {
-
-            expect(detect.getConnectionSpeed(null, null)).toBe('high');
-
-            expect(detect.getConnectionSpeed(null, null, true)).toBe('unknown');
-
-        });
-    });
-
     describe('Breakpoint', function () {
         beforeEach(function () {
             this.originalGetViewport = detect.getViewport;


### PR DESCRIPTION
This used to be passed up to Omniture analytics (as 'prop48'), but seems to have been dropped at some point over the last few years. As it's no longer used, we should probably delete the implementation.
