### PR TITLE
Fix paid popup styling

### DIFF
--- a/common/app/views/fragments/commercial/paidForMeta.scala.html
+++ b/common/app/views/fragments/commercial/paidForMeta.scala.html
@@ -6,7 +6,7 @@
     <span class="paidfor-meta__label">Paid content</span>
     <div class="paidfor-label paidfor-meta__more has-popup">
         <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="js-paidfor-popup@dataId">About @inlineSvg("arrow-down", "icon")</button>
-        <div class="popup is-off paidfor-popup js-paidfor-popup@dataId">
+        <div class="popup popup--paidfor is-off paidfor-popup js-paidfor-popup@dataId">
             <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team</h3>
             <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
         </div>

--- a/common/app/views/fragments/commercial/paidForMeta.scala.html
+++ b/common/app/views/fragments/commercial/paidForMeta.scala.html
@@ -6,9 +6,9 @@
     <span class="paidfor-meta__label">Paid content</span>
     <div class="paidfor-label paidfor-meta__more has-popup">
         <button class="u-button-reset paidfor-label__btn popup__toggle" data-toggle="js-paidfor-popup@dataId">About @inlineSvg("arrow-down", "icon")</button>
-        <div class="popup popup--paidfor is-off paidfor-popup js-paidfor-popup@dataId">
-            <h3 class="paidfor-popup__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team</h3>
-            <a class="paidfor-popup__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
+        <div class="popup popup--paidfor is-off js-paidfor-popup@dataId">
+            <h3 class="popup--paidfor__title">Paid content is paid for and controlled by an advertiser and produced by the Guardian Labs team</h3>
+            <a class="popup--paidfor__link" href="@LinkTo("/content-funding")">Learn more about Guardian Labs content @inlineSvg("arrow-right", "icon")</a>
         </div>
     </div>
 </div>

--- a/common/app/views/fragments/discussionFooter.scala.html
+++ b/common/app/views/fragments/discussionFooter.scala.html
@@ -32,7 +32,7 @@
             <button class="u-button-reset popup__toggle" data-toggle="popup--comments-order"
                     aria-haspopup="true" aria-controls="comments-order-popup">Order by <span class="js-comment-order"></span></button>
 
