### PR TITLE
Gimbap should follow grid on wide breakpoint

### DIFF
--- a/static/src/stylesheets/module/commercial/gimbap/_gimbap-wrap.scss
+++ b/static/src/stylesheets/module/commercial/gimbap/_gimbap-wrap.scss
@@ -130,6 +130,7 @@ $gimbap-width-quarter: calc(25% - 20px);
     }
 
     @include mq(wide) {
+        width: 940px;
         margin-left: $gimbap-wrap-left-space-wide;
     }
 


### PR DESCRIPTION
I don't really have anything to add. It's now taking 100% and it should take only 940px;

@regiskuckaertz 
