### PR TITLE
Forward campaign codes on /latest/email routes

### DIFF
--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -16,8 +16,11 @@ object LatestIndexController extends Controller with ExecutionContexts with impl
     loadLatest(path).map { _.map { index =>
       index.page match {
         case tag: Tag if tag.isSeries || tag.isBlog => index.trails.headOption.map(latest => {
-          if (request.isEmail) Found(latest.metadata.url + "/email")
-          else                 Found(latest.metadata.url)
+          if (request.isEmail) {
+            request.campaignCode.map(code => Redirect(latest.metadata.url + "/email", Map("CMP" -> Seq(code))))
+              .getOrElse(Found(latest.metadata.url + "/email"))
+          }
+          else Found(latest.metadata.url)
         }).getOrElse(NotFound)
 
         case tag: Tag => MovedPermanently(s"${tag.metadata.url}/all")

--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -17,8 +17,7 @@ object LatestIndexController extends Controller with ExecutionContexts with impl
       index.page match {
         case tag: Tag if tag.isSeries || tag.isBlog => index.trails.headOption.map(latest => {
           if (request.isEmail) {
-            request.campaignCode.map(code => Redirect(latest.metadata.url + "/email", Map("CMP" -> Seq(code))))
-              .getOrElse(Found(latest.metadata.url + "/email"))
+            Redirect(latest.metadata.url + "/email", request.campaignCode.fold(Map[String, Seq[String]]())(c => Map("CMP" -> Seq(c))))
           }
           else Found(latest.metadata.url)
         }).getOrElse(NotFound)

--- a/common/app/implicits/Requests.scala
+++ b/common/app/implicits/Requests.scala
@@ -44,6 +44,8 @@ trait Requests {
     lazy val isXmlHttpRequest: Boolean = r.headers.get("X-Requested-With").contains("XMLHttpRequest")
 
     lazy val isCrosswordFront: Boolean = r.path.endsWith("/crosswords")
+
+    lazy val campaignCode: Option[String] = r.getQueryString("CMP")
   }
 }
 


### PR DESCRIPTION
This allows us to enter the campaign code in ExactTarget and retain it after we redirect to the actual article.
