### PR TITLE
Style richlinks based on presence of a byline pic, not comment tone

### DIFF
--- a/static/src/stylesheets/module/_rich-links.scss
+++ b/static/src/stylesheets/module/_rich-links.scss
@@ -120,7 +120,7 @@
     padding-left: $gs-gutter / 4;
 
     @include mq(tablet) {
-        .tone-comment--item.rich-link--has-byline-pic & {
+        .rich-link--has-byline-pic & {
             position: absolute;
             bottom: 0;
         }
@@ -218,7 +218,7 @@
     margin: 5px $gs-gutter $gs-baseline 0;
     clear: both;
 
-    .tone-comment--item {
+    .rich-link--has-byline-pic {
         .rich-link__standfirst {
             display: none;
         }
@@ -257,13 +257,13 @@
     }
 
     @include mq(tablet) {
-        .rich-link--has-byline-pic.tone-comment--item .rich-link__container {
+        .rich-link--has-byline-pic .rich-link__container {
             padding-bottom: $gs-baseline * 10;
         }
     }
 
     @include mq(leftCol) {
-        &.element--supporting .rich-link--has-byline-pic.tone-comment--item .rich-link__container {
+        &.element--supporting .rich-link--has-byline-pic .rich-link__container {
             padding-bottom: ($gs-baseline * 2) + 8;
         }
     }
@@ -272,7 +272,7 @@
         margin-left: -1 * (gs-span(2) + $gs-gutter);
         &.element--supporting {
             width: gs-span(4);
-            .tone-comment--item {
+            .rich-link--has-byline-pic {
                 .rich-link__standfirst {
                     display: block;
                 }


### PR DESCRIPTION
## What is the value of this and can you measure success?

rich links with byline pics and special report tone are unusable – hopefully this fixes that.
## Screenshots
### before

thumbnail:
![screen shot 2016-04-05 at 20 15 18](https://cloud.githubusercontent.com/assets/867233/14294994/99980b42-fb6b-11e5-9cf3-b98258bb1235.png)
supporting:
![screen shot 2016-04-05 at 20 16 35](https://cloud.githubusercontent.com/assets/867233/14295044/de43e2ac-fb6b-11e5-9dea-ce5efb44c56f.png)
### after

thumbnail:
![screen shot 2016-04-05 at 20 15 43](https://cloud.githubusercontent.com/assets/867233/14295066/f3f57750-fb6b-11e5-8627-77590878ca29.png)
supporting:
![screen shot 2016-04-05 at 20 16 35](https://cloud.githubusercontent.com/assets/867233/14295051/e391c7ba-fb6b-11e5-891c-402c53f0a2ee.png)
