### PR TITLE
completely remove posters from fronts

### DIFF
--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -55,8 +55,10 @@
                     <object type="application/x-shockwave-flash" data="@Static("flash/components/mediaelement/flashmediaelement-cdn.swf")" width="@player.width" height="@player.height">
                         <param name="allowFullScreen" value="true" />
                         <param name="movie" value="@Static("flash/components/mediaelement/flashmediaelement.swf")" />
-                        <param name="flashvars" value="controls=true&file=@encoding.url&poster=@player.poster" />
-                        <img src="@player.poster" alt="" width="@player.width" height="@player.height" />
+                        <param name="flashvars" value="controls=true&file=@encoding.url&@if(showPoster){poster=@player.poster}" />
+                        @if(showPoster) {
+                            <img src="@player.poster" alt="" width="@player.width" height="@player.height" />
+                        }
                         <div class="vjs-error-display">
                             <div>Sorry, your browser is unable to play this video.<br/>
                                 Please install <a href="http://get.adobe.com/flashplayer/">Adobe Flash</a>™ and try again.


### PR DESCRIPTION
# Completely remove posters from fronts

Extension of #12375. For the same reasons
We now don't include them in the flash / fallback either, which strangely download even when they're invisible.
## Request for comment

@akash1810 @sndrs @paperboyo
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
