### PR TITLE
Replace outbrain-on-amp switch with generic outbrain switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -230,15 +230,6 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val OutbrainOnAmp = Switch(
-    "Commercial",
-    "outbrain-on-amp",
-    "Show an Outbrain component on amp pages",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 4, 5),
-    exposeClientSide = false
-  )
-
   val BritishCouncilBeacon = Switch(
     "Commercial",
     "british-council-beacon",

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -26,7 +26,7 @@ trait FeatureSwitches {
   val OutbrainSwitch = Switch(
     "Feature",
     "outbrain",
-    "Enable the Outbrain content recommendation widget.",
+    "Enable the Outbrain content recommendation widget on web and AMP.",
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -35,7 +35,7 @@ trait FeatureSwitches {
   val PlistaForOutbrainAU = Switch(
     "Feature",
     "plista-for-outbrain-au",
-    "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition.",
+    "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition (for web only).",
     safeState = Off,
     sellByDate = new LocalDate(2016, 4, 6),
     exposeClientSide = true

--- a/common/app/views/fragments/amp/outbrain.scala.html
+++ b/common/app/views/fragments/amp/outbrain.scala.html
@@ -1,8 +1,8 @@
 @(page: model.Page)
-@import conf.switches.Switches.OutbrainOnAmp
+@import conf.switches.Switches.OutbrainSwitch
 @import views.support.URLEncode
 
-@if(OutbrainOnAmp.isSwitchedOn) {
+@if(OutbrainSwitch.isSwitchedOn) {
     @defining(page.metadata.webUrl) { htmlUrl =>
         <amp-iframe height=175
         sandbox="allow-scripts allow-same-origin allow-popups"


### PR DESCRIPTION
This PR removes the AMP-specific switch for outbrain (which is about to expire).

Now that AMP has been stable for a while, we can use the old outbrain switch to control outbrain on both web and AMP.

/@stephanfowler 
