### PR TITLE
remove cacheSeconds from pressed json

### DIFF
--- a/common/app/model/Formats.scala
+++ b/common/app/model/Formats.scala
@@ -76,7 +76,6 @@ object MetaDataFormat {
     contentType: String,
     hasHeader: Boolean,
     schemaType: Option[String],
-    cacheSeconds: Int,
     cacheTime: CacheTime,
     openGraphImages: Seq[String],
     membershipAccess: Option[String],
@@ -150,7 +149,6 @@ object MetaDataFormat {
           meta.contentType,
           meta.hasHeader,
           meta.schemaType,
-          meta.cacheTime.cacheSeconds,//TODO remove after deploy
           meta.cacheTime,
           meta.openGraphImages,
           meta.membershipAccess,


### PR DESCRIPTION
Because https://github.com/guardian/frontend/pull/12391 was a breaking change to facia json, I had to add the new parameter and keep the old one.  Once I have deployed, I will merge this which will get rid of the redundant parameter!  Fun :cold_sweat: 
@janua @rich-nguyen 
