### PR TITLE
don't show poster on fronts

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -58,7 +58,7 @@
                 )) { player =>
                     <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player">
                         <div class="fc-item__video-container">
-                            @video(player, false, item.cardTypes.showVideoEndSlate)
+                            @video(player, false, item.cardTypes.showVideoEndSlate, showPoster = false)
                         </div>
                     </div>
                 @fallback.map { fallbackImage =>

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -1,4 +1,4 @@
-@(player: model.VideoPlayer, enhance: Boolean, showEndSlate: Boolean = true, amp: Boolean = false)
+@(player: model.VideoPlayer, enhance: Boolean, showEndSlate: Boolean = true, amp: Boolean = false, showPoster: Boolean = true)
 
 @import conf.Static
 @import views.support.RenderClasses
@@ -38,7 +38,7 @@
             ))" data-title="@player.title"
                 data-auto-play="@player.autoPlay"
                 data-show-end-slate="@(player.showEndSlate && showEndSlate)"
-                poster="@player.poster"
+                @if(showPoster) { poster="@player.poster" }
                 data-duration="@player.video.videos.duration.toString()"
                 data-media-id="@player.video.properties.id"
                 data-end-slate="@player.endSlatePath"


### PR DESCRIPTION
# Don't use posters on fronts

As trail slots and videos are of a different ratio - so are the trail images and video posters.
This creates a jerky experience when pressing play on a video on a front when you go from trail image => poster => video.

We also save some bandwidth as per #8118.
## What is the value of this and can you measure success?

Better UX for all and bandwidth.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

It's hard to Gif as it's milliseconds, but just press play [here](http://theguardian.com/video) for the bad experience and with a little imagination, you can image that it doesn't.
## Request for comment

@akash1810 @paperboyo
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
