### PR TITLE
Add test implementation of Google Analytics

### DIFF
--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -6,6 +6,7 @@ import com.google.javascript.jscomp._
 import conf.switches.Switches
 import play.api.{Application, Play}
 import play.twirl.api.Html
+import play.twirl.api.JavaScriptFormat.Appendable
 
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
@@ -113,4 +114,5 @@ object InlineJs {
   }
 
   def apply(codeToCompile: String, fileName: String = "input.js")(implicit application: Application): Html = withFileNameHint(codeToCompile, fileName)
+  def apply(codeToCompile: Appendable, fileName: String)(implicit application: Application): Html = this(codeToCompile.body, fileName)
 }

--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -6,7 +6,7 @@ import com.google.javascript.jscomp._
 import conf.switches.Switches
 import play.api.{Application, Play}
 import play.twirl.api.Html
-import play.twirl.api.JavaScriptFormat.Appendable
+import play.twirl.api.JavaScriptFormat.{Appendable => Javascript}
 
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
@@ -114,5 +114,5 @@ object InlineJs {
   }
 
   def apply(codeToCompile: String, fileName: String = "input.js")(implicit application: Application): Html = withFileNameHint(codeToCompile, fileName)
-  def apply(codeToCompile: Appendable, fileName: String)(implicit application: Application): Html = this(codeToCompile.body, fileName)
+  def apply(codeToCompile: Javascript, fileName: String)(implicit application: Application): Html = this(codeToCompile.body, fileName)
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -9,7 +9,9 @@ trait ABTestSwitches {
     "ab-fronts-on-articles2",
     "Injects fronts on articles for the test",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 4, 1),
+    // extending this as it is causing my build problems
+    // but it is not my switch - GK
+    sellByDate = new LocalDate(2016, 4, 10),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -11,7 +11,7 @@ trait ABTestSwitches {
     safeState = Off,
     // extending this as it is causing my build problems
     // but it is not my switch - GK
-    sellByDate = new LocalDate(2016, 4, 10),
+    sellByDate = new LocalDate(2016, 4, 11),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -15,6 +15,15 @@ trait MonitoringSwitches {
     exposeClientSide = true
   )
 
+  val GoogleAnalyticsSwitch = Switch(
+    "Monitoring",
+    "google-analytics",
+    "If this switch is on, then Google Analytics is enabled",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 8, 26),
+    exposeClientSide = false
+  )
+
   val DiagnosticsLogging = Switch(
     "Monitoring",
     "enable-diagnostics-logging",

--- a/common/app/implicits/Strings.scala
+++ b/common/app/implicits/Strings.scala
@@ -68,3 +68,5 @@ trait Strings {
     lazy val stringDecoded = URLDecoder.decode(s, "UTF-8")
   }
 }
+
+object Strings extends Strings

--- a/common/app/templates/inlineJS/blocking/googleAnalytics.scala.js
+++ b/common/app/templates/inlineJS/blocking/googleAnalytics.scala.js
@@ -10,7 +10,7 @@ try {
     We are more interested in "users" than in raw page views.
     *@
     if (window.localStorage) {
-        var gaStorageKey = 'gu_ga_participation';
+        var gaStorageKey = 'gu.ga.participation';
         gaParticipation = window.localStorage.getItem(gaStorageKey) || gaParticipation;
         window.localStorage.setItem(gaStorageKey, gaParticipation);
     }

--- a/common/app/templates/inlineJS/blocking/googleAnalytics.scala.js
+++ b/common/app/templates/inlineJS/blocking/googleAnalytics.scala.js
@@ -1,0 +1,35 @@
+@(page: model.Page)
+@import implicits.Strings.string2encodings
+
+var gaRandomParticipation = Math.floor(Math.random() * 100) < @GoogleAnalyticsAccount.samplePercent;
+var gaParticipation = gaRandomParticipation ? 'in' : 'out';
+
+try {
+    @*
+    Once a person is in the test group we want them to stay in.
+    We are more interested in "users" than in raw page views.
+    *@
+    if (window.localStorage) {
+        var gaStorageKey = 'gu_ga_participation';
+        gaParticipation = window.localStorage.getItem(gaStorageKey) || gaParticipation;
+        window.localStorage.setItem(gaStorageKey, gaParticipation);
+    }
+} catch (ex) {
+    @* if for some reason we cannot read/write to localStorage don't be in the test *@
+    gaParticipation = 'out';
+}
+
+if (gaParticipation === 'in') {
+
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '@GoogleAnalyticsAccount.account', 'auto');
+    ga('send', {
+        hitType: 'pageview',
+        title: '@Html(page.metadata.webTitle.javascriptEscaped)'
+    });
+
+}

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -1,7 +1,7 @@
 @(page: model.Page)( implicit request:RequestHeader)
 @import conf.Configuration
 @import common.AnalyticsHost
-@import views.support.{OmnitureAnalyticsData, OmnitureAnalyticsAccount}
+@import views.support.{OmnitureAnalyticsData, GoogleAnalyticsAccount}
 @import conf.Static
 @import conf.switches.Switches.NonBlockingOmniture
 @import conf.switches.Switches.BritishCouncilBeacon
@@ -56,6 +56,29 @@
 </noscript>
 
 <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
