### PR TITLE
Glabs CAPI card styling fixes

### DIFF
--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -47,7 +47,7 @@
 
     .inline-glabs-logo-small {
         svg {
-            right: 0;
+            right: $gs-gutter / 4;
             left: auto;
             top: 4px;
             width: 75px;

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
@@ -40,7 +40,7 @@
 .popup--paidfor__link {
     color: $paidfor-background;
     font-size: get-font-size(textSans, 2);
-    line-height: 10px;
+    line-height: 0.8;
     display: block;
 
     svg {

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
@@ -40,7 +40,7 @@
 .popup--paidfor__link {
     color: $paidfor-background;
     font-size: get-font-size(textSans, 2);
-    line-height: 0.8;
+    line-height: .8;
     display: block;
 
     svg {

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-popup.scss
@@ -1,7 +1,7 @@
 .popup--paidfor {
     background: $neutral-1;
     box-shadow: none;
-    left: 50%;
+    left: 100%;
     top: 100%;
     padding: 16px;
     color: #ffffff;
@@ -26,7 +26,7 @@
         width: 0;
         position: absolute;
         bottom: 100%;
-        left: 50%;
+        left: 35%;
         transform: translate(-50%, 0);
     }
 }
@@ -38,15 +38,15 @@
 }
 
 .popup--paidfor__link {
-    color: #676767;
+    color: $paidfor-background;
     font-size: get-font-size(textSans, 2);
-    line-height: get-line-height(textSans, 1);
+    line-height: 10px;
     display: block;
 
     svg {
         display: inline-block;
         vertical-align: middle;
-        fill: #676767;
+        fill: $paidfor-background;
         height: 20px;
         width: 20px;
     }


### PR DESCRIPTION
## What does this change?

This PR fixes styling bugs of the Glabs paid content dropdown eg: more vivid colour and smaller line-height of the cta text, position of the dropdown layer, position of the glabs logo.
## Screenshots

Before:
![screen shot 2016-04-20 at 14 50 59](https://cloud.githubusercontent.com/assets/489567/14677327/220c073c-0709-11e6-932c-28fc922316ee.png)

After:
![screen shot 2016-04-20 at 14 46 41](https://cloud.githubusercontent.com/assets/489567/14677361/43fd387a-0709-11e6-9ac8-4901d318b9f9.png)
