### PR TITLE
add minute script to articles

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -61,6 +61,10 @@ define([
                 bootstrapContext('article', article);
                 bootstrapContext('article : image-content', imageContent);
             });
+
+            if (ab.isInVariant('Minute', 'on')) {
+                require('bootstraps/enhanced/minute', function() {});
+            }
         }
 
         if (config.page.contentType === 'Crossword' || config.page.pageId === 'offline-page') {


### PR DESCRIPTION
# Minute.ly test

Adding the Minute script to the article page will make it possible to test the automation.
Reiterating, this will never be served to anyone, unless you set the A/B test.
## What is the value of this and can you measure success?

We can test the minute script
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screamshots

:scream: 
## Request for comment

@akash1810 @rich-nguyen 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
