### PR TITLE
etag should be in quotes!

### DIFF
--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -63,7 +63,7 @@ object Cached extends implicits.Dates {
       "Cache-Control" -> cacheControl,
       "Expires" -> expiresTime.toHttpDateTimeString,
       "Date" -> now.toHttpDateTimeString,
-      "ETag" -> s"johnTest${scala.util.Random.nextInt}${scala.util.Random.nextInt}" // see if we get any If-None-Match requests
+      "ETag" -> s""""johnTest${scala.util.Random.nextInt}${scala.util.Random.nextInt}"""" // see if we get any If-None-Match requests
     )
   }
 }


### PR DESCRIPTION
Turns out etag should be
ETag: "etag goes here"

note the quotes... I was mentally discounting them!

@jamespamplin 
