### PR TITLE
Service worker lower cachetime and fix

### DIFF
--- a/applications/app/controllers/WebAppController.scala
+++ b/applications/app/controllers/WebAppController.scala
@@ -21,7 +21,7 @@ case class OfflinePage(crossword: CrosswordData) extends StandalonePage {
 object WebAppController extends Controller with ExecutionContexts with Logging {
 
   def serviceWorker() = Action { implicit request =>
-    Cached(3600) { Ok(templates.js.serviceWorker()) }
+    Cached(60) { Ok(templates.js.serviceWorker()) }
   }
 
   def manifest() = Action {

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -13,6 +13,8 @@
 
 var staticCacheName = 'static';
 
+console.log("++GET TROSAS")
+
 var getISODate = function () {
     return new Date().toISOString().split('T')[0];
 };
@@ -151,7 +153,7 @@ self.addEventListener('push', function(event) {
             var gcmBrowserId = sub.endpoint.substring(sub.endpoint.lastIndexOf('/') + 1);
 
             var endpoint = '@{JavaScript(Configuration.Notifications.latestMessageUrl)}/' + gcmBrowserId;
-            fetch(endpoint, {
+            return fetch(endpoint, {
                 headers: {
                     'Accept': 'application/json',
                     'Content-Type': 'application/json'
@@ -172,8 +174,8 @@ self.addEventListener('push', function(event) {
                            tag: message.title,
                            data: data
                        });
-                   }
-                })
+                }
+            })
 
         })
     );

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -161,19 +161,20 @@ self.addEventListener('push', function(event) {
             })
             .then(function (json) {
 
-               if(json.status === "ok" && json.messages.length > 0)
-                    /* Client returns current messages for a given browserid ( which are then deleted ) We want the latest one.
-                       If we loop displaying all of them the promise doesn't resolved and a 'website being updated in the background' message is displayed
-                     */
-                    var message = json.messages.slice(-1)[0];
-                    var data = {topic: message.topic};
-                    return self.registration.showNotification(message.title, {
-                        body: message.body,
-                        icon: '@{JavaScript(Static("images/favicons/114x114.png").path)}',
-                        tag: message.title,
-                        data: data
-                    });
-                })
+               if(json.status === "ok" && json.messages.length > 0) {
+                   /* Client returns current messages for a given browserid ( which are then deleted ) We want the latest one.
+                    If we loop displaying all of them the promise doesn't resolved and a 'website being updated in the background' message is displayed
+                    */
+                   var message = json.messages.slice(-1)[0];
+                   var data = {topic: message.topic};
+                   return self.registration.showNotification(message.title, {
+                       body: message.body,
+                       icon: '@{JavaScript(Static("images/favicons/114x114.png").path)}',
+                       tag: message.title,
+                       data: data
+                   });
+               }
+            })
 
         })
     );

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -157,7 +157,9 @@ self.addEventListener('push', function(event) {
                     'Content-Type': 'application/json'
                 }
             }).then(function (response) {
-               return response.json().then(function(json){
+               return response.json();
+            })
+            .then(function (json) {
                    if(json.status === "ok" && json.messages.length > 0) {
                        /* Client returns current messages for a given browserid ( which are then deleted ) We want the latest one.
                         If we loop displaying all of them the promise doesn't resolved and a 'website being updated in the background' message is displayed
@@ -171,9 +173,8 @@ self.addEventListener('push', function(event) {
                            data: data
                        });
                    }
+                })
 
-               });
-            })
         })
     );
 });

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -13,8 +13,6 @@
 
 var staticCacheName = 'static';
 
-console.log("++GET TROSAS")
-
 var getISODate = function () {
     return new Date().toISOString().split('T')[0];
 };

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -157,25 +157,23 @@ self.addEventListener('push', function(event) {
                     'Content-Type': 'application/json'
                 }
             }).then(function (response) {
-               return response.json();
-            })
-            .then(function (json) {
+               return response.json().then(function(json){
+                   if(json.status === "ok" && json.messages.length > 0) {
+                       /* Client returns current messages for a given browserid ( which are then deleted ) We want the latest one.
+                        If we loop displaying all of them the promise doesn't resolved and a 'website being updated in the background' message is displayed
+                        */
+                       var message = json.messages.slice(-1)[0];
+                       var data = {topic: message.topic};
+                       return self.registration.showNotification(message.title, {
+                           body: message.body,
+                           icon: '@{JavaScript(Static("images/favicons/114x114.png").path)}',
+                           tag: message.title,
+                           data: data
+                       });
+                   }
 
-               if(json.status === "ok" && json.messages.length > 0) {
-                   /* Client returns current messages for a given browserid ( which are then deleted ) We want the latest one.
-                    If we loop displaying all of them the promise doesn't resolved and a 'website being updated in the background' message is displayed
-                    */
-                   var message = json.messages.slice(-1)[0];
-                   var data = {topic: message.topic};
-                   return self.registration.showNotification(message.title, {
-                       body: message.body,
-                       icon: '@{JavaScript(Static("images/favicons/114x114.png").path)}',
-                       tag: message.title,
-                       data: data
-                   });
-               }
+               });
             })
-
         })
     );
 });


### PR DESCRIPTION
# My Awesome Pull Request
## What does this change?

Tries again to fix the 'website updated in the background' that this didn't fix: 
https://github.com/guardian/frontend/pull/12350
1. Correctly handles the promise: http://stackoverflow.com/questions/31108699/chrome-push-notification-this-site-has-been-updated-in-the-background as here 
   (plus fix schoolboy error)
2. Lowers the cachetime on the service-worker.js file so that this is more easily updated. See "Updating a service-worker" here: https://github.com/slightlyoff/ServiceWorker/blob/master/explainer.md

Tidies up correctly returning the promise

Fixes my not so awesome service worker code: 
## What is the value of this and can you measure success?
## Does this affect other platforms - Amp, Apps, etc?
## Screenshots
## Request for comment
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
