### PR TITLE
Remove border between content and header

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -1,5 +1,4 @@
 .content {
-    border-top: 1px solid #ffffff;
     padding-top: 0;
     padding-bottom: $gs-baseline*3;
 


### PR DESCRIPTION
I consulted @sammorrisdesign and @zeftilldeath on this one. They said we don't need it :smile: 
# Before

![image](https://cloud.githubusercontent.com/assets/921609/14357256/e813d402-fcdf-11e5-952e-822bce4805c4.png)
# After

![image](https://cloud.githubusercontent.com/assets/921609/14357263/f0a396d4-fcdf-11e5-856b-e013186cc2d9.png)
