### PR TITLE
Fix "post comment" button styling

### DIFF
--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -28,7 +28,7 @@
             <span class="d-discussion__error-text">Your comments are currently being pre-moderated (<a href="/community-faqs#311" target="_blank">why?</a>)</span>
         </div>
         <textarea name="body" class="textarea d-comment-box__body" placeholder="Join the discussion…"></textarea>
-        <button type="submit" data-link-name="post comment" class="u-button-reset button button--large button--primary submit-input d-comment-box__submit">Post your comment</button>
+        <button type="submit" data-link-name="post comment" class="u-button-reset button button--large button--primary submit-input--behaviour d-comment-box__submit">Post your comment</button>
         <span class="u-fauxlink d-comment-box__preview" role="button">Preview</span>
         <span class="u-fauxlink d-comment-box__hide-preview" role="button">Hide preview</span>
         <span class="u-fauxlink d-comment-box__cancel" role="button">Cancel</span>

--- a/static/src/stylesheets/components/pasteup-forms/src/_forms.scss
+++ b/static/src/stylesheets/components/pasteup-forms/src/_forms.scss
@@ -250,7 +250,7 @@ category: Common
     min-height: ($gs-baseline/3)*40;
 }
 
-@mixin submit-input--behaviour {
+.submit-input, .submit-input--behaviour {
     background: $pasteup-forms-submit-background;
     border: 0 none;
     color: #ffffff;
@@ -273,11 +273,7 @@ category: Common
 }
 
 .submit-input {
-    @include submit-input--behaviour;
     padding: 11px $gs-gutter/2;
-}
-.submit-input--behaviour {
-    @include submit-input--behaviour;
 }
 
 .submit-input[disabled] {

--- a/static/src/stylesheets/components/pasteup-forms/src/_forms.scss
+++ b/static/src/stylesheets/components/pasteup-forms/src/_forms.scss
@@ -250,7 +250,7 @@ category: Common
     min-height: ($gs-baseline/3)*40;
 }
 
-.submit-input {
+@mixin submit-input--behaviour {
     background: $pasteup-forms-submit-background;
     border: 0 none;
     color: #ffffff;
@@ -259,7 +259,6 @@ category: Common
     font-size: 14px;
     margin: 0 $gs-gutter 0 0;
     min-width: gs-span(2);
-    padding: 11px $gs-gutter/2;
     outline: none;
     text-align: center;
 
@@ -271,6 +270,14 @@ category: Common
     &:active {
         background: $pasteup-forms-submit-background-active;
     }
+}
+
+.submit-input {
+    @include submit-input--behaviour;
+    padding: 11px $gs-gutter/2;
+}
+.submit-input--behaviour {
+    @include submit-input--behaviour;
 }
 
 .submit-input[disabled] {


### PR DESCRIPTION
The Post your comment text was languishing at the bottom of the button itself.  This is of course related to the change of order I introduced in https://github.com/guardian/frontend/pull/12298.

I have rejigged the CSS to not rely on one padding overriding the other - only one should apply at a time.

I could have used extend or mixin, but after googling, it seems mixin wins out slightly over extend!

@OliverJAsh thanks for the help!

PS the file in pasteup https://github.com/guardian/pasteup-forms/blob/master/src/_forms.scss doesn't seem to match the _forms.scss that I edited so it presumably isn't being used by the build as we just have another copy?
