### PR TITLE
Video fade out

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -22,6 +22,12 @@
 
         @fragments.headTonal(media)
         <div class="content__main tonal__main tonal__main--@toneClass(media)">
+            @media match {
+                case video: Video => {
+                    <div class="video__fader"></div>
+                }
+                case _ => {}
+            }
             <div class="gs-container">
                 <div class="content__main-column content__main-column--media content__main-column--@mediaType">
                     <div class="media-body">

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -24,7 +24,7 @@
         <div class="content__main tonal__main tonal__main--@toneClass(media)">
             @media match {
                 case video: Video => {
-                    <div class="video__fader"></div>
+                    <div class="video-fader"></div>
                 }
                 case _ => {}
             }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -367,9 +367,7 @@ define([
                 var related = $('.content-footer').offset().top;
                 var scroll = $(window).scrollTop();
                 var position = Math.floor(related - scroll);
-                console.log(position);
                 if (position <= 200){
-                    console.log('tihsihsih');
                     fader.removeClass('is-faded');
                     clearTimeout(faderTimeout);
                     bean.off(document.body, 'mousemove', setFaderTimeout);

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -364,14 +364,16 @@ define([
             bonzo(player.el()).removeClass(endState);
             bean.on(document.body, 'mousemove', setFaderTimeout);
             bean.on(window, 'scroll', function (){
-                var related = $('#more-media-in-section').offset().top;
+                var related = $('.content-footer').offset().top;
                 var scroll = $(window).scrollTop();
                 var position = Math.floor(related - scroll);
-                if (position <= 0){
+                console.log(position);
+                if (position <= 200){
+                    console.log('tihsihsih');
                     fader.removeClass('is-faded');
                     clearTimeout(faderTimeout);
                     bean.off(document.body, 'mousemove', setFaderTimeout);
-                }else if (position > 0 && !player.paused()){
+                }else if (!player.paused()){
                     fader.addClass('is-faded');
                     bean.on(document.body, 'mousemove', setFaderTimeout);
                 }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -358,9 +358,8 @@ define([
                 bean.on(document.body, 'mousemove', function() {
                     fader.removeClass('is-faded');
                     if(videoCheck === false){
-                        console.log('video is paused');
+                        return;
                     }else{
-                        console.log('video is playing');
                         clearTimeout(faderTimeout);
                         faderTimeout = setTimeout(function() {
                         fader.addClass('is-faded');

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -349,7 +349,12 @@ define([
             });
         });
         player.on('playing', function () {
+            $('.video__fader').addClass('isPlaying').css('opacity', '1');
             bonzo(player.el()).removeClass(endState);
+        });
+        
+        player.on('pause', function(){
+           $('.video__fader').removeClass('isPlaying').css('opacity', '0'); 
         });
     }
 

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -338,6 +338,7 @@ define([
 
     function initEndSlate(player, endSlatePath) {
         var fader = $('.video__fader');
+        var videoCheck = false;
         var faderTimeout;
         var endSlate = new Component(),
             endState = 'vjs-has-ended';
@@ -351,19 +352,34 @@ define([
             });
         });
         player.on('playing', function () {
+            videoCheck = true;
             fader.addClass('is-faded');
             bonzo(player.el()).removeClass(endState);
-
-            bean.on(document.body, 'mousemove', function() {
-                fader.removeClass('is-faded');
-                clearTimeout(faderTimeout);
-                faderTimeout = setTimeout(function() {
-                    fader.addClass('is-faded');
-                }, 1000);
-            });
+                bean.on(document.body, 'mousemove', function() {
+                    fader.removeClass('is-faded');
+                    if(videoCheck === false){
+                        console.log('video is paused');
+                    }else{
+                        console.log('video is playing');
+                        clearTimeout(faderTimeout);
+                        faderTimeout = setTimeout(function() {
+                        fader.addClass('is-faded');
+                        }, 3000);
+                    }
+                });
         });
-
+        bean.on(window, 'scroll', function (){
+           var related = $('#more-media-in-section').offset().top;
+           var scroll = $(window).scrollTop();
+           var position = Math.floor(related -scroll);
+           if (position <= 0){
+               fader.removeClass('is-faded');
+           }
+        });
+        //add in on video stop remove class
         player.on('pause', function(){
+            videoCheck = false;
+            clearTimeout(faderTimeout);
             fader.removeClass('is-faded');
         });
     }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -337,6 +337,7 @@ define([
     }
 
     function initEndSlate(player, endSlatePath) {
+        var fader = $('.video__fader');
         var endSlate = new Component(),
             endState = 'vjs-has-ended';
 
@@ -349,13 +350,14 @@ define([
             });
         });
         player.on('playing', function () {
-            $('.video__fader').addClass('isPlaying').css('opacity', '1');
+            fader.addClass('isPlaying');
             bonzo(player.el()).removeClass(endState);
         });
-        
+
         player.on('pause', function(){
-           $('.video__fader').removeClass('isPlaying').css('opacity', '0'); 
+            fader.removeClass('isPlaying');
         });
+
     }
 
     function initMoreInSection() {

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -340,7 +340,6 @@ define([
         var fader = $('.video__fader');
         var faderTimeout;
         function setFaderTimeout(){
-            console.log('still listening');
             fader.removeClass('is-faded');
             clearTimeout(faderTimeout);
             faderTimeout = setTimeout(function() {
@@ -364,9 +363,7 @@ define([
             fader.addClass('is-faded');
             bonzo(player.el()).removeClass(endState);
             bean.on(document.body, 'mousemove', setFaderTimeout);
-
             bean.on(window, 'scroll', function (){
-                
                 var related = $('#more-media-in-section').offset().top;
                 var scroll = $(window).scrollTop();
                 var position = Math.floor(related - scroll);
@@ -375,8 +372,8 @@ define([
                     clearTimeout(faderTimeout);
                     bean.off(document.body, 'mousemove', setFaderTimeout);
                 }else if (position > 0 && !player.paused()){
-                    console.log('this isissi');
                     fader.addClass('is-faded');
+                    bean.on(document.body, 'mousemove', setFaderTimeout);
                 }
             });
         });
@@ -384,7 +381,6 @@ define([
         //add in on video stop remove class
         player.on('pause', function(){
             clearTimeout(faderTimeout);
-            console.log('cleared?');
             bean.off(document.body, 'mousemove', setFaderTimeout);
             fader.removeClass('is-faded');
         });

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -338,8 +338,16 @@ define([
 
     function initEndSlate(player, endSlatePath) {
         var fader = $('.video__fader');
-        var videoCheck = false;
         var faderTimeout;
+        function setFaderTimeout(){
+            console.log('still listening');
+            fader.removeClass('is-faded');
+            clearTimeout(faderTimeout);
+            faderTimeout = setTimeout(function() {
+            fader.addClass('is-faded');
+            }, 3000);
+        }
+
         var endSlate = new Component(),
             endState = 'vjs-has-ended';
 
@@ -351,34 +359,33 @@ define([
                 bonzo(player.el()).addClass(endState);
             });
         });
+
         player.on('playing', function () {
-            videoCheck = true;
             fader.addClass('is-faded');
             bonzo(player.el()).removeClass(endState);
-                bean.on(document.body, 'mousemove', function() {
+            bean.on(document.body, 'mousemove', setFaderTimeout);
+
+            bean.on(window, 'scroll', function (){
+                
+                var related = $('#more-media-in-section').offset().top;
+                var scroll = $(window).scrollTop();
+                var position = Math.floor(related - scroll);
+                if (position <= 0){
                     fader.removeClass('is-faded');
-                    if(videoCheck === false){
-                        return;
-                    }else{
-                        clearTimeout(faderTimeout);
-                        faderTimeout = setTimeout(function() {
-                        fader.addClass('is-faded');
-                        }, 3000);
-                    }
-                });
+                    clearTimeout(faderTimeout);
+                    bean.off(document.body, 'mousemove', setFaderTimeout);
+                }else if (position > 0 && !player.paused()){
+                    console.log('this isissi');
+                    fader.addClass('is-faded');
+                }
+            });
         });
-        bean.on(window, 'scroll', function (){
-           var related = $('#more-media-in-section').offset().top;
-           var scroll = $(window).scrollTop();
-           var position = Math.floor(related -scroll);
-           if (position <= 0){
-               fader.removeClass('is-faded');
-           }
-        });
+
         //add in on video stop remove class
         player.on('pause', function(){
-            videoCheck = false;
             clearTimeout(faderTimeout);
+            console.log('cleared?');
+            bean.off(document.body, 'mousemove', setFaderTimeout);
             fader.removeClass('is-faded');
         });
     }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -338,6 +338,7 @@ define([
 
     function initEndSlate(player, endSlatePath) {
         var fader = $('.video__fader');
+        var faderTimeout;
         var endSlate = new Component(),
             endState = 'vjs-has-ended';
 
@@ -350,14 +351,21 @@ define([
             });
         });
         player.on('playing', function () {
-            fader.addClass('isPlaying');
+            fader.addClass('is-faded');
             bonzo(player.el()).removeClass(endState);
+
+            bean.on(document.body, 'mousemove', function() {
+                fader.removeClass('is-faded');
+                clearTimeout(faderTimeout);
+                faderTimeout = setTimeout(function() {
+                    fader.addClass('is-faded');
+                }, 1000);
+            });
         });
 
         player.on('pause', function(){
-            fader.removeClass('isPlaying');
+            fader.removeClass('is-faded');
         });
-
     }
 
     function initMoreInSection() {

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -24,11 +24,13 @@
         right: 0;
         background-color: rgba(0, 0, 0, .8);
         opacity: 0;
-        transition: opacity .5s ease-in-out;
-        display: none;
+        transition: all 1s ease-in-out;
+        visibility: hidden;
         
         &.isPlaying {
-            display: block;
+            visibility: visible;
+            opacity: 1;
+            transition: all 1s ease-in-out;
         }
     }
 

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -15,7 +15,7 @@
         }
     }
 
-    .video__fader {
+    .video-fader {
         position: fixed;
         z-index: 9999;
         top: 0;
@@ -27,7 +27,7 @@
         transition: all 1s ease-in-out;
         visibility: hidden;
         
-        &.is-faded {
+        &--active {
             visibility: visible;
             opacity: 1;
             transition: all 1s ease-in-out;

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -15,8 +15,26 @@
         }
     }
 
+    .video__fader {
+        position: fixed;
+        z-index: 9999;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background-color: rgba(0, 0, 0, .8);
+        opacity: 0;
+        transition: opacity .5s ease-in-out;
+        display: none;
+        
+        &.isPlaying{
+            display: block;
+        }
+    }
+
     .player {
         margin-bottom: $gs-baseline/2;
+        z-index: 99999;
     }
 
     .gu-media-wrapper {

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -27,7 +27,7 @@
         transition: opacity .5s ease-in-out;
         display: none;
         
-        &.isPlaying{
+        &.isPlaying {
             display: block;
         }
     }

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -27,7 +27,7 @@
         transition: all 1s ease-in-out;
         visibility: hidden;
         
-        &.isPlaying {
+        &.is-faded {
             visibility: visible;
             opacity: 1;
             transition: all 1s ease-in-out;

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -17,26 +17,26 @@
 
     .video-fader {
         position: fixed;
-        z-index: 9999;
+        z-index: 900;
         top: 0;
         bottom: 0;
         left: 0;
         right: 0;
         background-color: rgba(0, 0, 0, .8);
         opacity: 0;
-        transition: all 1s ease-in-out;
+        transition: opacity 1s ease-in-out, visibility 1s ease-in-out;
         visibility: hidden;
         
         &--active {
             visibility: visible;
             opacity: 1;
-            transition: all 1s ease-in-out;
+            transition: opacity 1s ease-in-out, visibility 1s ease-in-out;
         }
     }
 
     .player {
         margin-bottom: $gs-baseline/2;
-        z-index: 99999;
+        z-index: 1000;
     }
 
     .gu-media-wrapper {


### PR DESCRIPTION
Adds an element to the video page which fades the screen when the video is playing. 

Some javascript to handle the fading in and out. When the mouse moves the page fades back there is a timeout on the transition of 3 seconds. So if the mouse is inactive again it comes back in. 

The screen fades back in as the page scrolls and gets to the related content at the bottom. 

<img width="1440" alt="picture 33" src="https://cloud.githubusercontent.com/assets/11950919/14676085/e372928e-0703-11e6-94b0-3b6ebbe84ea6.png">

![screenfade](https://cloud.githubusercontent.com/assets/11950919/14677260/c6af538a-0708-11e6-9257-11e4ce437b69.gif)

Request comment @sammorrisdesign @rich-nguyen @jamesgorrie 
