### PR TITLE
Introduce onboarding message for first-time commenters

### DIFF
--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -21,13 +21,24 @@
         </div>
     </div>
 
+    <div class="d-comment-box__onboarding">
+        <h3>Welcome, you’re about to make your first comment!</h3>
+        <p>Before you post, we’d like to thank you for joining the debate - we’re glad you’ve chosen to participate and we value your opinions and experiences.</p>
+        <p>Please keep your posts respectful and abide by the <a href="/community-standards">community guidelines</a> - and if you spot a comment you think doesn’t adhere to the guidelines, please use the ‘Report’ link next to it to let us know.</p>
+        <p>Please preview your comment below and click ‘post’ when you’re happy with it.</p>
+        <div class="d-comment-box__onboarding-preview-body"></div>
+        <button type="submit" class="u-button-reset button button--large button--primary submit-input--behaviour d-comment-box__onboarding-submit">Post your comment</button>
+        <button type="button" class="u-button-reset button button--large button--primary submit-input--behaviour d-comment-box__onboarding-cancel">Cancel</button>
+    </div>
+
     <div class="d-comment-box__content">
         <div class="d-comment-box__messages"></div>
-        <div class="d-comment-box__community-standards">Please keep comments respectful and abide by the <a href="/community-standards">community guidelines</a>.</div>
         <div class="d-discussion__error d-comment-box__premod">
             @fragments.inlineSvg("status-alert", "icon")
             <span class="d-discussion__error-text">Your comments are currently being pre-moderated (<a href="/community-faqs#311" target="_blank">why?</a>)</span>
         </div>
+
+        <div class="d-comment-box__community-standards">Please keep comments respectful and abide by the <a href="/community-standards">community guidelines</a>.</div>
         <textarea name="body" class="textarea d-comment-box__body" placeholder="Join the discussion…"></textarea>
         <button type="submit" data-link-name="post comment" class="u-button-reset button button--large button--primary submit-input--behaviour d-comment-box__submit">Post your comment</button>
         <span class="u-fauxlink d-comment-box__preview" role="button">Preview</span>

--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -22,9 +22,9 @@
     </div>
 
     <div class="d-comment-box__onboarding">
-        <h3>Welcome, you’re about to make your first comment!</h3>
+        <h3>Welcome <span class="d-comment-box__onboarding-author"></span>, you’re about to make your first comment!</h3>
         <p>Before you post, we’d like to thank you for joining the debate - we’re glad you’ve chosen to participate and we value your opinions and experiences.</p>
-        <p>Please keep your posts respectful and abide by the <a href="/community-standards">community guidelines</a> - and if you spot a comment you think doesn’t adhere to the guidelines, please use the ‘Report’ link next to it to let us know.</p>
+        <p>Please keep your posts respectful and abide by the <a target="_blank" href="/community-standards">community guidelines</a> - and if you spot a comment you think doesn’t adhere to the guidelines, please use the ‘Report’ link next to it to let us know.</p>
         <p>Please preview your comment below and click ‘post’ when you’re happy with it.</p>
         <div class="d-comment-box__onboarding-preview-body"></div>
         <button type="submit" class="u-button-reset button button--large button--primary submit-input--behaviour d-comment-box__onboarding-submit">Post your comment</button>

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -155,6 +155,7 @@ CommentBox.prototype.showOnboarding = function(e) {
         this.removeState('onboarding-visible');
         this.postComment();
     } else {
+        this.getElem('onboarding-author').innerHTML = this.getUserData().displayName;
         this.setState('onboarding-visible');
         this.previewComment(this.onboardingPreviewSuccess);
     }

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -96,6 +96,7 @@ CommentBox.prototype.defaultOptions = {
     apiRoot: null,
     maxLength: 5000,
     premod: false,
+    newCommenter: false,
     focus: false,
     state: 'top-level',
     replyTo: null,
@@ -145,6 +146,25 @@ CommentBox.prototype.prerender = function() {
     }
 };
 
