### PR TITLE
Revert "Short urls should be cacheable"

### DIFF
--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -17,7 +17,7 @@ object ShortUrlsController extends Controller with Logging with ExecutionContext
   private def redirectUrl(shortUrl: String, queryString: Map[String, Seq[String]])(implicit request: RequestHeader) = {
     LiveContentApi.getResponse(LiveContentApi.item(shortUrl)).map { response =>
       response.content.map(_.id).map { id =>
-        Redirect(LinkTo(s"/$id"), queryString = queryString, status = MOVED_PERMANENTLY)
+        Redirect(LinkTo(s"/$id"), queryString)
       }.getOrElse(NotFound)
     }.recover(convertApiExceptionsWithoutEither).map(Cached.explicitlyCache(1800))
   }


### PR DESCRIPTION
Reverts guardian/frontend#12272

this is somehow causing fastly to strip the campaign codes, roll back now and we can look tomorrow as it's not obvious why this is happening

@JustinPinner @rich-nguyen 
