### PR TITLE
Fix element--inline images in The Minute at non-mobile breakpoints

### DIFF
--- a/common/app/views/support/MinuteCleaner.scala
+++ b/common/app/views/support/MinuteCleaner.scala
@@ -70,7 +70,7 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
           figure.getElementsByClass("u-responsive-ratio").headOption.map { outer => {
             figure.insertChildren(0, Seq(outer))
             outer.getElementsByClass("gu-image").headOption.map(image => image.addClass("js-is-fixed-height"))
-            outer.addClass("element--inline__outer")
+            outer.addClass("element--inline__image-wrapper")
           }}
           figure.getElementsByClass("article__img-container").headOption.map(container => container.remove())
         }

--- a/common/app/views/support/MinuteCleaner.scala
+++ b/common/app/views/support/MinuteCleaner.scala
@@ -67,10 +67,11 @@ case class MinuteCleaner(article: model.Article) extends HtmlCleaner {
         // Inline (fullscreen) image mark-up
         // Move the picture element out of thumbnail anchor and responsive image
         block.getElementsByClass("element--inline").headOption.map { figure =>
-          figure.getElementsByTag("picture").headOption.map(picture => {
-            figure.insertChildren(0, Seq(picture))
-            picture.getElementsByClass("gu-image").headOption.map(image => image.addClass("js-is-fixed-height"))
-          })
+          figure.getElementsByClass("u-responsive-ratio").headOption.map { outer => {
+            figure.insertChildren(0, Seq(outer))
+            outer.getElementsByClass("gu-image").headOption.map(image => image.addClass("js-is-fixed-height"))
+            outer.addClass("element--inline__outer")
+          }}
           figure.getElementsByClass("article__img-container").headOption.map(container => container.remove())
         }
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -571,7 +571,7 @@ $minute-layout-margin-nudge: gs-span(1);
                     width: 100%;
                 }
 
-                .element--inline__outer {
+                .element--inline__image-wrapper {
                     height: 100vh;
                 }
 

--- a/static/src/stylesheets/module/content/_article-minute.scss
+++ b/static/src/stylesheets/module/content/_article-minute.scss
@@ -571,8 +571,12 @@ $minute-layout-margin-nudge: gs-span(1);
                     width: 100%;
                 }
 
-                .gu-image {
+                .element--inline__outer {
                     height: 100vh;
+                }
+
+                .gu-image {
+                    height: 100%;
                     width: 100vw;
                     object-fit: cover;
                 }


### PR DESCRIPTION
There was a bug in the cleaner for The Minute that removed the container
for inline images. This container was later added as an empty element
after the image, and its padding was rendered as empty space.

This restores the image container and updates the styles as required.

Before: 
![screen shot 2016-04-04 at 14 44 37](https://cloud.githubusercontent.com/assets/1064734/14249944/190b22e0-fa74-11e5-9787-adae687fa733.png)

After:
![screen shot 2016-04-04 at 14 46 39](https://cloud.githubusercontent.com/assets/1064734/14249947/1c3a416c-fa74-11e5-8507-91728de9ab6f.png)

(full-height images still work on mobile, which is what the original update to the cleaner was for):
![screen shot 2016-04-04 at 14 47 28](https://cloud.githubusercontent.com/assets/1064734/14249990/5c8fd2f4-fa74-11e5-9b41-a3e76aab834f.png)
