### PR TITLE
Add video overlay option to video player

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -79,7 +79,7 @@
                                                 showControlsAtStart = true,
                                                 endSlatePath = video.endSlatePath,
                                                 overrideIsRatioHd = None
-                                            ), true, showTitle = true, seriesTag = media.content.blogOrSeriesTag)
+                                            ), true)
                                         }
                                     </figure>
                                 }

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -79,7 +79,7 @@
                                                 showControlsAtStart = true,
                                                 endSlatePath = video.endSlatePath,
                                                 overrideIsRatioHd = None
-                                            ), true)
+                                            ), true, showTitle = true, seriesTag = media.content.blogOrSeriesTag)
                                         }
                                     </figure>
                                 }

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -104,11 +104,10 @@ case class VideoAsset(
     }
   }
 
-  // The video duration in seconds
-  val duration: Int = fields.get("durationSeconds").getOrElse("0").toInt +
-                           (fields.get("durationMinutes").getOrElse("0").toInt * 60)
   val durationSeconds: Int = fields.get("durationSeconds").getOrElse("0").toInt
   val durationMinutes: Int = fields.get("durationMinutes").getOrElse("0").toInt
+  // The video duration in seconds
+  val duration: Int = durationSeconds + (durationMinutes * 60)
   val blockVideoAds: Boolean = fields.get("blockAds").exists(_.toBoolean)
   val source: Option[String] = fields.get("source")
   val embeddable: Boolean = fields.get("embeddable").exists(_.toBoolean)

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -107,8 +107,9 @@ case class VideoAsset(
   // The video duration in seconds
   val duration: Int = fields.get("durationSeconds").getOrElse("0").toInt +
                            (fields.get("durationMinutes").getOrElse("0").toInt * 60)
+  val durationSeconds: Int = fields.get("durationSeconds").getOrElse("0").toInt
+  val durationMinutes: Int = fields.get("durationMinutes").getOrElse("0").toInt
   val blockVideoAds: Boolean = fields.get("blockAds").exists(_.toBoolean)
-
   val source: Option[String] = fields.get("source")
   val embeddable: Boolean = fields.get("embeddable").exists(_.toBoolean)
   val caption: Option[String] = fields.get("caption")

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -97,8 +97,6 @@ final case class VideoMedia(videoAssets: List[VideoAsset]) {
   val formattedDuration: String = {
     videoAssets.headOption.map(_.durationMinutes).getOrElse(0).toString() + ":" + "%02d".format(videoAssets.headOption.map(_.durationSeconds).getOrElse(0))
   }
-
-
   val durationMinutes: Int = videoAssets.headOption.map(_.durationMinutes).getOrElse(0)
   val durationSeconds: Int = videoAssets.headOption.map(_.durationSeconds).getOrElse(0)
   val ISOduration: String = new Duration(duration*1000.toLong).toString()

--- a/common/app/model/Element.scala
+++ b/common/app/model/Element.scala
@@ -94,6 +94,13 @@ final case class VideoMedia(videoAssets: List[VideoAsset]) {
     }.flatten.sorted
   }
   val duration: Int = videoAssets.headOption.map(_.duration).getOrElse(0)
+  val formattedDuration: String = {
+    videoAssets.headOption.map(_.durationMinutes).getOrElse(0).toString() + ":" + "%02d".format(videoAssets.headOption.map(_.durationSeconds).getOrElse(0))
+  }
+
+
+  val durationMinutes: Int = videoAssets.headOption.map(_.durationMinutes).getOrElse(0)
+  val durationSeconds: Int = videoAssets.headOption.map(_.durationSeconds).getOrElse(0)
   val ISOduration: String = new Duration(duration*1000.toLong).toString()
   val height: String = videoAssets.headOption.map(_.height).getOrElse(0).toString
   val width: String = videoAssets.headOption.map(_.width).getOrElse(0).toString

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -1,4 +1,4 @@
-@(player: model.VideoPlayer, enhance: Boolean, showEndSlate: Boolean = true, amp: Boolean = false, showPoster: Boolean = true)
+@(player: model.VideoPlayer, enhance: Boolean, showEndSlate: Boolean = true, amp: Boolean = false, showPoster: Boolean = true, showTitle: Boolean = false, seriesTag: Option[model.Tag] = None)
 
 @import conf.Static
 @import views.support.RenderClasses
@@ -67,6 +67,16 @@
                     </object>
                 }
             </video>
+            @if(showTitle){
+            <div class="video__overlay">
+                <div class="video__series">@seriesTag.map { series =>
+                    @series.name
+                }</div>
+                <div class="video__headline">
+                    @player.title
+                </div>
+            </div>
+            }
         </div>
     }
 </div>

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -68,16 +68,16 @@
                 }
             </video>
             @if(showOverlay){
-            <div class="video__overlay">
+            <div class="video-overlay">
                 @seriesTag.map { series =>
-                    <div class="video__series-label">
+                    <div class="video-overlay__series-label">
                         @series.name
                     </div>
                 }
-                <h1 class="video__headline">
+                <h1 class="video-overlay__headline">
                     @player.title
                 </h1>
-                <span class="video-duration">
+                <span class="video-overlay__duration">
                     @player.video.videos.formattedDuration
                 </span>
             </div>

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -1,4 +1,4 @@
-@(player: model.VideoPlayer, enhance: Boolean, showEndSlate: Boolean = true, amp: Boolean = false, showPoster: Boolean = true, showTitle: Boolean = false, seriesTag: Option[model.Tag] = None)
+@(player: model.VideoPlayer, enhance: Boolean, showEndSlate: Boolean = true, amp: Boolean = false, showPoster: Boolean = true, showOverlay: Boolean = false, seriesTag: Option[model.Tag] = None)
 
 @import conf.Static
 @import views.support.RenderClasses
@@ -67,7 +67,7 @@
                     </object>
                 }
             </video>
-            @if(showTitle){
+            @if(showOverlay){
             <div class="video__overlay">
                 @seriesTag.map { series =>
                     <div class="video__series-label">

--- a/common/app/views/fragments/media/video.scala.html
+++ b/common/app/views/fragments/media/video.scala.html
@@ -69,12 +69,17 @@
             </video>
             @if(showTitle){
             <div class="video__overlay">
-                <div class="video__series">@seriesTag.map { series =>
-                    @series.name
-                }</div>
-                <div class="video__headline">
+                @seriesTag.map { series =>
+                    <div class="video__series-label">
+                        @series.name
+                    </div>
+                }
+                <h1 class="video__headline">
                     @player.title
-                </div>
+                </h1>
+                <span class="video-duration">
+                    @player.video.videos.formattedDuration
+                </span>
             </div>
             }
         </div>


### PR DESCRIPTION
## What does this change?

Adds an optional field to the `Video` template to add a video overlay to the player. This adds a headline, tag if needed and video duration. At the moment it's not visible to users. But it needs to go in as it will be used in my [Video Container PR](https://github.com/guardian/frontend/pull/12584/) and some stuff by @blongden73.
## Request for comment

@rich-nguyen @jamesgorrie 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
