### PR TITLE
Also stop flashing dot on facia

### DIFF
--- a/static/src/stylesheets/facia.scss
+++ b/static/src/stylesheets/facia.scss
@@ -31,3 +31,4 @@
 @import 'module/facia/snaps/_facia';
 @import 'module/crosswords/_main';
 @import 'module/email/_main';
+@import 'module/_accessibility';


### PR DESCRIPTION
I rejigged how we hide flashing dots when someone turned their accessibility settings that way in https://github.com/guardian/frontend/pull/12271

However I didn't include the css file on facia meaning it didn't help on fronts e.g. /tone/minutebyminute

This PR is just to add in the missing line.
@OliverJAsh if you have a minute :smile_cat: 
