### PR TITLE
Log heap size regularly

### DIFF
--- a/admin/app/dfp/DfpDataCacheLifecycle.scala
+++ b/admin/app/dfp/DfpDataCacheLifecycle.scala
@@ -90,7 +90,7 @@ trait DfpDataCacheLifecycle extends GlobalSettings with ExecutionContexts {
     jobs foreach { job =>
       Jobs.deschedule(job.name)
       Jobs.scheduleEveryNMinutes(job.name, job.interval) {
-        job.run()
+        job.run().map(_ => ())
       }
     }
 

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -12,6 +12,8 @@ import play.api.GlobalSettings
 import services.EmailService
 import tools.{CloudWatch, LoadBalancer}
 
+import scala.concurrent.Future
+
 trait AdminLifecycle extends GlobalSettings with Logging {
 
   lazy val adminPressJobStandardPushRateInMinutes: Int = Configuration.faciatool.adminPressJobStandardPushRateInMinutes
@@ -48,14 +50,17 @@ trait AdminLifecycle extends GlobalSettings with Logging {
 
     Jobs.scheduleEveryNMinutes("FrontPressJobHighFrequency", adminPressJobHighPushRateInMinutes) {
       if(FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(HighFrequency)
+      Future.successful(())
     }
 
     Jobs.scheduleEveryNMinutes("FrontPressJobStandardFrequency", adminPressJobStandardPushRateInMinutes) {
       if(FrontPressJobSwitchStandardFrequency.isSwitchedOn) RefreshFrontsJob.runFrequency(StandardFrequency)
+      Future.successful(())
     }
 
     Jobs.scheduleEveryNMinutes("FrontPressJobLowFrequency", adminPressJobLowPushRateInMinutes) {
       if(FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(LowFrequency)
+      Future.successful(())
     }
 
     Jobs.schedule("RebuildIndexJob", s"9 0/$adminRebuildIndexRateInMinutes * 1/1 * ? *") {
@@ -69,14 +74,14 @@ trait AdminLifecycle extends GlobalSettings with Logging {
 
     if (environment.isProd) {
       val londonTime = TimeZone.getTimeZone("Europe/London")
-      Jobs.schedule("AdsStatusEmailJob", "0 44 8 ? * MON-FRI", londonTime) {
+      Jobs.scheduleWeekdayJob("AdsStatusEmailJob", 8, 44, londonTime) {
         AdsStatusEmailJob.run()
       }
-      Jobs.schedule("ExpiringAdFeaturesEmailJob", "0 47 8 ? * MON-FRI", londonTime) {
+      Jobs.scheduleWeekdayJob("ExpiringAdFeaturesEmailJob", 8, 47, londonTime) {
         log.info(s"Starting ExpiringAdFeaturesEmailJob")
         ExpiringAdFeaturesEmailJob.run()
       }
-      Jobs.schedule("ExpiringSwitchesEmailJob", "0 48 8 ? * MON-FRI", londonTime) {
+      Jobs.scheduleWeekdayJob("ExpiringSwitchesEmailJob", 8, 48, londonTime) {
         log.info(s"Starting ExpiringSwitchesEmailJob")
         ExpiringSwitchesEmailJob.run()
       }

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -74,14 +74,14 @@ trait AdminLifecycle extends GlobalSettings with Logging {
 
     if (environment.isProd) {
       val londonTime = TimeZone.getTimeZone("Europe/London")
-      Jobs.scheduleWeekdayJob("AdsStatusEmailJob", 8, 44, londonTime) {
+      Jobs.scheduleWeekdayJob("AdsStatusEmailJob", 44, 8, londonTime) {
         AdsStatusEmailJob.run()
       }
-      Jobs.scheduleWeekdayJob("ExpiringAdFeaturesEmailJob", 8, 47, londonTime) {
+      Jobs.scheduleWeekdayJob("ExpiringAdFeaturesEmailJob", 47, 8, londonTime) {
         log.info(s"Starting ExpiringAdFeaturesEmailJob")
         ExpiringAdFeaturesEmailJob.run()
       }
-      Jobs.scheduleWeekdayJob("ExpiringSwitchesEmailJob", 8, 48, londonTime) {
+      Jobs.scheduleWeekdayJob("ExpiringSwitchesEmailJob", 48, 8, londonTime) {
         log.info(s"Starting ExpiringSwitchesEmailJob")
         ExpiringSwitchesEmailJob.run()
       }

--- a/common/app/common/dfp/DfpAgentLifecycle.scala
+++ b/common/app/common/dfp/DfpAgentLifecycle.scala
@@ -3,6 +3,8 @@ package common.dfp
 import common.{AkkaAsync, Jobs}
 import play.api.{Application, GlobalSettings}
 
+import scala.concurrent.Future
+
 trait DfpAgentLifecycle extends GlobalSettings {
 
   def refreshDfpAgent(): Unit = DfpAgent.refresh()
@@ -13,6 +15,7 @@ trait DfpAgentLifecycle extends GlobalSettings {
     Jobs.deschedule("DfpDataRefreshJob")
     Jobs.scheduleEveryNMinutes("DfpDataRefreshJob", 1) {
       refreshDfpAgent()
+      Future.successful(())
     }
 
     AkkaAsync {

--- a/common/app/common/jobs.scala
+++ b/common/app/common/jobs.scala
@@ -46,7 +46,7 @@ object Jobs extends Logging {
     schedule(name, CronScheduleBuilder.cronSchedule(new CronExpression(cron)))(Future(block))// TODO make a version to take a future
   }
 
-  def scheduleWeekdayJob(name: String, hour: Int, minute: Int, timeZone: TimeZone)(block: => Future[Unit]): Unit = {
+  def scheduleWeekdayJob(name: String, minute: Int, hour: Int, timeZone: TimeZone)(block: => Future[Unit]): Unit = {
     schedule(name,
       CronScheduleBuilder.cronSchedule(new CronExpression(s"0 $minute $hour ? * MON-FRI")).inTimeZone(timeZone))(block)
   }

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -12,6 +12,7 @@ import model.diagnostics.CloudWatch
 import play.api.{GlobalSettings, Application => PlayApp}
 
 import scala.collection.JavaConversions._
+import scala.concurrent.Future
 
 object SystemMetrics extends implicits.Numbers {
 
@@ -34,37 +35,34 @@ object SystemMetrics extends implicits.Numbers {
 
   lazy val garbageCollectors: Seq[GcRateMetric] = ManagementFactory.getGarbageCollectorMXBeans.map(new GcRateMetric(_))
 
-  // divide by 1048576 to convert bytes to MB
-  private def asMb(bytes: Long): Long = bytes / 1048576
-
   val MaxHeapMemoryMetric = GaugeMetric(
     name = "max-heap-memory",
     description = "Max heap memory (MB)",
-    get = () => asMb(ManagementFactory.getMemoryMXBean.getHeapMemoryUsage.getMax)
+    get = () => bytesAsMb(ManagementFactory.getMemoryMXBean.getHeapMemoryUsage.getMax)
   )
 
   val UsedHeapMemoryMetric = GaugeMetric(
     name ="used-heap-memory",
     description = "Used heap memory (MB)",
-    get = () => asMb(ManagementFactory.getMemoryMXBean.getHeapMemoryUsage.getUsed)
+    get = () => bytesAsMb(ManagementFactory.getMemoryMXBean.getHeapMemoryUsage.getUsed)
   )
 
   val MaxNonHeapMemoryMetric = GaugeMetric(
     name = "max-non-heap-memory",
     description = "Max non heap memory (MB)",
-    get = () => asMb(ManagementFactory.getMemoryMXBean.getNonHeapMemoryUsage.getMax)
+    get = () => bytesAsMb(ManagementFactory.getMemoryMXBean.getNonHeapMemoryUsage.getMax)
   )
 
   val UsedNonHeapMemoryMetric = GaugeMetric(
     name = "used-non-heap-memory",
     description = "Used non heap memory (MB)",
-    get = () => asMb(ManagementFactory.getMemoryMXBean.getNonHeapMemoryUsage.getUsed)
+    get = () => bytesAsMb(ManagementFactory.getMemoryMXBean.getNonHeapMemoryUsage.getUsed)
   )
 
   val FreeDiskSpaceMetric = GaugeMetric(
     name = "free-disk-space",
     description = "Free disk space (MB)",
-    get = () => asMb(new File("/").getUsableSpace)
+    get = () => bytesAsMb(new File("/").getUsableSpace)
   )
 
   val ThreadCountMetric = GaugeMetric(
@@ -78,7 +76,7 @@ object SystemMetrics extends implicits.Numbers {
   val TotalPhysicalMemoryMetric = GaugeMetric(
     name = "total-physical-memory", description = "Total physical memory",
     get = () => ManagementFactory.getOperatingSystemMXBean match {
-      case b: com.sun.management.OperatingSystemMXBean => b.getTotalPhysicalMemorySize
+      case b: com.sun.management.OperatingSystemMXBean => bytesAsMb(b.getTotalPhysicalMemorySize)
       case _ => -1
     }
   )
@@ -86,7 +84,7 @@ object SystemMetrics extends implicits.Numbers {
   val FreePhysicalMemoryMetric = GaugeMetric(
     name = "free-physical-memory", description = "Free physical memory",
     get = () => ManagementFactory.getOperatingSystemMXBean match {
-      case b: com.sun.management.OperatingSystemMXBean => b.getFreePhysicalMemorySize
+      case b: com.sun.management.OperatingSystemMXBean => bytesAsMb(b.getFreePhysicalMemorySize)
       case _ => -1
     }
   )
@@ -148,7 +146,7 @@ object EmailSubsciptionMetrics {
   val ListIDError = CountMetric("email-list-id-error", "Invalid list ID in email subscription")
 }
 
-trait CloudWatchApplicationMetrics extends GlobalSettings {
+trait CloudWatchApplicationMetrics extends GlobalSettings with Logging {
   val applicationMetricsNamespace: String = "Application"
   val applicationDimension = List(new Dimension().withName("ApplicationName").withValue(applicationName))
 
@@ -187,11 +185,22 @@ trait CloudWatchApplicationMetrics extends GlobalSettings {
     Jobs.schedule("ApplicationSystemMetricsJob", "36 * * * * ?"){
       report()
     }
+    Jobs.scheduleEveryNSeconds("LogMetricsJob", 5) {
+      val heapUsed = bytesAsMb(ManagementFactory.getMemoryMXBean.getHeapMemoryUsage.getUsed)
+      log.info(s"heap used: $heapUsed")
+      Future.successful(())
+    }
   }
 
   override def onStop(app: PlayApp) {
     Jobs.deschedule("ApplicationSystemMetricsJob")
+    Jobs.deschedule("LogMetricsJob")
     super.onStop(app)
   }
 
+}
+
+object bytesAsMb {
+  // divide by 1048576 to convert bytes to MB
+  def apply(bytes: Long): Long = bytes / 1048576
 }

--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -5,11 +5,10 @@ import java.lang.management.{GarbageCollectorMXBean, ManagementFactory}
 import java.util.concurrent.atomic.AtomicLong
 
 import com.amazonaws.services.cloudwatch.model.{Dimension, StandardUnit}
-
+import conf.Configuration
 import metrics._
 import model.diagnostics.CloudWatch
-import play.api.{Application => PlayApp, Play, GlobalSettings}
-import play.api.Play.current
+import play.api.{Application => PlayApp, GlobalSettings}
 
 import scala.collection.JavaConversions._
 import scala.concurrent.Future
@@ -185,7 +184,7 @@ trait CloudWatchApplicationMetrics extends GlobalSettings with Logging {
     Jobs.schedule("ApplicationSystemMetricsJob", "36 * * * * ?"){
       report()
     }
-    if (!Play.isDev) {
+    if (Configuration.environment.isProd) {
       Jobs.scheduleEveryNSeconds("LogMetricsJob", 5) {
         val heapUsed = bytesAsMb(ManagementFactory.getMemoryMXBean.getHeapMemoryUsage.getUsed)
         log.info(s"heap used: ${heapUsed}Mb")
@@ -196,7 +195,7 @@ trait CloudWatchApplicationMetrics extends GlobalSettings with Logging {
 
   override def onStop(app: PlayApp) {
     Jobs.deschedule("ApplicationSystemMetricsJob")
-    if (!Play.isDev) {
+    if (Configuration.environment.isProd) {
       Jobs.deschedule("LogMetricsJob")
     }
     super.onStop(app)


### PR DESCRIPTION
applications blew up a few times with no change in load, basically due to crazy gc
cloudwatch metrics only log every minute
This PR makes it log heap usage every 5 seconds, and hopefully logs the job starting/finishing more accurately in some cases.
heap size vs time spent in GC for applications:
![image](https://cloud.githubusercontent.com/assets/7304387/14391359/73dffba4-fdb3-11e5-8492-d49496fd0799.png)
There's still a little more work to make all the jobs use futures and log when they finish.
@rich-nguyen 
