### PR TITLE
Hide the video play icon on facia item lists on mobile

### DIFF
--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -65,6 +65,10 @@
 .fc-item--list-mobile {
     @include mq($until: tablet) {
         @include fc-item--list;
+
+        .fc-item__video-play {
+            display: none;
+        }
     }
 }
 


### PR DESCRIPTION
Fix for this on our uk front:

![screen shot 2016-04-05 at 10 30 38](https://cloud.githubusercontent.com/assets/4549425/14278134/0a93596c-fb1e-11e5-968a-218a7503b83c.png)
