### PR TITLE
Expose test results in Teamcity

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11803,6 +11803,9 @@
         }
       }
     },
+    "karma-teamcity-reporter": {
+      "version": "0.2.2"
+    },
     "load-grunt-config": {
       "version": "0.17.1",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.3.4",
+    "karma-teamcity-reporter": "^0.2.2",
     "postcss-pxtorem": "^2.3.0",
     "require-dir": "^0.3.0"
   },

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,8 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
   Resolver.typesafeRepo("releases"),
   Resolver.url("guardian sbt-plugins", new URL("https://dl.bintray.com/guardian/sbt-plugins/"))(Resolver.ivyStylePatterns),
-  Resolver.url("sbt sbt-plugins", new URL("https://dl.bintray.com/sbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
+  Resolver.url("sbt sbt-plugins", new URL("https://dl.bintray.com/sbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns),
+  Resolver.url("bintray-sbt-plugin-releases", url("https://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 )
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0")
@@ -24,3 +25,5 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.1.10")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
+
+addSbtPlugin("org.jetbrains.teamcity.plugins" % "sbt-teamcity-logger" % "0.3.0")

--- a/static/test/javascripts/conf/settings.js
+++ b/static/test/javascripts/conf/settings.js
@@ -1,3 +1,6 @@
+var isTeamcityReporterEnabled = process.env.KARMA_TEAMCITY_REPORTER === 'true',
+    karmaReporters = [ isTeamcityReporterEnabled ? 'teamcity' : 'spec' ];
+
 module.exports = function (config) {
     return {
         // root of project
@@ -22,7 +25,7 @@ module.exports = function (config) {
 
         // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
         port: 9876,
-        reporters: ['spec'],
+        reporters: karmaReporters,
         // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
         logLevel: config.LOG_ERROR,
         autoWatch: true,


### PR DESCRIPTION
## What does this change?
- Log `sbt test` output in teamcity with `sbt-teamcity-logger` plugin from Jetbrains
- Log JS test output in teamcity with `karma-teamcity-reporter`
- See [Build 7835](http://teamcity.gu-web.net:8111/viewLog.html?buildTypeId=dotcom_pullrequests&buildId=7835) for output.
## What is the value of this and can you measure success?
- Should make it faster to determine what has broken a build
- Exposes number of tests run per build - useful if number changes significantly between builds, which may mean that something is wrong.
## Does this affect other platforms - Amp, Apps, etc?
- Build only
## Screenshots

![dotcom-teamcity-test-results-1](https://cloud.githubusercontent.com/assets/2298529/14277277/6cd9c6fa-fb1a-11e5-9ba5-610d4f9ffe14.png)
![dotcom-teamcity-test-results-2](https://cloud.githubusercontent.com/assets/2298529/14277282/711f80d8-fb1a-11e5-9589-b6a271bb68d4.png)
