### PR TITLE
Refactor SCSS to remove duplication between facia and content bootstraps

### DIFF
--- a/static/src/stylesheets/_common.scss
+++ b/static/src/stylesheets/_common.scss
@@ -2,10 +2,6 @@
 
 @import 'base/_zindex';
 
-@import '_vars';
-@import '_mixins';
-@import '_extends-only';
-
 @import 'module/_search';
 @import 'module/_search-tool';
 @import 'module/_weather';

--- a/static/src/stylesheets/_facia-content.scss
+++ b/static/src/stylesheets/_facia-content.scss
@@ -1,0 +1,27 @@
+@charset 'UTF-8';
+
+@import 'base/_zindex';
+
+@import '_vars';
+@import '_mixins';
+@import '_extends-only';
+
+@import 'module/_search';
+@import 'module/_search-tool';
+@import 'module/_weather';
+@import 'module/_tabs';
+@import 'module/_headline-list';
+@import 'module/_rich-links';
+@import 'components/pasteup-buttons/src/_buttons';
+@import 'module/facia/_pagination';
+@import 'module/_release-message';
+@import 'module/onward/_breaking-news';
+@import 'module/facia/_facia-show-more';
+@import 'module/_tag-list';
+@import 'module/_submeta';
+@import 'layout/_footer';
+@import 'module/content/_media-player';
+@import 'module/commercial/_commercial';
+@import 'module/crosswords/_main';
+@import 'module/email/_main';
+@import 'module/_accessibility';

--- a/static/src/stylesheets/content.scss
+++ b/static/src/stylesheets/content.scss
@@ -1,14 +1,13 @@
 @charset 'UTF-8';
 
+@import '_facia-content';
+
 /* ==========================================================================
    Variables and mixins
    ========================================================================== */
 
-@import '_vars';
-@import '_mixins';
 @import 'module/facia/_mixins';
 @import 'module/_discussion-mixins';
-@import '_extends-only';
 
 
 /* ==========================================================================
@@ -16,28 +15,19 @@
    ========================================================================== */
 
 @import 'base/_tables';
-@import 'base/_zindex';
 @import 'components/pasteup-forms/src/_forms';
-@import 'components/pasteup-buttons/src/_buttons';
 
 
 /* ==========================================================================
    Global modules
    ========================================================================== */
 
-@import 'module/_tabs';
-@import 'module/_headline-list';
 @import 'module/_cta';
-@import 'layout/_footer';
 @import 'module/content/_gallerythumbs';
 @import 'module/_dropdown';
 @import 'module/charts/_doughnuts';
 
-@import 'module/_search';
-@import 'module/_search-tool';
-
 @import 'module/content/_content.global';
-@import 'module/content/_media-player';
 @import 'module/content/_media.global';
 @import 'module/_loader';
 
@@ -54,16 +44,11 @@
 @import 'module/content/_block-level-sharing';
 
 @import 'module/preferences/_notifications';
-@import 'module/crosswords/_main';
-@import 'module/_weather';
 @import 'module/_sudoku';
 
 @import 'module/onward/_right-hand-most-popular';
-@import 'module/onward/_breaking-news';
 @import 'module/_clamp';
-@import 'module/_submeta';
 
-@import 'module/_rich-links';
 @import 'module/_membership-events';
 
 @import 'module/_save-for-later';
@@ -99,8 +84,6 @@
    Facia
    ========================================================================== */
 
-@import 'module/facia/_facia-show-more';
-@import 'module/facia/_pagination';
 @import 'module/facia/_tag-meta';
 @import 'module/facia/_l-list';
 @import 'module/facia/_container';
@@ -128,18 +111,8 @@
 @import 'module/_icons';
 
 /* ==========================================================================
-   Commercial modules
-   ========================================================================== */
-
-@import 'module/commercial/_commercial';
-
-/* ==========================================================================
    Misc
    ========================================================================== */
 
-@import 'module/_release-message';
-@import 'module/_tag-list';
 @import 'module/_childrens-books-site';
-@import 'module/email/_main';
 @import 'module/content/_article-test';
-@import 'module/_accessibility';

--- a/static/src/stylesheets/content.scss
+++ b/static/src/stylesheets/content.scss
@@ -1,14 +1,16 @@
 @charset 'UTF-8';
 
-@import '_facia-content';
-
 /* ==========================================================================
    Variables and mixins
    ========================================================================== */
 
+@import '_vars';
+@import '_mixins';
 @import 'module/facia/_mixins';
 @import 'module/_discussion-mixins';
+@import '_extends-only';
 
+@import '_common';
 
 /* ==========================================================================
    Base

--- a/static/src/stylesheets/facia.scss
+++ b/static/src/stylesheets/facia.scss
@@ -1,6 +1,10 @@
 @charset 'UTF-8';
 
-@import '_facia-content';
+@import '_vars';
+@import '_mixins';
+@import '_extends-only';
+
+@import '_common';
 
 @import 'module/_popup';
 

--- a/static/src/stylesheets/facia.scss
+++ b/static/src/stylesheets/facia.scss
@@ -1,34 +1,12 @@
 @charset 'UTF-8';
 
-@import 'base/_zindex';
-
-@import '_vars';
-@import '_mixins';
-@import '_extends-only';
+@import '_facia-content';
 
 @import 'module/_popup';
-@import 'module/_search';
-@import 'module/_search-tool';
-@import 'module/_weather';
+
 @import 'module/_social';
-@import 'module/_tabs';
-@import 'module/_headline-list';
-@import 'module/_rich-links';
-@import 'components/pasteup-buttons/src/_buttons';
-@import 'module/facia/_pagination';
-@import 'module/_release-message';
-@import 'module/onward/_breaking-news';
-@import 'module/facia/_facia-show-more';
-@import 'module/_tag-list';
-@import 'module/_submeta';
-@import 'layout/_footer';
 @import 'icons/_video-icons-sprite';
 @import 'icons/_video-icons-svg';
-@import 'module/content/_media-player';
-@import 'module/commercial/_commercial';
 @import 'module/business/_stocks';
 @import 'module/live-pulse';
 @import 'module/facia/snaps/_facia';
-@import 'module/crosswords/_main';
-@import 'module/email/_main';
-@import 'module/_accessibility';


### PR DESCRIPTION
As per @OliverJAsh comment on https://github.com/guardian/frontend/pull/12289

We should have a common stylesheet between facia and content, as it's full of duplication anyway.
