### PR TITLE
added SwitchGroup case class with optional description

### DIFF
--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -17,7 +17,10 @@
     <form id="switchboard" action="/dev/switchboard" method="POST">
         <input type="hidden" name="lastModified" value="@lastModified" />
         @conf.switches.Switches.grouped.map { case (group, switches) =>
-            <h4>@group</h4>
+            <h4>@group.name</h4>
+            @for(description <- group.description){
+                <p class="sub-heading">@description</p>
+            }
             <div class="well">
                 @switches.map { switch =>
                     @defining(Switch.expiry(switch)) { expiry =>

--- a/admin/public/css/switchboard.css
+++ b/admin/public/css/switchboard.css
@@ -17,6 +17,10 @@ html {
     margin: 20px;
 }
 
+.sub-heading {
+    font-style: italic;
+}
+
 input[type="text"] {
     background-color: #DFF0D8;
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -5,7 +5,7 @@ import org.joda.time.LocalDate
 trait ABTestSwitches {
 
   val ABDummyTest = Switch(
-    "A/B Tests",
+    SwitchGroup.ABTests,
     "ab-dummy-test",
     "A do-nothing AA test, for the data team",
     safeState = Off,
@@ -15,7 +15,7 @@ trait ABTestSwitches {
 
   // Owner: Dotcom Reach
   val ABFrontsOnArticles2 = Switch(
-    "A/B Tests",
+    SwitchGroup.ABTests,
     "ab-fronts-on-articles2",
     "Injects fronts on articles for the test",
     safeState = Off,
@@ -24,7 +24,7 @@ trait ABTestSwitches {
   )
 
   val ABNextInSeries = Switch(
-    "A/B Tests",
+    SwitchGroup.ABTests,
     "ab-next-in-series",
     "Show next in series",
     safeState = Off,
@@ -33,7 +33,7 @@ trait ABTestSwitches {
   )
 
   val ABIdentityRegisterMembershipStandfirst = Switch(
-    "A/B Tests",
+    SwitchGroup.ABTests,
     "ab-identity-register-membership-standfirst",
     "Membership registration page variant for Identity",
     safeState = Off,
@@ -42,7 +42,7 @@ trait ABTestSwitches {
   )
 
   val ABLiveBlogChromeNotificationsInternal = Switch(
-    "A/B Tests",
+    SwitchGroup.ABTests,
     "ab-live-blog-chrome-notifications-internal",
     "Live blog chrome notifications - Internal",
     safeState = Off,
@@ -51,7 +51,7 @@ trait ABTestSwitches {
   )
 
   val ABLiveBlogChromeNotificationsProd = Switch(
-    "A/B Tests",
+    SwitchGroup.ABTests,
     "ab-live-blog-chrome-notifications-prod",
     "Live blog chrome notifications - prod",
     safeState = Off,
@@ -60,7 +60,7 @@ trait ABTestSwitches {
   )
 
   val ABMembership = Switch(
-    "A/B Tests",
+    SwitchGroup.ABTests,
     "ab-membership",
     "Membership propositions",
     safeState = Off,
@@ -69,7 +69,7 @@ trait ABTestSwitches {
   )
 
   val ABLoyalAdblockingSurvey = Switch(
-    "A/B Tests",
+    SwitchGroup.ABTests,
     "ab-loyal-adblocking-survey",
     "An adblock ongoing survey for all loyal users",
     safeState = Off,
@@ -78,7 +78,7 @@ trait ABTestSwitches {
   )
 
   val ABMinute = Switch(
-    "A/B Tests",
+    SwitchGroup.ABTests,
     "ab-minute",
     "Switch to include the minute.ly script",
     safeState = Off,

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -6,7 +6,7 @@ import org.joda.time.LocalDate
 trait CommercialSwitches {
 
   val DfpCachingSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "dfp-caching",
     "Have Admin will poll DFP to precache adserving data.",
     safeState = On,
@@ -15,7 +15,7 @@ trait CommercialSwitches {
   )
 
   val HeaderBiddingUS = Switch(
-     "Commercial",
+     SwitchGroup.Commercial,
      "header-bidding-us",
      "Auction adverts on the client before calling DFP (US edition only)",
      safeState = Off,
@@ -24,7 +24,7 @@ trait CommercialSwitches {
   )
 
   val CommercialSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "commercial",
     "If this switch is OFF, no calls will be made to the ad server. BEWARE!",
     safeState = On,
@@ -33,7 +33,7 @@ trait CommercialSwitches {
   )
 
   val StandardAdvertsSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "standard-adverts",
     "Display 'standard' adverts, e.g. top banner ads, inline ads, MPUs, etc.",
     safeState = On,
@@ -42,7 +42,7 @@ trait CommercialSwitches {
   )
 
   val CommercialComponentsSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "commercial-components",
     "Display commercial components, e.g. jobs, soulmates.",
     safeState = On,
@@ -51,7 +51,7 @@ trait CommercialSwitches {
   )
 
   val VideoAdvertsSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "video-adverts",
     "Show adverts on videos.",
     safeState = On,
@@ -60,7 +60,7 @@ trait CommercialSwitches {
   )
 
   val SponsoredSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "sponsored",
     "Show sponsored badges, logos, etc.",
     safeState = On,
@@ -69,7 +69,7 @@ trait CommercialSwitches {
   )
 
   val LiveblogAdvertsSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "liveblog-adverts",
     "Show inline adverts on liveblogs",
     safeState = Off,
@@ -78,7 +78,7 @@ trait CommercialSwitches {
   )
 
   val AudienceScienceSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "audience-science",
     "If this switch is on, Audience Science segments will be used to target ads.",
     safeState = Off,
@@ -87,7 +87,7 @@ trait CommercialSwitches {
   )
 
   val AudienceScienceGatewaySwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "audience-science-gateway",
     "If this switch is on, Audience Science Gateway segments will be used to target ads.",
     safeState = Off,
@@ -96,7 +96,7 @@ trait CommercialSwitches {
   )
 
   val ImrWorldwideSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "imr-worldwide",
     "Enable the IMR Worldwide audience segment tracking.",
     safeState = Off,
@@ -105,7 +105,7 @@ trait CommercialSwitches {
   )
 
   val KruxSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "krux",
     "Enable Krux Control Tag",
     safeState = Off,
@@ -114,7 +114,7 @@ trait CommercialSwitches {
   )
 
   val RemarketingSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "remarketing",
     "Enable Remarketing tracking",
     safeState = Off,
@@ -123,7 +123,7 @@ trait CommercialSwitches {
   )
 
   val TravelFeedFetchSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "gu-travel-feed-fetch",
     "If this switch is on, cached travel offers feed will be updated from external source.",
     safeState = Off,
@@ -132,7 +132,7 @@ trait CommercialSwitches {
   )
 
   val TravelFeedParseSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "gu-travel-feed-parse",
     "If this switch is on, commercial components will be fed by travel offers feed.",
     safeState = Off,
@@ -141,7 +141,7 @@ trait CommercialSwitches {
   )
 
   val JobFeedReadSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "gu-jobs-feed-read",
     "If this switch is on, cached jobs feed will be updated from external source.",
     safeState = Off,
@@ -150,7 +150,7 @@ trait CommercialSwitches {
   )
 
   val JobParseSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "gu-jobs-parse",
     "If this switch is on, commercial components will be fed by job feed.",
     safeState = Off,
@@ -159,7 +159,7 @@ trait CommercialSwitches {
   )
 
   val MembersAreaSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "gu-members-area",
     "If this switch is on, content flagged with membershipAccess will be protected",
     safeState = On,
@@ -168,7 +168,7 @@ trait CommercialSwitches {
   )
 
   val EventsFeedSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "gu-events",
     "If this switch is on, commercial components will be fed by masterclass and live-events feeds.",
     safeState = Off,
@@ -177,7 +177,7 @@ trait CommercialSwitches {
   )
 
   val SoulmatesFeedSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "gu-soulmates",
     "If this switch is on, commercial components will be fed by soulmates feed.",
     safeState = Off,
@@ -186,7 +186,7 @@ trait CommercialSwitches {
   )
 
   val MoneysupermarketFeedsSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "moneysupermarket",
     "If this switch is on, commercial components will be fed by Moneysupermarket feeds.",
     safeState = Off,
@@ -195,7 +195,7 @@ trait CommercialSwitches {
   )
 
   val LCMortgageFeedSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "lc-mortgages",
     "If this switch is on, commercial components will be fed by London & Country mortgage feed.",
     safeState = Off,
@@ -204,7 +204,7 @@ trait CommercialSwitches {
   )
 
   val GuBookshopFeedsSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "gu-bookshop",
     "If this switch is on, commercial components will be fed by the Guardian Bookshop feed.",
     safeState = Off,
@@ -213,7 +213,7 @@ trait CommercialSwitches {
   )
 
   val BookLookupSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "book-lookup",
     "If this switch is on, book data will be looked up using a third-party service.",
     safeState = Off,
@@ -222,7 +222,7 @@ trait CommercialSwitches {
   )
 
   val AdBlockMessage = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "adblock",
     "Switch for the Adblock Message.",
     safeState = Off,
@@ -231,7 +231,7 @@ trait CommercialSwitches {
   )
 
   val FixedTopAboveNavAdSlotSwitch = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "fixed-top-above-nav",
     "Fixes size of top-above-nav ad slot on fronts.",
     safeState = Off,
@@ -240,7 +240,7 @@ trait CommercialSwitches {
   )
 
   val KruxVideoTracking = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "krux-video-tracking",
     "If this switch is ON, there will be a Krux pixel fired to track particular videos",
     safeState = On,
@@ -249,7 +249,7 @@ trait CommercialSwitches {
   )
 
   val BritishCouncilBeacon = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "british-council-beacon",
     "British Council's beacon",
     safeState = Off,
@@ -258,7 +258,7 @@ trait CommercialSwitches {
   )
 
   val v2JobsTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-jobs-template",
     "Jobs component using template v2",
     safeState = Off,
@@ -267,7 +267,7 @@ trait CommercialSwitches {
   )
 
   val v2MasterclassesTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-masterclasses-template",
     "Masterclasses component using template v2",
     safeState = Off,
@@ -276,7 +276,7 @@ trait CommercialSwitches {
   )
 
   val v2BooksTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-books-template",
     "Books component using template v2",
     safeState = Off,
@@ -285,7 +285,7 @@ trait CommercialSwitches {
   )
 
   val v2TravelTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-travel-template",
     "Travel component using template v2",
     safeState = Off,
@@ -294,7 +294,7 @@ trait CommercialSwitches {
   )
 
   val v2SoulmatesTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-soulmates-template",
     "Soulmates component using template v2",
     safeState = Off,
@@ -303,7 +303,7 @@ trait CommercialSwitches {
   )
 
   val v2BlendedTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-blended-template",
     "Blended component using template v2",
     safeState = Off,
@@ -312,7 +312,7 @@ trait CommercialSwitches {
   )
 
   val v2ManualSingleTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-manual-single-template",
     "Manual single component using template v2",
     safeState = Off,
@@ -321,7 +321,7 @@ trait CommercialSwitches {
   )
 
   val v2ManualMultipleTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-manual-multiple-template",
     "Manual multiple component using template v2",
     safeState = Off,
@@ -330,7 +330,7 @@ trait CommercialSwitches {
   )
 
   val v2CapiSingleTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-capi-single-template",
     "Capi single component using template v2",
     safeState = Off,
@@ -339,7 +339,7 @@ trait CommercialSwitches {
   )
 
   val v2CapiMultipleTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-capi-multiple-template",
     "Capi multiple component using template v2",
     safeState = Off,
@@ -348,7 +348,7 @@ trait CommercialSwitches {
   )
 
   val v2FixedContainerTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-fixed-container-template",
     "Fixed paid containers using template v2",
     safeState = Off,
@@ -357,7 +357,7 @@ trait CommercialSwitches {
   )
 
   val v2DynamicContainerTemplate = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "v2-dynamic-container-template",
     "Dynamic paid containers using template v2",
     safeState = Off,
@@ -366,7 +366,7 @@ trait CommercialSwitches {
   )
 
   val cardsDecidePaidContainerBranding = Switch(
-    "Commercial",
+    SwitchGroup.Commercial,
     "cards-decide-paid-container-branding",
     "If on, the cards will decide the branding of their container",
     safeState = Off,

--- a/common/app/conf/switches/FaciaSwitches.scala
+++ b/common/app/conf/switches/FaciaSwitches.scala
@@ -7,7 +7,7 @@ trait FaciaSwitches {
   // Facia
 
   val FaciaToolDraftContent = Switch(
-    "Facia",
+    SwitchGroup.Facia,
     "facia-tool-draft-content",
     "If this switch is on facia tool will offer draft content to editors, and press draft fronts from draft content",
     safeState = On,
@@ -16,7 +16,7 @@ trait FaciaSwitches {
   )
 
   val FrontPressJobSwitch = Switch(
-    "Facia",
+    SwitchGroup.Facia,
     "front-press-job-switch",
     "If this switch is on then the jobs to push and pull from SQS will run",
     safeState = Off,
@@ -25,7 +25,7 @@ trait FaciaSwitches {
   )
 
   val FrontPressJobSwitchStandardFrequency = Switch(
-    "Facia",
+    SwitchGroup.Facia,
     "front-press-job-switch-standard-frequency",
     "If this switch is on then the jobs to push and pull from SQS will run",
     safeState = Off,
@@ -34,7 +34,7 @@ trait FaciaSwitches {
   )
 
   val FaciaPressOnDemand = Switch(
-    "Facia",
+    SwitchGroup.Facia,
     "facia-press-on-demand",
     "If this is switched on, you can force facia to press on demand (Leave off)",
     safeState = Off,
@@ -43,7 +43,7 @@ trait FaciaSwitches {
   )
 
   val FaciaInlineEmbeds = Switch(
-    "Facia",
+    SwitchGroup.Facia,
     "facia-inline-embeds",
     "If this is switched on, facia will prefetch embeds and render them on the server",
     safeState = Off,
@@ -52,7 +52,7 @@ trait FaciaSwitches {
   )
 
   val FaciaPressStatusNotifications = Switch(
-    "Facia",
+    SwitchGroup.Facia,
     "facia-press-status-notifications",
     "If this is switched off, facia press will not send status notification on kinesis",
     safeState = On,

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -6,7 +6,7 @@ import org.joda.time.LocalDate
 trait FeatureSwitches {
 
   val FixturesAndResultsContainerSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "fixtures-and-results-container",
     "Fixtures and results container on football tag pages",
     safeState = On,
@@ -15,7 +15,7 @@ trait FeatureSwitches {
   )
 
   val ChapterHeadingsSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "chapter-headings",
     "If this switch is turned on, we will add a block of chapter headings to the top of article pages",
     safeState = Off,
@@ -24,7 +24,7 @@ trait FeatureSwitches {
   )
 
   val OutbrainSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "outbrain",
     "Enable the Outbrain content recommendation widget on web and AMP.",
     safeState = Off,
@@ -33,7 +33,7 @@ trait FeatureSwitches {
   )
 
   val PlistaForOutbrainAU = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "plista-for-outbrain-au",
     "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition (for web only).",
     safeState = Off,
@@ -42,7 +42,7 @@ trait FeatureSwitches {
   )
 
   val ForeseeSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "foresee",
     "Enable Foresee surveys for a sample of our audience",
     safeState = Off,
@@ -51,7 +51,7 @@ trait FeatureSwitches {
   )
 
   val GeoMostPopular = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "geo-most-popular",
     "If this is switched on users then 'most popular' will be upgraded to geo targeted",
     safeState = On,
@@ -60,7 +60,7 @@ trait FeatureSwitches {
   )
 
   val FontSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "web-fonts",
     "If this is switched on then the custom Guardian web font will load.",
     safeState = On,
@@ -69,7 +69,7 @@ trait FeatureSwitches {
   )
 
   val FontKerningSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "font-kerning",
     "If this is switched on then fonts will be kerned/optimised for legibility.",
     safeState = On,
@@ -78,7 +78,7 @@ trait FeatureSwitches {
   )
 
   val SearchSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "google-search",
     "If this switch is turned on then Google search is added to the sections nav.",
     safeState = On,
@@ -87,7 +87,7 @@ trait FeatureSwitches {
   )
 
   val IdentityProfileNavigationSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "id-profile-navigation",
     "If this switch is on you will see the link in the topbar taking you through to the users profile or sign in..",
     safeState = On,
@@ -96,7 +96,7 @@ trait FeatureSwitches {
   )
 
   val FacebookAutoSigninSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "facebook-autosignin",
     "If this switch is on then users who have previously authorized the guardian app in facebook and who have not " +
       "recently signed out are automatically signed in.",
@@ -106,7 +106,7 @@ trait FeatureSwitches {
   )
 
   val FacebookShareUseTrailPicFirstSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "facebook-shareimage",
     "Facebook shares try to use article trail picture image first when switched ON, or largest available " +
       "image when switched OFF.",
@@ -116,7 +116,7 @@ trait FeatureSwitches {
   )
 
   val IdentityFormstackSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "id-formstack",
     "If this switch is on, formstack forms will be available",
     safeState = Off,
@@ -125,7 +125,7 @@ trait FeatureSwitches {
   )
 
   val IdentityAvatarUploadSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "id-avatar-upload",
     "If this switch is on, users can upload avatars on their profile page",
     safeState = Off,
@@ -134,7 +134,7 @@ trait FeatureSwitches {
   )
 
   val IdentityCookieRefreshSwitch = Switch(
-    "Identity",
+    SwitchGroup.Identity,
     "id-cookie-refresh",
     "If switched on, users cookies will be refreshed.",
     safeState = Off,
@@ -143,7 +143,7 @@ trait FeatureSwitches {
   )
 
   val EnhanceTweetsSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "enhance-tweets",
     "If this switch is turned on then embedded tweets will be enhanced using Twitter's widgets.",
     safeState = Off,
@@ -152,7 +152,7 @@ trait FeatureSwitches {
   )
 
   val EnhancedMediaPlayerSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "enhanced-media-player",
     "If this is switched on then videos are enhanced using our JavaScript player",
     safeState = On,
@@ -161,7 +161,7 @@ trait FeatureSwitches {
   )
 
   val MediaPlayerSupportedBrowsers = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "media-player-supported-browsers",
     "If this is switched on then a message will be displayed to UAs not supported by our media player",
     safeState = On,
@@ -170,7 +170,7 @@ trait FeatureSwitches {
   )
 
   val BreakingNewsSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "breaking-news",
     "If this is switched on then the breaking news feed is requested and articles are displayed",
     safeState = Off,
@@ -179,7 +179,7 @@ trait FeatureSwitches {
   )
 
   val WeatherSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "weather",
     "If this is switched on then the weather component is displayed",
     safeState = Off,
@@ -188,7 +188,7 @@ trait FeatureSwitches {
   )
 
   val HistoryTags = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "history-tags",
     "If this is switched on then personalised history tags are shown in the meganav",
     safeState = Off,
@@ -197,7 +197,7 @@ trait FeatureSwitches {
   )
 
   val IdentityBlockSpamEmails = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "id-block-spam-emails",
     "If switched on, any new registrations with emails from ae blacklisted domin will be blocked",
     safeState = On,
@@ -206,7 +206,7 @@ trait FeatureSwitches {
   )
 
   val IdentityLogRegistrationsFromTor = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "id-log-tor-registrations",
     "If switched on, any user registrations from a known tor exit node will be logged",
     safeState = On,
@@ -215,7 +215,7 @@ trait FeatureSwitches {
   )
 
   val FootballFeedRecorderSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "football-feed-recorder",
     "If switched on then football matchday feeds will be recorded every minute",
     safeState = Off,
@@ -224,7 +224,7 @@ trait FeatureSwitches {
   )
 
   val CrosswordSvgThumbnailsSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "crossword-svg-thumbnails",
     "If switched on, crossword thumbnails will be accurate SVGs",
     safeState = Off,
@@ -233,7 +233,7 @@ trait FeatureSwitches {
   )
 
   val SudokuSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "sudoku",
     "If switched on, sudokus will be available",
     safeState = Off,
@@ -242,7 +242,7 @@ trait FeatureSwitches {
   )
 
   val CricketScoresSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "cricket-scores",
     "If switched on, cricket score and scorecard link will be displayed",
     safeState = Off,
@@ -251,7 +251,7 @@ trait FeatureSwitches {
   )
 
   val RugbyScoresSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "rugby-world-cup",
     "If this switch is on rugby world cup scores will be loaded in to rugby match reports and liveblogs",
     safeState = Off,
@@ -260,7 +260,7 @@ trait FeatureSwitches {
   )
 
   val StocksWidgetSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "stocks-widget",
     "If switched on, a stocks widget will be displayed on the business front",
     safeState = On,
@@ -269,7 +269,7 @@ trait FeatureSwitches {
   )
 
   val DiscussionAllPageSizeSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "discussion-all-page-size",
     "If this is switched on then users will have the option to load all comments",
     safeState = Off,
@@ -278,7 +278,7 @@ trait FeatureSwitches {
   )
 
   val MissingVideoEndcodingsJobSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "check-for-missing-video-encodings",
     "If this switch is switched on then the job will run which will check all video content for missing encodings",
     safeState = Off,
@@ -287,7 +287,7 @@ trait FeatureSwitches {
   )
 
   val EmailInlineInFooterSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "email-inline-in-footer",
     "show the email sign-up in the footer",
     safeState = Off,
@@ -296,7 +296,7 @@ trait FeatureSwitches {
   )
 
   val UseAtomsSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "use-atoms",
     "use atoms from content api to enhance content",
     safeState = Off,
@@ -305,7 +305,7 @@ trait FeatureSwitches {
   )
 
   val AmpSwitch = Switch(
-    "Server-side A/B Tests",
+    SwitchGroup.ServerSideABTests,
     "amp-switch",
     "If this switch is on, link to amp pages will be in the metadata for articles",
     safeState = On,
@@ -314,7 +314,7 @@ trait FeatureSwitches {
   )
 
   val R2PagePressServiceSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "r2-page-press-service",
     "When ON, the R2 page press service will monitor the queue and press pages to S3",
     safeState = On,
@@ -323,7 +323,7 @@ trait FeatureSwitches {
   )
 
   val EmailInArticleSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "email-in-article",
     "When ON, the email sign-up form will show on articles matching the email lists utilising the email module",
     safeState = On,
@@ -332,7 +332,7 @@ trait FeatureSwitches {
   )
 
   val USElectionSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "us-election",
     "When ON, items tagged with us-news/us-elections-2016 will have visual elements added",
     safeState = On,
@@ -342,7 +342,7 @@ trait FeatureSwitches {
 
   // Owner: Dotcom loyalty
   val EmailInArticleGtodaySwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "email-in-article-gtoday",
     "When ON, the email sign-up form will show the Guardian today email sign-up on articles",
     safeState = On,
@@ -352,7 +352,7 @@ trait FeatureSwitches {
 
   // Owner: Dotcom loyalty
   val EmailInArticleOutbrainSwitch = Switch(
-    "Feature",
+    SwitchGroup.Feature,
     "email-in-article-outbrain",
     "When ON, we will check whether email sign-up will be shown and, if so, the outbrain non-compliant merchandising widget will be shown",
     safeState = On,

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -7,7 +7,7 @@ trait MonitoringSwitches {
   // Monitoring
 
   val OphanSwitch = Switch(
-    "Monitoring",
+    SwitchGroup.Monitoring,
     "ophan",
     "Enables the new Ophan tracking javascript",
     safeState = On,
@@ -16,7 +16,7 @@ trait MonitoringSwitches {
   )
 
   val GoogleAnalyticsSwitch = Switch(
-    "Monitoring",
+    SwitchGroup.Monitoring,
     "google-analytics",
     "If this switch is on, then Google Analytics is enabled",
     safeState = Off,
@@ -25,7 +25,7 @@ trait MonitoringSwitches {
   )
 
   val ScrollDepthSwitch = Switch(
-    "Monitoring",
+    SwitchGroup.Monitoring,
     "scroll-depth",
     "Enables tracking and measurement of scroll depth",
     safeState = Off,
@@ -34,7 +34,7 @@ trait MonitoringSwitches {
   )
 
   val CssLogging = Switch(
-    "Monitoring",
+    SwitchGroup.Monitoring,
     "css-logging",
     "If this is on, then a subset of clients will post css selector information for diagnostics.",
     safeState = Off,
@@ -43,7 +43,7 @@ trait MonitoringSwitches {
   )
 
   val CspReporting = Switch(
-    "Monitoring",
+    SwitchGroup.Monitoring,
     "csp-reporting",
     "Enables logging of CSP violations",
     safeState = Off,
@@ -52,7 +52,7 @@ trait MonitoringSwitches {
   )
 
   val ThirdPartyEmbedTracking = Switch(
-    "Monitoring",
+    SwitchGroup.Monitoring,
     "third-party-embed-tracking",
     "Enables tracking on our off-site third party embedded content. Such as: videos on embed.theguardian.com.",
     safeState = Off,
@@ -61,7 +61,7 @@ trait MonitoringSwitches {
   )
 
   val LogstashLogging = Switch(
-    "Monitoring",
+    SwitchGroup.Monitoring,
     "logstash-logging",
     "Enables sending logs to Logstash",
     safeState = Off,

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -6,7 +6,7 @@ import org.joda.time.LocalDate
 trait PerformanceSwitches {
 
   val InlineJSStandardOptimisation = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "inline-standard-optimisation",
     "If this switch is on, the inline JS will be compressed using closure compiler's standard optimisation instead of whitespace only",
     safeState = On,
@@ -16,7 +16,7 @@ trait PerformanceSwitches {
 
   // Performance
   val LazyLoadContainersSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "lazy-load-containers",
     "If this switch is on, containers past the 8th will be lazily loaded on mobile and tablet",
     safeState = Off,
@@ -25,7 +25,7 @@ trait PerformanceSwitches {
   )
 
   val TagPageSizeSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "tag-page-size",
     "If this switch is on then we will request more items for larger tag pages",
     safeState = Off,
@@ -34,7 +34,7 @@ trait PerformanceSwitches {
   )
 
   val SoftPurgeSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "soft-purge-switch",
     "If this switch is on then articles will be automatically soft purged them from the CDN",
     safeState = Off,
@@ -43,7 +43,7 @@ trait PerformanceSwitches {
   )
 
   val LongCacheSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "long-cache-switch",
     "If this switch is on then articles will get a longer cache time",
     safeState = Off,
@@ -52,7 +52,7 @@ trait PerformanceSwitches {
   )
 
   val CircuitBreakerSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "circuit-breaker",
     "If this switch is switched on then the Content API circuit breaker will be operational",
     safeState = Off,
@@ -61,7 +61,7 @@ trait PerformanceSwitches {
   )
 
   val AutoRefreshSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "auto-refresh",
     "Enables auto refresh in pages such as live blogs and live scores. Turn off to help handle exceptional load.",
     safeState = Off,
@@ -70,7 +70,7 @@ trait PerformanceSwitches {
   )
 
   val DoubleCacheTimesSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "double-cache-times",
     "Doubles the cache time of every endpoint. Turn on to help handle exceptional load.",
     safeState = On,
@@ -79,7 +79,7 @@ trait PerformanceSwitches {
   )
 
   val RelatedContentSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "related-content",
     "If this switch is turned on then related content will show. Turn off to help handle exceptional load.",
     safeState = On,
@@ -88,7 +88,7 @@ trait PerformanceSwitches {
   )
 
   val RichLinkSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "rich-links",
     "If this switch is turned off then rich links will not be shown. Turn off to help handle exceptional load.",
     safeState = On,
@@ -97,7 +97,7 @@ trait PerformanceSwitches {
   )
 
   val InlineCriticalCss = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "inline-critical-css",
     "If this switch is on critical CSS will be inlined into the head of the document.",
     safeState = On,
@@ -106,7 +106,7 @@ trait PerformanceSwitches {
   )
 
   val AsyncCss = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "async-css",
     "If this switch is on CSS will be loaded with media set to 'only x' and updated to 'all' when the stylesheet " +
       "has loaded using javascript. Disabling it will use standard link elements.",
@@ -116,7 +116,7 @@ trait PerformanceSwitches {
   )
 
   val ShowAllArticleEmbedsSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "show-all-embeds",
     "If switched on then all embeds will be shown inside article bodies",
     safeState = On,
@@ -125,7 +125,7 @@ trait PerformanceSwitches {
   )
 
   val ExternalVideoEmbeds = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "external-video-embeds",
     "If switched on then we will accept and display external video views",
     safeState = Off,
@@ -134,7 +134,7 @@ trait PerformanceSwitches {
   )
 
   val DiscussionSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "discussion",
     "If this switch is on, comments are displayed on articles. Turn this off if the Discussion API is blowing up.",
     safeState = On,
@@ -143,7 +143,7 @@ trait PerformanceSwitches {
   )
 
   val DiscussionPageSizeSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "discussion-page-size",
     "If this is switched on then users will have the option to change their discussion page size",
     safeState = Off,
@@ -152,7 +152,7 @@ trait PerformanceSwitches {
   )
 
   val OpenCtaSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "open-cta",
     "If this switch is on, will see a CTA to comments on the right hand side. Turn this off if the Open API " +
       "is blowing up.",
@@ -162,7 +162,7 @@ trait PerformanceSwitches {
   )
 
   val ImageServerSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "image-server",
     "If this switch is on images will be served off i.guim.co.uk (dynamic image host).",
     safeState = On,
@@ -171,7 +171,7 @@ trait PerformanceSwitches {
   )
 
   val Viewability = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "viewability",
     "Viewability - Includes whole viewability package: ads lazy loading, sticky ad banner, sticky MPU, spacefinder 2.0, dynamic ads, ad next to comments",
     safeState = Off,
@@ -180,7 +180,7 @@ trait PerformanceSwitches {
   )
 
   val DisableStickyAdBannerOnMobileSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "disable-sticky-ad-banner-on-mobile",
     "If this switch is on, the sticky ad banner will be disabled on mobile.",
     safeState = Off,
@@ -189,7 +189,7 @@ trait PerformanceSwitches {
   )
 
   val SaveForLaterSwitch = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "save-for-later",
     "It this switch is turned on, user are able to save articles. Turn off if this causes overload on then identity api",
     safeState = Off,
@@ -198,7 +198,7 @@ trait PerformanceSwitches {
   )
 
   val IphoneConfidence = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "iphone-confidence",
     "If this switch is on then some beacons will be dropped to gauge iPhone confidence",
     safeState = Off,
@@ -207,7 +207,7 @@ trait PerformanceSwitches {
   )
 
   val ContentApiUseThrift = Switch(
-    "Performance",
+    SwitchGroup.Performance,
     "content-api-use-thrift",
     "If this switch is on then content api calls will be requested in thrift format, instead of json format.",
     safeState = Off,

--- a/common/app/conf/switches/ServerSideABTestSwitches.scala
+++ b/common/app/conf/switches/ServerSideABTestSwitches.scala
@@ -9,7 +9,7 @@ trait ServerSideABTestSwitches {
     val tests = mvt.ActiveTests.tests
 
     Switch(
-      "Server-side A/B Tests",
+      SwitchGroup.ServerSideABTests,
       "server-side-tests",
       "Enables the server side testing system",
       safeState = Off,

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -13,6 +13,21 @@ sealed trait SwitchState
 case object On extends SwitchState
 case object Off extends SwitchState
 
+case class SwitchGroup(name: String, description: Option[String] = None)
+object SwitchGroup {
+  val ABTests = SwitchGroup("A/B Tests",
+                            Some("The expiry date of these switches does NOT affect the expiry of the AB tests; " +
+                                 "these switches serve only to quickly enable/disable said tests."))
+  val Commercial = SwitchGroup("Commercial")
+  val Facia = SwitchGroup("Facia")
+  val Feature = SwitchGroup("Feature")
+  val Identity = SwitchGroup("Identity")
+  val Monitoring = SwitchGroup("Monitoring")
+  val Performance = SwitchGroup("Performance")
+  val ServerSideABTests = SwitchGroup("Server-side A/B Tests")
+}
+
+
 trait Initializable[T] extends ExecutionContexts with Logging {
 
   private val initialized = Promise[T]()
@@ -33,7 +48,7 @@ trait Initializable[T] extends ExecutionContexts with Logging {
 }
 
 case class Switch(
-  group: String,
+  group: SwitchGroup,
   name: String,
   description: String,
   safeState: SwitchState,
@@ -70,7 +85,7 @@ case class Switch(
 object Switch {
 
   def apply(
-    group: String,
+    group: SwitchGroup,
     name: String,
     description: String,
     safeState: SwitchState,
@@ -126,9 +141,9 @@ with MonitoringSwitches {
 
   def eventuallyAll: Future[List[Switch]] = Switch.eventuallyAllSwitches
 
-  def grouped: List[(String, Seq[Switch])] = {
+  def grouped: List[(SwitchGroup, Seq[Switch])] = {
     val sortedSwitches = all.groupBy(_.group).map { case (key, value) => (key, value.sortBy(_.name)) }
-    sortedSwitches.toList.sortBy(_._1)
+    sortedSwitches.toList.sortBy(_._1.name)
   }
 
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -2,7 +2,7 @@ package mvt
 
 import MultiVariateTesting._
 import common.InternationalEditionVariant
-import conf.switches.Switch
+import conf.switches.{SwitchGroup, Switch}
 import org.joda.time.LocalDate
 import play.api.mvc.RequestHeader
 import views.support.CamelCase
@@ -107,7 +107,7 @@ case class TestDefinition (
   sellByDate: LocalDate
 ) {
   val switch: Switch = Switch(
-    "Server-side A/B Tests",
+    SwitchGroup.ServerSideABTests,
     name,
     description,
     conf.switches.Off,

--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -12,8 +12,10 @@ class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
     whenReady(Switches.eventuallyAll)(_ foreach { switch => test(switch) withClue s"(switch: '${switch.name}')" })
   }
 
+  private val testSwitchGroup = new SwitchGroup("category")
+
   def testSwitch = Switch(
-    "category",
+    testSwitchGroup,
     "test-switch",
     "exciting switch",
     safeState = Off,
@@ -22,7 +24,7 @@ class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
   )
 
   def foreverSwitch = Switch(
-    "category",
+    testSwitchGroup,
     "forever-switch",
     "exciting switch",
     safeState = Off,


### PR DESCRIPTION
## What does this change?

Currently a `Switch` has a `group` which is a string - this PR turns `group` into a `SwitchGroup`, which has both a `name` and a `description`.
## What is the value of this and can you measure success?

It enables us to add useful caveats/descriptions that might provide some useful context to the switches in a given group.

This morning, there was a fairly large bug with one of the AB tests, partly due to conflation between the switch expiry date and the AB test expiry date. Whilst it might seem obvious, the ability to add a description to a switch group could be generally useful and seemed like the best way of persisting this knowledge.

**I am happy to be shot down about this and if so will scrap this away to the dustbin of closed PRs**
## Does this affect other platforms - Amp, Apps, etc?

Not really.
## Screenshots

![image](https://cloud.githubusercontent.com/assets/1821099/14568354/571c8032-0330-11e6-9d32-830b181b3c66.png)
## Request for comment

/@kenlim 
