### PR TITLE
Notifications site updated in background fix

### DIFF
--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -9,6 +9,7 @@
 //
 // Offline page
 //
+"use strict";
 
 var staticCacheName = 'static';
 
@@ -161,16 +162,13 @@ self.addEventListener('push', function(event) {
             .then(function (json) {
 
                if(json.status === "ok")
-                    var messages = json.messages;
-
-                    messages.forEach( function(message) {
-                        var data = {topic: message.topic};
-                        self.registration.showNotification(message.title, {
-                            body: message.body,
-                            icon: '@{JavaScript(Static("images/favicons/114x114.png").path)}',
-                            tag: message.title,
-                            data: data
-                        });
+                    var message = json.messages.slice(-1)[0];
+                    var data = {topic: message.topic};
+                    return self.registration.showNotification(message.title, {
+                        body: message.body,
+                        icon: '@{JavaScript(Static("images/favicons/114x114.png").path)}',
+                        tag: message.title,
+                        data: data
                     });
                 })
 

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -161,7 +161,10 @@ self.addEventListener('push', function(event) {
             })
             .then(function (json) {
 
-               if(json.status === "ok")
+               if(json.status === "ok" && json.messages.length > 0)
+                    /* Client returns current messages for a given browserid ( which are then deleted ) We want the latest one.
+                       If we loop displaying all of them the promise doesn't resolved and a 'website being updated in the background' message is displayed
+                     */
                     var message = json.messages.slice(-1)[0];
                     var data = {topic: message.topic};
                     return self.registration.showNotification(message.title, {


### PR DESCRIPTION
# My Awesome Pull Request
## What does this change?

Deals with push notifications displaying a message that says 'This site has been updated in the background' as well as the push notification itself
## What is the value of this and can you measure success?

Non annoying push notifications
## Does this affect other platforms - Amp, Apps, etc?

Obviously, when Push notifications are working properly, nobody will bother with apps anymore. 
## Screenshots

![fucked-note](https://cloud.githubusercontent.com/assets/986155/14019469/d726c0ca-f1ca-11e5-9007-1a7394402e73.png)
## Request for comment
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
