### PR TITLE
Explicitly cache redirects from the short urls controller

### DIFF
--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -19,7 +19,7 @@ object ShortUrlsController extends Controller with Logging with ExecutionContext
       response.content.map(_.id).map { id =>
         Redirect(LinkTo(s"/$id"), queryString)
       }.getOrElse(NotFound)
-    }.recover(convertApiExceptionsWithoutEither).map(Cached(60))
+    }.recover(convertApiExceptionsWithoutEither).map(Cached.explicitlyCache(1800))
   }
 
   def fetchCampaignAndRedirectShortCode(shortUrl: String, campaignCode: String) = Action.async { implicit request =>

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -26,6 +26,10 @@ object Cached extends implicits.Dates {
     if (cacheableStatusCodes.exists(_ == result.header.status)) cacheHeaders(page.metadata.cacheSeconds, result) else result
   }
 
+  // Use this when you are sure your result needs caching headers, even though the result status isn't
+  // conventionally cacheable. Typically we only cache 200 and 404 responses.
+  def explicitlyCache(seconds: Int)(result: Result): Result = cacheHeaders(seconds, result)
+
   private def cacheHeaders(seconds: Int, result: Result) = {
     val now = DateTime.now
     val expiresTime = now + seconds.seconds


### PR DESCRIPTION
This attempts to fix router alarms we are regularly seeing. I think this is happening because of short urls.

I see latency spikes in router correlated to applications latency spikes. They are very brief. The fastly logs show an increase in 503s, and all these errors come from applications, specifically `/p/4hhjp` urls.

None of these responses were being cached in `ShortUrlsController` because the `Cached` helper does not add cache headers to 303 responses (and rightly so, we use internal redirecting).

@jennysivapalan @JustinPinner 
