### PR TITLE
Enable Chrome’s web app install banners

### DIFF
--- a/applications/app/templates/webAppManifest.scala.js
+++ b/applications/app/templates/webAppManifest.scala.js
@@ -10,6 +10,11 @@
     },
     {
         "type": "image/png",
+        "sizes": "144x144",
+        "src": "@{JavaScript(Static("images/favicons/144x144.png").path)}"
+    },
+    {
+        "type": "image/png",
         "sizes": "114x114",
         "src": "@{JavaScript(Static("images/favicons/114x114.png").path)}"
     }


### PR DESCRIPTION
[Chrome will prompt loyal users to add the website to their home screen](https://developers.google.com/web/updates/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android) if the following conditions are true. We are fulfilling all but one (in bold) which this PR fixes:

> - You have a web app manifest file, which defines how your app appears on the user’s system and how its hould be launched
>   - The manifest must have a `short_name`, a name for display in the banner,
>   - A start URL (e.g. / or index.html) which must be loadable,
>   - **At least an `144x144` PNG icon**
>   - Your icon declarations should include a mime type of image/png
> - You have a service worker registered on your site. We recommend a simple custom offline page service worker
> - Your site is served over HTTPS (service worker requires HTTPS for security)
> - The user has visited your site at least twice, with at least five minutes between visits.

— https://developers.google.com/web/updates/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android

Seeing as we're not yet fully HTTPS, I doubt many people will see this.
## What is the value of this and can you measure success?

Value: users will have another way to come back to the site
Measure: page views with the campaign code of `INTCMP=webapp`
## Screenshot

![image](https://cloud.githubusercontent.com/assets/921609/13854561/05f5afa4-ec64-11e5-97d4-fe9643392c50.png)
## To do
- [ ] Bump version in name to ensure cache bust
