### PR TITLE
Add subscribeDate to the notifications subscription database

### DIFF
--- a/applications/app/model/notifications/DynamoDbStore.scala
+++ b/applications/app/model/notifications/DynamoDbStore.scala
@@ -24,7 +24,7 @@ object DynamoDbStore extends Logging with ExecutionContexts {
       .withKey(Map[String, AttributeValue](
         ("notificationTopicId", new AttributeValue().withS(notificationTopicId)),
         ("gcmBrowserId", new AttributeValue().withS(gcmBrowserId)),
-        ("subscribeDate", new AttributeValue().withN(DateTime.now.getMillis.toString))
+        ("subscribeDate", new AttributeValue().withN((DateTime.now.getMillis / 1000).toString))
       ).asJava)
 
     client.updateItemFuture(updateItemRequest) onFailure {

--- a/applications/app/model/notifications/DynamoDbStore.scala
+++ b/applications/app/model/notifications/DynamoDbStore.scala
@@ -5,6 +5,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, DeleteItemRequest, UpdateItemRequest}
 import common.{ExecutionContexts, Logging}
 import conf.Configuration
+import org.joda.time.DateTime
 import scala.collection.JavaConverters._
 import awswrappers.dynamodb._
 
@@ -22,7 +23,8 @@ object DynamoDbStore extends Logging with ExecutionContexts {
       .withTableName(tableName)
       .withKey(Map[String, AttributeValue](
         ("notificationTopicId", new AttributeValue().withS(notificationTopicId)),
-        ("gcmBrowserId", new AttributeValue().withS(gcmBrowserId))
+        ("gcmBrowserId", new AttributeValue().withS(gcmBrowserId)),
+        ("subscribeDate", new AttributeValue().withN(DateTime.now.getMillis.toString))
       ).asJava)
 
     client.updateItemFuture(updateItemRequest) onFailure {


### PR DESCRIPTION
This adds the subscribe date as a unix timestamp to each new record in the `frontend-notifications` database to track who is subscribed to what.

@NathanielBennett 
