### PR TITLE
Retry timed out requests made to the Accuweather API

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -215,4 +215,14 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
+  // Owner: dotcom health (tbonnin)
+  val RetryFailedAccuWeatherApiRequests = Switch(
+    SwitchGroup.Performance,
+    "retry-failed-accuweather-requests",
+    "If this switch is ON then failed requests to the Accuweather would be retried 2 more times before failing",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 27), //Wednesday
+    exposeClientSide = false
+  )
+
 }

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -11,13 +11,19 @@ import play.api.libs.ws.WS
 import weather.geo.LatitudeLongitude
 import weather.models.CityId
 import weather.models.accuweather.{ForecastResponse, LocationResponse, WeatherResponse}
-
-import scala.concurrent.Future
+import dispatch._, Defaults._
+import java.util.concurrent.{TimeoutException, TimeUnit}
+import scala.concurrent.duration.Duration
 
 object WeatherApi extends ExecutionContexts with ResourcesHelper {
   lazy val weatherApiKey: String = Configuration.weather.apiKey.getOrElse(
     throw new RuntimeException("Weather API Key not set")
   )
+
+  val requestTimeout = 300
+  val requestRetryMax = 3
+  val requestRetryDelay = Duration(100, TimeUnit.MILLISECONDS)
+  val requestRetryBackoffBase = 2
 
   private def autocompleteUrl(query: String): String =
     s"http://api.accuweather.com/locations/v1/cities/autocomplete?apikey=$weatherApiKey&q=${URLEncoder.encode(query, "utf-8")}"
@@ -35,8 +41,24 @@ object WeatherApi extends ExecutionContexts with ResourcesHelper {
   private def getJson(url: String): Future[JsValue] = {
     if (Play.isTest) {
       Future(Json.parse(slurpOrDie(new URI(url).getPath.stripPrefix("/"))))
+    } else if(conf.switches.Switches.RetryFailedAccuWeatherApiRequests.isSwitchedOn) {
+      getJsonWithRetry(url)
     } else {
       WS.url(url).get().filter(_.status == 200).map(_.json)
+    }
+  }
+
+  private def getJsonWithRetry(url: String): Future[JsValue] = {
+    val fetchRequest = () => WS.url(url).withRequestTimeout(requestTimeout).get().filter(_.status == 200)
+      .map { response =>
+        Right(response.json)
+      }
+      .recover {
+        case t : TimeoutException => Left(t)
+      }
+    retry.Backoff(max = requestRetryMax, delay = requestRetryDelay, base = requestRetryBackoffBase)(fetchRequest).flatMap {
+      case Left(error) => Future.failed(error)
+      case Right(json) => Future.successful(json)
     }
   }
 


### PR DESCRIPTION
## What does this change?

Accuweather api sometimes times out.
This PR introduces a retry mechanism in case of Accuweather request times out
## What is the value of this and can you measure success?

Less errors http://kibana.gu-web.net/goto/419b21b70d4627fd030b79dd089ac958
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@jamespamplin @johnduffell 
