### PR TITLE
Add switch to enable constant DFP request of 1x1 ad slot

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -373,4 +373,13 @@ trait CommercialSwitches {
     sellByDate = new LocalDate(2016, 4, 27),
     exposeClientSide = false
   )
+
+  val requestOutOfPageSlotAlways = Switch(
+    SwitchGroup.Commercial,
+    "request-out-of-page-slot-always",
+    "If on, the out of page slot (1x1) will be added to each page, regardless of pageskins, surveys or other dependent features",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 5, 3),
+    exposeClientSide =  false
+  )
 }

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -82,7 +82,7 @@
 
         @fragments.analytics.base(page)
 
-        @if(page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
+        @if(requestOutOfPageSlotAlways.isSwitchedOn || page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
             @fragments.commercial.pageSkin()
         }
 


### PR DESCRIPTION
## What does this change?

@rich-nguyen [put in a change](https://github.com/guardian/frontend/pull/12620) that stops us requesting a 1x1 (out-pf-page) ad slot on every page.

Surveys depend on this slot being there and so this switch allows us to revert back to this behaviour when surveys are live.

**NB**
Surveys are soon to be delivered via MPU slots and so will no longer depend on the 1x1 ad slot, meaning that this switch can then be discarded.
## What is the value of this and can you measure success?

Surveys can be run in their current form on the desktop site.
## Does this affect other platforms - Amp, Apps, etc?

Nope.
