### PR TITLE
Fix discussion email status code

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -83,7 +83,7 @@ CommentBox.prototype.errorMessages = {
         ' your email address' + '. Once verified post your comment.</span>',
     EMAIL_VERIFIED_FAIL: 'We are having technical difficulties. Please try again later or ' +
         '<a href="/send/email" class="js-id-send-validation-email"><strong>resend the verification</strong></a>.',
-    EMAIL_NOT_VERIFIED: 'Please confirm your email address to post your first comment.<br />' +
+    EMAIL_NOT_VALIDATED: 'Please confirm your email address to comment.<br />' +
         'If you can\'t find the email, we can <a href="_#" class="js-id-send-validation-email"><strong>resend the verification email</strong></a><span class="d-comment-box__error-meta"> to ' +
         ' your email address' + '.</span>'
 };
@@ -261,7 +261,7 @@ CommentBox.prototype.postComment = function() {
     };
 
     var invalidEmailError = function () {
-        self.error('EMAIL_NOT_VERIFIED');
+        self.error('EMAIL_NOT_VALIDATED');
         ValidationEmail.init();
     };
 


### PR DESCRIPTION
Ensures users see a sensible error message when they comment and their email is not verified by using the correct Discussion code.
