### PR TITLE
New header: add opt-in controller

### DIFF
--- a/applications/app/controllers/NewHeaderCookieController.scala
+++ b/applications/app/controllers/NewHeaderCookieController.scala
@@ -1,0 +1,23 @@
+package controllers
+
+import model.Cached
+import play.api.mvc.{Action, Controller, Cookie, DiscardingCookie}
+
+import scala.concurrent.duration._
+
+object NewHeaderCookieController extends Controller {
+  private val NewHeaderOptIn = "new_header_opt_in"
+  private val lifetime = 90.days.toSeconds.toInt
+
+  def optIn() = Action { implicit request =>
+    Cached(60)(SeeOther("/").withCookies(
+      Cookie(NewHeaderOptIn, "true", maxAge = Some(lifetime))
+    ))
+  }
+
+  def optOut() = Action { implicit request =>
+    Cached(60)(SeeOther("/").discardingCookies(
+      DiscardingCookie(NewHeaderOptIn)
+    ))
+  }
+}

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -51,6 +51,9 @@ GET        /crosswords/optout                                                   
 GET        /https/optin                                                         controllers.HTTPSCookieController.optIn()
 GET        /https/optout                                                        controllers.HTTPSCookieController.optOut()
 
+GET        /new-header/optin                                                    controllers.NewHeaderCookieController.optIn()
+GET        /new-header/optout                                                   controllers.NewHeaderCookieController.optOut()
+
 # Web App paths
 GET        /offline-page.json                                                   controllers.WebAppController.offlinePage()
 GET        /service-worker.js                                                   controllers.WebAppController.serviceWorker()


### PR DESCRIPTION
This adds or removes the `new_header_opt_in` cookie as used by https://github.com/guardian/fastly-edge-cache/pull/604
