### PR TITLE
Fix GET /news-alert/alerts on preview

### DIFF
--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -185,7 +185,8 @@ object Frontend extends Build with Prototypes {
     applications,
     sport,
     commercial,
-    onward
+    onward,
+    adminJobs
   )
 
   val preview = application("preview").dependsOn(withTests(common), standalone).settings(

--- a/standalone/conf/standalone.routes
+++ b/standalone/conf/standalone.routes
@@ -196,6 +196,9 @@ GET        /weatherapi/city/:id.json                                            
 GET        /weatherapi/city.json                                                               weather.controllers.LocationsController.whatIsMyCity()
 GET        /weatherapi/locations                                                               weather.controllers.LocationsController.findCity(query: String)
 
+# Breaking News
+GET        /news-alert/alerts                                                                  controllers.NewsAlertController.alerts()
+
 # Articles
 GET        /*path.json                                                                         controllers.ArticleController.renderLiveBlogJson(path, lastUpdate: Option[String], rendered: Option[Boolean], isLivePage: Option[Boolean])
 GET        /*path/email                                                                        controllers.ArticleController.renderArticle(path)


### PR DESCRIPTION
## What does this change?

GET /news-alert/alerts is currently failing on preview. This patch fixes the problem by adding admin-jobs to the standalone app and creating the correct route in standalone routes file
## What is the value of this and can you measure success?

No more error when fetching /news-alert/alerts from preview
## Request for comment

@jamespamplin 
