### PR TITLE
sup

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -192,6 +192,7 @@ define([
                             renderTable(competition + '/' + resp.group, extras, dropdownTemplate);
                         }
 
+                        // Other games today
                         $.create('<div class="js-football-match-day" data-link-name="football-match-day-embed"></div>').each(function (container) {
                             football.matchDayFor(competition, resp.matchDate).fetch(container).then(function () {
                                 extras[1] = {

--- a/static/src/javascripts/projects/common/utils/page.js
+++ b/static/src/javascripts/projects/common/utils/page.js
@@ -1,12 +1,14 @@
 define([
     'common/utils/$',
     'common/utils/config',
+    'common/utils/detect',
     'lodash/objects/assign',
     'lodash/collections/find',
     'lodash/arrays/intersection'
 ], function (
     $,
     config,
+    detect,
     assign,
     find,
     intersection
@@ -45,7 +47,8 @@ define([
     }
 
     function isCompetition(yes, no) {
-        var competition = ($('.js-football-competition').attr('data-link-name') || '').replace('keyword: football/', '');
+        var notMobile = detect.getBreakpoint() !== 'mobile',
+            competition =  notMobile ? ($('.js-football-competition').attr('data-link-name') || '').replace('keyword: football/', '') : '';
         return isit(competition, yes, no);
     }
 


### PR DESCRIPTION
# My Awesome Pull Request

Or, so much pain for so little
## What does this change?

There was a problem with subscribing to live notfications on football livebloigs on android. Turns out this is because of the extra components in the left hand column for football. At the mobile breakpoiint, the tables are requested, but not inserted into the dom and for some reason, this meant the notifications click handler didn't get registered. If you look at a liveblog at the mobile breakpoint like this one ( https://www.theguardian.com/football/live/2016/apr/10/sunderland-v-leicester-premier-league-live ) and then expand it the tables don't appear so there's no change in functionality. A mobile browser will just make three less ajax calls
## What is the value of this and can you measure success?

Live notifications work on mobile for football blogs. Un mucho grande audience.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

![match-components](https://cloud.githubusercontent.com/assets/986155/14464939/f3d59496-00c8-11e6-9bbb-a8b52dc8dd3a.png)
## Request for comment
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