+CommentBox.prototype.showOnboarding = function(e) {
+    e.preventDefault();
+
+    // Check if new commenter as they may have already commented on this article
+    if (this.hasState('onboarding-visible') || !this.options.newCommenter) {
+        this.options.newCommenter = false;
+        this.removeState('onboarding-visible');
+        this.postComment();
+    } else {
+        this.setState('onboarding-visible');
+        this.previewComment(this.onboardingPreviewSuccess);
+    }
+};
+
+CommentBox.prototype.hideOnboarding = function(e) {
+    e.preventDefault();
+    this.removeState('onboarding-visible');
+};
+
 /** @override */
 CommentBox.prototype.ready = function() {
     if (this.getDiscussionId() === null) {
@@ -156,12 +176,19 @@ CommentBox.prototype.ready = function() {
     this.setFormState();
 
     // TODO (jamesgorrie): Could definitely use the this.on and make the default context this
-    bean.on(document.body, 'submit', [this.elem], this.postComment.bind(this));
+
+    if (this.options.newCommenter) {
+         bean.on(document.body, 'submit', [this.elem], this.showOnboarding.bind(this));
+         bean.on(document.body, 'click', this.getClass('onboarding-cancel'), this.hideOnboarding.bind(this));
+    } else {
+        bean.on(document.body, 'submit', [this.elem], this.submitPostComment.bind(this));
+    }
+
     bean.on(document.body, 'change keyup', [commentBody], this.setFormState.bind(this));
     bean.on(commentBody, 'focus', this.setExpanded.bind(this)); // this isn't delegated as bean doesn't support it
 
     this.on('change', '.d-comment-box__body', this.resetPreviewComment);
-    this.on('click', this.getClass('preview'), this.previewComment);
+    this.on('click', this.getClass('preview'), this.previewComment.bind(this, this.previewCommentSuccess));
     this.on('click', this.getClass('hide-preview'), this.resetPreviewComment);
 
     this.on('click', this.getClass('cancel'), this.cancelComment);
@@ -195,13 +222,18 @@ CommentBox.prototype.urlify = function(str) {
 /**
  * @param {Event}
  */
-CommentBox.prototype.postComment = function(e) {
+CommentBox.prototype.submitPostComment = function(e) {
+    e.preventDefault();
+    this.postComment();
+};
+
+
+CommentBox.prototype.postComment = function() {
     var self = this,
         comment = {
             body: this.elem.body.value
         };
 
-    e.preventDefault();
     self.clearErrors();
 
     var validEmailCommentSubmission = function () {
@@ -313,6 +345,10 @@ CommentBox.prototype.fail = function(xhr) {
     }
 };
 
+CommentBox.prototype.onboardingPreviewSuccess = function(comment, resp) {
+    this.getElem('onboarding-preview-body').innerHTML = resp.commentBody;
+};
+
 /**
  * @param {Object} comment
  * @param {Object} resp
@@ -379,13 +415,12 @@ CommentBox.prototype.verificationEmailFail = function() {
 /**
  * @param {Event=} e (optional)
  */
-CommentBox.prototype.previewComment = function(e) {
+CommentBox.prototype.previewComment = function(callback) {
     var self = this,
         comment = {
             body: this.getElem('body').value
         };
 
-    e.preventDefault();
     self.clearErrors();
 
     if (comment.body === '') {
@@ -401,7 +436,7 @@ CommentBox.prototype.previewComment = function(e) {
     if (self.errors.length === 0) {
         DiscussionApi
             .previewComment(comment)
-            .then(self.previewCommentSuccess.bind(self, comment), self.fail.bind(self));
+            .then(callback.bind(self, comment), self.fail.bind(self));
     }
 };
 

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -345,7 +345,8 @@ Loader.prototype.commentPosted = function () {
 Loader.prototype.renderCommentBox = function(elem) {
     return new CommentBox({
         discussionId: this.getDiscussionId(),
-        premod: this.user.privateFields.isPremoderated
+        premod: this.user.privateFields.isPremoderated,
+        newCommenter: !this.user.privateFields.hasCommented
     }).render(elem).on('post:success', this.commentPosted.bind(this));
 };
 

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -1441,3 +1441,33 @@ $comment-recommend-button-size: 19px;
     padding: ($gs-baseline / 3) * 2 ($gs-gutter / 2);
     margin-top: $gs-baseline / 2;
 }
+
+.d-comment-box__onboarding {
+    display: none;
+}
+
+.d-comment-box__onboarding h3 {
+    font-weight: bold;
+}
+
+.d-comment-box--onboarding-visible .d-comment-box__onboarding {
+    @include fs-textSans(2);
+    display: block;
+    background-color: colour(neutral-7);
+    padding: $gs-baseline $gs-gutter;
+}
+
+.d-comment-box--onboarding-visible .d-comment-box__content {
+    display: none;
+}
+
+.d-comment-box__onboarding-preview-body p {
+    background-color: #ffffff;
+    padding: $gs-baseline $gs-gutter;
+    margin-bottom: $gs-baseline;
+}
+
+.d-comment-box__onboarding-cancel {
+    background-color: colour(neutral-3);
+    border-color: colour(neutral-3);
+}


### PR DESCRIPTION
# My Awesome Pull Request
## What does this change?

Introduces an onboarding stage for first-time commenters. When pressing 'post' the user is shown a welcome message linking to the community standards and showing a preview of the comment.
## What is the value of this and can you measure success?

The hope is that the onboarding will educate users about our community standards and reduce the number of abusive comments.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

<img width="636" alt="screen shot 2016-04-07 at 18 27 22" src="https://cloud.githubusercontent.com/assets/858402/14360478/8200c21a-fcee-11e5-90cc-be4345001f08.png">
## Request for comment

I've gone over this with @OliverJAsh in the initial stages (all faults entirely my own yada yada) but I'm fumbling around here so all feedback welcome!

cc @guardian/discussion 
