### PR TITLE
Admin login: Allow multiple oauth callback urls

### DIFF
--- a/admin/app/conf/AdminConfiguration.scala
+++ b/admin/app/conf/AdminConfiguration.scala
@@ -1,7 +1,7 @@
 package conf
 
 import com.gu.conf.ConfigurationFactory
-import conf.Configuration.OAuthCredentials
+import conf.Configuration.OAuthCredentialsWithMultipleCallbacks
 
 case class OmnitureCredentials(userName: String, secret: String)
 
@@ -42,12 +42,11 @@ object AdminConfiguration {
     lazy val appName = configuration.getStringProperty("api.dfp.applicationName")
   }
 
-  lazy val oauthCredentials: Option[OAuthCredentials] =
+  lazy val oauthCredentials: Option[OAuthCredentialsWithMultipleCallbacks] =
       for {
         oauthClientId <- configuration.getStringProperty("admin.oauth.clientid")
         oauthSecret <- configuration.getStringProperty("admin.oauth.secret")
-        oauthCallback <- configuration.getStringProperty("admin.oauth.callback")
-      } yield OAuthCredentials(oauthClientId, oauthSecret, oauthCallback)
+      } yield OAuthCredentialsWithMultipleCallbacks(oauthClientId, oauthSecret, configuration.getStringPropertiesSplitByComma("admin.oauth.callbacks"))
 
   lazy val omnitureCredentials: Option[OmnitureCredentials] =
     for {

--- a/admin/app/conf/GoogleAuth.scala
+++ b/admin/app/conf/GoogleAuth.scala
@@ -2,19 +2,27 @@ package conf
 
 import com.gu.googleauth.GoogleAuthConfig
 
-object GoogleAuth {
-  val config = AdminConfiguration.oauthCredentials.map { cred =>
-    GoogleAuthConfig(
-      cred.oauthClientId,     // The client ID from the dev console
-      cred.oauthSecret,       // The client secret from the dev console
-      cred.oauthCallback,     // The redirect URL Google send users back to (must be the same as
-      // that configured in the developer console)
-      Some("guardian.co.uk"), // Google App domain to restrict login
-      None
-    )
+case class GoogleAuth(currentHost: Option[String]) {
+  val config = AdminConfiguration.oauthCredentials.flatMap { cred =>
+    for {
+      callback <- cred.authorizedOauthCallbacks.collectFirst {
+        case defaultHost if currentHost.isEmpty => defaultHost  // if oauthCallbackHost is NOT defineed, return the first authorized host in the list
+        case host if host.startsWith(currentHost.get) => host   // if an authorized callback starts with current host, return it
+                                                                // otherwise None will be returned
+      }
+    } yield {
+      GoogleAuthConfig(
+        cred.oauthClientId,      // The client ID from the dev console
+        cred.oauthSecret,        // The client secret from the dev console
+        callback,                // The redirect URL Google send users back to (must be the same as that configured in the developer console)
+        Some("guardian.co.uk")   // Google App domain to restrict login
+      )
+    }
   }
 
   def getConfigOrDie = config getOrElse {
     throw new RuntimeException("You must set up credentials for Google Auth")
   }
 }
+
+object GoogleAuth extends GoogleAuth(None)

--- a/admin/app/controllers/OAuthLoginController.scala
+++ b/admin/app/controllers/OAuthLoginController.scala
@@ -1,8 +1,8 @@
 package controllers.admin
 
-import com.gu.googleauth.{GoogleAuth, GoogleAuthConfig, UserIdentity}
+import com.gu.googleauth.{GoogleAuth, UserIdentity}
 import common.ExecutionContexts
-import conf.{Configuration, AdminConfiguration}
+import conf.Configuration
 import org.joda.time.DateTime
 import play.api.libs.json.Json
 import play.api.mvc.{Action, Controller}
@@ -26,7 +26,8 @@ object OAuthLoginController extends Controller with ExecutionContexts {
   Redirect to Google with anti forgery token (that we keep in session storage - note that flashing is NOT secure)
    */
   def loginAction = Action.async { implicit request =>
-    conf.GoogleAuth.config.map { config =>
+    val host = Some(s"${if (request.secure) "https" else "http"}://${request.host}")
+    conf.GoogleAuth(host).config.map { config =>
       val antiForgeryToken = GoogleAuth.generateAntiForgeryToken()
       GoogleAuth.redirectToGoogle(config, antiForgeryToken).map {
         _.withSession {
@@ -42,7 +43,8 @@ object OAuthLoginController extends Controller with ExecutionContexts {
   will return a Future[UserIdentity] if the authentication is successful. If unsuccessful then the Future will fail.
    */
   def oauth2Callback = Action.async { implicit request =>
-    conf.GoogleAuth.config.map { config =>
+    val host = Some(s"${if (request.secure) "https" else "http"}://${request.host}")
+    conf.GoogleAuth(host).config.map { config =>
       request.session.get(ANTI_FORGERY_KEY) match {
         case None =>
           Future.successful(Redirect(routes.OAuthLoginController.login())

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -19,6 +19,7 @@ class BadConfigurationException(msg: String) extends RuntimeException(msg)
 class GuardianConfiguration(val application: String, val webappConfDirectory: String = "env") extends Logging {
 
   case class OAuthCredentials(oauthClientId: String, oauthSecret: String, oauthCallback: String)
+  case class OAuthCredentialsWithMultipleCallbacks(oauthClientId: String, oauthSecret: String, authorizedOauthCallbacks: List[String])
 
   protected val configuration = ConfigurationFactory.getNonLoggingConfiguration(application, webappConfDirectory)
 

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -91,7 +91,7 @@ faciatool.show_test_containers=true
 
 #Admin Oauth
 admin.oauth.clientid=265127054270-oh215l6pe6csgtucra1ugjruuqptgsjh.apps.googleusercontent.com
-admin.oauth.callback=https://frontend.code.dev-gutools.co.uk/oauth2callback
+admin.oauth.callbacks=https://frontend.code.dev-gutools.co.uk/oauth2callback,http://admin-code.frontend.gutools.co.uk.global.prod.fastly.net/oauth2callback
 
 # Headlines AB Test
 headlines.spreadsheet=1aKGsfMI60Qa3xHURuaEmp-5urdPGPxgPL1G77OCNS2I

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -77,7 +77,7 @@ faciatool.show_test_containers=true
 
 #Admin Oauth
 admin.oauth.clientid=265127054270-97f63kb58ns533alnhlb1vj4jds79q2f.apps.googleusercontent.com
-admin.oauth.callback=http://localhost:9000/oauth2callback
+admin.oauth.callbacks=http://localhost:9000/oauth2callback,http://127.0.0.1:9000/oauth2callback
 
 #Preview Oauth
 standalone.oauth.clientid=768784040766-1eq1drssgu65vrs4oi1hjh70d9b30fti.apps.googleusercontent.com

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -85,7 +85,7 @@ admin.pressjob.low.push.rate.inminutes=60
 
 #Admin Oauth
 admin.oauth.clientid=265127054270-h00sqjp6mo4p9rpmb6ivsgfl5qr0dqf4.apps.googleusercontent.com
-admin.oauth.callback=https://frontend.gutools.co.uk/oauth2callback
+admin.oauth.callbacks=https://frontend.gutools.co.uk/oauth2callback,http://admin.frontend.gutools.co.uk.global.prod.fastly.net/oauth2callback
 
 # TODO moving to platform properties - delete after that
 #Preview Oauth


### PR DESCRIPTION
## What does this change?

Allow to configure multiple oauth callbacks for the admin pages depending on the domain it is accessed from
## What is the value of this and can you measure success?

Short term goal: keep a way to access admin page while changing frontend.gutools.co.uk dns 
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@dominickendrick 
