### PR TITLE
R1 urls should be normalised always. Remove redundant switch.

### DIFF
--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -7,7 +7,6 @@ import services.{Archive, DynamoDB, Googlebot404Count, Destination}
 import java.net.URLDecoder
 import model.Cached
 import scala.concurrent.Future
-import conf.switches.Switches.ArchiveResolvesR1UrlsInRedirectTableSwitch
 
 object ArchiveController extends Controller with Logging with ExecutionContexts {
 
@@ -57,7 +56,7 @@ object ArchiveController extends Controller with Logging with ExecutionContexts 
   // Our redirects are 'normalised' Vignette URLs, Ie. path/to/0,<n>,123,<n>.html -> path/to/0,,123,.html
   def normalise(path: String, zeros: String = ""): String = {
     val normalised = path match {
-      case R1ArtifactUrl(path, artifactOrContextId, extension) if ArchiveResolvesR1UrlsInRedirectTableSwitch.isSwitchedOff =>
+      case R1ArtifactUrl(path, artifactOrContextId, extension) =>
         val normalisedUrl = s"www.theguardian.com/$path/0,,$artifactOrContextId,$zeros.html"
         Some(normalisedUrl)
       case ShortUrl(path) =>

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -398,14 +398,4 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
-
-  // Owner: Dotcom health (R2/R1 decommissioning)
-  val ArchiveResolvesR1UrlsInRedirectTableSwitch = Switch(
-    "Feature",
-    "archive-service-resolves-r1-urls",
-    "When ON, the archive service can resolve un-normalisd R1 paths from the redirects table.",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 4, 28), //Thursday
-    exposeClientSide = false
-  )
 }


### PR DESCRIPTION
## Remove redundant feature switch
## What does this change?

Removes a switch that I added temporarily.
## What is the value of this and can you measure success?

We can all be a little happier when the switch is removed. If you really want to you can sing :notes: "Ding dong the switch is dead" :notes: over and over. But I wouldn't recommend it. 
## Does this affect other platforms - Amp, Apps, etc?

No.
## Request for comment
## Free-for-all :scream: 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
