### PR TITLE
Start fetching travel offer feeds again

### DIFF
--- a/commercial/app/commercial/feeds/FeedFetcher.scala
+++ b/commercial/app/commercial/feeds/FeedFetcher.scala
@@ -24,10 +24,10 @@ trait FeedFetcher {
 class SingleFeedFetcher(val feedMetaData: FeedMetaData) extends FeedFetcher {
 
   def fetch()(implicit executionContext: ExecutionContext): Future[FetchResponse] = {
-    feedMetaData.switch.isGuaranteedSwitchedOn flatMap { reallyOn =>
+    feedMetaData.fetchSwitch.isGuaranteedSwitchedOn flatMap { reallyOn =>
       if (reallyOn) {
         FeedFetcher.fetch(feedMetaData)
-      } else Future.failed(SwitchOffException(feedMetaData.switch.name))
+      } else Future.failed(SwitchOffException(feedMetaData.fetchSwitch.name))
     }
   }
 }
@@ -58,7 +58,7 @@ class EventbriteMultiPageFeedFetcher(override val feedMetaData: EventsFeedMetaDa
 
   def fetch()(implicit executionContext: ExecutionContext): Future[FetchResponse] = {
 
-    feedMetaData.switch.isGuaranteedSwitchedOn flatMap { reallyOn =>
+    feedMetaData.fetchSwitch.isGuaranteedSwitchedOn flatMap { reallyOn =>
       if (reallyOn) {
 
         fetchPage(0) flatMap { initialFetch =>
@@ -69,7 +69,7 @@ class EventbriteMultiPageFeedFetcher(override val feedMetaData: EventsFeedMetaDa
             combineFetchResponses((initialFetch +: fetches.toSeq).seq)
           }
         }
-      } else Future.failed(SwitchOffException(feedMetaData.switch.name))
+      } else Future.failed(SwitchOffException(feedMetaData.fetchSwitch.name))
     }
   }
 }
@@ -145,7 +145,7 @@ object FeedFetcher {
       )
 
   private val travelOffers: Option[FeedFetcher] =
-    Configuration.commercial.traveloffers_url map { url =>
+    Configuration.commercial.travelFeedUrl map { url =>
       new SingleFeedFetcher(TravelOffersFeedMetaData(url))
     }
 

--- a/commercial/app/commercial/feeds/FeedMetaData.scala
+++ b/commercial/app/commercial/feeds/FeedMetaData.scala
@@ -13,7 +13,10 @@ sealed trait FeedMetaData {
   def url: String
   def parameters: Map[String, String] = Map.empty
   def timeout: Duration = 2.seconds
-  def switch: Switch
+
+  def fetchSwitch: Switch
+
+  def parseSwitch: Switch
   def responseEncoding: String = ResponseEncoding.default
 }
 
@@ -31,7 +34,9 @@ case class JobsFeedMetaData(urlTemplate: String) extends FeedMetaData {
     urlTemplate replace("yyyy-MM-dd", feedDate)
   }
 
-  val switch = Switches.JobFeedReadSwitch
+  override val fetchSwitch = Switches.JobFeedReadSwitch
+  override val parseSwitch = Switches.JobParseSwitch
+
   override val responseEncoding = utf8
 }
 
@@ -39,7 +44,10 @@ case class SoulmatesFeedMetaData(baseUrl: String, agent: SoulmatesAgent) extends
 
   val name = s"soulmates/${agent.groupName}"
   val url = s"$baseUrl/${agent.feed.path}"
-  val switch = Switches.SoulmatesFeedSwitch
+
+  override val fetchSwitch = Switches.SoulmatesFeedSwitch
+  override val parseSwitch = Switches.SoulmatesFeedSwitch
+
   override val responseEncoding = utf8
 }
 
@@ -47,11 +55,16 @@ case class BestsellersFeedMetaData(domain: String) extends FeedMetaData {
 
   val name = "bestsellers"
   val url = s"http://$domain/bertrams/feed/independentsTop20"
-  val switch = Switches.GuBookshopFeedsSwitch
+
+  override val fetchSwitch = Switches.GuBookshopFeedsSwitch
+  override val parseSwitch = Switches.GuBookshopFeedsSwitch
+
   override val responseEncoding = utf8
 }
 
