### PR TITLE
Adjust start & expiry of membership test to run for a week

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/membership.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/membership.js
@@ -10,8 +10,8 @@ define([
     return function () {
 
         this.id = 'Membership';
-        this.start = '2016-03-21';
-        this.expiry = '2016-04-01';
+        this.start = '2016-03-29';
+        this.expiry = '2016-04-05';
         this.author = 'Joseph Smith';
         this.description = '404 test to determine interest in three possible membership propositions';
         this.audience = 0.12;


### PR DESCRIPTION
This test should run for a week. The start & expiry dates didn't reflect the actual time I started running the test (yesterday).
