### PR TITLE
Scale back survey overlays on mobile breakpoints

### DIFF
--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -36,7 +36,7 @@
         transform: translateY(-50%);
         left: 7.5%;
         right: 7.5%;
-        max-height: 85%;
+        max-height: 90%;
         padding: $gs-row-height $gs-column-width*.5;
         background-color: #01558b;
         color: #ffffff;
@@ -92,7 +92,7 @@
         margin-bottom: $gs-column-width/2;
 
         @include mq(mobile) {
-            margin-bottom: 0;
+            margin-bottom: $gs-column-width/4;
         }
 
         @include mq(mobileLandscape) {

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -32,10 +32,11 @@
 
     .survey-container {
         position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
+        top: 50%;
+        transform: translateY(-50%);
+        left: 7.5%;
+        right: 7.5%;
+        max-height: 85%;
         padding: $gs-row-height $gs-column-width*.5;
         background-color: #01558b;
         color: #ffffff;
@@ -43,7 +44,7 @@
 
         @include mq(tablet) {
             left: 50%;
-            top: percentage(1/5);
+            top: percentage(1/3);
             width: $gs-column-width * 10;
             height: auto;
             margin-left: -$gs-column-width * 5;
@@ -90,10 +91,14 @@
         font-weight: bold;
         margin-bottom: $gs-column-width/2;
 
+        @include mq(mobile) {
+            margin-bottom: 0;
+        }
+
         @include mq(mobileLandscape) {
             @include fs-headline(5);
             font-weight: bold;
-            margin: -27px 50px 0 0;
+            margin: -27px 50px $gs-column-width/2 0;
         }
 
         @include mq(tablet) {
@@ -102,12 +107,11 @@
     }
 
     .survey-content {
-        position: absolute;
-        bottom: 35px;
         padding-right: 30px;
 
         @include mq(tablet) {
             position: static;
+            bottom: 35px;
             padding: 0;
         }
     }


### PR DESCRIPTION
The survey overlays on mobile are full-page in scale:

![image](https://cloud.githubusercontent.com/assets/3148617/14252569/e8744b82-fa7f-11e5-991e-1bc6ee2cdf50.png)

We don't like this - we think it's too aggressive and disruptive.

We want something more like this instead:

![image](https://cloud.githubusercontent.com/assets/3148617/14252891/35a0ddc0-fa81-11e5-98f3-0e318c87be35.png)

We want the overlay to look more dialog-like, with negative space around it with the page's underlying content peeking through.

The dialog is vertically centred and takes whatever height it needs:

_iPhone 5 portrait_:
![image](https://cloud.githubusercontent.com/assets/3148617/14252955/7686d240-fa81-11e5-8816-ccbc86e5938e.png)

_iPhone 4 landscape_:
![image](https://cloud.githubusercontent.com/assets/3148617/14253056/e7c3105e-fa81-11e5-94b3-e0391b81dc25.png)

_iPhone 6 landscape_:
![image](https://cloud.githubusercontent.com/assets/3148617/14253103/0d9fe36a-fa82-11e5-80ae-c9ce56bc2360.png)

The desktop view remains slightly different - it's positioned a little higher on the page:

![image](https://cloud.githubusercontent.com/assets/3148617/14253019/bd496328-fa81-11e5-9fae-53c9a9579411.png)
