### PR TITLE
Add link to Guardian holidays to more section (UK only)

### DIFF
--- a/common/app/views/fragments/topNav/servicesLinks.scala.html
+++ b/common/app/views/fragments/topNav/servicesLinks.scala.html
@@ -52,6 +52,10 @@
                         <a class="brand-bar__item--action" data-link-name="uk : topNav : courses"
                         href="http://courses.theguardian.com?INTCMP=NGW_TOPNAV_UK_GU_COURSES">courses</a>
                     </li>
+                    <li class="popup__item">
+                        <a class="brand-bar__item--action" data-link-name="uk : topNav : holidays"
+                        href="https://holidays.theguardian.com/?utm_source=theguardian&utm_medium=guardian-links&utm_campaign=topnav&INTCMP=topnav">holidays</a>
+                    </li>
                 </ul>
                 <div class="brand-bar__popup--membership hide-on-desktop show-on-slim-header">
                     <h3 class="popup__group-header">join us:</h3>


### PR DESCRIPTION
## What does this change?

Add new holidays link in the 'more' dropdown for UK header
