### PR TITLE
Adblocking response AB test - Firefox excluded from the test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -30,7 +30,7 @@ define([
 
         this.canRun = function () {
             return contains(['desktop', 'leftCol', 'wide'], detect.getBreakpoint())
-                && config.page.edition === 'UK';
+                && config.page.edition === 'UK' && detect.getUserAgent.browser !== 'Firefox';
         };
 
         this.variants = [{

--- a/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/adblocking-response.js
@@ -30,7 +30,7 @@ define([
 
         this.canRun = function () {
             return contains(['desktop', 'leftCol', 'wide'], detect.getBreakpoint())
-                && config.page.edition === 'UK' && detect.getUserAgent.browser !== 'Firefox';
+                && config.page.edition === 'UK';
         };
 
         this.variants = [{
@@ -39,7 +39,7 @@ define([
         }, {
             id: 'variantA',
             test: function () {
-                detect.getFfOrGenericAdbockInstalled.then(function (adblockUsed) {
+                detect.adblockInUse.then(function (adblockUsed) {
                     if (adblockUsed && !config.page.isFront &&
                         !userFeatures.isPayingMember() &&
                         config.page.webTitle !== 'Subscriber number form' &&
@@ -69,7 +69,7 @@ define([
         }, {
             id: 'variantB',
             test: function () {
-                detect.getFfOrGenericAdbockInstalled.then(function (adblockUsed) {
+                detect.adblockInUse.then(function (adblockUsed) {
                     if (adblockUsed && !config.page.isFront &&
                         !userFeatures.isPayingMember() &&
                         config.page.webTitle !== 'Subscriber number form' &&


### PR DESCRIPTION
## What does this change?

Firefox is now excluded from the Adblocking response AB test. 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
