### PR TITLE
Add proxy pass and referer for idapi

### DIFF
--- a/nginx/frontend.conf
+++ b/nginx/frontend.conf
@@ -61,3 +61,29 @@ server {
         proxy_set_header "X-Forwarded-Proto" "https";
     }
 }
+
+server {
+    listen                      443;
+    server_name                 idapi-code-proxy.thegulocal.com;
+
+    ssl on;
+    ssl_certificate frontend-test.crt;
+    ssl_certificate_key frontend-test.key;
+
+    ssl_session_timeout 5m;
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+        resolver                8.8.8.8;
+        proxy_pass              https://idapi.code.dev-theguardian.com/;
+        proxy_redirect          default;
+        proxy_set_header        Host                    idapi.code.dev-theguardian.com;
+        proxy_set_header        X-Real-IP               $remote_addr;
+        proxy_set_header        X-Forwarded-For         $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Protocol    $scheme;
+        proxy_set_header        Referer                 "http://m.code.dev-theguardian.com";
+    }
+}


### PR DESCRIPTION
## What does this change?

Adds a simple proxy server to nginx
The proxy server will proxy the referer so that access is no longer denied when attempting to perform identity based actions.
## What is the value of this and can you measure success?

Permits users to use the identity and membership features on localhost (login, saved for later, etc.)
## Request for comment

@jamespamplin 
