### PR TITLE
Fix for older crosswords with printable instructions not being linked properly (#10434)

### DIFF
--- a/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
+++ b/applications/app/views/fragments/crosswords/crosswordMetaHeader.scala.html
@@ -46,7 +46,7 @@
 
             @crosswordPage.crossword.instructions.map { instructions =>
                 <div class="crossword__instructions">
-                    <strong>Special instructions:</strong> @instructions
+                    <strong>Special instructions:</strong> @Html(instructions)
                 </div>
             }
         </div>


### PR DESCRIPTION
### What does this change?

Fixes issue #10434 wherein the "special instructions" are being HTML escaped on older crosswords.
### Does this affect other platforms - Amp, Apps, etc?

No
### Screenshots

**before**:
![image](https://cloud.githubusercontent.com/assets/1821099/14244610/ea9ea1b8-fa53-11e5-8e30-13b2eb942826.png)

**after**:
![image](https://cloud.githubusercontent.com/assets/1821099/14244617/f7240db0-fa53-11e5-8180-a5d411f3c5dd.png)

-- /@ScottPainterGNM
