### PR TITLE
Log build number and vcs revision for cloudwatch logs

### DIFF
--- a/common/app/common/metrics.scala
+++ b/common/app/common/metrics.scala
@@ -184,6 +184,8 @@ trait CloudWatchApplicationMetrics extends GlobalSettings with Logging {
     Jobs.schedule("ApplicationSystemMetricsJob", "36 * * * * ?"){
       report()
     }
+
+    // Log heap usage every 5 seconds.
     if (Configuration.environment.isProd) {
       Jobs.scheduleEveryNSeconds("LogMetricsJob", 5) {
         val heapUsed = bytesAsMb(ManagementFactory.getMemoryMXBean.getHeapMemoryUsage.getUsed)
@@ -191,6 +193,9 @@ trait CloudWatchApplicationMetrics extends GlobalSettings with Logging {
         Future.successful(())
       }
     }
+
+    // Log the build number and revision number on startup.
+    log.info(s"Build number: ${ManifestData.build}, vcs revision: ${ManifestData.revision}")
   }
 
   override def onStop(app: PlayApp) {


### PR DESCRIPTION
I thought it would be nice to send the build number to the aws logs.

`INFO  Global$ - Build number: 1808, vcs revision: e8aeb18361929e46e4191ff6ce97ccc41549fb9b`

@janua @johnduffell 
