### PR TITLE
Initialise phone number reflection on application startup

### DIFF
--- a/identity/app/conf/IdentityLifecycle.scala
+++ b/identity/app/conf/IdentityLifecycle.scala
@@ -2,6 +2,7 @@ package conf
 
 import common.{AkkaAsync, Jobs, ExecutionContexts}
 import jobs.{TorExitNodeList, BlockedEmailDomainList}
+import model.PhoneNumbers
 import play.api.GlobalSettings
 
 trait IdentityLifecycle extends GlobalSettings with ExecutionContexts {
@@ -29,6 +30,7 @@ trait IdentityLifecycle extends GlobalSettings with ExecutionContexts {
     AkkaAsync {
       BlockedEmailDomainList.run()
       TorExitNodeList.run()
+      PhoneNumbers
     }
   }
 

--- a/identity/test/controllers/EditProfileControllerTest.scala
+++ b/identity/test/controllers/EditProfileControllerTest.scala
@@ -5,7 +5,7 @@ import client.Auth
 import com.gu.identity.cookie.GuUCookieData
 import com.gu.identity.model._
 import idapiclient.{TrackingData, _}
-import model.Countries
+import model.{PhoneNumbers, Countries}
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, Matchers}
 import org.scalatest._
@@ -32,6 +32,7 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
   val user = User("test@example.com", userId, statusFields = StatusFields(receive3rdPartyMarketing = Some(true), receiveGnmMarketing = Some(true)))
   val testAuth = ScGuU("abc", GuUCookieData(user, 0, None))
   val authenticatedUser = AuthenticatedUser(user, testAuth)
+  val phoneNumbers = PhoneNumbers
 
   val authenticatedActions = new AuthenticatedActions(authService, api, mock[IdentityUrlBuilder])
 
@@ -69,7 +70,7 @@ class EditProfileControllerTest extends path.FreeSpec with ShouldMatchers with M
 
       val result = controller.submitPublicProfileForm().apply(fakeRequest)
 
-      Await.result(result, 5.seconds)
+      Await.result(result, 2.seconds)
 
       "then the user should be saved on the ID API" in {
         val userUpdateCapture = ArgumentCaptor.forClass(classOf[UserUpdate])

--- a/identity/test/model/PhoneNumbersTest.scala
+++ b/identity/test/model/PhoneNumbersTest.scala
@@ -1,0 +1,15 @@
+package model
+
+import org.scalatest.{ShouldMatchers, FlatSpec}
+
+class PhoneNumbersTest extends FlatSpec with ShouldMatchers {
+
+  behavior of "PhoneNumbers"
+
+  it should "correct country codes" in {
+    PhoneNumbers.countryCodes.contains(1) should be(true)
+    PhoneNumbers.countryCodes.contains(44) should be(true)
+    PhoneNumbers.countryCodes.contains(61) should be(true)
+  }
+
+}


### PR DESCRIPTION
# Initialise phone number reflection on application startup
## What does this change?

This moves the potentially slow reflection code into application startup rather than executing on rendering of the account edit page.
## What is the value of this and can you measure success?

Faster rendering of the account edit page.  Blocking reflection code is removed from page rendering.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

None
## Request for comment
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
