### PR TITLE
Enable Content API with thrift

### DIFF
--- a/admin-jobs/app/Global.scala
+++ b/admin-jobs/app/Global.scala
@@ -17,8 +17,8 @@ with SwitchboardLifecycle {
   override lazy val applicationName = "frontend-admin-jobs"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ List(
-    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
-    ContentApiMetrics.ElasticHttpTimingMetric,
+    ContentApiMetrics.HttpTimeoutCountMetric,
+    ContentApiMetrics.HttpLatencyTimingMetric,
     ContentApiMetrics.ContentApiErrorMetric
   )
 }

--- a/admin/app/conf/AdminConfiguration.scala
+++ b/admin/app/conf/AdminConfiguration.scala
@@ -23,10 +23,6 @@ object AdminConfiguration {
 
   lazy val topStoriesKey = configuration.getStringProperty("top-stories.config").getOrElse(throw new RuntimeException("Top Stories file name is not setup"))
 
-  object contentapi {
-    val previewHost: String = configuration.getStringProperty("content.api.preview.host").getOrElse(throw new RuntimeException("Preview host is not configured"))
-  }
-
   object fastly {
     lazy val key = configuration.getStringProperty("fastly.key").getOrElse(throw new RuntimeException("Fastly key not configured"))
     lazy val serviceId = configuration.getStringProperty("fastly.serviceId").getOrElse(throw new RuntimeException("Fastly service id not configured"))

--- a/admin/app/controllers/Api.scala
+++ b/admin/app/controllers/Api.scala
@@ -17,7 +17,7 @@ object Api extends Controller with Logging with AuthLogging with ExecutionContex
        "%s=%s".format(p._1, p._2.head.urlEncoded)
     }.mkString("&")
 
-    val url = s"${Configuration.contentApi.contentApiLiveHost}/$path?$queryString${Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
+    val url = s"${Configuration.contentApi.contentApiHost}/$path?$queryString${Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
 
     log("Proxying tag API query to: %s" format url, request)
 
@@ -28,7 +28,7 @@ object Api extends Controller with Logging with AuthLogging with ExecutionContex
 
   def tag(q: String, callback: String) = AuthActions.AuthActionTest.async { request =>
     val url = "%s/tags?format=json&page-size=50%s&callback=%s&q=%s".format(
-      Configuration.contentApi.contentApiLiveHost,
+      Configuration.contentApi.contentApiHost,
       Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse(""),
       callback.javascriptEscaped.urlEncoded,
       q.javascriptEscaped.urlEncoded
@@ -43,7 +43,7 @@ object Api extends Controller with Logging with AuthLogging with ExecutionContex
 
   def item(path: String, callback: String) = AuthActions.AuthActionTest.async { request =>
     val url = "%s/%s?format=json&page-size=1%s&callback=%s".format(
-      Configuration.contentApi.contentApiLiveHost,
+      Configuration.contentApi.contentApiHost,
       path.javascriptEscaped.urlEncoded,
       Configuration.contentApi.key.map(key => s"&api-key=$key").getOrElse(""),
       callback.javascriptEscaped.urlEncoded

--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -3,8 +3,8 @@ package controllers.admin
 import common.dfp.{GuCreativeTemplate, LineItemReport}
 import common.{Edition, ExecutionContexts, Logging}
 import conf.Configuration.environment
-import conf.LiveContentApi.getResponse
-import conf.{Configuration, LiveContentApi}
+import contentapi.ContentApiClient
+import conf.Configuration
 import controllers.AuthLogging
 import dfp.{CreativeTemplateAgent, DfpApi}
 import model._
@@ -75,8 +75,8 @@ object CommercialController extends Controller with Logging with AuthLogging wit
 
   def sponsoredContainers = AuthActions.AuthActionTest.async { implicit request =>
     // get some example trails
-    lazy val trailsFuture = getResponse(
-      LiveContentApi.search(Edition(request))
+    lazy val trailsFuture = ContentApiClient.getResponse(
+      ContentApiClient.search(Edition(request))
         .pageSize(2)
     ).map { response  =>
       response.results.map { item =>

--- a/admin/app/indexes/ContentApiTagsEnumerator.scala
+++ b/admin/app/indexes/ContentApiTagsEnumerator.scala
@@ -2,8 +2,8 @@ package indexes
 
 import common.Logging
 import common.StringEncodings.asAscii
-import conf.LiveContentApi
-import LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import ContentApiClient.getResponse
 
 import scala.concurrent.Future
 import com.gu.contentapi.client.model.v1.{TagsResponse, Tag}
@@ -39,7 +39,7 @@ object ContentApiTagsEnumerator extends Logging {
   }
 
   def enumerateTagType(tagType: String) = enumeratePages { page =>
-    getResponse(LiveContentApi.tags.tagType(tagType).pageSize(MaxPageSize).page(page))
+    getResponse(ContentApiClient.tags.tagType(tagType).pageSize(MaxPageSize).page(page))
   }
 
   implicit class RichTag(tag: Tag) {

--- a/admin/app/jobs/MissingVideoEncodingsJob.scala
+++ b/admin/app/jobs/MissingVideoEncodingsJob.scala
@@ -4,8 +4,8 @@ import common.{Edition, Logging, ExecutionContexts, AkkaAgent}
 import conf.switches.Switches
 import model.{Content, Video}
 import scala.language.postfixOps
-import conf.LiveContentApi
-import LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import ContentApiClient.getResponse
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration._
 import akka.util.Timeout
@@ -37,7 +37,7 @@ object VideoEncodingsJob extends ExecutionContexts with Logging  {
   private def checkForMissingEncodings() {
      log.info("Checking for missing video encodings")
 
-     val apiVideoResponse = getResponse(LiveContentApi.search(Edition.defaultEdition)
+     val apiVideoResponse = getResponse(ContentApiClient.search(Edition.defaultEdition)
         .tag("type/video")
         .showElements("all")
         .pageSize(100)

--- a/admin/app/purge/SoftPurge.scala
+++ b/admin/app/purge/SoftPurge.scala
@@ -6,7 +6,7 @@ import cache.SurrogateKey
 import common.{AkkaAsync, ExecutionContexts, Jobs, Logging}
 import conf.AdminConfiguration.fastly
 import conf.Configuration.environment
-import conf.LiveContentApi.{getResponse, search}
+import contentapi.ContentApiClient.{getResponse, search}
 import implicits.Dates
 import play.api.Play.current
 import play.api.libs.ws.WS

--- a/applications/app/Global.scala
+++ b/applications/app/Global.scala
@@ -23,8 +23,8 @@ object Global extends WithFilters(Filters.common: _*)
   override lazy val applicationName = "frontend-applications"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ List(
-    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
-    ContentApiMetrics.ElasticHttpTimingMetric,
+    ContentApiMetrics.HttpTimeoutCountMetric,
+    ContentApiMetrics.HttpLatencyTimingMetric,
     ContentApiMetrics.ContentApiErrorMetric,
     EmailSubsciptionMetrics.EmailSubmission,
     EmailSubsciptionMetrics.EmailFormError,

--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -3,8 +3,8 @@ package controllers
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
 import common.Edition.defaultEdition
 import common.{Edition, ExecutionContexts, Logging}
-import conf.LiveContentApi
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import contentapi.ContentApiClient.getResponse
 import implicits.{Dates, ItemResponses}
 import model._
 import org.joda.time.format.DateTimeFormat
@@ -93,7 +93,7 @@ object AllIndexController extends Controller with ExecutionContexts with ItemRes
   // this is simply the latest by date. No lead content, editors picks, or anything else
   private def loadLatest(path: String, date: DateTime)(implicit request: RequestHeader): Future[Option[IndexPage]] = {
     val result = getResponse(
-      LiveContentApi.item(s"/$path", Edition(request)).pageSize(50).toDate(date).orderBy("newest")
+      ContentApiClient.item(s"/$path", Edition(request)).pageSize(50).toDate(date).orderBy("newest")
     ).map{ item =>
       item.section.map( section =>
         IndexPage(
@@ -117,7 +117,7 @@ object AllIndexController extends Controller with ExecutionContexts with ItemRes
 
   private def findByDate(path: String, date: DateTime)(implicit request: RequestHeader): Future[Option[DateTime]] = {
     val result = getResponse(
-      LiveContentApi.item(s"/$path", Edition(request))
+      ContentApiClient.item(s"/$path", Edition(request))
         .pageSize(1)
         .fromDate(date)
         .orderBy("oldest")

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -2,7 +2,8 @@ package controllers
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent, Crossword, Section => ApiSection, ItemResponse}
 import common.{Edition, ExecutionContexts, Logging}
-import conf.{LiveContentApi, Static}
+import conf.Static
+import contentapi.ContentApiClient
 import crosswords.{AccessibleCrosswordRows, CrosswordPage, CrosswordSearchPage, CrosswordSvg}
 import model._
 import org.joda.time.{DateTime, LocalDate}
@@ -18,7 +19,7 @@ trait CrosswordController extends Controller with Logging with ExecutionContexts
   def noResults()(implicit request: RequestHeader): Result
 
   def getCrossword(crosswordType: String, id: Int)(implicit request: RequestHeader): Future[ItemResponse] = {
-    LiveContentApi.getResponse(LiveContentApi.item(s"crosswords/$crosswordType/$id", Edition(request)).showFields("all"))
+    ContentApiClient.getResponse(ContentApiClient.item(s"crosswords/$crosswordType/$id", Edition(request)).showFields("all"))
   }
 
   def withCrossword(crosswordType: String, id: Int)(f: (Crossword, ApiContent) => Result)(implicit request: RequestHeader): Future[Result] = {
@@ -110,7 +111,7 @@ object CrosswordSearchController extends CrosswordController {
       empty => Future.successful(Cached(7.days)(Ok(views.html.crosswordSearch(CrosswordSearchPage.make())))),
 
       params => {
-        val withoutSetter = LiveContentApi.item(s"crosswords/series/${params.crosswordType}")
+        val withoutSetter = ContentApiClient.item(s"crosswords/series/${params.crosswordType}")
           .stringParam("from-date", params.fromDate.toString("yyyy-MM-dd"))
           .stringParam("to-date", params.toDate.toString("yyyy-MM-dd"))
           .pageSize(50)
@@ -119,7 +120,7 @@ object CrosswordSearchController extends CrosswordController {
           withoutSetter.stringParam("tag", s"profile/${setter.toLowerCase}")
         }
 
-        LiveContentApi.getResponse(maybeSetter.showFields("all")).map { response =>
+        ContentApiClient.getResponse(maybeSetter.showFields("all")).map { response =>
           response.results.getOrElse(Nil) match {
             case Nil => noResults
 

--- a/applications/app/controllers/EmbedController.scala
+++ b/applications/app/controllers/EmbedController.scala
@@ -6,7 +6,7 @@ import common._
 import model._
 import play.api.mvc._
 import scala.concurrent.Future
-import LiveContentApi.getResponse
+import contentapi.ContentApiClient
 
 case class EmbedPage(model: Option[Video], title: String, isExpired: Boolean = false)
 
@@ -24,7 +24,7 @@ object EmbedController extends Controller with Logging with ExecutionContexts {
 
     log.info(s"Fetching video: $path for edition $edition")
 
-    val response: Future[ItemResponse] = getResponse(LiveContentApi.item(path, edition)
+    val response: Future[ItemResponse] = ContentApiClient.getResponse(ContentApiClient.item(path, edition)
       .showFields("all")
     )
 

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent, ItemResponse}
 import common._
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
 import conf._
 import conf.switches.Switches
 import model._
@@ -49,7 +49,7 @@ object GalleryController extends Controller with RendersItemResponse with Loggin
                     (implicit request: RequestHeader) = {
     val edition = Edition(request)
     log.info(s"Fetching gallery: $path for edition $edition")
-    getResponse(LiveContentApi.item(path, edition)
+    ContentApiClient.getResponse(ContentApiClient.item(path, edition)
       .showFields("all")
     ).map { response =>
       val gallery = response.content.map(Content(_))

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.gu.contentapi.client.model.v1.ItemResponse
 import common._
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
 import conf._
 import conf.switches.Switches
 import model._
@@ -24,8 +24,8 @@ object InteractiveController extends Controller with RendersItemResponse with Lo
                     (implicit request: RequestHeader): Future[Either[InteractivePage, Result]] = {
     val edition = Edition(request)
     log.info(s"Fetching interactive: $path for edition $edition")
-    val response: Future[ItemResponse] = getResponse(
-      LiveContentApi.item(path, edition)
+    val response: Future[ItemResponse] = ContentApiClient.getResponse(
+      ContentApiClient.item(path, edition)
         .showFields("all")
     )
 

--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -1,8 +1,8 @@
 package controllers
 
 import common._
-import conf.LiveContentApi
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import contentapi.ContentApiClient.getResponse
 import contentapi.Paths
 import model._
 import org.joda.time.DateTime
@@ -34,7 +34,7 @@ object LatestIndexController extends Controller with ExecutionContexts with impl
   // this is simply the latest by date. No lead content, editors picks, or anything else
   private def loadLatest(path: String)(implicit request: RequestHeader): Future[Option[IndexPage]] = {
     val result = getResponse(
-      LiveContentApi.item(s"/$path", Edition(request))
+      ContentApiClient.item(s"/$path", Edition(request))
         .pageSize(1)
         .orderBy("newest")
     ).map{ item =>

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -2,8 +2,7 @@ package controllers
 
 import com.gu.contentapi.client.model.v1.{Content => ApiContent, ItemResponse}
 import common._
-import conf.LiveContentApi.getResponse
-import conf._
+import contentapi.ContentApiClient
 import conf.switches.Switches
 import model._
 import play.api.libs.json.{Format, JsObject, Json}
@@ -34,8 +33,8 @@ object MediaController extends Controller with RendersItemResponse with Logging 
     val edition = Edition(request)
 
     log.info(s"Fetching media: $path for edition $edition")
-    val response: Future[ItemResponse] = getResponse(
-      LiveContentApi.item(path, edition)
+    val response: Future[ItemResponse] = ContentApiClient.getResponse(
+      ContentApiClient.item(path, edition)
         .showFields("all")
     )
 

--- a/applications/app/controllers/QuizController.scala
+++ b/applications/app/controllers/QuizController.scala
@@ -1,8 +1,8 @@
 package controllers
 
 import common._
-import conf.{Configuration, LiveContentApi}
-import conf.LiveContentApi.getResponse
+import conf.Configuration
+import contentapi.ContentApiClient
 import model._
 import model.content.{Quiz, Atoms}
 import quiz.form
@@ -58,8 +58,8 @@ object QuizController extends Controller with ExecutionContexts with Logging {
     val edition = Edition(request)
 
     log.info(s"Fetching quiz atom: $quizId from content id: $path: ${RequestLog(request)}")
-    val capiQuery = LiveContentApi.item(path, edition).showAtoms("all")
-    val result = getResponse(capiQuery) map { itemResponse =>
+    val capiQuery = ContentApiClient.item(path, edition).showAtoms("all")
+    val result = ContentApiClient.getResponse(capiQuery) map { itemResponse =>
       val maybePage: Option[QuizAnswersPage] = itemResponse.content.flatMap { content =>
 
         val quiz = Atoms.make(content).flatMap(_.quizzes.find(_.id == quizId))

--- a/applications/app/controllers/ShortUrlsController.scala
+++ b/applications/app/controllers/ShortUrlsController.scala
@@ -3,7 +3,7 @@ package controllers
 import common.{ExecutionContexts, LinkTo, Logging}
 import common.`package`._
 import campaigns.ShortCampaignCodes
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import model.Cached
 import play.api.mvc.{RequestHeader, Action, Controller}
 
@@ -15,7 +15,7 @@ object ShortUrlsController extends Controller with Logging with ExecutionContext
   }
 
   private def redirectUrl(shortUrl: String, queryString: Map[String, Seq[String]])(implicit request: RequestHeader) = {
-    LiveContentApi.getResponse(LiveContentApi.item(shortUrl)).map { response =>
+    ContentApiClient.getResponse(ContentApiClient.item(shortUrl)).map { response =>
       response.content.map(_.id).map { id =>
         Redirect(LinkTo(s"/$id"), queryString = queryString, status = MOVED_PERMANENTLY)
       }.getOrElse(NotFound)

--- a/applications/app/controllers/WebAppController.scala
+++ b/applications/app/controllers/WebAppController.scala
@@ -2,7 +2,8 @@ package controllers
 
 import com.gu.contentapi.client.model.v1.Crossword
 import common.{JsonComponent, Edition, ExecutionContexts, Logging}
-import conf.{Static, LiveContentApi}
+import contentapi.ContentApiClient
+import conf.Static
 import model._
 import play.api.mvc.{Action, Controller, RequestHeader, Result}
 import play.api.libs.json.{JsArray, JsString, JsObject}
@@ -30,7 +31,7 @@ object WebAppController extends Controller with ExecutionContexts with Logging {
 
 
   protected def withCrossword(crosswordType: String)(f: (Crossword) => Result)(implicit request: RequestHeader): Future[Result] = {
-    LiveContentApi.getResponse(LiveContentApi.item(s"crosswords/series/quick", Edition(request)).showFields("all")).map { response =>
+    ContentApiClient.getResponse(ContentApiClient.item(s"crosswords/series/quick", Edition(request)).showFields("all")).map { response =>
       val maybeCrossword = for {
         content <- response.results.getOrElse(Nil).headOption
         crossword <- content.crossword }

--- a/applications/app/services/ImageQuery.scala
+++ b/applications/app/services/ImageQuery.scala
@@ -2,8 +2,8 @@ package services
 
 import com.gu.contentapi.client.model.v1.ItemResponse
 import common.{Edition, _}
-import conf.LiveContentApi
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import contentapi.ContentApiClient.getResponse
 import controllers.ImageContentPage
 import model.{ApiContent2Is, Content, ImageContent, RelatedContent}
 import play.api.mvc.{RequestHeader, Result => PlayResult}
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 trait ImageQuery extends ConciergeRepository {
   def image(edition: Edition, path: String)(implicit request: RequestHeader): Future[Either[ImageContentPage, PlayResult]] = {
     log.info(s"Fetching image content: $path for edition ${edition.id}")
-    val response = getResponse(LiveContentApi.item(path, edition)
+    val response = getResponse(ContentApiClient.item(path, edition)
       .showFields("all")
     ) map { response: ItemResponse =>
         val mainContent = response.content.filter(_.isImageContent).map(Content(_))

--- a/applications/app/services/NewsSiteMap.scala
+++ b/applications/app/services/NewsSiteMap.scala
@@ -1,8 +1,8 @@
 package services
 
 import common.{ExecutionContexts, Edition}
-import conf.{Configuration, LiveContentApi}
-import conf.LiveContentApi._
+import conf.Configuration
+import contentapi.ContentApiClient
 import model.Content
 import org.joda.time.{DateTimeZone, DateTime}
 import implicits.Dates.DateTime2ToCommonDateFormats
@@ -52,7 +52,7 @@ object NewsSiteMap extends ExecutionContexts {
 
   def getLatestContent: Future[NodeSeq] = {
 
-    val query = LiveContentApi.search(Edition.defaultEdition)
+    val query = ContentApiClient.search(Edition.defaultEdition)
       .pageSize(200)
       .tag("-tone/sponsoredfeatures,-type/crossword,-extra/extra,-tone/advertisement-features")
       .orderBy("newest")
@@ -62,11 +62,11 @@ object NewsSiteMap extends ExecutionContexts {
       .showElements("all")
       .fromDate(DateTime.now(DateTimeZone.UTC).minusDays(2))
 
-    val responses = getResponse(query).flatMap { initialResponse =>
+    val responses = ContentApiClient.getResponse(query).flatMap { initialResponse =>
       // Request any further pages if needed.
       val followingPages = for {
         pageNumber <- 2 to initialResponse.pages
-      } yield getResponse(query.page(pageNumber))
+      } yield ContentApiClient.getResponse(query.page(pageNumber))
       Future.sequence(Future.successful(initialResponse) +: followingPages)
     }
 

--- a/applications/app/services/NewspaperQuery.scala
+++ b/applications/app/services/NewspaperQuery.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.client.model.v1.{Content => ApiContent, Tag}
 import com.gu.facia.api.utils.{ResolvedMetaData, ContentProperties}
 import com.gu.facia.api.{models => fapi}
 import common._
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import implicits.Dates
 import layout.{CollectionEssentials, FaciaContainer}
 import model.pressed.{CollectionConfig, LinkSnap, PressedContent}
@@ -50,7 +50,7 @@ object NewspaperQuery extends ExecutionContexts with Dates with Logging {
 
   private def bookSectionContainers(itemId: String, newspaperDate: DateTime, publication: String): Future[List[FaciaContainer]] = {
 
-    val itemQuery = LiveContentApi.item(itemId)
+    val itemQuery = ContentApiClient.item(itemId)
       .useDate("newspaper-edition")
       .showFields("all")
       .showElements("all")
@@ -59,7 +59,7 @@ object NewspaperQuery extends ExecutionContexts with Dates with Logging {
       .fromDate(newspaperDate.withTimeAtStartOfDay())
       .toDate(newspaperDate)
 
-    LiveContentApi.getResponse(itemQuery).map { resp =>
+    ContentApiClient.getResponse(itemQuery).map { resp =>
 
       //filter out the first page results to make a Front Page container
       val (firstPageContent, otherContent) = resp.results.getOrElse(Nil).partition(content => getNewspaperPageNumber(content).contains(1))

--- a/applications/app/services/VideoSiteMap.scala
+++ b/applications/app/services/VideoSiteMap.scala
@@ -1,8 +1,8 @@
 package services
 
 import common.{ExecutionContexts, Edition}
-import conf.{Configuration, LiveContentApi}
-import conf.LiveContentApi._
+import conf.Configuration
+import contentapi.ContentApiClient
 import model.{Video, Content}
 import org.joda.time.{DateTimeZone, DateTime}
 import implicits.Dates.DateTime2ToCommonDateFormats
@@ -53,7 +53,7 @@ object VideoSiteMap extends ExecutionContexts {
 
   def getLatestContent: Future[NodeSeq] = {
 
-    val query = LiveContentApi.search(Edition.defaultEdition)
+    val query = ContentApiClient.search(Edition.defaultEdition)
       .pageSize(200)
       .tag("type/video,-tone/sponsoredfeatures,-tone/advertisement-features")
       .orderBy("newest")
@@ -63,11 +63,11 @@ object VideoSiteMap extends ExecutionContexts {
       .showElements("all")
       .fromDate(DateTime.now(DateTimeZone.UTC).minusDays(2))
 
-    val responses = getResponse(query).flatMap { initialResponse =>
+    val responses = ContentApiClient.getResponse(query).flatMap { initialResponse =>
       // Request any further pages if needed.
       val followingPages = for {
         pageNumber <- 2 to initialResponse.pages
-      } yield getResponse(query.page(pageNumber))
+      } yield ContentApiClient.getResponse(query.page(pageNumber))
       Future.sequence(Future.successful(initialResponse) +: followingPages)
     }
 

--- a/applications/test/ShareLinksTest.scala
+++ b/applications/test/ShareLinksTest.scala
@@ -1,7 +1,7 @@
 package test
 
 import com.gu.contentapi.client.model.v1.ItemResponse
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import org.scalatest.concurrent.{Futures, ScalaFutures}
 
@@ -10,8 +10,8 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
   private val edition = common.editions.Uk
 
   "ShareLink" should "provide valid page-level campaign-links in the correct order" in {
-    val response = getResponse(
-      conf.LiveContentApi.item("politics/blog/live/2016/feb/03/eu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live", edition)
+    val response = ContentApiClient.getResponse(
+      ContentApiClient.item("politics/blog/live/2016/feb/03/eu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live", edition)
     )
 
     whenReady(response) { item: ItemResponse =>
@@ -33,8 +33,8 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
   }
 
   it should "provide valid block-level campaign-links in the correct order for galleries" in {
-    val response = getResponse(
-      conf.LiveContentApi.item("environment/gallery/2014/oct/22/2014-wildlife-photographer-of-the-year", edition)
+    val response = ContentApiClient.getResponse(
+      ContentApiClient.item("environment/gallery/2014/oct/22/2014-wildlife-photographer-of-the-year", edition)
     )
 
     whenReady(response) { item: ItemResponse =>
@@ -54,8 +54,8 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
   }
 
   it should "provide valid block-level campaign-links in the correct order for liveblogs" in {
-    val response = getResponse(
-      conf.LiveContentApi.item("politics/blog/live/2016/feb/03/eu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live", edition)
+    val response = ContentApiClient.getResponse(
+      ContentApiClient.item("politics/blog/live/2016/feb/03/eu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live", edition)
     )
 
     whenReady(response) { item: ItemResponse =>

--- a/article/app/Global.scala
+++ b/article/app/Global.scala
@@ -19,8 +19,8 @@ object Global
   override lazy val applicationName = "frontend-article"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(
-    ContentApiMetrics.ElasticHttpTimingMetric,
-    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
+    ContentApiMetrics.HttpLatencyTimingMetric,
+    ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.ContentApiErrorMetric
   )
 }

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -3,8 +3,7 @@ package controllers
 import _root_.liveblog.LiveBlogCurrentPage
 import com.gu.contentapi.client.model.v1.{Content => ApiContent, ItemResponse}
 import common._
-import conf.LiveContentApi.getResponse
-import conf._
+import contentapi.ContentApiClient
 import conf.switches.Switches
 import model._
 import model.liveblog.{BodyBlock, KeyEventData}
@@ -155,14 +154,14 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
     val edition = Edition(request)
 
     log.info(s"Fetching article: $path for edition ${edition.id}: ${RequestLog(request)}")
-    val capiItem = LiveContentApi.item(path, edition)
+    val capiItem = ContentApiClient.item(path, edition)
       .showTags("all")
       .showFields("all")
       .showReferences("all")
       .showAtoms("all")
 
     val capiItemWithBlocks = if (blocks) capiItem.showBlocks("body") else capiItem
-    getResponse(capiItemWithBlocks)
+    ContentApiClient.getResponse(capiItemWithBlocks)
 
   }
 

--- a/commercial/app/model/commercial/Lookup.scala
+++ b/commercial/app/model/commercial/Lookup.scala
@@ -3,8 +3,8 @@ package model.commercial
 import com.gu.contentapi.client.model.v1.Tag
 import common.Edition.defaultEdition
 import common.{ExecutionContexts, Logging}
-import conf.LiveContentApi
-import LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import ContentApiClient.getResponse
 import model.{ImageElement, ContentType, Content}
 
 import scala.concurrent.Future
@@ -13,7 +13,7 @@ object Lookup extends ExecutionContexts with Logging {
 
   def content(contentId: String): Future[Option[ContentType]] = {
     val response = try {
-      getResponse(LiveContentApi.item(contentId, defaultEdition))
+      getResponse(ContentApiClient.item(contentId, defaultEdition))
     } catch {
       case e: Exception => Future.failed(e)
     }
@@ -29,14 +29,14 @@ object Lookup extends ExecutionContexts with Logging {
   def contentByShortUrls(shortUrls: Seq[String]): Future[Seq[ContentType]] = {
     if (shortUrls.nonEmpty) {
       val shortIds = shortUrls map (_.stripPrefix("http://").stripPrefix("gu.com").stripPrefix("/")) mkString ","
-      getResponse(LiveContentApi.search(defaultEdition).ids(shortIds)) map {
+      getResponse(ContentApiClient.search(defaultEdition).ids(shortIds)) map {
         _.results map (Content(_))
       }
     } else Future.successful(Nil)
   }
 
   def latestContentByKeyword(keywordId: String, maxItemCount: Int): Future[Seq[ContentType]] = {
-    getResponse(LiveContentApi.search(defaultEdition).tag(keywordId).pageSize(maxItemCount).orderBy("newest")) map {
+    getResponse(ContentApiClient.search(defaultEdition).tag(keywordId).pageSize(maxItemCount).orderBy("newest")) map {
       _.results map (Content(_))
     }
   }
@@ -46,7 +46,7 @@ object Lookup extends ExecutionContexts with Logging {
   }
 
   def keyword(term: String, section: Option[String] = None): Future[Seq[Tag]] = {
-    val baseQuery = LiveContentApi.tags.q(term).tagType("keyword").pageSize(50)
+    val baseQuery = ContentApiClient.tags.q(term).tagType("keyword").pageSize(50)
     val query = section.foldLeft(baseQuery)((acc, sectionName) => acc section sectionName)
 
     val result = getResponse(query).map(_.results) recover {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -89,12 +89,14 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   case class Auth(user: String, password: String)
 
   object contentApi {
-    val contentApiLiveHost: String = configuration.getMandatoryStringProperty("content.api.host")
+    val contentApiHost: String = configuration.getMandatoryStringProperty("content.api.host")
 
     def contentApiDraftHost: String =
         configuration.getStringProperty("content.api.draft.host")
           .filter(_ => Switches.FaciaToolDraftContent.isSwitchedOn)
-          .getOrElse(contentApiLiveHost)
+          .getOrElse(contentApiHost)
+
+    val previewHost: String = configuration.getStringProperty("content.api.preview.host").getOrElse(contentApiHost)
 
     lazy val key: Option[String] = configuration.getStringProperty("content.api.key")
     lazy val timeout: Int = configuration.getIntegerProperty("content.api.timeout.millis").getOrElse(2000)

--- a/common/app/common/dfp/CapiLookupAgent.scala
+++ b/common/app/common/dfp/CapiLookupAgent.scala
@@ -1,8 +1,7 @@
 package common.dfp
 
 import common.{AkkaAgent, ExecutionContexts, Logging}
-import conf.LiveContentApi
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
 
 import scala.concurrent.Future
 
@@ -22,8 +21,8 @@ object CapiLookupAgent extends ExecutionContexts with Logging {
   private def lookup(paidForTags: Seq[PaidForTag]): Future[Map[(TagType, String), Seq[String]]] = {
 
     def lookup(tagType: TagType, tagName: String): Future[((TagType, String), Seq[String])] = {
-      val query = LiveContentApi.tags.q(tagName).tagType(tagType.name).pageSize(50)
-      val lookupResult = getResponse(query) map { response =>
+      val query = ContentApiClient.tags.q(tagName).tagType(tagType.name).pageSize(50)
+      val lookupResult = ContentApiClient.getResponse(query) map { response =>
         response.results
       } recover {
         case e: Exception =>

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -3,10 +3,8 @@ package common.editions
 import java.util.Locale
 
 import common.editions.Uk._
-import conf.switches.Switches
 import org.joda.time.DateTimeZone
 import common._
-import contentapi.QueryDefaults
 import common.NavItem
 
 //This object exists to be used with ItemTrailblockDescription and is not a real edition like the others.
@@ -18,7 +16,7 @@ object Au extends Edition(
   DateTimeZone.forID("Australia/Sydney"),
   locale = Locale.forLanguageTag("en-au"),
   networkFrontId = "au"
-) with QueryDefaults {
+) {
 
   implicit val AU = Au
 

--- a/common/app/common/editions/Us.scala
+++ b/common/app/common/editions/Us.scala
@@ -4,9 +4,7 @@ import java.util.Locale
 
 import common._
 import common.editions.Uk._
-import conf.switches.Switches
 import org.joda.time.DateTimeZone
-import contentapi.QueryDefaults
 import common.NavItem
 
 object Us extends Edition(
@@ -15,7 +13,7 @@ object Us extends Edition(
   timezone = DateTimeZone.forID("America/New_York"),
   locale = Locale.forLanguageTag("en-us"),
   networkFrontId = "us"
-) with QueryDefaults {
+) {
 
   implicit val US = Us
 

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -105,14 +105,14 @@ object SystemMetrics extends implicits.Numbers {
 }
 
 object ContentApiMetrics {
-  val ElasticHttpTimingMetric = TimingMetric(
-    "elastic-content-api-call-latency",
-    "Elastic outgoing requests to content api"
+  val HttpLatencyTimingMetric = TimingMetric(
+    "content-api-call-latency",
+    "Content api call latency"
   )
 
-  val ElasticHttpTimeoutCountMetric = CountMetric(
-    "elastic-content-api-timeouts",
-    "Elastic Content api calls that timeout"
+  val HttpTimeoutCountMetric = CountMetric(
+    "content-api-timeouts",
+    "Content api calls that timeout"
   )
 
   val ContentApiErrorMetric = CountMetric(

--- a/common/app/common/package.scala
+++ b/common/app/common/package.scala
@@ -4,8 +4,8 @@ import java.util.concurrent.TimeoutException
 
 import akka.pattern.CircuitBreakerOpenException
 import com.gu.contentapi.client.GuardianContentApiThriftError
+import com.gu.contentapi.client.model.v1.ErrorResponse
 import conf.switches.Switch
-import contentapi.ErrorResponseHandler.isCommercialExpiry
 import model.{Cached, NoCache}
 import org.apache.commons.lang.exception.ExceptionUtils
 import play.api.Logger
@@ -13,6 +13,10 @@ import play.api.mvc.{RequestHeader, Result}
 import play.twirl.api.Html
 
 object `package` extends implicits.Strings with implicits.Requests with play.api.mvc.Results {
+
+  def isCommercialExpiry(error: ErrorResponse): Boolean = {
+    error.message == "The requested resource has expired for commercial reason."
+  }
 
   def convertApiExceptions[T](implicit request: RequestHeader,
                               log: Logger): PartialFunction[Throwable, Either[T, Result]] = {

--- a/common/app/conf/application.scala
+++ b/common/app/conf/application.scala
@@ -1,5 +1,4 @@
 package conf
 
 object Configuration extends common.GuardianConfiguration("frontend", webappConfDirectory = "env")
-object LiveContentApi extends contentapi.LiveContentApiClient
 object Static extends common.Assets.Assets(Configuration.assets.path)

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -206,4 +206,13 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
+  val ContentApiUseThrift = Switch(
+    "Performance",
+    "content-api-use-thrift",
+    "If this switch is on then content api calls will be requested in thrift format, instead of json format.",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 8, 5),
+    exposeClientSide = false
+  )
+
 }

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -109,6 +109,8 @@ trait ApiQueryDefaults extends Logging {
     .showElements("all")
 }
 
+// This trait extends ContentApiClientLogic with Cloudwatch metrics that monitor
+// the average response time, and the number of timeouts, from Content Api.
 trait MonitoredContentApiClientLogic extends ContentApiClientLogic with ApiQueryDefaults with Logging {
 
   def httpTimingMetric: TimingMetric

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -181,7 +181,7 @@ object ContentApiClient extends ApiQueryDefaults {
     httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
     targetUrl = contentApi.contentApiHost,
     apiKey = contentApi.key.getOrElse(""),
-    useThrift = false)
+    useThrift = true)
 
   private def getClient: CircuitBreakingContentApiClient = {
     if (ContentApiUseThrift.isSwitchedOn) thriftClient else jsonClient

--- a/common/app/contentapi/ContentApiClient.scala
+++ b/common/app/contentapi/ContentApiClient.scala
@@ -2,23 +2,26 @@ package contentapi
 
 import akka.actor.ActorSystem
 import com.gu.contentapi.client.ContentApiClientLogic
-import com.gu.contentapi.client.model.v1.ErrorResponse
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichCapiDateTime
-import conf.switches.Switches
+import conf.Configuration
+import conf.switches.Switches.{CircuitBreakerSwitch, ContentApiUseThrift}
+import metrics.{CountMetric, TimingMetric}
 import scala.concurrent.{ExecutionContext, Future}
 import common._
 import model.{Content, Trail}
 import org.joda.time.DateTime
 import org.scala_tools.time.Implicits._
 import conf.Configuration.contentApi
-import com.gu.contentapi.client.model.{SearchQuery, ItemQuery}
+import com.gu.contentapi.client.model.{SearchQuery, ItemQuery, TagsQuery, SectionsQuery, EditionsQuery}
 import com.gu.contentapi.client.model.v1.ItemResponse
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.{Duration, MILLISECONDS}
-import akka.pattern.{CircuitBreakerOpenException, CircuitBreaker}
+import akka.pattern.CircuitBreaker
 
-trait QueryDefaults extends implicits.Collections {
+import scala.util.Try
+
+object QueryDefaults extends implicits.Collections {
   // NOTE - do NOT add body to this list
   val trailFields = List(
     "byline",
@@ -81,40 +84,60 @@ trait QueryDefaults extends implicits.Collections {
   }
 }
 
+trait ApiQueryDefaults extends Logging {
 
-trait ApiQueryDefaults extends QueryDefaults with implicits.Collections with Logging { self: ContentApiClientLogic =>
+  def item(id:String): ItemQuery
+  def search: SearchQuery
+
   def item(id: String, edition: Edition): ItemQuery = item(id, edition.id)
 
   //common fields that we use across most queries.
   def item(id: String, edition: String): ItemQuery = item(id)
     .edition(edition)
     .showTags("all")
-    .showFields(trailFields)
+    .showFields(QueryDefaults.trailFields)
     .showElements("all")
-    .showReferences(references)
+    .showReferences(QueryDefaults .references)
     .showPackages(true)
     .showRights("syndicatable")
 
   //common fields that we use across most queries.
   def search(edition: Edition): SearchQuery = search
     .showTags("all")
-    .showReferences(references)
-    .showFields(trailFields)
+    .showReferences(QueryDefaults.references)
+    .showFields(QueryDefaults.trailFields)
     .showElements("all")
 }
 
-trait ContentApiClient extends ContentApiClientLogic with ApiQueryDefaults with DelegateHttp with Logging {
-  override val apiKey = contentApi.key.getOrElse("")
+trait MonitoredContentApiClientLogic extends ContentApiClientLogic with ApiQueryDefaults with Logging {
+
+  def httpTimingMetric: TimingMetric
+  def httpTimeoutMetric: CountMetric
+
+  var _http: Http = new WsHttp(httpTimingMetric, httpTimeoutMetric)
+
+  override def get(url: String, headers: Map[String, String])(implicit executionContext: ExecutionContext): Future[HttpResponse] = {
+    val futureContent = _http.GET(url, headers) map { response: Response =>
+      HttpResponse(response.body, response.status, response.statusText)
+    }
+    futureContent.onFailure{ case t =>
+      val tryDecodedUrl: String = Try(java.net.URLDecoder.decode(url, "UTF-8")).getOrElse(url)
+      log.error(s"$t: $tryDecodedUrl")}
+    futureContent
+  }
 }
 
-trait CircuitBreakingContentApiClient extends ContentApiClient {
-  private final val circuitBreakerActorSystem = ActorSystem("content-api-client-circuit-breaker")
+final case class CircuitBreakingContentApiClient(
+  override val httpTimingMetric: TimingMetric,
+  override val httpTimeoutMetric: CountMetric,
+  override val targetUrl: String,
+  override val apiKey: String,
+  override val useThrift: Boolean) extends MonitoredContentApiClientLogic {
 
-  /** Read this:
-    *
-    * http://doc.akka.io/docs/akka/snapshot/common/circuitbreaker.html
-    */
-  private final val circuitBreaker = new CircuitBreaker(
+  private val circuitBreakerActorSystem = ActorSystem("content-api-client-circuit-breaker")
+
+  // http://doc.akka.io/docs/akka/snapshot/common/circuitbreaker.html
+  private val circuitBreaker = new CircuitBreaker(
     scheduler = circuitBreakerActorSystem.scheduler,
     maxFailures = contentApi.circuitBreakerErrorThreshold,
     callTimeout = Duration(contentApi.timeout, MILLISECONDS),
@@ -134,7 +157,7 @@ trait CircuitBreakingContentApiClient extends ContentApiClient {
   })
 
   override def fetch(url: String)(implicit executionContext: ExecutionContext) = {
-    if (Switches.CircuitBreakerSwitch.isSwitchedOn) {
+    if (CircuitBreakerSwitch.isSwitchedOn) {
       circuitBreaker.withCircuitBreaker(super.fetch(url)(executionContext))
     } else {
       super.fetch(url)
@@ -142,18 +165,69 @@ trait CircuitBreakingContentApiClient extends ContentApiClient {
   }
 }
 
-class LiveContentApiClient extends CircuitBreakingContentApiClient {
-  lazy val httpTimingMetric = ContentApiMetrics.ElasticHttpTimingMetric
-  lazy val httpTimeoutMetric = ContentApiMetrics.ElasticHttpTimeoutCountMetric
-  override val targetUrl = contentApi.contentApiLiveHost
-  override val useThrift = false
+object ContentApiClient extends ApiQueryDefaults {
+
+  // Public val for test.
+  val jsonClient = CircuitBreakingContentApiClient(
+    httpTimingMetric = ContentApiMetrics.HttpLatencyTimingMetric,
+    httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
+    targetUrl = contentApi.contentApiHost,
+    apiKey = contentApi.key.getOrElse(""),
+    useThrift = false)
+
+  // Public val for test.
+  val thriftClient = CircuitBreakingContentApiClient(
+    httpTimingMetric = ContentApiMetrics.HttpLatencyTimingMetric,
+    httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
+    targetUrl = contentApi.contentApiHost,
+    apiKey = contentApi.key.getOrElse(""),
+    useThrift = false)
+
+  private def getClient: CircuitBreakingContentApiClient = {
+    if (ContentApiUseThrift.isSwitchedOn) thriftClient else jsonClient
+  }
+
+  def item(id: String) = getClient.item(id)
+  def tags = getClient.tags
+  def search = getClient.search
+  def sections = getClient.sections
+  def editions = getClient.editions
+
+  def getResponse(itemQuery: ItemQuery)(implicit context: ExecutionContext) = getClient.getResponse(itemQuery)
+
+  def getResponse(searchQuery: SearchQuery)(implicit context: ExecutionContext) = getClient.getResponse(searchQuery)
+
+  def getResponse(tagsQuery: TagsQuery)(implicit context: ExecutionContext) = getClient.getResponse(tagsQuery)
+
+  def getResponse(sectionsQuery: SectionsQuery)(implicit context: ExecutionContext) = getClient.getResponse(sectionsQuery)
+
+  def getResponse(editionsQuery: EditionsQuery)(implicit context: ExecutionContext) = getClient.getResponse(editionsQuery)
+
+  // Used for testing, and training preview.
+  def setHttp(http: Http): Unit ={
+    thriftClient._http = http
+    jsonClient._http = http
+  }
 }
 
-object ErrorResponseHandler {
+object DraftContentApi {
+  val client = CircuitBreakingContentApiClient(
+    httpTimingMetric = ContentApiMetrics.HttpLatencyTimingMetric,
+    httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
+    targetUrl = Configuration.contentApi.contentApiDraftHost,
+    apiKey = contentApi.key.getOrElse(""),
+    useThrift = false
+  )
+}
 
-  private val commercialExpiryMessage = "The requested resource has expired for commercial reason."
-
-  def isCommercialExpiry(error: ErrorResponse): Boolean = {
-    error.message == commercialExpiryMessage
-  }
+// The Admin server uses this PreviewContentApi to check the preview environment.
+// The Preview server uses the standard ContentApiClient object, configured with preview settings.
+object PreviewContentApi {
+  val client = CircuitBreakingContentApiClient(
+    httpTimingMetric = ContentApiMetrics.HttpLatencyTimingMetric,
+    httpTimeoutMetric = ContentApiMetrics.HttpTimeoutCountMetric,
+    targetUrl = Configuration.contentApi.previewHost,
+    apiKey = contentApi.key.getOrElse(""),
+    useThrift = false
+  )
 }

--- a/common/app/contentapi/SectionsLookUp.scala
+++ b/common/app/contentapi/SectionsLookUp.scala
@@ -2,8 +2,6 @@ package contentapi
 
 import com.gu.contentapi.client.model.v1.Section
 import common.{AkkaAgent, ExecutionContexts, Logging}
-import conf.LiveContentApi
-import LiveContentApi.getResponse
 
 import scala.util.{Failure, Success}
 
@@ -11,7 +9,7 @@ object SectionsLookUp extends Logging with ExecutionContexts {
   private val sections = AkkaAgent[Option[Map[String, Section]]](None)
 
   def refresh() = {
-    getResponse(LiveContentApi.sections) onComplete {
+    ContentApiClient.getResponse(ContentApiClient.sections) onComplete {
       case Success(response) =>
         log.info("Refreshed sections from Content API")
         sections send Some(response.results.flatMap({ section =>

--- a/common/app/contentapi/http.scala
+++ b/common/app/contentapi/http.scala
@@ -68,19 +68,6 @@ class WsHttp(val httpTimingMetric: TimingMetric, val httpTimeoutMetric: CountMet
   }
 }
 
-// allows us to inject a test Http
-trait DelegateHttp { self: ContentApiClientLogic =>
-  val httpTimingMetric: TimingMetric
-  val httpTimeoutMetric: CountMetric
-
-  var _http: Http = new WsHttp(httpTimingMetric, httpTimeoutMetric)
-
-  override def get(url: String, headers: Map[String, String])(implicit executionContext: ExecutionContext) =
-    _http.GET(url, headers) map { response: Response =>
-      self.HttpResponse(response.body, response.status, response.statusText)
-  }
-}
-
 private object RequestDebugInfo {
   import java.net.URLEncoder.encode
 

--- a/common/app/controllers/RendersItemResponse.scala
+++ b/common/app/controllers/RendersItemResponse.scala
@@ -3,7 +3,7 @@ package controllers
 
 import com.gu.contentapi.client.model.v1.ItemResponse
 import common.{Edition, ExecutionContexts}
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import model.NoCache
 import play.api.mvc.{Action, Controller, RequestHeader, Result}
 
@@ -23,10 +23,10 @@ trait RendersItemResponse {
 class ItemResponseController(val controllers: RendersItemResponse*) extends Controller with ExecutionContexts {
 
   def render(path: String) = Action.async{ implicit request =>
-    val itemRequest = LiveContentApi.item(path, Edition(request))
+    val itemRequest = ContentApiClient.item(path, Edition(request))
 
     controllers.find(_.canRender(path)).map(_.renderItem(path)).getOrElse {
-      LiveContentApi.getResponse(itemRequest).flatMap { response =>
+      ContentApiClient.getResponse(itemRequest).flatMap { response =>
         controllers.find(_.canRender(response))
           .map(_.renderItem(path))
           .getOrElse(successful(NoCache(NotFound)))

--- a/common/app/crosswords/TodaysCrosswordGrid.scala
+++ b/common/app/crosswords/TodaysCrosswordGrid.scala
@@ -2,7 +2,7 @@ package crosswords
 
 import com.gu.contentapi.client.model.v1.ItemResponse
 import common.{ExecutionContexts, Edition, AutoRefresh}
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import org.joda.time.{DateTimeZone, DateTime}
 
 import scala.concurrent.Future
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 object TodaysCrosswordGrid extends AutoRefresh[CrosswordGrid](0.seconds, 1.minute) with ExecutionContexts {
   override protected def refresh(): Future[CrosswordGrid] = {
 
-    val response: Future[ItemResponse] = LiveContentApi.getResponse(LiveContentApi.item("type/crossword", Edition.defaultEdition)
+    val response: Future[ItemResponse] = ContentApiClient.getResponse(ContentApiClient.item("type/crossword", Edition.defaultEdition)
       .pageSize(1)
       .fromDate(DateTime.now(DateTimeZone.UTC)))
 

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -3,9 +3,8 @@ package services
 import com.gu.contentapi.client.GuardianContentApiThriftError
 import com.gu.contentapi.client.model.v1.{Section => ApiSection, ItemResponse, SearchResponse}
 import common._
-import conf.LiveContentApi
-import conf.LiveContentApi.getResponse
-import contentapi.{QueryDefaults, SectionTagLookUp, SectionsLookUp}
+import contentapi.{ContentApiClient, QueryDefaults, SectionTagLookUp, SectionsLookUp}
+import implicits.Collections
 import model._
 import org.joda.time.DateTime
 import org.scala_tools.time.Implicits._
@@ -13,9 +12,9 @@ import play.api.mvc.{RequestHeader, Result => PlayResult}
 
 import scala.concurrent.Future
 
-trait Index extends ConciergeRepository with QueryDefaults {
+trait Index extends ConciergeRepository with Collections {
 
-  private val rssFields = s"$trailFields,byline,body,standfirst"
+  private val rssFields = s"${QueryDefaults.trailFields},byline,body,standfirst"
 
   def normaliseTag(tag: String): String = {
     val conversions: Map[String, String] =
@@ -60,11 +59,11 @@ trait Index extends ConciergeRepository with QueryDefaults {
       }
     )
 
-    val promiseOfResponse = getResponse(LiveContentApi.search(edition)
+    val promiseOfResponse = ContentApiClient.getResponse(ContentApiClient.search(edition)
       .tag(s"$firstTag,$secondTag")
       .page(page)
       .pageSize(if (isRss) IndexPagePagination.rssPageSize else IndexPagePagination.pageSize)
-      .showFields(if (isRss) rssFields else trailFields)
+      .showFields(if (isRss) rssFields else QueryDefaults.trailFields)
     ).map {response =>
       val trails = response.results.map(IndexPageItem(_))
       trails match {
@@ -108,7 +107,7 @@ trait Index extends ConciergeRepository with QueryDefaults {
 
   def index(edition: Edition, path: String, pageNum: Int, isRss: Boolean)(implicit request: RequestHeader): Future[Either[IndexPage, PlayResult]] = {
     val pageSize = if (isRss) IndexPagePagination.rssPageSize else IndexPagePagination.pageSize
-    val fields = if (isRss) rssFields else trailFields
+    val fields = if (isRss) rssFields else QueryDefaults.trailFields
 
     val maybeSection = SectionsLookUp.get(path)
 
@@ -122,7 +121,7 @@ trait Index extends ConciergeRepository with QueryDefaults {
       */
     val queryPath = maybeSection.fold(path)(s => SectionTagLookUp.tagId(s.id))
 
-    val promiseOfResponse = getResponse(LiveContentApi.item(queryPath, edition).page(pageNum)
+    val promiseOfResponse = ContentApiClient.getResponse(ContentApiClient.item(queryPath, edition).page(pageNum)
       .pageSize(pageSize)
       .showFields(fields)
     ) map { response =>
@@ -152,7 +151,7 @@ trait Index extends ConciergeRepository with QueryDefaults {
 
   private def tag(response: ItemResponse, page: Int) = {
     val tag = response.tag map { Tag.make(_, pagination(response)) }
-    val leadContentCutOff = DateTime.now - leadContentMaxAge
+    val leadContentCutOff = DateTime.now - QueryDefaults.leadContentMaxAge
     val editorsPicks = response.editorsPicks.getOrElse(Nil).map(IndexPageItem(_))
     val leadContent = if (editorsPicks.isEmpty && page == 1) //only promote lead content on first page
       response.leadContent.getOrElse(Nil).take(1).map(IndexPageItem(_)).filter(_.item.trail.webPublicationDate > leadContentCutOff)

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -4,8 +4,8 @@ import java.io.File
 
 import com.gargoylesoftware.htmlunit.BrowserVersion
 import common.ExecutionContexts
-import conf.{Configuration, LiveContentApi}
-import contentapi.Http
+import conf.Configuration
+import contentapi.{ContentApiClient, Http}
 import org.apache.commons.codec.digest.DigestUtils
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatestplus.play._
@@ -37,7 +37,7 @@ trait TestSettings {
     val originalHttp = http
 
     verify(
-      Configuration.contentApi.contentApiLiveHost,
+      Configuration.contentApi.contentApiHost,
       "5f755b14e59810c1c7ed8a79dfe9bc132340d22ee255f3b41bd4f3e2af5e5393",
       "YOU ARE NOT USING THE CORRECT ELASTIC SEARCH LIVE CONTENT API HOST"
     )
@@ -57,7 +57,8 @@ trait TestSettings {
     }
   }
 
-  LiveContentApi._http = toRecorderHttp(LiveContentApi._http)
+  ContentApiClient.thriftClient._http = toRecorderHttp(ContentApiClient.thriftClient._http)
+  ContentApiClient.jsonClient._http = toRecorderHttp(ContentApiClient.jsonClient._http)
 }
 
 trait ConfiguredTestSuite extends ConfiguredServer with ConfiguredBrowser with ExecutionContexts {

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -196,7 +196,6 @@ GET            /sport/rugby/api/score/:year/:month/:day/:team1Id/:team2Id.json  
 GET            /sport/rugby/api/score/:year/:month/:day/:team1Id/:team2Id                                                        rugby.controllers.MatchesController.score(year, month, day, team1Id, team2Id)
 
 # Admin
-# authentication endpoints
 GET            /login                                                                                                            controllers.admin.OAuthLoginController.login
 POST           /login                                                                                                            controllers.admin.OAuthLoginController.loginAction
 GET            /oauth2callback                                                                                                   controllers.admin.OAuthLoginController.oauth2Callback
@@ -235,6 +234,10 @@ GET            /troubleshoot/pages                                              
 GET            /troubleshoot/test                                                                                                controllers.admin.TroubleshooterController.test(id, testPath)
 GET            /redirects                                                                                                        controllers.admin.RedirectController.redirect()
 POST           /redirect-post                                                                                                    controllers.admin.RedirectController.redirectPost()
+GET            /press/r2                                                                                                         controllers.admin.R2PressController.pressForm()
+POST           /press/r2                                                                                                         controllers.admin.R2PressController.press()
+GET            /press/r2/batchupload                                                                                             controllers.admin.R2PressController.pressForm()
+POST           /press/r2/batchupload                                                                                             controllers.admin.R2PressController.batchUpload()
 
 # css reports
 GET            /css-reports                                                                                                      controllers.admin.CssReportController.entry

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -13,8 +13,8 @@ object Global extends GlobalSettings
 
   override def applicationMetrics = List(
     FaciaPressMetrics.FrontPressCronSuccess,
-    ContentApiMetrics.ElasticHttpTimingMetric,
-    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
+    ContentApiMetrics.HttpLatencyTimingMetric,
+    ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.ContentApi404Metric,
     ContentApiMetrics.ContentApiErrorMetric,
     FaciaPressMetrics.UkPressLatencyMetric,

--- a/facia-press/app/frontpress/DraftContentApi.scala
+++ b/facia-press/app/frontpress/DraftContentApi.scala
@@ -1,8 +1,0 @@
-package frontpress
-
-import conf.Configuration
-import contentapi.LiveContentApiClient
-
-object DraftContentApi extends LiveContentApiClient {
-  override val targetUrl = Configuration.contentApi.contentApiDraftHost
-}

--- a/identity/app/model/SaveForLaterPageData.scala
+++ b/identity/app/model/SaveForLaterPageData.scala
@@ -3,8 +3,8 @@ package model
 import com.google.inject.{Inject, Singleton}
 import com.gu.identity.model.{SavedArticle, SavedArticles}
 import common.{ExecutionContexts, Edition, Pagination}
-import conf.LiveContentApi
-import conf.LiveContentApi._
+import contentapi.ContentApiClient
+import contentapi.ContentApiClient._
 import layout.{ItemClasses, FaciaCard, ContentCard}
 import services.{FaciaContentConvert, IdRequestParser, IdentityRequest, IdentityUrlBuilder}
 import implicits.Articles._
@@ -44,7 +44,7 @@ class SaveForLaterDataBuilder @Inject()(idUrlBuilder: IdentityUrlBuilder) extend
     val articles = savedArticles.getPage(pageNum)
     val shortUrls = articles.map(_.shortUrl)
 
-    getResponse(LiveContentApi.search(Edition.defaultEdition)
+    getResponse(ContentApiClient.search(Edition.defaultEdition)
       .ids(shortUrls.map(_.drop(1)).mkString(","))
       .showFields("all")
       .showElements ("all")

--- a/onward/app/Global.scala
+++ b/onward/app/Global.scala
@@ -18,7 +18,7 @@ object Global extends WithFilters(Filters.common: _*)
   override lazy val applicationName = "frontend-onward"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ Seq(
-    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
+    ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.ContentApiErrorMetric
   )
 }

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -3,8 +3,8 @@ package controllers
 import com.gu.contentapi.client.GuardianContentApiThriftError
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import common._
-import conf.LiveContentApi
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import contentapi.ContentApiClient.getResponse
 import implicits.Requests
 import layout.{CollectionEssentials, FaciaContainer}
 import model._
@@ -38,7 +38,7 @@ object MediaInSectionController extends Controller with Logging with Paging with
     def isCurrentStory(content: ApiContent) =
       content.fields.flatMap(_.shortUrl).exists(!_.equals(currentShortUrl))
 
-    val promiseOrResponse = getResponse(LiveContentApi.search(edition)
+    val promiseOrResponse = getResponse(ContentApiClient.search(edition)
       .section(sectionId)
       .tag(tags)
       .showTags("all")

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -8,7 +8,7 @@ import play.api.mvc.{ RequestHeader, Controller, Action }
 import views.support.FaciaToMicroFormat2Helpers._
 import scala.concurrent.Future
 import play.api.libs.json._
-import LiveContentApi.getResponse
+import contentapi.ContentApiClient
 
 object MostPopularController extends Controller with Logging with ExecutionContexts {
   val page = SimplePage(MetaData.make(
@@ -101,7 +101,7 @@ object MostPopularController extends Controller with Logging with ExecutionConte
 
   private def lookup(edition: Edition, path: String)(implicit request: RequestHeader) = {
     log.info(s"Fetching most popular: $path for edition $edition")
-    getResponse(LiveContentApi.item(path, edition)
+    ContentApiClient.getResponse(ContentApiClient.item(path, edition)
       .tag(None)
       .showMostViewed(true)
     ).map{response =>

--- a/onward/app/controllers/MostViewedSocialController.scala
+++ b/onward/app/controllers/MostViewedSocialController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import common.`package`._
 import common.{Edition, ExecutionContexts, JsonNotFound}
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import feed.MostPopularSocialAutoRefresh
 import layout.{CollectionEssentials, FaciaContainer}
 import model.FrontProperties
@@ -25,8 +25,8 @@ object MostViewedSocialController extends Controller with ExecutionContexts {
 
     articles match {
       case Some(articleIds) if articleIds.nonEmpty =>
-        LiveContentApi.getResponse(
-          LiveContentApi
+        ContentApiClient.getResponse(
+          ContentApiClient
             .search(Edition(request))
             .ids(articleIds.take(7).map(item => feed.urlToContentPath(item.url)).mkString(","))
         ) map { response =>

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -5,10 +5,10 @@ import common.{JsonComponent, Edition, ExecutionContexts, Logging}
 import implicits.Requests
 import model.{NoCache, Cached, Content, ContentType}
 import scala.concurrent.Future
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import com.gu.contentapi.client.model.v1.ItemResponse
 import play.twirl.api.HtmlFormat
-import LiveContentApi.getResponse
+import ContentApiClient.getResponse
 
 object RichLinkController extends Controller with Paging with Logging with ExecutionContexts with Requests   {
 
@@ -25,7 +25,7 @@ object RichLinkController extends Controller with Paging with Logging with Execu
     log.info(s"Fetching article: $path for edition: ${edition.id}:")
 
     val response: Future[ItemResponse] = getResponse(
-      LiveContentApi.item(path, edition)
+      ContentApiClient.item(path, edition)
         .showFields("headline,standfirst,shortUrl,webUrl,byline,starRating,trailText,liveBloggingNow")
         .showTags("all")
         .showElements("all")

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -4,8 +4,8 @@ import com.gu.contentapi.client.GuardianContentApiThriftError
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import com.gu.facia.client.models.Backfill
 import common._
-import conf.LiveContentApi
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import contentapi.ContentApiClient.getResponse
 import implicits.Requests
 import layout.{CollectionEssentials, DescriptionMetaHeader, FaciaContainer}
 import model._
@@ -48,7 +48,7 @@ object SeriesController extends Controller with Logging with Paging with Executi
     def isCurrentStory(content: ApiContent) =
       content.fields.flatMap(_.shortUrl).exists(_.equals(currentShortUrl))
 
-    val seriesResponse: Future[Option[Series]] = getResponse(LiveContentApi.item(seriesId, edition)
+    val seriesResponse: Future[Option[Series]] = getResponse(ContentApiClient.item(seriesId, edition)
       .showFields("all")
     ).map { response =>
         response.tag.flatMap { tag =>

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -2,8 +2,8 @@ package controllers
 
 import com.gu.contentapi.client.GuardianContentApiThriftError
 import common._
-import conf.LiveContentApi
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import contentapi.ContentApiClient.getResponse
 import model._
 import play.api.libs.json.{JsArray, Json}
 import play.api.mvc.{Action, Controller, RequestHeader}
@@ -45,7 +45,7 @@ object TaggedContentController extends Controller with Related with Logging with
 
   private def lookup(tag: String, edition: Edition)(implicit request: RequestHeader): Future[Seq[ContentType]] = {
     log.info(s"Fetching tagged stories for edition ${edition.id}")
-    getResponse(LiveContentApi.search(edition)
+    getResponse(ContentApiClient.search(edition)
       .tag(tag)
       .pageSize(3)
     ).map { response =>

--- a/onward/app/controllers/TopStoriesController.scala
+++ b/onward/app/controllers/TopStoriesController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import com.gu.contentapi.client.GuardianContentApiThriftError
 import common._
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
 import conf._
 import model._
 import model.pressed.PressedContent
@@ -31,7 +31,7 @@ object TopStoriesController extends Controller with Logging with Paging with Exe
 
   private def lookup(edition: Edition)(implicit request: RequestHeader): Future[Option[RelatedContent]] = {
     log.info(s"Fetching top stories for edition ${edition.id}")
-    getResponse(LiveContentApi.item("/", edition)
+    ContentApiClient.getResponse(ContentApiClient.item("/", edition)
       .showEditorsPicks(true)
     ).map { response =>
         response.editorsPicks.getOrElse(Nil) map { item =>

--- a/onward/app/controllers/VideoEndSlateController.scala
+++ b/onward/app/controllers/VideoEndSlateController.scala
@@ -3,8 +3,8 @@ package controllers
 import com.gu.contentapi.client.GuardianContentApiThriftError
 import com.gu.contentapi.client.model.v1.{Content => ApiContent}
 import common._
-import conf.LiveContentApi
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import contentapi.ContentApiClient.getResponse
 import implicits.Requests
 import model._
 import play.api.mvc.{Action, Controller, RequestHeader}
@@ -26,7 +26,7 @@ object VideoEndSlateController extends Controller with Logging with Paging with 
 
     def isCurrentStory(content: ApiContent) = content.fields.flatMap(_.shortUrl).exists(_ == currentShortUrl)
 
-    val promiseOrResponse = getResponse(LiveContentApi.search(edition)
+    val promiseOrResponse = getResponse(ContentApiClient.search(edition)
       .section(sectionId)
       .tag("type/video")
       .showTags("all")
@@ -68,7 +68,7 @@ object VideoEndSlateController extends Controller with Logging with Paging with 
 
     def isCurrentStory(content: ApiContent) = content.fields.flatMap(_.shortUrl).exists(_ == currentShortUrl)
 
-    val promiseOrResponse = getResponse(LiveContentApi.item(seriesId, edition)
+    val promiseOrResponse = getResponse(ContentApiClient.item(seriesId, edition)
       .tag("type/video")
       .showTags("all")
       .showFields("all")

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -1,13 +1,13 @@
 package feed
 
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import common._
 import services.OphanApi
 import play.api.libs.json.{JsArray, JsValue}
 import model.RelatedContentItem
 import scala.concurrent.duration._
 import scala.concurrent.Future
-import LiveContentApi.getResponse
+import ContentApiClient.getResponse
 
 object MostPopularAgent extends Logging with ExecutionContexts {
 
@@ -20,7 +20,7 @@ object MostPopularAgent extends Logging with ExecutionContexts {
     Edition.all foreach refresh
   }
 
-  def refresh(edition: Edition) = getResponse(LiveContentApi.item("/", edition)
+  def refresh(edition: Edition) = getResponse(ContentApiClient.item("/", edition)
       .showMostViewed(true)
     ).map { response =>
       val mostViewed = response.mostViewed.getOrElse(Nil) map { RelatedContentItem(_) } take 10
@@ -56,7 +56,7 @@ object GeoMostPopularAgent extends Logging with ExecutionContexts {
         item: JsValue <- ophanResults.asOpt[JsArray].map(_.value).getOrElse(Nil)
         url <- (item \ "url").asOpt[String]
       } yield {
-        getResponse(LiveContentApi.item(urlToContentPath(url), Edition.defaultEdition))
+        getResponse(ContentApiClient.item(urlToContentPath(url), Edition.defaultEdition))
           .map(_.content.map(RelatedContentItem(_)))
           .fallbackTo{
             log.error(s"Error requesting $url")
@@ -106,7 +106,7 @@ object DayMostPopularAgent extends Logging with ExecutionContexts {
         item: JsValue <- ophanResults.asOpt[JsArray].map(_.value).getOrElse(Nil)
         url <- (item \ "url").asOpt[String]
       } yield {
-        getResponse(LiveContentApi.item(urlToContentPath(url), Edition.defaultEdition ))
+        getResponse(ContentApiClient.item(urlToContentPath(url), Edition.defaultEdition ))
           .map(_.content.map(RelatedContentItem(_)))
           .fallbackTo{
             log.error(s"Error requesting $url")
@@ -140,7 +140,7 @@ object MostPopularExpandableAgent extends Logging with ExecutionContexts {
   def refresh() {
     log.info("Refreshing most popular.")
     Edition.all foreach { edition =>
-      getResponse(LiveContentApi.item("/", edition)
+      getResponse(ContentApiClient.item("/", edition)
         .showMostViewed(true)
         .showFields("headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl,body")
       ).foreach { response =>

--- a/onward/app/feed/MostViewedAudioAgent.scala
+++ b/onward/app/feed/MostViewedAudioAgent.scala
@@ -1,11 +1,11 @@
 package feed
 
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import common._
 import model.RelatedContentItem
 import play.api.libs.json.{JsArray, JsValue}
 import scala.concurrent.Future
-import LiveContentApi.getResponse
+import ContentApiClient.getResponse
 
 object MostViewedAudioAgent extends Logging with ExecutionContexts {
 
@@ -27,7 +27,7 @@ object MostViewedAudioAgent extends Logging with ExecutionContexts {
         url <- (item \ "url").asOpt[String]
         count <- (item \ "count").asOpt[Int]
       } yield {
-        getResponse(LiveContentApi.item(urlToContentPath(url), Edition.defaultEdition)).map(_.content.map { item =>
+        getResponse(ContentApiClient.item(urlToContentPath(url), Edition.defaultEdition)).map(_.content.map { item =>
           RelatedContentItem(item)
         })
       }

--- a/onward/app/feed/MostViewedGalleryAgent.scala
+++ b/onward/app/feed/MostViewedGalleryAgent.scala
@@ -1,11 +1,11 @@
 package feed
 
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import common._
 import model.RelatedContentItem
 import play.api.libs.json.{JsArray, JsValue}
 import scala.concurrent.Future
-import LiveContentApi.getResponse
+import ContentApiClient.getResponse
 
 object MostViewedGalleryAgent extends Logging with ExecutionContexts {
 
@@ -25,7 +25,7 @@ object MostViewedGalleryAgent extends Logging with ExecutionContexts {
         url <- (item \ "url").asOpt[String]
         count <- (item \ "count").asOpt[Int]
       } yield {
-        getResponse(LiveContentApi.item(urlToContentPath(url), Edition.defaultEdition)).map(_.content.map { item =>
+        getResponse(ContentApiClient.item(urlToContentPath(url), Edition.defaultEdition)).map(_.content.map { item =>
           RelatedContentItem(item)
         })
       }

--- a/onward/app/feed/MostViewedVideoAgent.scala
+++ b/onward/app/feed/MostViewedVideoAgent.scala
@@ -3,8 +3,8 @@ package feed
 import com.gu.contentapi.client
 import common._
 import common.editions.Uk
-import conf.LiveContentApi
-import conf.LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import contentapi.ContentApiClient.getResponse
 import model.{Video, _}
 import play.api.libs.json._
 
@@ -40,7 +40,7 @@ object MostViewedVideoAgent extends Logging with ExecutionContexts {
         .map(id => id.drop(1)) // drop leading '/'
         .mkString(",")
 
-      val mostViewed: Future[Seq[Video]] = getResponse(LiveContentApi.search(Uk)
+      val mostViewed: Future[Seq[Video]] = getResponse(ContentApiClient.search(Uk)
         .ids(contentIds)
         .pageSize(20)
       ).map{ r =>

--- a/onward/app/services/repositories.scala
+++ b/onward/app/services/repositories.scala
@@ -7,10 +7,10 @@ import model.{RelatedContentItem, RelatedContent}
 import org.json4s.native.JsonMethods
 import play.api.libs.ws.WS
 import scala.concurrent.Future
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import feed.MostReadAgent
 import conf.switches.Switches.RelatedContentSwitch
-import LiveContentApi.getResponse
+import ContentApiClient.getResponse
 
 trait Related extends ConciergeRepository {
   def related(edition: Edition, path: String, excludeTags: Seq[String] = Nil): Future[RelatedContent] = {
@@ -25,7 +25,7 @@ trait Related extends ConciergeRepository {
         case excluding => Some(excluding.map(t => s"-$t").mkString(","))
       }
 
-      val response = getResponse(LiveContentApi.item(path, edition)
+      val response = getResponse(ContentApiClient.item(path, edition)
         .tag(tags)
         .showRelated(true)
       )
@@ -69,7 +69,7 @@ trait Related extends ConciergeRepository {
     val tags = (tag +: excludeTags.map(t => s"-$t")).mkString(",")
 
     val response = getResponse(
-      LiveContentApi.search(edition)
+      ContentApiClient.search(edition)
         .tag(tags)
         .pageSize(50)
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.10.58"
-  val faciaVersion = "1.5.0"
+  val faciaVersion = "1.5.1"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.3.5"

--- a/rss/app/Global.scala
+++ b/rss/app/Global.scala
@@ -17,8 +17,8 @@ object Global extends WithFilters(Filters.common: _*)
   override lazy val applicationName = "frontend-rss"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ List(
-    ContentApiMetrics.ElasticHttpTimeoutCountMetric,
-    ContentApiMetrics.ElasticHttpTimingMetric,
+    ContentApiMetrics.HttpTimeoutCountMetric,
+    ContentApiMetrics.HttpLatencyTimingMetric,
     ContentApiMetrics.ContentApiErrorMetric
   )
 }

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -1,7 +1,7 @@
 package football.controllers
 
 import common._
-import conf.{LiveContentApi, Configuration}
+import conf.Configuration
 import feed.Competitions
 import football.model.FootballMatchTrail
 import implicits.{Football, Requests}
@@ -13,7 +13,7 @@ import pa.FootballMatch
 import play.api.libs.json._
 import play.api.mvc.{Action, Controller, RequestHeader, Result}
 import play.twirl.api.Html
-import LiveContentApi.getResponse
+import contentapi.ContentApiClient
 import scala.concurrent.Future
 
 case class Report(trail: FootballMatchTrail, name: String)
@@ -93,7 +93,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
   def loadMoreOn(request: RequestHeader, theMatch: FootballMatch): Future[Seq[ContentType]] = {
     val matchDate = theMatch.date.toLocalDate
 
-    getResponse(LiveContentApi.search(Edition(request))
+    ContentApiClient.getResponse(ContentApiClient.search(Edition(request))
       .section("football")
       .tag("tone/minutebyminute|tone/matchreports|football/series/squad-sheets|football/series/match-previews|football/series/saturday-clockwatch")
       .fromDate(matchDate.minusDays(2).toDateTimeAtStartOfDay)

--- a/sport/app/football/model/LiveBlogAgent.scala
+++ b/sport/app/football/model/LiveBlogAgent.scala
@@ -1,8 +1,8 @@
 package model
 
 import common._
-import conf.LiveContentApi
-import LiveContentApi.getResponse
+import contentapi.ContentApiClient
+import ContentApiClient.getResponse
 
 trait LiveBlogAgent extends ExecutionContexts with Logging {
   import Edition.{all => editions}
@@ -21,7 +21,7 @@ trait LiveBlogAgent extends ExecutionContexts with Logging {
     log.info(s"Fetching football blogs with tag: $tag")
 
     getResponse(
-      LiveContentApi.item("/football", edition)
+      ContentApiClient.item("/football", edition)
         .tag(tag)
         .showEditorsPicks(true)
     ).map {response =>

--- a/sport/app/football/model/TeamMap.scala
+++ b/sport/app/football/model/TeamMap.scala
@@ -1,10 +1,10 @@
 package model
 
 import common._
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import feed.Competitions
 import pa._
-import LiveContentApi.getResponse
+import ContentApiClient.getResponse
 
 case class Team(team: FootballTeam, tag: Option[Tag], shortName: Option[String]) extends FootballTeam {
   lazy val url = tag.map(_.metadata.url)
@@ -108,7 +108,7 @@ object TeamMap extends ExecutionContexts with Logging {
 
   def refresh(page: Int = 1) { //pages are 1 based
     log.info(s"Refreshing team tag mappings - page $page")
-    getResponse(LiveContentApi.tags
+    getResponse(ContentApiClient.tags
       .page(page)
       .pageSize(50)
       .referenceType("pa-football-team")

--- a/sport/app/rugby/feed/CapiFeed.scala
+++ b/sport/app/rugby/feed/CapiFeed.scala
@@ -1,7 +1,7 @@
 package rugby.feed
 
 import common.{Edition, Logging, ExecutionContexts}
-import conf.LiveContentApi
+import contentapi.ContentApiClient
 import model.{Content, ContentType}
 import org.joda.time.DateTimeZone
 import rugby.jobs.RugbyStatsJob
@@ -35,7 +35,7 @@ object CapiFeed extends ExecutionContexts with Logging {
 
     log.info(s"Looking for ${rugbyMatch.toString}")
 
-    LiveContentApi.getResponse(LiveContentApi.search(Edition.defaultEdition)
+    ContentApiClient.getResponse(ContentApiClient.search(Edition.defaultEdition)
       .section("sport")
       .tag(searchTags)
       .fromDate(matchDate.toDateTimeAtStartOfDay)

--- a/training-preview/app/controllers/TrainingHealthCheck.scala
+++ b/training-preview/app/controllers/TrainingHealthCheck.scala
@@ -1,12 +1,11 @@
 package controllers
 
 import common.ExecutionContexts
-import conf.{LiveContentApi, AllGoodHealthcheckController}
+import conf.AllGoodHealthcheckController
 import dispatch.{FunctionHandler, Http}
 import scala.concurrent.Future
-import contentapi.Response
+import contentapi.{ContentApiClient, Response}
 import conf.Configuration.contentApi.previewAuth
-import play.api.mvc.Action
 
 class TrainingHttp extends contentapi.Http with ExecutionContexts {
 
@@ -44,14 +43,13 @@ object TrainingHealthCheck extends AllGoodHealthcheckController(
  "/world/2012/sep/11/barcelona-march-catalan-independence"
 ) {
 
-  lazy val init = {
-    LiveContentApi._http = new TrainingHttp
-    ()=>()
+  def init: Unit = {
+    ContentApiClient.setHttp(new TrainingHttp)
   }
 
   override def healthcheck() = {
     if (!isOk) {
-      init()
+      init
     }
     super.healthcheck()
   }


### PR DESCRIPTION
Adding a switch which, when enabled, makes requests to CAPI in thrift format. Dev tests show a small bandwidth saving, but the main test will be how much CPU saving we make from improved parsing performance.
