### PR TITLE
Use unsafe-url for referrer policy

### DIFF
--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -77,6 +77,17 @@
 <meta name="theme-color" content="#005689">
 <meta name="msapplication-TileImage" content="@Static("images/favicons/windows_tile_144_b.png")" />
 
+@*
+ * This referrer policy preserves URLs in the Referrer header when navigating
+ * from HTTPS->HTTP.
+ *
+ * We need it for tracking to work properly while we do section-by-section
+ * rollout of HTTPS.
+ *
+ * See https://www.w3.org/TR/referrer-policy/#referrer-policy-state-unsafe-url
+*@
+<meta name="referrer" content="unsafe-url">
+
 @* https://support.google.com/plus/answer/1713826 *@
 <link rel="publisher" href="https://plus.google.com/113000071431138202574" />
 


### PR DESCRIPTION
This preserves referrer URLs when navigating from HTTPS->HTTP so Ophan tracking won't break for navigations between protocols.

The danger of this policy is that it'd be possible to find out which secure URLs someone had visited, but that won't really affect us since we redirect https-enabled URLs from http via fastly anyway. When we upgrade to https properly, I'll get rid of this.

https://www.w3.org/TR/referrer-policy/#referrer-policy-state-unsafe-url

@philwills @rich-nguyen 
