### PR TITLE
Accept Thrift arraybuffer in model

### DIFF
--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -105,7 +105,7 @@ object AllIndexController extends Controller with ExecutionContexts with ItemRes
         )
       ).orElse(item.tag.map( apitag => {
         val tag = Tag.make(apitag)
-        IndexPage(page = tag, contents = item.results.getOrElse(Nil).map(IndexPageItem(_)), Tags(Seq(tag)), date, tzOverride = None)
+        IndexPage(page = tag, contents = item.results.getOrElse(Nil).map(IndexPageItem(_)), Tags(List(tag)), date, tzOverride = None)
       }))
     }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -263,7 +263,7 @@ object Content {
     val fields = Fields.make(apiContent)
     val metadata = MetaData.make(fields, apiContent)
     val elements = Elements.make(apiContent)
-    val tags = Tags(apiContent.tags map { Tag.make(_) })
+    val tags = Tags.make(apiContent)
     val commercial = Commercial.make(metadata, tags, apiContent)
     val trail = Trail.make(tags, fields, commercial, elements, metadata, apiContent)
     val sharelinks = ShareLinks(tags, fields, metadata)

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -520,7 +520,7 @@ final case class Elements(elements: Seq[Element]) {
  * Tags lets you extract meaning from tags on a page.
  */
 final case class Tags(
-  tags: Seq[Tag]) {
+  tags: List[Tag]) {
 
   def contributorAvatar: Option[String] = tags.flatMap(_.contributorImagePath).headOption
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -640,4 +640,8 @@ object Tags {
   val reviewMappings = Seq(
     "tone/reviews"
   )
+
+  def make(apiContent: contentapi.Content) = {
+    Tags(apiContent.tags.toList map { Tag.make(_) })
+  }
 }

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -162,7 +162,7 @@ trait Index extends ConciergeRepository with Collections {
     val latest: Seq[IndexPageItem] = response.results.getOrElse(Nil).map(IndexPageItem(_)).filterNot(c => leadContentIds.contains(c.item.metadata.id))
     val allTrails = (leadContent ++ editorsPicks ++ latest).distinctBy(_.item.metadata.id)
     tag map { tag =>
-      IndexPage(page = tag, contents = allTrails, tags = Tags(Seq(tag)), date = DateTime.now, tzOverride = None)
+      IndexPage(page = tag, contents = allTrails, tags = Tags(List(tag)), date = DateTime.now, tzOverride = None)
     }
   }
 

--- a/common/app/views/fragments/meta/bylineImage.scala.html
+++ b/common/app/views/fragments/meta/bylineImage.scala.html
@@ -7,7 +7,7 @@
     @profile.properties.contributorLargeImagePath.map{ src =>
         <div class="byline-img">
         @if(request.isAmp) {
-            @if(model.Tags(tags.tones).isComment) {
+            @if(model.Tags(tags.tones.toList).isComment) {
                 <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="180" height="150" />
             } else {
                 <amp-img class="byline-img__img" src="@ImgSrc(src, Item300)" alt="@profile.name" width="79" height="66" />

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -53,12 +53,12 @@ class ContentTest extends FlatSpec with Matchers with OneAppPerSuite with implic
 
   "Tags" should "understand tag types" in {
 
-    val theKeywords = Seq(Tag.make(tag("/keyword1", TagType.Keyword)), Tag.make(tag("/keyword2", TagType.Keyword)))
-    val theSeries = Seq(Tag.make(tag("/series", TagType.Series)))
-    val theContributors = Seq(Tag.make(tag("/contributor", TagType.Contributor)))
-    val theTones = Seq(Tag.make(tag("/tone", TagType.Tone)))
-    val theBlogs = Seq(Tag.make(tag("/blog", TagType.Blog)))
-    val theTypes = Seq(Tag.make(tag("/type", TagType.Type)))
+    val theKeywords = List(Tag.make(tag("/keyword1", TagType.Keyword)), Tag.make(tag("/keyword2", TagType.Keyword)))
+    val theSeries = List(Tag.make(tag("/series", TagType.Series)))
+    val theContributors = List(Tag.make(tag("/contributor", TagType.Contributor)))
+    val theTones = List(Tag.make(tag("/tone", TagType.Tone)))
+    val theBlogs = List(Tag.make(tag("/blog", TagType.Blog)))
+    val theTypes = List(Tag.make(tag("/type", TagType.Type)))
 
     val tags = Tags(tags = theBlogs ++ theTones ++ theContributors ++ theSeries ++ theKeywords ++ theTypes)
 

--- a/common/test/views/support/TemplatesTest.scala
+++ b/common/test/views/support/TemplatesTest.scala
@@ -26,7 +26,7 @@ class TemplatesTest extends FlatSpec with Matchers with OneAppPerSuite {
   }
 
   "typeOrTone" should "ignore Article and find Video" in {
-    val tags = Tags(tags = Seq(
+    val tags = Tags(tags = List(
         Tag.make(tag(id = "type/article", tagType = TagType.Type)),
         Tag.make(tag(id = "tone/foo", tagType = TagType.Tone)),
         Tag.make(tag(id = "type/video", tagType = TagType.Type))
@@ -36,7 +36,7 @@ class TemplatesTest extends FlatSpec with Matchers with OneAppPerSuite {
   }
 
   it should "find tone when only content type is Article" in {
-    val tags = Tags(tags = Seq(
+    val tags = Tags(tags = List(
         Tag.make(tag(id = "type/article", tagType = TagType.Type)),
         Tag.make(tag(id = "tone/foo", tagType = TagType.Tone))
       ))


### PR DESCRIPTION
The `Tags` object was using a `Seq` to hold tags, whose type was implicitly defined by the CAPI client. In thrift format, this `Seq` was an `ArrayBuffer`, so our pattern matches began to fail.
