### PR TITLE
Add series view counts to onward/history

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -20,7 +20,10 @@ define([
     'lodash/objects/keys',
     'lodash/objects/assign',
     'lodash/collections/reduce',
+    'lodash/collections/contains',
     'lodash/objects/isArray',
+    'lodash/objects/pick',
+    'lodash/objects/mapValues',
     'lodash/collections/map',
     'common/utils/chain',
     'lodash/arrays/compact',
@@ -46,7 +49,10 @@ define([
     keys,
     assign,
     reduce,
+    contains,
     isArray,
+    pick,
+    mapValues,
     map,
     chain,
     compact,
@@ -132,6 +138,19 @@ define([
             }
         }
         return summaryCache;
+    }
+
+    function seriesSummary() {
+        function views(item) {
+            return reduce(item, function (acc, record) {
+                return acc + record[1];
+            }, 0);
+        }
+
+        return chain(getSummary().tags)
+            .and(pick, function(v, k) { return contains(k, 'series'); })
+            .and(mapValues, function(tag) { return views(tag[1]) + views(tag[2]); })
+            .value();
     }
 
     function deleteFromSummary(tag) {
@@ -413,11 +432,13 @@ define([
         deleteFromSummary: deleteFromSummary,
         isRevisit: isRevisit,
         reset: reset,
+        seriesSummary: seriesSummary,
 
         test: {
             getSummary: getSummary,
             getHistory: getHistory,
-            pruneSummary: pruneSummary
+            pruneSummary: pruneSummary,
+            seriesSummary: seriesSummary
         }
     };
 });

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -92,9 +92,9 @@ define([
                 indexInRecord: 2
             }
         ],
-        summaryPeriodDays = 30,
+        summaryPeriodDays = 90,
         forgetUniquesAfter = 10,
-        historySize = 100,
+        historySize = 50,
 
         storageKeyHistory = 'gu.history',
         storageKeySummary = 'gu.history.summary',

--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -94,7 +94,7 @@ define([
         ],
         summaryPeriodDays = 30,
         forgetUniquesAfter = 10,
-        historySize = 50,
+        historySize = 100,
 
         storageKeyHistory = 'gu.history',
         storageKeySummary = 'gu.history.summary',

--- a/static/test/javascripts/spec/common/onward/history.spec.js
+++ b/static/test/javascripts/spec/common/onward/history.spec.js
@@ -216,10 +216,10 @@ define([
                 'g/series/h': 1,
                 'j/series/k': 1,
                 'x/series/y': 1
-            }
+            };
 
             pages.forEach(function (page, i) { hist.logSummary(page, today + i); });
             expect(hist.seriesSummary()).toEqual(expected);
-        })
+        });
     });
 });

--- a/static/test/javascripts/spec/common/onward/history.spec.js
+++ b/static/test/javascripts/spec/common/onward/history.spec.js
@@ -176,5 +176,50 @@ define([
                 hist.getPopular()[1][0]
             ).toEqual('less/visited');
         });
+
+        it('should calculate series summary', function() {
+            var pages = [
+                {
+                    pageId: '111',
+                    section: 'a/series/b',
+                    sectionName: 'A series (two views)'
+                },
+                {
+                    pageId: '112',
+                    section: 'a/series/b',
+                    sectionName: 'A series (two views)'
+                },
+                {
+                    pageId: '222',
+                    section: 'g/series/h',
+                    sectionName: 'Another series'
+                },
+                {
+                    pageId: '333',
+                    section: 'j/series/k',
+                    sectionName: 'A different series'
+                },
+                {
+                    pageId: '444',
+                    section: 'x/series/y',
+                    sectionName: 'A really different series'
+                },
+                {
+                    pageId: '555',
+                    section: 'a/sport/z',
+                    sectionName: 'Not a series'
+                }
+            ];
+
+            var expected = {
+                'a/series/b': 2,
+                'g/series/h': 1,
+                'j/series/k': 1,
+                'x/series/y': 1
+            }
+
+            pages.forEach(function (page, i) { hist.logSummary(page, today + i); });
+            expect(hist.seriesSummary()).toEqual(expected);
+        })
     });
 });


### PR DESCRIPTION
This gives you a count of hits against any series tags recorded (see the test for an example). I've also increased how long we store history data for. It'll help us work out how to promote series content to different users.

@stephanfowler 
