### PR TITLE
Supported by articles in Paid for by containers

### DIFF
--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -122,6 +122,10 @@
             min-height: $gs-baseline * 11;
             width: 100%;
         }
+
+        .advert__standfirst {
+            margin-bottom: $gs-baseline / 2;
+        }
     }
 
     .advert__image-container {

--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -592,11 +592,11 @@
         display: inline-block;
         float: none;
         clear: none;
+        margin-left: $gs-gutter / 2;
     }
 
     .ad-slot--paid-for-badge .ad-slot--paid-for-badge__logo {
         display: inline-block;
-        margin-left: $gs-gutter / 2;
         vertical-align: middle;
         max-height: 5 * $gs-baseline;
     }

--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -604,6 +604,10 @@
     .ad-slot--paid-for-badge--front .ad-slot--paid-for-badge__link:after {
         content: none;
     }
+
+    .ad-slot--paid-for-badge__help {
+        display: none;
+    }
 }
 /* /remove */
 


### PR DESCRIPTION
This small update to accommodate the rare but possible case where a 'supported by' article is linked inside a paid for container along with other 'paid for by' articles.

Before:
![picture 2](https://cloud.githubusercontent.com/assets/629976/14778928/992c39e6-0acd-11e6-9906-866a1f23e12c.jpg)

After:
![picture 1](https://cloud.githubusercontent.com/assets/629976/14778955/b6f116cc-0acd-11e6-8b81-dc862f244d96.jpg)

cc @uplne I have a list of styles in adverts.scss that will need to be removed when you refactor badges 🏇 
