### PR TITLE
Force grey background on liveblogs

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -5,6 +5,11 @@ $block-padding-right: $gs-gutter;
 
 /* Layout
    ========================================================================== */
+
+.content--liveblog .content__main {
+    background-color: colour(neutral-8);
+}
+
 .content__main-column--liveblog {
     @include mq(desktop) {
         margin-left: $right-column + $gs-gutter;


### PR DESCRIPTION
# Force grey background on liveblogs
## What does this change?

It forces a grey background on liveblogs (even if they have a different non-liveblog tone)
## What is the value of this and can you measure success?

The value is inherent in the way it forces a grey background on liveblogs
## Does this affect other platforms - Amp, Apps, etc?

Nobody if someone hasn't, we should force them to have a grey background on liveblogs
## Screenshots

Before:
![screen shot 2016-04-06 at 11 23 39](https://cloud.githubusercontent.com/assets/1607666/14313591/50551734-fbea-11e5-90a2-3a73cbffc39f.png)

After:
![screen shot 2016-04-06 at 11 23 06](https://cloud.githubusercontent.com/assets/1607666/14313597/56191b66-fbea-11e5-8b2d-43bbb0ecbfee.png)
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
