### PR TITLE
Put paid branding decisions behind switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -346,4 +346,13 @@ trait CommercialSwitches {
     sellByDate = new LocalDate(2016, 4, 13),
     exposeClientSide = false
   )
+
+  val cardsDecidePaidContainerBranding = Switch(
+    "Commercial",
+    "cards-decide-paid-container-branding",
+    "If on, the cards will decide the branding of their container",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 13),
+    exposeClientSide = false
+  )
 }


### PR DESCRIPTION
There are two ways to decide how a paid container should be branded:
1. Use the backfill query that populated the container
2. Use the metadata of the cards in the container

The latter is the better way but we're currently using the former.
This switch enables us to iron out all the edge cases until we're ready to stop using the backfill query altogether.

/cc @JonNorman 
