### PR TITLE
Set test expiry to weekday

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -90,7 +90,7 @@ trait ABTestSwitches {
     "ab-membership",
     "Membership propositions",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 4, 30),
+    sellByDate = new LocalDate(2016, 5, 2),
     exposeClientSide = true
   )
 }


### PR DESCRIPTION
Sets the membership test expiry to a weekday to fix a test failure caused by #12357. (I accidentally merged that PR with a failing test)

@jbreckmckye 
