### PR TITLE
Restore jQuery script to pressed interactive pages that need it.

### DIFF
--- a/admin/app/pagepresser/InteractiveHtmlCleaner.scala
+++ b/admin/app/pagepresser/InteractiveHtmlCleaner.scala
@@ -67,6 +67,8 @@ object InteractiveHtmlCleaner extends HtmlCleaner with implicits.WSRequests {
 
   override def removeScripts(document: Document): Document = {
     val scripts = document.getElementsByTag("script")
+    val needsJquery = scripts.exists(_.html().toLowerCase.contains("jquery"))
+
     val (interactiveScripts, nonInteractiveScripts) = scripts.partition { e =>
       val parentIds = e.parents().map(p => p.id()).toList
       parentIds.contains("interactive-content")
@@ -78,6 +80,22 @@ object InteractiveHtmlCleaner extends HtmlCleaner with implicits.WSRequests {
         addSwfObjectScript(document)
       }
     }
+
+    if (needsJquery) {
+      addJqueryScript(document)
+    }
+
+    document
+  }
+
+  private def addJqueryScript(document: Document): Document = {
+    val jqScript = """
+    <script src="//pasteup.guim.co.uk/js/lib/jquery/1.8.1/jquery.min.js"></script>
+    <script>
+    var jQ = jQuery.noConflict();
+    jQ.ajaxSetup({ cache: true });
+  </script>"""
+    document.body().prepend(jqScript)
     document
   }
 

--- a/admin/test/package.scala
+++ b/admin/test/package.scala
@@ -1,6 +1,7 @@
 package test
 
 import org.scalatest.Suites
+import pagepresser.InteractiveHtmlCleanerTest
 
 class AdminTestSuite extends Suites (
   new football.PlayerControllerTest,
@@ -9,6 +10,7 @@ class AdminTestSuite extends Suites (
   new indexes.TagPagesTest,
   new services.AdminHealthCheckTest,
   new pagepresser.HtmlCleanerTest,
+  new pagepresser.InteractiveHtmlCleanerTest,
   new controllers.admin.DeploysRadiatorControllerTest,
   new controllers.admin.DeploysNotifyControllerTest
 ) with SingleServerSuite {

--- a/admin/test/pagepresser/InteractiveHtmlCleanerTest.scala
+++ b/admin/test/pagepresser/InteractiveHtmlCleanerTest.scala
@@ -1,0 +1,22 @@
+package pagepresser
+
+import org.jsoup.Jsoup
+import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import test.ConfiguredTestSuite
+
+import scala.io.Source
+
+@DoNotDiscover class InteractiveHtmlCleanerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+
+  "InteractiveHtmlCleaner" should "remove all non-interactive scripts and re-write jQuery when pressing a page" in {
+    val originalSource = Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("pagepresser/r2/interactivePageWithJQuery.html"))
+    val originalDoc = Jsoup.parse(originalSource.mkString)
+
+    val expectedCleanedDocFromSource = Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html"))
+    val expectedDoc = Jsoup.parse(expectedCleanedDocFromSource.mkString)
+
+    val actualResult = InteractiveHtmlCleaner.removeScripts(originalDoc)
+    actualResult.html().replace(" ","") should be(expectedDoc.html().replace(" ",""))
+  }
+
+}

--- a/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithJQuery.html
@@ -1,0 +1,2751 @@
+<!DOCTYPE html>
+<html lang="en" itemtype="http://schema.org/Recipe" itemscope >
+
+<head>
+    <title> Thanksgiving recipe swap | Life and style | theguardian.com </title>
+
+
+    <meta charset="utf-8" />
+
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1"/>
+
+    <link rel="canonical" href="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" />
+
+    <meta name="description" content="We asked 12 American food bloggers to rethink the traditional Thanksgiving meal – and they each swapped an established dish in favor of something from their own cultural background. Mix and match from&hellip;" />
+
+    <meta name="DC.date.issued" content="2013-11-20">
+
+
+
+
+
+    <meta name="llt" content="AUqh23Ho" />
+
+
+    <meta property="og:title" content="Thanksgiving recipe swap"/>
+
+
+
+    <meta property="article:published_time" content="2013-11-20T15:40:26Z" />
+
+    <meta property="article:modified_time" content="2014-12-31T19:38:27Z" />
+
+    <meta property="article:author" content="http://www.theguardian.com/profile/nadja-popovich" />
+    <meta property="article:author" content="http://www.theguardian.com/profile/ruth-spencer" />
+    <meta property="article:author" content="http://www.theguardian.com/profile/greg-chen" />
+
+    <meta property="article:tag" content="Thanksgiving" />
+    <meta property="article:tag" content="Life and style" />
+    <meta property="article:tag" content="Food & drink" />
+
+    <meta property="article:section" content="Life and style" />
+
+    <meta property="og:url" content="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes"/>
+
+
+
+
+
+    <meta property="og:type" content="article"/>
+    <meta property="og:image" content="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/20/1384960262992/Thanksgiving-recipe-swap--006.jpg"/>
+    <meta property="og:site_name" content="the Guardian"/>
+    <meta property="og:description" content="We asked 12 American food bloggers to rethink the traditional Thanksgiving meal – and they each swapped an established dish in favor of something from their own cultural background. Mix and match from the recipes below to bring something new to your table this year"/>
+    <meta property="fb:app_id" content="180444840287"/>
+
+
+    <meta name="author" content="Nadja Popovich" />
+    <meta name="author" content="Ruth Spencer" />
+    <meta name="author" content="Greg Chen" />
+
+    <meta name="keywords" content="Thanksgiving,Life and style,Food & drink,Life and style" />
+    <meta name="news_keywords" content="Thanksgiving,Life and style,Food & drink,Life and style" />
+
+
+    <link rel="shortcut icon" href="http://static.guim.co.uk/favicon.ico" type="image/x-icon" />
+
+    <meta name="application-name" content="The Guardian"/>
+    <meta name="msapplication-TileColor" content="#004983"/>
+    <meta name="msapplication-TileImage" content="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/favicons/windows_tile_144_b.png"/>
+
+
+
+
+
+
+    <link rel="shorturl" href="http://gu.com/p/3kft2" />
+
+    <meta name="content-id" content="/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes"/>
+
+    <link rel="publisher" href="https://plus.google.com/113000071431138202574"/>
+
+
+
+
+
+    <meta name="twitter:card" content="summary">
+
+    <meta name="twitter:site" content="@guardian">
+
+
+    <meta name="twitter:app:name:iphone" content="The Guardian">
+    <meta name="twitter:app:id:iphone" content="409128287">
+
+    <meta name="twitter:app:name:googleplay" content="The Guardian">
+    <meta name="twitter:app:id:googleplay" content="com.guardian">
+    <meta name="twitter:app:url:googleplay" content="guardian://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">
+
+
+    <meta name="p:domain_verify" content="4f4576e6bac27d86fd926c4579b97f23"/>
+    <meta name="pocket-site-verification" content="be6d97bc1f6961ce6348e7ced4f1f4" />
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/content-wide.css" media="all" />
+
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/zones/life-and-style/styles/zone-accent.css" media="screen" class="contrast" />
+
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/base-typography.css" media="screen" />
+
+
+
+
+    <!--[if ie 7]>
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/ie7.css" media="screen" class="ie" />
+    <![endif]-->
+
+    <!--[if ie 8]>
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/ie8.css" media="screen" class="ie" />
+    <![endif]-->
+
+    <!--[if lte IE 6]>
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/ie-scratch.css" media="screen" class="ie" />
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/zones/life-and-style/styles/zone-navigation-ie.css" media="screen" class="contrast" />
+    <![endif]-->
+
+    <!--[if lte IE 9]>
+    <script src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/external-scripts/html5enable.js"></script>
+    <![endif]-->
+
+    <link rel="stylesheet" type="text/css" href="http://combo.guim.co.uk/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/badge+common/styles/content-actions+common/styles/header-local-info+common/styles/page-toolbox+common/styles/series-component+common/styles/sprites+common/styles/tag-badging+common/styles/top-navigation.css" />
+
+
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/shame.css"/>
+
+
+</head>
+
+<body class="interactive content-wide">
+
+
+
+
+
+<script type="text/javascript">
+    //<![CDATA[
+    if (!commonStaticRoot) {
+        var commonStaticRoot = "http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/";
+    }
+    if (!sectionStaticRoot) {
+        var sectionStaticRoot = "http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/lifeandstyle/";
+    }
+    if (!staticHost) {
+        var staticHost="http://www.guardian.co.uk/";
+    }
+    if (!sitePrefixUrl) {
+        var sitePrefixUrl = "http://www.theguardian.com";
+    }
+    if(!discussionApiUrl) {
+        var discussionApiUrl = "http://discussion.guardianapis.com";
+    }
+
+    //]]>
+</script>
+
+<script>
+
+    var guardian = {
+        r2: {
+            comScoreVideoEnabled: true,
+            dfpEnabled: true,
+            liveEnvironment: true
+        },
+        page: {
+            contentId: '/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes',
+            type: 'interactive',
+            contentTypes : 'interactive',
+            livePage:  false ,
+            section: 'lifeandstyle',
+            sectionName: 'Life and style',
+            zone: 'life-and-style',
+            edition: 'UK',
+            productionOffice: 'US',
+            showAdverts: false,
+            showRelated:  true ,
+            showCommercialRelated: true,
+            contributorIds: [					'profile/nadja-popovich' ,									'profile/ruth-spencer' ,									'profile/greg-chen' 				 ],
+            contributors: [                     'Nadja Popovich' ,                                    'Ruth Spencer' ,                                    'Greg Chen'                  ],
+            keywordIds: [                     'lifeandstyle/thanksgiving' ,                                    'lifeandstyle/lifeandstyle' ,                                    'lifeandstyle/food-and-drink'                  ],
+            keywords: [                     'Thanksgiving' ,                                    'Life and style' ,                                    'Food & drink'                  ],
+            series: [  ],
+            seriesId: [  ]
+
+        },
+        user: {
+            edition: 'uk'
+        },
+        capabilities: {
+            localStorage: (function() {
+                try {
+                    localStorage.setItem("gdn-test", "test-item");
+                    localStorage.removeItem("gdn-test");
+                    return true;
+                } catch (e) {
+                    return false;
+                }
+            })()
+        },
+        keys: {}
+    };
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+<script type='text/javascript'>
+    // Chartbeat timing variable
+    var _sf_startpt=(new Date()).getTime();
+</script>
+
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="http://pasteup.guim.co.uk/js/lib/jquery/1.8.1/jquery.min.js">\x3C/script>')</script>
+<script src="http://pasteup.guim.co.uk/js/lib/jquery.cookie/1.2/jquery.cookie.min.js"></script>
+<script src="http://pasteup.guim.co.uk/js/lib/jquery.writecapture/1.0.5/jquery.writecapture.min.js"></script>
+
+<script>
+    var jQ = jQuery.noConflict();
+    jQ.ajaxSetup({ cache: true });
+</script>
+
+
+<script>
+    var getCookieValue = function (cookieName) {
+        var regexp = new RegExp(cookieName + "=([^;]*)")
+        var cookieMatch = document.cookie.match(regexp);
+        if (cookieMatch && cookieMatch.length > 1) {
+            return unescape(cookieMatch[1]);
+        }
+        return "";
+    }
+
+    var revSciString = (function() {
+        var hasStorage = (function() {
+            try {
+                localStorage.setItem("xxx_localstorage_test", "xxx_localstorage_test");
+                localStorage.removeItem("xxx_localstorage_test");
+                return true;
+            } catch(e) {
+                return false;
+            }
+        }());
+
+        if (hasStorage && true && localStorage.getItem('rsi_segs_csv')) {
+            return localStorage.getItem('rsi_segs_csv');
+        } else {
+            return getCookieValue("rsi_segs_csv");
+        }
+    }());
+    OAS_listpos = '';
+
+    OAS_query = 'k=lifeandstyle&k=thanksgiving&k=food-and-drink&cf=food+and+drink&pid=&ct=interactive&pt=interactive&';
+
+    // hold references to all videos on page
+    var jwVideoPlayers = [];
+</script>
+
+<script type='text/javascript'> function crtg_getCookie(a){var b,c,d,e=document.cookie.split(";");for(b=0;b<e.length;b++){c=e[b].substr(0,e[b].indexOf("="));d=e[b].substr(e[b].indexOf("=")+1);c=c.replace(/^\s+|\s+$/g,"");if(c==a){return unescape(d)}}return""}var crtg_nid="1476";var crtg_cookiename="cto2_guardian";var crtg_content=crtg_getCookie(crtg_cookiename);var crtg_rnd=Math.floor(Math.random()*99999999999);var crtg_url="http://rtax.criteo.com/delivery/rta/rta.js?netid="+escape(crtg_nid);crtg_url+="&cookieName="+escape(crtg_cookiename);crtg_url+="&rnd="+crtg_rnd;crtg_url+="&varName=crtg_content";var crtg_script=document.createElement("script");crtg_script.type="text/javascript";crtg_script.src=crtg_url;crtg_script.async=true;if(document.getElementsByTagName("head").length>0)document.getElementsByTagName("head")[0].appendChild(crtg_script);else if(document.getElementsByTagName("body").length>0)document.getElementsByTagName("body")[0].appendChild(crtg_script)</script>
+
+<script type='text/javascript'>
+    var gptadslots = [];
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    (function () {
+        var gads = document.createElement('script');
+        gads.async = true;
+        gads.type = 'text/javascript';
+        var useSSL = 'https:' == document.location.protocol;
+        gads.src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';
+        var node = document.getElementsByTagName('script')[0];
+        node.parentNode.insertBefore(gads, node);
+    })();
+</script>
+<script type="text/javascript">
+    var targetSegments = function(segmentsString) {
+        var targetingVars = {};
+        jQ(segmentsString.split("&")).each(function (idx, segment) {
+            var kv = segment.split("=");
+            if (typeof kv[1] !== 'undefined') {
+                if (kv[0] in targetingVars) {
+                    targetingVars[kv[0]].push(kv[1]);
+                } else {
+                    targetingVars[kv[0]] = [kv[1]];
+                }
+            }
+        });
+        for(v in targetingVars) {
+            googletag.cmd.push(function () {
+                googletag.pubads().setTargeting(v, targetingVars[v]);
+            });
+        }
+    }
+
+    googletag.cmd.push(function () {
+        googletag.pubads().enableSingleRequest();
+        googletag.pubads().enableAsyncRendering();
+        googletag.pubads().collapseEmptyDivs();
+
+        targetSegments("k=lifeandstyle&k=thanksgiving&k=food-and-drink&cf=food+and+drink&pid=&ct=interactive&pt=interactive&");
+
+        googletag.pubads().setTargeting("url", "/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes".replace(/\+/g, '-'));
+        googletag.pubads().setTargeting("edition", "uk");
+        googletag.pubads().setTargeting("p", "r2");
+
+        targetSegments(crtg_content);
+
+
+
+
+
+
+
+
+
+
+
+
+
+        var adtest = getCookieValue("adtest");
+        if (adtest.length > 0) {
+            googletag.pubads().setTargeting("at", adtest);
+        }
+
+        googletag.pubads().addEventListener('slotRenderEnded', function (event) {
+            var divId = event.slot.getSlotId().getDomId();
+            if (divId === "dfp-top" && !event.isEmpty) {
+                var width = event.size[0];
+                if (width === 970) {
+                    document.getElementById("dfp-top").style.marginLeft = "-15px";
+                }
+            } else if (divId === "dfp-merch1") {
+                var merchIframe = document.getElementById(divId).getElementsByTagName('iframe')[0];
+                var slotJson = merchIframe.contentWindow.TopRightJSON;
+                showNFMerchandisingTopRight(slotJson);
+                jQ(merchIframe).remove();
+            } else if (divId === "dfp-merch2") {
+                var merchIframe = document.getElementById(divId).getElementsByTagName('iframe')[0];
+                var slotJson = merchIframe.contentWindow.BottomRightJSON;
+                showNFMerchandisingBottomRight(slotJson);
+                jQ(merchIframe).remove();
+            } else if (divId === "dfp-sf") {
+                var sfIframe = document.getElementById(divId).getElementsByTagName('iframe')[0];
+                var slotJson = sfIframe.contentWindow.sponJSON;
+                showSponsoredFeaturex31(slotJson);
+                jQ(sfIframe).remove();
+            }
+        });
+
+        googletag.enableServices();
+    });
+</script>
+
+
+
+
+
+<script src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/scripts/gu-core.js"></script>
+<script>
+    var thirdPartyReferralCookieService = new guardian.r2.ThirdPartyReferralCookieService();
+    thirdPartyReferralCookieService.setThirdPartyReferralCookie();
+
+    var communitiesSite = false;
+
+
+    guardian.r2.resourceRoot = "http://resource.guim.co.uk/";
+    var pageUrl = "http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes";
+
+    var RESOURCE_ROOT = 'http://resource.guim.co.uk/';
+
+</script>
+
+
+<script src="//pasteup.guim.co.uk/js/lib/requirejs/2.1.5/require.min.js"
+        data-main="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/scripts/main.js"
+        data-modules="gu/author-twitter-handles"
+        data-callback=""
+        id="require-js"></script>
+
+
+<script type="text/javascript">
+    //<![CDATA[
+    function insertStyleSheet(href) {
+        var styleObject = document.createElement('link');
+        styleObject.setAttribute('href', commonStaticRoot + href);
+        styleObject.setAttribute('type', 'text/css');
+        styleObject.setAttribute('media', 'screen');
+        styleObject.setAttribute('rel', 'stylesheet');
+        var head = document.getElementsByTagName('head')[0];
+        head.appendChild(styleObject);
+    }
+    insertStyleSheet('styles/js-on.css');
+    insertPluckStylesheet = true;
+    //]]>
+</script>
+<script type="text/javascript" src="http://combo.guim.co.uk/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/scripts/button-facebook+common/scripts/button-google-plus+common/scripts/button-linkedin+common/scripts/button-tweet+common/scripts/formChecker+common/scripts/guardian.geolocation+common/scripts/guardian.r2.EmailToAFriend+common/scripts/guardian.r2.OmnitureTracking+common/scripts/guardian.r2.ShareThis+common/scripts/mediamath-tag+common/scripts/sendtoafriend.js"></script>
+
+
+<script type='text/javascript'>
+    ensurePackage('guardian.r2.omniture');
+    guardian.r2.omniture.isAvailable = function(){
+        return true;
+    }
+</script>
+
+
+
+<div id="wrapper">
+
+
+
+    <div id="header">
+
+        <div id="sub-header">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+            <div class="top-navigation twelve-col top-navigation-js">
+                <div class="user-functions">
+                    <div id="video-settings">
+                        <div class="cookied">
+                            <p class="on"><a class="autoplay-off" href="#skiplinks">Turn autoplay off</a></p>
+                            <p class="off"><a class="autoplay-on" href="#skiplinks">Turn autoplay on</a></p>
+                        </div>
+                        <div class="not-cookied">
+                            <p>Please activate cookies in order to turn autoplay off</p>
+                        </div>
+                    </div>
+
+                    <div id="skiplinks">
+                        <ul>
+                            <li><a href="#box" accesskey="s">Jump to content [s]</a></li>
+                            <li><a href="#global-nav" accesskey="0">Jump to site navigation [0]</a></li>
+                            <li><a href="#searchbeta" accesskey="4">Jump to search [4]</a></li>
+                            <li><a href="http://www.theguardian.com/help/terms-of-service" accesskey="8">Terms and conditions [8]</a></li>
+                        </ul>
+                    </div>
+
+
+
+
+
+
+
+
+
+
+
+
+                    <div id="edition-selector">
+
+                        <div id="drop-down-edition" class="change-to-us" tabindex="20">
+                            <h2>Edition:</h2>
+                            <span class="UK current-edition">UK</span>
+                            <span class="US"><a href="http://www.theguardian.com/edition-permission/us">US</a></span>
+                            <span class="AU"><a href="http://www.theguardian.com/edition-permission/au">AU</a></span>
+                        </div>
+
+                    </div>
+
+
+                    <div class="user-details">
+                        <div class="drop-down id-profile-links initially-off">
+                            <h2 class="id-populate-with-display-name"></h2>
+                            <ul>
+                                <li><a href="https://id.theguardian.com/profile/?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Your activity</a></li>
+                                <li><a href="https://id.theguardian.com/email/list?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Email subscriptions</a></li>
+                                <li><a href="https://id.theguardian.com/dashboard?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Account details</a></li>
+                                <li><a href="https://id.theguardian.com/linked-services?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Linked services</a></li>
+                                <li><a href="https://id.theguardian.com/signout?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Sign out</a></li>
+                            </ul>
+                        </div>
+
+                        <noscript>
+                            <span><a href="https://id.theguardian.com/dashboard?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Profile</a></span>
+                        </noscript>
+
+                        <span class='id-sign-in-top-nav initially-off'><a></a></span>
+                        <span class="trackable-component" style="background-color:#4bc6df" data-component="ngw-optin"><a href="/preference/platform/mobile?page=http%3A%2F%2Fwww.theguardian.com%3Fview%3Dmobile%23opt-in-message" style="color:white" class="switch-to-mobile" data-link-name="Switch to beta" rel="nofollow">Beta</a></span>
+
+                    </div>
+                    <div id="drop-down-1" class="drop-down" tabindex="21">
+                        <h2>
+
+                            About us
+                        </h2>
+                        <ul>
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/info"  class="link-text">About us,</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/help/contact-us"  class="link-text">Contact us</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/gnm-press-office"  class="link-text">Press office</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/gpc"  class="link-text">Guardian Print Centre</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/theguardian/page/readerseditor"  class="link-text">Guardian readers' editor</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/observer-readers-editor"  class="link-text">Observer readers' editor</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/help/terms-of-service"  class="link-text">Terms of service</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/help/privacy-policy"  class="link-text">Privacy policy</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/advertising"  class="link-text">Advertising guide</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/archive"  class="link-text">Digital archive</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://guardian.newspaperdirect.com/epaper/viewer.aspx"  class="link-text">Digital edition</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/weekly"  class="link-text">Guardian Weekly</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://3276.e-printphoto.co.uk/guardian"  class="link-text">Buy Guardian and Observer photos</a>
+                            </li>
+
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="other-functions">
+                    <div id="drop-down-2" class="drop-down mirror" tabindex="22">
+                        <h2>
+
+                            Today's paper
+                        </h2>
+                        <ul>
+
+
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/theguardian"  class="link-text">Main section</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/theguardian/g2"  class="link-text">G2 features</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/theguardian/mainsection/commentanddebate"  class="link-text">Comment and debate</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/theguardian/mainsection/editorialsandreply"  class="link-text">Editorials, letters and corrections</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/tone/obituaries"  class="link-text">Obituaries</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/theguardian/series/otherlives"  class="link-text">Other lives</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/uk/sport"  class="link-text">Sport</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://www.theguardian.com/theguardian/mainsection/society"  class="link-text">SocietyGuardian</a>
+                            </li>
+
+
+
+
+
+
+
+
+
+                            <li>
+
+                                <a href="http://subscribe.theguardian.com/?INTCMP=R2_SIDEBAR_UK_GU_SUBSCRIBE"  class="link-text">Subscribe</a>
+                            </li>
+
+                        </ul>
+                    </div>
+                    <div id="drop-down-3" class="drop-down-single mirror" tabindex="23">
+                        <h2>
+
+                            <a href="http://subscribe.theguardian.com/?INTCMP=R2_TOPNAV_UK_GU_SUBSCRIBE"  class="link-text">Subscribe</a>
+                        </h2>
+                    </div>
+                </div>
+
+            </div>
+
+
+
+
+
+
+
+
+
+
+
+
+            <!-- Beginning Sync AdSlot -->
+            <script type="text/javascript">
+                var topSlot;
+                var dfpAdUnit = "/59666047/theguardian.com/lifeandstyle/interactive/r2";
+                var sectionName = "Life and style";
+                googletag.cmd.push(function () {
+                    // Ad slot declaration
+                    topSlot = googletag.defineSlot('/59666047/theguardian.com/lifeandstyle/interactive/r2', [[728,90],[900,90],[940,230],[900,250],[970,250],[940,300]], 'dfp-top')
+                        .setTargeting('slot', ['top'])
+                        .addService(googletag.pubads());
+                });
+            </script>
+            <div id='dfp-top' style='text-align:center'>
+                <script type='text/javascript'>
+                    googletag.cmd.push(function() {
+                        googletag.display('dfp-top');
+                    });
+                </script>
+            </div>
+            <!-- End AdSlot -->
+
+
+        </div>
+
+
+
+
+        <div id="guardian-logo" class="trackable-component"         	        data-component="Interactive:guardian logo">
+            <a href="http://www.theguardian.com/uk"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/logos/the-guardian/life-and-style.gif" width="115" height="22" alt="The Guardian home" /></a>
+        </div>
+
+
+
+
+
+        <div class="top-search-box">
+            <div class="gcse-search">
+                <form action="http://www.google.com/search" class="placeholder-search-box">
+                    <input type="hidden" name="as_sitesearch" value="theguardian.com"/>
+                    <input type="text" id="searchbox" name="q" placeholder="Your search terms" />
+                    <input id="search-button" type="submit" value="Search" />
+                </form>
+            </div>
+        </div>
+
+        <div id="zones-nav">
+
+
+            <div id="global-nav" class="trackable-component"         	        data-component="Interactive:global nav">
+                <ul>
+
+                    <li class="first news">
+                        <a href="http://www.theguardian.com/uk" data-link-name="1:Home">Home</a>
+                    </li>
+
+                    <li class="news">
+                        <a href="http://www.theguardian.com/uk-news" data-link-name="2:UK">UK</a>
+                    </li>
+
+                    <li class="news">
+                        <a href="http://www.theguardian.com/world" data-link-name="3:World">World</a>
+                    </li>
+
+                    <li class="sport">
+                        <a href="http://www.theguardian.com/uk/sport" data-link-name="4:Sport">Sport</a>
+                    </li>
+
+                    <li class="sport">
+                        <a href="http://www.theguardian.com/football" data-link-name="5:Football">Football</a>
+                    </li>
+
+                    <li class="comment">
+                        <a href="http://www.theguardian.com/commentisfree" data-link-name="6:Opinion">Opinion</a>
+                    </li>
+
+                    <li class="culture">
+                        <a href="http://www.theguardian.com/uk/culture" data-link-name="7:Culture">Culture</a>
+                    </li>
+
+                    <li class="business">
+                        <a href="http://www.theguardian.com/uk/business" data-link-name="8:Economy">Economy</a>
+                    </li>
+
+                    <li class="life-and-style">
+                        <a href="http://www.theguardian.com/uk/lifeandstyle" data-link-name="9:Lifestyle">Lifestyle</a>
+                    </li>
+
+                    <li class="life-and-style">
+                        <a href="http://www.theguardian.com/fashion" data-link-name="10:Fashion">Fashion</a>
+                    </li>
+
+                    <li class="environment">
+                        <a href="http://www.theguardian.com/uk/environment" data-link-name="11:Environment">Environment</a>
+                    </li>
+
+                    <li class="news">
+                        <a href="http://www.theguardian.com/uk/technology" data-link-name="12:Tech">Tech</a>
+                    </li>
+
+                    <li class="travel">
+                        <a href="http://www.theguardian.com/travel" data-link-name="13:Travel">Travel</a>
+                    </li>
+
+                    <li class="last money">
+                        <a href="http://www.theguardian.com/money" data-link-name="14:Money">Money</a>
+                    </li>
+                </ul>
+            </div>
+
+
+
+
+
+
+
+
+            <div class="trackable-component crumb-wrapper"         	        data-component="Interactive:crumb nav" xmlns:v="http://rdf.data-vocabulary.org/#">
+
+                <ul class="crumb-nav">
+                    <li id="crumb1">
+                    <span typeof="v:Breadcrumb">
+                        <a rel="v:url" property="v:title" href="http://www.theguardian.com/lifeandstyle" data-link-name="Life & style">Life & style</a>
+                    </span>
+                    </li>
+                    <li id="crumb2">
+                    <span typeof="v:Breadcrumb">
+                        <a rel="v:url" property="v:title" href="http://www.theguardian.com/lifeandstyle/thanksgiving" data-link-name="Thanksgiving">Thanksgiving</a>
+                    </span>
+                    </li>
+                </ul>
+
+
+            </div>
+
+        </div>
+
+
+
+
+
+
+
+
+
+
+
+
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <div id="box">
+        <div id="content">
+
+
+
+
+
+
+
+
+
+
+            <div id="article-header">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                <div id="main-article-info">
+
+
+
+                    <h1 itemprop="name headline  "
+                        >Thanksgiving recipe swap</h1>
+
+                    <div itemprop="description" id="stand-first"
+                         class="stand-first-alone"                        	        data-component="Interactive:standfirst_cta"			>We asked 12 food bloggers to rethink the traditional Thanksgiving meal – and they each swapped an established dish in favor of something from their own cultural background. Mix and match from the recipes below to bring something new to your table this year or contribute your own idea <a href="http://www.theguardian.com/lifeandstyle/2013/nov/20/thanksgiving-recipes-what-would-you-add">here</a></div>
+
+
+                </div>
+
+                <ul id="content-actions" class="share-links trackable-component"         	        data-component="Interactive:top share tools">
+
+
+
+
+
+
+
+
+
+
+
+
+
+                    <li class="full-line facebook">
+        <span class="facebook-share">
+            <a class="facebook-share-btn" href="https://www.facebook.com/sharer/sharer.php?u=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" data-href="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" data-link-name="Facebook Share Top">
+                <span class="facebook-share-icon"></span>
+                <span class="facebook-share-label">Share</span>
+            </a>
+        </span>
+                    </li>
+
+                    <li class="full-line" data-link-name="Twitter Top">
+                        <a href="http://twitter.com/share" class="twitter-share-button" data-url="http://gu.com/p/3kft2/tw" data-via="guardian" data-counturl="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" data-related="lifeandstyle" data-text="Thanksgiving recipe swap">Tweet this</a>
+                    </li>
+
+                    <li class="full-line google-plus" data-link-name="Google plus Top" >
+
+
+                        <div class="g-plusone" data-size="medium" data-callback="trackGPlusTop"></div>
+
+                    </li>
+
+
+                    <li class="full-line linked-in" data-link-name="LinkedIn Top">
+                        <script type="IN/Share" data-counter="right" data-showzero="true"></script>
+                    </li>
+
+                    <li class="full-line email" data-link-name="email this story Top">
+                        <a class="rollover send-email" href="#"  title="Send to a friend" ><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/icon-email.png" alt="" class="trail-icon" />Email</a>
+                    </li>
+
+
+
+
+                </ul>
+
+            </div>
+
+
+            <div id="content-info">
+
+
+
+
+
+
+
+                <ul class="article-attributes trackable-component b4"         	        data-component="Interactive:byline">
+                    <li class="byline">
+                        <div class="contributor-full">
+
+                            <span itemscope itemprop="author" itemtype="http://schema.org/Person"><span itemprop="name"><a class="contributor" rel="author" itemprop="url" href="http://www.theguardian.com/profile/greg-chen">Greg Chen</a></span></span>, <span itemscope itemprop="author" itemtype="http://schema.org/Person"><span itemprop="name"><a class="contributor" rel="author" itemprop="url" href="http://www.theguardian.com/profile/nadja-popovich">Nadja Popovich</a></span></span> and <span itemscope itemprop="author" itemtype="http://schema.org/Person"><span itemprop="name"><a class="contributor" rel="author" itemprop="url" href="http://www.theguardian.com/profile/ruth-spencer">Ruth Spencer</a></span></span>	</div>
+                    </li>
+                    <li class="article-attributes-social-buttons">
+                        <span class="social-buttons-twitter-contributor trackable-component" data-component="Twitter Follow Journalist"></span>
+                        <span class="social-buttons-twitter-brand trackable-component" data-component="Twitter Follow Brand"></span>
+                    </li>
+
+
+
+                    <li class="publication">
+                        <a itemprop="publisher" href="http://www.theguardian.com/" >theguardian.com</a>,
+                        <time itemprop="datePublished" datetime="2013-11-20T15:40GMT" pubdate>Wednesday 20 November 2013 15.40 GMT</time>
+                    </li>
+
+
+
+                </ul>
+
+
+
+
+
+
+
+
+                <ul id="article-toolbox-side" class="b4 trackable-component left"         	        data-component="Interactive:RHS icon tools">
+
+
+
+                    <li data-link-name="icon-share"><a class="rollover send-share relative-position"   href="http://www.theguardian.com/share/1999406" title="Opens a share this page in a new window" ><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/icon-share.png" alt="" class="trail-icon" /><span>Share</span></a></li>
+
+                    <li data-link-name="icon-contact"><a href="http://www.theguardian.com/contactus/1999406"  class="rollover contact-link relative-position" title="Displays contact data for guardian.co.uk"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/icon-email-us.png" alt="" class="trail-icon" /><span>Contact us</span></a></li>
+
+
+
+
+                </ul>
+
+
+
+                <div class="toolbox-popup trackable-component" id="send-email-box"         	        data-component="Interactive:send email box">
+                    <div class="send-inner">
+                        <div class="share-top">
+                            <h3>Send to a friend</h3>
+                            <span class="js-show"><a class="close-toolbox" href="#send-email"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/close-popup.png" alt="Close this popup" title="Close this popup" /></a></span>
+                        </div>
+                        <div>
+
+                            <form method="post" name="emailthis" id="emailthis" >
+                                <fieldset>
+                                    <div><label for="from">Sender&#39;s name</label></div>
+                                    <input type="text" id="from" name="from" maxlength="50" />
+                                </fieldset>
+                                <fieldset>
+                                    <div><label for="to">Recipient's email address</label></div>
+                                    <input type="text" id="to" name="to" maxlength="50" value="" />
+                                </fieldset>
+                                <div class="inputrow">
+                                    <input type="submit" class="share-this-tracking" data-link-name="Email"  value="Send" />
+                                </div>
+                                <p class="ip_logged">Your IP address will be logged</p>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+
+
+
+
+
+                <div class="toolbox-popup trackable-component" id="send-share-box"         	        data-component="Interactive:share box">
+                    <div class="send-inner">
+                        <div class="share-top">
+                            <h3>Share</h3>
+                            <span class="js-show"><a class="close-toolbox" href="#send-share-box"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/close-popup.png" alt="Close this popup" title="Close this popup" /></a></span>
+                        </div>
+
+                        <div class="shortlink">
+                            Short link for this page:
+                            <a rel="shortlink nofollow" href="http://gu.com/p/3kft2">http://gu.com/p/3kft2</a>
+                        </div>
+                        <ul class="share-this-tracking">
+                            <li>
+                                <a data-link-name="Stumbleupon"
+                                   name="lid={share}{stumbleupon}"
+                                   href="http://www.stumbleupon.com/submit?url=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;title=Thanksgiving+recipe+swap">
+                                    <span class="spr-16 stumbleupon"></span>StumbleUpon
+                                </a>
+                            </li>
+                            <li>
+                                <a data-link-name="Reddit"
+                                   name="lid={share}{reddit}"
+                                   href="http://reddit.com/submit?url=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;title=Thanksgiving+recipe+swap">
+                                    <span class="spr-16 reddit"></span>reddit
+                                </a>
+                            </li>
+                            <li>
+                                <a data-link-name="Tumblr"
+                                   name="lid={share}{Tumblr}"
+                                   href="http://www.tumblr.com/share?v=3&amp;u=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;t=Thanksgiving+recipe+swap" title="Share on Tumblr">
+                                    <span class="spr-16 tumblr"></span>Tumblr
+                                </a>
+                            </li>
+                            <li>
+                                <a data-link-name="Digg"
+                                   name="lid={share}{Digg}"
+                                   href="http://digg.com/submit?phase=2&amp;url=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;title=Thanksgiving+recipe+swap">
+                                    <span class="spr-16 digg"></span>Digg
+                                </a>
+                            </li>
+                            <li>
+                                <a data-link-name="LinkedIn"
+                                   name="lid={share}{LinkedIn}"
+                                   href="http://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;title=Thanksgiving+recipe+swap&amp;source=The%20Guardian">
+                                    <span class="spr-16 linkedin"></span>LinkedIn
+                                </a>
+                            </li>
+                            <li>
+                                <a data-link-name="del.icio.us"
+                                   name="lid={share}{del.icio.us}"
+                                   href="http://del.icio.us/post?url=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;title=Thanksgiving+recipe+swap">
+                                    <span class="spr-16 delicious"></span>del.icio.us
+                                </a>
+                            </li>
+                            <li>
+                                <a data-link-name="Facebook"
+                                   name="lid={share}{Facebook}"
+                                   href="http://www.facebook.com/sharer.php?u=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes">
+                                    <span class="spr-16 facebook"></span>Facebook
+                                </a>
+                            </li>
+                            <li>
+                                <a data-link-name="Twitter"
+                                   name="lid={share}{Twitter}"
+                                   href="http://twitter.com/home?status=Thanksgiving recipe swap - http%3A%2F%2Fgu.com%2Fp%2F3kft2%2Ftw">
+                                    <span class="spr-16 twitter"></span>Twitter
+                                </a>
+                            </li>
+                        </ul>
+                        <div class="clear"></div>
+                    </div>
+                </div>
+
+
+                <div class="toolbox-popup" id="contact-link-box">
+                    <div class="send-inner">
+                        <div class="share-top">
+                            <h3>Contact us</h3>
+                            <span class="js-show"><a class="close-toolbox" href="#contact"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/close-popup.png" alt="Close this popup" title="Close this popup" /></a></span>
+                        </div>
+
+                        <div class="col first">
+                            <ul>
+                                <li>
+
+
+                                    Contact Life &amp; Style editor<br><a href="mailto:lifeandstyle@theguardian.com">lifeandstyle@<br>theguardian.com</a>
+                                </li>
+                                <li>
+                                    Report errors or inaccuracies: <a href="mailto:userhelp@theguardian.com">userhelp@theguardian.com</a>
+                                </li>
+                                <li>
+                                    Letters for publication should be sent to: <a href="mailto:guardian.letters@theguardian.com">guardian.letters@theguardian.com</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="col">
+                            <ul>
+                                <li>
+                                    If you need help using the site: <a href="mailto:userhelp@theguardian.com">userhelp@theguardian.com</a>
+                                </li>
+                                <li>
+                                    Call the main Guardian and Observer switchboard: <br /><span>+44 (0)20 3353 2000</span>
+                                </li>
+                                <li>
+                                    <ul>
+                                        <li>
+                                            <a href="http://adinfo-guardian.co.uk/">Advertising guide</a>
+                                        </li>
+                                        <li>
+                                            <a href="http://www.theguardian.com/syndication/">License/buy our content</a>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+
+
+            </div>
+
+
+            <div id="interactive-content">
+                <div id="interactive" class="flash">
+
+
+                    <style type="text/css">
+                        #gia-header div,
+                        #gia-header h1,
+                        #gia-header p,
+                        #gia-header ul,
+                        #gia-header li {
+                            margin: 0;
+                            padding: 0;
+                            border: 0;
+                            font-size: 100%;
+                            font: inherit;
+                            vertical-align: baseline;
+                        }
+
+                        #article-header {
+                            display: none;
+                        }
+
+                        #gia-header {
+                            width: 780px;
+                            margin: 0 auto 30px auto;
+                        }
+
+                        #gia-header .clearfix {
+                            content: ".";
+                            display: block;
+                            clear: both;
+                            visibility: hidden;
+                            line-height: 0;
+                            height: 0;
+                        }
+
+                        #gia-header #social-tools-container {
+                            display: block;
+                            width: 420px;
+                            min-height: 20px;
+                            margin: 0 auto;
+                            padding-top: 20px;
+                        }
+
+                        #gia-header #social-tools-container ul#content-actions {
+                            float: none;
+                            width: 420px;
+                        }
+
+                        #gia-header #social-tools-container ul#content-actions li {
+                            display: block;
+                            float: left;
+                            width: 100px;
+                            margin: 0 20px;
+                        }
+
+                        #gia-header h1 {
+                            margin-top: 14px;
+                            margin-bottom: 12px;
+                            font-family: Georgia, Times, serif;
+                            font-size: 48px;
+                            line-height: 1.1em;
+                            text-align: center;
+                        }
+
+                        #gia-header p {
+                            font-size: 15px;
+                            font-family: Arial, sans-serif;
+                            line-height: 1.5em;
+                            text-align: center;
+                        }
+
+                        #gia-header #turkey-swap{
+                            width:120px;
+                            height:120px;
+                            margin: 0 auto;
+                            background-image: url("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/31/1420054656404/turkeygif.gif");
+                        }
+                    </style>
+
+                    <div id="gia-header">
+                        <div id="social-tools-container">
+                            <!--this is where your social buttons will show up-->
+                        </div>
+                        <div id="turkey-swap">
+                        </div>
+                        <!--this is where the turkey gif will go-->
+                        <div id="gia-standin">
+                            <!--this is where your headline and chatter will show up-->
+                        </div>
+                    </div>
+
+                    <script type="text/javascript">
+                        (function($) {
+                            var moveSocial = function() {
+                                var $contentActions = $('#content-actions');
+
+                                $contentActions.appendTo('#social-tools-container');
+                                $('.google-plus', $contentActions).remove();
+                                $('.linked-in', $contentActions).remove();
+                            }
+
+                            var moveHeaders = function() {
+                                $('#gia-standin').append( $('#main-article-info h1') );
+                                $('#gia-standin').append( '<p>' +  $('#main-article-info #stand-first').html() + '</p>' );
+                            }
+
+                            moveSocial();
+                            moveHeaders();
+                        })(jQuery);
+                    </script>
+
+                    <script src='http://pasteup.guim.co.uk/js/lib/jquery/1.8.1/jquery.min.js' type='text/javascript'></script>
+                    <script type='text/javascript'>
+                        var recipes =[
+                            {
+                                'recipe-no': 0,
+                                'hed': 'Sichuan dry-fried green beans',
+                                'sub': 'Diana Kuan adds extra crunch to a Thanksgiving staple',
+                                'auth': 'Diana Kuan',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-sichuan-green-beans-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/20/1384977174760/pic01.jpg'
+                            },
+                            {
+                                'recipe-no': 1,
+                                'hed': 'Gratin dauphinoise with sweet potato and pink turnips',
+                                'sub': 'B&#233;eatrice Peltre gives potatoes some seasonal color',
+                                'auth': 'B&#233;eatrice Peltre',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-gratin-dauphinoise-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815350741/Gratin-dauphinoise-001.jpg'
+                            },
+                            {
+                                'recipe-no': 2,
+                                'hed': 'Leeks in olive oil',
+                                'sub': 'Maureen Abood brightens the palate with this light-but-flavorful dish',
+                                'auth': 'Maureen Abood',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-leeks-in-olive-oil-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815382837/Leeks-in-olive-oil-001.jpg'
+                            },
+                            {
+                                'recipe-no': 3,
+                                'hed': 'Cellophane noodles with crab <br/>(Mi&#7871;n x&#224;o cua)',
+                                'sub': 'Andrea Nguyen dumps the mashers for a big bowl of noodles',
+                                'auth': 'Andrea Nguyen',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-crab-cellophane-noodles-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815403765/Crab-glass-noodles-001.jpg'
+                            },
+                            {
+                                'recipe-no': 4,
+                                'hed': 'Masala roasted chicken <br/>(Murg Musallam)',
+                                'sub': 'Prerna Singh puts the turkey to rest',
+                                'auth': 'Prerna Singh',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-murg-musallam-chicken-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815745497/Murgh-Musallam-001.jpg'
+                            },
+                            {
+                                'recipe-no': 5,
+                                'hed': 'Sweet potato latkes with celeriac root and apple',
+                                'sub': 'Joan Nathan brings a taste of Hanukkah to Thanksgiving',
+                                'auth': 'Joan Nathan',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-sweet-potato-latke-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815784817/Swet-potato-latkes-001.jpg'
+                            },
+                            {
+                                'recipe-no': 6,
+                                'hed': 'Persian stuffed eggplant',
+                                'sub': 'Azita Mehran reinvents the meaning of "stuffing"',
+                                'auth': 'Azita Mehran',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-persian-stuffed-eggplant-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815840844/Bademjan-Shekam-por-001.jpg'
+                            },
+                            {
+                                'recipe-no': 7,
+                                'hed': 'Roasted butternut squash with Asian tahini',
+                                'sub': 'Einat Admony swaps out "much too sweet" sweet potato casserole',
+                                'auth': 'Einat Admony',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-roasted-squash-asian-tahini-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815886441/Squash-with-tahini-001.jpg'
+                            },
+                            {
+                                'recipe-no': 8,
+                                'hed': 'West African jollof rice',
+                                'sub': 'Shakirat Adeyemi packs a lot of flavor into a simple side',
+                                'auth': 'Shakirat Adeyemi',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-jollof-rice-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815912870/Jollof-rice-001.jpg'
+                            },
+                            {
+                                'recipe-no': 9,
+                                'hed': 'Thai steamed pumpkin custard',
+                                'sub': 'Leela Punyaratabandhu deconstructs dessert',
+                                'auth': 'Leela Punyaratabandhu',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-thai-pumpkin-custard-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815941806/Pumpkin-custard-001.jpg'
+                            },
+                            {
+                                'recipe-no': 10,
+                                'hed': 'Hungarian sour cherry strudel',
+                                'sub': 'Kathy Goldman redefines the phrase "easy as pie"',
+                                'auth': 'Kathy Goldman',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-sour-cherry-strudel-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815967008/Sour-cherry-strudel-001.jpg'
+                            },
+                            {
+                                'recipe-no': 11,
+                                'hed': 'Dulce de leche cheesecake brownies',
+                                'sub': 'Luciana Davidzon adds a sweet Argentinian twist to her favorite American dessert',
+                                'auth': 'Luciana Davidzon',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-dulce-de-leche-brownies-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384816027578/Dulce-de-leche-brownies-001.jpg'
+                            }
+                        ]
+
+
+                        jQ(document).ready(function () {
+
+                            //create recipe grid
+                            for (var i=0; i<recipes.length; i++){
+
+                                jQ('#recipe-grid').append('<div class="recipe-square"><img src="' + recipes[i]['image'] + '"><div class="recipe-active" url="' + recipes[i]['permalink'] + '"><div class="recipe-screen"></div><div class="recipe-title Guardian-Egyp-Web-Regular">'+ recipes[i]['hed'] + ' </div><div class="recipe-subtitle"><p>'+ recipes[i]['sub'] + ' </p></div><div class="recipe-btn"><img src="http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/16/1384621942753/click_button.png"></div></div> ');
+
+                            }
+
+                            //recipe grid mouseover function
+                            jQ('.recipe-square').mouseover(function(){
+                                jQ(this).find('.recipe-active').css('display','inline-block');
+                            })
+                            jQ('.recipe-square').mouseout(function(){
+                                jQ(this).find('.recipe-active').css('display','none');
+                            })
+
+                            //recipe grid click function
+                            jQ('.recipe-active').click(function(){
+                                window.location = jQ(this).attr("url");
+                                return false; //need this to prevent event bubbling
+                            })
+
+                        });
+
+
+                    </script>
+
+                    <style>
+                        @font-face {
+                            font-family: 'Guardian-Text-Egyp-Web-Reg';
+                            src: url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg.eot');
+                            src: url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg.eot?#iefix') format('embedded-opentype'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg.woff') format('woff'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg.ttf') format('truetype'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg.svg#Guardian-Text-Egyp-Web-Reg') format('svg');
+                            font-weight: normal;
+                            font-style: normal;
+                            font-stretch: normal;
+                        }
+                        @font-face {
+                            font-family: 'Guardian-Text-Egyp-Web-Reg-It';
+                            src: url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg-It.eot');
+                            src: url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg-It.eot?#iefix') format('embedded-opentype'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg-It.woff') format('woff'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg-It.ttf') format('truetype'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg-It.svg#Guardian-Text-Egyp-Web-Reg-It') format('svg');
+                            font-weight: normal;
+                            font-style: italic;
+                            font-stretch: normal;
+                        }
+
+                        .Guardian-Egyp-Web-Regular {
+                            font-family: 'Guardian-Text-Egyp-Web-Reg', monospace;
+                            font-weight: normal;
+                            font-style: normal;
+                        }
+                        .Guardian-Egyp-Web-Regular-It {
+                            font-family: 'Guardian-Text-Egyp-Web-Reg-It', monospace;
+                            font-weight: normal;
+                            font-style: italic;
+                        }
+
+                        body{
+                            margin:0;
+                        }
+
+                        #recipe-grid{
+                            float: left;
+                            display: inline;
+                            width: 940px;
+                            height: 100%;
+                        }
+
+                        .recipe-square{
+                            float: left;
+                            display: inline-block;
+                            position: relative;
+                            width: 312px;
+                            height:312px;
+                            z-index: 2;
+                        }
+
+                        .recipe-square img{
+                            width: 312px;
+                            height:312px;
+                            z-index: 2;
+                        }
+
+                        .recipe-active{
+                            display: none;
+                            position: absolute;
+                            top: 0;
+                            left: 0;
+                            width: 100%;
+                            height: 100%;
+                            cursor: pointer;
+                        }
+                        .recipe-screen{
+                            background: #fff;
+                            float: left;
+                            display: inline-block;
+                            position: absolute;
+                            left:0;
+                            top:0;
+                            opacity: 0.75;
+                            width: 312px;
+                            height: 312px;
+                            z-index: 6;
+                        }
+
+                        .recipe-title{
+                            float: left;
+                            display: inline;
+                            position: absolute;
+                            width: 272px;
+                            height: 100px;
+                            z-index: 10;
+                            padding: 20px 20px 0px 20px;
+                            text-align: center;
+                            font-size: 20pt;
+                            margin-bottom: 10px;
+                            font-weight:bold;
+                            color:#000000;
+                            opacity: 1;
+                        }
+
+                        .recipe-subtitle{
+                            float: left;
+                            display: inline;
+                            position: absolute;
+                            left:0;
+                            top:125px;
+                            width:280px;
+                            height: 150px;
+                            margin: 10px;
+                            z-index: 10;
+                        }
+                        .recipe-subtitle p{
+                            text-align: center;
+                            font-family: Arial;
+                            font-size: 12pt;
+                            margin: 10px 10px;
+                            font-weight:bold;
+                            color:#000000;
+                            opacity: 1;
+                        }
+
+                        .recipe-btn{
+                            float: left;
+                            display: inline;
+                            position: absolute;
+                            left:131px;
+                            bottom:30px;
+                            margin: 0 auto;
+                            z-index: 12;
+                        }
+                        .recipe-btn img{
+                            width: 50px;
+                            height: 50px;
+                            margin-bottom: 10px;
+                        }
+                    </style>
+
+
+                    <div id='recipe-grid'>
+                    </div>
+
+                    <script>
+                        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+                        ga('create', 'UA-33493121-29', 'theguardian.com');
+                        ga('send', 'pageview');
+
+                    </script>
+                </div>
+                <script>
+                    // send the query string to the iFrame
+                    (function() {
+                        var interactive = jQ('#interactive iframe');
+                        if (interactive.length > 0) {
+                            var qs = window.location.search;
+                            interactive[0].src = interactive[0].src + qs;
+                        }
+                    })();
+                </script>
+            </div>
+        </div>
+
+        <div id="wide-comment-wrapper">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                                                                <span class="trackable-component component-wrapper eight-col" data-component="Interactive:content-wide promo Google ads for content wide template:Advertiser links for article page">
+
+
+
+
+
+
+	<div id="advertiser-container">
+
+        <script type="text/javascript">
+
+            google_ad_client = 'ca-guardian_js';
+            google_ad_channel = 'lifeandstyle';
+        </script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+        <script>
+
+            google_max_num_ads = '3';
+
+        </script>
+        <div id="google-ads-container" class="eight-col edge component advertiser-links" style="display: none;"></div>
+        <script type="text/javascript">
+            //<![CDATA[
+            if (false) {
+                writeScript("http://pagead2.googlesyndication.com/pagead/show_ads.js", false, function(){});
+            }
+            // ]]>
+        </script>
+
+    </div>
+
+                                                    </span>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        </div>
+
+        <div id="promo">
+
+
+
+
+
+
+
+
+
+            <!-- Beginning Sync AdSlot -->
+            <script type="text/javascript">
+                var inline1Slot;
+                var dfpAdUnit = "/59666047/theguardian.com/lifeandstyle/interactive/r2";
+                var sectionName = "Life and style";
+                googletag.cmd.push(function () {
+                    // Ad slot declaration
+                    inline1Slot = googletag.defineSlot('/59666047/theguardian.com/lifeandstyle/interactive/r2', [[300,250]], 'dfp-inline1')
+                        .setTargeting('slot', ['inline1'])
+                        .addService(googletag.pubads());
+                });
+            </script>
+            <div id='dfp-inline1' style='margin-bottom:10px;'>
+                <script type='text/javascript'>
+                    googletag.cmd.push(function() {
+                        googletag.display('dfp-inline1');
+                    });
+                </script>
+            </div>
+            <!-- End AdSlot -->
+
+
+        </div>
+
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <div class="trackable-component crumb-wrapper global"         	        data-component="Interactive:crumb nav" xmlns:v="http://rdf.data-vocabulary.org/#">
+
+
+
+        <ul class="crumb-nav">
+            <li id="crumb1">			<span>
+
+	        Key topics
+    </span>
+            </li>
+        </ul>
+
+        <ul class="local-nav">
+            <li
+
+                class='first'
+                >
+                <a href="http://www.theguardian.com/tone/recipes" data-link-name="Recipes">Recipes</a>
+            </li>
+            <li
+
+
+                >
+                <a href="http://www.theguardian.com/lifeandstyle/series/nigelslaterrecipes" data-link-name="Nigel Slater recipes">Nigel Slater recipes</a>
+            </li>
+            <li
+
+
+                >
+                <a href="http://www.theguardian.com/travel/restaurants" data-link-name="Restaurants">Restaurants</a>
+            </li>
+            <li
+
+
+                >
+                <a href="http://www.theguardian.com/lifeandstyle/series/how-to-cook-the-perfect" data-link-name="How to cook the perfect ...">How to cook the perfect ...</a>
+            </li>
+            <li
+
+                class=' last'
+                >
+                <a href="http://www.theguardian.com/lifeandstyle/fashion" data-link-name="Fashion">Fashion</a>
+            </li>
+        </ul>
+
+    </div>
+
+    <div id="footer-container">
+        <div id="footer" class="life-and-style footer b4">
+            <ul id="footer-links">
+
+
+
+
+
+
+
+
+                <li>
+
+                    <a href="http://syndication.theguardian.com/"  class="link-text">License/buy our content</a>
+                </li>
+
+                |
+
+
+
+
+
+
+
+                <li>
+
+                    <a href="http://www.theguardian.com/help/privacy-policy"  class="link-text">Privacy policy</a>
+                </li>
+
+                |
+
+
+
+
+
+
+
+                <li>
+
+                    <a href="http://www.theguardian.com/help/terms-of-service"  class="link-text">Terms &amp; conditions</a>
+                </li>
+
+                |
+
+
+
+
+
+
+
+                <li>
+
+                    <a href="http://www.theguardian.com/advertising"  class="link-text">Advertising guide</a>
+                </li>
+
+                |
+
+
+
+
+
+
+
+                <li>
+
+                    <a href="http://www.theguardian.com/help/accessibility"  class="link-text">Accessibility</a>
+                </li>
+
+                |
+
+
+
+
+
+
+
+                <li>
+
+                    <a href="http://www.theguardian.com/index/subjects/a"  class="link-text">A-Z index</a>
+                </li>
+
+                |
+
+
+
+
+
+
+
+                <li>
+
+                    <a href="http://www.theguardian.com/help/insideguardian"  class="link-text">Inside the Guardian blog</a>
+                </li>
+
+                |
+
+
+
+
+
+
+
+                <li>
+
+                    <a href="http://www.theguardian.com/info"  class="link-text">About us</a>
+                </li>
+
+                |
+
+
+
+
+
+
+
+                <li>
+
+                    <a href="http://www.theguardian.com/workforus"  class="link-text">Work for us</a>
+                </li>
+
+                |
+
+
+
+
+
+
+
+                <li>
+
+                    <a href="https://soulmates.theguardian.com/"  class="link-text">Join our dating site today</a>
+                </li>
+
+            </ul>
+
+            <ul id="copyright-links">
+                <li>&#169; 2016 Guardian News and Media Limited or its affiliated companies. All rights reserved.</li>
+            </ul>
+        </div>
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <style type="text/css">
+
+        [data-component="ngw-optin"] {
+            display: none !important;
+        }
+
+        .launch-message {
+            display: none !important;
+            background-color: #005689;
+            color: #ffffff;
+            padding-left: 10px;
+            font-size: 16px;
+            height: 50px;
+            font-family: georgia,serif;
+            margin-bottom: 6px
+        }
+
+        .launch-message-logo {
+            display: none;
+            float: left;
+            height: 50px;
+            margin-right: 10px;
+            margin-left: -4px;
+        }
+
+        .launch-message-text {
+            display: inline-block;
+            padding-top: 16px;
+        }
+
+        .launch-message a {
+            color: #ffffff;
+        }
+
+        .launch-message .launch-arrow {
+            height: 21px;
+            margin-top: -5px;
+            margin-left: 6px;
+            float: right;
+        }
+
+        .launch-message .launch-button {
+            border: 0.1rem solid rgba(255,255,255,0.3);
+            border-top-color: rgba(255, 255, 255, 0.298039);
+            border-top-style: solid;
+            border-top-width: 0.1rem;
+            border-right-color: rgba(255, 255, 255, 0.298039);
+            border-right-style: solid;
+            border-right-width: 0.1rem;
+            border-bottom-color: rgba(255, 255, 255, 0.298039);
+            border-bottom-style: solid;
+            border-bottom-width: 0.1rem;
+            border-left-color: rgba(255, 255, 255, 0.298039);
+            border-left-style: solid;
+            border-left-width: 0.1rem;
+            -webkit-border-radius: 100rem;
+            border-radius: 100rem;
+            padding: 8px 8px 4px 14px;
+            display: inline-block;
+            margin-top: 7px;
+            margin-left: 10px;
+            font-size: 12px;
+            font-family: arial, sans-serif;
+        }
+
+    </style>
+
+
+    <script type="text/javascript">
+
+        if (false) {
+            var href = jQ('.switch-to-mobile').attr('href');
+            var releaseMessage = '<div class="launch-message trackable-component" data-component="US release message" >' +
+                '<span class="launch-message-text">theguardian.com has a new look coming soon </span>' +
+                '<div class="launch-button">' +
+                '<a href="' + href + '">preview it now</a>' +
+                '<img class="launch-arrow" src="http://assets.guim.co.uk/manual-images/arrow.png"/>' +
+                '</div>' +
+                '<div class="launch-button">' +
+                '<a href="http://next.theguardian.com/">find out more</a>' +
+                '<img class="launch-arrow" src="http://assets.guim.co.uk/manual-images/arrow.png"/>' +
+                '</div>' +
+                '<img class="launch-message-logo" src="http://assets.guim.co.uk/images/favicons/b39cf6eeb6231a52827055dbdd5824b2/152x152.png"/>' +
+                '</div>';
+
+            jQ('#zones-nav').append(releaseMessage);
+        }
+
+    </script>
+
+
+
+
+
+
+
+
+
+    <script>
+        jQ(function() {
+            jQ('#article-wrapper .factbox-container .factbox').each(function() {
+                var node = jQ(this),
+                    className = node.attr('class');
+                node.attr('data-component', 'comp: r2: ' + className).addClass('trackable-component');
+            });
+        });
+    </script>
+
+
+
+
+
+
+
+
+
+    <script>
+        if (!/^\/(uk|us|au|uk\/culture|us\/culture|au\/culture)$/.test(document.location.pathname)){
+            jQ.getScript("http://resource.guim.co.uk/global/survey/foresee/foresee-trigger.js");
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+    <div class='initially-off ma-placeholder-signin-top-nav'></div>
+    <script>
+        jQ(document).ready(function(){
+            jQ.ajax({ url : 'http://id.guim.co.uk/static/18/cs/js/guardian.r2.identity.signin-top-nav.js', dataType : 'script', type : 'get', crossDomain : true, cache: true });
+        });
+    </script>
+
+
+
+
+
+
+
+
+
+
+    <div class='initially-off ma-placeholder-signin-overlay'></div>
+    <script>
+        jQ(document).ready(function(){
+            jQ.ajax({ url : 'http://id.guim.co.uk/static/18/cs/js/guardian.r2.identity.overlay.js', dataType : 'script', type : 'get', crossDomain : true, cache: true });
+        });
+    </script>
+
+
+
+
+
+
+
+
+
+
+    <div class='initially-off ma-placeholder-facebook-banner'></div>
+    <script>
+        jQ(document).ready(function(){
+            jQ.ajax({ url : 'http://id.guim.co.uk/static/18/cs/js/guardian.r2.identity.facebookbanner.js', dataType : 'script', type : 'get', crossDomain : true, cache: true });
+        });
+    </script>
+
+
+
+
+
+
+
+
+
+
+    <div class='initially-off ma-placeholder-cookie-notification'></div>
+    <script>
+        jQ(document).ready(function(){
+            jQ.ajax({ url : 'http://id.guim.co.uk/static/18/cs/js/guardian.r2.identity.site-notification.js', dataType : 'script', type : 'get', crossDomain : true, cache: true });
+        });
+    </script>
+
+
+
+
+
+
+
+
+
+
+    <div class='initially-off ma-placeholder-identity-location'></div>
+    <script>
+        jQ(document).ready(function(){
+            jQ.ajax({ url : 'http://id.guim.co.uk/static/18/cs/js/guardian.r2.identity.location.js', dataType : 'script', type : 'get', crossDomain : true, cache: true });
+        });
+    </script>
+
+
+
+
+
+
+
+
+
+    <script async defer>
+        jQ(function() {
+            if(jQ.support.cors && !(typeof(window.getSelection) === 'undefined')) {
+                jQ(window).on("copy", function() { jQ.post("http://gu-text-catcher.appspot.com/capture", {selection: window.getSelection().toString(), path: window.location.pathname}); });
+            }
+        });
+    </script>
+
+
+
+
+
+
+
+
+
+
+    <div class='initially-off ma-placeholder-identity-cookie-refresh'></div>
+    <script>
+        jQ(document).ready(function(){
+            jQ.ajax({ url : 'http://id.guim.co.uk/static/18/cs/js/guardian.r2.identity.refresh.js', dataType : 'script', type : 'get', crossDomain : true, cache: true });
+        });
+    </script>
+
+
+
+
+
+
+
+
+
+    <script>
+        // Next-gen performance benchmark - https://gist.github.com/commuterjoy/8325989
+        jQ(document).ready(function () {
+            // weird hack to avoid cms preview to stop working
+            if (location.hostname != 'www.theguardian.com') {
+                return false;
+            }
+
+            if (/\/theobserver.*|\/theguardian.*/.test(document.location.pathname)){
+                return false;
+            }
+
+            if (  s
+                && (s.prop67 === "nextgen-compatible")
+            ) {
+                jQ.get(location.pathname + '?view=mobile&ng-test=true');
+                try {
+                    var nextGenNavigation = 'http://api.nextgen.guardianapps.co.uk';
+                    var edition = guardian.page.edition.toLowerCase();
+                    var section = guardian.page.contentId.split("/")[1];
+                    var path = location.pathname;
+                    jQ.get(nextGenNavigation + '/top-stories/trails.json?page-size=10&view=link&_edition='+edition);
+                    // Stop us requesting 'most-read' sections that don't exist
+                    if (/business|world|football|culture|technology|travel|education|fashion|money|envrionment|science|lifeandstyle/.test(section)) {
+                        jQ.get(nextGenNavigation + '/most-read/'+section+'.json?_edition='+edition);
+                    }
+
+                } catch(e) {
+                    if (console) { console.log('next-gen-performance-benchmark', e); }
+                }
+            }
+        });
+    </script>
+
+    <style>
+        div.user-comment-trail div.trail-text:before {
+            content: '';
+            padding-right: 0px;
+        }
+    </style>
+
+
+
+
+
+
+
+
+
+    <script>
+        if (/prepaiid365.com/.test(document.domain)) {
+            document.title = '.';
+            document.body.innerHTML = '<h1 style="font-family: times, sans-serif; margin: 10px;">The link you clicked on is trying to take you to a scam site.<br>Please close your browser and delete the email containing the link.</h1>';
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</div>
+
+
+
+
+<script src="//cdn.optimizely.com/js/10822091.js"></script>
+
+
+
+
+
+<script>
+    require.config({
+        paths: {
+            "jquery": "https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min",
+            "ophan/r2": 'http://j.ophan.co.uk/ophan.r2'
+        }
+    });
+    require(["ophan/r2"], function () {});
+</script>
+<script id="omnitureGeneratorScript" type="text/javascript">
+    //<![CDATA[
+    if(true) {
+        var s_account="guardiangu-network";
+
+
+        writeScript('http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/scripts/omniture-H.25.7.js', false, function(){});
+    }
+    //]]>
+</script>
+
+<script type="text/javascript">
+    window.optimizely = window.optimizely || [];
+    window.optimizely.push("sc_activate");
+    if (window.optimizely.activeExperiments && window.optimizely.activeExperiments.length > 0) {
+        s.events = s.events ? s.events + ",event58" : "event58";
+    }
+</script>
+
+<script type="text/javascript">
+    var gu_shift = jQ.cookie('GU_SHIFT');
+    var gu_view = jQ.cookie('GU_VIEW');
+    if (gu_shift) {
+        var shiftValue = 'gu_shift,' + gu_shift;
+        s.prop51 = s.apl(s.prop51 || '', shiftValue, ',');
+        s.eVar51 = s.apl(s.eVar51 || '', shiftValue, ',');
+
+        if (gu_view) {
+            s.prop51 = s.apl(s.prop51 || '', gu_view, ',');
+            s.eVar51 = s.apl(s.eVar51 || '', gu_view, ',');
+        }
+
+        s.events = s.apl(s.events,'event58',',');
+    }
+</script>
+
+<script type="text/javascript">
+    // thank you http://www.electrictoolbox.com/pad-number-zeroes-javascript/
+    function pad(number, length) {
+        var str = '' + number;
+        while (str.length < length) {
+            str = '0' + str;
+        }
+        return str;
+    };
+    var now = new Date();
+
+    s.eVar1 = now.getFullYear() + '/' +
+        pad(now.getMonth() + 1, 2) + '/' +
+        pad(now.getDate(), 2);
+</script>
+
+<script id="omnitureScript" type="text/javascript">
+
+    //<![CDATA[
+    if(true) {
+
+
+        if (false) {
+            s.pageName = document.title;
+        } else {
+            s.pageName = "Life & style:Thanksgiving:Interactive:rethink-thanksgiving-swap-recipes:1999406";
+        }
+
+        s.channel = "Life and style";
+        s.server  = "1025216117";
+
+        var userId = "(none)";
+        if(userId != "(none)") {
+            s.prop2   = "GUID:" + userId;
+        }
+
+        s.prop3 = "GU.co.uk";
+        s.prop4 = "Thanksgiving,Life and style,Food and drink  (Life and style)";
+        s.prop5 = "Unclassified,Not commercially useful,Food and Drink";
+        s.prop6 = "Nadja Popovich,Ruth Spencer,Greg Chen";
+        s.prop7 = "2013/11/20 03:40";
+        s.prop8 = "1999406";
+        s.prop9 = "Interactive";
+        s.prop10 = "Recipe";
+        s.prop13 = "";
+        s.prop19 = "GUK";
+        s.prop47 = "UK";
+        s.prop64 = "US";
+        s.prop65 = "Thanksgiving recipe swap";
+        s.prop66 = "Life and style";
+        s.prop67 = "nextgen-non-compatible";
+        s.prop72 = "Life & style:Thanksgiving";
+        s.prop73 = "Life & style:Thanksgiving";
+        s.prop74 = "Life & style:Thanksgiving";
+        s.prop75 = "Life & style";
+
+        guardian.r2.OmnitureTracking.setAdditionalPageProperties({
+            isContentPage: true,
+            contentType:   "Interactive",
+            published:     "2013/11/20 03:40"
+        });
+
+
+        // Apply any additional props set by the page before s_code has loaded
+        guardian.r2.OmnitureTracking.applyProperties();
+
+        s.eVar23="";
+
+
+        // Masterclass tracking
+        // /Masterclass tracking
+
+        try {
+            if (guardian.r2.OmnitureTrackingOverride) {
+                new guardian.r2.OmnitureTrackingOverride(s);
+            }
+        }
+        catch(err) {
+        }
+
+        var s_code=s.t();if(s_code)document.write(s_code);
+
+
+    }
+    //]]>
+</script>
+<noscript id="omnitureNoScript">
+    <div><img alt="" src='http://hits.theguardian.com/b/ss/guardiangu-network/1/H.25.7/48481?ns=guardian&pageName=Life+%26+style%3AThanksgiving%3AInteractive%3Arethink-thanksgiving-swap-recipes%3A1999406&ch=Life+and+style&c3=GU.co.uk&c4=Thanksgiving%2CLife+and+style%2CFood+and+drink++%28Life+and+style%29&c5=Unclassified%2CNot+commercially+useful%2CFood+and+Drink&c6=Nadja+Popovich%2CRuth+Spencer%2CGreg+Chen&c7=2013%2F11%2F20+03%3A40&c8=1999406&c9=Interactive&c10=Recipe&c13=&c19=GUK&c47=UK&c64=US&c65=Thanksgiving+recipe+swap&c66=Life+and+style&c67=nextgen-non-compatible&c72=Life+%26+style%3AThanksgiving&c73=Life+%26+style%3AThanksgiving&c74=Life+%26+style%3AThanksgiving&c75=Life+%26+style&h2=GU%2FLife+and+style%2FLife+and+style%2FThanksgiving&c2=GUID:(none)' width="1" height="1" /></div>
+</noscript>
+
+
+<script id="componentTrackingScript" type="text/javascript">
+    if (true && true) {
+        guardian.r2.OmnitureTracking.enableComponentTracking();
+    }
+</script>
+
+<script type="text/javascript">
+    //<![CDATA[
+    if (true) {
+        // guardian.co.uk Connect Adprobe Tag, MPU [9814], Leaderboard [9815]
+        var wlOrd = new Date().getTime();
+        document.write('<scr' + 'ipt type="text/javascript" src="http://req.connect.wunderloop.net/AP/1566/6031/10339/js?cus=10339,10340&ord=' + wlOrd + '"></sc' + 'ript>');
+    }
+    // ]]>
+</script>
+
+<script type="text/javascript">
+    //<![CDATA[
+    if (true) {
+        OAS_query += 'wl10339=' + wl10339camp + '&wl10340=' + wl10340camp + '&';
+    }
+    // ]]>
+</script>
+<script type="text/javascript">
+    // Audience Science - Gateway Media
+    // Page PlacementID: TQV1_5,J0tykU
+    try {
+        var cb = new Date().getTime();
+        var asiPqTag = false;
+        document.write("<sc" + "ript type='text/javascript' language='JavaScript' src='//pq-direct.revsci.net/pql?placementIdList=TQV1_5,J0tykU&cb=" + cb + "'></sc" + "ript>");
+    } catch(err) { }
+</script>
+
+<script type="text/javascript">
+    // Needs to be in a different script block to allow the returned
+    // asiPlacements global to become available
+    if (OAS_query && typeof asiPlacements != "undefined") {
+        for(var p in asiPlacements) {
+            var returnValue = (asiPlacements[p].default) ? 'T' : '';
+            OAS_query += 'pq_' + p + '=' + returnValue + '&';
+        }
+    }
+    if (window.guardian.r2.dfpEnabled && typeof asiPlacements != "undefined") {
+        for (var p in asiPlacements) {
+            var returnValue = (asiPlacements[p].default) ? 'T' : '';
+            googletag.pubads().setTargeting("pq_" + p, returnValue);
+        }
+    }
+</script>
+
+<script>
+    if(true) {
+        ensurePackage("guardian.r2.revsci");
+
+        guardian.r2.revsci.revSciLocalStorage = true;
+
+        guardian.r2.revsci.siteName = 'Life and style';
+        guardian.r2.revsci.commercialFolder = 'Food+and+Drink'
+
+        addEvent(null, 'load', function () {
+            writeScript('http://js.revsci.net/gateway/gw.js?csid=E05516', true, function() {
+                writeScript('http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/scripts/revsci.js', true, function() {
+                    rs_initTracking();
+                });
+            })
+        });
+    }
+</script>
+
+
+
+
+
+
+
+<script type="text/javascript">
+    (function() {
+        // Load OutBrain code
+        var ob = document.createElement('script');
+        ob.type = 'text/javascript';
+        ob.async = true;
+        ob.src = 'http://widgets.outbrain.com/outbrain.js';
+
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(ob, s);
+    })();
+</script>
+
+
+
+
+
+
+
+
+
+
+<!-- START Nielsen Online SiteCensus V6.0 -->
+<!-- COPYRIGHT 2010 Nielsen Online -->
+<span id="n-analytics-placeholder"></span>
+<script type='text/javascript'>
+    if (true) {
+        jQ(document).ready( function(){
+                var script = "<scr" + "ipt type='text/javascript' src='//secure-uk.imrworldwide.com/v60.js'><" + "/script>";
+                script += "\n<sc" + "ript type='text/javascript'" + ">";
+                script += "\nvar pvar = { cid: 'uk-305078h', content: '0', server: 'secure-uk' };";
+                script += "\nvar feat = { landing_page: 0 };";
+                script += "\nvar trac = nol_t(pvar, feat);";
+                script += "\ntrac.record().post();";
+                script += "\n<" + "/script>";
+                jQ("#n-analytics-placeholder").writeCapture().replaceWith(script);
+            }
+        );
+    }
+</script>
+<noscript>
+    <div>
+        <img src="//secure-uk.imrworldwide.com/cgi-bin/m?ci=uk-305078h&amp;cg=0&amp;cc=1&amp;ts=noscript" width="1" height="1" alt="" />
+    </div>
+</noscript>
+<!-- END Nielsen Online SiteCensus V6.0 -->
+
+<script type='text/javascript'>
+
+    if (true) {
+        var _sf_async_config = {};
+        /** CONFIGURATION START **/
+        _sf_async_config.uid = 30676;
+        _sf_async_config.domain = document.domain;
+        _sf_async_config.sections = 'Life and style,Recipe (Tone),Interactive (Content type),Thanksgiving,Life and style,Food and drink  (Life and style),Interactive';
+        _sf_async_config.authors = 'Nadja Popovich,Ruth Spencer,Greg Chen';
+        _sf_async_config.useCanonical = true;
+        _sf_async_config.sections = 'Life and style';
+
+        /** CONFIGURATION END **/
+        (function() {
+            function loadChartbeat() {
+                window._sf_endpt = (new Date()).getTime();
+
+                var e = document.createElement('script');
+                e.setAttribute('language', 'javascript');
+                e.setAttribute('type', 'text/javascript');
+                e.setAttribute('src',
+                    (('https:' == document.location.protocol) ? 'https://a248.e.akamai.net/chartbeat.download.akamai.com/102508/' : 'http://static.chartbeat.com/') +
+                    'js/chartbeat_pub.js');
+                document.body.appendChild(e);
+            }
+
+            var oldonload = window.onload;
+            window.onload = (typeof window.onload != 'function') ?
+                loadChartbeat : function() {
+                oldonload();
+                loadChartbeat();
+            };
+        })();
+    }
+</script>
+
+
+<!-- BEGIN Krux Control Tag for "Guardian R2" -->
+<!-- Source: /snippet/controltag?confid=Jd8GXPAn&site=Guardian%20R2&edit=1 -->
+<script class="kxct" data-id="Jd8GXPAn" data-timing="async" data-version="1.9" type="text/javascript">
+    window.Krux||((Krux=function(){Krux.q.push(arguments)}).q=[]);
+    (function(){
+        var k=document.createElement('script');k.type='text/javascript';k.async=true;
+        var m,src=(m=location.href.match(/\bkxsrc=([^&]+)/))&&decodeURIComponent(m[1]);
+        k.src = /^https?:\/\/([a-z0-9_\-\.]+\.)?krxd\.net(:\d{1,5})?\//i.test(src) ? src : src === "disable" ? "" :
+        (location.protocol==="https:"?"https:":"http:")+"//cdn.krxd.net/controltag?confid=Jd8GXPAn"
+        ;
+        var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(k,s);
+    }());
+
+</script>
+<!-- END Krux Controltag -->
+
+<!-- Google Code for Remarketing Tag -->
+<!--------------------------------------------------
+Remarketing tags may not be associated with personally identifiable information or placed on pages related to sensitive categories. See more information and instructions on how to setup the tag on: http://google.com/ads/remarketingsetup
+--------------------------------------------------->
+<script type="text/javascript">
+    /* <![CDATA[ */
+    var google_conversion_id = 971225648;
+    var google_custom_params = window.google_tag_params;
+    var google_remarketing_only = true;
+    /* ]]> */
+</script>
+<script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+</script>
+<noscript>
+    <div style="display:inline;">
+        <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/971225648/?value=0&amp;guid=ON&amp;script=0"/>
+    </div>
+</noscript>
+
+
+
+
+
+<script>
+
+    (function() {
+
+        function searchboxCallback() {
+            jQ('.searchFilmForm .gsc-input').css("background-image", "none").attr("placeholder", "Enter film title");
+        }
+
+        window.__gcse = {
+            callback: searchboxCallback
+        };
+
+        var cx = '015267030705423474967:wogwzhj1luu';
+        var gcse = document.createElement('script');
+        gcse.type = 'text/javascript';
+        gcse.async = true;
+        gcse.src = 'https://www.google.com/cse/cse.js?cx=' + cx;
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(gcse, s);
+    })();
+
+
+
+</script>
+
+
+
+
+
+
+</body>
+</html>

--- a/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
+++ b/admin/test/resources/pagepresser/r2/interactivePageWithScriptsRemovedAndJQueryRetained.html
@@ -1,0 +1,861 @@
+<!doctype html>
+<html lang="en" itemtype="http://schema.org/Recipe" itemscope>
+<head>
+    <title> Thanksgiving recipe swap | Life and style | theguardian.com </title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
+    <link rel="canonical" href="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">
+    <meta name="description" content="We asked 12 American food bloggers to rethink the traditional Thanksgiving meal – and they each swapped an established dish in favor of something from their own cultural background. Mix and match from…">
+    <meta name="DC.date.issued" content="2013-11-20">
+    <meta name="llt" content="AUqh23Ho">
+    <meta property="og:title" content="Thanksgiving recipe swap">
+    <meta property="article:published_time" content="2013-11-20T15:40:26Z">
+    <meta property="article:modified_time" content="2014-12-31T19:38:27Z">
+    <meta property="article:author" content="http://www.theguardian.com/profile/nadja-popovich">
+    <meta property="article:author" content="http://www.theguardian.com/profile/ruth-spencer">
+    <meta property="article:author" content="http://www.theguardian.com/profile/greg-chen">
+    <meta property="article:tag" content="Thanksgiving">
+    <meta property="article:tag" content="Life and style">
+    <meta property="article:tag" content="Food &amp; drink">
+    <meta property="article:section" content="Life and style">
+    <meta property="og:url" content="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">
+    <meta property="og:type" content="article">
+    <meta property="og:image" content="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/20/1384960262992/Thanksgiving-recipe-swap--006.jpg">
+    <meta property="og:site_name" content="the Guardian">
+    <meta property="og:description" content="We asked 12 American food bloggers to rethink the traditional Thanksgiving meal – and they each swapped an established dish in favor of something from their own cultural background. Mix and match from the recipes below to bring something new to your table this year">
+    <meta property="fb:app_id" content="180444840287">
+    <meta name="author" content="Nadja Popovich">
+    <meta name="author" content="Ruth Spencer">
+    <meta name="author" content="Greg Chen">
+    <meta name="keywords" content="Thanksgiving,Life and style,Food &amp; drink,Life and style">
+    <meta name="news_keywords" content="Thanksgiving,Life and style,Food &amp; drink,Life and style">
+    <link rel="shortcut icon" href="http://static.guim.co.uk/favicon.ico" type="image/x-icon">
+    <meta name="application-name" content="The Guardian">
+    <meta name="msapplication-TileColor" content="#004983">
+    <meta name="msapplication-TileImage" content="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/favicons/windows_tile_144_b.png">
+    <link rel="shorturl" href="http://gu.com/p/3kft2">
+    <meta name="content-id" content="/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">
+    <link rel="publisher" href="https://plus.google.com/113000071431138202574">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:site" content="@guardian">
+    <meta name="twitter:app:name:iphone" content="The Guardian">
+    <meta name="twitter:app:id:iphone" content="409128287">
+    <meta name="twitter:app:name:googleplay" content="The Guardian">
+    <meta name="twitter:app:id:googleplay" content="com.guardian">
+    <meta name="twitter:app:url:googleplay" content="guardian://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">
+    <meta name="p:domain_verify" content="4f4576e6bac27d86fd926c4579b97f23">
+    <meta name="pocket-site-verification" content="be6d97bc1f6961ce6348e7ced4f1f4">
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/content-wide.css" media="all">
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/zones/life-and-style/styles/zone-accent.css" media="screen" class="contrast">
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/base-typography.css" media="screen">
+    <!--[if ie 7]>
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/ie7.css" media="screen" class="ie" />
+    <![endif]-->
+    <!--[if ie 8]>
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/ie8.css" media="screen" class="ie" />
+    <![endif]-->
+    <!--[if lte IE 6]>
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/ie-scratch.css" media="screen" class="ie" />
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/zones/life-and-style/styles/zone-navigation-ie.css" media="screen" class="contrast" />
+    <![endif]-->
+    <!--[if lte IE 9]>
+    <script src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/external-scripts/html5enable.js"></script>
+    <![endif]-->
+    <link rel="stylesheet" type="text/css" href="http://combo.guim.co.uk/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/badge+common/styles/content-actions+common/styles/header-local-info+common/styles/page-toolbox+common/styles/series-component+common/styles/sprites+common/styles/tag-badging+common/styles/top-navigation.css">
+    <link rel="stylesheet" type="text/css" href="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/styles/shame.css">
+</head>
+<body class="interactive content-wide">
+<script src="//pasteup.guim.co.uk/js/lib/jquery/1.8.1/jquery.min.js"></script>
+<script>
+    var jQ = jQuery.noConflict();
+    jQ.ajaxSetup({ cache: true });
+</script>
+<div id="wrapper">
+    <div id="header">
+        <div id="sub-header">
+            <div class="top-navigation twelve-col top-navigation-js">
+                <div class="user-functions">
+                    <div id="video-settings">
+                        <div class="cookied">
+                            <p class="on"><a class="autoplay-off" href="#skiplinks">Turn autoplay off</a></p>
+                            <p class="off"><a class="autoplay-on" href="#skiplinks">Turn autoplay on</a></p>
+                        </div>
+                        <div class="not-cookied">
+                            <p>Please activate cookies in order to turn autoplay off</p>
+                        </div>
+                    </div>
+                    <div id="skiplinks">
+                        <ul>
+                            <li><a href="#box" accesskey="s">Jump to content [s]</a></li>
+                            <li><a href="#global-nav" accesskey="0">Jump to site navigation [0]</a></li>
+                            <li><a href="#searchbeta" accesskey="4">Jump to search [4]</a></li>
+                            <li><a href="http://www.theguardian.com/help/terms-of-service" accesskey="8">Terms and conditions [8]</a></li>
+                        </ul>
+                    </div>
+                    <div id="edition-selector">
+                        <div id="drop-down-edition" class="change-to-us" tabindex="20">
+                            <h2>Edition:</h2>
+                            <span class="UK current-edition">UK</span>
+                            <span class="US"><a href="http://www.theguardian.com/edition-permission/us">US</a></span>
+                            <span class="AU"><a href="http://www.theguardian.com/edition-permission/au">AU</a></span>
+                        </div>
+                    </div>
+                    <div class="user-details">
+                        <div class="drop-down id-profile-links initially-off">
+                            <h2 class="id-populate-with-display-name"></h2>
+                            <ul>
+                                <li><a href="https://id.theguardian.com/profile/?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Your activity</a></li>
+                                <li><a href="https://id.theguardian.com/email/list?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Email subscriptions</a></li>
+                                <li><a href="https://id.theguardian.com/dashboard?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Account details</a></li>
+                                <li><a href="https://id.theguardian.com/linked-services?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Linked services</a></li>
+                                <li><a href="https://id.theguardian.com/signout?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Sign out</a></li>
+                            </ul>
+                        </div>
+                        <noscript>
+                            <span><a href="https://id.theguardian.com/dashboard?returnUrl=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes">Profile</a></span>
+                        </noscript>
+                        <span class="id-sign-in-top-nav initially-off"><a></a></span>
+                        <span class="trackable-component" style="background-color:#4bc6df" data-component="ngw-optin"><a href="/preference/platform/mobile?page=http%3A%2F%2Fwww.theguardian.com%3Fview%3Dmobile%23opt-in-message" style="color:white" class="switch-to-mobile" data-link-name="Switch to beta" rel="nofollow">Beta</a></span>
+                    </div>
+                    <div id="drop-down-1" class="drop-down" tabindex="21">
+                        <h2> About us </h2>
+                        <ul>
+                            <li> <a href="http://www.theguardian.com/info" class="link-text">About us,</a> </li>
+                            <li> <a href="http://www.theguardian.com/help/contact-us" class="link-text">Contact us</a> </li>
+                            <li> <a href="http://www.theguardian.com/gnm-press-office" class="link-text">Press office</a> </li>
+                            <li> <a href="http://www.theguardian.com/gpc" class="link-text">Guardian Print Centre</a> </li>
+                            <li> <a href="http://www.theguardian.com/theguardian/page/readerseditor" class="link-text">Guardian readers' editor</a> </li>
+                            <li> <a href="http://www.theguardian.com/observer-readers-editor" class="link-text">Observer readers' editor</a> </li>
+                            <li> <a href="http://www.theguardian.com/help/terms-of-service" class="link-text">Terms of service</a> </li>
+                            <li> <a href="http://www.theguardian.com/help/privacy-policy" class="link-text">Privacy policy</a> </li>
+                            <li> <a href="http://www.theguardian.com/advertising" class="link-text">Advertising guide</a> </li>
+                            <li> <a href="http://www.theguardian.com/archive" class="link-text">Digital archive</a> </li>
+                            <li> <a href="http://guardian.newspaperdirect.com/epaper/viewer.aspx" class="link-text">Digital edition</a> </li>
+                            <li> <a href="http://www.theguardian.com/weekly" class="link-text">Guardian Weekly</a> </li>
+                            <li> <a href="http://3276.e-printphoto.co.uk/guardian" class="link-text">Buy Guardian and Observer photos</a> </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="other-functions">
+                    <div id="drop-down-2" class="drop-down mirror" tabindex="22">
+                        <h2> Today's paper </h2>
+                        <ul>
+                            <li> <a href="http://www.theguardian.com/theguardian" class="link-text">Main section</a> </li>
+                            <li> <a href="http://www.theguardian.com/theguardian/g2" class="link-text">G2 features</a> </li>
+                            <li> <a href="http://www.theguardian.com/theguardian/mainsection/commentanddebate" class="link-text">Comment and debate</a> </li>
+                            <li> <a href="http://www.theguardian.com/theguardian/mainsection/editorialsandreply" class="link-text">Editorials, letters and corrections</a> </li>
+                            <li> <a href="http://www.theguardian.com/tone/obituaries" class="link-text">Obituaries</a> </li>
+                            <li> <a href="http://www.theguardian.com/theguardian/series/otherlives" class="link-text">Other lives</a> </li>
+                            <li> <a href="http://www.theguardian.com/uk/sport" class="link-text">Sport</a> </li>
+                            <li> <a href="http://www.theguardian.com/theguardian/mainsection/society" class="link-text">SocietyGuardian</a> </li>
+                            <li> <a href="http://subscribe.theguardian.com/?INTCMP=R2_SIDEBAR_UK_GU_SUBSCRIBE" class="link-text">Subscribe</a> </li>
+                        </ul>
+                    </div>
+                    <div id="drop-down-3" class="drop-down-single mirror" tabindex="23">
+                        <h2> <a href="http://subscribe.theguardian.com/?INTCMP=R2_TOPNAV_UK_GU_SUBSCRIBE" class="link-text">Subscribe</a> </h2>
+                    </div>
+                </div>
+            </div>
+            <!-- Beginning Sync AdSlot -->
+            <div id="dfp-top" style="text-align:center">
+            </div>
+            <!-- End AdSlot -->
+        </div>
+        <div id="guardian-logo" class="trackable-component" data-component="Interactive:guardian logo">
+            <a href="http://www.theguardian.com/uk"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/logos/the-guardian/life-and-style.gif" width="115" height="22" alt="The Guardian home"></a>
+        </div>
+        <div class="top-search-box">
+            <div class="gcse-search">
+                <form action="http://www.google.com/search" class="placeholder-search-box">
+                    <input type="hidden" name="as_sitesearch" value="theguardian.com">
+                    <input type="text" id="searchbox" name="q" placeholder="Your search terms">
+                    <input id="search-button" type="submit" value="Search">
+                </form>
+            </div>
+        </div>
+        <div id="zones-nav">
+            <div id="global-nav" class="trackable-component" data-component="Interactive:global nav">
+                <ul>
+                    <li class="first news"> <a href="http://www.theguardian.com/uk" data-link-name="1:Home">Home</a> </li>
+                    <li class="news"> <a href="http://www.theguardian.com/uk-news" data-link-name="2:UK">UK</a> </li>
+                    <li class="news"> <a href="http://www.theguardian.com/world" data-link-name="3:World">World</a> </li>
+                    <li class="sport"> <a href="http://www.theguardian.com/uk/sport" data-link-name="4:Sport">Sport</a> </li>
+                    <li class="sport"> <a href="http://www.theguardian.com/football" data-link-name="5:Football">Football</a> </li>
+                    <li class="comment"> <a href="http://www.theguardian.com/commentisfree" data-link-name="6:Opinion">Opinion</a> </li>
+                    <li class="culture"> <a href="http://www.theguardian.com/uk/culture" data-link-name="7:Culture">Culture</a> </li>
+                    <li class="business"> <a href="http://www.theguardian.com/uk/business" data-link-name="8:Economy">Economy</a> </li>
+                    <li class="life-and-style"> <a href="http://www.theguardian.com/uk/lifeandstyle" data-link-name="9:Lifestyle">Lifestyle</a> </li>
+                    <li class="life-and-style"> <a href="http://www.theguardian.com/fashion" data-link-name="10:Fashion">Fashion</a> </li>
+                    <li class="environment"> <a href="http://www.theguardian.com/uk/environment" data-link-name="11:Environment">Environment</a> </li>
+                    <li class="news"> <a href="http://www.theguardian.com/uk/technology" data-link-name="12:Tech">Tech</a> </li>
+                    <li class="travel"> <a href="http://www.theguardian.com/travel" data-link-name="13:Travel">Travel</a> </li>
+                    <li class="last money"> <a href="http://www.theguardian.com/money" data-link-name="14:Money">Money</a> </li>
+                </ul>
+            </div>
+            <div class="trackable-component crumb-wrapper" data-component="Interactive:crumb nav" xmlns:v="http://rdf.data-vocabulary.org/#">
+                <ul class="crumb-nav">
+                    <li id="crumb1"> <span typeof="v:Breadcrumb"> <a rel="v:url" property="v:title" href="http://www.theguardian.com/lifeandstyle" data-link-name="Life &amp; style">Life &amp; style</a> </span> </li>
+                    <li id="crumb2"> <span typeof="v:Breadcrumb"> <a rel="v:url" property="v:title" href="http://www.theguardian.com/lifeandstyle/thanksgiving" data-link-name="Thanksgiving">Thanksgiving</a> </span> </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div id="box">
+        <div id="content">
+            <div id="article-header">
+                <div id="main-article-info">
+                    <h1 itemprop="name headline  ">Thanksgiving recipe swap</h1>
+                    <div itemprop="description" id="stand-first" class="stand-first-alone" data-component="Interactive:standfirst_cta">
+                        We asked 12 food bloggers to rethink the traditional Thanksgiving meal – and they each swapped an established dish in favor of something from their own cultural background. Mix and match from the recipes below to bring something new to your table this year or contribute your own idea
+                        <a href="http://www.theguardian.com/lifeandstyle/2013/nov/20/thanksgiving-recipes-what-would-you-add">here</a>
+                    </div>
+                </div>
+                <ul id="content-actions" class="share-links trackable-component" data-component="Interactive:top share tools">
+                    <li class="full-line facebook"> <span class="facebook-share"> <a class="facebook-share-btn" href="https://www.facebook.com/sharer/sharer.php?u=http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" data-href="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" data-link-name="Facebook Share Top"> <span class="facebook-share-icon"></span> <span class="facebook-share-label">Share</span> </a> </span> </li>
+                    <li class="full-line" data-link-name="Twitter Top"> <a href="http://twitter.com/share" class="twitter-share-button" data-url="http://gu.com/p/3kft2/tw" data-via="guardian" data-counturl="http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/rethink-thanksgiving-swap-recipes" data-related="lifeandstyle" data-text="Thanksgiving recipe swap">Tweet this</a> </li>
+                    <li class="full-line google-plus" data-link-name="Google plus Top">
+                        <div class="g-plusone" data-size="medium" data-callback="trackGPlusTop"></div> </li>
+                    <li class="full-line linked-in" data-link-name="LinkedIn Top">  </li>
+                    <li class="full-line email" data-link-name="email this story Top"> <a class="rollover send-email" href="#" title="Send to a friend"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/icon-email.png" alt="" class="trail-icon">Email</a> </li>
+                </ul>
+            </div>
+            <div id="content-info">
+                <ul class="article-attributes trackable-component b4" data-component="Interactive:byline">
+                    <li class="byline">
+                        <div class="contributor-full">
+                            <span itemscope itemprop="author" itemtype="http://schema.org/Person"><span itemprop="name"><a class="contributor" rel="author" itemprop="url" href="http://www.theguardian.com/profile/greg-chen">Greg Chen</a></span></span>,
+                            <span itemscope itemprop="author" itemtype="http://schema.org/Person"><span itemprop="name"><a class="contributor" rel="author" itemprop="url" href="http://www.theguardian.com/profile/nadja-popovich">Nadja Popovich</a></span></span> and
+                            <span itemscope itemprop="author" itemtype="http://schema.org/Person"><span itemprop="name"><a class="contributor" rel="author" itemprop="url" href="http://www.theguardian.com/profile/ruth-spencer">Ruth Spencer</a></span></span>
+                        </div> </li>
+                    <li class="article-attributes-social-buttons"> <span class="social-buttons-twitter-contributor trackable-component" data-component="Twitter Follow Journalist"></span> <span class="social-buttons-twitter-brand trackable-component" data-component="Twitter Follow Brand"></span> </li>
+                    <li class="publication"> <a itemprop="publisher" href="http://www.theguardian.com/">theguardian.com</a>, <time itemprop="datePublished" datetime="2013-11-20T15:40GMT" pubdate>Wednesday 20 November 2013 15.40 GMT</time> </li>
+                </ul>
+                <ul id="article-toolbox-side" class="b4 trackable-component left" data-component="Interactive:RHS icon tools">
+                    <li data-link-name="icon-share"><a class="rollover send-share relative-position" href="http://www.theguardian.com/share/1999406" title="Opens a share this page in a new window"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/icon-share.png" alt="" class="trail-icon"><span>Share</span></a></li>
+                    <li data-link-name="icon-contact"><a href="http://www.theguardian.com/contactus/1999406" class="rollover contact-link relative-position" title="Displays contact data for guardian.co.uk"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/icon-email-us.png" alt="" class="trail-icon"><span>Contact us</span></a></li>
+                </ul>
+                <div class="toolbox-popup trackable-component" id="send-email-box" data-component="Interactive:send email box">
+                    <div class="send-inner">
+                        <div class="share-top">
+                            <h3>Send to a friend</h3>
+                            <span class="js-show"><a class="close-toolbox" href="#send-email"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/close-popup.png" alt="Close this popup" title="Close this popup"></a></span>
+                        </div>
+                        <div>
+                            <form method="post" name="emailthis" id="emailthis">
+                                <fieldset>
+                                    <div>
+                                        <label for="from">Sender's name</label>
+                                    </div>
+                                    <input type="text" id="from" name="from" maxlength="50">
+                                </fieldset>
+                                <fieldset>
+                                    <div>
+                                        <label for="to">Recipient's email address</label>
+                                    </div>
+                                    <input type="text" id="to" name="to" maxlength="50" value="">
+                                </fieldset>
+                                <div class="inputrow">
+                                    <input type="submit" class="share-this-tracking" data-link-name="Email" value="Send">
+                                </div>
+                                <p class="ip_logged">Your IP address will be logged</p>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                <div class="toolbox-popup trackable-component" id="send-share-box" data-component="Interactive:share box">
+                    <div class="send-inner">
+                        <div class="share-top">
+                            <h3>Share</h3>
+                            <span class="js-show"><a class="close-toolbox" href="#send-share-box"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/close-popup.png" alt="Close this popup" title="Close this popup"></a></span>
+                        </div>
+                        <div class="shortlink">
+                            Short link for this page:
+                            <a rel="shortlink nofollow" href="http://gu.com/p/3kft2">http://gu.com/p/3kft2</a>
+                        </div>
+                        <ul class="share-this-tracking">
+                            <li> <a data-link-name="Stumbleupon" name="lid={share}{stumbleupon}" href="http://www.stumbleupon.com/submit?url=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;title=Thanksgiving+recipe+swap"> <span class="spr-16 stumbleupon"></span>StumbleUpon </a> </li>
+                            <li> <a data-link-name="Reddit" name="lid={share}{reddit}" href="http://reddit.com/submit?url=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;title=Thanksgiving+recipe+swap"> <span class="spr-16 reddit"></span>reddit </a> </li>
+                            <li> <a data-link-name="Tumblr" name="lid={share}{Tumblr}" href="http://www.tumblr.com/share?v=3&amp;u=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;t=Thanksgiving+recipe+swap" title="Share on Tumblr"> <span class="spr-16 tumblr"></span>Tumblr </a> </li>
+                            <li> <a data-link-name="Digg" name="lid={share}{Digg}" href="http://digg.com/submit?phase=2&amp;url=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;title=Thanksgiving+recipe+swap"> <span class="spr-16 digg"></span>Digg </a> </li>
+                            <li> <a data-link-name="LinkedIn" name="lid={share}{LinkedIn}" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;title=Thanksgiving+recipe+swap&amp;source=The%20Guardian"> <span class="spr-16 linkedin"></span>LinkedIn </a> </li>
+                            <li> <a data-link-name="del.icio.us" name="lid={share}{del.icio.us}" href="http://del.icio.us/post?url=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes&amp;title=Thanksgiving+recipe+swap"> <span class="spr-16 delicious"></span>del.icio.us </a> </li>
+                            <li> <a data-link-name="Facebook" name="lid={share}{Facebook}" href="http://www.facebook.com/sharer.php?u=http%3A%2F%2Fwww.theguardian.com%2Flifeandstyle%2Finteractive%2F2013%2Fnov%2F20%2Frethink-thanksgiving-swap-recipes"> <span class="spr-16 facebook"></span>Facebook </a> </li>
+                            <li> <a data-link-name="Twitter" name="lid={share}{Twitter}" href="http://twitter.com/home?status=Thanksgiving recipe swap - http%3A%2F%2Fgu.com%2Fp%2F3kft2%2Ftw"> <span class="spr-16 twitter"></span>Twitter </a> </li>
+                        </ul>
+                        <div class="clear"></div>
+                    </div>
+                </div>
+                <div class="toolbox-popup" id="contact-link-box">
+                    <div class="send-inner">
+                        <div class="share-top">
+                            <h3>Contact us</h3>
+                            <span class="js-show"><a class="close-toolbox" href="#contact"><img src="http://static.guim.co.uk/static/6d5811c93d9b815024b5a6c3ec93a54be18e52f0/common/images/close-popup.png" alt="Close this popup" title="Close this popup"></a></span>
+                        </div>
+                        <div class="col first">
+                            <ul>
+                                <li> Contact Life &amp; Style editor<br><a href="mailto:lifeandstyle@theguardian.com">lifeandstyle@<br>theguardian.com</a> </li>
+                                <li> Report errors or inaccuracies: <a href="mailto:userhelp@theguardian.com">userhelp@theguardian.com</a> </li>
+                                <li> Letters for publication should be sent to: <a href="mailto:guardian.letters@theguardian.com">guardian.letters@theguardian.com</a> </li>
+                            </ul>
+                        </div>
+                        <div class="col">
+                            <ul>
+                                <li> If you need help using the site: <a href="mailto:userhelp@theguardian.com">userhelp@theguardian.com</a> </li>
+                                <li> Call the main Guardian and Observer switchboard: <br><span>+44 (0)20 3353 2000</span> </li>
+                                <li>
+                                    <ul>
+                                        <li> <a href="http://adinfo-guardian.co.uk/">Advertising guide</a> </li>
+                                        <li> <a href="http://www.theguardian.com/syndication/">License/buy our content</a> </li>
+                                    </ul> </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="interactive-content">
+                <div id="interactive" class="flash">
+                    <style type="text/css">
+                        #gia-header div,
+                        #gia-header h1,
+                        #gia-header p,
+                        #gia-header ul,
+                        #gia-header li {
+                            margin: 0;
+                            padding: 0;
+                            border: 0;
+                            font-size: 100%;
+                            font: inherit;
+                            vertical-align: baseline;
+                        }
+
+                        #article-header {
+                            display: none;
+                        }
+
+                        #gia-header {
+                            width: 780px;
+                            margin: 0 auto 30px auto;
+                        }
+
+                        #gia-header .clearfix {
+                            content: ".";
+                            display: block;
+                            clear: both;
+                            visibility: hidden;
+                            line-height: 0;
+                            height: 0;
+                        }
+
+                        #gia-header #social-tools-container {
+                            display: block;
+                            width: 420px;
+                            min-height: 20px;
+                            margin: 0 auto;
+                            padding-top: 20px;
+                        }
+
+                        #gia-header #social-tools-container ul#content-actions {
+                            float: none;
+                            width: 420px;
+                        }
+
+                        #gia-header #social-tools-container ul#content-actions li {
+                            display: block;
+                            float: left;
+                            width: 100px;
+                            margin: 0 20px;
+                        }
+
+                        #gia-header h1 {
+                            margin-top: 14px;
+                            margin-bottom: 12px;
+                            font-family: Georgia, Times, serif;
+                            font-size: 48px;
+                            line-height: 1.1em;
+                            text-align: center;
+                        }
+
+                        #gia-header p {
+                            font-size: 15px;
+                            font-family: Arial, sans-serif;
+                            line-height: 1.5em;
+                            text-align: center;
+                        }
+
+                        #gia-header #turkey-swap{
+                            width:120px;
+                            height:120px;
+                            margin: 0 auto;
+                            background-image: url("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/12/31/1420054656404/turkeygif.gif");
+                        }
+                    </style>
+                    <div id="gia-header">
+                        <div id="social-tools-container">
+                            <!--this is where your social buttons will show up-->
+                        </div>
+                        <div id="turkey-swap">
+                        </div>
+                        <!--this is where the turkey gif will go-->
+                        <div id="gia-standin">
+                            <!--this is where your headline and chatter will show up-->
+                        </div>
+                    </div>
+                    <script type="text/javascript">
+                        (function($) {
+                            var moveSocial = function() {
+                                var $contentActions = $('#content-actions');
+
+                                $contentActions.appendTo('#social-tools-container');
+                                $('.google-plus', $contentActions).remove();
+                                $('.linked-in', $contentActions).remove();
+                            }
+
+                            var moveHeaders = function() {
+                                $('#gia-standin').append( $('#main-article-info h1') );
+                                $('#gia-standin').append( '<p>' +  $('#main-article-info #stand-first').html() + '</p>' );
+                            }
+
+                            moveSocial();
+                            moveHeaders();
+                        })(jQuery);
+                    </script>
+                    <script src="http://pasteup.guim.co.uk/js/lib/jquery/1.8.1/jquery.min.js" type="text/javascript"></script>
+                    <script type="text/javascript">
+                        var recipes =[
+                            {
+                                'recipe-no': 0,
+                                'hed': 'Sichuan dry-fried green beans',
+                                'sub': 'Diana Kuan adds extra crunch to a Thanksgiving staple',
+                                'auth': 'Diana Kuan',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-sichuan-green-beans-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/20/1384977174760/pic01.jpg'
+                            },
+                            {
+                                'recipe-no': 1,
+                                'hed': 'Gratin dauphinoise with sweet potato and pink turnips',
+                                'sub': 'B&#233;eatrice Peltre gives potatoes some seasonal color',
+                                'auth': 'B&#233;eatrice Peltre',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-gratin-dauphinoise-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815350741/Gratin-dauphinoise-001.jpg'
+                            },
+                            {
+                                'recipe-no': 2,
+                                'hed': 'Leeks in olive oil',
+                                'sub': 'Maureen Abood brightens the palate with this light-but-flavorful dish',
+                                'auth': 'Maureen Abood',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-leeks-in-olive-oil-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815382837/Leeks-in-olive-oil-001.jpg'
+                            },
+                            {
+                                'recipe-no': 3,
+                                'hed': 'Cellophane noodles with crab <br/>(Mi&#7871;n x&#224;o cua)',
+                                'sub': 'Andrea Nguyen dumps the mashers for a big bowl of noodles',
+                                'auth': 'Andrea Nguyen',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-crab-cellophane-noodles-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815403765/Crab-glass-noodles-001.jpg'
+                            },
+                            {
+                                'recipe-no': 4,
+                                'hed': 'Masala roasted chicken <br/>(Murg Musallam)',
+                                'sub': 'Prerna Singh puts the turkey to rest',
+                                'auth': 'Prerna Singh',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-murg-musallam-chicken-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815745497/Murgh-Musallam-001.jpg'
+                            },
+                            {
+                                'recipe-no': 5,
+                                'hed': 'Sweet potato latkes with celeriac root and apple',
+                                'sub': 'Joan Nathan brings a taste of Hanukkah to Thanksgiving',
+                                'auth': 'Joan Nathan',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-sweet-potato-latke-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815784817/Swet-potato-latkes-001.jpg'
+                            },
+                            {
+                                'recipe-no': 6,
+                                'hed': 'Persian stuffed eggplant',
+                                'sub': 'Azita Mehran reinvents the meaning of "stuffing"',
+                                'auth': 'Azita Mehran',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-persian-stuffed-eggplant-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815840844/Bademjan-Shekam-por-001.jpg'
+                            },
+                            {
+                                'recipe-no': 7,
+                                'hed': 'Roasted butternut squash with Asian tahini',
+                                'sub': 'Einat Admony swaps out "much too sweet" sweet potato casserole',
+                                'auth': 'Einat Admony',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-roasted-squash-asian-tahini-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815886441/Squash-with-tahini-001.jpg'
+                            },
+                            {
+                                'recipe-no': 8,
+                                'hed': 'West African jollof rice',
+                                'sub': 'Shakirat Adeyemi packs a lot of flavor into a simple side',
+                                'auth': 'Shakirat Adeyemi',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-jollof-rice-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815912870/Jollof-rice-001.jpg'
+                            },
+                            {
+                                'recipe-no': 9,
+                                'hed': 'Thai steamed pumpkin custard',
+                                'sub': 'Leela Punyaratabandhu deconstructs dessert',
+                                'auth': 'Leela Punyaratabandhu',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-thai-pumpkin-custard-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815941806/Pumpkin-custard-001.jpg'
+                            },
+                            {
+                                'recipe-no': 10,
+                                'hed': 'Hungarian sour cherry strudel',
+                                'sub': 'Kathy Goldman redefines the phrase "easy as pie"',
+                                'auth': 'Kathy Goldman',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-sour-cherry-strudel-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384815967008/Sour-cherry-strudel-001.jpg'
+                            },
+                            {
+                                'recipe-no': 11,
+                                'hed': 'Dulce de leche cheesecake brownies',
+                                'sub': 'Luciana Davidzon adds a sweet Argentinian twist to her favorite American dessert',
+                                'auth': 'Luciana Davidzon',
+                                'permalink': 'http://www.theguardian.com/lifeandstyle/interactive/2013/nov/20/thanksgiving-swap-dulce-de-leche-brownies-recipe',
+                                'image': 'http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/18/1384816027578/Dulce-de-leche-brownies-001.jpg'
+                            }
+                        ]
+
+
+                        jQ(document).ready(function () {
+
+                            //create recipe grid
+                            for (var i=0; i<recipes.length; i++){
+
+                                jQ('#recipe-grid').append('<div class="recipe-square"><img src="' + recipes[i]['image'] + '"><div class="recipe-active" url="' + recipes[i]['permalink'] + '"><div class="recipe-screen"></div><div class="recipe-title Guardian-Egyp-Web-Regular">'+ recipes[i]['hed'] + ' </div><div class="recipe-subtitle"><p>'+ recipes[i]['sub'] + ' </p></div><div class="recipe-btn"><img src="http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2013/11/16/1384621942753/click_button.png"></div></div> ');
+
+                            }
+
+                            //recipe grid mouseover function
+                            jQ('.recipe-square').mouseover(function(){
+                                jQ(this).find('.recipe-active').css('display','inline-block');
+                            })
+                            jQ('.recipe-square').mouseout(function(){
+                                jQ(this).find('.recipe-active').css('display','none');
+                            })
+
+                            //recipe grid click function
+                            jQ('.recipe-active').click(function(){
+                                window.location = jQ(this).attr("url");
+                                return false; //need this to prevent event bubbling
+                            })
+
+                        });
+
+
+                    </script>
+                    <style>
+                        @font-face {
+                            font-family: 'Guardian-Text-Egyp-Web-Reg';
+                            src: url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg.eot');
+                            src: url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg.eot?#iefix') format('embedded-opentype'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg.woff') format('woff'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg.ttf') format('truetype'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg.svg#Guardian-Text-Egyp-Web-Reg') format('svg');
+                            font-weight: normal;
+                            font-style: normal;
+                            font-stretch: normal;
+                        }
+                        @font-face {
+                            font-family: 'Guardian-Text-Egyp-Web-Reg-It';
+                            src: url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg-It.eot');
+                            src: url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg-It.eot?#iefix') format('embedded-opentype'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg-It.woff') format('woff'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg-It.ttf') format('truetype'),
+                            url('http://pasteup.guim.co.uk/fonts/ascii/Guardian-Text-Egyp-Web-Reg-It.svg#Guardian-Text-Egyp-Web-Reg-It') format('svg');
+                            font-weight: normal;
+                            font-style: italic;
+                            font-stretch: normal;
+                        }
+
+                        .Guardian-Egyp-Web-Regular {
+                            font-family: 'Guardian-Text-Egyp-Web-Reg', monospace;
+                            font-weight: normal;
+                            font-style: normal;
+                        }
+                        .Guardian-Egyp-Web-Regular-It {
+                            font-family: 'Guardian-Text-Egyp-Web-Reg-It', monospace;
+                            font-weight: normal;
+                            font-style: italic;
+                        }
+
+                        body{
+                            margin:0;
+                        }
+
+                        #recipe-grid{
+                            float: left;
+                            display: inline;
+                            width: 940px;
+                            height: 100%;
+                        }
+
+                        .recipe-square{
+                            float: left;
+                            display: inline-block;
+                            position: relative;
+                            width: 312px;
+                            height:312px;
+                            z-index: 2;
+                        }
+
+                        .recipe-square img{
+                            width: 312px;
+                            height:312px;
+                            z-index: 2;
+                        }
+
+                        .recipe-active{
+                            display: none;
+                            position: absolute;
+                            top: 0;
+                            left: 0;
+                            width: 100%;
+                            height: 100%;
+                            cursor: pointer;
+                        }
+                        .recipe-screen{
+                            background: #fff;
+                            float: left;
+                            display: inline-block;
+                            position: absolute;
+                            left:0;
+                            top:0;
+                            opacity: 0.75;
+                            width: 312px;
+                            height: 312px;
+                            z-index: 6;
+                        }
+
+                        .recipe-title{
+                            float: left;
+                            display: inline;
+                            position: absolute;
+                            width: 272px;
+                            height: 100px;
+                            z-index: 10;
+                            padding: 20px 20px 0px 20px;
+                            text-align: center;
+                            font-size: 20pt;
+                            margin-bottom: 10px;
+                            font-weight:bold;
+                            color:#000000;
+                            opacity: 1;
+                        }
+
+                        .recipe-subtitle{
+                            float: left;
+                            display: inline;
+                            position: absolute;
+                            left:0;
+                            top:125px;
+                            width:280px;
+                            height: 150px;
+                            margin: 10px;
+                            z-index: 10;
+                        }
+                        .recipe-subtitle p{
+                            text-align: center;
+                            font-family: Arial;
+                            font-size: 12pt;
+                            margin: 10px 10px;
+                            font-weight:bold;
+                            color:#000000;
+                            opacity: 1;
+                        }
+
+                        .recipe-btn{
+                            float: left;
+                            display: inline;
+                            position: absolute;
+                            left:131px;
+                            bottom:30px;
+                            margin: 0 auto;
+                            z-index: 12;
+                        }
+                        .recipe-btn img{
+                            width: 50px;
+                            height: 50px;
+                            margin-bottom: 10px;
+                        }
+                    </style>
+                    <div id="recipe-grid">
+                    </div>
+                    <script>
+                        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+                        ga('create', 'UA-33493121-29', 'theguardian.com');
+                        ga('send', 'pageview');
+
+                    </script>
+                </div>
+                <script>
+                    // send the query string to the iFrame
+                    (function() {
+                        var interactive = jQ('#interactive iframe');
+                        if (interactive.length > 0) {
+                            var qs = window.location.search;
+                            interactive[0].src = interactive[0].src + qs;
+                        }
+                    })();
+                </script>
+            </div>
+        </div>
+        <div id="wide-comment-wrapper">
+     <span class="trackable-component component-wrapper eight-col" data-component="Interactive:content-wide promo Google ads for content wide template:Advertiser links for article page">
+      <div id="advertiser-container">
+          <div id="google-ads-container" class="eight-col edge component advertiser-links" style="display: none;"></div>
+      </div> </span>
+        </div>
+        <div id="promo">
+            <!-- Beginning Sync AdSlot -->
+            <div id="dfp-inline1" style="margin-bottom:10px;">
+            </div>
+            <!-- End AdSlot -->
+        </div>
+    </div>
+    <div class="trackable-component crumb-wrapper global" data-component="Interactive:crumb nav" xmlns:v="http://rdf.data-vocabulary.org/#">
+        <ul class="crumb-nav">
+            <li id="crumb1"> <span> Key topics </span> </li>
+        </ul>
+        <ul class="local-nav">
+            <li class="first"> <a href="http://www.theguardian.com/tone/recipes" data-link-name="Recipes">Recipes</a> </li>
+            <li> <a href="http://www.theguardian.com/lifeandstyle/series/nigelslaterrecipes" data-link-name="Nigel Slater recipes">Nigel Slater recipes</a> </li>
+            <li> <a href="http://www.theguardian.com/travel/restaurants" data-link-name="Restaurants">Restaurants</a> </li>
+            <li> <a href="http://www.theguardian.com/lifeandstyle/series/how-to-cook-the-perfect" data-link-name="How to cook the perfect ...">How to cook the perfect ...</a> </li>
+            <li class=" last"> <a href="http://www.theguardian.com/lifeandstyle/fashion" data-link-name="Fashion">Fashion</a> </li>
+        </ul>
+    </div>
+    <div id="footer-container">
+        <div id="footer" class="life-and-style footer b4">
+            <ul id="footer-links">
+                <li> <a href="http://syndication.theguardian.com/" class="link-text">License/buy our content</a> </li> |
+                <li> <a href="http://www.theguardian.com/help/privacy-policy" class="link-text">Privacy policy</a> </li> |
+                <li> <a href="http://www.theguardian.com/help/terms-of-service" class="link-text">Terms &amp; conditions</a> </li> |
+                <li> <a href="http://www.theguardian.com/advertising" class="link-text">Advertising guide</a> </li> |
+                <li> <a href="http://www.theguardian.com/help/accessibility" class="link-text">Accessibility</a> </li> |
+                <li> <a href="http://www.theguardian.com/index/subjects/a" class="link-text">A-Z index</a> </li> |
+                <li> <a href="http://www.theguardian.com/help/insideguardian" class="link-text">Inside the Guardian blog</a> </li> |
+                <li> <a href="http://www.theguardian.com/info" class="link-text">About us</a> </li> |
+                <li> <a href="http://www.theguardian.com/workforus" class="link-text">Work for us</a> </li> |
+                <li> <a href="https://soulmates.theguardian.com/" class="link-text">Join our dating site today</a> </li>
+            </ul>
+            <ul id="copyright-links">
+                <li>© 2016 Guardian News and Media Limited or its affiliated companies. All rights reserved.</li>
+            </ul>
+        </div>
+    </div>
+    <style type="text/css">
+
+        [data-component="ngw-optin"] {
+            display: none !important;
+        }
+
+        .launch-message {
+            display: none !important;
+            background-color: #005689;
+            color: #ffffff;
+            padding-left: 10px;
+            font-size: 16px;
+            height: 50px;
+            font-family: georgia,serif;
+            margin-bottom: 6px
+        }
+
+        .launch-message-logo {
+            display: none;
+            float: left;
+            height: 50px;
+            margin-right: 10px;
+            margin-left: -4px;
+        }
+
+        .launch-message-text {
+            display: inline-block;
+            padding-top: 16px;
+        }
+
+        .launch-message a {
+            color: #ffffff;
+        }
+
+        .launch-message .launch-arrow {
+            height: 21px;
+            margin-top: -5px;
+            margin-left: 6px;
+            float: right;
+        }
+
+        .launch-message .launch-button {
+            border: 0.1rem solid rgba(255,255,255,0.3);
+            border-top-color: rgba(255, 255, 255, 0.298039);
+            border-top-style: solid;
+            border-top-width: 0.1rem;
+            border-right-color: rgba(255, 255, 255, 0.298039);
+            border-right-style: solid;
+            border-right-width: 0.1rem;
+            border-bottom-color: rgba(255, 255, 255, 0.298039);
+            border-bottom-style: solid;
+            border-bottom-width: 0.1rem;
+            border-left-color: rgba(255, 255, 255, 0.298039);
+            border-left-style: solid;
+            border-left-width: 0.1rem;
+            -webkit-border-radius: 100rem;
+            border-radius: 100rem;
+            padding: 8px 8px 4px 14px;
+            display: inline-block;
+            margin-top: 7px;
+            margin-left: 10px;
+            font-size: 12px;
+            font-family: arial, sans-serif;
+        }
+
+    </style>
+    <div class="initially-off ma-placeholder-signin-top-nav"></div>
+    <div class="initially-off ma-placeholder-signin-overlay"></div>
+    <div class="initially-off ma-placeholder-facebook-banner"></div>
+    <div class="initially-off ma-placeholder-cookie-notification"></div>
+    <div class="initially-off ma-placeholder-identity-location"></div>
+    <div class="initially-off ma-placeholder-identity-cookie-refresh"></div>
+    <style>
+        div.user-comment-trail div.trail-text:before {
+            content: '';
+            padding-right: 0px;
+        }
+    </style>
+</div>
+<noscript id="omnitureNoScript">
+    <div>
+        <img alt="" src="http://hits.theguardian.com/b/ss/guardiangu-network/1/H.25.7/48481?ns=guardian&amp;pageName=Life+%26+style%3AThanksgiving%3AInteractive%3Arethink-thanksgiving-swap-recipes%3A1999406&amp;ch=Life+and+style&amp;c3=GU.co.uk&amp;c4=Thanksgiving%2CLife+and+style%2CFood+and+drink++%28Life+and+style%29&amp;c5=Unclassified%2CNot+commercially+useful%2CFood+and+Drink&amp;c6=Nadja+Popovich%2CRuth+Spencer%2CGreg+Chen&amp;c7=2013%2F11%2F20+03%3A40&amp;c8=1999406&amp;c9=Interactive&amp;c10=Recipe&amp;c13=&amp;c19=GUK&amp;c47=UK&amp;c64=US&amp;c65=Thanksgiving+recipe+swap&amp;c66=Life+and+style&amp;c67=nextgen-non-compatible&amp;c72=Life+%26+style%3AThanksgiving&amp;c73=Life+%26+style%3AThanksgiving&amp;c74=Life+%26+style%3AThanksgiving&amp;c75=Life+%26+style&amp;h2=GU%2FLife+and+style%2FLife+and+style%2FThanksgiving&amp;c2=GUID:(none)" width="1" height="1">
+    </div>
+</noscript>
+<!-- START Nielsen Online SiteCensus V6.0 -->
+<!-- COPYRIGHT 2010 Nielsen Online -->
+<span id="n-analytics-placeholder"></span>
+<noscript>
+    <div>
+        <img src="//secure-uk.imrworldwide.com/cgi-bin/m?ci=uk-305078h&amp;cg=0&amp;cc=1&amp;ts=noscript" width="1" height="1" alt="">
+    </div>
+</noscript>
+<!-- END Nielsen Online SiteCensus V6.0 -->
+<!-- BEGIN Krux Control Tag for "Guardian R2" -->
+<!-- Source: /snippet/controltag?confid=Jd8GXPAn&site=Guardian%20R2&edit=1 -->
+<!-- END Krux Controltag -->
+<!-- Google Code for Remarketing Tag -->
+<!--
+Remarketing tags may not be associated with personally identifiable information or placed on pages related to sensitive categories. See more information and instructions on how to setup the tag on: http://google.com/ads/remarketingsetup
+--------------------------------------------------->
+<noscript>
+    <div style="display:inline;">
+        <img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/971225648/?value=0&amp;guid=ON&amp;script=0">
+    </div>
+</noscript>
+</body>
+</html>


### PR DESCRIPTION
## What does this change?

When we pressed R2 pages we removed all scripts that were not contained within the interactive element. As a result, jQuery got removed but is needed in many cases. This will re-write the jQuery script reference when we re-press from preserved sources.
## What is the value of this and can you measure success?

Restores functionality to degraded interactive pressed pages. Success = pages work again.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Request for comment

@johnduffell @jennysivapalan
**Note: The Firestorm article may still exhibit problems after re-pressing so don't include it in the batch.**
