### PR TITLE
Move back image to html element instead of css background

### DIFF
--- a/static/src/javascripts/projects/common/views/commercial/creatives/gimbap/gimbap-simple-blob.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/gimbap/gimbap-simple-blob.html
@@ -1,5 +1,6 @@
 <a class="gimbap gimbap--simple gimbap--tone-<%=componenttone%><%=gimbapEffects%>"
    href="<%=clickMacro%><%=offerurl%>"
-   data-link-name="<%=offertitle%>" style="background: url('<%=offerimage%>') center center no-repeat;">
+   data-link-name="<%=offertitle%>">
+   	<img class="gimbap__image" src="<%=offerimage%>" />
     <p class="gimbap__cta gimbap__cta--simple"><%=offertitle%><%=arrowRight%></p>
 </a>


### PR DESCRIPTION
I was testing this approach while working on the gimbap richmedia and totally deployed it by an accident.

This approach doesn't work as scaling effect on background image isn't very smooth. So back to img.

@jbreckmckye @regiskuckaertz @Calanthe 
