### PR TITLE
Set correct credentials for Logback kinesis appender

### DIFF
--- a/common/app/common/Logback/Logstash.scala
+++ b/common/app/common/Logback/Logstash.scala
@@ -40,7 +40,7 @@ object Logstash {
     )
   }
 
-  def init(logger: LoggerLike) = {
+  def init(logger: LoggerLike): Unit = {
     if(Switches.LogstashLogging.isSwitchedOn) {
       config.fold(logger.info("Logstash config is missing"))(LogbackConfig.initLogger(logger, _))
     } else {

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -502,7 +502,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val enabled = configuration.getStringProperty("logstash.enabled").map(_.toBoolean).getOrElse(false)
     lazy val stream = configuration.getStringProperty("logstash.stream.name")
     lazy val streamRegion = configuration.getStringProperty("logstash.stream.region")
-    lazy val streamRole = configuration.getStringProperty("logstash.stream.role")
   }
 }
 


### PR DESCRIPTION
## What does this change?

Set correct credentials for Logback kinesis appender

Also refactor LogbackConfig so it doesn't rely on the Configuration
object
## What is the value of this and can you measure success?

Applications can then publish logs to the kinesis stream
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@jamespamplin 
