### PR TITLE
add omniture to vieo embed page

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -101,9 +101,8 @@
                     }
 
                     document.documentElement.className = docClass;
+                    @Html(Static.js.omnitureJs)
                 </script>
-
-                @fragments.omnitureScript(None)
 
                 <script>
                     var curl = {


### PR DESCRIPTION
Adding omniture tracking to the video embed page.
As we don't have a metadata on the [`EmbedPage`](https://github.com/guardian/frontend/blob/master/applications/app/controllers/EmbedController.scala#L11), passing `None` through to [`OmnitureAnalyticsData`](was doing nothing).

Now we just include the script directly. Again, a more robust solution could have been found, but we'll be tearing this out soon.
## Screamshots

:scream_cat: 
## Request for comment

@akash1810 @OliverJAsh 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
