### PR TITLE
Turning embeded interactives into amp-iframes for amp

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/buttons.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/buttons.scala.html
@@ -97,25 +97,3 @@
         margin-top: 12px;
     }
 }
-
-.element-interactive a {
-    background-color: #efefef;
-    border-radius: 1.125rem;
-    -webkit-border-radius: 1.125rem;
-    border-bottom: none;
-}
-
-.element-interactive a::before {
-    content: "Visual: ";
-}
-
-.element-interactive a::after {
-    content: "";
-    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNCIgdmlld0JveD0iMCAwIDE2IDE0Ij48cGF0aCBmaWxsPSIjMDA1Njg5IiBkPSJNMTIgMS4xTDguMjcgNC44M2wuOTAyLjlMMTMgMi4wNyAxMy4yIDVoLjhWLjRsLS40LS40SDl2Ljh6TTExLjcgNi42MjVWOC43SDEuMlYyLjJoNWwuOC0uNlYxSC42bC0uNi42djcuOGwuNi42aDExLjhsLjYtLjZWNmgtLjd6Ii8+PC9zdmc+);
-    width: 16px;
-    height: 14px;
-    position: relative;
-    top: 9px;
-    margin-right: 3px;
-    float: left;
-}

--- a/common/app/views/fragments/amp/stylesheets/embeds.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/embeds.scala.html
@@ -61,6 +61,10 @@ figure.element.element--thumbnail {
     margin: auto;
 }
 
+.element-interactive iframe {
+    border: none;
+}
+
 @* Video related styling below *@
 .gu-media-wrapper, .gu-video {
     background: #000000;

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -97,7 +97,8 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
       iframe.attr("width", "5")
       iframe.attr("height", "1")
       iframe.attr("layout", "responsive")
-      iframe.attr("sandbox", "allow-scripts")
+      iframe.attr("resizable", "")
+      iframe.attr("sandbox", "allow-scripts allow-same-origin")
       iframe.attr("src", linkToInteractive)
 
       // All interactives should resize to the correct height once they load,

--- a/common/app/views/support/cleaner/AmpEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/AmpEmbedCleaner.scala
@@ -90,15 +90,24 @@ case class AmpEmbedCleaner(article: Article) extends HtmlCleaner {
       val link = interactive.getElementsByTag("a")
       val linkToInteractive = link.first().attr("href")
       val iframe = document.createElement("amp-iframe")
-      // AMP uses the height and width ratio, so exact values don't matter
-      // All interactives should resize to the correct height once they load
+      val overflowElem = document.createElement("div")
+      // In AMP, when using the layout `responsive`, width is 100%,
+      // and height is decided by the ratio between width and height.
+      // https://www.ampproject.org/docs/guides/responsive/control_layout.html
       iframe.attr("width", "5")
       iframe.attr("height", "1")
       iframe.attr("layout", "responsive")
       iframe.attr("sandbox", "allow-scripts")
       iframe.attr("src", linkToInteractive)
 
+      // All interactives should resize to the correct height once they load,
+      // but if they don't this overflow element will show and load it fully once it is clicked
+      overflowElem.addClass("cta cta--medium cta--show-more cta--show-more__unindent")
+      overflowElem.text("See the full visual")
+      overflowElem.attr("overflow", "")
+
       link.remove()
+      iframe.appendChild(overflowElem)
       interactive.appendChild(iframe)
     }
   }


### PR DESCRIPTION
## What does this change?

Currently embedded interactives don't work on AMP. With this pull request and [this change](https://github.com/ampproject/amphtml/pull/2835) on the amphtml repo they should work. Until the PR on amphtml is released, I won't merge this PR. 
## Does this affect other platforms - Amp, Apps, etc?

Only affects AMP
## Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/8774970/14381211/83dfaa0e-fd7c-11e5-9b9b-19b6947e6dc5.png)

With just this PR:
![image](https://cloud.githubusercontent.com/assets/8774970/14381219/91b113fc-fd7c-11e5-9a60-1c6dfa9c16a4.png)

With this PR, and the amphtml PR:
![image](https://cloud.githubusercontent.com/assets/8774970/14381229/a202c9ee-fd7c-11e5-90b1-1ac96c2f7a35.png)
## Request for comment

@guardian/interactive-team and @mattosborn I will let you know when this change is out :)
