### PR TITLE
Retire facia containers

### DIFF
--- a/common/app/slices/FixedContainers.scala
+++ b/common/app/slices/FixedContainers.scala
@@ -80,7 +80,6 @@ object FixedContainers {
 
   val all: Map[String, ContainerDefinition] = Map(
     ("fixed/small/slow-I", slices(FullMedia75)),
-    ("fixed/small/slow-II", slices(HalfHalf)),
     ("fixed/small/slow-III", slices(HalfQQ)),
     ("fixed/small/slow-IV", fixedSmallSlowIV),
     ("fixed/small/slow-V-half", slices(Hl4Half)),
@@ -89,15 +88,11 @@ object FixedContainers {
       slicesWithoutMpu = Seq(QuarterQuarterQuarterQuarter))),
     ("fixed/small/slow-VI", fixedSmallSlowVI),
     ("fixed/small/fast-VIII", slices(QuarterQuarterQlQl)),
-    ("fixed/small/fast-X", slices(QuarterQlQlQl)),
-    ("fixed/medium/slow-VI", fixedMediumSlowVI),
     ("fixed/medium/slow-VII", fixedMediumSlowVII),
-    ("fixed/medium/slow-VIII", fixedMediumSlowVIII),
     ("fixed/medium/slow-XII-mpu", fixedMediumSlowXIIMpu),
     ("fixed/medium/fast-XI", fixedMediumFastXI),
     ("fixed/medium/fast-XII", fixedMediumFastXII),
     ("fixed/large/slow-XIV", slices(ThreeQuarterQuarter, QuarterQuarterQuarterQuarter, Ql2Ql2Ql2Ql2)),
-    ("fixed/large/fast-XV", slices(HalfQQ, Ql3Ql3Ql3Ql3)),
     ("fixed/thrasher", thrasher)
   ) ++ (if (Configuration.faciatool.showTestContainers) Map(
     ("all-items/not-for-production", slices(FullMedia100, FullMedia75, FullMedia50, HalfHalf, QuarterThreeQuarter, ThreeQuarterQuarter, Hl4Half, HalfQuarterQl2Ql4, TTTL4, Ql3Ql3Ql3Ql3))


### PR DESCRIPTION
We are retiring the following facia containers. @piuccio has already removed them from facia tool.

fixed/large/fast-XV
fixed/small/fast-X
fixed/medium/slow-VIII
fixed/small/slow-II
fixed/small/slow-VI
