### PR TITLE
Catch ad callback exceptions

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -124,7 +124,8 @@ define([
         },
         '300,250': function (event, $adSlot) {
             if (config.switches.viewability && $adSlot.hasClass('ad-slot--right')) {
-                if ($adSlot.attr('data-mobile').indexOf('300,251') > -1) {
+                var mobileAdSizes = $adSlot.attr('data-mobile');
+                if (mobileAdSizes && mobileAdSizes.indexOf('300,251') > -1) {
                     stickyMpu($adSlot);
                 }
             }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -727,7 +727,7 @@ define([
                         $adSlot.addClass('ad-slot__fluid250');
                     });
                 }
-            }).catch(raven.captureException)
+            }).catch(raven.captureException);
         }
 
         allAdsRendered(adSlotId);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -726,7 +726,7 @@ define([
                         $adSlot.addClass('ad-slot__fluid250');
                     });
                 }
-            });
+            }).catch(raven.captureException)
         }
 
         allAdsRendered(adSlotId);


### PR DESCRIPTION
On pages like [this](http://www.theguardian.com/commentisfree/audio/2016/mar/17/podcast-feminism-jessica-valenti), a DFP advert callback for creating a sticky right-column ad throws an ugly exception:

![image](https://gm1.ggpht.com/qwHBcL9TRKgva0-GNIl03WwYFkk1L79r1yJuCkhh_Y0VykG6TrWkIY5vsfhNeYQQwUQDwi7t_Md8t3NBkMgvODil7kr99Ox-aNhx7pDf1uQSkUFA06IAMrKJrMqFa2gYOSXL8tVJUmvXmtbHo6ef1rBnnwzJM8rdrUDnlU-xRu0iA-ib7Jltq71_gaCOwU9geNCFW06Af8-g3xpb-e81J_cuoROxEdo5cOLZjYyaecHl-V_7RhUDE4Qsj2dlixlG32PdEYnRKeNTzSS0DRkAP4VyMrnFzslu2vIujk8CCBTPYiXUiy1AMR9796eYjnggJsFBR_3p11lHZyzyNdC6MjGd8GXJ8TzbLNaPGMN2RtseQiU8A3LiGfzKmRiKq5vr-jIKX7DTq45fizRwrEScIsnFknKhRmw0-gJjqYRQ-L5Cbc3HCowAcsgZvz11YGyrJWWiA0hGfcsugj7IBGBrm_KXVOEw0zY23vN7LEgsh1-wv2PO8D-TeoGXQHcCMFHJGMK0VpREDI41_QveyzpdolyDUrZ3WaqRG_Vd4MB6b6M84ptdQUnl3QoMS3l1AhFdazy4xFwr8mRjFsph093NJopWAnObHwNwkl3SPhfINElZC9U52S3R-DoAUug2-q3XFkpONYh4iDjjpASg9EAeyycw__DHkYRGdafBJDJldZYHQP6uQ2zTEGS0AbzJr1E=w1008-h126-l75-ft)

This pull request:
- fixes the error (guards against trying to find an element in an array which is null)
- makes sure the 'parseAds' stage of the ad lifecycle is monitored by Sentry

Now our unhandled error is logged with an accompanying console warning:

![image](https://cloud.githubusercontent.com/assets/3148617/14110731/adc3ca5e-f5bf-11e5-9ed6-29193facb844.png)
