### PR TITLE
Make sure Seq-based objects pattern match as List

### DIFF
--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -121,7 +121,7 @@ object CrosswordSearchController extends CrosswordController {
         }
 
         ContentApiClient.getResponse(maybeSetter.showFields("all")).map { response =>
-          response.results.getOrElse(Nil) match {
+          response.results.getOrElse(Seq.empty).toList match {
             case Nil => noResults
 
             case results =>

--- a/commercial/app/controllers/commercial/BookOffersController.scala
+++ b/commercial/app/controllers/commercial/BookOffersController.scala
@@ -52,7 +52,7 @@ object BookOffersController
 
   def renderBooks = Action.async { implicit request =>
 
-    def result(books: Seq[Book]): Result = books.distinctBy(_.isbn).take(5) match {
+    def result(books: Seq[Book]): Result = books.distinctBy(_.isbn).take(5).toList match {
       case Nil =>
         NoCache(jsonFormat.nilResult)
       case someBooks =>

--- a/commercial/app/controllers/commercial/ContentApiOffersController.scala
+++ b/commercial/app/controllers/commercial/ContentApiOffersController.scala
@@ -62,7 +62,7 @@ object ContentApiOffersController extends Controller with ExecutionContexts with
       (specific ++ latestByKeyword.filter(_.trail.trailPicture.nonEmpty)).distinct take 4
     }
 
-    futureContents map {
+    futureContents.map(_.toList) map {
       case Nil => NoCache(format.nilResult)
       case contents => Cached(componentMaxAge) {
 

--- a/commercial/app/controllers/commercial/JobAds.scala
+++ b/commercial/app/controllers/commercial/JobAds.scala
@@ -26,7 +26,7 @@ object JobAds extends Controller with implicits.Requests {
 
   def renderJobs = Action.async { implicit request =>
     Future.successful {
-      (JobsAgent.specificJobs(specificIds) ++ JobsAgent.jobsTargetedAt(segment)).distinct match {
+      (JobsAgent.specificJobs(specificIds) ++ JobsAgent.jobsTargetedAt(segment)).distinct.toList match {
         case Nil => NoCache(jsonFormat.nilResult)
         case jobs => Cached(componentMaxAge) {
           val clickMacro = request.getParameter("clickMacro")

--- a/commercial/app/controllers/commercial/Masterclasses.scala
+++ b/commercial/app/controllers/commercial/Masterclasses.scala
@@ -15,7 +15,7 @@ object Masterclasses extends Controller with implicits.Requests {
 
       val selectedMasterclasses: Seq[Masterclass] = (MasterclassAgent.specificMasterclasses(specificIds) ++
                                              MasterclassAgent.masterclassesTargetedAt(segment)).distinct
-      selectedMasterclasses match {
+      selectedMasterclasses.toList match {
         case Nil => NoCache(jsonFormat.nilResult)
         case masterclasses => Cached(componentMaxAge) {
           val clickMacro = request.getParameter("clickMacro")

--- a/commercial/app/controllers/commercial/SoulmatesController.scala
+++ b/commercial/app/controllers/commercial/SoulmatesController.scala
@@ -23,7 +23,7 @@ object SoulmatesController extends Controller with implicits.Requests {
       } else SoulmatesAgent.sample(groupName)
     }
 
-    sample match {
+    sample.toList match {
       case Nil => NoCache(jsonFormat.nilResult)
       case soulmates => Cached(componentMaxAge) {
         val clickMacro = request.getParameter("clickMacro")

--- a/commercial/app/controllers/commercial/TravelOffers.scala
+++ b/commercial/app/controllers/commercial/TravelOffers.scala
@@ -12,7 +12,7 @@ object TravelOffers extends Controller with implicits.Requests {
     Future.successful {
       val travelOffers = (TravelOffersAgent.specificTravelOffers(specificIds) ++
                       TravelOffersAgent.offersTargetedAt(segment)).distinct
-      travelOffers match {
+      travelOffers.toList match {
         case Nil => NoCache(jsonFormat.nilResult)
         case offers => Cached(componentMaxAge) {
           val clickMacro = request.getParameter("clickMacro")

--- a/common/app/common/Futures.scala
+++ b/common/app/common/Futures.scala
@@ -8,7 +8,7 @@ object Futures extends ExecutionContexts {
     require(batchSize > 0, "Batch size must be greater than 0")
 
     @tailrec
-    def iter(as: Seq[Seq[A]], acc: Future[Seq[B]]): Future[Seq[B]] = as match {
+    def iter(as: Seq[Seq[A]], acc: Future[Seq[B]]): Future[Seq[B]] = as.toList match {
       case Nil => acc
 
       case batch +: remainingBatches =>

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -524,17 +524,17 @@ final case class Tags(
 
   def contributorAvatar: Option[String] = tags.flatMap(_.contributorImagePath).headOption
 
-  private def tagsOfType(tagType: String): Seq[Tag] = tags.filter(_.properties.tagType == tagType)
+  private def tagsOfType(tagType: String): List[Tag] = tags.filter(_.properties.tagType == tagType)
 
-  lazy val keywords: Seq[Tag] = tagsOfType("Keyword")
-  lazy val nonKeywordTags: Seq[Tag] = tags.filterNot(_.properties.tagType == "Keyword")
-  lazy val contributors: Seq[Tag] = tagsOfType("Contributor")
+  lazy val keywords: List[Tag] = tagsOfType("Keyword")
+  lazy val nonKeywordTags: List[Tag] = tags.filterNot(_.properties.tagType == "Keyword")
+  lazy val contributors: List[Tag] = tagsOfType("Contributor")
   lazy val isContributorPage: Boolean = contributors.nonEmpty
-  lazy val series: Seq[Tag] = tagsOfType("Series")
-  lazy val blogs: Seq[Tag] = tagsOfType("Blog")
-  lazy val tones: Seq[Tag] = tagsOfType("Tone")
-  lazy val types: Seq[Tag] = tagsOfType("Type")
-  lazy val tracking: Seq[Tag] = tagsOfType("Tracking")
+  lazy val series: List[Tag] = tagsOfType("Series")
+  lazy val blogs: List[Tag] = tagsOfType("Blog")
+  lazy val tones: List[Tag] = tagsOfType("Tone")
+  lazy val types: List[Tag] = tagsOfType("Type")
+  lazy val tracking: List[Tag] = tagsOfType("Tracking")
 
   lazy val richLink: Option[String] = tags.flatMap(_.richLinkId).headOption
   lazy val openModule: Option[String] = tags.flatMap(_.openModuleId).headOption

--- a/common/app/services/repositories.scala
+++ b/common/app/services/repositories.scala
@@ -65,7 +65,7 @@ trait Index extends ConciergeRepository with Collections {
       .pageSize(if (isRss) IndexPagePagination.rssPageSize else IndexPagePagination.pageSize)
       .showFields(if (isRss) rssFields else QueryDefaults.trailFields)
     ).map {response =>
-      val trails = response.results.map(IndexPageItem(_))
+      val trails = response.results.map(IndexPageItem(_)).toList
       trails match {
         case Nil => Right(NotFound)
         case head :: _ =>

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -45,7 +45,7 @@ object MediaInSectionController extends Controller with Logging with Paging with
       .showFields("all")
     ).map {
       response =>
-        response.results filter { content => isCurrentStory(content) } map { result =>
+        response.results.toList filter { content => isCurrentStory(content) } map { result =>
           RelatedContentItem(result)
         } match {
           case Nil => None

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -31,9 +31,9 @@ object MostPopularController extends Controller with Logging with ExecutionConte
     val sectionPopular: Future[List[MostPopular]] = if (path.nonEmpty) lookup(edition, path).map(_.toList) else Future(Nil)
 
     sectionPopular.map { sectionPopular =>
-      lazy val sectionFirst = sectionPopular ++ globalPopular
-      lazy val globalFirst = globalPopular.toList ++ sectionPopular
-      lazy val mostPopular = if (path == "global-development") sectionFirst else globalFirst
+      val sectionFirst = sectionPopular ++ globalPopular
+      val globalFirst = globalPopular.toList ++ sectionPopular
+      val mostPopular: List[MostPopular] = if (path == "global-development") sectionFirst else globalFirst
 
       mostPopular match {
         case Nil => NotFound

--- a/onward/app/controllers/MostViewedAudioController.scala
+++ b/onward/app/controllers/MostViewedAudioController.scala
@@ -24,14 +24,14 @@ object MostViewedAudioController extends Controller with Logging with ExecutionC
     }
   }
 
-  private def getMostViewedAudio()(implicit request: RequestHeader): Seq[RelatedContentItem] = {
+  private def getMostViewedAudio()(implicit request: RequestHeader): List[RelatedContentItem] = {
     val size = request.getQueryString("size").getOrElse("4").toInt
-    MostViewedAudioAgent.mostViewedAudio().take(size)
+    MostViewedAudioAgent.mostViewedAudio().take(size).toList
   }
 
-  private def getMostViewedPodcast()(implicit request: RequestHeader): Seq[RelatedContentItem] = {
+  private def getMostViewedPodcast()(implicit request: RequestHeader): List[RelatedContentItem] = {
     val size = request.getQueryString("size").getOrElse("4").toInt
-    MostViewedAudioAgent.mostViewedPodcast().take(size)
+    MostViewedAudioAgent.mostViewedPodcast().take(size).toList
   }
 
   private def renderMostViewedAudio(audios: Seq[RelatedContentItem], mediaType: String)(implicit request: RequestHeader) = Cached(900) {

--- a/onward/app/controllers/MostViewedGalleryController.scala
+++ b/onward/app/controllers/MostViewedGalleryController.scala
@@ -33,9 +33,9 @@ object MostViewedGalleryController extends Controller with Logging with Executio
   }
   def renderMostViewedHtml() = renderMostViewed()
 
-  private def getMostViewedGallery()(implicit request: RequestHeader): Seq[RelatedContentItem] = {
+  private def getMostViewedGallery()(implicit request: RequestHeader): List[RelatedContentItem] = {
     val size = request.getQueryString("size").getOrElse("6").toInt
-    MostViewedGalleryAgent.mostViewedGalleries().take(size)
+    MostViewedGalleryAgent.mostViewedGalleries().take(size).toList
   }
 
   private def renderMostViewedGallery(galleries: Seq[RelatedContentItem])(implicit request: RequestHeader) = {

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -43,13 +43,13 @@ object TaggedContentController extends Controller with Related with Logging with
     "theguardian/series/guardiancommentcartoon"
   )
 
-  private def lookup(tag: String, edition: Edition)(implicit request: RequestHeader): Future[Seq[ContentType]] = {
+  private def lookup(tag: String, edition: Edition)(implicit request: RequestHeader): Future[List[ContentType]] = {
     log.info(s"Fetching tagged stories for edition ${edition.id}")
     getResponse(ContentApiClient.search(edition)
       .tag(tag)
       .pageSize(3)
     ).map { response =>
-        response.results map { Content(_) }
+        response.results.toList map { Content(_) }
     } recover { case GuardianContentApiThriftError(404, message, _) =>
       log.info(s"Got a 404 while calling content api: $message")
       Nil

--- a/onward/app/controllers/TopStoriesController.scala
+++ b/onward/app/controllers/TopStoriesController.scala
@@ -34,7 +34,7 @@ object TopStoriesController extends Controller with Logging with Paging with Exe
     ContentApiClient.getResponse(ContentApiClient.item("/", edition)
       .showEditorsPicks(true)
     ).map { response =>
-        response.editorsPicks.getOrElse(Nil) map { item =>
+        response.editorsPicks.getOrElse(Seq.empty).toList map { item =>
           RelatedContentItem(item)
         } match {
           case Nil => None

--- a/onward/app/controllers/VideoEndSlateController.scala
+++ b/onward/app/controllers/VideoEndSlateController.scala
@@ -33,7 +33,7 @@ object VideoEndSlateController extends Controller with Logging with Paging with 
       .showFields("all")
     ).map {
         response =>
-          response.results filter { content => !isCurrentStory(content) } map { result =>
+          response.results.toList filter { content => !isCurrentStory(content) } map { result =>
             Content(result)
           } collect {
             case v: Video => v

--- a/onward/app/services/repositories.scala
+++ b/onward/app/services/repositories.scala
@@ -20,7 +20,7 @@ trait Related extends ConciergeRepository {
     } else {
 
       // doesn't like "tag" being an empty string - need to explicitly pass a None
-      val tags: Option[String] = excludeTags match {
+      val tags: Option[String] = excludeTags.toList match {
         case Nil => None
         case excluding => Some(excluding.map(t => s"-$t").mkString(","))
       }

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -90,7 +90,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
     response map { Cached(60) }
   }
 
-  def loadMoreOn(request: RequestHeader, theMatch: FootballMatch): Future[Seq[ContentType]] = {
+  def loadMoreOn(request: RequestHeader, theMatch: FootballMatch): Future[List[ContentType]] = {
     val matchDate = theMatch.date.toLocalDate
 
     ContentApiClient.getResponse(ContentApiClient.search(Edition(request))
@@ -100,7 +100,7 @@ object MoreOnMatchController extends Controller with Football with Requests with
       .toDate(matchDate.plusDays(2).toDateTimeAtStartOfDay)
       .reference(s"pa-football-team/${theMatch.homeTeam.id},pa-football-team/${theMatch.awayTeam.id}")
     ).map{ response =>
-        response.results.map(Content(_))
+        response.results.map(Content(_)).toList
     }
   }
 

--- a/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
+++ b/sport/app/rugby/feed/rugbyOptaDeserialisation.scala
@@ -255,7 +255,7 @@ object Parser {
   }
 
   private def chainAttributes(attributes: Iterable[MetaData]): MetaData = {
-    attributes match {
+    attributes.toList match {
       case Nil => Null
       case head :: tail => new UnprefixedAttribute(head.key, head.value, chainAttributes(tail))
     }


### PR DESCRIPTION
I've gone through the all code since https://github.com/guardian/frontend/pull/12529 and fixed any places where a `Seq` reference is used to pattern match with a `Nil` case. `Nil` is a subclass of `List`, not `Seq`. That means it's possible for a non-`List` object to passed in, and the pattern match will fail with an exception.
