### PR TITLE
Assetmonitor grunt task: monitor all js

### DIFF
--- a/grunt-configs/assetmonitor.js
+++ b/grunt-configs/assetmonitor.js
@@ -2,8 +2,10 @@ module.exports = function (grunt, options) {
     return {
         common: {
             src: [
-                options.staticTargetDir + 'javascripts/bootstraps/*.js',
-                options.staticTargetDir + 'stylesheets/*.css',
+                options.staticTargetDir + 'javascripts/**/*.js',
+                '!' + options.staticTargetDir + 'javascripts/components/**/*.js',
+                '!' + options.staticTargetDir + 'javascripts/vendor/**/*.js',
+                options.staticTargetDir + 'stylesheets/**/*.css',
                 '!' + options.staticTargetDir + 'stylesheets/*head.identity.css'
             ],
             options: {


### PR DESCRIPTION
## What does this change?

Monitor all js files size, not just the one in the bootstrap subdirectory. Same for css files

I will work on improving https://frontend.gutools.co.uk/metrics/assets to show the stats for all those files
## What is the value of this and can you measure success?

Monitor app.js and enhanced-vendor.js which were excluded before
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@sndrs 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
