### PR TITLE
Aim to limit football competition agents to polling the current season only

### DIFF
--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -97,6 +97,14 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
     DateTimeComparator.getInstance.asInstanceOf[Comparator[DateTime]]
   )
 
+  private def mostRecentCompetitionSeasons(competitions: List[Season], numToTake: Int): List[Season] = {
+    competitionDefinitions.flatMap{ compDef =>
+      competitions.filter(_.competitionId == compDef.id)
+        .sortBy(_.startDate.toDateTimeAtStartOfDay.getMillis).reverse
+        .take(numToTake)
+    }
+  }
+
   val competitionDefinitions = Seq(
     Competition("500", "/football/championsleague", "Champions League", "Champions League", "European", tableDividers = List(2, 6, 21)),
     Competition("100", "/football/premierleague", "Premier League", "Premier League", "English", showInTeamsList = true, tableDividers = List(4, 5, 17)),
@@ -136,15 +144,23 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
   //one http call updates all competitions
   def refreshCompetitionData() = {
     log.info("Refreshing competition data")
-    FootballClient.competitions.map(_.flatMap { season =>
-      competitionAgents.find(_.competition.id == season.id).map { agent =>
-        val newCompetition = agent.competition.startDate match {
-          case Some(existingStartDate) if season.startDate.isAfter(existingStartDate.toDateTimeAtStartOfDay) => agent.update(agent.competition.copy(startDate = Some(season.startDate)))
-          case None => agent.update(agent.competition.copy(startDate = Some(season.startDate)))
-          case _ =>
+    FootballClient.competitions.map { allComps =>
+      mostRecentCompetitionSeasons(allComps, numToTake = 1).map { season =>
+        competitionAgents.find(_.competition.id == season.id).map { agent =>
+          val newCompetition = agent.competition.startDate match {
+            case Some(existingStartDate) if season.startDate.isAfter(existingStartDate.toDateTimeAtStartOfDay) => {
+              log.info(s"updating competition: ${season.id} season: ${season.seasonId} startDate was: ${existingStartDate.toString} now: ${season.startDate.toString}")
+              agent.update(agent.competition.copy(startDate = Some(season.startDate)))
+            }
+            case None => {
+              log.info(s"setting competition: ${season.id} season: ${season.seasonId} startDate was: None now: ${season.startDate.toString}")
+              agent.update(agent.competition.copy(startDate = Some(season.startDate)))
+            }
+            case _ =>
+          }
         }
       }
-    }).recover(FootballClient.logErrors)
+    }.recover(FootballClient.logErrors)
   }
 
   //one http call updates all competitions

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -97,11 +97,11 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
     DateTimeComparator.getInstance.asInstanceOf[Comparator[DateTime]]
   )
 
-  private def mostRecentCompetitionSeasons(competitions: List[Season], numToTake: Int): List[Season] = {
+  private def mostRecentCompetitionSeasons(competitions: List[Season]): List[Season] = {
     competitionDefinitions.flatMap{ compDef =>
       competitions.filter(_.competitionId == compDef.id)
         .sortBy(_.startDate.toDateTimeAtStartOfDay.getMillis).reverse
-        .take(numToTake)
+        .take(2)
     }
   }
 
@@ -145,7 +145,7 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
   def refreshCompetitionData() = {
     log.info("Refreshing competition data")
     FootballClient.competitions.map { allComps =>
-      mostRecentCompetitionSeasons(allComps, numToTake = 1).map { season =>
+      mostRecentCompetitionSeasons(allComps).map { season =>
         competitionAgents.find(_.competition.id == season.id).map { agent =>
           val newCompetition = agent.competition.startDate match {
             case Some(existingStartDate) if season.startDate.isAfter(existingStartDate.toDateTimeAtStartOfDay) => {


### PR DESCRIPTION
I opened this PR mainly to run tests (lots of unrelated tests failed locally), and to put the idea out there.
## What does this change?

We currently poll PA for football season data going way back (to the 1880s in some cases). There's probably not much point in polling for updates to data beyond the current season, so this PR attempts to limit the date range it considers.
## What is the value of this and can you measure success?

We'll reduce the number of calls to PA for old data.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Request for comment

@TBonnin

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
