### PR TITLE
Format TravelOffer price

### DIFF
--- a/commercial/app/model/commercial/travel/TravelOffer.scala
+++ b/commercial/app/model/commercial/travel/TravelOffer.scala
@@ -28,6 +28,13 @@ case class TravelOffer(id: String,
     case Some(x) => s"$x nights"
     case None => ""
   }
+
+  def formattedPrice : Option[String] = fromPrice map { price =>
+    if (price % 1 == 0)
+      f"£$price%,.0f"
+    else
+      f"£$price%,.2f"
+  }
 }
 
 object TravelOffer {

--- a/commercial/app/model/commercial/travel/TravelOffersAgent.scala
+++ b/commercial/app/model/commercial/travel/TravelOffersAgent.scala
@@ -15,8 +15,7 @@ object TravelOffersAgent extends MerchandiseAgent[TravelOffer] with ExecutionCon
   }
 
   def specificTravelOffers(offerIdStrings: Seq[String]): Seq[TravelOffer] = {
-    val offerIds = offerIdStrings map (_.toInt)
-    available filter (offer => offerIds contains offer.id)
+    available filter (offer => offerIdStrings contains offer.id)
   }
 
   def refresh(feedMetaData: FeedMetaData, feedContent: => Option[String]): Future[ParsedFeed[TravelOffer]] = {

--- a/commercial/app/views/travel/travelCard.scala.html
+++ b/commercial/app/views/travel/travelCard.scala.html
@@ -7,7 +7,7 @@
         <img class="advert__image" src="@offer.imageUrl">
     </div>
     <div class="advert__meta">
-        @offer.durationInWords from <strong>£@offer.fromPrice</strong>
+        @offer.durationInWords from <strong>@offer.formattedPrice</strong>
     </div>
     <span class="advert__more button button--small">
         Buy now @fragments.inlineSvg("arrow-right", "icon", List("i-right"))

--- a/commercial/app/views/travel/travelFragment.scala.html
+++ b/commercial/app/views/travel/travelFragment.scala.html
@@ -19,7 +19,7 @@
                 </div>
                 <h4 class="lineitem__title">@travelOffer.title</h4>
                 <div class="lineitem__offer">
-                    <p class="lineitem__meta">@travelOffer.durationInWords from <span class="lineitem__price">£@travelOffer.fromPrice</span></p>
+                    <p class="lineitem__meta">@travelOffer.durationInWords from <span class="lineitem__price">@travelOffer.formattedPrice</span></p>
                 </div>
             </a>
             <a class="lineitem__cta button button--primary button--small" href="@clickMacro@travelOffer.offerUrl">

--- a/commercial/app/views/travel/travelProminent.scala.html
+++ b/commercial/app/views/travel/travelProminent.scala.html
@@ -41,7 +41,7 @@
                                 <div class="lineitem--high__offer">
                                     <a class="lineitem__link" href="@clickMacro@offer.offerUrl" data-link-name="merchandising-travel-v@{version}_@{date}-high-@{offer.title}-title">
                                         <h4 class="lineitem__title">@offer.title</h4>
-                                        <p class="lineitem__meta">@offer.durationInWords from <span class="lineitem__price">£@offer.fromPrice</span></p>
+                                        <p class="lineitem__meta">@offer.durationInWords from <span class="lineitem__price">@offer.formattedPrice</span></p>
                                     </a>
                                     <a class="lineitem__cta button button--primary button--small" href="@clickMacro@offer.offerUrl" data-link-name="merchandising-travel-v@{version}_@{date}-high-@{offer.title}-book-now">
                                         Book now@fragments.inlineSvg("arrow-right", "icon", List("i-right"))
@@ -58,7 +58,7 @@
                                 <a class="lineitem__link" href="@clickMacro@offer.offerUrl" data-link-name="merchandising-travel-v@{version}_@{date}-high-@{offer.title}">
                                     <div class="lineitem__image-crop"><img class="lineitem__image" src="@offer.imageUrl" alt=""/></div>
                                     <h4 class="lineitem__title">@offer.title</h4>
-                                    <p class="lineitem__meta">@offer.durationInWords from <span class="lineitem__price">£@offer.fromPrice</span></p>
+                                    <p class="lineitem__meta">@offer.durationInWords from <span class="lineitem__price">@offer.formattedPrice</span></p>
                                 </a>
                                 <a class="lineitem__cta button button--primary button--small" href="@clickMacro@offer.offerUrl" data-link-name="merchandising-travel-v@{version}_@{date}-high-@{offer.title}-book-now">
                                     Book now@fragments.inlineSvg("arrow-right", "icon", List("i-right"))

--- a/commercial/app/views/travel/travelStandard.scala.html
+++ b/commercial/app/views/travel/travelStandard.scala.html
@@ -36,7 +36,7 @@
                             <a class="lineitem__link" href="@clickMacro@offer.offerUrl" data-link-name="merchandising-travel-v@{version}_@{date}-low-@{offer.title}">
                                 <div class="lineitem__image-crop"><img class="lineitem__image" src="@offer.imageUrl" alt=""/></div>
                                 <h4 class="lineitem__title">@offer.title</h4>
-                                <p class="lineitem__meta">@offer.durationInWords from <span class="lineitem__price">£@offer.fromPrice</span></p>
+                                <p class="lineitem__meta">@offer.durationInWords from <span class="lineitem__price">@offer.formattedPrice</span></p>
                             </a>
                             <a class="lineitem__cta button button--primary button--small" href="@clickMacro@offer.offerUrl" data-link-name="merchandising-travel-v@{version}_@{date}-low-@{offer.title}-book-now">
                                 Book now@fragments.inlineSvg("arrow-right", "icon", List("i-right"))


### PR DESCRIPTION
This is a slight extension to #12608, which formats the price a little more clearly.

**Before:**
![image](https://cloud.githubusercontent.com/assets/1821099/14675491/23cc68f8-0701-11e6-8624-50bb4a8081ee.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/1821099/14675464/0aa83636-0701-11e6-8aa0-0aa40734face.png)

(also removed a `toInt` call given that the attribute is now a `String`)

/@regiskuckaertz 
