### PR TITLE
Adding the liveEvents FeedFetcher job back into the feeds to fetch

### DIFF
--- a/commercial/app/commercial/feeds/FeedFetcher.scala
+++ b/commercial/app/commercial/feeds/FeedFetcher.scala
@@ -149,7 +149,7 @@ object FeedFetcher {
       new SingleFeedFetcher(TravelOffersFeedMetaData(url))
     }
 
-  val all: Seq[FeedFetcher] = soulmates ++ Seq(bestsellers, masterclasses, travelOffers, jobs).flatten
+  val all: Seq[FeedFetcher] = soulmates ++ Seq(bestsellers, masterclasses, travelOffers, jobs, liveEvents).flatten
 
 }
 


### PR DESCRIPTION
It looks  like the `liveEvents` feedFetch job was inadvertently merged out of the `all` list in `FeedFetcher` between the commit 7391e91 and ea0b951.

Just adding it back in.
