### PR TITLE
fix admin creative templates page to show creatives

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -68,7 +68,7 @@ object CommercialController extends Controller with Logging with AuthLogging wit
     val emptyTemplates = CreativeTemplateAgent.get
     val creatives = Store.getDfpTemplateCreatives
     val templates = emptyTemplates.foldLeft(Seq.empty[GuCreativeTemplate]) { (soFar, template) =>
-      soFar :+ template.copy(creatives = creatives.filter(_.templateId == template.id).sortBy(_.name))
+      soFar :+ template.copy(creatives = creatives.filter(_.templateId.get == template.id).sortBy(_.name))
     }.sortBy(_.name)
     NoCache(Ok(views.html.commercial.templates(environment.stage, templates)))
   }

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -184,7 +184,8 @@ object DataMapper {
       lastModified = toJodaTime(dfpCreative.getLastModifiedDateTime),
       args = Option(dfpCreative.getCreativeTemplateVariableValues).map(_.map(arg)).map(_.toMap).getOrElse(Map.empty),
       templateId = Some(dfpCreative.getCreativeTemplateId),
-      snippet = None
+      snippet = None,
+      previewUrl = Some(dfpCreative.getPreviewUrl)
     )
   }
 }

--- a/admin/app/views/commercial/templates.scala.html
+++ b/admin/app/views/commercial/templates.scala.html
@@ -1,4 +1,4 @@
-@(env: String, templates: Seq[dfp.GuCreativeTemplate])(implicit request: RequestHeader)
+@(env: String, templates: Seq[common.dfp.GuCreativeTemplate])(implicit request: RequestHeader)
 @import tools.DfpLink
 @import model.{SimplePage, MetaData}
 

--- a/admin/app/views/commercial/templates.scala.html
+++ b/admin/app/views/commercial/templates.scala.html
@@ -15,11 +15,20 @@
                     All unarchived custom creative templates are shown.</p>
             </div>
 
+            <div class="facia-container__inner">
+                <h2>Creative Templates: Contents</h2>
+                <ul>
+                    @for(template <- templates) {
+                    <li><a href="#@template.name">@template.name</a></li>
+                    }
+                </ul>
+            </div>
+
             <ul class="u-unstyled">
                 @for(template <- templates) {
-                    <li class="container__border">
+                    <li class="container__border" >
                         <div class="facia-container__inner">
-                            <h2>
+                            <h2 id="@template.name">
                                 @template.name (<a href="@DfpLink.creativeTemplate(template.id)">@template.id</a>)
                             </h2>
                             <p>@{template.description}</p>
@@ -27,7 +36,7 @@
                                 <p><b>This template is not in use.</b></p>
                             }
                             @if(template.creatives.nonEmpty){
-                                <p>Creatives built from this template:</p>
+                                <p>Creatives built from this template (see preview <a href="@template.examplePreviewUrl">here</a>):</p>
                                 <ul>
                                     @for(creative <- template.creatives){
                                         <li>@{creative.name} (<a href="@DfpLink.creative(creative.id)">@{creative.id}</a>)</li>
@@ -35,11 +44,6 @@
                                 </ul>
                             }
                         </div>
-                        @for(example <- template.example) {
-                            <h3 class="facia-container__inner">Example</h3>
-                            TODO
-                            @Html(example)
-                        }
                     </li>
                 }
             </ul>


### PR DESCRIPTION
Fixes up the admin creatives page:
- the creatives now display underneath their respective templates
- removed the example creative in favour of using the `previewUrl` from the first creative of each template.

_cc_ @kelvin-chappell 
