### PR TITLE
Renaming the header bidding ab test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -49,9 +49,9 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
-  val ABHeaderBiddingUSAll = Switch(
+  val ABHeaderBiddingUS = Switch(
     "A/B Tests",
-    "ab-header-bidding-us-all",
+    "ab-header-bidding-us",
     "Auction adverts on the client before calling DFP (US edition only)",
     safeState = Off,
     sellByDate = new LocalDate(2016, 4, 20),

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -152,7 +152,7 @@ define([
     var recordFirstAdRendered = once(function () {
         beacon.beaconCounts('ad-render');
     });
-    var prebidEnabled = ab.isInVariant('HeaderBiddingUsAll', 'variant');
+    var prebidEnabled = ab.isInVariant('HeaderBiddingUs', 'variant');
 
     /**
      * Initial commands

--- a/static/src/javascripts/projects/common/modules/experiments/tests/header-bidding-us.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/header-bidding-us.js
@@ -6,7 +6,7 @@ define([
     noop
 ) {
     return function () {
-        this.id = 'HeaderBiddingUsAll';
+        this.id = 'HeaderBiddingUs';
         this.start = '2016-03-08';
         this.expiry = '2016-04-06';
         this.author = 'Jimmy Breck-McKye, Zofia Korcz';


### PR DESCRIPTION
## This PR changes the header bidding ab test id because otherwise, the DFP targeting won't work.

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
