### PR TITLE
Fix video loading

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -236,7 +236,7 @@ define([
             endSlateUri = $el.attr('data-end-slate'),
             embedPath = $el.attr('data-embed-path'),
             // we need to look up the embedPath for main media videos
-            canonicalUrl = $el.attr('data-canonical-url') || '/' + embedPath,
+            canonicalUrl = $el.attr('data-canonical-url') || (embedPath ? '/' + embedPath : null),
             techPriority = techOrder(el),
             withPreroll = shouldPreroll && !blockVideoAds,
             player,

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -61,6 +61,7 @@ define([
                     id: id,
                     eventType: event.type
                 };
+                console.log(eventObject);
                 ophan.record(eventObject);
             });
         }

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -61,7 +61,6 @@ define([
                     id: id,
                     eventType: event.type
                 };
-                console.log(eventObject);
                 ophan.record(eventObject);
             });
         }


### PR DESCRIPTION
We were accidentally setting canonicalUrl to '/null'.
This is a hotfix as tracking is down, I will look at a longer term fix later.
