### PR TITLE
Removing force schema switch for amp

### DIFF
--- a/article/app/views/fragments/articleBody.scala.html
+++ b/article/app/views/fragments/articleBody.scala.html
@@ -4,16 +4,15 @@
 @import common.LinkTo
 @import views.BodyCleaner
 @import views.support.TrailCssClasses.toneClass
-@import conf.switches.Switches.ForceSchemaOrgTypeForAmpArticlesSwitch
 @import views.support.RenderClasses
 
-@*Feb 2015: Google does only support NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/Review*@
-@shouldForceSchemaType = @{amp && ForceSchemaOrgTypeForAmpArticlesSwitch.isSwitchedOn}
+@* Feb 2015: Google does only support NewsArticle in their amp carousel. To remove once Google starts supporting other schemas like schema.org/Review *@
 @schemaType(page: ArticlePage) = @{
-    if (shouldForceSchemaType) "http://schema.org/NewsArticle" else page.article.metadata.schemaType
+    if (amp) "http://schema.org/NewsArticle" else page.article.metadata.schemaType
 }
+
 @bodyType(page: ArticlePage) = @{
-    if (page.article.tags.isReview && !shouldForceSchemaType) "reviewBody" else "articleBody"
+    if (page.article.tags.isReview && !amp) "reviewBody" else "articleBody"
 }
 
 @defining(model.article) { article =>

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -349,16 +349,6 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
-  // Owner: Dotcom reach
-  val ForceSchemaOrgTypeForAmpArticlesSwitch = Switch(
-    "Feature",
-    "force-schema-org-type-for-amp-articles",
-    "When ON, all amplified articles have schema.org type set to 'NewsArticle' (which is the only type Google search carousel supports as of Feb 2015)",
-    safeState = On,
-    sellByDate = new LocalDate(2016, 4, 6),
-    exposeClientSide = false
-  )
-
   // Owner: Dotcom loyalty
   val EmailInArticleGtodaySwitch = Switch(
     "Feature",


### PR DESCRIPTION
Removing a switch for amp which forces the schema. The schema is still being forced, but I am just removing the switch.

All AMP pages to pass Google's validation, and show in the AMP carousel, need to have a schema of `NewsArticle`.

We put the switch in as a reminder to check with Google about this and to see whether they would start accepted other schemas like review. They are not planning to support other schemas anytime soon, and will let us know when they do. Therefore, I am removing the switch.

@TBonnin 
