### PR TITLE
Slightly nicer error messaging when you haven't setup your AWS creds

### DIFF
--- a/common/app/fronts/FrontsApi.scala
+++ b/common/app/fronts/FrontsApi.scala
@@ -10,6 +10,6 @@ object FrontsApi extends ExecutionContexts {
   val amazonClient: ApiClient = {
     val client = new AmazonS3Client(Configuration.aws.mandatoryCredentials)
     client.setEndpoint(AwsEndpoints.s3)
-    ApiClient("aws-frontend-store", Configuration.facia.stage.toUpperCase, AmazonSdkS3Client(client))
+    ApiClient(Configuration.aws.bucket, Configuration.facia.stage.toUpperCase, AmazonSdkS3Client(client))
   }
 }

--- a/common/app/fronts/FrontsApi.scala
+++ b/common/app/fronts/FrontsApi.scala
@@ -8,7 +8,7 @@ import services.AwsEndpoints
 
 object FrontsApi extends ExecutionContexts {
   val amazonClient: ApiClient = {
-    val client = new AmazonS3Client(Configuration.aws.credentials.get)
+    val client = new AmazonS3Client(Configuration.aws.mandatoryCredentials)
     client.setEndpoint(AwsEndpoints.s3)
     ApiClient("aws-frontend-store", Configuration.facia.stage.toUpperCase, AmazonSdkS3Client(client))
   }


### PR DESCRIPTION
- Produces a better error when you haven't configured your AWS credentials locally
- Use configuration instead of hard coded string for fronts bucket
