### PR TITLE
Manually floor header-bidding CPMs to appropriate buckets

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/PrebidService.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/PrebidService.js
@@ -114,7 +114,7 @@ define([
                 alwaysUseBid : false,
                 adserverTargeting : [{
                     key : 'hb_pb',
-                    val : cpmToPriceBucket
+                    val : getBidCpm
                 }, {
                     key : 'hb_adid',
                     val : function getBidAdId(bidResponse) {
@@ -130,25 +130,32 @@ define([
         };
     }
 
-    function cpmToPriceBucket(bidResponse) {
+    function getBidCpm(bidResponse) {
         var cpm = parseFloat(bidResponse.cpm);
+        var bucket;
 
         if (cpm >= 20.00) {
-            return '20.00';
+            bucket = 20;
         } else if (cpm >= 5.00) {
-            return bidResponse.pbLg; // .50 increments
+            bucket = priceToNearestBucket(cpm, 0.50);
         } else if (cpm >= 1.00) {
-            return bidResponse.pbMg; // .10 increments
+            bucket = priceToNearestBucket(cpm, 0.10);
         } else {
-            return toFiveCentBucket(cpm).toString();
+            bucket = priceToNearestBucket(cpm, 0.05);
         }
 
-        function toFiveCentBucket(dollars) {
-            // Use cents to avoid float manipulation
-            var cents = dollars * 100;
-            var fiveCents = Math.floor(cents / 5);
-            return (fiveCents * 5) / 100;
-        }
+        return bucket.toFixed(2);
+    }
+
+    function priceToNearestBucket(price, bucket) {
+        // Work in minor units (cents, pence) to avoid float manipulation
+        price = price * 100;
+        bucket = bucket * 100;
+
+        var bucketCount = Math.floor(price / bucket);
+        var bucketValue = bucketCount * bucket;
+
+        return bucketValue / 100;
     }
 
     function logError(e) {

--- a/static/test/javascripts/spec/common/commercial/dfp/PrebidService.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/PrebidService.spec.js
@@ -76,15 +76,25 @@ define([
                 });
 
                 it('Caps price values at $20', function () {
-                    expect(
-                        getPriceBucket({cpm: 28.61})
-                    ).toBe('20.00');
+                    expect(getPriceBucket({cpm: 28.61})).toBe('20.00');
                 });
 
-                it('Values under $1 are floored to 5 cent segments', function () {
-                    expect(
-                        getPriceBucket({cpm: 0.89})
-                    ).toBe('0.85');
+                it('Floors values from $5 to $19.99 to the nearest 50c', function () {
+                    expect(getPriceBucket({cpm: 5.00})).toBe('5.00');
+                    expect(getPriceBucket({cpm: 5.49})).toBe('5.00');
+                    expect(getPriceBucket({cpm: 5.50})).toBe('5.50');
+                });
+
+                it('Floors values from $1 to $4.99 to the nearest 10c', function () {
+                    expect(getPriceBucket({cpm: 1.00})).toBe('1.00');
+                    expect(getPriceBucket({cpm: 1.09})).toBe('1.00');
+                    expect(getPriceBucket({cpm: 1.10})).toBe('1.10');
+                });
+
+                it('Floors values under $1 to the nearest 5c', function () {
+                    expect(getPriceBucket({cpm: 0.00})).toBe('0.00');
+                    expect(getPriceBucket({cpm: 0.04})).toBe('0.00');
+                    expect(getPriceBucket({cpm: 0.05})).toBe('0.05');
                 });
             });
         });


### PR DESCRIPTION
This fixes an issue where prices between $5 and $15 were being artificially capped at $5.00, because Prebid.js applies that ceiling to the low-granularity CPM value (but none of the others, bizarrely).

This change puts the CPM bucketing behaviour squarely in our control.
