### PR TITLE
Paid content card's height in the most popular fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -81,17 +81,21 @@ define([
     }
 
     function adjustMostPopHeight(el) {
-        var height;
+        var adSlotHeight;
         var $adSlot = $(el);
         var $mostPopTabs = $('.js-most-popular-footer .tabs__pane');
+        var mostPopTabsHeight;
 
         if ($adSlot.hasClass('ad-slot--mostpop')) {
             fastdom.read(function () {
-                height = $adSlot.dim().height;
-            });
+                adSlotHeight = $adSlot.dim().height;
+                mostPopTabsHeight = $mostPopTabs.dim().height;
 
-            fastdom.write(function () {
-                $mostPopTabs.css('height', height);
+                if (adSlotHeight > mostPopTabsHeight) {
+                    fastdom.write(function () {
+                        $mostPopTabs.css('height', adSlotHeight);
+                    });
+                }
             });
         }
     }

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -30,7 +30,7 @@
     .gu-title {
         @include f-headlineSans;
         @include font-size(20, 24);
-        margin-bottom: 5px;
+        padding-bottom: 5px;
         font-weight: normal;
     }
 


### PR DESCRIPTION
## What does this change?

This PR fixes the bug when the paid content card is being cut by the most popular container. In order to show the whole paid content card inside the most popular container, that container should have a height at least the same as the paid content card. But there is no point of setting this height, when the height of the paid content card is smaller than the most popular container.
## Screenshots

Before:
![screen shot 2016-04-06 at 15 21 39](https://cloud.githubusercontent.com/assets/489567/14319717/28777b74-fc0a-11e5-968b-f11c2908fab7.png)

After:
![screen shot 2016-04-06 at 15 24 20](https://cloud.githubusercontent.com/assets/489567/14319726/36918dc6-fc0a-11e5-8d07-aca6dc57100c.png)
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
