### PR TITLE
Adblocking response AB test - correct ophan id value

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/loyal-adblocking-survey.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/loyal-adblocking-survey.js
@@ -14,8 +14,7 @@ define([
     SurveySimple
 ) {
     function getSurveyLink(adblockUsed) {
-        //var ophanId = '&ophanId=' + config.ophan.pageViewId;
-        var ophanId = '&ophanId=XXXX'; //temporary
+        var ophanId = '&ophanId=' + config.ophan.pageViewId;
         return adblockUsed ? 'https://surveys.theguardian.com/R.aspx?a=684&as=AC5tF8XE6G' + ophanId : 'https://surveys.theguardian.com/R.aspx?a=685&as=Aj5jo96J9j' + ophanId;
     }
 


### PR DESCRIPTION
## What does this change?

This PR adds a correct ophan id value to the AB test. The audience is still 0% so we can test it. 
