### PR TITLE
Add completion event to A/B tests

### DIFF
--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -63,12 +63,24 @@ define(['bonzo'], function (bonzo) {
             {
                 id: 'control',
                 test: function (context, config) {
+                },
+
+                success: function(complete) {
+                    // do something that determines whether the user has completed
+                    // the test (e.g. set up an event listener) and call 'complete' afterwards
+                    complete();
                 }
             },
             {
                 id: 'hide',
                 test: function (context, config) {
                     bonzo(context.querySelector('.js-related')).hide();
+                },
+
+                success: function(complete) {
+                    // do something that determines whether the user has completed
+                    // the test (e.g. set up an event listener) and call 'complete' afterwards
+                    complete();
                 }
             }
         ];
@@ -95,7 +107,12 @@ The AMD module must return an object with the following properties,
 - `dataLinkNames`: Link names or custom link names used for test.
 - `idealOutcome`: What is the outcome that you want to see from the new variant (We want to see Y when we do X)?
 - `canRun`: A function to determine if the test is allowed to run (Eg, so you can target individual pages, segments etc.).
-- `variants`: An array of two functions - the first representing the _control_ group, the second the variant.  See "Detecting a user's bucket" below if you want to affect existing code rather than running new code.
+- `variants`: An array of objects representing the groups in your test. See "Detecting a user's bucket" below if you want to affect existing code rather than running new code.
+    - the variant objects can contain three properties:
+        - variant.id: the name of the variant
+        - variant.test: the main test function that applies the treatment for the test
+        - variant.success: a function that's called alongside test that determines if the user has finished the test. it receives a callback as a parameter that you must call when the test is completed.
+
 
 You will also need to mark the module as a dependency of the AB testing module.
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -21,6 +21,7 @@ define([
     'lodash/collections/map',
     'lodash/collections/find',
     'lodash/objects/pick',
+    'lodash/utilities/noop',
     'common/utils/chain'
 ], function (
     reportError,
@@ -45,6 +46,7 @@ define([
     map,
     find,
     pick,
+    noop,
     chain
 ) {
 
@@ -164,7 +166,10 @@ define([
                 variantId = participations[test.id].variant;
             var variant = getVariant(test, variantId);
             if (variant) {
+                var success = variant.success || noop;
+
                 variant.test();
+                success(ab.trackEvent);
             } else if (variantId === 'notintest' && test.notInTest) {
                 test.notInTest();
             }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -178,7 +178,7 @@ define([
                 var active = tests[0];
                 var server = tests[1];
 
-                if (isParticipating(active) && testCanBeRun(active)) {
+                if (active && isParticipating(active) && testCanBeRun(active)) {
                     var variant = getTestVariantId(active.id);
 
                     if (variant && variant !== 'notintest') {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/next-in-series.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/next-in-series.js
@@ -1,11 +1,13 @@
 define([
-    'bean',
     'common/utils/$',
-    'lodash/collections/find'
+    'lodash/collections/find',
+    'lodash/collections/pluck',
+    'lodash/collections/some'
 ], function (
-    bean,
     $,
-    find
+    find,
+    pluck,
+    some
 ) {
     var path = '/surveys/404-test/next-in-series/';
     var render = function (state) {
@@ -69,7 +71,15 @@ define([
                 },
 
                 success: function(complete) {
-                    bean.on($('.next-in-series-test__remind-me-link')[0], 'click', complete);
+                    var onSurvey = window.location.href.match(path.replace(/\/$/, '')).length > 0;
+
+                    var referredFromSeries = some(pluck(allSeries, 'pageId'), function (id) {
+                        return window.document.referrer.match(id).length > 0;
+                    });
+
+                    if (onSurvey && referredFromSeries) {
+                        complete();
+                    }
                 }
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/next-in-series.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/next-in-series.js
@@ -64,6 +64,10 @@ define([
                         var el = $.create(render(series));
                         el.insertAfter($articleBody);
                     }
+                },
+
+                success: function(complete) {
+                    bean.on($('.next-in-series-test__remind-me-link'), 'click', complete));
                 }
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/next-in-series.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/next-in-series.js
@@ -1,7 +1,9 @@
 define([
+    'bean',
     'common/utils/$',
     'lodash/collections/find'
 ], function (
+    bean,
     $,
     find
 ) {
@@ -67,7 +69,7 @@ define([
                 },
 
                 success: function(complete) {
-                    bean.on($('.next-in-series-test__remind-me-link'), 'click', complete));
+                    bean.on($('.next-in-series-test__remind-me-link')[0], 'click', complete);
                 }
             }
         ];

--- a/static/test/javascripts/spec/common/experiments/ab.spec.js
+++ b/static/test/javascripts/spec/common/experiments/ab.spec.js
@@ -29,7 +29,7 @@ define([
 
                 config.tests = [];
 
-                // a list of ab-tests that can be used in the spec's
+                // a list of ab-tests that can be used in the specs
                 test = {
                     one: new ABTest('DummyTest'),
                     two: new ABTest('DummyTest2')
@@ -261,6 +261,30 @@ define([
                 expect(ab.makeOmnitureTag()).toBe('AB | DummyTest | control');
             });
 
+            it('should generate the correct structure for Ophan', function() {
+                ab.addTest(test.one);
+                ab.segment();
+
+                expect(ab.getAbLoggableObject()).toEqual({
+                    'DummyTest': {
+                        variantName: 'control',
+                        complete: 'false'
+                    }
+                });
+            });
+
+            it('should fire the success function', function() {
+                var spy = sinon.spy();
+
+                ab.addTest(test.one);
+
+                test.one.variants[0].success = spy;
+
+                ab.segment();
+                ab.run();
+
+                expect(spy).toHaveBeenCalled();
+            });
         });
 
     });


### PR DESCRIPTION
@dominickendrick and I have been looking adding a "complete" state to the A/B data we send to Ophan so it's more simple to find out conversion/success rates for our tests.

Related PR: https://github.com/guardian/frontend/pull/12393

This updates the structure of the event we send to Ophan and adds a completion step to the _next in series_ test. You can add  a `success` function to your variant to specify what needs to happen for the test to be completed. That function is passed a callback that will fire the completion data to Ophan.

Later on we'll add dashboards to display the success rate of tests.
