### PR TITLE
Add note on community standards

### DIFF
--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -23,6 +23,7 @@
 
     <div class="d-comment-box__content">
         <div class="d-comment-box__messages"></div>
+        <div class="d-comment-box__community-standards">Please keep comments respectful and abide by the <a href="/community-standards">community guidelines</a>.</div>
         <div class="d-discussion__error d-comment-box__premod">
             @fragments.inlineSvg("status-alert", "icon")
             <span class="d-discussion__error-text">Your comments are currently being pre-moderated (<a href="/community-faqs#311" target="_blank">why?</a>)</span>

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -1235,6 +1235,7 @@ $comment-recommend-button-size: 19px;
     }
 }
 .d-comment-box--expanded .d-comment-box__body {
+    margin-top: $gs-baseline / 6;
     height: gs-height(3);
 }
 .d-comment-box__add-comment {
@@ -1427,4 +1428,16 @@ $comment-recommend-button-size: 19px;
     &:hover {
         border-color: colour(guardian-brand);
     }
+}
+
+.d-comment-box__community-standards {
+    display: none;
+}
+
+.d-comment-box--expanded .d-comment-box__community-standards {
+    @include fs-textSans(1);
+    display: block;
+    background-color: colour(neutral-7);
+    padding: ($gs-baseline / 3) * 2 ($gs-gutter / 2);
+    margin-top: $gs-baseline / 2;
 }


### PR DESCRIPTION
# Add community standards note to comment form
## What does this change?

Adds a note about community standards to the comment form when expanded.
## What is the value of this and can you measure success?

The aim is to remind people of the standards and discourage abusive behaviour. We already track the number of abusive comments so can see any impact easily. We can also observe changes/increases to the page views of the community standards page.
## Does this affect other platforms - Amp, Apps, etc?

Not at the moment.
## Screenshots

<img width="668" alt="screen shot 2016-04-06 at 12 11 48" src="https://cloud.githubusercontent.com/assets/858402/14314907/08950b9a-fbf2-11e5-87a2-d128b4d4c4c2.png">
## Request for comment

We're looking at getting this out quickly. I'm not very knowledgeable about frontend standards - happy to take on feedback!
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
