### PR TITLE
Pageskin adcall filtering

### DIFF
--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -9,7 +9,7 @@ trait PageskinAdAgent {
 
   protected def pageSkinSponsorships: Seq[PageSkinSponsorship]
 
-  def isPageSkinned(adUnitWithoutRoot: String, edition: Edition): Boolean = {
+  private def findSponsorship(adUnitWithoutRoot: String, edition: Edition): Option[PageSkinSponsorship] = {
     if (PageSkin.isValidForNextGenPageSkin(adUnitWithoutRoot)) {
       val adUnitWithRoot = s"$dfpAdUnitRoot/$adUnitWithoutRoot"
 
@@ -20,11 +20,22 @@ trait PageskinAdAgent {
           !sponsorship.isR2Only
       }
 
-      pageSkinSponsorships.exists { sponsorship =>
-        val isPageTargeted = targetsAdUnitAndMatchesTheEdition(sponsorship)
-        isPageTargeted && (!isProd || !sponsorship.targetsAdTest)
+      pageSkinSponsorships.find { sponsorship =>
+       targetsAdUnitAndMatchesTheEdition(sponsorship)
       }
+    } else None
+  }
 
-    } else false
+  // The ad unit is considered to have a page skin if it has a corresponding sponsorship.
+  // If the sponsorship is an adTest, it is only considered outside of production.
+  def hasPageSkin(adUnitWithoutRoot: String, edition: Edition): Boolean = {
+    findSponsorship(adUnitWithoutRoot, edition).exists { sponsorship =>
+      !sponsorship.targetsAdTest || !isProd
+    }
+  }
+
+  // True if there is any candidate sponsorship for this ad unit. Used to decide when to render the out-of-page ad slot.
+  def hasPageSkinOrAdTestPageSkin(adUnitWithoutRoot: String, edition: Edition): Boolean = {
+    findSponsorship(adUnitWithoutRoot, edition).isDefined
   }
 }

--- a/common/app/model/KeywordSponsorshipHandling.scala
+++ b/common/app/model/KeywordSponsorshipHandling.scala
@@ -29,5 +29,5 @@ case class KeywordSponsorshipHandling(
 
   lazy val sponsor: Option[String] = keywordIds.flatMap(DfpAgent.getSponsor(_)).headOption
 
-  def hasPageSkin(edition: Edition): Boolean = DfpAgent.isPageSkinned(adUnitSuffix, edition)
+  def hasPageSkin(edition: Edition): Boolean = DfpAgent.hasPageSkin(adUnitSuffix, edition)
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -244,7 +244,10 @@ final case class MetaData (
 ){
 
   def hasPageSkin(edition: Edition) = if (isPressedPage){
-    DfpAgent.isPageSkinned(adUnitSuffix, edition)
+    DfpAgent.hasPageSkin(adUnitSuffix, edition)
+  } else false
+  def hasPageSkinOrAdTestPageSkin(edition: Edition) = if (isPressedPage){
+    DfpAgent.hasPageSkinOrAdTestPageSkin(adUnitSuffix, edition)
   } else false
   def sizeOfTakeoverAdsInSlot(slot: AdSlot, edition: Edition): Seq[AdSize] = if (isPressedPage) {
     DfpAgent.sizeOfTakeoverAdsInSlot(slot, adUnitSuffix, edition)

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -82,7 +82,9 @@
 
         @fragments.analytics.base(page)
 
-        @fragments.commercial.pageSkin()
+        @if(page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
+            @fragments.commercial.pageSkin()
+        }
 
     </body>
     </html>

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -49,7 +49,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
   }
 
   "isPageSkinned" should "be true for a front with a pageskin in given edition" in {
-    TestPageskinAdAgent.has("business/front", edition = defaultEdition) should be(true)
+    TestPageskinAdAgent.hasPageSkin("business/front", edition = defaultEdition) should be(true)
   }
 
   it should "be false for a front with a pageskin in another edition" in {

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -49,32 +49,32 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
   }
 
   "isPageSkinned" should "be true for a front with a pageskin in given edition" in {
-    TestPageskinAdAgent.isPageSkinned("business/front", edition = defaultEdition) should be(true)
+    TestPageskinAdAgent.has("business/front", edition = defaultEdition) should be(true)
   }
 
   it should "be false for a front with a pageskin in another edition" in {
-    TestPageskinAdAgent.isPageSkinned("business/front", edition = Au) should be(false)
+    TestPageskinAdAgent.hasPageSkin("business/front", edition = Au) should be(false)
   }
 
   it should "be false for a front without a pageskin" in {
-    TestPageskinAdAgent.isPageSkinned("culture/front", edition = defaultEdition) should be(false)
+    TestPageskinAdAgent.hasPageSkin("culture/front", edition = defaultEdition) should be(false)
   }
 
   it should "be false for a front with a pageskin in no edition" in {
-    TestPageskinAdAgent.isPageSkinned("music/front", edition = defaultEdition) should be(false)
-    TestPageskinAdAgent.isPageSkinned("music/front", edition = Us) should be(false)
+    TestPageskinAdAgent.hasPageSkin("music/front", edition = defaultEdition) should be(false)
+    TestPageskinAdAgent.hasPageSkin("music/front", edition = Us) should be(false)
   }
 
   it should "be false for any content (non-front) page" in {
-    TestPageskinAdAgent.isPageSkinned("sport", edition = defaultEdition) should be(false)
+    TestPageskinAdAgent.hasPageSkin("sport", edition = defaultEdition) should be(false)
   }
 
   "production DfpAgent" should "not recognise adtest targetted line items" in {
-    TestPageskinAdAgent.isPageSkinned("testSport/front", edition = defaultEdition) should be(false)
+    TestPageskinAdAgent.hasPageSkin("testSport/front", edition = defaultEdition) should be(false)
   }
 
   "non production DfpAgent" should "should recognise adtest targetted line items" in {
-    NotProductionTestPageskinAdAgent.isPageSkinned("testSport/front",
+    NotProductionTestPageskinAdAgent.hasPageSkin("testSport/front",
       edition = defaultEdition) should be(
       true)
   }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -89,7 +89,7 @@ define([
      *
      * Create a new ad slot using the following code:
      *
-     * <div class="ad-slot__dfp AD_SLOT_CLASS" data-name="AD_SLOT_NAME" data-mobile="300,50|320,50"
+     * <div class="js-ad-slot AD_SLOT_CLASS" data-name="AD_SLOT_NAME" data-mobile="300,50|320,50"
      *      data-desktop="300,250" data-refresh="false" data-label="false">
      *     <div id="SLOT_ID" class="ad-container"></div>
      * </div>


### PR DESCRIPTION
This reduces the appearance of the out-of-page ad slot html. The server should only render this ad slot when the ad unit for the request has a targeted page skin. Currently this unfilled dfp call costs us hundreds of pounds everyday.
