### PR TITLE
extending the plista toggle switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -37,7 +37,7 @@ trait FeatureSwitches {
     "plista-for-outbrain-au",
     "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition (for web only).",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 4, 6),
+    sellByDate = new LocalDate(2016, 5, 5),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
We still need the switch that allows AU to toggle between serving outbrain and plista - extending for a month.
