### PR TITLE
place cta so that it remains in place on updates

### DIFF
--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -44,7 +44,7 @@
         </header>
         <div class="content__main tonal__main tonal__main--@toneClass(article)">
             <div class="gs-container">
-                <div class="content__main-column content__main-column--liveblog js-main-column--liveblog">
+                <div class="content__main-column content__main-column--liveblog">
                     <div class="js-sport-tabs js-football-meta football-tabs content__mobile-full-width"></div>
                     <div class="js-cricket-score"></div>
 

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -44,13 +44,15 @@
         </header>
         <div class="content__main tonal__main tonal__main--@toneClass(article)">
             <div class="gs-container">
-                <div class="content__main-column content__main-column--liveblog">
+                <div class="content__main-column content__main-column--liveblog js-main-column--liveblog">
                     <div class="js-sport-tabs js-football-meta football-tabs content__mobile-full-width"></div>
                     <div class="js-cricket-score"></div>
 
                     @fragments.mainMedia(article)
 
                     @fragments.witnessCallToAction(article.content)
+
+                    @fragments.liveNotificationsCallToActionPlaceHolder()
 
                     <div class="blog__left-col">
 

--- a/common/app/views/fragments/liveNotificationsCallToActionPlaceHolder.scala.html
+++ b/common/app/views/fragments/liveNotificationsCallToActionPlaceHolder.scala.html
@@ -1,0 +1,2 @@
+@()(implicit request: RequestHeader)
+<aside id="notifications" class="notifications js-notifications" role="complementary"></aside>

--- a/static/src/javascripts/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts/bootstraps/enhanced/notifications.js
@@ -55,7 +55,7 @@ define([
                 });
 
             fastdom.write(function () {
-                $('.js-liveblog-body').prepend(src);
+                $('.js-notifications').prepend(src);
             });
 
             bean.one(document.body, 'click', '.js-notifications-subscribe-link', handler);

--- a/static/src/stylesheets/module/preferences/_notifications.scss
+++ b/static/src/stylesheets/module/preferences/_notifications.scss
@@ -2,11 +2,13 @@
     display: none;
 }
 
-.from-content-api .notifications-subscribe-link__headline {
+.notifications-subscribe-link__headline {
     @include fs-header(3);
+    margin: 0;
 }
 
 .notifications-link {
+    margin-top: $gs-baseline;
     margin-bottom: $gs-baseline / 2;
 
     .button--follow {


### PR DESCRIPTION
# My Awesome Pull Request
## What does this change?

Fixes the Notifications CTA in a different DOM position so that it isn't shifted down on subsequent updates
## What is the value of this and can you measure success?
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

Before: 
![before](https://cloud.githubusercontent.com/assets/986155/13994510/0e9ebfa2-f11d-11e5-81ad-05a2b3008811.png)

After:
![after](https://cloud.githubusercontent.com/assets/986155/13994511/0eaff54c-f11d-11e5-81f1-e6118f0e2f67.png)
## Request for comment
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
