### PR TITLE
Removing logging of css report content

### DIFF
--- a/diagnostics/app/model/diagnostics/css/Css.scala
+++ b/diagnostics/app/model/diagnostics/css/Css.scala
@@ -22,7 +22,6 @@ object Css extends common.Logging {
   def report(requestBody: JsValue): Unit = {
     requestBody.validate[CssReport] match {
       case JsSuccess(report, _) =>
-        log.info("\n" + report.toString)
         DynamoDbReport.report(report)
       case JsError(e) => throw new Exception(JsError.toJson(e).toString())
     }


### PR DESCRIPTION
## What does this change?

Removes unused logging of css reports. 

Css reports are sent to Dynamodb anyway. 
No reason to also log it
## What is the value of this and can you measure success?

Less noise in the logs, less 💰  paid to Amazon  😎 
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

Currently the diagnostics logs looks like below. Pages of css selectors 😕 
![screen shot 2016-04-07 at 11 12 54](https://cloud.githubusercontent.com/assets/233326/14348001/c02590da-fcb1-11e5-8e87-6298dc5d9c53.png)
## Request for comment

@rich-nguyen 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
