### PR TITLE
Add function to get most viewed series from history

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/history.js
+++ b/static/src/javascripts/projects/common/modules/onward/history.js
@@ -153,6 +153,12 @@ define([
             .value();
     }
 
+    function mostViewedSeries() {
+        return reduce(seriesSummary(), function (best, views, tag, summary) {
+            return views > (summary[best] || 0) ? tag : best;
+        }, '');
+    }
+
     function deleteFromSummary(tag) {
         var summary = getSummary();
 
@@ -433,6 +439,7 @@ define([
         isRevisit: isRevisit,
         reset: reset,
         seriesSummary: seriesSummary,
+        mostViewedSeries: mostViewedSeries,
 
         test: {
             getSummary: getSummary,

--- a/static/test/javascripts/spec/common/onward/history.spec.js
+++ b/static/test/javascripts/spec/common/onward/history.spec.js
@@ -177,7 +177,7 @@ define([
             ).toEqual('less/visited');
         });
 
-        it('should calculate series summary', function() {
+        describe('series summary', function() {
             var pages = [
                 {
                     pageId: '111',
@@ -211,15 +211,24 @@ define([
                 }
             ];
 
-            var expected = {
-                'a/series/b': 2,
-                'g/series/h': 1,
-                'j/series/k': 1,
-                'x/series/y': 1
-            };
+            beforeEach(function() {
+                pages.forEach(function (page, i) {
+                    hist.logSummary(page, today + i);
+                });
+            });
 
-            pages.forEach(function (page, i) { hist.logSummary(page, today + i); });
-            expect(hist.seriesSummary()).toEqual(expected);
+            it('should calculate series summary', function() {
+                expect(hist.seriesSummary()).toEqual({
+                    'a/series/b': 2,
+                    'g/series/h': 1,
+                    'j/series/k': 1,
+                    'x/series/y': 1
+                });
+            });
+
+            it('should calculate most viewed series', function() {
+                expect(hist.mostViewedSeries()).toEqual('a/series/b');
+            });
         });
     });
 });


### PR DESCRIPTION
A little extension that'll tell us which series tag has the highest number of views.
@stephanfowler 
