### PR TITLE
Fix the font displayed in the crossword preview, issue #12059

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -77,8 +77,8 @@
             case Some(svg@CrosswordSvg(_)) => {
                 <div class="fc-item__media-wrapper">
                     <div class="fc-item__image-container u-responsive-ratio inlined-image">
-                        <img src="@svg.imageUrl" class="responsive-img js-crossword-thumbnail" alt=""
-                        role="presentation" data-crossword-id="@svg.persistenceId" />
+                        <object type="image/svg+xml" data="@svg.imageUrl" class="responsive-img js-crossword-thumbnail" alt=""
+                        role="presentation" data-crossword-id="@svg.persistenceId" ></object>
                     </div>
                 </div>
             }


### PR DESCRIPTION
## What does this change?

Fonts cannot be loaded by a svg inside an img tag, however, placing the svg inside an object tag will allow scriptable content; the cell numbers can then have the correct, sans-serif font displayed.
## What is the value of this and can you measure success?

Aesthetic improvement to the crossword Front.
#### BEFORE

<img width="797" alt="crossword-before" src="https://cloud.githubusercontent.com/assets/8607683/14645043/1693283a-064c-11e6-88a3-0eefe52cba97.png">
#### AFTER

<img width="644" alt="crossword-after" src="https://cloud.githubusercontent.com/assets/8607683/14645071/307049b8-064c-11e6-9e7e-d6c6a13326a4.png">

additional screenshots: https://www.browserstack.com/screenshots/915efaa38c33d9e5f5b9639dea9c1c466068cfd6
## Request for comment

@sndrs 
