### PR TITLE
Fix HTML escaping in ExactTarget variables

### DIFF
--- a/common/app/views/fragments/email/ampScript.scala.html
+++ b/common/app/views/fragments/email/ampScript.scala.html
@@ -1,14 +1,15 @@
 @(page: model.ContentPage)
 
-@import views.support.StripHtmlTags
+@import views.support.StripHtmlTagsAndUnescapeEntities
 
 <!--
 %%[
     Var @@subject, @@intro
-    Set @@subject = "@page.item.trail.headline"
+    Set @@subject = "@Html(StripHtmlTagsAndUnescapeEntities(page.item.trail.headline))"
+
 
     @page.item.trail.fields.trailText.map { byline =>
-        Set @@intro = "@StripHtmlTags(byline)"
+    Set @@intro = "@Html(StripHtmlTagsAndUnescapeEntities(byline))"
     }
 ]%%
 -->


### PR DESCRIPTION
to stop this happening:
![screen shot 2016-03-29 at 15 17 25](https://cloud.githubusercontent.com/assets/1064734/14111117/6065438a-f5c1-11e5-9d8f-5c1787147989.png)
