### PR TITLE
fake adBlokers val in video embed page

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -78,7 +78,8 @@
                                 || 'XDomainRequest' in window
                             )
                         ),
-                        config: @Html(templates.js.javaScriptConfig(model.SimpleContentPage(video)).body)
+                        config: @Html(templates.js.javaScriptConfig(model.SimpleContentPage(video)).body),
+                        adBlockers: {}
                     };
                     var docClass = document.documentElement.className;
 


### PR DESCRIPTION
Adding a fake value as the page is breaking, and also thus, not tracking.
## What is the value of this and can you measure success?

Tracking is back
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

:scream: 
## Request for comment

@OliverJAsh @akash1810 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
