### PR TITLE
Harmonise the disclosure widget in commercial containers with the ones in standard containers

### DIFF
--- a/common/app/views/commercial/containers/paidContainerV2.scala.html
+++ b/common/app/views/commercial/containers/paidContainerV2.scala.html
@@ -53,7 +53,7 @@
                 <summary class="button button--medium button--primary button--show-more" data-text="@containerModel.content.title">
                     @fragments.inlineSvg("plus", "icon")
                     @fragments.inlineSvg("minus", "icon")
-                    <span class="button__label">More @containerModel.content.title</span>
+                    <span class="js-button__label">More @containerModel.content.title</span>
                 </summary>
                 <div class="adverts__row adverts__row--wrap">
                     @containerModel.content.showMoreCards.map(card => views.html.commercial.cards.itemSmallCard(card, omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card)))

--- a/common/app/views/commercial/containers/paidContainerV2.scala.html
+++ b/common/app/views/commercial/containers/paidContainerV2.scala.html
@@ -50,10 +50,10 @@
 
         @if(containerModel.content.showMoreCards != Nil && containerModel.content.showMoreCards.length > 0){
             <details class="adverts__more">
-                <summary class="button button--medium button--primary button--show-more">
+                <summary class="button button--medium button--primary button--show-more" data-text="@containerModel.content.title">
                     @fragments.inlineSvg("plus", "icon")
                     @fragments.inlineSvg("minus", "icon")
-                    More @containerModel.content.title
+                    <span class="button__label">More @containerModel.content.title</span>
                 </summary>
                 <div class="adverts__row adverts__row--wrap">
                     @containerModel.content.showMoreCards.map(card => views.html.commercial.cards.itemSmallCard(card, omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card)))

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -11,7 +11,8 @@ define([
     'common/modules/commercial/top-banner-below-container',
     'common/modules/commercial/slice-adverts',
     'common/modules/commercial/third-party-tags',
-    'common/modules/commercial/paidfor-band'
+    'common/modules/commercial/paidfor-band',
+    'common/modules/commercial/adverts'
 ], function (
     Promise,
     config,
@@ -25,7 +26,8 @@ define([
     topBannerBelowContainer,
     sliceAdverts,
     thirdPartyTags,
-    paidforBand
+    paidforBand,
+    adverts
 ) {
     var modules = [
         ['cm-dfp', dfp.init],
@@ -56,6 +58,7 @@ define([
                 robust.catchErrorsAndLogAll([
                     ['cm-adverts', dfp.loadAds],
                     ['cm-paidforBand', paidforBand.init],
+                    ['cm-new-adverts', adverts.init],
                     ['cm-ready', function () {
                         mediator.emit('page:commercial:ready');
                     }]

--- a/static/src/javascripts/projects/common/modules/commercial/adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adverts.js
@@ -44,7 +44,7 @@ define([
     function onOpenClick(event) {
         var summary = event.currentTarget;
         var details = summary.parentNode;
-        var label = summary.querySelector('.button__label');
+        var label = summary.querySelector('.js-button__label');
         if (details.hasAttribute('open')) {
             fastdom.write(function () {
                 label.textContent = 'More ' + summary.getAttribute('data-text');

--- a/static/src/javascripts/projects/common/modules/commercial/adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adverts.js
@@ -1,8 +1,8 @@
 define([
-    'bean',
     'qwery',
+    'bean',
     'fastdom'
-], function (bean, qwery, fastdom) {
+], function (qwery, bean, fastdom) {
     var shouldWePolyfill = !('open' in document.createElement('details'));
 
     return {

--- a/static/src/javascripts/projects/common/modules/commercial/adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adverts.js
@@ -1,0 +1,59 @@
+define([
+    'bean',
+    'qwery',
+    'fastdom'
+], function (bean, qwery, fastdom) {
+    var shouldWePolyfill = !('open' in document.createElement('details'));
+
+    return {
+        init: init
+    };
+
+    function init() {
+        if (shouldWePolyfill) {
+            bean.on(document, 'click', 'summary', onClick);
+            bean.on(document, 'keypress', 'summary', onKeyPress(onClick));
+        }
+
+        var showMores = qwery('.adverts__more > summary');
+        bean.on(document, 'click', showMores, onOpenClick);
+        bean.on(document, 'click', showMores, onKeyPress(onOpenClick));
+    }
+
+    function onClick(event) {
+        var details = event.currentTarget.parentNode;
+        if (details.hasAttribute('open')) {
+            fastdom.write(function () {
+                details.removeAttribute('open');
+            });
+        } else {
+            fastdom.write(function () {
+                details.setAttribute('open', 'open');
+            });
+        }
+    }
+
+    function onKeyPress(handler) {
+        return function (event) {
+            if (event.keyCode === 0x20 || event.keyCode === 0x0D) {
+                handler(event);
+            }
+        };
+    }
+
+    function onOpenClick(event) {
+        var summary = event.currentTarget;
+        var details = summary.parentNode;
+        var label = summary.querySelector('.button__label');
+        if (details.hasAttribute('open')) {
+            fastdom.write(function () {
+                label.textContent = 'More ' + summary.getAttribute('data-text');
+            });
+        } else {
+            fastdom.write(function () {
+                label.textContent = 'Less';
+            });
+        }
+    }
+
+});

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -5,8 +5,11 @@
     background-color: colour(neutral-6);
 
     > .adverts__header {
-        @include f-headlineSans;
         background: guss-colour(paidfor-background, $frontend-palette);
+    }
+
+    .adverts__title {
+        @include f-headlineSans;
     }
 
     .adverts__logo {
@@ -119,4 +122,7 @@
         }
     }
 
+    .advert__image-container {
+        height: auto;
+    }
 }

--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -348,6 +348,10 @@
     &[open] .inline-plus {
         display: none;
     }
+
+    &:not([open]) > *:not(summary) {
+        display: none;
+    }
 }
 
 


### PR DESCRIPTION
The existing 'Show more' buttons carry a lot of baggage with them, which we don't want in our new adverts component: the 'Loading' state plus all the styling and markup that comes with `fc-container-*`. Hence I had to partially recreate its behaviour. I'm using the standard `DETAILS` element which is the defacto disclosure widget in HTML, with some polyfilling for browsers not supporting it.

Next I'm just overcoating the standard behaviour with some text replacement that tells the reader, once the widget is expanded there will be **less** content if she ever clicks the button again... Shocking! The result? If the user ever clicks the middle-to-right part of the button, because of the dramatic change in size, she will have to re-target it if she ever wants to click it again. 🎯 

/cc @uplne 
