### PR TITLE
Commercial component - no ad call without isbn

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -54,7 +54,12 @@ define([
 
     function bookUrlBuilder(url) {
         return function (params) {
-            return buildComponentUrl(url, merge(params, { t: config.page.isbn || params.isbn }));
+            var isbn = config.page.isbn || params.isbn;
+            if (isbn) {
+                return buildComponentUrl(url, merge(params, { t: config.page.isbn || params.isbn }));
+            } else {
+                return false;
+            }
         };
     }
 
@@ -155,12 +160,14 @@ define([
     }
 
     CommercialComponent.prototype.create = function () {
-        lazyload({
-            url: this.url,
-            container: this.adSlot,
-            success: onSuccess.bind(this),
-            error: onError.bind(this)
-        });
+        if (this.url) {
+            lazyload({
+                url: this.url,
+                container: this.adSlot,
+                success: onSuccess.bind(this),
+                error: onError.bind(this)
+            });
+        }
 
         return this;
 


### PR DESCRIPTION
## What does this change?

This PR fixes the bug which in a situation when there is no isbn provided (for a commercial component) there was a redundant ad call made with a 404 status. Right now, when there is no isbn, there will be no ad call.
## Screenshots

Before:
<img width="929" alt="screen shot 2016-04-08 at 10 29 47" src="https://cloud.githubusercontent.com/assets/489567/14379711/5365d1fe-fd73-11e5-8bb6-5e69e2002c84.png">
