### PR TITLE
Fix js error in admin AB tests dashboard

### DIFF
--- a/admin/app/views/abtests.scala.html
+++ b/admin/app/views/abtests.scala.html
@@ -43,5 +43,8 @@
                 "@CamelCase.fromHyphenated(s.name)": @s.isSwitchedOn,
             }
         };
+        window.guardian = {
+            adBlockers: {}
+        }
     </script>
 }

--- a/admin/app/views/abtests.scala.html
+++ b/admin/app/views/abtests.scala.html
@@ -43,8 +43,5 @@
                 "@CamelCase.fromHyphenated(s.name)": @s.isSwitchedOn,
             }
         };
-        window.guardian = {
-            adBlockers: {}
-        }
     </script>
 }

--- a/admin/app/views/admin_main.scala.html
+++ b/admin/app/views/admin_main.scala.html
@@ -87,6 +87,10 @@
             };
 
             @Html(Static.js.curl)
+
+            window.guardian = {
+                adBlockers: {}
+            };
         </script>
         <script src="//code.jquery.com/jquery.js"></script>
         <script type="text/javascript" src="@UncachedWebAssets.at("lib/bootstrap/js/bootstrap.min.js")"></script>


### PR DESCRIPTION
The detect ad blocker system expects a valid key in the guardian config object. I reckon it should always be present, rather than guarded, so added it to the admin_main template
