### PR TITLE
Intersperse storyPackages stories

### DIFF
--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -187,7 +187,12 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
         case (liveBlog: Article, Some(Some(requiredBlockId))/*page param specified and valid format*/) if liveBlog.isLiveBlog =>
           createLiveBlogModel(liveBlog, response, Some(requiredBlockId))
         case (article: Article, None) =>
-          Left(ArticlePage(article, RelatedContent(article, response)))
+          if(mvt.ABIntersperseMultipleStoryPackagesStories.isParticipating) {
+            Left(ArticlePage(article, StoryPackages(article, response)))
+          }
+          else {
+            Left(ArticlePage(article, RelatedContent(article, response)))
+          }
         case _ =>
           Right(NotFound)
       }

--- a/common/app/model/RelatedContent.scala
+++ b/common/app/model/RelatedContent.scala
@@ -16,9 +16,7 @@ case class RelatedContentItem (
   faciaContent: PressedContent
 )
 
-case class RelatedContent (
-  items: Seq[RelatedContentItem]
-  ) {
+case class RelatedContent ( items: Seq[RelatedContentItem], storyPackagesCount: Int = 0) {
   val hasStoryPackage: Boolean = items.nonEmpty
   val faciaItems: Seq[PressedContent] = items.map(_.faciaContent)
 }
@@ -37,5 +35,24 @@ object RelatedContent {
       RelatedContentItem(frontendContent, FaciaContentConvert.contentToFaciaContent(item))
     }
     RelatedContent(items.filterNot(_.content.metadata.id == parent.metadata.id))
+  }
+}
+
+object StoryPackages {
+  def apply(parent: ContentType, response: ItemResponse): RelatedContent = {
+    val storyPackagesContent = response.packages.map { packages =>
+      packages.map { p =>
+        p.articles.map(_.content)
+      }
+       .flatMap(_.zipWithIndex) // zip content with its position
+       .sortBy(_._2).map(_._1) // sort by position and extract content to intermix stories from all packages
+       .distinct // remove duplicates
+    }.getOrElse(List.empty)
+
+    val items = storyPackagesContent.map { item =>
+      val frontendContent = Content(item)
+      RelatedContentItem(frontendContent, FaciaContentConvert.contentToFaciaContent(item))
+    }
+    RelatedContent(items.filterNot(_.content.metadata.id == parent.metadata.id), response.packages.fold(0)(_.size))
   }
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -68,8 +68,29 @@ object SeriesOnwardPosition extends TestDefinition(
     }
 }
 
+object ABIntersperseMultipleStoryPackagesStories extends TestDefinition(
+  List(Variant8), // 1% of our audience
+  "intersperse-multiple-story-packages-stories",
+  "To test if mixing storyPackages stories (when article has more than one storyPackage) results in more clicks",
+  new LocalDate(2016, 5, 3)
+)
+object ABIntersperseMultipleStoryPackagesStoriesControl extends TestDefinition(
+  List(Variant9), // 1% of our audience
+  "intersperse-multiple-story-packages-stories-control",
+  "Control for the intersperse-multiple-story-packages-stories A/B test",
+  new LocalDate(2016, 5, 3)
+)
+
 object ActiveTests extends Tests {
-  val tests: Seq[TestDefinition] = List(ABNewHeaderVariant, CMTopBannerPosition, ABHeadlinesTestControl, ABHeadlinesTestVariant, SeriesOnwardPosition)
+  val tests: Seq[TestDefinition] = List(
+    ABNewHeaderVariant,
+    CMTopBannerPosition,
+    ABHeadlinesTestControl,
+    ABHeadlinesTestVariant,
+    SeriesOnwardPosition,
+    ABIntersperseMultipleStoryPackagesStories,
+    ABIntersperseMultipleStoryPackagesStoriesControl
+  )
 
   def getJavascriptConfig(implicit request: RequestHeader): String = {
 

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -11,7 +11,10 @@
 
 @defining(Seq("related") ++ (if(content.commercial.isAdvertisementFeature) Seq("fc-container--advertisement-feature") else Nil)) { classes =>
     @if(related.hasStoryPackage) {
-        <aside class="@classes.mkString(" ") more-on-this-story" role="complementary" aria-labelledby="related-content-head">
+        <aside class="@classes.mkString(" ") more-on-this-story" role="complementary" aria-labelledby="related-content-head"
+            @if(mvt.ABIntersperseMultipleStoryPackagesStories.isParticipating && related.storyPackagesCount > 1){data-link-name="ab-multiple-story-packages"}
+            @if(mvt.ABIntersperseMultipleStoryPackagesStoriesControl.isParticipating && related.storyPackagesCount > 1){data-link-name="ab-multiple-story-packages-control"}
+        >
             @container("more on this story", "more-on-this-story", href = None)
         </aside>
     } else {


### PR DESCRIPTION
## What does this change?

Reorder the stories within a story package container to mix stories from multiple
packages rather than showing stories from package 2 before stories from
package2
## What is the value of this and can you measure success?

We suspect reordering the stories will bring more click on story packages' stories
## Does this affect other platforms - Amp, Apps, etc?

No. @piuccio and I decided not to make any change for now about how we show story packages on amp
## Screenshots
## Request for comment

@piuccio @OliverJAsh @dominickendrick 
