### PR TITLE
badges on amp should be amp-img

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -86,13 +86,8 @@
 
     .badge-slot {
         float: left;
-        width: 2.0625rem;
         margin-top: 0.125rem;
         margin-right: 0.3125rem;
-    }
-
-    .badge-slot__img {
-        width: 100%;
     }
 
     @@media (min-width: 30rem) {

--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -11,7 +11,7 @@
             <div class="content__main-column">
 
                 @if(showMeta) {
-                    @fragments.meta.metaInline(item)
+                    @fragments.meta.metaInline(item, amp)
                 }
 
                 <h1 class="content__headline js-score" itemprop="headline">

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -1,4 +1,4 @@
-@(item: model.ContentType)(implicit request: RequestHeader)
+@(item: model.ContentType, isAmp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.{LinkTo, Localisation}
 @import conf.switches.Switches._
@@ -11,7 +11,11 @@
 
         @if(isUSElection) {
             <div class="badge-slot badge-slot--us-election">
-                <img class="badge-slot__img" src="@Configuration.static.path/sys-images/Guardian/Pix/pictures/2016/2/2/1454424596176/USElectionlogooffset.png"/>
+                @if(isAmp) {
+                    <amp-img class="badge-slot__img" src="@Configuration.static.path/sys-images/Guardian/Pix/pictures/2016/2/2/1454424596176/USElectionlogooffset.png" layout="fixed" height="33" width="33"></amp-img>
+                } else {
+                    <img class="badge-slot__img" src="@Configuration.static.path/sys-images/Guardian/Pix/pictures/2016/2/2/1454424596176/USElectionlogooffset.png"/>
+                }
             </div>
         }
 


### PR DESCRIPTION
## What does this change?

The US election badge wasn't validated on amp:
![image](https://cloud.githubusercontent.com/assets/8774970/14394305/8cb77a3e-fdc3-11e5-81c9-56d0c3dfc47e.png)

This was preventing some important AMP stories to not appear in the AMP carousel. This change fixes that :)
## What is the value of this and can you measure success?

On the webmaster search console for amp it is hard to tell exactly how many stories are affected as it seems to be under the label `Unknown syntax error`. This label has 9,993 stories under it, but not all will be fixed by this change. It will help all of our articles on US elections pass amp validation though.
## Does this affect other platforms - Amp, Apps, etc?

Just AMP :)
