### PR TITLE
Remove toast div that covers content

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/autoupdate.js
+++ b/static/src/javascripts/projects/common/modules/ui/autoupdate.js
@@ -89,10 +89,12 @@ define([
             fastdom.write(function () {
                 if (count > 0) {
                     var updateText = (count > 1) ? ' new updates' : ' new update';
-                    $toastButton.removeClass('toast__button--closed').addClass('toast__button--open');
+                    $toastButton.removeClass('toast__button--closed');
+                    $(toastContainer).addClass('toast__container--open');
                     $toastText.html(count + updateText);
                 } else {
-                    $toastButton.removeClass('toast__button--open').removeClass('loading').addClass('toast__button--closed');
+                    $toastButton.removeClass('loading').addClass('toast__button--closed');
+                    $(toastContainer).removeClass('toast__container--open');
                 }
             });
         };
@@ -210,9 +212,7 @@ define([
 
         fastdom.write(function () {
             // Enables the animations for injected blocks
-            $('.js-article__container').addClass('toast-enabled');
             $liveblogBody.addClass('autoupdate--has-animation');
-            $('.js-live-toolbar').remove(); // only necessary in the AB test
         });
     };
 });

--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -583,7 +583,6 @@ $timeline-width: 15px;
 }
 
 .toast__container {
-    z-index: $zindex-content;
     padding-bottom: $gs-baseline;
     text-align: center;
     transition: transform .3s ease-in-out;
@@ -608,6 +607,10 @@ $timeline-width: 15px;
     @include mq(wide) {
         width: gs-span(8);
     }
+}
+
+.toast__container--open {
+    z-index: $zindex-content;
 }
 
 .toast__button {


### PR DESCRIPTION
At the moment, there's a toast div sitting on top of the content all the time, blocking up some links near the top of the screen.  This just moves the div to the back when toast isn't popped.

Before:
![coveredlink](https://cloud.githubusercontent.com/assets/7304387/13927979/d11ab4a2-ef8b-11e5-8825-26f6a3ad790f.gif)

After:
![linkworks](https://cloud.githubusercontent.com/assets/7304387/13928033/114124da-ef8c-11e5-8348-b7f192704fa2.gif)

@OliverJAsh I just used a new class in the end!
