### PR TITLE
Fix ansi-styles version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -770,7 +770,7 @@
           "version": "1.1.1",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -2138,7 +2138,7 @@
                       "version": "1.1.1",
                       "dependencies": {
                         "ansi-styles": {
-                          "version": "2.2.0",
+                          "version": "2.2.1",
                           "dependencies": {
                             "color-convert": {
                               "version": "1.0.0"
@@ -2992,7 +2992,7 @@
           "version": "1.1.1",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -3086,7 +3086,7 @@
           "version": "1.1.1",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -3938,7 +3938,7 @@
           "version": "1.0.0",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -4126,7 +4126,7 @@
           "version": "1.1.1",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -4542,7 +4542,7 @@
           "version": "1.1.1",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -5375,7 +5375,7 @@
                                   "version": "1.1.1",
                                   "dependencies": {
                                     "ansi-styles": {
-                                      "version": "2.2.0",
+                                      "version": "2.2.1",
                                       "dependencies": {
                                         "color-convert": {
                                           "version": "1.0.0"
@@ -5908,7 +5908,7 @@
           "version": "1.0.0",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -5968,7 +5968,7 @@
               "version": "1.1.1",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.2.0",
+                  "version": "2.2.1",
                   "dependencies": {
                     "color-convert": {
                       "version": "1.0.0"
@@ -7090,7 +7090,7 @@
           "version": "1.1.1",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -7415,7 +7415,7 @@
           "version": "1.1.1",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -7788,7 +7788,7 @@
               "version": "1.1.1",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.2.0",
+                  "version": "2.2.1",
                   "dependencies": {
                     "color-convert": {
                       "version": "1.0.0"
@@ -8981,7 +8981,7 @@
           "version": "1.1.1",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -11956,7 +11956,7 @@
           "version": "1.1.1",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"
@@ -12333,7 +12333,7 @@
               "version": "1.1.1",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.2.0",
+                  "version": "2.2.1",
                   "dependencies": {
                     "color-convert": {
                       "version": "1.0.0"
@@ -13381,7 +13381,7 @@
           "version": "1.1.1",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.2.0",
+              "version": "2.2.1",
               "dependencies": {
                 "color-convert": {
                   "version": "1.0.0"


### PR DESCRIPTION
One of the dependencies in our `npm-shrinkwrap.json` was unpublished (https://github.com/chalk/ansi-styles/issues/17) so we need to update it.

This definitely took longer than doing a manual find and replace and I nearly went insane writing it, but I imagine it'll happen again so here's the command to do it:

```
grep -nHC1 "2\.2\.0" npm-shrinkwrap.json | grep -A1 ansi-styles | grep npm-shrinkwrap.json: | cut -d: -f2 | xargs -I"{}" -n1 sed -i {}s/\.0/\.1/ npm-shrinkwrap.json
```

@sammorrisdesign @jbreckmckye 
