### PR TITLE
Updated healthcheck for training-preview

### DIFF
--- a/training-preview/app/controllers/TrainingHealthCheck.scala
+++ b/training-preview/app/controllers/TrainingHealthCheck.scala
@@ -40,7 +40,7 @@ class TrainingHttp extends contentapi.Http with ExecutionContexts {
 
 object TrainingHealthCheck extends AllGoodHealthcheckController(
  9016,
- "/world/2012/sep/11/barcelona-march-catalan-independence"
+ "/info/developer-blog/2016/apr/14/training-preview-healthcheck"
 ) {
 
   def init: Unit = {


### PR DESCRIPTION
Healthcheck is currently failing for training-preview. This is due to a CAPI reindex of content on CODE whereby the previous healthcheck no longer exists.
## What does this change?

Healthcheck on training-preview
## What is the value of this and can you measure success?

Fixes training-preview - used by editorial for training on composer code
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshot

Of the page being healthchecked:

![training-preview-healthcheck](https://cloud.githubusercontent.com/assets/2298529/14531310/bc6dee12-0254-11e6-85de-374a0d823ba9.png)
