### PR TITLE
Log better error when MostPopularAgent update requests fail

### DIFF
--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -5,8 +5,8 @@ import common._
 import services.OphanApi
 import play.api.libs.json.{JsArray, JsValue}
 import model.RelatedContentItem
-import scala.concurrent.duration._
 import scala.concurrent.Future
+import scala.util.control.NonFatal
 import ContentApiClient.getResponse
 
 object MostPopularAgent extends Logging with ExecutionContexts {
@@ -59,7 +59,7 @@ object GeoMostPopularAgent extends Logging with ExecutionContexts {
         getResponse(ContentApiClient.item(urlToContentPath(url), Edition.defaultEdition))
           .map(_.content.map(RelatedContentItem(_)))
           .recover {
-            case e: Throwable =>
+            case NonFatal(e)  =>
               log.error(s"Error requesting $url", e)
               None
           }
@@ -111,7 +111,7 @@ object DayMostPopularAgent extends Logging with ExecutionContexts {
         getResponse(ContentApiClient.item(urlToContentPath(url), Edition.defaultEdition ))
           .map(_.content.map(RelatedContentItem(_)))
           .recover {
-            case e: Throwable =>
+            case NonFatal(e) =>
               log.error(s"Error requesting $url", e)
               None
           }

--- a/onward/app/feed/MostPopularAgent.scala
+++ b/onward/app/feed/MostPopularAgent.scala
@@ -58,9 +58,11 @@ object GeoMostPopularAgent extends Logging with ExecutionContexts {
       } yield {
         getResponse(ContentApiClient.item(urlToContentPath(url), Edition.defaultEdition))
           .map(_.content.map(RelatedContentItem(_)))
-          .fallbackTo{
-            log.error(s"Error requesting $url")
-            Future.successful(None)}
+          .recover {
+            case e: Throwable =>
+              log.error(s"Error requesting $url", e)
+              None
+          }
       }
 
       Future.sequence(mostRead).map { contentSeq =>
@@ -108,9 +110,11 @@ object DayMostPopularAgent extends Logging with ExecutionContexts {
       } yield {
         getResponse(ContentApiClient.item(urlToContentPath(url), Edition.defaultEdition ))
           .map(_.content.map(RelatedContentItem(_)))
-          .fallbackTo{
-            log.error(s"Error requesting $url")
-            Future.successful(None)}
+          .recover {
+            case e: Throwable =>
+              log.error(s"Error requesting $url", e)
+              None
+          }
       }
 
       Future.sequence(mostRead).map { contentSeq =>


### PR DESCRIPTION
## What does this change?

Better logging when the MostPopularAgents update requests fail
## What is the value of this and can you measure success?

This is one of the most recurrent error on preview and training-preview. (see below)
Trying to find out what is the issue is
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![screen shot 2016-04-15 at 17 18 49](https://cloud.githubusercontent.com/assets/233326/14567920/52536798-032e-11e6-9fcf-5c50d67b2cfb.png)
## Request for comment

@jamespamplin 
