### PR TITLE
Commercial CAPI card styling fixes

### DIFF
--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -31,6 +31,7 @@
         @include f-headlineSans;
         @include font-size(20, 24);
         margin-bottom: 5px;
+        font-weight: normal;
     }
 
     &:before {
@@ -47,7 +48,7 @@
     .inline-glabs-logo-small {
         svg {
             right: 0;
-            left: unset;
+            left: auto;
             top: 4px;
             width: 75px;
             height: 23px;
@@ -107,8 +108,7 @@
 }
 
 .paidfor-logo {
-    max-width: $gs-baseline * 6;
-    height: $gs-baseline * 3;
+    max-height: $gs-baseline * 5;
 }
 
 .paidfor-band {


### PR DESCRIPTION
## What does this change?

This PR fixes: the size of a logo, weight of a header and a safari bug with glabs logo.
## Screenshots

Before:
![screen shot 2016-03-23 at 14 18 14](https://cloud.githubusercontent.com/assets/489567/13988215/dc69c456-f102-11e5-9b4a-b125f99c30e3.png)

After:
![screen shot 2016-03-23 at 14 18 43](https://cloud.githubusercontent.com/assets/489567/13988229/e3ddacca-f102-11e5-836c-3cb6e2d85c8c.png)
