### PR TITLE
Use isGuaranteedSwitchOn to get value of Logstash-logging switch

### DIFF
--- a/common/app/common/Logback/LogbackConfig.scala
+++ b/common/app/common/Logback/LogbackConfig.scala
@@ -53,22 +53,22 @@ object LogbackConfig {
       try {
         val rootLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME)
         asLogBack(rootLogger).map { lb =>
-            lb.info("Configuring Logback")
-            val context = lb.getLoggerContext
-            val layout = makeLayout(makeCustomFields(config.customFields))
-            val bufferSize = 1000
-            val appender  = makeKinesisAppender(
-              layout,
-              context,
-              KinesisAppenderConfig(
-                config.stream,
-                config.region,
-                config.awsCredentialsProvider,
-                bufferSize
-              )
+          lb.info("Configuring Logback")
+          val context = lb.getLoggerContext
+          val layout = makeLayout(makeCustomFields(config.customFields))
+          val bufferSize = 1000
+          val appender  = makeKinesisAppender(
+            layout,
+            context,
+            KinesisAppenderConfig(
+              config.stream,
+              config.region,
+              config.awsCredentialsProvider,
+              bufferSize
             )
-            lb.addAppender(appender)
-            lb.info("Configured Logback")
+          )
+          lb.addAppender(appender)
+          lb.info("Configured Logback")
         } getOrElse(PlayLogger.info("not running using logback"))
       } catch {
         case ex: Throwable => PlayLogger.info(s"Error while adding Logback Kinesis appender: ${ex}")

--- a/common/app/common/Logback/Logstash.scala
+++ b/common/app/common/Logback/Logstash.scala
@@ -4,7 +4,8 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import conf.switches.Switches
 import conf.Configuration
 import play.api.{Logger => PlayLogger, Application => PlayApp, GlobalSettings}
-
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Success, Failure}
 
 case class LogStashConf(enabled: Boolean,
                         stream: String,
@@ -41,10 +42,15 @@ object Logstash {
   }
 
   def init: Unit = {
-    if(Switches.LogstashLogging.isSwitchedOn) {
-      config.fold(PlayLogger.info("Logstash config is missing"))(LogbackConfig.init(_))
-    } else {
-      PlayLogger.info("Logstash logging switch is Off")
+
+    Switches.LogstashLogging.isGuaranteedSwitchedOn.onComplete {
+      case Success(isOn) =>
+        if(isOn) {
+          config.fold(PlayLogger.info("Logstash config is missing"))(LogbackConfig.init(_))
+        } else {
+          PlayLogger.info("Logstash logging switch is Off")
+        }
+      case Failure(_) => PlayLogger.error("Failed retrieving the logtash-logging switch value")
     }
   }
 }


### PR DESCRIPTION
## What does this change?

Since the appender configuration is happening very early on in the lifecycle of the app, the switchboard was not read yet and always returned the safe state of the logstash-logging switch (which is off)

This PR makes sure the logstash-logging switch value has been read before returning its state.
## What is the value of this and can you measure success?

Make logging to logstash possible :)
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @jamespamplin 
