### PR TITLE
Remote file for loading KRUX for Facebook IA

### DIFF
--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -15,6 +15,7 @@ GET        /humans.txt                                                          
 GET        /rockabox/rockabox_buster.html                                           controllers.Assets.at(path="/public", file="rockabox_buster.html")
 GET        /external/eyeblaster/addineyeV2.html                                     controllers.Assets.at(path="/public", file="addineyeV2.html")
 GET        /amp/remote.html                                                         controllers.Assets.at(path="/public", file="amp_remote.html")
+GET        /facebook-ia/remote.html                                                 controllers.Assets.at(path="/public", file="facebook_ia_remote.html")
 
 # AMP
 GET        /container/count/:count/offset/:offset/mf2.json                                      controllers.FaciaController.renderSomeFrontContainersMf2(count: Int, offset: Int, section = "", edition = "")

--- a/facia/public/facebook_ia_remote.html
+++ b/facia/public/facebook_ia_remote.html
@@ -10,160 +10,149 @@
 <div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;">
 
     <script>
-        (function () {
+        var scripts = parseParameters();
 
-            function parseParameters() {
-                var script = document.createElement("script");
-                script.id = "ad-slot-id";
+        var slot = scripts[scripts.length - 1];
 
-                var args = window.location.hash.substr(1).split('&');
+        var slotName = "ad-slot-" + scripts.length;
 
-                for (var i = 0; i < args.length; ++i) {
-                    var arg = args[i].split("=");
-                    var argName = arg[0];
-                    var argValue = decodeURIComponent(arg[1]);
+        var config = {} ;
 
-                    var currValue = script.getAttribute(argName);
-                    if (currValue) {
-                        script.setAttribute(argName, currValue + "," + argValue);
-                    } else {
-                        script.setAttribute(argName, argValue);
-                    }
+        function parseParameters() {
+            var script = document.createElement("script");
+            script.id = "ad-slot-id";
+
+            var args = window.location.hash.substr(1).split('&');
+            var i, argsLength = args.length;
+
+            for (i = 0; i < argsLength; ++i) {
+                var arg = args[i].split("=");
+                var argName = arg[0];
+                var argValue = decodeURIComponent(arg[1]);
+
+                var currValue = script.getAttribute(argName);
+                if (currValue) {
+                    script.setAttribute(argName, currValue + "," + argValue);
+                } else {
+                    script.setAttribute(argName, argValue);
                 }
-                document.getElementsByTagName("div")[0].appendChild(script);
-
-                return document.querySelectorAll("script[id$='" + script.id + "']");
             }
+            document.getElementsByTagName("div")[0].appendChild(script);
 
-            var networkId = "59666047";
+            return document.querySelectorAll("script[id$='" + script.id + "']");
+        }
 
-            var scripts = parseParameters();
+        function toTitleCase(str) {
+            return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+        }
 
-            var slot = scripts[scripts.length - 1];
+        function exposeMetaDataForKrux() {
+            config = {
+                'pageId' : slot.getAttribute("url"),
+                'edition' : toTitleCase(slot.getAttribute("edition")),
+                'seriesId' : slot.getAttribute("se"),
+                'contentType' : toTitleCase(slot.getAttribute("ct")),
+                'keywordIds' : slot.getAttribute("keywordIds"),
+                'keywords' : slot.getAttribute("k").split(',').map(function (x) { return toTitleCase(x)}),
+                'authorIds' : slot.getAttribute("authorIds"),
+                'blogIds' : slot.getAttribute("bl"),
+                'referrer' : 'facebook-ia',
+                'section' : slot.getAttribute("section")
+            };
+        }
 
-            var slotName = "ad-slot-" + scripts.length;
+        function loadKrux() {
+            var krux = document.createElement('script');
+            krux.setAttribute("class", "kxct");
+            krux.setAttribute("data-id", "J_RxuxWJ");
+            krux.setAttribute("data-timing", "async");
+            krux.setAttribute("data-version", "1.9");
+            krux.setAttribute("type", "text/javascript");
 
-            var config = {} ;
+            krux.innerHTML = "window.Krux||((Krux=function(){Krux.q.push(arguments)}).q=[]); " +
+                "(function(){ " +
+                "var k=document.createElement('script');k.type='text/javascript';k.async=true; " +
+                "var m,src=(m=location.href.match(/\bkxsrc=([^&]+)/))&&decodeURIComponent(m[1]); " +
+                "k.src = /^https?:\\/\\/([a-z0-9_\\-\\.]+\\.)?krxd\\.net(:\\d{1,5})?\\//i.test(src) ? src : src === 'disable' ? '' : " +
+                "(location.protocol==='https:'?'https:':'http:')+'//cdn.krxd.net/controltag?confid=J_RxuxWJ' ; " +
+                "var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(k,s); }());";
 
-            function toTitleCase(str) {
-                return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+            document.body.appendChild(krux);
+        }
+
+        function buildSegments() {
+            var filling, kruxSegments, output, ref;
+            var targeting = "";
+            kruxSegments = (ref = localStorage.getItem('kxsegs')) != null ? ref : "";
+            if (kruxSegments !== "") {
+                filling = kruxSegments.split(',').join("','");
+                output = "['" + filling + "']";
+                targeting += ".setTargeting('x', " + output + ")";
             }
+            return targeting;
+        }
 
-            function exposeMetaDataForKrux() {
-                config = {
-                    'pageId' : slot.getAttribute("url"),
-                    'edition' : toTitleCase(slot.getAttribute("edition")),
-                    'seriesId' : slot.getAttribute("se"),
-                    'contentType' : toTitleCase(slot.getAttribute("ct")),
-                    'keywordIds' : slot.getAttribute("keywordIds"),
-                    'keywords' : slot.getAttribute("k").split(',').map(function (x) { return toTitleCase(x)}),
-                    'authorIds' : slot.getAttribute("authorIds"),
-                    'blogIds' : slot.getAttribute("bl"),
-                    'referrer' : 'facebook-ia',
-                    'section' : slot.getAttribute("section")
-                };
-            }
+        function insertScript(content) {
+            var script = document.createElement("script");
+            slot.parentElement.appendChild(script);
+            script.type = "text/javascript";
+            return script.text = content;
+        }
 
-            function loadKrux() {
-                var krux = document.createElement('script');
-                krux.setAttribute("class", "kxct");
-                krux.setAttribute("data-id", "J_RxuxWJ");
-                krux.setAttribute("data-timing", "async");
-                krux.setAttribute("data-version", "1.9");
-                krux.setAttribute("type", "text/javascript");
+        function buildTargetSize(size) {
+            var formatted = size.replace(/\s*,\s*/g, "],[").replace(/\s*x\s*/g, ",");
+            return "[[" + formatted + "]]";
+        }
 
-                krux.innerHTML = "window.Krux||((Krux=function(){Krux.q.push(arguments)}).q=[]); " +
-                    "(function(){ " +
-                    "var k=document.createElement('script');k.type='text/javascript';k.async=true; " +
-                    "var m,src=(m=location.href.match(/\bkxsrc=([^&]+)/))&&decodeURIComponent(m[1]); " +
-                    "k.src = /^https?:\\/\\/([a-z0-9_\\-\\.]+\\.)?krxd\\.net(:\\d{1,5})?\\//i.test(src) ? src : src === 'disable' ? '' : " +
-                    "(location.protocol==='https:'?'https:':'http:')+'//cdn.krxd.net/controltag?confid=J_RxuxWJ' ; " +
-                    "var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(k,s); }());";
-
-                document.body.appendChild(krux);
-            }
-
-            function buildTargetSize(size) {
-                var formatted = size.replace(/\s*,\s*/g, "],[").replace(/\s*x\s*/g, ",");
-                return "[[" + formatted + "]]";
-            }
-
-            function buildCustomTargeting() {
-                var attr, i, key, len, match, value;
-                var targeting = "";
-                var ref = slot.attributes;
-                for (i = 0, len = ref.length; i < len; i++) {
-                    attr = ref[i];
-                    match = attr.name.match(/^data-ad-target-(.+)$/);
-                    if (match != null) {
-                        key = match[1];
-                        value = attr.value.replace(/\s*,\s*/g, "','");
-                        targeting += ".setTargeting('" + key + "',['" + value + "'])";
-                    }
+        function buildCustomTargeting() {
+            var attr, i, key, len, match, value;
+            var targeting = "";
+            var ref = slot.attributes;
+            for (i = 0, len = ref.length; i < len; i++) {
+                attr = ref[i];
+                match = attr.name.match(/^data-ad-target-(.+)$/);
+                if (match != null) {
+                    key = match[1];
+                    value = attr.value.replace(/\s*,\s*/g, "','");
+                    targeting += ".setTargeting('" + key + "',['" + value + "'])";
                 }
-                return targeting;
             }
+            return targeting;
+        }
 
-            function buildSegments() {
-                var filling, kruxSegments, output, ref;
-                var targeting = "";
-                kruxSegments = (ref = localStorage.getItem('kxsegs')) != null ? ref : "";
-                if (kruxSegments !== "") {
-                    filling = kruxSegments.split(',').join("','");
-                    output = "['" + filling + "']";
-                    targeting += ".setTargeting('x', " + output + ")";
-                }
-                return targeting;
+
+        function insertAdConfig() {
+            var isFirstAd = scripts.length === 1;
+            if (isFirstAd) {
+                var pageLevelCodePart1 = "var googletag = googletag || {}; googletag.cmd = googletag.cmd || []; (function() { var gads = document.createElement(\"script\"); gads.async = true; gads.type = \"text/javascript\"; var useSSL = \"https:\" == document.location.protocol; gads.src = (useSSL ? \"https:\" : \"http:\") + \"//www.googletagservices.com/tag/js/gpt.js\"; var node = document.getElementsByTagName(\"script\")[0]; node.parentNode.insertBefore(gads, node); })();";
+                insertScript(pageLevelCodePart1);
+                var pageLevelCodePart2 = "googletag.cmd.push(function() { googletag.pubads().enableAsyncRendering(); googletag.pubads().collapseEmptyDivs(); googletag.enableServices(); });";
+                insertScript(pageLevelCodePart2);
             }
+            var size = slot.getAttribute("data-ad-size");
+            var adUnitName = slot.getAttribute("data-ad-unit");
+            var slotDeclaration = "googletag.cmd.push(function() { googletag.defineSlot('/59666047/" + adUnitName + "', " + (buildTargetSize(size)) + ", '" + slotName + "')" + (buildCustomTargeting()) + (buildSegments()) + ".addService(googletag.pubads()); });";
+            return insertScript(slotDeclaration);
+        }
 
-            var pageLevelCodePart1 = "var googletag = googletag || {}; googletag.cmd = googletag.cmd || []; (function() { var gads = document.createElement(\"script\"); gads.async = true; gads.type = \"text/javascript\"; var useSSL = \"https:\" == document.location.protocol; gads.src = (useSSL ? \"https:\" : \"http:\") + \"//www.googletagservices.com/tag/js/gpt.js\"; var node = document.getElementsByTagName(\"script\")[0]; node.parentNode.insertBefore(gads, node); })();";
+        function insertAd() {
+            var slotDiv = document.createElement("div");
+            slotDiv.setAttribute("id", slotName);
+            slot.parentElement.appendChild(slotDiv);
+            var slotCode = "googletag.cmd.push(function() { googletag.display('" + slotName + "'); });";
+            return insertScript(slotCode);
+        }
 
-            var pageLevelCodePart2 = "googletag.cmd.push(function() { googletag.pubads().enableAsyncRendering(); googletag.pubads().collapseEmptyDivs(); googletag.enableServices(); });";
+        function init() {
+            exposeMetaDataForKrux();
+            loadKrux();
 
-            function buildSlotDeclaration(size) {
-                var adUnitName = slot.getAttribute("data-ad-unit");
-                return "googletag.cmd.push(function() { googletag.defineSlot('/" + networkId + "/" + adUnitName + "', " + (buildTargetSize(size)) + ", '" + slotName + "')" + (buildCustomTargeting()) + (buildSegments()) + ".addService(googletag.pubads()); });";
-            }
+            insertAdConfig();
+            insertAd();
+        }
 
-            function buildSlotCode() {
-                return "googletag.cmd.push(function() { googletag.display('" + slotName + "'); });";
-            }
+        init();
 
-            function insertScript(content) {
-                var script = document.createElement("script");
-                slot.parentElement.appendChild(script);
-                script.type = "text/javascript";
-                return script.text = content;
-            }
-
-            function insertAdConfig() {
-                var isFirstAd = scripts.length === 1;
-                if (isFirstAd) {
-                    insertScript(pageLevelCodePart1);
-                    insertScript(pageLevelCodePart2);
-                }
-                var size = slot.getAttribute("data-ad-size");
-                return insertScript(buildSlotDeclaration(size));
-            }
-
-            function insertAd() {
-                var slotDiv = document.createElement("div");
-                slotDiv.setAttribute("id", slotName);
-                slot.parentElement.appendChild(slotDiv);
-                return insertScript(buildSlotCode());
-            }
-
-            function init() {
-                exposeMetaDataForKrux();
-                loadKrux();
-
-                insertAdConfig();
-                insertAd();
-            }
-
-            init();
-
-        }).call(this);
     </script>
 
 </div>

--- a/facia/public/facebook_ia_remote.html
+++ b/facia/public/facebook_ia_remote.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex">
+    <script>
+    </script>
+</head>
+<body style="margin:0">
+<div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;">
+
+    <script>
+        (function () {
+
+            var script = document.createElement("script");
+            script.id = "ad-slot-id";
+
+            var args = window.location.search.substr(1).split('&');
+
+            for (var i = 0; i < args.length; ++i) {
+                var arg = args[i].split("=");
+                var argName = arg[0];
+                var argValue = decodeURIComponent(arg[1]);
+
+                var currValue = script.getAttribute(argName);
+                if (currValue) {
+                    script.setAttribute(argName, currValue + "," + argValue);
+                } else {
+                    script.setAttribute(argName, argValue);
+                }
+            }
+
+            document.getElementsByTagName("div")[0].appendChild(script);
+
+            var networkId = "59666047";
+
+            var scripts = document.querySelectorAll("script[id$='" + script.id + "']");
+
+            var slot = scripts[scripts.length - 1];
+
+            var slotName = "ad-slot-" + scripts.length;
+
+            var buildTargetSize = function (size) {
+                var formatted = size.replace(/\s*,\s*/g, "],[").replace(/\s*x\s*/g, ",");
+                return "[[" + formatted + "]]";
+            };
+
+            var buildCustomTargeting = function () {
+                var attr, i, key, len, match, value;
+                var targeting = "";
+                var ref = slot.attributes;
+                for (i = 0, len = ref.length; i < len; i++) {
+                    attr = ref[i];
+                    match = attr.name.match(/^data-ad-target-(.+)$/);
+                    if (match != null) {
+                        key = match[1];
+                        value = attr.value.replace(/\s*,\s*/g, "','");
+                        targeting += ".setTargeting('" + key + "',['" + value + "'])";
+                    }
+                }
+                return targeting;
+            };
+
+            var pageLevelCodePart1 = "var googletag = googletag || {}; googletag.cmd = googletag.cmd || []; (function() { var gads = document.createElement(\"script\"); gads.async = true; gads.type = \"text/javascript\"; var useSSL = \"https:\" == document.location.protocol; gads.src = (useSSL ? \"https:\" : \"http:\") + \"//www.googletagservices.com/tag/js/gpt.js\"; var node = document.getElementsByTagName(\"script\")[0]; node.parentNode.insertBefore(gads, node); })();";
+
+            var pageLevelCodePart2 = "googletag.cmd.push(function() { googletag.pubads().enableAsyncRendering(); googletag.pubads().collapseEmptyDivs(); googletag.enableServices(); });";
+
+            var buildSlotDeclaration = function (size) {
+                var adUnitName = slot.getAttribute("data-ad-unit");
+                return "googletag.cmd.push(function() { googletag.defineSlot('/" + networkId + "/" + adUnitName + "', " + (buildTargetSize(size)) + ", '" + slotName + "')" + (buildCustomTargeting()) + ".addService(googletag.pubads()); });";
+            };
+
+            var buildSlotCode = function () {
+                return "googletag.cmd.push(function() { googletag.display('" + slotName + "'); });";
+            };
+
+            var insertScript = function (content) {
+                var script = document.createElement("script");
+                slot.parentElement.appendChild(script);
+                script.type = "text/javascript";
+                return script.text = content;
+            };
+
+            var insertAdConfig = function () {
+                var isFirstAd = scripts.length === 1;
+                if (isFirstAd) {
+                    insertScript(pageLevelCodePart1);
+                    insertScript(pageLevelCodePart2);
+                }
+                var size = slot.getAttribute("data-ad-size");
+                return insertScript(buildSlotDeclaration(size));
+            };
+
+            var insertAd = function () {
+                var slotDiv = document.createElement("div");
+                slotDiv.setAttribute("id", slotName);
+                slot.parentElement.appendChild(slotDiv);
+                return insertScript(buildSlotCode());
+            };
+
+            // Krux
+
+            var guardian = {} ;
+
+            function toTitleCase(str) {
+                return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+            }
+
+            function exposeMetaDataForKrux() {
+                guardian = { 'config' : {
+                    'page' : {
+                        'pageId' : slot.getAttribute("url"),
+                        'edition' : toTitleCase(slot.getAttribute("edition")),
+                        'seriesId' : slot.getAttribute("se"),
+                        'contentType' : toTitleCase(slot.getAttribute("ct")),
+                        'keywordIds' : slot.getAttribute("keywordIds"),
+                        'keywords' : slot.getAttribute("k").split(',').map(function (x) { return toTitleCase(x)}),
+                        'authorIds' : slot.getAttribute("authorIds"),
+                        'blogIds' : slot.getAttribute("bl"),
+                        'referrer' : 'facebook-ia',
+                        'section' : slot.getAttribute("section")
+                    }
+                }
+                };
+            }
+
+            function loadKrux() {
+                var krux = document.createElement('script');
+                krux.setAttribute("class", "kxct");
+                krux.setAttribute("data-id", "KS_cfybw");
+                krux.setAttribute("data-timing", "async");
+                krux.setAttribute("data-version", "1.9");
+                krux.setAttribute("type", "text/javascript");
+
+                krux.innerHTML = "window.Krux||((Krux=function(){Krux.q.push(arguments)}).q=[]); " +
+                    "(function(){ " +
+                    "var k=document.createElement('script');k.type='text/javascript';k.async=true; " +
+                    "var m,src=(m=location.href.match(/\bkxsrc=([^&]+)/))&&decodeURIComponent(m[1]); " +
+                    "k.src = /^https?:\\/\\/([a-z0-9_\\-\\.]+\\.)?krxd\\.net(:\\d{1,5})?\\//i.test(src) ? src : src === 'disable' ? '' : " +
+                    "(location.protocol==='https:'?'https:':'http:')+'//cdn.krxd.net/controltag?confid=KS_cfybw' ; " +
+                    "var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(k,s); }());";
+
+                document.body.appendChild(krux);
+            }
+
+            function attachKruxSegments() {
+                if (localStorage.getItem('kxsegs') !== null) {
+                    var kxSegList = localStorage.getItem('kxsegs').split(',');
+                    console.log(kxSegList);
+                    if (kxSegList.length > 0) {
+                        guardian.krux = kxSegList;
+                    }
+                }
+                else {
+                    console.log('No krux segments.')
+                }
+            }
+
+            function init(){
+                exposeMetaDataForKrux();
+                loadKrux();
+                attachKruxSegments();
+
+                insertAdConfig();
+                insertAd();
+            }
+
+            init();
+
+        }).call(this);
+    </script>
+
+</div>
+<script>if (window.docEndCallback) window.docEndCallback()</script>
+</body>
+</html>

--- a/facia/public/facebook_ia_remote.html
+++ b/facia/public/facebook_ia_remote.html
@@ -43,33 +43,31 @@
 
             var slotName = "ad-slot-" + scripts.length;
 
-            var guardian = {} ;
+            var config = {} ;
 
             function toTitleCase(str) {
                 return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
             }
 
             function exposeMetaDataForKrux() {
-                guardian = {
-                    'config' : {
-                        'pageId' : slot.getAttribute("url"),
-                        'edition' : toTitleCase(slot.getAttribute("edition")),
-                        'seriesId' : slot.getAttribute("se"),
-                        'contentType' : toTitleCase(slot.getAttribute("ct")),
-                        'keywordIds' : slot.getAttribute("keywordIds"),
-                        'keywords' : slot.getAttribute("k").split(',').map(function (x) { return toTitleCase(x)}),
-                        'authorIds' : slot.getAttribute("authorIds"),
-                        'blogIds' : slot.getAttribute("bl"),
-                        'referrer' : 'facebook-ia',
-                        'section' : slot.getAttribute("section")
-                    }
+                config = {
+                    'pageId' : slot.getAttribute("url"),
+                    'edition' : toTitleCase(slot.getAttribute("edition")),
+                    'seriesId' : slot.getAttribute("se"),
+                    'contentType' : toTitleCase(slot.getAttribute("ct")),
+                    'keywordIds' : slot.getAttribute("keywordIds"),
+                    'keywords' : slot.getAttribute("k").split(',').map(function (x) { return toTitleCase(x)}),
+                    'authorIds' : slot.getAttribute("authorIds"),
+                    'blogIds' : slot.getAttribute("bl"),
+                    'referrer' : 'facebook-ia',
+                    'section' : slot.getAttribute("section")
                 };
             }
 
             function loadKrux() {
                 var krux = document.createElement('script');
                 krux.setAttribute("class", "kxct");
-                krux.setAttribute("data-id", "KS_cfybw");
+                krux.setAttribute("data-id", "J_RxuxWJ");
                 krux.setAttribute("data-timing", "async");
                 krux.setAttribute("data-version", "1.9");
                 krux.setAttribute("type", "text/javascript");
@@ -79,7 +77,7 @@
                     "var k=document.createElement('script');k.type='text/javascript';k.async=true; " +
                     "var m,src=(m=location.href.match(/\bkxsrc=([^&]+)/))&&decodeURIComponent(m[1]); " +
                     "k.src = /^https?:\\/\\/([a-z0-9_\\-\\.]+\\.)?krxd\\.net(:\\d{1,5})?\\//i.test(src) ? src : src === 'disable' ? '' : " +
-                    "(location.protocol==='https:'?'https:':'http:')+'//cdn.krxd.net/controltag?confid=KS_cfybw' ; " +
+                    "(location.protocol==='https:'?'https:':'http:')+'//cdn.krxd.net/controltag?confid=J_RxuxWJ' ; " +
                     "var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(k,s); }());";
 
                 document.body.appendChild(krux);

--- a/facia/public/facebook_ia_remote.html
+++ b/facia/public/facebook_ia_remote.html
@@ -111,7 +111,6 @@
                 var filling, kruxSegments, output, ref;
                 var targeting = "";
                 kruxSegments = (ref = localStorage.getItem('kxsegs')) != null ? ref : "";
-                console.log(kruxSegments);
                 if (kruxSegments !== "") {
                     filling = kruxSegments.split(',').join("','");
                     output = "['" + filling + "']";

--- a/facia/public/facebook_ia_remote.html
+++ b/facia/public/facebook_ia_remote.html
@@ -12,93 +12,36 @@
     <script>
         (function () {
 
-            var script = document.createElement("script");
-            script.id = "ad-slot-id";
+            function parseParameters() {
+                var script = document.createElement("script");
+                script.id = "ad-slot-id";
 
-            var args = window.location.search.substr(1).split('&');
+                var args = window.location.hash.substr(1).split('&');
 
-            for (var i = 0; i < args.length; ++i) {
-                var arg = args[i].split("=");
-                var argName = arg[0];
-                var argValue = decodeURIComponent(arg[1]);
+                for (var i = 0; i < args.length; ++i) {
+                    var arg = args[i].split("=");
+                    var argName = arg[0];
+                    var argValue = decodeURIComponent(arg[1]);
 
-                var currValue = script.getAttribute(argName);
-                if (currValue) {
-                    script.setAttribute(argName, currValue + "," + argValue);
-                } else {
-                    script.setAttribute(argName, argValue);
+                    var currValue = script.getAttribute(argName);
+                    if (currValue) {
+                        script.setAttribute(argName, currValue + "," + argValue);
+                    } else {
+                        script.setAttribute(argName, argValue);
+                    }
                 }
-            }
+                document.getElementsByTagName("div")[0].appendChild(script);
 
-            document.getElementsByTagName("div")[0].appendChild(script);
+                return document.querySelectorAll("script[id$='" + script.id + "']");
+            }
 
             var networkId = "59666047";
 
-            var scripts = document.querySelectorAll("script[id$='" + script.id + "']");
+            var scripts = parseParameters();
 
             var slot = scripts[scripts.length - 1];
 
             var slotName = "ad-slot-" + scripts.length;
-
-            var buildTargetSize = function (size) {
-                var formatted = size.replace(/\s*,\s*/g, "],[").replace(/\s*x\s*/g, ",");
-                return "[[" + formatted + "]]";
-            };
-
-            var buildCustomTargeting = function () {
-                var attr, i, key, len, match, value;
-                var targeting = "";
-                var ref = slot.attributes;
-                for (i = 0, len = ref.length; i < len; i++) {
-                    attr = ref[i];
-                    match = attr.name.match(/^data-ad-target-(.+)$/);
-                    if (match != null) {
-                        key = match[1];
-                        value = attr.value.replace(/\s*,\s*/g, "','");
-                        targeting += ".setTargeting('" + key + "',['" + value + "'])";
-                    }
-                }
-                return targeting;
-            };
-
-            var pageLevelCodePart1 = "var googletag = googletag || {}; googletag.cmd = googletag.cmd || []; (function() { var gads = document.createElement(\"script\"); gads.async = true; gads.type = \"text/javascript\"; var useSSL = \"https:\" == document.location.protocol; gads.src = (useSSL ? \"https:\" : \"http:\") + \"//www.googletagservices.com/tag/js/gpt.js\"; var node = document.getElementsByTagName(\"script\")[0]; node.parentNode.insertBefore(gads, node); })();";
-
-            var pageLevelCodePart2 = "googletag.cmd.push(function() { googletag.pubads().enableAsyncRendering(); googletag.pubads().collapseEmptyDivs(); googletag.enableServices(); });";
-
-            var buildSlotDeclaration = function (size) {
-                var adUnitName = slot.getAttribute("data-ad-unit");
-                return "googletag.cmd.push(function() { googletag.defineSlot('/" + networkId + "/" + adUnitName + "', " + (buildTargetSize(size)) + ", '" + slotName + "')" + (buildCustomTargeting()) + ".addService(googletag.pubads()); });";
-            };
-
-            var buildSlotCode = function () {
-                return "googletag.cmd.push(function() { googletag.display('" + slotName + "'); });";
-            };
-
-            var insertScript = function (content) {
-                var script = document.createElement("script");
-                slot.parentElement.appendChild(script);
-                script.type = "text/javascript";
-                return script.text = content;
-            };
-
-            var insertAdConfig = function () {
-                var isFirstAd = scripts.length === 1;
-                if (isFirstAd) {
-                    insertScript(pageLevelCodePart1);
-                    insertScript(pageLevelCodePart2);
-                }
-                var size = slot.getAttribute("data-ad-size");
-                return insertScript(buildSlotDeclaration(size));
-            };
-
-            var insertAd = function () {
-                var slotDiv = document.createElement("div");
-                slotDiv.setAttribute("id", slotName);
-                slot.parentElement.appendChild(slotDiv);
-                return insertScript(buildSlotCode());
-            };
-
-            // Krux
 
             var guardian = {} ;
 
@@ -143,23 +86,80 @@
                 document.body.appendChild(krux);
             }
 
-            function attachKruxSegments() {
-                if (localStorage.getItem('kxsegs') !== null) {
-                    var kxSegList = localStorage.getItem('kxsegs').split(',');
-                    console.log(kxSegList);
-                    if (kxSegList.length > 0) {
-                        guardian.krux = kxSegList;
+            function buildTargetSize(size) {
+                var formatted = size.replace(/\s*,\s*/g, "],[").replace(/\s*x\s*/g, ",");
+                return "[[" + formatted + "]]";
+            }
+
+            function buildCustomTargeting() {
+                var attr, i, key, len, match, value;
+                var targeting = "";
+                var ref = slot.attributes;
+                for (i = 0, len = ref.length; i < len; i++) {
+                    attr = ref[i];
+                    match = attr.name.match(/^data-ad-target-(.+)$/);
+                    if (match != null) {
+                        key = match[1];
+                        value = attr.value.replace(/\s*,\s*/g, "','");
+                        targeting += ".setTargeting('" + key + "',['" + value + "'])";
                     }
                 }
-                else {
-                    console.log('No krux segments.')
+                return targeting;
+            }
+
+            function buildSegments() {
+                var filling, kruxSegments, output, ref;
+                var targeting = "";
+                kruxSegments = (ref = localStorage.getItem('kxsegs')) != null ? ref : "";
+                console.log(kruxSegments);
+                if (kruxSegments !== "") {
+                    filling = kruxSegments.split(',').join("','");
+                    output = "['" + filling + "']";
+                    targeting += ".setTargeting('x', " + output + ")";
                 }
+                return targeting;
+            }
+
+            var pageLevelCodePart1 = "var googletag = googletag || {}; googletag.cmd = googletag.cmd || []; (function() { var gads = document.createElement(\"script\"); gads.async = true; gads.type = \"text/javascript\"; var useSSL = \"https:\" == document.location.protocol; gads.src = (useSSL ? \"https:\" : \"http:\") + \"//www.googletagservices.com/tag/js/gpt.js\"; var node = document.getElementsByTagName(\"script\")[0]; node.parentNode.insertBefore(gads, node); })();";
+
+            var pageLevelCodePart2 = "googletag.cmd.push(function() { googletag.pubads().enableAsyncRendering(); googletag.pubads().collapseEmptyDivs(); googletag.enableServices(); });";
+
+            function buildSlotDeclaration(size) {
+                var adUnitName = slot.getAttribute("data-ad-unit");
+                return "googletag.cmd.push(function() { googletag.defineSlot('/" + networkId + "/" + adUnitName + "', " + (buildTargetSize(size)) + ", '" + slotName + "')" + (buildCustomTargeting()) + (buildSegments()) + ".addService(googletag.pubads()); });";
+            }
+
+            function buildSlotCode() {
+                return "googletag.cmd.push(function() { googletag.display('" + slotName + "'); });";
+            }
+
+            function insertScript(content) {
+                var script = document.createElement("script");
+                slot.parentElement.appendChild(script);
+                script.type = "text/javascript";
+                return script.text = content;
+            }
+
+            function insertAdConfig() {
+                var isFirstAd = scripts.length === 1;
+                if (isFirstAd) {
+                    insertScript(pageLevelCodePart1);
+                    insertScript(pageLevelCodePart2);
+                }
+                var size = slot.getAttribute("data-ad-size");
+                return insertScript(buildSlotDeclaration(size));
+            }
+
+            function insertAd() {
+                var slotDiv = document.createElement("div");
+                slotDiv.setAttribute("id", slotName);
+                slot.parentElement.appendChild(slotDiv);
+                return insertScript(buildSlotCode());
             }
 
             function init(){
                 exposeMetaDataForKrux();
                 loadKrux();
-                attachKruxSegments();
 
                 insertAdConfig();
                 insertAd();

--- a/facia/public/facebook_ia_remote.html
+++ b/facia/public/facebook_ia_remote.html
@@ -50,8 +50,8 @@
             }
 
             function exposeMetaDataForKrux() {
-                guardian = { 'config' : {
-                    'page' : {
+                guardian = {
+                    'config' : {
                         'pageId' : slot.getAttribute("url"),
                         'edition' : toTitleCase(slot.getAttribute("edition")),
                         'seriesId' : slot.getAttribute("se"),
@@ -63,7 +63,6 @@
                         'referrer' : 'facebook-ia',
                         'section' : slot.getAttribute("section")
                     }
-                }
                 };
             }
 
@@ -156,7 +155,7 @@
                 return insertScript(buildSlotCode());
             }
 
-            function init(){
+            function init() {
                 exposeMetaDataForKrux();
                 loadKrux();
 


### PR DESCRIPTION
Adding a remote file for Facebook Instant Articles to send data to KRUX.
- Creating a global JS object to expose data for KRUX. Example of how the parameters are sent to the iframe:
  `https://www.theguardian.com/facebook-ia/remote.html#param_1=value_1&...&param_n=value_n`
- Loading KRUX.
- Inserting ad using the KRUX segments.

@NataliaLKB 
