### PR TITLE
Change header bidding price buckets

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/PrebidService.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/PrebidService.js
@@ -136,6 +136,8 @@ define([
 
         if (cpm >= 20.00) {
             bucket = 20;
+        } else if (cpm >= 10.00) {
+            bucket = priceToNearestBucket(cpm, 1.00);
         } else if (cpm >= 5.00) {
             bucket = priceToNearestBucket(cpm, 0.50);
         } else if (cpm >= 1.00) {

--- a/static/test/javascripts/spec/common/commercial/dfp/PrebidService.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/PrebidService.spec.js
@@ -79,22 +79,32 @@ define([
                     expect(getPriceBucket({cpm: 28.61})).toBe('20.00');
                 });
 
-                it('Floors values from $5 to $19.99 to the nearest 50c', function () {
+                it('Floors values from $10 to $19.99 to the nearest $1', function () {
+                    expect(getPriceBucket({cpm: 10.00})).toBe('10.00');
+                    expect(getPriceBucket({cpm: 10.99})).toBe('10.00');
+                    expect(getPriceBucket({cpm: 11.00})).toBe('11.00');
+                    expect(getPriceBucket({cpm: 19.99})).toBe('19.00');
+                });
+
+                it('Floors values from $5 to $9.99 to the nearest 50c', function () {
                     expect(getPriceBucket({cpm: 5.00})).toBe('5.00');
                     expect(getPriceBucket({cpm: 5.49})).toBe('5.00');
                     expect(getPriceBucket({cpm: 5.50})).toBe('5.50');
+                    expect(getPriceBucket({cpm: 9.99})).toBe('9.50');
                 });
 
                 it('Floors values from $1 to $4.99 to the nearest 10c', function () {
                     expect(getPriceBucket({cpm: 1.00})).toBe('1.00');
                     expect(getPriceBucket({cpm: 1.09})).toBe('1.00');
                     expect(getPriceBucket({cpm: 1.10})).toBe('1.10');
+                    expect(getPriceBucket({cpm: 4.99})).toBe('4.90');
                 });
 
                 it('Floors values under $1 to the nearest 5c', function () {
                     expect(getPriceBucket({cpm: 0.00})).toBe('0.00');
                     expect(getPriceBucket({cpm: 0.04})).toBe('0.00');
                     expect(getPriceBucket({cpm: 0.05})).toBe('0.05');
+                    expect(getPriceBucket({cpm: 0.99})).toBe('0.95');
                 });
             });
         });


### PR DESCRIPTION
Prices between $10 and $20 should be aliased to $1 increments.
