### PR TITLE
Fix branding of containers

### DIFF
--- a/admin/app/views/commercial/sponsoredContainers.scala.html
+++ b/admin/app/views/commercial/sponsoredContainers.scala.html
@@ -1,8 +1,8 @@
+@import com.gu.facia.client.models.Backfill
 @(env: String, page: controllers.admin.CommercialPage, trails: Seq[model.pressed.PressedContent])(implicit request: RequestHeader)
 
-@import layout.CollectionEssentials
+@import layout.{CollectionEssentials, FaciaContainer}
 @import model.pressed.CollectionConfig
-@import layout.FaciaContainer
 @import services.CollectionConfigWithId
 @import slices.Fixed
 @import slices.FixedContainers.fixedMediumSlowVI
@@ -41,7 +41,7 @@
                     Fixed(fixedMediumSlowVI),
                     CollectionConfigWithId("type", CollectionConfig.empty.copy(
                         displayName = Some(c("title")),
-                        apiQuery = Some(c("keyword"))
+                        backfill = Some(Backfill(`type` = "capi", query = c("keyword")))
                     )),
                     CollectionEssentials.fromFaciaContent(trails))
                 ))(request)

--- a/common/app/common/dfp/PaidForTagAgent.scala
+++ b/common/app/common/dfp/PaidForTagAgent.scala
@@ -126,9 +126,9 @@ trait PaidForTagAgent {
     def containerCapiTagIds(config: CollectionConfig): Seq[String] = {
       val stopWords = Set("newest", "order-by", "published", "search", "tag", "use-date")
 
-      config.apiQuery map { encodedQuery =>
+      config.backfill map { backfill =>
         def negativeClause(token: String): Boolean = token.startsWith("-")
-        val query = URLDecoder.decode(encodedQuery, "utf-8")
+        val query = URLDecoder.decode(backfill.query, "utf-8")
         val tokens = query.split( """\?|&|=|\(|\)|\||\,""")
         (tokens filterNot negativeClause filterNot stopWords.contains flatMap frontKeywordIds).toSeq
       } getOrElse Nil

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -1,17 +1,16 @@
 package model.pressed
 
-import com.gu.facia.api.{utils => fapiutils}
-import com.gu.facia.api.{models => fapi}
-import com.gu.facia.client.models.CollectionConfigJson
-import fapiutils.FaciaContentUtils
-import model.{SupportedUrl, ContentType}
+import com.gu.facia.api.utils.FaciaContentUtils
+import com.gu.facia.api.{models => fapi, utils => fapiutils}
+import com.gu.facia.client.models.{Backfill, CollectionConfigJson}
+import model.{ContentType, SupportedUrl}
 import org.joda.time.DateTime
 
 object CollectionConfig {
   def make(config: fapi.CollectionConfig): CollectionConfig = {
     CollectionConfig(
       displayName = config.displayName,
-      apiQuery = config.apiQuery,
+      backfill = config.backfill,
       collectionType = config.collectionType,
       href = config.href,
       description = config.description,
@@ -36,7 +35,7 @@ object CollectionConfig {
 }
 final case class CollectionConfig(
   displayName: Option[String],
-  apiQuery: Option[String],
+  backfill: Option[Backfill],
   collectionType: String,
   href: Option[String],
   description: Option[String],

--- a/common/test/common/dfp/PaidForTagAgentTest.scala
+++ b/common/test/common/dfp/PaidForTagAgentTest.scala
@@ -2,7 +2,7 @@ package common.dfp
 
 import com.gu.contentapi.client.model.v1.{Tag => ApiTag, TagType => ApiTagType}
 import com.gu.facia.api.{models => fapi}
-import com.gu.facia.client.models.CollectionConfigJson
+import com.gu.facia.client.models.{Backfill, CollectionConfigJson}
 import common.Edition.defaultEdition
 import common.editions.Us
 import model.Tag
@@ -170,8 +170,12 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
     }
   }
 
-  private def apiQuery(apiQuery: String) = {
-    CollectionConfig.make(fapi.CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(apiQuery = Some(apiQuery))))
+  private def apiQuery(apiQuery: String): CollectionConfig = {
+    CollectionConfig.make(
+      fapi.CollectionConfig.fromCollectionJson(
+        CollectionConfigJson.withDefaults(backfill = Some(Backfill("capi", apiQuery)))
+      )
+    )
   }
 
   "isAdvertisementFeature" should "be true for an advertisement feature" in {

--- a/onward/app/controllers/MostViewedSocialController.scala
+++ b/onward/app/controllers/MostViewedSocialController.scala
@@ -1,15 +1,16 @@
 package controllers
 
 import common.`package`._
-import common.{ExecutionContexts, Edition, JsonNotFound}
+import common.{Edition, ExecutionContexts, JsonNotFound}
 import conf.LiveContentApi
 import feed.MostPopularSocialAutoRefresh
 import layout.{CollectionEssentials, FaciaContainer}
 import model.FrontProperties
 import model.pressed.CollectionConfig
 import play.api.mvc.{Action, Controller}
-import services.{FaciaContentConvert, CollectionConfigWithId}
+import services.{CollectionConfigWithId, FaciaContentConvert}
 import slices.Fixed
+
 import scala.concurrent.Future.{successful => unit}
 
 object MostViewedSocialController extends Controller with ExecutionContexts {
@@ -38,7 +39,7 @@ object MostViewedSocialController extends Controller with ExecutionContexts {
           val properties = FrontProperties(None, None, None, None, false, None)
 
           val config = CollectionConfig.empty.copy(
-            apiQuery = None, displayName = displayName, href = None
+            backfill = None, displayName = displayName, href = None
           )
 
           val facebookResponse = () => views.html.fragments.containers.facia_cards.container(

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -2,6 +2,7 @@ package controllers
 
 import com.gu.contentapi.client.GuardianContentApiError
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
+import com.gu.facia.client.models.Backfill
 import common._
 import conf.LiveContentApi
 import conf.LiveContentApi.getResponse
@@ -9,14 +10,14 @@ import implicits.Requests
 import layout.{CollectionEssentials, DescriptionMetaHeader, FaciaContainer}
 import model._
 import model.pressed.CollectionConfig
-import play.api.libs.json.{Json, JsArray}
+import play.api.libs.json.{JsArray, Json}
 import play.api.mvc.{Action, Controller, RequestHeader}
-import services.{CollectionConfigWithId, FaciaContentConvert}
+import services.CollectionConfigWithId
 import slices.Fixed
 import views.support.FaciaToMicroFormat2Helpers._
-import scala.concurrent.duration._
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 case class Series(id: String, tag: Tag, trails: RelatedContent) {
   lazy val displayName = tag.id match {
@@ -87,7 +88,9 @@ object SeriesController extends Controller with Logging with Paging with Executi
 
 
     val config = CollectionConfig.empty.copy(
-      apiQuery = Some(series.id), displayName = displayName, href = Some(series.id)
+      backfill = Some(Backfill(`type` = "capi", query = series.id)),
+      displayName = displayName,
+      href = Some(series.id)
     )
 
     val response = () => views.html.fragments.containers.facia_cards.container(


### PR DESCRIPTION
The facia model has changed so that container config now has a backfill.query instead of a capiQuery, which means that the commercial branding on containers is failing.

This change fixes it.
