### PR TITLE
Remove date stamps from the labs merchandising component

### DIFF
--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -49,18 +49,6 @@
                                                     @item.metadata.webTitle
                                                 </h2>
                                             </div>
-                                            <div class="fc-item__meta">
-                                                <time
-                                                    class="fc-item__timestamp js-item__timestamp"
-                                                    datetime="@item.trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
-                                                    data-timestamp="@item.trail.webPublicationDate.getMillis"
-                                                    data-relativeformat="short">
-                                                    <span class="timestamp__text">
-                                                        <span class="u-h">Published: </span>
-                                                        @Format(item.trail.webPublicationDate, "d MMM y")
-                                                    </span>
-                                                </time>
-                                            </div>
                                         </div>
                                     </div>
                                     <a href="@optClickMacro@item.metadata.webUrl" class="u-faux-block-link__overlay" data-link-name="merchandising-capi-v@{version}_@{date}-@item.metadata.webTitle" tabindex="-1">
@@ -130,18 +118,6 @@
                                                         @insertItemMediaIcon(item)
                                                         @item.metadata.webTitle
                                                     </h2>
-                                                </div>
-                                                <div class="fc-item__meta">
-                                                    <time
-                                                        class="fc-item__timestamp js-item__timestamp"
-                                                        datetime="@item.trail.webPublicationDate.toString("yyyy-MM-dd'T'HH:mm:ssZ")"
-                                                        data-timestamp="@item.trail.webPublicationDate.getMillis"
-                                                        data-relativeformat="short">
-                                                        <span class="timestamp__text">
-                                                            <span class="u-h">Published: </span>
-                                                            @Format(item.trail.webPublicationDate, "d MMM y")
-                                                        </span>
-                                                    </time>
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
## What does this change?

Date stamps should be removed from the items in glabs containers in these examples:

[http://m.code.dev-theguardian.com/fashion/2016/apr/07/whisker-foxtrot-tango-post-hipster-beards-and-what-they-say-about-you](http://m.code.dev-theguardian.com/fashion/2016/apr/07/whisker-foxtrot-tango-post-hipster-beards-and-what-they-say-about-you)

[http://m.code.dev-theguardian.com/books/picture/2016/apr/12/re-illustrating-the-jungle-book-mowgli-and-bagheera-by-jill-calder](http://m.code.dev-theguardian.com/books/picture/2016/apr/12/re-illustrating-the-jungle-book-mowgli-and-bagheera-by-jill-calder)

It only affects old versions of the containers (not v2)

Here is the [trello card](https://trello.com/c/PNyZ0OSZ/266-labs-merchandising-component-remove-the-date-stamp-seen-against-articles)
