### PR TITLE
Use tracking names instead of tracking ids

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -207,7 +207,7 @@ final case class Content(
     // Tracking tags are used for things like commissioning desks.
     val trackingMeta = tags.tracking match {
       case Nil => None
-      case trackingTags => Some("trackingIds", JsString(trackingTags.map(_.id).mkString(",")))
+      case trackingTags => Some("trackingNames", JsString(trackingTags.map(_.name).mkString(",")))
     }
 
     val articleMeta = if (tags.isUSMinuteSeries) {

--- a/common/app/templates/inlineJS/blocking/analytics.scala.js
+++ b/common/app/templates/inlineJS/blocking/analytics.scala.js
@@ -63,7 +63,7 @@ try {
         // Previous Content type
         s.prop70    = s.getPreviousValue(s.prop9, "s_prev_ct");
         s.prop10    = config.page.tones || '';
-        s.prop5     = config.page.trackingIds || '';
+        s.prop5     = config.page.trackingNames || '';
 
         s.prop25    = config.page.blogs || '';
 


### PR DESCRIPTION
Omniture is reporting tracking tags with the id of the tag, instead of the user-friendly tag name. 
