### PR TITLE
don't reuse CompilerOptions across threads

### DIFF
--- a/common/app/common/JsMinifier.scala
+++ b/common/app/common/JsMinifier.scala
@@ -13,7 +13,7 @@ import scala.util.Try
 
 object JsMinifier {
 
-  val compilerOptions = {
+  def compilerOptions = {
     val options = new CompilerOptions()
 
     /* Checks */
@@ -53,12 +53,14 @@ object JsMinifier {
   private def compileUnsafe(codeToCompile: String, fileName: String, compilationLevel: CompilationLevel): String = {
     val compiler = new Compiler()
 
-    compilationLevel.setOptionsForCompilationLevel(compilerOptions)
+    val options = compilerOptions
+
+    compilationLevel.setOptionsForCompilationLevel(options)
 
     val extern: SourceFile = SourceFile.fromCode("extern.js", "")
     val input: SourceFile = SourceFile.fromCode(fileName, codeToCompile)
 
-    val result: Result = compiler.compile(extern, input, compilerOptions)
+    val result: Result = compiler.compile(extern, input, options)
 
     if (result.warnings.isEmpty && result.errors.isEmpty && result.success) {
       compiler.toSource


### PR DESCRIPTION
Deploys have been super slow recently due to boxes not coming up.

Upon looking into it we're getting some errors from google closure compiler caused by CompilerOptions [not being thread safe](https://groups.google.com/forum/#!topic/closure-compiler-discuss/7w-qplzkYf8)

This just uses one per request (although after that it's memoised into a TrieMap anyway)

This probably isn't causing the box issues, but it shouldn't be happening anyway and it'll make the logs clearer.

@jamespamplin @janua 
