### PR TITLE
Liveblog jankiness ad-related bug fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -117,7 +117,7 @@ define([
         };
     }
 
-    function _enforceRules(slots, rules, bodyTop, bodyHeight) {
+    function _enforceRules(slots, rules, bodyHeight) {
         var filtered = Promise.resolve(slots);
 
         // enforce absoluteMinAbove rule
@@ -235,7 +235,7 @@ define([
         }
 
         function enforceRules(data) {
-            return _enforceRules(data[2], rules, data[0], data[1]);
+            return _enforceRules(data[2], rules, data[1]);
         }
 
         function filterSlots(slots) {

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -109,9 +109,10 @@ define([
     }
 
     function _mapElementToDimensions(el) {
+        var rect = el.getBoundingClientRect();
         return {
-            top: el.offsetTop,
-            bottom: el.offsetTop + el.offsetHeight,
+            top: rect.top,
+            bottom: rect.bottom,
             element: el
         };
     }
@@ -122,7 +123,7 @@ define([
         // enforce absoluteMinAbove rule
         if (rules.absoluteMinAbove > 0) {
             filtered = filtered.then(filter(slots, function (slot) {
-                return bodyTop + slot.top >= rules.absoluteMinAbove;
+                return slot.top >= rules.absoluteMinAbove;
             }));
         }
 
@@ -226,7 +227,7 @@ define([
             return fastdom.read(function () {
                 var rect = body.getBoundingClientRect();
                 return [
-                    rect.top + window.pageYOffset,
+                    rect.top,
                     rect.height,
                     map(slots, _mapElementToDimensions)
                 ];


### PR DESCRIPTION
## What does this change?

This PR fixes the bug which caused jankiness on liveblogs pages. Now only adslots located below the viewport should be loaded.
## What is the value of this and can you measure success?

Smaller jankiness on liveblogs pages

cc @regiskuckaertz 
