### PR TITLE
Commercial Jobs switch names

### DIFF
--- a/commercial/app/commercial/feeds/FeedFetcher.scala
+++ b/commercial/app/commercial/feeds/FeedFetcher.scala
@@ -111,16 +111,10 @@ object FeedFetcher {
     }
   }
 
-  private val jobs: Seq[FeedFetcher] = {
-      val dynamicDateJob = Configuration.commercial.jobsUrlTemplate map { template =>
-        new SingleFeedFetcher(JobsFeedMetaData(template))
-      }
-
-      val staticDateJob = Configuration.commercial.jobsStaticUrl map { url =>
+  private val jobs: Option[FeedFetcher] = {
+      Configuration.commercial.jobsStaticUrl map { url =>
         new SingleFeedFetcher(JobsFeedMetaData(url))
       }
-
-      List(dynamicDateJob, staticDateJob).flatten
   }
 
   private val soulmates: Seq[FeedFetcher] = {
@@ -155,7 +149,7 @@ object FeedFetcher {
       new SingleFeedFetcher(TravelOffersFeedMetaData(url))
     }
 
-  val all: Seq[FeedFetcher] = soulmates ++ jobs ++ Seq(bestsellers, masterclasses, travelOffers).flatten
+  val all: Seq[FeedFetcher] = soulmates ++ Seq(bestsellers, masterclasses, travelOffers, jobs).flatten
 
 }
 

--- a/commercial/app/commercial/feeds/FeedFetcher.scala
+++ b/commercial/app/commercial/feeds/FeedFetcher.scala
@@ -112,7 +112,7 @@ object FeedFetcher {
   }
 
   private val jobs: Option[FeedFetcher] = {
-      Configuration.commercial.jobsStaticUrl map { url =>
+      Configuration.commercial.jobsUrl map { url =>
         new SingleFeedFetcher(JobsFeedMetaData(url))
       }
   }

--- a/commercial/app/commercial/feeds/FeedMetaData.scala
+++ b/commercial/app/commercial/feeds/FeedMetaData.scala
@@ -24,8 +24,8 @@ case class JobsFeedMetaData(override val url: String) extends FeedMetaData {
 
   val name = "jobs"
 
-  override val fetchSwitch = Switches.JobFeedReadSwitch
-  override val parseSwitch = Switches.JobParseSwitch
+  override val fetchSwitch = Switches.JobsFeedFetchSwitch
+  override val parseSwitch = Switches.JobsFeedParseSwitch
 
   override val responseEncoding = utf8
 }

--- a/commercial/app/commercial/feeds/FeedParser.scala
+++ b/commercial/app/commercial/feeds/FeedParser.scala
@@ -20,10 +20,10 @@ sealed trait FeedParser[+T] extends ExecutionContexts {
 object FeedParser {
 
   private val jobs: Option[FeedParser[Job]] = {
-    Configuration.commercial.jobsUrlTemplate map { template =>
+    Configuration.commercial.jobsStaticUrl map { url =>
       new FeedParser[Job] {
 
-        val feedMetaData = JobsFeedMetaData(template)
+        val feedMetaData = JobsFeedMetaData(url)
 
         def parse(feedContent: => Option[String]) = JobsAgent.refresh(feedMetaData, feedContent)
       }

--- a/commercial/app/commercial/feeds/FeedParser.scala
+++ b/commercial/app/commercial/feeds/FeedParser.scala
@@ -20,7 +20,7 @@ sealed trait FeedParser[+T] extends ExecutionContexts {
 object FeedParser {
 
   private val jobs: Option[FeedParser[Job]] = {
-    Configuration.commercial.jobsStaticUrl map { url =>
+    Configuration.commercial.jobsUrl map { url =>
       new FeedParser[Job] {
 
         val feedMetaData = JobsFeedMetaData(url)

--- a/commercial/app/model/commercial/jobs/JobsFeed.scala
+++ b/commercial/app/model/commercial/jobs/JobsFeed.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 import scala.xml.{Elem, XML}
-import conf.switches.Switches.JobParseSwitch
+import conf.switches.Switches.JobsFeedParseSwitch
 
 object JobsFeed extends ExecutionContexts with Logging {
 
@@ -21,7 +21,7 @@ object JobsFeed extends ExecutionContexts with Logging {
   } yield Job(jobXml)
 
   def parsedJobs(feedMetaData: FeedMetaData, feedContent: => Option[String]): Future[ParsedFeed[Job]] = {
-    JobParseSwitch.isGuaranteedSwitchedOn flatMap { switchedOn =>
+    JobsFeedParseSwitch.isGuaranteedSwitchedOn flatMap { switchedOn =>
       if (switchedOn) {
         val start = currentTimeMillis
         feedContent map { body =>
@@ -31,7 +31,7 @@ object JobsFeed extends ExecutionContexts with Logging {
           Future.failed(MissingFeedException(feedMetaData.name))
         }
       } else {
-        Future.failed(SwitchOffException(JobParseSwitch.name))
+        Future.failed(SwitchOffException(JobsFeedParseSwitch.name))
       }
     } recoverWith {
       case NonFatal(e) => Future.failed(e)

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -308,7 +308,6 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val masterclassesToken = configuration.getStringProperty("masterclasses.token")
     lazy val liveEventsToken = configuration.getStringProperty("live-events.token")
     lazy val liveEventsImagesUrl = "https://membership.theguardian.com/events.json"
-    lazy val jobsUrlTemplate = configuration.getStringProperty("jobs.api.url.template")
     lazy val jobsStaticUrl= configuration.getStringProperty("jobs.api.url")
     lazy val mortgagesUrl = configuration.getStringProperty("lc.mortgages.api.url")
     lazy val moneyUrl = configuration.getStringProperty("moneysupermarket.api.url")

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -308,7 +308,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val masterclassesToken = configuration.getStringProperty("masterclasses.token")
     lazy val liveEventsToken = configuration.getStringProperty("live-events.token")
     lazy val liveEventsImagesUrl = "https://membership.theguardian.com/events.json"
-    lazy val jobsStaticUrl= configuration.getStringProperty("jobs.api.url")
+    lazy val jobsUrl= configuration.getStringProperty("jobs.api.url")
     lazy val mortgagesUrl = configuration.getStringProperty("lc.mortgages.api.url")
     lazy val moneyUrl = configuration.getStringProperty("moneysupermarket.api.url")
 

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -140,19 +140,19 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
-  val JobFeedReadSwitch = Switch(
+  val JobsFeedFetchSwitch = Switch(
     "Commercial",
-    "gu-jobs-feed-read",
-    "If this switch is on, cached jobs feed will be updated from external source.",
+    "gu-jobs-feed-fetch",
+    "If this switch is on, jobs feed will be periodically updated from external source.",
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
   )
 
-  val JobParseSwitch = Switch(
+  val JobsFeedParseSwitch = Switch(
     "Commercial",
-    "gu-jobs-parse",
-    "If this switch is on, commercial components will be fed by job feed.",
+    "gu-jobs-feed-parse",
+    "If this switch is on, commercial components will be fed by jobs feed.",
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -141,7 +141,7 @@ trait CommercialSwitches {
   )
 
   val JobsFeedFetchSwitch = Switch(
-    SwitchGroup.Commercial,,
+    SwitchGroup.Commercial,
     "gu-jobs-feed-fetch",
     "If this switch is on, jobs feed will be periodically updated from external source.",
     safeState = Off,
@@ -150,7 +150,7 @@ trait CommercialSwitches {
   )
 
   val JobsFeedParseSwitch = Switch(
-    SwitchGroup.Commercial,,
+    SwitchGroup.Commercial,
     "gu-jobs-feed-parse",
     "If this switch is on, commercial components will be fed by jobs feed.",
     safeState = Off,


### PR DESCRIPTION
Renamed the jobs feed switches to match travel's naming. Removed `jobsUrlTemplate` so that we fully rely on the static url system. @lps88 
