### PR TITLE
Fix exception in test

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -117,7 +117,9 @@ define([
         robust.catchErrorsAndLog('ab-tests', function () {
             if (guardian.isEnhanced) {
                 ab.segmentUser();
-                ab.run();
+                robust.catchErrorsAndLog('ab-tests-run', function () {
+                    ab.run();
+                });
                 ab.trackEvent();
             }
         });

--- a/static/src/javascripts/projects/common/modules/experiments/tests/next-in-series.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/next-in-series.js
@@ -9,13 +9,13 @@ define([
     pluck,
     some
 ) {
-    var path = '/surveys/404-test/next-in-series/';
+    var surveyPath = '/surveys/404-test/next-in-series/';
     var render = function (state) {
         return '<div class="next-in-series-test">' +
             '<h3>Coming up next week</h3>' +
             '<h4>' + state.title + '</h4>' +
             '<p class="next-in-series-test__teaser">' + state.trail + '</p>' +
-            '<a href="' + path + state.id + '"' +
+            '<a href="' + surveyPath + state.id + '"' +
                 ' data-link-name="next in series | remind me"' +
                 ' class="button button--large next-in-series-test__remind-me-link">Remind me</a>' +
         '</div>';
@@ -83,7 +83,7 @@ define([
                 },
 
                 success: function(complete) {
-                    var onSurvey = window.location.href.match(path.replace(/\/$/, '')).length > 0;
+                    var onSurvey = new RegExp(surveyPath.replace(/\/$/, '')).test(window.location.href);
 
                     var referredFromSeries = some(pluck(allSeries, 'pageId'), function (id) {
                         return window.document.referrer.match(id).length > 0;


### PR DESCRIPTION
Fixes exception re. https://github.com/guardian/frontend/pull/12447

The `success` function was throwing an exception because `String.prototype.match` returned `null` instead of the expected `array`.

The effected test variant is out to a total of 50% of users. Unfortunately this means other A/B tests may not have run for those users, and/or we may not have tracked their presence to Ophan.

/cc @desbo @dominickendrick 

https://github.com/guardian/frontend/pull/12311#issuecomment-199518409
