### PR TITLE
Show /all links in Topics area on curated fronts

### DIFF
--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -103,6 +103,9 @@ case class PressedPage (
       s"/${Paths.withoutEdition(id).getOrElse(id)}/all"
     }
   }
+
+  def alwaysAvailableAllPath = allPath.orElse(Some(s"/${Paths.withoutEdition(id).getOrElse(id)}/all"))
+
   val navSection: String = metadata.section
 
   val keywordIds: Seq[String] = frontKeywordIds(id)

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -99,12 +99,17 @@ case class PressedPage (
       Paths.withoutEdition(id)
     ).flatten
 
-    tagAndSectionIds.find(validIds contains) map { id =>
+    tagAndSectionIds.find(validIds contains).map { id =>
       s"/${Paths.withoutEdition(id).getOrElse(id)}/all"
-    }
+    }.orElse(allPathFromTreats)
   }
 
-  def alwaysAvailableAllPath = allPath.orElse(Some(s"/${Paths.withoutEdition(id).getOrElse(id)}/all"))
+  private def allPathFromTreats: Option[String] = {
+    collections.flatMap(_.treats.collect {
+        case treat if SupportedUrl.fromFaciaContent(treat).endsWith("/all") => SupportedUrl.fromFaciaContent(treat)
+      }
+    ).headOption
+  }
 
   val navSection: String = metadata.section
 

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -50,13 +50,7 @@
 
                 <div class="js-front-bottom"></div>
 
-                @defining(faciaPage.allPath) { allPath =>
-                    @if(allPath.isEmpty) {
-                        @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.alwaysAvailableAllPath)
-                    } else {
-                        @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
-                    }
-                }
+                @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
 
                 @if(!isAdFeature) {
                     <div class="fc-container fc-container--commercial">

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -50,7 +50,13 @@
 
                 <div class="js-front-bottom"></div>
 
-                @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
+                @defining(faciaPage.allPath) { allPath =>
+                    @if(allPath.isEmpty) {
+                        @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.alwaysAvailableAllPath)
+                    } else {
+                        @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
+                    }
+                }
 
                 @if(!isAdFeature) {
                     <div class="fc-container fc-container--commercial">


### PR DESCRIPTION
## What does this change?

On wider breakpoints, some fronts have been given treats with ![screen shot 2016-04-11 at 17 18 12](https://cloud.githubusercontent.com/assets/690395/14434216/9809d470-0009-11e6-8d53-a2a10cf2c2c3.png) links to the /all tag page;
![screen shot 2016-04-11 at 17 05 04](https://cloud.githubusercontent.com/assets/690395/14433785/948c363c-0007-11e6-9189-2e738dfb3bda.png)

On narrower breakpoints these treats are hidden as their columns are removed, and so is the link to the /all page;
![screen shot 2016-04-11 at 17 06 20](https://cloud.githubusercontent.com/assets/690395/14433815/b17bf886-0007-11e6-9e9e-b6500dae2c55.png)

And in this state, the live site doesn't include any link to today's stories in their Topics area;
![screen shot 2016-04-11 at 17 07 53](https://cloud.githubusercontent.com/assets/690395/14433875/0b918ed0-0008-11e6-96ad-8b645b19bf50.png)

On some fronts, we do already see an "All today's stories" link in the Topics section near the end of the page, but this is due to the curated content they contain, and not because of the presence of the treats.

Now, if we don't have a pre-existing /all link in Topics and we do have a treat with an /all link, we'll show that in the Topics area;
![screen shot 2016-04-11 at 17 14 07](https://cloud.githubusercontent.com/assets/690395/14434038/c59b5734-0008-11e6-99dd-56c951d46d0d.png)

Even at very narrow breakpoints;
![screen shot 2016-04-11 at 17 24 21](https://cloud.githubusercontent.com/assets/690395/14434362/41ec8d16-000a-11e6-8718-6ef32167c085.png)
## What is the value of this and can you measure success?

It gives readers on mobile devices the opportunity to explore more of the content related to the front they are viewing. If it's particularly successful we may see an uplift in traffic to /all pages (and therefore content) from mobile devices, but at the very least we're making a navigation route available consistently across formats. 
## Does this affect other platforms - Amp, Apps, etc?

No.
## Request for comment

cc @rich-nguyen @janua 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
