### PR TITLE
Fix twitter selection sharing #11241 #12615

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -40,7 +40,7 @@ define([
         $emailAction,
         twitterShortUrl = config.page.shortUrl + '/stw',
         twitterHrefTemplate = 'https://twitter.com/intent/tweet?text=%E2%80%9C<%=text%>%E2%80%9D&url=<%=url%>',
-        twitterMessageLimit = 115, // 140 - t.co length - 3 chars for quotes and url spacing
+        twitterMessageLimit = 114, // 140 - t.co length - 3 chars for quotes and url spacing
         emailShortUrl = config.page.shortUrl + '/sbl',
         emailHrefTemplate = 'mailto:?subject=<%=subject%>&body=%E2%80%9C<%=selection%>%E2%80%9D <%=url%>',
         validAncestors = ['js-article__body', 'content__standfirst', 'block', 'caption--main', 'content__headline'],

--- a/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
+++ b/static/src/javascripts/projects/common/modules/ui/selection-sharing.js
@@ -91,7 +91,7 @@ define([
             }
 
             twitterHref = template(twitterHrefTemplate, {
-                text: encodeURI(twitterMessage),
+                text: encodeURIComponent(twitterMessage),
                 url: encodeURI(twitterShortUrl)
             });
             emailHref = template(emailHrefTemplate, {


### PR DESCRIPTION
## What does this change?
- Sharing highlighted text via twitter no longer slices a section that is 141 characters, it now only takes the 140 required for a valid tweet.
- Sharing text containing semicolons no longer truncates the text; encodeURIComponent will convert the semicolon to UTF-8 (encodeURI does not cover all special characters).
## What is the value of this and can you measure success?

e6da9c9 fixes issue #11241 (too many characters being passed to a tweet)
1deb267 fixes issue #12615 (semicolons in selected text cause truncation of tweet)
## Screenshots

**141 char issue BEFORE:**
<img width="678" alt="tweetbefore" src="https://cloud.githubusercontent.com/assets/8607683/14673678/336b2790-06f7-11e6-8ecc-e34d9932fbdc.png">

**141 char issue AFTER:**
<img width="688" alt="tweetafter" src="https://cloud.githubusercontent.com/assets/8607683/14673699/643b75be-06f7-11e6-9f18-96e8c6c8b941.png">

**Semicolon issue BEFORE:**
<img width="675" alt="semicolons missing" src="https://cloud.githubusercontent.com/assets/8607683/14680776/5d19dbda-0716-11e6-9947-64e1efc02fbc.png">

**Semicolon issue AFTER:**

<img width="666" alt="semicolons present" src="https://cloud.githubusercontent.com/assets/8607683/14680757/497139de-0716-11e6-9cee-e8ac5988e46a.png">
## Request for comment

@gtrufitt 
