### PR TITLE
Extend Identity Register Membership Standfirst AB test by a month

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -27,7 +27,7 @@ trait ABTestSwitches {
     "ab-identity-register-membership-standfirst",
     "Membership registration page variant for Identity",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 4, 1),
+    sellByDate = new LocalDate(2016, 5, 4),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/identity-register-membership-standfirst.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/identity-register-membership-standfirst.js
@@ -12,7 +12,7 @@ define([], function () {
 
         this.id = 'IdentityRegisterMembershipStandfirst';
         this.start = '2016-02-25';
-        this.expiry = '2016-04-01';
+        this.expiry = '2016-05-04';
         this.author = 'James Pamplin';
         this.description = 'Membership registration page variant for Identity';
         this.audience = 0.5;


### PR DESCRIPTION
## What does this change?

Extends the `IdentityRegisterMembershipStandfirst` A/B test by a month.
## What is the value of this and can you measure success?

Keeps the test running to see if membership registrations are increasing with the added standfirst.
## Does this affect other platforms - Amp, Apps, etc?

Identity
## Screenshots

![identity-frontend-membership-register-standfirst](https://cloud.githubusercontent.com/assets/2298529/14209771/a06cf424-f81d-11e5-998d-90c9695fc6c4.png)
## Request for comment

@markjamesbutler 
