### PR TITLE
Fix resend link when email not validated

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -339,6 +339,8 @@ CommentBox.prototype.fail = function(xhr) {
 
     if (xhr.status == 0) {
         this.error('API_CORS_BLOCKED');
+    } else if (response.errorCode === 'EMAIL_NOT_VALIDATED') {
+        this.invalidEmailError();
     } else if (this.errorMessages[response.errorCode]) {
         this.error(response.errorCode);
     } else {


### PR DESCRIPTION
Fixes email validation resend link when a user has attempted to comment and DAPI has refused with a 403 and error code 'EMAIL_NOT_VALIDATED'.

@gidsg 
