### PR TITLE
Use cards to determine container branding

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -256,7 +256,12 @@ object FaciaContainer {
       case MostPopular => ContainerCommercialOptions.mostPopular(omitMPU)
       case Commercial(SingleCampaign(_)) => ContainerCommercialOptions.fromCollection(collectionEssentials)
       case Commercial(MultiCampaign(_)) => ContainerCommercialOptions.empty
-      case _ => ContainerCommercialOptions.fromConfig(config.config)
+      case _ =>
+        if (Switches.cardsDecidePaidContainerBranding.isSwitchedOn) {
+          ContainerCommercialOptions.empty
+        } else {
+          ContainerCommercialOptions.fromConfig(config.config)
+        }
     },
     config.config.description.map(DescriptionMetaHeader),
     None,

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -19,6 +19,30 @@
     </div>
 }
 
+@renderBrandingDataAttributes() = {
+    @if(Switches.cardsDecidePaidContainerBranding.isSwitchedOn) {
+        @for(container <- maybeContainerModel) {
+            @for(branding <- container.branding) {
+                data-sponsor="@branding.sponsor"
+                @for(seriesId <- branding.seriesId) { data-series="@seriesId" }
+                @for(keywordId <- branding.keywordId) { data-keywords="@keywordId" }
+                data-sponsorship="@branding.sponsorshipType"
+            }
+        }
+    } else {
+        @for(sponsor <- containerDefinition.commercialOptions.sponsor) { data-sponsor="@sponsor"}
+        @for(tag <- containerDefinition.commercialOptions.sponsorshipTag) {
+            @tag.tagType match {
+                case Series => { data-series="@{ tag.tagId}"}
+                case Keyword => { data-keywords="@{ tag.tagId}"}
+            }
+        }
+        @containerDefinition.commercialOptions.sponsorshipType.map { sponsorshipType =>
+        data-sponsorship="@sponsorshipType"
+        }
+    }
+}
+
 @defining((containerDefinition.displayName, containerDefinition.faciaComponentName)) { case (title, componentName) =>
     @containerDefinition.customHeader.map {
         case header: MetaDataHeader => {
@@ -41,19 +65,15 @@
 
         case _ => {
         <section id="@componentName"
-        class="@GetClasses.forContainerDefinition(containerDefinition)"
+        class="@GetClasses.forContainerDefinition(containerDefinition)
+        @if(Switches.cardsDecidePaidContainerBranding.isSwitchedOn){
+            @for(container <- maybeContainerModel){
+                @if(container.branding.isDefined){ js-sponsored-container }
+            }
+        }"
         data-link-name="container-@{containerDefinition.index + 1} | @componentName"
         data-id="@containerDefinition.dataId"
-            @for(sponsor <- containerDefinition.commercialOptions.sponsor) { data-sponsor="@sponsor" }
-            @for(tag <- containerDefinition.commercialOptions.sponsorshipTag) {
-                @tag.tagType match {
-                    case Series => { data-series="@{tag.tagId}" }
-                    case Keyword => { data-keywords="@{tag.tagId}" }
-                }
-            }
-            @containerDefinition.commercialOptions.sponsorshipType.map { sponsorshipType =>
-            data-sponsorship="@sponsorshipType"
-            }
+        @renderBrandingDataAttributes()
         data-component="@componentName"
         aria-expanded="true">
 


### PR DESCRIPTION
Use cards to determine the branding of sponsored and foundation-funded containers.
This uses the same logic as the paid containers.

/cc @JonNorman 
