### PR TITLE
Logstash Logging: only add kinesis appender to root logger

### DIFF
--- a/common/app/common/Logback/LogbackConfig.scala
+++ b/common/app/common/Logback/LogbackConfig.scala
@@ -5,8 +5,8 @@ import ch.qos.logback.classic.{Logger => LogbackLogger, LoggerContext}
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.logback.appender.kinesis.KinesisAppender
 import net.logstash.logback.layout.LogstashLayout
-import org.slf4j.LoggerFactory
-import play.api.LoggerLike
+import org.slf4j.{Logger => SLFLogger, LoggerFactory}
+import play.api.{Logger => PlayLogger}
 
 object LogbackConfig {
 
@@ -21,7 +21,7 @@ object LogbackConfig {
     "{" + (for((k, v) <- customFields) yield(s""""${k}":"${v}"""")).mkString(",") + "}"
   }
 
-  def asLogBack(l: LoggerLike): Option[LogbackLogger] = l.logger match {
+  def asLogBack(l: SLFLogger): Option[LogbackLogger] = l match {
     case l: LogbackLogger => Some(l)
     case _ => None
   }
@@ -34,6 +34,7 @@ object LogbackConfig {
 
   def makeKinesisAppender(layout: LogstashLayout, context: LoggerContext, appenderConfig: KinesisAppenderConfig) = {
     val a = new KinesisAppender[ILoggingEvent]()
+    a.setName("LoggingKinesisAppender")
     a.setStreamName(appenderConfig.stream)
     a.setRegion(appenderConfig.region)
     a.setCredentialsProvider(appenderConfig.awsCredentialsProvider)
@@ -47,30 +48,33 @@ object LogbackConfig {
     a
   }
 
-  def initLogger(logger: LoggerLike, config: LogStashConf) = {
+  def init(config: LogStashConf) = {
     if (config.enabled) {
-      asLogBack(logger).map { lb =>
-        try {
-          lb.info("Configuring Logback")
-          val context = lb.getLoggerContext
-          val layout = makeLayout(makeCustomFields(config.customFields))
-          val bufferSize = 1000
-          val appender  = makeKinesisAppender(layout, context,
-            KinesisAppenderConfig(
-              config.stream,
-              config.region,
-              config.awsCredentialsProvider,
-              bufferSize
+      try {
+        val rootLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME)
+        asLogBack(rootLogger).map { lb =>
+            lb.info("Configuring Logback")
+            val context = lb.getLoggerContext
+            val layout = makeLayout(makeCustomFields(config.customFields))
+            val bufferSize = 1000
+            val appender  = makeKinesisAppender(
+              layout,
+              context,
+              KinesisAppenderConfig(
+                config.stream,
+                config.region,
+                config.awsCredentialsProvider,
+                bufferSize
+              )
             )
-          )
-          lb.addAppender(appender)
-          lb.info("Configured Logback")
-        } catch {
-          case ex: Throwable => logger.info(s"Error while adding Logback appender: ${ex}")
-        }
-      } getOrElse(logger.info("not running using logback"))
+            lb.addAppender(appender)
+            lb.info("Configured Logback")
+        } getOrElse(PlayLogger.info("not running using logback"))
+      } catch {
+        case ex: Throwable => PlayLogger.info(s"Error while adding Logback Kinesis appender: ${ex}")
+      }
     } else {
-      logger.info("Logging disabled")
+      PlayLogger.info("Logging disabled")
     }
   }
 

--- a/common/app/common/Logback/Logstash.scala
+++ b/common/app/common/Logback/Logstash.scala
@@ -3,7 +3,7 @@ package common.Logback
 import com.amazonaws.auth.AWSCredentialsProvider
 import conf.switches.Switches
 import conf.Configuration
-import play.api.{Logger => PlayLogger, Application => PlayApp, GlobalSettings, LoggerLike}
+import play.api.{Logger => PlayLogger, Application => PlayApp, GlobalSettings}
 
 
 case class LogStashConf(enabled: Boolean,
@@ -16,7 +16,7 @@ trait Logstash extends GlobalSettings {
 
   override def onStart(app: PlayApp) = {
     super.onStart(app)
-    Logstash.init(PlayLogger) // Setup Play default Logger to send logs to logstash
+    Logstash.init
   }
 }
 
@@ -40,11 +40,11 @@ object Logstash {
     )
   }
 
-  def init(logger: LoggerLike): Unit = {
+  def init: Unit = {
     if(Switches.LogstashLogging.isSwitchedOn) {
-      config.fold(logger.info("Logstash config is missing"))(LogbackConfig.initLogger(logger, _))
+      config.fold(PlayLogger.info("Logstash config is missing"))(LogbackConfig.init(_))
     } else {
-      logger.info("Logstash logging switch is Off")
+      PlayLogger.info("Logstash logging switch is Off")
     }
   }
 }

--- a/common/app/common/Logging.scala
+++ b/common/app/common/Logging.scala
@@ -2,15 +2,11 @@ package common
 
 import play.api.Logger
 import org.apache.commons.lang.exception.ExceptionUtils
-import common.Logback.Logstash
 
 trait Logging {
 
-  lazy implicit val log = {
-    val logger = Logger(getClass)
-    Logstash.init(logger) // Setup logger to send logs to logstash
-    logger
-  }
+  lazy implicit val log = Logger(getClass)
+
   protected def logException(e: Exception) = {
     log.error(ExceptionUtils.getStackTrace(e))
   }


### PR DESCRIPTION
## What does this change?

Previous implementation would append a new kinesis appender every time a new logger would be initialized.
This fix ensure the kinesis appender is appended only once to the root logger when the app starts
## What is the value of this and can you measure success?

No more wasted resources.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@jamespamplin @johnduffell 
