### PR TITLE
First line of PR tempalte doesn't bring much info. Removing it

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@
 
 ## Request for comment
 
---
 
+<!--
 *Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-# My Awesome Pull Request
-
 ## What does this change?
 
 ## What is the value of this and can you measure success?


### PR DESCRIPTION
## What does this change?

The first line of the PR template (title) doesn't bring much value.
I noticed a lot of people (including myself) remove it all together
before to submit a PR anyway
I propose to remove it. What to do you think?

This PR also put the contribution guideline hint in a html comment so it is only visible to devs creating/editing the PR but not to reviewers. :)
## What is the value of this and can you measure success?

Less noise 🔕 
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@gtrufitt 
## 

_Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?_
