### PR TITLE
Update A/B for marketing checkbox, extend switch and increase audience

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -67,12 +67,12 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABEmailSignupMarketingCheckbox = Switch(
+  val ABEmailSignupMarketingCheckboxV2 = Switch(
     "A/B Tests",
-    "ab-email-signup-marketing-checkbox",
+    "ab-email-signup-marketing-checkbox-v2",
     "Test marketing checkbox in email sign-up",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 3, 23),
+    sellByDate = new LocalDate(2016, 3, 29),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -138,8 +138,8 @@ define([
                     formModClass = (opts && opts.formModClass) || formData.formModClass || false,
                     formCloseButton = (opts && opts.formCloseButton) || formData.formCloseButton || false,
                     showMarketingCheckbox = (opts && opts.showMarketingCheckbox) || formData.showMarketingCheckbox || false,
-                    showCheckedMarketing = ab.isInVariant('EmailSignupMarketingCheckbox', 'marketing-default-checked'),
-                    showUncheckedMarketing = ab.isInVariant('EmailSignupMarketingCheckbox', 'marketing-default-unchecked');
+                    showCheckedMarketing = ab.isInVariant('EmailSignupMarketingCheckboxV2', 'marketing-default-checked'),
+                    showUncheckedMarketing = ab.isInVariant('EmailSignupMarketingCheckboxV2', 'marketing-default-unchecked');
 
                 Id.getUserFromApi(function (userFromId) {
                     ui.updateFormForLoggedIn(userFromId, el);

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -11,7 +11,7 @@ define([
     'common/modules/experiments/tests/header-bidding-us',
     'common/modules/experiments/tests/article-video-autoplay',
     'common/modules/experiments/tests/next-in-series',
-    'common/modules/experiments/tests/email-signup-marketing-checkbox',
+    'common/modules/experiments/tests/email-signup-marketing-checkbox-v2',
     'common/modules/experiments/tests/adblocking-response',
     'common/modules/experiments/tests/people-who-read-this-also-read-variants',
     'lodash/arrays/flatten',
@@ -36,7 +36,7 @@ define([
     HeaderBiddingUS,
     ArticleVideoAutoplay,
     NextInSeries,
-    EmailSignupMarketingCheckbox,
+    EmailSignupMarketingCheckboxV2,
     AdblockingResponse,
     PeopleWhoReadThisAlsoReadVariants,
     flatten,
@@ -58,7 +58,7 @@ define([
         new ArticleVideoAutoplay(),
         new NextInSeries(),
         new AdblockingResponse(),
-        new EmailSignupMarketingCheckbox(),
+        new EmailSignupMarketingCheckboxV2(),
         new PeopleWhoReadThisAlsoReadVariants()
     ]);
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/email-signup-marketing-checkbox-v2.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/email-signup-marketing-checkbox-v2.js
@@ -7,12 +7,12 @@ define([
 ) {
     return function () {
 
-        this.id = 'EmailSignupMarketingCheckbox';
+        this.id = 'EmailSignupMarketingCheckboxV2';
         this.start = '2016-03-09';
-        this.expiry = '2016-03-23';
+        this.expiry = '2016-03-29';
         this.author = 'Gareth Trufitt';
         this.description = 'Testing how the marketing checkbox affects engagement and sign-ups';
-        this.audience = 0.01;
+        this.audience = 0.15;
         this.audienceOffset = 0.3;
         this.successMeasure = 'Sign-ups to email when the checkbox is shown and the difference made to checked/un-checked checkbox';
         this.audienceCriteria = 'All users who see the email sign-up';


### PR DESCRIPTION
## What does this change?

Updates the marketing A/B test deadline and increases inclusion to 15%. To ensure opt-ins renamed the test.
