### PR TITLE
Breaking-News: Notification message should be used as headline

### DIFF
--- a/admin-jobs/app/controllers/BreakingNews/BreakingNewsUpdater.scala
+++ b/admin-jobs/app/controllers/BreakingNews/BreakingNewsUpdater.scala
@@ -35,7 +35,6 @@ class BreakingNewsUpdater(breakingNewsApi: BreakingNewsApi) extends Actor with L
     def save(b: BreakingNews) = Some(breakingNewsApi.putBreakingNews(Json.toJson(b)))
 
     try {
-      //Cache current BreakingNews instead of fetching it every time
       val result = for {
         currentBreakingNewsJson <- fetch
         currentBreakingNews <- parse(currentBreakingNewsJson)

--- a/admin-jobs/app/models/BreakingNews.scala
+++ b/admin-jobs/app/models/BreakingNews.scala
@@ -18,9 +18,9 @@ object BreakingNewsFormats {
 
   implicit val breakingNewsEntryReads: Reads[NewsAlertNotification] = (
     (__ \ "uid").read[UUID] and
-    (__ \ "id").read[URI] and
+      (__ \ "id").read[URI] and
+      (__ \ "title").read[String] and
       (__ \ "headline").read[String] and
-      (__ \ "message").read[String] and
       (__ \ "thumbnail").readNullable[URI] and
       (__ \ "shortUrl").read[URI] and
       Reads.pure(None) and //imageUrl
@@ -31,8 +31,8 @@ object BreakingNewsFormats {
     def writes(notification: NewsAlertNotification): JsValue = {
       Json.obj(
         "uid" -> notification.uid,
-        "headline" -> notification.title,
-        "message" -> notification.message,
+        "title" -> notification.title,
+        "headline" -> notification.message,
         "thumbnail" -> notification.thumbnailUrl,
         "shortUrl" -> notification.link,
         "id" -> notification.urlId,

--- a/admin-jobs/test/models/BreakingNewsTest.scala
+++ b/admin-jobs/test/models/BreakingNewsTest.scala
@@ -39,8 +39,8 @@ class BreakingNewsTest extends WordSpec with Matchers {
           |"content": [
           |{
           |"uid": "$randomUid",
-          |"headline": "$title",
-          |"message": "$message",
+          |"title": "$title",
+          |"headline": "$message",
           |"thumbnail": "$thumbnailUrl",
           |"shortUrl": "$link",
           |"id": "$id",
@@ -64,8 +64,8 @@ class BreakingNewsTest extends WordSpec with Matchers {
           |"content": [
           |{
           |"uid": "$randomUid",
-          |"headline": "$title",
-          |"message": "$message",
+          |"title": "$title",
+          |"headline": "$message",
           |"thumbnail": "$thumbnailUrl",
           |"shortUrl": "$link",
           |"id": "$id",


### PR DESCRIPTION
## What does this change?

Notification message should be used as the breaking-news headline, instead of the notification title
Title is always 'The Guardian', which is only used by the Android app
## Does this affect other platforms - Amp, Apps, etc?

No

@johnduffell 
