### PR TITLE
Failed requests are logged as warning

### DIFF
--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -23,7 +23,7 @@ object RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
         }
 
       case Failure(error) =>
-        log.error(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed} ms", error)
+        log.warn(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed} ms", error)
     }
 
     result

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -155,7 +155,6 @@ object CommentsController extends DiscussionController with ExecutionContexts {
     }
       .recover {
         case NonFatal(e) =>
-          log.error(s"Error fetching comments from request with following headers: ${request.headers}", e)
           NotFound(s"Discussion ${key} cannot be retrieved")
       }
   }


### PR DESCRIPTION
## What does this change?

Requests can failed for external reasons (non existing paths for
example). It's better not to add noise to our error logs.
Also if an internal error happens while processing a requests, it is
likely to be logged as well
## What is the value of this and can you measure success?

Better logs structure, easier to monitor internal errors by removing noise
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@jamespamplin 
