### PR TITLE
Don't send HTTP body if clients already have the content

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -51,6 +51,15 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
+  val CheckETagsSwitch = Switch(
+    SwitchGroup.Performance,
+    "check-etags",
+    "If this switch is on, empty 304 not modified responses will be returned for requests with the correct etag",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 5, 20),
+    exposeClientSide = false
+  )
+
   val CircuitBreakerSwitch = Switch(
     SwitchGroup.Performance,
     "circuit-breaker",

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -1,9 +1,10 @@
 package model
 
+import conf.switches.Switches
 import conf.switches.Switches._
 import org.joda.time.DateTime
 import org.scala_tools.time.Imports._
-import play.api.mvc.{Request, Action, Result}
+import play.api.mvc._
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -41,32 +42,31 @@ object Cached extends implicits.Dates {
     if (cacheableStatusCodes.contains(result.header.status)) cacheHeaders(cacheSeconds, result) else result
   }
 
-  case class StringResult(result: Result, body: Option[String])
-  object StringResult {
-    def apply(result: Result, body: String) = new StringResult(result, Some(body))
-    def withoutString(result: Result) = StringResult(result, None)
+  case class Hash(string: String)
+  case class RevalidatableResult(result: Result, hash: Hash)
+  object RevalidatableResult {
+    def apply(result: Result, body: String) = {
+      // hashing function from Arrays.java
+      val hashLong: Long = body.getBytes("UTF-8").foldLeft(z = 1L){
+        case (accu, nextByte) => 31 * accu + nextByte
+      }
+      new RevalidatableResult(result, Hash(hashLong.toString))
+    }
   }
 
-  def withEtag(page: Page)(stringResult: StringResult): Result = {
+  def withRevalidation(page: Page)(stringResult: RevalidatableResult)(implicit request: RequestHeader): Result = {
     val cacheSeconds = page.metadata.cacheTime.cacheSeconds
-    if (cacheableStatusCodes.contains(stringResult.result.header.status)) cacheHeaders(cacheSeconds, stringResult.result, stringResult.body) else stringResult.result
+    if (cacheableStatusCodes.contains(stringResult.result.header.status)) cacheHeaders(cacheSeconds, stringResult.result, Some((stringResult.hash, request.headers.get("If-None-Match")))) else stringResult.result
   }
 
   // Use this when you are sure your result needs caching headers, even though the result status isn't
   // conventionally cacheable. Typically we only cache 200 and 404 responses.
   def explicitlyCache(seconds: Int)(result: Result): Result = cacheHeaders(seconds, result)
 
-  private def cacheHeaders(seconds: Int, result: Result, maybeBody: Option[String] = None) = {
+  private def cacheHeaders(seconds: Int, result: Result, maybeHash: Option[(Hash, Option[String])] = None) = {
     val now = DateTime.now
     val expiresTime = now + seconds.seconds
     val maxAge = if (DoubleCacheTimesSwitch.isSwitchedOn) seconds * 2 else seconds
-
-    val maybeHash = maybeBody.map {
-      // hashing function from Arrays.java
-      _.getBytes("UTF-8").foldLeft(z = 1L){
-        case (accu, nextByte) => 31 * accu + nextByte
-      }
-    }
 
     // NOTE, if you change these headers make sure they are compatible with our Edge Cache
 
@@ -76,17 +76,24 @@ object Cached extends implicits.Dates {
     // http://docs.fastly.com/guides/22966608/40347813
     val staleWhileRevalidateSeconds = math.max(maxAge / 10, 1)
     val cacheControl = s"max-age=$maxAge, stale-while-revalidate=$staleWhileRevalidateSeconds, stale-if-error=$tenDaysInSeconds"
-    val etag = maybeHash.map{ hashInt: Long =>
-      s"hash${hashInt.toString}"
+
+    val (etagHeaderString, validatedResult): (String, Result) = maybeHash.map { case (hash, maybeHashToMatch) =>
+      val etag = s"""W/"hash${hash.string}""""
+      if (Switches.CheckETagsSwitch.isSwitchedOn && maybeHashToMatch.contains(etag)) {
+        (etag, Results.NotModified)
+      } else {
+        (etag, result)
+      }
     }.getOrElse(
-      s"johnRandom${scala.util.Random.nextInt}${scala.util.Random.nextInt}" // just to see if they come back in
+      (s""""johnRandom${scala.util.Random.nextInt}${scala.util.Random.nextInt}"""", result) // just to see if they come back in
     )
-    result.withHeaders(
+
+    validatedResult.withHeaders(
       "Surrogate-Control" -> cacheControl,
       "Cache-Control" -> cacheControl,
       "Expires" -> expiresTime.toHttpDateTimeString,
       "Date" -> now.toHttpDateTimeString,
-      "ETag" -> s""""$etag"""")
+      "ETag" -> etagHeaderString)
 
 
   }


### PR DESCRIPTION
This changes facia so that if the client has the content already (as illustrated by the if-none-match header) the server will respond with 304 not modified and an empty body.

This will save bandwidth - current stats show that 25% (878 out of 3528) of requests for fronts (rss and html are supported) during a sample period (1/6th of the traffic between 9:35 and 9:54 this morning) were when the client had the correct content.  A further 123 of the requests, the client had no content to revalidate.  So this is a significant saving on bandwidth.

@JustinPinner I've also tidied up that weird code I wrote last time!  I hope it is more logical now.
@piuccio time to save some bandwidth ;)
