### PR TITLE
Remove sass rem

### DIFF
--- a/static/src/stylesheets/layout/_side-margins.scss
+++ b/static/src/stylesheets/layout/_side-margins.scss
@@ -9,7 +9,7 @@
 @mixin side-margins-position($container-width) {
     &:before,
     &:after {
-        width: calc((100% - #{rem($container-width + $gs-gutter * 2)}) / 2);
+        width: calc((100% - #{$container-width + $gs-gutter * 2}) / 2);
     }
 }
 

--- a/static/src/stylesheets/layout/_side-margins.scss
+++ b/static/src/stylesheets/layout/_side-margins.scss
@@ -7,9 +7,12 @@
  */
 
 @mixin side-margins-position($container-width) {
+    // stupid fix for sasslint AST error
+    $size: $container-width + $gs-gutter * 2;
+
     &:before,
     &:after {
-        width: calc((100% - #{$container-width + $gs-gutter * 2}) / 2);
+        width: calc((100% - #{$size}) / 2);
     }
 }
 

--- a/static/src/stylesheets/module/_popup.scss
+++ b/static/src/stylesheets/module/_popup.scss
@@ -13,7 +13,7 @@ $control-offset: 36 + $gs-gutter/2;
 
 .popup--default {
     background: $c-popup-bg;
-    box-shadow: 0 rem(1px 1px) 0 rgba(0, 0, 0, .25);
+    box-shadow: 0 1px 1px 0 rgba(0, 0, 0, .25);
     left: 0;
     top: $popup-top - 2;
     padding: 0;

--- a/static/src/stylesheets/pasteup/layout/_src.scss
+++ b/static/src/stylesheets/pasteup/layout/_src.scss
@@ -94,8 +94,8 @@
 ) {
     @if $browser-supports-columns {
         #{$class} {
-            column-width: rem($column-min-width);
-            column-gap: rem($column-gap);
+            column-width: $column-min-width;
+            column-gap: $column-gap;
             column-fill: balance;
         }
         #{$class}__item {


### PR DESCRIPTION
## What does this change?

removes old calls to `rem()` that should have been removed
## What is the value of this and can you measure success?

restores some broken designs
## Screenshots

before
![screen shot 2016-04-13 at 11 24 17](https://cloud.githubusercontent.com/assets/867233/14490366/5d8ec7a8-016a-11e6-9df1-706fc1b3a1f7.png)
after
![screen shot 2016-04-13 at 11 24 27](https://cloud.githubusercontent.com/assets/867233/14490373/634ed82c-016a-11e6-98da-82efa9124938.png)
## Request for comment

@johnduffell 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
