### PR TITLE
Adblocking response survey - FF excluded and proper links set

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/loyal-adblocking-survey.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/loyal-adblocking-survey.js
@@ -14,8 +14,9 @@ define([
     SurveySimple
 ) {
     function getSurveyLink(adblockUsed) {
-        var ophanId = '&ophanId=' + config.ophan.pageViewId;
-        return adblockUsed ? 'https://surveys.theguardian.com/R.aspx?a=684&as=AC5tF8XE6G&t=1' + ophanId : 'https://surveys.theguardian.com/R.aspx?a=685&as=Aj5jo96J9j&t=1' + ophanId;
+        //var ophanId = '&ophanId=' + config.ophan.pageViewId;
+        var ophanId = '&ophanId=XXXX'; //temporary
+        return adblockUsed ? 'https://surveys.theguardian.com/R.aspx?a=684&as=AC5tF8XE6G' + ophanId : 'https://surveys.theguardian.com/R.aspx?a=685&as=Aj5jo96J9j' + ophanId;
     }
 
     return function () {
@@ -32,7 +33,7 @@ define([
         this.idealOutcome = 'We want to understand what causes people to block ads on theguardian.com and what would make them consider unblocking.';
 
         this.canRun = function () {
-            return true;
+            return detect.getUserAgent.browser !== 'Firefox';
         };
 
         this.variants = [{


### PR DESCRIPTION
## What does this change?

This PR excludes FF from the test (because we can't detect adblock properly) and sets up proper survey links. The audience is still 0% because we need to test if a dummy ophanId value is passed to the survey servers correctly.
