### PR TITLE
create video status endpoint

### DIFF
--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -83,6 +83,7 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(cartoon|picture|graphic)/.*>            
 
 # Audio and Video paths
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>.json                   controllers.MediaController.renderJson(path)
+GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>/info.json              controllers.MediaController.renderInfoJson(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>                        controllers.MediaController.render(path)
 
 

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -82,8 +82,8 @@ GET        /$path<[\w\d-]*(/[\w\d-]*)?/(cartoon|picture|graphic)/.*>.json       
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(cartoon|picture|graphic)/.*>            controllers.ImageContentController.render(path)
 
 # Audio and Video paths
-GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>.json                   controllers.MediaController.renderJson(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>/info.json              controllers.MediaController.renderInfoJson(path)
+GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>.json                   controllers.MediaController.renderJson(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>                        controllers.MediaController.render(path)
 
 

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -411,6 +411,7 @@ GET            /$path<[\w\d-]*(/[\w\d-]*)?/gallery/.*>                          
 GET            /$path<[\w\d-]*(/[\w\d-]*)?/(cartoon|graphic|picture)/.*>.json                                                    controllers.ImageContentController.renderJson(path)
 GET            /$path<[\w\d-]*(/[\w\d-]*)?/(cartoon|graphic|picture)/.*>                                                         controllers.ImageContentController.render(path)
 
+GET            /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>/info.json                                                           controllers.MediaController.renderInfoJson(path)
 GET            /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>.json                                                                controllers.MediaController.renderJson(path)
 GET            /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>                                                                     controllers.MediaController.render(path)
 

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -136,6 +136,7 @@ GET        /sport/rugby/api/score/:year/:month/:day/:team1Id/:team2Id           
 # Onward journeys
 GET        /series/*path.json                                                                  controllers.SeriesController.renderSeriesStories(path)
 
+GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>/info.json                             controllers.MediaController.renderInfoJson(path)
 GET        /$path<[\w\d-]*(/[\w\d-]*)?/(video|audio)/.*>.json                                  controllers.MediaController.renderJson(path)
 
 # Facia


### PR DESCRIPTION
# Get video info endpoint

We currently need to know whether videos are expired as we don't have this information available from flex when the video is embedded. 

I could have used the [video json](http://gu.com/film/video/2016/mar/01/sacha-baron-cohan-appears-as-ali-g-at-oscars-video.json) as it has the `"status": "GONE"` but the file is a few kilobytes big, and this call might happen across multiple videos on a page.

There is also a question around caching, but it seems the media endpoints don't have much in place for that? Is this correct, or shall we be changing that? @sndrs?
## What does this change?

Nothing, it adds value.
## What is the value of this and can you measure success?

We will have an endpoint, it serves JSON, valuable JSON.
## Does this affect other platforms - Amp, Apps, etc?

Nope, but we eventually be doing something similar there.
## Request for comment
## @akash1810 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
