### PR TITLE
Fix block level links in notifications

### DIFF
--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -185,8 +185,8 @@ self.addEventListener('notificationclick', function(event){
     var url = '@{JavaScript(Configuration.site.host)}/'
         + event.notification.data.topic
         + "?page=with:block-" + event.notification.data.blockId
-        + "#block-" + event.notification.data.blockId
-        +  "&CMP=not_b-webalert";
+        +  "&CMP=not_b-webalert"
+        + "#block-" + event.notification.data.blockId;
 
     event.waitUntil(
         clients.matchAll({


### PR DESCRIPTION
This fixes the links in notifications that link to live blog block level.

The anchor link should be at the end.

@NathanielBennett 
