### PR TITLE
Add video series page test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -86,4 +86,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABVideoSeriesPage = Switch(
+    SwitchGroup.ABTests,
+    "ab-video-series-page",
+    "Testing new video series layout",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 4, 25),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -14,6 +14,7 @@ define([
     'common/modules/experiments/tests/membership',
     'common/modules/experiments/tests/loyal-adblocking-survey',
     'common/modules/experiments/tests/minute',
+    'common/modules/experiments/tests/video-series-page',
     'lodash/arrays/flatten',
     'lodash/arrays/zip',
     'lodash/collections/forEach',
@@ -43,6 +44,7 @@ define([
     Membership,
     LoyalAdblockingSurvey,
     Minute,
+    VideoSeriesPage,
     flatten,
     zip,
     forEach,
@@ -67,7 +69,8 @@ define([
         new NextInSeries(),
         new Membership(),
         new LoyalAdblockingSurvey(),
-        new Minute()
+        new Minute(),
+        new VideoSeriesPage()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-series-page.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-series-page.js
@@ -1,0 +1,36 @@
+define([
+    'common/utils/config'
+], function (
+    config
+) {
+    return function () {
+
+        this.id = 'VideoSeries';
+        this.start = '2016-04-21';
+        this.expiry = '2016-04-25';
+        this.author = 'James Gorrie';
+        this.description = 'New video series page (initial numbers test)';
+        this.audience = 1.0;
+        this.audienceOffset = 0.0;
+        this.successMeasure = '';
+        this.showForSensitive = true;
+        this.audienceCriteria = '';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            return config.page.contentType === 'Video' && config.page.seriesTags;
+        };
+
+        this.variants = [
+            {
+                id: 'test1',
+                test: function () {}
+            },
+            {
+                id: 'test2',
+                test: function () {}
+            }
+        ];
+    };
+});


### PR DESCRIPTION
## What does this change?

Adding a test to get some confidence around the numbers on video series pages.
## What is the value of this and can you measure success?

We get numbers
## Request for comment

@akash1810 @harrysalmon

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
