### PR TITLE
Don't show email sign-up on sensitive content

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -69,6 +69,7 @@ final case class Content(
   showByline: Boolean,
   hasStoryPackage: Boolean,
   rawOpenGraphImage: String,
+  sensitive: Boolean,
   showFooterContainers: Boolean = false
 ) {
 
@@ -315,7 +316,8 @@ object Content {
           .orElse(elements.mainPicture.flatMap(_.images.largestImageUrl))
           .orElse(trail.trailPicture.flatMap(_.largestImageUrl))
           .getOrElse(Configuration.images.fallbackLogo)
-      }
+      },
+      sensitive = apifields.flatMap(_.sensitive).getOrElse(false)
 
     )
   }
@@ -358,7 +360,8 @@ object Article {
       ("hasInlineMerchandise", JsBoolean(commercial.hasInlineMerchandise)),
       ("lightboxImages", lightbox.javascriptConfig),
       ("hasMultipleVideosInPage", JsBoolean(content.hasMultipleVideosInPage)),
-      ("isImmersive", JsBoolean(content.isImmersive))
+      ("isImmersive", JsBoolean(content.isImmersive)),
+      ("isSensitive", JsBoolean(content.sensitive))
     ) ++ bookReviewIsbn
 
     val opengraphProperties: Map[String, String] = Map(

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -61,7 +61,8 @@ define([
                 description: 'Sign up to Film Today and we\'ll deliver to you the latest movie news, blogs, big name interviews, festival coverage, reviews and more.',
                 successHeadline: 'Thank you for signing up to Film Today',
                 successDescription: 'We will send you our picks of the most important headlines tomorrow afternoon.',
-                modClass: 'end-article'
+                modClass: 'end-article',
+                insertMethod: insertBottomOfArticle
             },
             theFiver: {
                 listId: '218',

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -127,6 +127,7 @@ define([
             version = detect.getUserAgent.version;
 
         return !config.page.shouldHideAdverts &&
+            !config.page.isSensitive &&
             !emailInserted &&
             !config.page.isFront &&
             config.switches.emailInArticle &&


### PR DESCRIPTION
## What does this change?

Add isSensitive js config and checks for it in email sign-up insertion. Also moves film today sign-up to bottom-of-page.
## What is the value of this and can you measure success?

Prevents showing the chirpy 'want stories like this in your inbox?' on things like obits.
## CC

@crifmulholland 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
