### PR TITLE
Immersive dividers only work with images

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -432,7 +432,7 @@ case class ImmersiveHeaders(isImmersive: Boolean) extends HtmlCleaner {
       document.getElementsByTag("h2").foreach{ h2 =>
         val beforeH2 = h2.previousElementSibling()
         if (beforeH2 != null) {
-          if(beforeH2.hasClass("element--immersive")) {
+          if(beforeH2.hasClass("element--immersive element-image")) {
             beforeH2.addClass("section-image")
             beforeH2.prepend("""<h2 class="section-title">""" + h2.text() + "</h2>")
             h2.remove()


### PR DESCRIPTION
## What does this change?

Adds the section dividers for `element-image` embeds only.
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