+
+@if(GoogleAnalyticsAccount.shouldTrack(page)) {
+    <script>
+
+        @* e.g. for one in every 10 mpage views *@
+        if (Math.floor(Math.random() * @GoogleAnalyticsAccount.sampleSize) === 0) {
+
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+            ga('create', '@GoogleAnalyticsAccount.account', 'auto');
+            ga('send', 'pageview');
+
+        }
+
+    </script>
+
+    @*
+        If at some point in the future this goes live, somebody think of "noscript" for Google Analytics
+    *@
+}
 
 @if(BritishCouncilBeacon.isSwitchedOn && page.metadata.url.contains("british-council-partner-zone")) {
     <img alt="DCSIMG" id="DCSIMG" width="1" height="1"

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -60,7 +60,7 @@
 @if(GoogleAnalyticsAccount.shouldTrack(page)) {
     <script>
 
-        @* e.g. for one in every 10 mpage views *@
+        @* e.g. for one in every 10 page views *@
         if (Math.floor(Math.random() * @GoogleAnalyticsAccount.sampleSize) === 0) {
 
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/common/app/views/fragments/analytics.scala.html
+++ b/common/app/views/fragments/analytics.scala.html
@@ -1,18 +1,20 @@
 @(page: model.Page)( implicit request:RequestHeader)
 @import conf.Configuration
 @import common.AnalyticsHost
-@import views.support.{OmnitureAnalyticsData, GoogleAnalyticsAccount}
+@import views.support.OmnitureAnalyticsData
 @import conf.Static
 @import conf.switches.Switches.NonBlockingOmniture
 @import conf.switches.Switches.BritishCouncilBeacon
+@import conf.switches.Switches.GoogleAnalyticsSwitch
 @import common.InlineJs
+@import templates.inlineJS.blocking.js._
 
 @if(NonBlockingOmniture.isSwitchedOn) {
     @fragments.omnitureScript(Some(page.metadata))
 
     <script>
         // analytics code
-        @InlineJs(templates.inlineJS.blocking.js.analytics().body, "analytics.js")
+        @InlineJs(templates.inlineJS.blocking.js.analytics(), "analytics.js")
     </script>
 }
 
@@ -57,26 +59,13 @@
 
 <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
 
-@if(GoogleAnalyticsAccount.shouldTrack(page)) {
-    <script>
-
-        @* e.g. for one in every 10 page views *@
-        if (Math.floor(Math.random() * @GoogleAnalyticsAccount.sampleSize) === 0) {
-
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-            ga('create', '@GoogleAnalyticsAccount.account', 'auto');
-            ga('send', 'pageview');
-
-        }
-
+@if(GoogleAnalyticsSwitch.isSwitchedOn) {
+    <script id='google_analytics'>
+        @InlineJs(googleAnalytics(page), "googleAnalytics.js")
     </script>
 
     @*
-        If at some point in the future this goes live, somebody think of "noscript" for Google Analytics
+        If at some point in the future this goes live, please somebody think of the "noscript" for Google Analytics
     *@
 }
 

--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -1,0 +1,28 @@
+package views.support
+
+import conf.Configuration.environment
+import model.Page
+import conf.switches.Switches.GoogleAnalyticsSwitch
+
+object GoogleAnalyticsAccount {
+
+  private val prod = "UA-33592456-1"
+  private val test = "UA-75852724-1"
+  private val useMainAccount = environment.isProd && !environment.isPreview
+
+  val account: String = if (useMainAccount) prod else test
+
+  /*
+  Free version of Google Analytics has rate limits.
+
+  https://developers.google.com/analytics/devguides/collection/ios/v3/limits-quotas
+
+  shouldTrack() & sampleSize should work together to keep us inside those during the test period.
+  */
+  def shouldTrack(page: Page): Boolean = GoogleAnalyticsSwitch.isSwitchedOn &&
+    "sport".equalsIgnoreCase(page.metadata.section)
+
+  // i.e. "One in every X page views"
+  val sampleSize: Int = if (useMainAccount) 20 else 1
+
+}

--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -1,8 +1,6 @@
 package views.support
 
 import conf.Configuration.environment
-import model.Page
-import conf.switches.Switches.GoogleAnalyticsSwitch
 
 object GoogleAnalyticsAccount {
 
@@ -12,17 +10,7 @@ object GoogleAnalyticsAccount {
 
   val account: String = if (useMainAccount) prod else test
 
-  /*
-  Free version of Google Analytics has rate limits.
-
-  https://developers.google.com/analytics/devguides/collection/ios/v3/limits-quotas
-
-  shouldTrack() & sampleSize should work together to keep us inside those during the test period.
-  */
-  def shouldTrack(page: Page): Boolean = GoogleAnalyticsSwitch.isSwitchedOn &&
-    "sport".equalsIgnoreCase(page.metadata.section)
-
-  // i.e. "One in every X page views"
-  val sampleSize: Int = if (useMainAccount) 20 else 1
+  // percentage of traffic to use in test
+  val samplePercent: Int = if (useMainAccount) 1 else 100
 
 }


### PR DESCRIPTION
# My Awesome Pull Request
## What does this change?

This allows us to do a limited evaluation rollout of Google Analytics. We want a chance to play with some real data and have a look at things like any effect on page performance.
## What is the value of this and can you measure success?

We are considering moving to GA. We are going to let people play with this data and see if it improves their use of analytics.

The audience team is in on this too.
## Does this affect other platforms - Amp, Apps, etc?

Not directly. Apps is aware we are doing this, and the Android app already has GA
## Screenshots

![image](https://cloud.githubusercontent.com/assets/76709/14213659/214b5d02-f831-11e5-9722-a561f9a8e292.png)
## Request for comment
## 

*Does this PR meet the [contributing guidelines]
