### PR TITLE
A switch that has been badly configured should still be readable

### DIFF
--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -63,6 +63,14 @@ case class Switch(
     }
     initialized(this)
   }
+  def switchToSafeState(): Unit = {
+    if (safeState == On) {
+      delegate.switchOn()
+    } else {
+      delegate.switchOff()
+    }
+    initialized(this)
+  }
 
   Switch.switches.send(this :: _)
 }


### PR DESCRIPTION
Discovered this one in dev, but it could happen in prod too.

If you rely on a parsed switch value, using something like `isGuaranteedSwitchedOn`, then a badly configured switch value will never be considered initialized, and you get a future failed, initialization timeout.

This tweaks the behaviour so that if the switch file has been read at least once, the switch is initialised, even when there is a problem parsing/finding the switch. The value will be safe state, as it was before the switch file was read, but future will be completed.
