### PR TITLE
Fix discussion exceptions

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -73,7 +73,9 @@ Loader.prototype.initTopComments = function() {
                 this.setState('has-top-comments');
             }
         }.bind(this)
-    );
+    ).catch(function () {
+        /* ignore */
+    });
 };
 
 Loader.prototype.initMainComments = function() {

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -73,9 +73,7 @@ Loader.prototype.initTopComments = function() {
                 this.setState('has-top-comments');
             }
         }.bind(this)
-    ).catch(function () {
-        /* ignore */
-    });
+    ).catch(this.logError.bind(this, 'Top comments'));
 };
 
 Loader.prototype.initMainComments = function() {
@@ -153,30 +151,32 @@ Loader.prototype.initMainComments = function() {
         this.loadComments({
             comment: commentId,
             shouldTruncate: shouldTruncate})
-            .catch(function(error) {
-                var reportMsg = 'Comments failed to load: ',
-                    request = error.request || {};
-                if (error.message === 'Request is aborted: timeout') {
-                    reportMsg += 'XHR timeout';
-                } else if (error.message) {
-                    reportMsg += error.message;
-                } else {
-                    reportMsg += 'status' in request ? request.status : '';
-                }
-                raven.captureMessage(reportMsg, {
-                    tags: {
-                        contentType: 'comments',
-                        discussionId: this.getDiscussionId(),
-                        status: 'status' in request ? request.status : '',
-                        readyState: 'readyState' in request ? request.readyState : '',
-                        response: 'response' in request ? request.response : '',
-                        statusText: 'status' in request ? request.statusText : ''
-                    }
-                });
-            }.bind(this));
+            .catch(this.logError.bind(this, 'Comments'));
     });
     this.getUser();
 };
+
+Loader.prototype.logError = function(commentType, error) {
+    var reportMsg = commentType + ' failed to load: ',
+        request = error.request || {};
+    if (error.message === 'Request is aborted: timeout') {
+        reportMsg += 'XHR timeout';
+    } else if (error.message) {
+        reportMsg += error.message;
+    } else {
+        reportMsg += 'status' in request ? request.status : '';
+    }
+    raven.captureMessage(reportMsg, {
+        tags: {
+            contentType: 'comments',
+            discussionId: this.getDiscussionId(),
+            status: 'status' in request ? request.status : '',
+            readyState: 'readyState' in request ? request.readyState : '',
+            response: 'response' in request ? request.response : '',
+            statusText: 'status' in request ? request.statusText : ''
+        }
+    });
+}
 
 Loader.prototype.initPageSizeDropdown = function(pageSize) {
 

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -155,7 +155,7 @@ Loader.prototype.initMainComments = function() {
             shouldTruncate: shouldTruncate})
             .catch(function(error) {
                 var reportMsg = 'Comments failed to load: ',
-                    request = error.request;
+                    request = error.request || {};
                 if (error.message === 'Request is aborted: timeout') {
                     reportMsg += 'XHR timeout';
                 } else if (error.message) {

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -176,7 +176,7 @@ Loader.prototype.logError = function(commentType, error) {
             statusText: 'status' in request ? request.statusText : ''
         }
     });
-}
+};
 
 Loader.prototype.initPageSizeDropdown = function(pageSize) {
 


### PR DESCRIPTION
## What does this change?

Exceptions thrown by the discussions loader cannibalise the console when run locally.
## What is the value of this and can you measure success?

No more unsightly exceptions (but still reported by raven).
