### PR TITLE
Tweaks to membership test before exposing to users

### DIFF
--- a/commercial/app/views/static/guardianExplorePage.scala.html
+++ b/commercial/app/views/static/guardianExplorePage.scala.html
@@ -80,6 +80,7 @@
                         </div>
                         <div class="membership-test__right">
                             <p>
+                                The Guardian is investigating new ways to report on the world.
                                 Guardian Explore is a concept we are currently developing.
                                 If you are interested in hearing more about this idea, please register for updates.
                             </p>

--- a/static/src/javascripts/projects/common/views/membership-thrasher.html
+++ b/static/src/javascripts/projects/common/views/membership-thrasher.html
@@ -14,6 +14,7 @@
                 <%=propositionDescription%>
             </p>
             <a class="thrasher-link" href="<%=linkHref%>" target="_blank" data-link-name="<%propositionName%>"></a>
+            <a href="<%=linkHref%>" class="button button--large">Find out more</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Tweaked the Guardian Explore copy to keep it in line with [this doc](https://docs.google.com/document/d/1fbpzgdfKpN8DCWtHnrTp91cgIAg4Y407nYA7ewaW-nw/edit?ts=56f17dd0).

Also added a CTA button to the thrasher at Nick Haley's request - he was concerned that the existing copy did not obviously invite people to click on it.
#### thrasher before

![picture 188](https://cloud.githubusercontent.com/assets/5122968/14113729/1fda7b0e-f5cc-11e5-9785-c6aa6ca56648.png)
#### thrasher after

![picture 189](https://cloud.githubusercontent.com/assets/5122968/14113730/243a8ee6-f5cc-11e5-8ed0-4e4e1cb46fd7.png)

@Calanthe 
