### PR TITLE
Adjust spacing for lists in standfirsts

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -332,11 +332,10 @@
 
         > li {
             position: relative;
-            margin-bottom: $gs-baseline/3;
         }
 
         * {
-            margin-top: .6em;
+            margin-bottom: $gs-baseline / 2;
         }
     }
 


### PR DESCRIPTION
## What does this change?

Makes the standfirsts with lists in them look designed
## What is the value of this and can you measure success?

The value is that the site looks like theguardian.com
## Does this affect other platforms - Amp, Apps, etc?

I hope amp hasn't done this otherwise @zeftilldeath will be put in front of Design Court
## Screenshots

Before:
![screen shot 2016-04-06 at 11 10 16](https://cloud.githubusercontent.com/assets/1607666/14313282/92cf601c-fbe8-11e5-9ac2-6cea3ed87097.png)

After:
![screen shot 2016-04-06 at 11 10 24](https://cloud.githubusercontent.com/assets/1607666/14313286/9c29ce9a-fbe8-11e5-9b43-b20e0eaad608.png)
