### PR TITLE
Disable pasteup publish warning

### DIFF
--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -57,6 +57,6 @@ jsTestResult=$?
 
 # Modified version of [Sindre Sorhus's gist](https://gist.github.com/sindresorhus/7996717),
 # to run notifiy you if you need to update the pasteup package on npm.
-changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
-echo $changed_files | grep 'pasteup' --quiet && node tools/messages.js pasteup
+# changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+# echo $changed_files | grep 'pasteup' --quiet && node tools/messages.js pasteup
 exit 0


### PR DESCRIPTION
## What does this change?

disables the message about needing to publish pasteup 
## What is the value of this and can you measure success?

it's not working properly, and causing problems
## Request for comment

@desbo @Calanthe @sammorrisdesign 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_

…r now
