### PR TITLE
Series description amp

### DIFF
--- a/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
+++ b/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
@@ -2,7 +2,7 @@
 @import conf.Configuration
 
 @* must be served by localhost, not thegulocal *@
-<amp-list layout="fixed-height" height="184" src="@Configuration.amp.baseUrl/@path" credentials="include" class="onward-list">
+<amp-list layout="fixed-height" height="184" src="@Configuration.amp.baseUrl/@path" @if(!Play.isDev) { credentials="include" } class="onward-list">
     <template type="amp-mustache">
         {{#showContent}}
             <div class="fc-container__inner">

--- a/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
+++ b/common/app/views/fragments/amp/onwardTemplateAmp.scala.html
@@ -9,6 +9,12 @@
                 <div class="fc-container__header__title">
                     <span>{{displayName}}</span>
                 </div>
+                {{#description}} @* Don't show if there is not description *@
+                    <div class="fc-container__header__description">
+                            {{description}}
+                    </div>
+                {{/description}}
+
                 {{#content}}
                     {{#headline}} @* Don't show if headline is empty*@
                         <div class="fc-item {{toneClass}}">

--- a/common/app/views/fragments/amp/stylesheets/fonts.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/fonts.scala.html
@@ -23,7 +23,8 @@
 .guardian-egyptian-loaded .headline-list__count,
 .guardian-egyptian-loaded .signposting__item,
 .guardian-egyptian-loaded .team__info,
-.guardian-egyptian-loaded .team__score {
+.guardian-egyptian-loaded .team__score,
+.guardian-egyptian-loaded .fc-container__header__description {
     font-family: "Guardian Egyptian Web", Georgia, serif;
 }
 

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -243,6 +243,14 @@
         list-style: none;
     }
 
+    .fc-container__header__description {
+        font-size: 1rem;
+        line-height: 1.25rem;
+        margin-top: -1rem;
+        padding-bottom: 1rem;
+        color: #767676;
+    }
+
     @* temporarily hiding these until after launch *@
     .inline-expand-image, .content__dateline-lm, .witness-cta-wrapper {
         display: none;

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -17,6 +17,9 @@ frontend.store=http://s3-eu-west-1.amazonaws.com/aws-frontend-store
 #ajax.url=//localhost:9000
 ajax.cors.origin=http://m.random.com,http://127.0.0.1:9000,http://www.random.com,http://m.thegulocal.com,https://profile.thegulocal.com,http://localhost:9000
 
+# uncomment to test cors on amp locally
+#amp.scheme=https://
+#amp.host=amp.int.gnl
 amp.cors.origin=http://127.0.0.1:9000,https://amp.random.com,https://m.thegulocal.com,http://localhost:9000,https://amp.int.gnl
 
 # ID

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -67,11 +67,13 @@ object SeriesController extends Controller with Logging with Paging with Executi
   private def rendermf2Series(series: Series)(implicit request: RequestHeader) = {
     val displayName = Some(series.displayName)
     val seriesStories = series.trails.items take 4
-
+    val description = series.tag.metadata.description.getOrElse("").replaceAll("<.*?>", "")
+    
     JsonComponent(
       "items" -> JsArray(Seq(
         Json.obj(
           "displayName" -> displayName,
+          "description" -> description,
           "showContent" -> seriesStories.nonEmpty,
           "content" -> seriesStories.map( collection => isCuratedContent(collection.faciaContent))
         )


### PR DESCRIPTION
## What does this change?

Adding Series container descriptions onto amp onward journeys
## Does this affect other platforms - Amp, Apps, etc?

Just Amp
## Screenshots

BEFORE:
![image](https://cloud.githubusercontent.com/assets/8774970/14396633/a1346096-fdd0-11e5-8051-c49d8be02bdd.png)

AFTER:
![image](https://cloud.githubusercontent.com/assets/8774970/14396647/af0d719e-fdd0-11e5-9b8e-9adb88758582.png)
