### PR TITLE
Only send crossword solutions out to clients if CAPI says it's ok.

### DIFF
--- a/common/app/model/CrosswordData.scala
+++ b/common/app/model/CrosswordData.scala
@@ -81,7 +81,12 @@ object CrosswordData {
     // group are incorrectly stored on the first group entry. We normalize
     // the data to store the separator locations on their corresponding entries.
 
-    val entries = crossword.entries.map(Entry.fromCrosswordEntry)
+    val shipSolutions = crossword.dateSolutionAvailable.map(_.toJodaDateTime.isBeforeNow).getOrElse(crossword.solutionAvailable)
+
+    val entries = crossword.entries.collect {
+      case entry if shipSolutions || entry.solution.isEmpty => Entry.fromCrosswordEntry(entry)
+      case entry => Entry.fromCrosswordEntry(entry.copy(solution = None))
+    }
 
     val entryGroups = entries
       .groupBy(_.group)

--- a/common/app/model/CrosswordData.scala
+++ b/common/app/model/CrosswordData.scala
@@ -84,8 +84,8 @@ object CrosswordData {
     val shipSolutions = crossword.dateSolutionAvailable.map(_.toJodaDateTime.isBeforeNow).getOrElse(crossword.solutionAvailable)
 
     val entries = crossword.entries.collect {
-      case entry if shipSolutions || entry.solution.isEmpty => Entry.fromCrosswordEntry(entry)
-      case entry => Entry.fromCrosswordEntry(entry.copy(solution = None))
+      case entry if !shipSolutions => Entry.fromCrosswordEntry(entry.copy(solution = None))
+      case entry => Entry.fromCrosswordEntry(entry)
     }
 
     val entryGroups = entries

--- a/static/src/javascripts/projects/common/modules/crosswords/main.js
+++ b/static/src/javascripts/projects/common/modules/crosswords/main.js
@@ -597,13 +597,7 @@ define([
         },
 
         hasSolutions: function () {
-            if (this.props.data.dateSolutionAvailable) {
-                return new Date(this.props.data.dateSolutionAvailable) <= new Date();
-            } else if (this.props.data.solutionAvailable) {
-                return this.props.data.solutionAvailable;
-            } else {
-                return false;
-            }
+            return 'solution' in this.props.data.entries[0];
         },
 
         render: function () {


### PR DESCRIPTION
## Following on from https://github.com/guardian/frontend/pull/12550...

At some point, CAPI are going to start returning all crossword solutions regardless of whether their other data (`dateSolutionAvailable` and `solutionAvailable`) say yes or no to the availability of those solutions. And when they do, we'll be ready for 'em.
## What does this change?

We're going to prevent the solutions being delivered to the client based on the aforementioned CAPI fields, so this is just a relatively small shift of decision functionality away from the client-side and back to the server-side. In fact the change made to the client-side code by the linked PR can now revert to its former state.
## What is the value of this and can you measure success?

Not that crossword users are likely to be a cheaty bunch, but if we ship the solutions out in the page data of prize puzzles before the closing date, well that just kind of makes a mockery of the concept, right?
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment
## @sndrs @desbo @philmcmahon

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
