### PR TITLE
Fix beacon URL for analytics confidence

### DIFF
--- a/common/app/views/fragments/analytics/omniture.scala.html
+++ b/common/app/views/fragments/analytics/omniture.scala.html
@@ -23,9 +23,7 @@
                 <img id="omnitureNoScriptImage" alt=""
                 src="@Html(omnitureCall)" width="1" height="1" class="u-h" />
                 <img id="omnitureConfidenceNoScriptImage" alt=""
-                src="@{
-                    Configuration.debug.beaconUrl
-                }/count/pva.gif" width="1" height="1" class="u-h" />
+                src="@{Configuration.debug.beaconUrl}/count/pva.gif" width="1" height="1" class="u-h" />
             </div>
         </noscript>
     }


### PR DESCRIPTION
## What does this change?

I noticed that Omniture confidence dropped after my release. Turns out my IDE auto-formatted a URL and somewhere out there it managed to upset some browsers.
## What is the value of this and can you measure success?

Omniture confidence returns to previous level
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![image](https://cloud.githubusercontent.com/assets/76709/14497807/03c759b2-0190-11e6-9cd8-57a39e12c2ab.png)
## Request for comment
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
