### PR TITLE
Serve appropriate ETag for facia pages

### DIFF
--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -77,9 +77,9 @@ object Cached extends implicits.Dates {
     val staleWhileRevalidateSeconds = math.max(maxAge / 10, 1)
     val cacheControl = s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$tenDaysInSeconds"
     val etag = maybeHash.map{ hashInt: Long =>
-      hashInt.toString
+      s"hash${hashInt.toString}"
     }.getOrElse(
-      s"johnFakeHash${scala.util.Random.nextInt}${scala.util.Random.nextInt}" // just to see if they come back in
+      s"johnRandom${scala.util.Random.nextInt}${scala.util.Random.nextInt}" // just to see if they come back in
     )
     result.withHeaders(
       "Surrogate-Control" -> cacheControl,

--- a/common/app/views/support/JavaScriptPage.scala
+++ b/common/app/views/support/JavaScriptPage.scala
@@ -63,7 +63,6 @@ object JavaScriptPage {
       ("isProd", JsBoolean(Configuration.environment.isProd)),
       ("idUrl", JsString(Configuration.id.url)),
       ("beaconUrl", JsString(Configuration.debug.beaconUrl)),
-      ("renderTime", JsString(DateTime.now.toISODateTimeNoMillisString)),
       ("isSSL", JsBoolean(Configuration.environment.secure)),
       ("assetsPath", JsString(Configuration.assets.path)),
       ("isPreview", JsBoolean(environment.isPreview)),

--- a/static/src/javascripts/projects/common/modules/ui/relativedates.js
+++ b/static/src/javascripts/projects/common/modules/ui/relativedates.js
@@ -1,19 +1,12 @@
 define([
     'common/utils/$',
-    'common/utils/config',
     'common/utils/mediator',
     'bonzo'
 ], function (
     $,
-    config,
     mediator,
     bonzo
 ) {
-    var timeAdjustmentMs = config.page && config.page.renderTime ? Math.max(0, new Date() - new Date(config.page.renderTime)) : 0;
-
-    function adjustedNow() {
-        return new Date(new Date().getTime() - timeAdjustmentMs);
-    }
 
     function dayOfWeek(day) {
         return ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][day];
@@ -28,29 +21,29 @@ define([
     }
 
     function isToday(date) {
-        var today = adjustedNow();
+        var today = new Date();
         return date && (date.toDateString() === today.toDateString());
     }
 
     function isWithin24Hours(date) {
-        var today = adjustedNow();
+        var today = new Date();
         return date && (date.valueOf() > today.valueOf() - (24 * 60 * 60 * 1000));
     }
 
     function isWithinSeconds(date, seconds) {
-        var today = adjustedNow();
+        var today = new Date();
         return date && (date.valueOf() > today.valueOf() - ((seconds || 0) * 1000));
     }
 
     function isYesterday(relative) {
-        var today = adjustedNow(),
-            yesterday = adjustedNow();
+        var today = new Date(),
+            yesterday = new Date();
         yesterday.setDate(today.getDate() - 1);
         return (relative.toDateString() === yesterday.toDateString());
     }
 
     function isWithinPastWeek(date) {
-        var weekAgo = adjustedNow().valueOf() - (7 * 24 * 60 * 60 * 1000);
+        var weekAgo = new Date().valueOf() - (7 * 24 * 60 * 60 * 1000);
         return date.valueOf() >= weekAgo;
     }
 
@@ -102,7 +95,7 @@ define([
 
         var minutes, hours, days, delta,
             then = new Date(Number(epoch)),
-            now = adjustedNow(),
+            now = new Date(),
             format = opts.format || 'short',
             extendedFormatting = (opts.format === 'short' || opts.format === 'med');
 


### PR DESCRIPTION
This makes it so we can serve an etag based on the content body of facia pages.

Based on looking at the incoming traffic after a couple of hours, I can estimate how many requests we don't need to serve with a full response because the content has not changed.

If this is a decent number, I can change it to serve 304s instead of 200s.  I will also keep a note whether doing the hashing has any negative impact on CPU on the instances.

The [adjusted time](https://github.com/guardian/frontend/pull/9016) on the client side stuff isnt' really compatible with caching, so I've removed it

@JustinPinner @TBonnin @gklopper any comments?
