### PR TITLE
Short urls should be cacheable

### DIFF
--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -17,7 +17,7 @@ object ShortUrlsController extends Controller with Logging with ExecutionContext
   private def redirectUrl(shortUrl: String, queryString: Map[String, Seq[String]])(implicit request: RequestHeader) = {
     LiveContentApi.getResponse(LiveContentApi.item(shortUrl)).map { response =>
       response.content.map(_.id).map { id =>
-        Redirect(LinkTo(s"/$id"), queryString)
+        Redirect(LinkTo(s"/$id"), queryString = queryString, status = MOVED_PERMANENTLY)
       }.getOrElse(NotFound)
     }.recover(convertApiExceptionsWithoutEither).map(Cached.explicitlyCache(1800))
   }


### PR DESCRIPTION
Short url responses are nearly cacheable, they pass the right cache headers, but fastly can't cache 303s