-            <ul id="comments-order-popup" class="popup popup__group popup--comments-order is-off">
+            <ul id="comments-order-popup" class="popup popup--default popup__group popup--comments-order is-off">
                 @List("newest", "oldest", "recommendations").map { value =>
                     <li class="popup__item">
                         <button class="u-button-reset popup__action" data-order="@value" data-link-name="comments-@value">@value</button>
@@ -46,7 +46,7 @@
                 <button class="u-button-reset popup__toggle" data-toggle="popup--comments-pagesize"
                         aria-haspopup="true" aria-controls="comments-pagesize-popup">Show <span class="js-comment-pagesize">25</span></button>
 
-                <ul id="comments-pagesize-popup" class="popup popup__group popup--comments-pagesize is-off">
+                <ul id="comments-pagesize-popup" class="popup popup--default popup__group popup--comments-pagesize is-off">
                 @pagesizePopUp
                 </ul>
             </div>
@@ -57,7 +57,7 @@
             <button class="u-button-reset popup__toggle" data-toggle="popup--comments-threading"
                     aria-haspopup="true" aria-controls="comments-order-threading">Threads <span class="js-comment-threading"></span></button>
 
-            <ul id="comments-order-threading" class="popup popup__group popup--comments-threading is-off">
+            <ul id="comments-order-threading" class="popup popup--default popup__group popup--comments-threading is-off">
                 @List("collapsed", "expanded", "unthreaded").map { value =>
                     <li class="popup__item">
                         <button class="u-button-reset popup__action" data-threading="@value" data-link-name="comments-threading-@value">@value</button>
@@ -71,7 +71,7 @@
                 <button class="u-button-reset popup__toggle" data-toggle="popup--timestamp"
                         aria-haspopup="true" aria-controls="timestamp-popup">Timestamps <span class="js-timestamps"></span></button>
 
-                <ul id="timestamp-popup" class="popup popup__group popup--timestamp is-off">
+                <ul id="timestamp-popup" class="popup popup--default popup__group popup--timestamp is-off">
                     @List("relative", "absolute").map { value =>
                         <li class="popup__item">
                             <button class="u-button-reset popup__action" data-timestamp="@value" data-link-name="comments-@value">@value</button>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -46,7 +46,7 @@
                                       data-test-id="sign-in-name">sign in</span>
                             </a>
                             <div class="js-profile-popup">
-                                <ul class="popup popup__group popup--profile is-off" data-link-name="Sub Sections" data-test-id="popup-profile">
+                                <ul class="popup popup--default popup__group popup--profile is-off" data-link-name="Sub Sections" data-test-id="popup-profile">
                                     @if(conf.switches.Switches.SaveForLaterSwitch.isSwitchedOn) {
                                         <li class="popup__item">
                                             <a href="@Configuration.id.url/saved-for-later" class="brand-bar__item--action brand-bar__item--saved-for-later" data-link-name="Saved for Later">
@@ -87,7 +87,7 @@
                 </div>
             </div>
 
-            <div class="popup popup--search is-off"><div class="js-search-placeholder"></div></div>
+            <div class="popup popup--default popup--search is-off"><div class="js-search-placeholder"></div></div>
 
             <div class="l-header-main">
                 @if((page.metadata.section == "observer" && page.metadata.isFront) || page.metadata.id == "theobserver") {

--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -33,7 +33,7 @@
         </div>
         <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--more">
             @ellipsis()
-            <div class="popup is-off top-bar__popup--more" id="guardian-services-top-menu">
+            <div class="popup popup--default is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
                     <li class="popup__item brand-bar__popup--jobs mobile-only show-on-slim-header">
@@ -77,7 +77,7 @@
         </div>
         <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--more mobile-only show-on-slim-header">
             @ellipsis()
-            <div class="popup is-off top-bar__popup--more" id="guardian-services-top-menu">
+            <div class="popup popup--default is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
                     <li class="popup__item brand-bar__popup--jobs mobile-only show-on-slim-header">
@@ -96,7 +96,7 @@
         </div>
         <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--more mobile-only show-on-slim-header">
             @ellipsis()
-            <div class="popup is-off top-bar__popup--more" id="guardian-services-top-menu">
+            <div class="popup popup--default is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
                     <li class="popup__item mobile-only">
@@ -119,7 +119,7 @@
         </div>
         <div class="brand-bar__item has-popup brand-bar__item--has-control brand-bar__item--more">
             @ellipsis()
-            <div class="popup is-off top-bar__popup--more" id="guardian-services-top-menu">
+            <div class="popup popup--default is-off top-bar__popup--more" id="guardian-services-top-menu">
                 <h3 class="popup__group-header">from the guardian:</h3>
                 <ul class="popup__group">
                     <li class="popup__item brand-bar__popup--soulmates hide-on-desktop show-on-slim-header">
@@ -144,7 +144,7 @@
            aria-haspopup="true" aria-controls="guardian-edition-menu">
             @Edition(request).displayName
         </a>
-        <ul class="popup popup__group is-off top-bar__popup--edition" id="guardian-edition-menu">
+        <ul class="popup popup--default popup__group is-off top-bar__popup--edition" id="guardian-edition-menu">
             @Edition.others(request).map{ edition =>
                 <li class="popup__item">
                     <a class="@RenderClasses(Map(

--- a/static/src/javascripts/projects/common/views/commercial/gustyle/label.html
+++ b/static/src/javascripts/projects/common/views/commercial/gustyle/label.html
@@ -1,6 +1,6 @@
 <div class="gu-comlabel has-popup">
 	<button class="u-button-reset gu-comlabel__btn popup__toggle" data-toggle="gu-compopup--<%=data.dataAttr%>"><%=data.buttonTitle%> <%=data.icon%></button>
-	<div class="popup is-off gu-compopup gu-compopup--<%=data.dataAttr%> gu-stylebox">
+	<div class="popup popup--default is-off gu-compopup gu-compopup--<%=data.dataAttr%> gu-stylebox">
 		<h3 class="gu-compopup__title"><%=data.infoTitle%></h3>
 		<p class="gu-compopup__text"><%=data.infoText%></p>
 		<a class="gu-compopup__link" href="<%=data.infoLinkUrl%>"><%=data.infoLinkText%></a>

--- a/static/src/stylesheets/facia.scss
+++ b/static/src/stylesheets/facia.scss
@@ -6,8 +6,6 @@
 
 @import '_common';
 
-@import 'module/_popup';
-
 @import 'module/_social';
 @import 'icons/_video-icons-sprite';
 @import 'icons/_video-icons-svg';

--- a/static/src/stylesheets/module/_popup.scss
+++ b/static/src/stylesheets/module/_popup.scss
@@ -11,17 +11,20 @@ $c-popup-bg: colour(neutral-8);
 // use a proper icon size variabe when the icons are redrawn at mulptile sizes
 $control-offset: 36 + $gs-gutter/2;
 
+.popup--default {
+    background: $c-popup-bg;
+    box-shadow: 0 rem(1px 1px) 0 rgba(0, 0, 0, .25);
+    left: 0;
+    top: $popup-top - 2;
+    padding: 0;
+}
+
 .popup {
     box-sizing: border-box;
     position: absolute;
-    left: 0;
-    background: $c-popup-bg;
     margin: 0;
-    padding: 0;
     list-style: none;
-    box-shadow: 0 rem(1px 1px) 0 rgba(0, 0, 0, .25);
     min-width: gs-span(2);
-    top: $popup-top - 2;
 
     @include mq(mobileLandscape) {
         right: auto;

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
@@ -4,9 +4,6 @@
     left: 50%;
     top: 100%;
     padding: 16px;
-}
-
-.paidfor-popup {
     color: #ffffff;
     transform: translate(-50%, 0);
     width: 240px;
@@ -34,13 +31,13 @@
     }
 }
 
-.paidfor-popup__title {
+.popup--paidfor__title {
     font-size: get-font-size(textSans, 3);
     line-height: get-line-height(textSans, 1);
     margin: 0 0 1em;
 }
 
-.paidfor-popup__link {
+.popup--paidfor__link {
     color: #676767;
     font-size: get-font-size(textSans, 2);
     line-height: get-line-height(textSans, 1);

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
@@ -1,12 +1,15 @@
-.paidfor-popup {
+.popup--paidfor {
     background: guss-colour(neutral-1, $pasteup-palette);
     box-shadow: none;
-    color: #ffffff;
-    transform: translate(-50%, 0);
     left: 50%;
     top: 100%;
-    width: 240px;
     padding: 16px;
+}
+
+.paidfor-popup {
+    color: #ffffff;
+    transform: translate(-50%, 0);
+    width: 240px;
     border-radius: 4px;
     font-weight: 700;
     z-index: 32000;


### PR DESCRIPTION
This PR is to fix the styling in the paidfor popup on https://www.theguardian.com/guardian-labs

![image](https://cloud.githubusercontent.com/assets/7304387/13983784/c4381374-f0e9-11e5-907f-f8067d1e9686.png)
changes to
![image](https://cloud.githubusercontent.com/assets/7304387/13983820/067925de-f0ea-11e5-983c-93ee22c1cbee.png)

This is because there was some conflicting styling on popup and popup__paidfor which were applied to the same divs and therefore depending on the order.  This showed up after th order changed in https://github.com/guardian/frontend/pull/12298

I have basically separated out the conflicting styles into separate classes so it doesn't override any more.  I've also removed the duplicate import of modules/_popup as it's imported in the head anyway.

Thanks for your advice @OliverJAsh 
@Calanthe thanks for diagnosing the problem
