### PR TITLE
Restore standfirsts on 'paid-for' audio content

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -691,7 +691,6 @@
     .tonal__standfirst {
         background-color: transparent;
         padding: $gs-baseline 0 $gs-baseline*2;
-        min-height: $gs-baseline*8;
 
         .content__standfirst {
             color: colour(neutral-1);
@@ -741,9 +740,18 @@
             }
         }
 
+        // On video, standfirsts are injected twice - once in their usual location, another time as a replacement for the body
+        // We want to hide the first instance and style the latter
         &.content--media--video {
+
+            // Original standfirst
             .content__head .tonal__standfirst {
                 display: none;
+            }
+
+            // Pseudo-body standfirst
+            .content__main .tonal__standfirst {
+                min-height: $gs-baseline*8;
             }
         }
 

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -741,7 +741,6 @@
             }
         }
 
-        &.content--media--audio,
         &.content--media--video {
             .content__head .tonal__standfirst {
                 display: none;

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -690,7 +690,6 @@
 
     .tonal__standfirst {
         background-color: transparent;
-        padding: $gs-baseline 0 $gs-baseline*2;
 
         .content__standfirst {
             color: colour(neutral-1);
@@ -751,6 +750,7 @@
 
             // Pseudo-body standfirst
             .content__main .tonal__standfirst {
+                padding: $gs-baseline 0 $gs-baseline*2;
                 min-height: $gs-baseline*8;
             }
         }


### PR DESCRIPTION
Commercialized audio content doesn't currently show standfirsts -

![image](https://cloud.githubusercontent.com/assets/3148617/13877896/8b044092-ed05-11e5-9978-60a1055d7d03.png)

This is the side effect of an errant CSS rule that caters to an oddity of video content - most videos don't have body content, only standfirsts, injected into the page a second time to substitute the body. We have CSS to hide the first standfirst (in the header) and style the second standfirst (acting the body), but real standfirsts in audio pages are getting caught in the crossfire.

Paid-for audio content now shows standfirsts as expected:

![image](https://cloud.githubusercontent.com/assets/3148617/13877990/30f2e8fa-ed06-11e5-8e7c-07289a44aa58.png)
