### PR TITLE
Podcast layout oddity fix

### DIFF
--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -74,7 +74,7 @@
 .content--has-body {
     // if it's audio and there's body text, we display an advert
     .content__main-column--audio {
-        min-height: 274px;
+        min-height: $gs-row-height * 9;
     }
 
     // increase height if we have sponsorship logos


### PR DESCRIPTION
## What does this change?

This PR fix the bug with layout oddity on podcast pages.
## Screenshots

Before:
![screen shot 2016-04-22 at 13 51 18](https://cloud.githubusercontent.com/assets/489567/14747823/5d213aa8-08ae-11e6-80a5-1dd4edab68a5.png)

After:
![screen shot 2016-04-22 at 17 23 15](https://cloud.githubusercontent.com/assets/489567/14747829/635bf48a-08ae-11e6-9bc9-d3d39dcddefe.png)
