### PR TITLE
Fix radiator by making it use new teamcity

### DIFF
--- a/admin/app/controllers/RadiatorController.scala
+++ b/admin/app/controllers/RadiatorController.scala
@@ -39,10 +39,6 @@ object RadiatorController extends Controller with Logging with AuthLogging with 
   }
   def renderRadiator() = AuthActions.AuthActionTest.async { implicit request =>
 
-    // Some features do not work outside our network
-    // /radiator?features=external disables these
-    val external = request.getParameter("features").contains("external")
-
     for {
       user50x <- CloudWatch.user50x
       shortLatency <- CloudWatch.shortStackLatency
@@ -53,7 +49,7 @@ object RadiatorController extends Controller with Logging with AuthLogging with 
       val graphs = Seq(user50x) ++ shortLatency ++ fastlyErrors
       NoCache(Ok(views.html.radiator(
         graphs, multiLineGraphs, cost, switchesExpiringSoon,
-        Configuration.environment.stage, external
+        Configuration.environment.stage
       )))
     }
   }

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -3,8 +3,7 @@
     hitMissCharts: Seq[tools.AwsLineChart],
     cost: tools.MaximumMetric,
     switches: Seq[conf.switches.Switch],
-    env: String,
-    external: Boolean)
+    env: String)
 
 @import org.joda.time.{DateTime, Days}
 
@@ -23,14 +22,13 @@
     </div>
 
     <div class="build-wrapper">
-        @if(!external) {
-            <h2>Teamcity builds</h2>
-            @*
-            To add another build just append another &buildTypeId=XXXXXX
-            Note, it will not show unless you enable the "External status widget" for the build in Teamcity
-            *@
-            <script type="text/javascript" src="https://teamcity.gutools.co.uk/externalStatus.html?js=1&buildTypeId=bt1304&buildTypeId=Frontend_IntegrationTests&buildTypeId=Frontend_SanityTests"></script>
-        }
+        <h2>Teamcity builds</h2>
+        @*
+        To add another build just append another &buildTypeId=XXXXXX
+        Note, it will not show unless you enable the "External status widget" for the build in Teamcity
+            for some reason the &js=1 hangs waiting for a http resp so just using the iframe version for now
+        *@
+        <iframe src="http://teamcity.gu-web.net:8111/externalStatus.html?buildTypeId=dotcom_master"></iframe>
     </div>
 
 
@@ -53,18 +51,16 @@
     </div>
 
     <div class="monitoring-wrapper">
-        @if(!external) {
-            <div class="riffraff-wrapper">
-                <h2>CODE Deployments</h2>
-                <ul class="riffraff" id="riffraffCODE"></ul>
-                <ul class="deployers" id="deployersCODE"></ul>
-            </div>
-            <div class="riffraff-wrapper">
-                <h2>PROD Deployments</h2>
-                <ul class="riffraff" id="riffraffPROD"></ul>
-                <ul class="deployers" id="deployersPROD"></ul>
-            </div>
-        }
+        <div class="riffraff-wrapper">
+            <h2>CODE Deployments</h2>
+            <ul class="riffraff" id="riffraffCODE"></ul>
+            <ul class="deployers" id="deployersCODE"></ul>
+        </div>
+        <div class="riffraff-wrapper">
+            <h2>PROD Deployments</h2>
+            <ul class="riffraff" id="riffraffPROD"></ul>
+            <ul class="deployers" id="deployersPROD"></ul>
+        </div>
     </div>
 
     @charts.map{ chart => @fragments.lineChart(chart)  }


### PR DESCRIPTION
The radiator is currently hanging.  This updates to use the external url for teamcity.

I also updated it to not think riffraff is internal at the same time.

Unfrotunately even though [this url](http://teamcity.gu-web.net:8111/externalStatus.html?buildTypeId=dotcom_master) works, the [js one](http://teamcity.gu-web.net:8111/externalStatus.html?buildTypeId=dotcom_master&js=1) doesn't.  No idea why, but I couldn't work it out after some searching and I didn't want it to block my changes.  Suggestions welcome.
