### PR TITLE
Logs error and request headers when GET /discussion/p/XXXX fails

### DIFF
--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -153,6 +153,11 @@ object CommentsController extends DiscussionController with ExecutionContexts {
         }
       }
     }
+      .recover {
+        case NonFatal(e) =>
+          log.error(s"Error fetching comments from request with following headers: ${request.headers}", e)
+          NotFound(s"Discussion ${key} cannot be retrieved")
+      }
   }
 
   private def getTopComments(key: DiscussionKey)(implicit request: RequestHeader): Future[Result] = {


### PR DESCRIPTION
## What does this change?

Logs error and request headers when GET /discussion/p/XXXX fails
## What is the value of this and can you measure success?

Understand where those requests come from
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@OliverJAsh 
