### PR TITLE
Paid content's richlinks styling fixes

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -696,6 +696,20 @@
         }
     }
 
+    .tone-news--item.rich-link {
+        background: colour(paid-article-subheader);
+    }
+
+    .rich-link__header,
+    .rich-link__read-more-text {
+        @include f-headlineSans;
+        font-size: get-font-size(header, 2);
+    }
+
+    .rich-link__header {
+        line-height: get-line-height(header, 1);
+    }
+
     .ad-slot__label,
     .ad-slot--inline {
         background-color: colour(paid-article-subheader);


### PR DESCRIPTION
## What does this change?

This PR fixes styling of richlinks on the paid content articles.
## Screenshots

Before:
![screen shot 2016-04-06 at 17 35 00](https://cloud.githubusercontent.com/assets/489567/14324371/700474b2-fc1c-11e5-89b2-a72cb84b4408.png)

After:
![screen shot 2016-04-06 at 17 35 06](https://cloud.githubusercontent.com/assets/489567/14324379/79359976-fc1c-11e5-91f3-d18902fa3d60.png)
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
