### PR TITLE
Fix ab test switch indicator

### DIFF
--- a/admin/app/views/abtests.scala.html
+++ b/admin/app/views/abtests.scala.html
@@ -39,7 +39,7 @@
 
     <script type="text/javascript">
         window.abSwitches = {
-            @conf.switches.Switches.all.filter(_.group.name == "A/B Tests").map{ s =>
+            @conf.switches.Switches.all.filter(_.group == conf.switches.SwitchGroup.ABTests).map{ s =>
                 "@CamelCase.fromHyphenated(s.name)": @s.isSwitchedOn,
             }
         };

--- a/admin/app/views/abtests.scala.html
+++ b/admin/app/views/abtests.scala.html
@@ -36,7 +36,8 @@
     <script type="text/template" id="tmpl-participation-item-template">@fragments.participationItem()</script>
     <script type="text/template" id="tmpl-audience-template">@fragments.audience()</script>
     <script type="text/template" id="tmpl-audience-item-template">@fragments.audienceItem()</script>
-    <script type="text/javascript">
+
+    <script type="text/javascript">    <script type="text/javascript">
         window.abSwitches = {
             @conf.switches.Switches.all.filter(_.group.name == "A/B Tests").map{ s =>
                 "@CamelCase.fromHyphenated(s.name)": @s.isSwitchedOn,

--- a/admin/app/views/abtests.scala.html
+++ b/admin/app/views/abtests.scala.html
@@ -37,7 +37,7 @@
     <script type="text/template" id="tmpl-audience-template">@fragments.audience()</script>
     <script type="text/template" id="tmpl-audience-item-template">@fragments.audienceItem()</script>
 
-    <script type="text/javascript">    <script type="text/javascript">
+    <script type="text/javascript">
         window.abSwitches = {
             @conf.switches.Switches.all.filter(_.group.name == "A/B Tests").map{ s =>
                 "@CamelCase.fromHyphenated(s.name)": @s.isSwitchedOn,

--- a/admin/app/views/abtests.scala.html
+++ b/admin/app/views/abtests.scala.html
@@ -36,10 +36,9 @@
     <script type="text/template" id="tmpl-participation-item-template">@fragments.participationItem()</script>
     <script type="text/template" id="tmpl-audience-template">@fragments.audience()</script>
     <script type="text/template" id="tmpl-audience-item-template">@fragments.audienceItem()</script>
-
     <script type="text/javascript">
         window.abSwitches = {
-            @conf.switches.Switches.all.filter(_.group == "A/B Tests").map{ s =>
+            @conf.switches.Switches.all.filter(_.group.name == "A/B Tests").map{ s =>
                 "@CamelCase.fromHyphenated(s.name)": @s.isSwitchedOn,
             }
         };


### PR DESCRIPTION
## What does this change?

This fixes the ab test switch indicator
Previously it was showing that all tests were turned off. This is not true!
## Screenshots

**before** :sad_face:
<img width="1249" alt="screen shot 2016-04-19 at 12 31 12" src="https://cloud.githubusercontent.com/assets/1289259/14637654/a6d0fc96-062a-11e6-80b8-a2ed18c396c9.png">

**after** :happy_face:
<img width="990" alt="screen shot 2016-04-19 at 12 30 37" src="https://cloud.githubusercontent.com/assets/1289259/14637666/b5431098-062a-11e6-993b-9099a21fb993.png">
## Request for comment
## @rich-nguyen 
