### PR TITLE
Fix old message layout #11515

### DIFF
--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -1130,3 +1130,15 @@
         }
     }
 }
+
+.content--interactive {
+    .tonal__main--tone-news {
+        .old-article-message {
+            @include mq(tablet) {
+                position: absolute;
+                left: 0;
+                top: 44px;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?

This fixes the layout of the old article message for tablet layout.
## What is the value of this and can you measure success?

Fixes a bug where elements were overlaying.
## Does this affect other platforms - Amp, Apps, etc?

This fix is targeted only at interactives with the news tone tag.
## Screenshots

<img width="719" alt="picture 1" src="https://cloud.githubusercontent.com/assets/8607683/14500176/05aa1d24-0199-11e6-9425-f6d5f4441766.png">
