### PR TITLE
fix styling of span

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -79,12 +79,12 @@ CommentBox.prototype.errorMessages = {
     /* Custom error codes */
     API_CORS_BLOCKED: /*CORS blocked by HTTP/1.0 proxy*/'Could not post due to your internet settings, which might be controlled by your provider. Please contact your administrator or disable any proxy servers or VPNs and try again.',
     API_ERROR: 'Sorry, there was a problem posting your comment.  Please try another browser or network connection.  Reference code ',
-    EMAIL_VERIFIED: '<span class="d-comment-box__error-meta">Sent. Please check your email to verify ' +
+    EMAIL_VERIFIED: '<span class="d-comment-box__error-text">Sent. Please check your email to verify ' +
         ' your email address' + '. Once verified post your comment.</span>',
     EMAIL_VERIFIED_FAIL: 'We are having technical difficulties. Please try again later or ' +
         '<a href="/send/email" class="js-id-send-validation-email"><strong>resend the verification</strong></a>.',
     EMAIL_NOT_VALIDATED: 'Please confirm your email address to comment.<br />' +
-        'If you can\'t find the email, we can <a href="_#" class="js-id-send-validation-email"><strong>resend the verification email</strong></a><span class="d-comment-box__error-meta"> to ' +
+        'If you can\'t find the email, we can <a href="_#" class="js-id-send-validation-email"><strong>resend the verification email</strong></a><span class="d-comment-box__error-text"> to ' +
         ' your email address' + '.</span>'
 };
 

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -84,8 +84,8 @@ CommentBox.prototype.errorMessages = {
     EMAIL_VERIFIED_FAIL: 'We are having technical difficulties. Please try again later or ' +
         '<a href="/send/email" class="js-id-send-validation-email"><strong>resend the verification</strong></a>.',
     EMAIL_NOT_VALIDATED: 'Please confirm your email address to comment.<br />' +
-        'If you can\'t find the email, we can <a href="_#" class="js-id-send-validation-email"><strong>resend the verification email</strong></a><span> to ' +
-        ' your email address' + '.</span>'
+        'If you can\'t find the email, we can <a href="_#" class="js-id-send-validation-email"><strong>resend the verification email</strong></a> to ' +
+        ' your email address' + '.'
 };
 
 /**

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -79,7 +79,7 @@ CommentBox.prototype.errorMessages = {
     /* Custom error codes */
     API_CORS_BLOCKED: /*CORS blocked by HTTP/1.0 proxy*/'Could not post due to your internet settings, which might be controlled by your provider. Please contact your administrator or disable any proxy servers or VPNs and try again.',
     API_ERROR: 'Sorry, there was a problem posting your comment.  Please try another browser or network connection.  Reference code ',
-    EMAIL_VERIFIED: '<span>Sent. Please check your email to verify ' +
+    EMAIL_VERIFIED: '<span class="d-comment-box__error-meta">Sent. Please check your email to verify ' +
         ' your email address' + '. Once verified post your comment.</span>',
     EMAIL_VERIFIED_FAIL: 'We are having technical difficulties. Please try again later or ' +
         '<a href="/send/email" class="js-id-send-validation-email"><strong>resend the verification</strong></a>.',

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -79,12 +79,12 @@ CommentBox.prototype.errorMessages = {
     /* Custom error codes */
     API_CORS_BLOCKED: /*CORS blocked by HTTP/1.0 proxy*/'Could not post due to your internet settings, which might be controlled by your provider. Please contact your administrator or disable any proxy servers or VPNs and try again.',
     API_ERROR: 'Sorry, there was a problem posting your comment.  Please try another browser or network connection.  Reference code ',
-    EMAIL_VERIFIED: '<span class="d-comment-box__error-text">Sent. Please check your email to verify ' +
+    EMAIL_VERIFIED: '<span>Sent. Please check your email to verify ' +
         ' your email address' + '. Once verified post your comment.</span>',
     EMAIL_VERIFIED_FAIL: 'We are having technical difficulties. Please try again later or ' +
         '<a href="/send/email" class="js-id-send-validation-email"><strong>resend the verification</strong></a>.',
     EMAIL_NOT_VALIDATED: 'Please confirm your email address to comment.<br />' +
-        'If you can\'t find the email, we can <a href="_#" class="js-id-send-validation-email"><strong>resend the verification email</strong></a><span class="d-comment-box__error-text"> to ' +
+        'If you can\'t find the email, we can <a href="_#" class="js-id-send-validation-email"><strong>resend the verification email</strong></a><span> to ' +
         ' your email address' + '.</span>'
 };
 


### PR DESCRIPTION
## What does this change?

Fix styling of discussion error message
## Screenshots

Before:
<img width="709" alt="screen shot 2016-04-25 at 12 32 58" src="https://cloud.githubusercontent.com/assets/1764158/14782638/7ff73d80-0ae2-11e6-8703-c8909141d28c.png">

After:
<img width="670" alt="screen shot 2016-04-25 at 12 33 08" src="https://cloud.githubusercontent.com/assets/1764158/14782649/8d0187ce-0ae2-11e6-9d08-f50fc6231e09.png">
## Request for comment

CC @nicl

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
