### PR TITLE
Spacefinder: streamlined DOM reads in a single run

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -1,28 +1,18 @@
 define([
     'common/utils/fastdom-promise',
     'qwery',
-    'bonzo',
     'bean',
     'Promise',
     'common/utils/config',
     'common/utils/mediator',
-    'lodash/collections/filter',
-    'lodash/collections/map',
-    'lodash/collections/every',
-    'lodash/objects/forOwn',
     'lodash/functions/curry'
 ], function (
     fastdom,
     qwery,
-    bonzo,
     bean,
     Promise,
     config,
     mediator,
-    filter,
-    map,
-    every,
-    forOwn,
     curry
 ) {
     // maximum time (in ms) to wait for images to be loaded and rich links
@@ -68,7 +58,7 @@ define([
     }
 
     function onImagesLoaded(body) {
-        var notLoaded = filter(qwery('img', body), function (img) {
+        var notLoaded = qwery('img', body).filter(function (img) {
             return !img.complete;
         });
 
@@ -96,81 +86,73 @@ define([
     }
 
     // test one element vs another for the given rules
-    function _testElem(rules, elem, other) {
-        var isMinAbove = elem.top - other.bottom >= rules.minAbove;
-        var isMinBelow = other.top - elem.top >= rules.minBelow;
+    function _testCandidate(rules, challenger, opponent) {
+        var isMinAbove = challenger.top - opponent.bottom >= rules.minAbove;
+        var isMinBelow = opponent.top - challenger.top >= rules.minBelow;
 
         return isMinAbove || isMinBelow;
     }
 
     // test one element vs an array of other elements for the given rules
-    function _testElems(rules, elem, others) {
-        return every(others, curry(_testElem)(rules, elem));
+    function _testCandidates(rules, challenger, opponents) {
+        return opponents.every(curry(_testCandidate)(rules, challenger));
     }
 
-    function _mapElementToDimensions(el, rules) {
+    function _mapElementToComputedDimensions(el) {
         var rect = el.getBoundingClientRect();
         return {
-            top: rules.absoluteMinAbove ? rect.top : el.offsetTop,
-            bottom: rules.absoluteMinAbove ? rect.bottom : el.offsetTop + el.offsetHeight,
+            top: rect.top,
+            bottom: rect.bottom,
             element: el
         };
     }
 
-    function _enforceRules(slots, rules, bodyHeight) {
-        var filtered = Promise.resolve(slots);
+    function _mapElementToDimensions(el) {
+        return {
+            top: el.offsetTop,
+            bottom: el.offsetTop + el.offsetHeight,
+            element: el
+        };
+    }
+
+    function _enforceRules(data, rules) {
+        var candidates = data.candidates;
 
         // enforce absoluteMinAbove rule
-        if (rules.absoluteMinAbove > 0) {
-            filtered = filtered.then(filter(slots, function (slot) {
-                return slot.top >= rules.absoluteMinAbove;
-            }));
+        if (rules.absoluteMinAbove) {
+            candidates = candidates.filter(function (candidate) {
+                return candidate.top >= rules.absoluteMinAbove;
+            });
         }
 
         // enforce minAbove and minBelow rules
-        filtered = filtered.then(function (slots) {
-            return filter(slots, function (slot) {
-                var farEnoughFromTopOfBody = slot.top >= rules.minAbove;
-                var farEnoughFromBottomOfBody = slot.top + rules.minBelow <= bodyHeight;
-                return farEnoughFromTopOfBody && farEnoughFromBottomOfBody;
-            });
+        candidates = candidates.filter(function (candidate) {
+            var farEnoughFromTopOfBody = candidate.top >= rules.minAbove;
+            var farEnoughFromBottomOfBody = candidate.top + rules.minBelow <= data.bodyHeight;
+            return farEnoughFromTopOfBody && farEnoughFromBottomOfBody;
         });
 
         // enforce content meta rule
         if (rules.clearContentMeta) {
-            filtered = filtered.then(function (slots) {
-                return [slots, qwery('.js-content-meta')[0]];
-            }).then(function (args) {
-                return fastdom.read(function () {
-                    return [args[0], _mapElementToDimensions(args[1], rules)];
-                });
-            }).then(function (args) {
-                return filter(args[0], function (slot) {
-                    return slot.top > (args[1].bottom + rules.clearContentMeta);
-                });
+            candidates = candidates.filter(function (candidate) {
+                return candidate.top > (data.contentMeta.bottom + rules.clearContentMeta);
             });
         }
 
         // enforce selector rules
         if (rules.selectors) {
-            forOwn(rules.selectors, function (params, selector) {
-                filtered = filtered.then(function (slots) {
-                    return [slots, qwery(rules.bodySelector + selector)];
-                }).then(function (args) {
-                    return fastdom.read(function () {
-                        return [args[0], map(args[1], function(slot) {
-                            return _mapElementToDimensions(slot, rules);
-                        })];
-                    });
-                }).then(function (args) {
-                    return filter(args[0], function (slot) {
-                        return _testElems(params, slot, args[1]);
-                    });
+            Object.keys(rules.selectors).forEach(function (selector) {
+                candidates = candidates.filter(function (candidate) {
+                    return _testCandidates(rules.selectors[selector], candidate, data.opponents[selector]);
                 });
             });
         }
 
-        return filtered;
+        if (rules.filter) {
+            candidates = candidates.filter(rules.filter);
+        }
+
+        return candidates;
     }
 
     function getReady(body) {
@@ -187,27 +169,27 @@ define([
     // Rather than calling this directly, use spaceFiller to inject content into the page.
     // SpaceFiller will safely queue up all the various asynchronous DOM actions to avoid any race conditions.
     function findSpace(rules) {
-        var body;
+        var body, getDimensions;
 
-        rules = rules || defaultRules;
+        rules || (rules = defaultRules);
         body = rules.bodySelector ? document.querySelector(rules.bodySelector) : document;
+        getDimensions = rules.absoluteMinAbove ? _mapElementToComputedDimensions : _mapElementToDimensions;
 
         return getReady(body)
-        .then(getSlots)
+        .then(getCandidates)
         .then(getMeasurements)
         .then(enforceRules)
-        .then(filterSlots)
-        .then(returnSlots);
+        .then(returnCandidates);
 
-        function getSlots() {
-            var slots = qwery(rules.bodySelector + rules.slotSelector);
+        function getCandidates() {
+            var candidates = qwery(rules.bodySelector + rules.slotSelector);
             if (rules.fromBottom) {
-                slots.reverse();
+                candidates.reverse();
             }
             if (rules.startAt) {
                 var drop = true;
-                slots = filter(slots, function (slot) {
-                    if (slot === rules.startAt) {
+                candidates = candidates.filter(function (candidate) {
+                    if (candidate === rules.startAt) {
                         drop = false;
                     }
                     return !drop;
@@ -215,42 +197,59 @@ define([
             }
             if (rules.stopAt) {
                 var keep = true;
-                slots = filter(slots, function (slot) {
-                    if (slot === rules.stopAt) {
+                candidates = candidates.filter(function (candidate) {
+                    if (candidate === rules.stopAt) {
                         keep = false;
                     }
                     return keep;
                 });
             }
-            return slots;
+            return candidates;
         }
 
-        function getMeasurements(slots) {
+        function getMeasurements(candidates) {
+            var contentMeta = rules.clearContentMeta ?
+                document.querySelector('.js-content-meta') :
+                null;
+            var opponents = rules.selectors ?
+                Object.keys(rules.selectors).map(function (selector) {
+                    return [selector, qwery(rules.bodySelector + selector)];
+                }) :
+                null;
+
             return fastdom.read(function () {
-                var rect = body.getBoundingClientRect();
-                return [
-                    rect.top,
-                    rect.height,
-                    map(slots, function(slot) {
-                        return _mapElementToDimensions(slot, rules);
-                    })
-                ];
+                var bodyDims = body.getBoundingClientRect();
+                var candidatesWithDims = candidates.map(getDimensions);
+                var contentMetaWithDims = rules.clearContentMeta ?
+                    getDimensions(contentMeta) :
+                    null;
+                var opponentsWithDims = opponents ?
+                    opponents.reduce(function (result, selectorAndElements) {
+                        result[selectorAndElements[0]] = selectorAndElements[1].map(getDimensions);
+                        return result;
+                    }, {}) :
+                    null;
+
+                if (rules.absoluteMinAbove) {
+                    rules.absoluteMinAbove -= bodyDims.top;
+                }
+
+                return {
+                    bodyHeight: bodyDims.height,
+                    candidates: candidatesWithDims,
+                    contentMeta: contentMetaWithDims,
+                    opponents: opponentsWithDims
+                };
             });
         }
 
         function enforceRules(data) {
-            return _enforceRules(data[2], rules, data[1]);
+            return _enforceRules(data, rules);
         }
 
-        function filterSlots(slots) {
-            return rules.filter ?
-                filter(slots, rules.filter) :
-                slots;
-        }
-
-        function returnSlots(slots) {
-            if (slots.length) {
-                return map(slots, function (slot) { return slot.element; });
+        function returnCandidates(candidates) {
+            if (candidates.length) {
+                return candidates.map(function (candidate) { return candidate.element; });
             } else {
                 throw new Error('There is no space left matching rules ' + JSON.stringify(rules));
             }
@@ -259,7 +258,7 @@ define([
 
     return {
         findSpace: findSpace,
-        _testElem: _testElem, // exposed for unit testing
-        _testElems: _testElems // exposed for unit testing
+        _testCandidate: _testCandidate, // exposed for unit testing
+        _testCandidates: _testCandidates // exposed for unit testing
     };
 });

--- a/static/test/javascripts/spec/common/content/spacefinder.spec.js
+++ b/static/test/javascripts/spec/common/content/spacefinder.spec.js
@@ -18,11 +18,11 @@ define(['common/modules/article/spacefinder'], function (
                 ];
 
             for (var i = 0; i < others.length; i++) {
-                expect(spacefinder._testElem(rules, para, others[i])).toBe(others[i].expectedResult);
+                expect(spacefinder._testCandidate(rules, para, others[i])).toBe(others[i].expectedResult);
             }
 
-            expect(spacefinder._testElems(rules, para, others)).toBe(false);
-            expect(spacefinder._testElems(rules, para, others.slice(0, 2))).toBe(true);
+            expect(spacefinder._testCandidates(rules, para, others)).toBe(false);
+            expect(spacefinder._testCandidates(rules, para, others.slice(0, 2))).toBe(true);
 
         });
     });


### PR DESCRIPTION
Working on the spacefinder, I noticed how difficult it was to understand how `_enforceRules` worked, mostly because it was using promises all over for what is essentially synchronous code with 2 DOM reads. I moved the reads to the initialisation phase so no need for promises anymore.

Also, I changed the wording from `slot` to `candidate`, it was misleading.

cc @jbreckmckye @uplne 
