### PR TITLE
Change password max length to 72 when changing password

### DIFF
--- a/identity/app/form/Mappings.scala
+++ b/identity/app/form/Mappings.scala
@@ -43,7 +43,7 @@ trait Mappings extends I18nSupport {
   val idSecondName: Mapping[String] = nonEmptyText(maxLength = 50)
 
   val idPassword: Mapping[String] = text verifying(
-    Messages("error.passwordLength"), {value => 6 <= value.length && value.length <= 20}
+    Messages("error.passwordLength"), {value => 6 <= value.length && value.length <= 72}
   )
 
   val idCountry = comboList("" :: Countries.all)

--- a/identity/app/views/password/changePassword.scala.html
+++ b/identity/app/views/password/changePassword.scala.html
@@ -33,7 +33,7 @@ passwordExists: Boolean
                         @inputField(Password(passwordForm("oldPassword"), ('_label, "Old Password"), ('class, "js-register-password"),
                         ('tabindex, 1), ('maxlength, 72), (Symbol("data-test-id"), "old-password")))
                     }
-                    @inputField(Password(passwordForm("newPassword1"), ('_label, "New Password"), ('_help, "Between 6 and 20 characters"),
+                    @inputField(Password(passwordForm("newPassword1"), ('_label, "New Password"), ('_help, "Between 6 and 72 characters"),
                     ('class, "js-register-password js-password-strength"), ('tabindex, 2), ('maxlength, 72), (Symbol("data-test-id"), "new-password")))
 
                     @inputField(Password(passwordForm("newPassword2"), ('_label, "Repeat New Password"), ('class, "js-register-password"),

--- a/identity/app/views/password/changePassword.scala.html
+++ b/identity/app/views/password/changePassword.scala.html
@@ -31,13 +31,13 @@ passwordExists: Boolean
                 <ul class="u-unstyled">
                     @if(passwordExists) {
                         @inputField(Password(passwordForm("oldPassword"), ('_label, "Old Password"), ('class, "js-register-password"),
-                        ('tabindex, 1), ('maxlength, 20), (Symbol("data-test-id"), "old-password")))
+                        ('tabindex, 1), ('maxlength, 72), (Symbol("data-test-id"), "old-password")))
                     }
                     @inputField(Password(passwordForm("newPassword1"), ('_label, "New Password"), ('_help, "Between 6 and 20 characters"),
-                    ('class, "js-register-password js-password-strength"), ('tabindex, 2), ('maxlength, 20), (Symbol("data-test-id"), "new-password")))
+                    ('class, "js-register-password js-password-strength"), ('tabindex, 2), ('maxlength, 72), (Symbol("data-test-id"), "new-password")))
 
                     @inputField(Password(passwordForm("newPassword2"), ('_label, "Repeat New Password"), ('class, "js-register-password"),
-                    ('tabindex, 3), ('maxlength, 20), (Symbol("data-test-id"), "new-password-repeat")))
+                    ('tabindex, 3), ('maxlength, 72), (Symbol("data-test-id"), "new-password-repeat")))
 
                     <li class="form-field form-field__submit">
                         <button type="submit" class="submit-input" data-link-name="Change password" tabindex="4" data-test-id="change-pwd">Change password</button>

--- a/identity/app/views/registration.scala.html
+++ b/identity/app/views/registration.scala.html
@@ -58,8 +58,8 @@
                         (Symbol("data-test-id"), "reg-username")))
 
                     @inputField(Password(registrationForm("user.password"), ('_label, "Password"),
-                        ('_help, "Between 6 and 20 characters"), ('class, "js-register-password js-password-strength"),
-                        ('tabindex, 3), ('maxlength, 20), (Symbol("data-test-id"), "reg-pwd")))
+                        ('_help, "Between 6 and 72 characters"), ('class, "js-register-password js-password-strength"),
+                        ('tabindex, 3), ('maxlength, 72), (Symbol("data-test-id"), "reg-pwd")))
 
                     <li class="form-field form-field--no-margin">
                         <label class="check-label" for="@registrationForm("receive_gnm_marketing").id">

--- a/identity/conf/messages.en
+++ b/identity/conf/messages.en
@@ -1,5 +1,5 @@
 error.email=Please enter a valid email address
-error.passwordLength=Please enter a password between 6 and 20 characters
+error.passwordLength=Please enter a password between 6 and 72 characters
 error.passwordsMustMatch=The passwords don't match, please try again
 error.passwordMustChange=The new password must be different from the current password.
 error.login=That email address/password combination doesn't match our records. Please try again


### PR DESCRIPTION
- change max length on input boxes on change password fields to 72
- Change max length copy 
- set new max length of 72 in the validation of user input

This affects the change password, reset password and the legacy sign up pages
