### PR TITLE
try sending ETag headers to fastly

### DIFF
--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -63,7 +63,7 @@ object Cached extends implicits.Dates {
       "Cache-Control" -> cacheControl,
       "Expires" -> expiresTime.toHttpDateTimeString,
       "Date" -> now.toHttpDateTimeString,
-      "ETag" -> "johnTest" // see if we get any If-None-Match requests
+      "ETag" -> s"johnTest${scala.util.Random.nextInt}${scala.util.Random.nextInt}" // see if we get any If-None-Match requests
     )
   }
 }

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -62,7 +62,8 @@ object Cached extends implicits.Dates {
       "Surrogate-Control" -> cacheControl,
       "Cache-Control" -> cacheControl,
       "Expires" -> expiresTime.toHttpDateTimeString,
-      "Date" -> now.toHttpDateTimeString
+      "Date" -> now.toHttpDateTimeString,
+      "ETag" -> "johnTest" // see if we get any If-None-Match requests
     )
   }
 }


### PR DESCRIPTION
We have a lot of requests to the back end.  This is composed of:
1. articles/fronts etc that have changed being requested (genuine)
2. requests done after we've deployed need to pick up the new code
3. we split the cache for server side ab tests and geo nav
4. fastly makes requests for the same content from different nodes
5. re-requesting content that has expired from the cache but still correct.

5 has been partly addressed by @gklopper 's work with soft purging when articles change.  However we still have things expire due to point 2 and other things we don't know about.

This PR is just to test whether there's a lot to be gained by implementing cache validation.  If we send an etag to fastly, they should include that in any requests where the content has expired but is still in the cache.

If we get enough requests with this in, we can calculate it from the inputs to the server (headers and requests to capi/facia json etc), and  if it matches we won't have to actually prepare and send the response, just a 204 Not Modified.
If we don't get many requests with it in, it's not worth going to the trouble and we should try to attack some of the other areas.

@TBonnin @jamespamplin @rich-nguyen any thoughts?