-case class EventsFeedMetaData(feedName: String, accessToken: String, additionalParameters: Map[String, String] = Map.empty)
+case class EventsFeedMetaData(feedName: String,
+                              accessToken: String,
+                              additionalParameters: Map[String, String] = Map.empty)
   extends FeedMetaData {
 
   val name = feedName
@@ -63,12 +76,17 @@ case class EventsFeedMetaData(feedName: String, accessToken: String, additionalP
   ) ++ additionalParameters
 
   override val timeout = 20.seconds
-  val switch = Switches.EventsFeedSwitch
+
+  override val fetchSwitch = Switches.EventsFeedSwitch
+  override val parseSwitch = Switches.EventsFeedSwitch
 }
 
 case class TravelOffersFeedMetaData(url: String) extends FeedMetaData {
 
   override def name: String = "travel-offers"
 
-  override def switch: Switch = Switches.TravelOffersFeedSwitch
+  override val timeout = 10.seconds
+
+  override val fetchSwitch = Switches.TravelFeedFetchSwitch
+  override val parseSwitch = Switches.TravelFeedParseSwitch
 }

--- a/commercial/app/commercial/feeds/FeedParser.scala
+++ b/commercial/app/commercial/feeds/FeedParser.scala
@@ -78,7 +78,7 @@ object FeedParser {
   }
 
   private val travelOffers: Option[FeedParser[TravelOffer]] = {
-    Configuration.commercial.traveloffers_url map { url =>
+    Configuration.commercial.travelFeedUrl map { url =>
       new FeedParser[TravelOffer] {
 
         val feedMetaData = TravelOffersFeedMetaData(url)

--- a/commercial/app/model/commercial/books/MagentoBestsellersFeed.scala
+++ b/commercial/app/model/commercial/books/MagentoBestsellersFeed.scala
@@ -41,7 +41,7 @@ object MagentoBestsellersFeed extends ExecutionContexts with Logging {
 
     val feedName = feedMetaData.name
 
-    feedMetaData.switch.isGuaranteedSwitchedOn flatMap { switchedOn =>
+    feedMetaData.parseSwitch.isGuaranteedSwitchedOn flatMap { switchedOn =>
       if (switchedOn) {
         val start = currentTimeMillis
         feedContent map { body =>
@@ -53,7 +53,7 @@ object MagentoBestsellersFeed extends ExecutionContexts with Logging {
           Future.failed(MissingFeedException(feedName))
         }
       } else {
-        Future.failed(SwitchOffException(feedMetaData.switch.name))
+        Future.failed(SwitchOffException(feedMetaData.parseSwitch.name))
       }
     } recoverWith {
       case NonFatal(e) => Future.failed(e)

--- a/commercial/app/model/commercial/events/Eventbrite.scala
+++ b/commercial/app/model/commercial/events/Eventbrite.scala
@@ -154,7 +154,7 @@ object Eventbrite extends ExecutionContexts with Logging {
   }
   def parsePagesOfEvents(feedMetaData: FeedMetaData, feedContent: => Option[String]): Future[ParsedFeed[EBEvent]] = {
 
-    feedMetaData.switch.isGuaranteedSwitchedOn flatMap { switchedOn =>
+    feedMetaData.parseSwitch.isGuaranteedSwitchedOn flatMap { switchedOn =>
       if (switchedOn) {
         val start = currentTimeMillis
         feedContent map { body =>
@@ -169,7 +169,7 @@ object Eventbrite extends ExecutionContexts with Logging {
           Future.failed(MissingFeedException(feedMetaData.name))
         }
       } else {
-        Future.failed(SwitchOffException(feedMetaData.switch.name))
+        Future.failed(SwitchOffException(feedMetaData.parseSwitch.name))
       }
     } recoverWith {
       case NonFatal(e) => Future.failed(e)

--- a/commercial/app/model/commercial/soulmates/SoulmatesFeed.scala
+++ b/commercial/app/model/commercial/soulmates/SoulmatesFeed.scala
@@ -33,7 +33,7 @@ trait SoulmatesFeed extends ExecutionContexts with Logging {
   }
 
   def parsedMembers(feedMetaData: FeedMetaData, feedContent: => Option[String]): Future[ParsedFeed[Member]] = {
-    feedMetaData.switch.isGuaranteedSwitchedOn flatMap { switchedOn =>
+    feedMetaData.parseSwitch.isGuaranteedSwitchedOn flatMap { switchedOn =>
       if (switchedOn) {
         val start = currentTimeMillis
         feedContent map { body =>
@@ -43,7 +43,7 @@ trait SoulmatesFeed extends ExecutionContexts with Logging {
           Future.failed(MissingFeedException(feedMetaData.name))
         }
       } else {
-        Future.failed(SwitchOffException(feedMetaData.switch.name))
+        Future.failed(SwitchOffException(feedMetaData.parseSwitch.name))
       }
     } recoverWith {
       case NonFatal(e) => Future.failed(e)

--- a/commercial/app/model/commercial/travel/TravelOffersApi.scala
+++ b/commercial/app/model/commercial/travel/TravelOffersApi.scala
@@ -40,7 +40,7 @@ object TravelOffersApi extends ExecutionContexts with Logging {
   def parse(xml: Elem): Seq[TravelOffer] = (xml \\ "offer") map buildOffer
 
   def parseOffers(feedMetaData: FeedMetaData, feedContent: => Option[String]): Future[ParsedFeed[TravelOffer]] = {
-    feedMetaData.switch.isGuaranteedSwitchedOn flatMap { switchedOn =>
+    feedMetaData.parseSwitch.isGuaranteedSwitchedOn flatMap { switchedOn =>
       if (switchedOn) {
         val start = System.currentTimeMillis
         feedContent map { body =>
@@ -51,7 +51,7 @@ object TravelOffersApi extends ExecutionContexts with Logging {
           Future.failed(MissingFeedException(feedMetaData.name))
         }
       } else {
-        Future.failed(SwitchOffException(feedMetaData.switch.name))
+        Future.failed(SwitchOffException(feedMetaData.parseSwitch.name))
       }
     } recoverWith {
       case NonFatal(e) => Future.failed(e)

--- a/commercial/app/views/travel/travelFragment.scala.html
+++ b/commercial/app/views/travel/travelFragment.scala.html
@@ -4,7 +4,7 @@
     <div class="commercial--travel commercial--tone-travel">
         <div class="commercial--multi__header">
             <h4 class="commercial__title">
-                <a href="@clickMacro@Configuration.commercial.travel_url/" data-link-name="merchandising-hybrid-travel-visit-all">
+                <a href="@{clickMacro}http://www.guardianholidayoffers.co.uk/" data-link-name="merchandising-hybrid-travel-visit-all">
                     @fragments.inlineSvg("logo-holidayoffers-26", "commercial", List("commercial--tone-holidayoffers-logo"))
                     <span class="u-h">Holiday Offers</span>
                 </a>

--- a/commercial/app/views/travel/travelProminent.scala.html
+++ b/commercial/app/views/travel/travelProminent.scala.html
@@ -1,20 +1,18 @@
 @(offers: Seq[model.commercial.travel.TravelOffer], omnitureId: Option[String], clickMacro: Option[String])(implicit request: RequestHeader)
 
-@import conf.Configuration
-
 @defining(("1_1", "2014-07-04")) { case (version, date) =>
     <div class="commercial commercial--travel commercial--tone-travel commercial--high commercial--prominent" data-link-name="commercial-high | travel | @omnitureId">
         <div class="commercial__inner">
             <div class="commercial__header">
                 <h3 class="commercial__title">
-                    <a href="@clickMacro@Configuration.commercial.travel_url/" data-link-name="merchandising-travel-v@{version}_@{date}-high-title">
+                    <a href="@{clickMacro}http://www.guardianholidayoffers.co.uk/" data-link-name="merchandising-travel-v@{version}_@{date}-high-title">
                         @fragments.inlineSvg("marque-54", "icon")
                         @fragments.inlineSvg("logo-guardian", "logo")
                         @fragments.inlineSvg("logo-holidayoffers", "commercial", List("inline-commercial-brand"))
                         <span class="u-h">The Guardian</span> <span class="u-h">Holiday Offers</span>
                     </a>
                 </h3>
-                <form class="commercial__search" action="@Configuration.commercial.travel_url/Search">
+                <form class="commercial__search" action="http://www.guardianholidayoffers.co.uk/Search">
                     <div class="commercial__search__inner">
                         <label for="traveloffer" class="u-h">Find hand picked holidays for hundreds of destinations</label>
                         <input id="traveloffer" name="search" class="commercial__search__input" type="text" placeholder="Find your perfect holiday" />
@@ -25,7 +23,7 @@
                         <input value="%JustOmnitureToken%" name="INTCMP" type="hidden" />
                     </div>
                 </form>
-                <a class="commercial__cta button button--tertiary button--large" href="@clickMacro@Configuration.commercial.travel_url" data-link-name="merchandising-travel-v@{version}_@{date}-high-visit-shop">
+                <a class="commercial__cta button button--tertiary button--large" href="@{clickMacro}http://www.guardianholidayoffers.co.uk" data-link-name="merchandising-travel-v@{version}_@{date}-high-visit-shop">
                     @fragments.inlineSvg("arrow-right", "icon", List("i-right"))
                     <span class="commercial__cta__label">View <span class="hide-on-mobile-inline">more great</span> deals</span>
                 </a>

--- a/commercial/app/views/travel/travelStandard.scala.html
+++ b/commercial/app/views/travel/travelStandard.scala.html
@@ -1,20 +1,18 @@
 @(offers: Seq[model.commercial.travel.TravelOffer], omnitureId: Option[String], clickMacro: Option[String])(implicit request: RequestHeader)
 
-@import conf.Configuration
-
 @defining(("2_1", "2014-07-04")) { case (version, date) =>
     <div class="commercial commercial--travel commercial--tone-travel commercial--low commercial-standard" data-link-name="commercial-low | travel | @omnitureId">
         <div class="commercial__inner">
             <div class="commercial__header">
                 <h3 class="commercial__title">
-                    <a href="@clickMacro@Configuration.commercial.travel_url/" data-link-name="merchandising-travel-v@{version}_@{date}-low-title">
+                    <a href="@{clickMacro}http://www.guardianholidayoffers.co.uk/" data-link-name="merchandising-travel-v@{version}_@{date}-low-title">
                         @fragments.inlineSvg("marque-54", "icon")
                         @fragments.inlineSvg("logo-guardian", "logo")
                         @fragments.inlineSvg("logo-holidayoffers", "commercial", List("inline-commercial-brand"))
                         <span class="u-h">The Guardian</span> <span class="u-h">Holiday Offers</span>
                     </a>
                 </h3>
-                <form class="commercial__search" action="@Configuration.commercial.travel_url/Search">
+                <form class="commercial__search" action="http://www.guardianholidayoffers.co.uk/Search">
                     <div class="commercial__search__inner">
                         <label for="traveloffer" class="u-h">Find hand picked holidays for hundreds of destinations</label>
                         <input id="traveloffer" name="search" class="commercial__search__input" type="text" placeholder="Find your perfect holiday" />
@@ -25,7 +23,7 @@
                         <input value="%JustOmnitureToken%" name="INTCMP" type="hidden" />
                     </div>
                 </form>
-                <a class="commercial__cta button button--tertiary button--large" href="@clickMacro@Configuration.commercial.travel_url" data-link-name="merchandising-travel-v@{version}_@{date}-low-visit-shop">
+                <a class="commercial__cta button button--tertiary button--large" href="@{clickMacro}http://www.guardianholidayoffers.co.uk" data-link-name="merchandising-travel-v@{version}_@{date}-low-visit-shop">
                     @fragments.inlineSvg("arrow-right", "icon", List("i-right"))
                     <span class="commercial__cta__label">View <span class="hide-on-mobile-inline">more great</span> deals</span>
                 </a>

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -270,14 +270,13 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val dfpFacebookIaAdUnitRoot = configuration.getMandatoryStringProperty("guardian.page.dfp.facebookIaAdUnitRoot")
     lazy val dfpMobileAppsAdUnitRoot = configuration.getMandatoryStringProperty("guardian.page.dfp.mobileAppsAdUnitRoot")
     lazy val dfpAccountId = configuration.getMandatoryStringProperty("guardian.page.dfpAccountId")
+
     lazy val books_url = configuration.getMandatoryStringProperty("commercial.books_url")
     lazy val masterclasses_url =
       configuration.getMandatoryStringProperty("commercial.masterclasses_url")
     lazy val soulmates_url = configuration.getMandatoryStringProperty("commercial.soulmates_url")
     lazy val soulmatesApiUrl = configuration.getStringProperty("soulmates.api.url")
-    lazy val travel_url = configuration.getMandatoryStringProperty("commercial.travel_url")
-    lazy val traveloffers_url =
-      configuration.getStringProperty("traveloffers.api.url") map (u => s"$u/consumerfeed")
+    lazy val travelFeedUrl = configuration.getStringProperty("travel.feed.url")
     lazy val guMerchandisingAdvertiserId =
       configuration.getMandatoryStringProperty("commercial.dfp.guMerchandising.advertiserId")
 

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -113,10 +113,19 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val TravelOffersFeedSwitch = Switch(
+  val TravelFeedFetchSwitch = Switch(
     "Commercial",
-    "gu-travel-offers",
-    "If this switch is on, commercial components will be fed by travel offer feed.",
+    "gu-travel-feed-fetch",
+    "If this switch is on, cached travel offers feed will be updated from external source.",
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
+  val TravelFeedParseSwitch = Switch(
+    "Commercial",
+    "gu-travel-feed-parse",
+    "If this switch is on, commercial components will be fed by travel offers feed.",
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -78,7 +78,6 @@ contentapi.post.endpoint=http://coolproxy.mobile-apps.guardianapis.com
 commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
-commercial.travel_url=http://www.guardianholidayoffers.co.uk
 commercial.dfp.guMerchandising.advertiserId=24113847
 commercial.showMpuInAllContainersPageId=dynamic-mpu
 

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -69,7 +69,6 @@ aws.region=eu-west-1
 commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
-commercial.travel_url=http://www.guardianholidayoffers.co.uk
 commercial.dfp.guMerchandising.advertiserId=24113847
 commercial.showMpuInAllContainersPageId=dynamic-mpu
 

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -53,7 +53,6 @@ aws.region=eu-west-1
 commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
-commercial.travel_url=http://www.guardianholidayoffers.co.uk
 
 # Headlines AB Test
 headlines.spreadsheet=1aGUa-Prxre5ul4nDc-7b31TOIyHaprCsmy6jkKevGL8

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -75,7 +75,6 @@ contentapi.post.endpoint=http://coolproxy.mobile-apps.guardianapis.com
 commercial.books_url=http://www.guardianbookshop.co.uk
 commercial.masterclasses_url=http://theguardian.com/guardian-masterclasses
 commercial.soulmates_url=https://soulmates.theguardian.com
-commercial.travel_url=http://www.guardianholidayoffers.co.uk
 commercial.dfp.guMerchandising.advertiserId=24113847
 
 # Pressing


### PR DESCRIPTION
This change is the first step in reinstating travel offer merch components.
It:
- separates fetching and parsing switches logically for all merchandising feeds
- separates fetching and parsing physically for the new travel feed
- removes a redundant property

Parsing is still to come in another PR
(in case I don't get it done this afternoon so someone else can take it on next week).

/cc @JonNorman @regiskuckaertz 
