### PR TITLE
Fabric v1 yet again

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -257,6 +257,15 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
+  val FabricAdverts = Switch(
+    SwitchGroup.Commercial,
+    "fabric-adverts",
+    "Request 'fabric' format adverts (88x71s) from DFP",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 5, 31),
+    exposeClientSide = true
+  )
+
   val v2JobsTemplate = Switch(
     SwitchGroup.Commercial,
     "v2-jobs-template",

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -34,9 +34,10 @@ object Commercial {
     }
 
     def adSizes(metaData: MetaData, edition: Edition): Map[String, Seq[String]] = {
+      val fabricAdvertsTop = if (FabricAdverts.isSwitchedOn) Some("88,71") else None
       Map(
-        "mobile" -> Seq("1,1", "88,70", "728,90"),
-        "desktop" -> Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250")
+        "mobile" -> (Seq("1,1", "88,70", "728,90") ++ fabricAdvertsTop),
+        "desktop" -> (Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250") ++ fabricAdvertsTop)
       )
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -96,7 +96,7 @@ define([
 
         function insertInlineAd(paras) {
             bodyAds += 1;
-            insertAdAtPara(paras[0], 'article-inline' + bodyAds, 'inline');
+            insertAdAtPara(paras[0], 'inline' + bodyAds, 'inline');
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -96,7 +96,7 @@ define([
 
         function insertInlineAd(paras) {
             bodyAds += 1;
-            insertAdAtPara(paras[0], 'inline' + bodyAds, 'inline');
+            insertAdAtPara(paras[0], 'article-inline' + bodyAds, 'inline');
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -13,6 +13,8 @@ define([
     isArray,
     transform
 ) {
+    var fabricMapping = '88,71';
+    var fabricMappingSwitch = config.switches.fabricAdverts ? ('|' + fabricMapping) : '';
     var adSlotDefinitions = {
         right: {
             sizeMappings: {
@@ -41,6 +43,13 @@ define([
         inline1: {
             sizeMappings: {
                 mobile:             '1,1|300,250',
+                'mobile-landscape': '1,1|300,250',
+                tablet:             '1,1|300,250'
+            }
+        },
+        'article-inline1': {
+            sizeMappings: {
+                mobile:             '1,1|300,250' + fabricMappingSwitch,
                 'mobile-landscape': '1,1|300,250',
                 tablet:             '1,1|300,250'
             }
@@ -94,7 +103,12 @@ define([
         },
         'top-above-nav': {
             sizeMappings: {
-                desktop: '1,1|88,70|728,90|940,230|900,250|970,250'
+                desktop: '1,1|88,70|728,90|940,230|900,250|970,250' + fabricMappingSwitch
+            }
+        },
+        'fabric': {
+            sizeMappings: {
+                mobile: fabricMapping
             }
         }
     };

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -47,13 +47,6 @@ define([
                 tablet:             '1,1|300,250'
             }
         },
-        'article-inline1': {
-            sizeMappings: {
-                mobile:             '1,1|300,250' + fabricMappingSwitch,
-                'mobile-landscape': '1,1|300,250',
-                tablet:             '1,1|300,250'
-            }
-        },
         inline: {
             sizeMappings: {
                 mobile:             '1,1|300,250',

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fabric-expanding-v1.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fabric-expanding-v1.js
@@ -1,0 +1,94 @@
+define([
+    'bean',
+    'bonzo',
+    'fastdom',
+    'common/utils/$',
+    'common/utils/detect',
+    'common/utils/mediator',
+    'common/utils/storage',
+    'common/utils/template',
+    'common/views/svgs',
+    'text!common/views/commercial/creatives/fabric-expanding-v1.html',
+    'lodash/objects/merge',
+    'common/modules/commercial/creatives/add-tracking-pixel',
+    'Promise'
+], function (
+    bean,
+    bonzo,
+    fastdom,
+    $,
+    detect,
+    mediator,
+    storage,
+    template,
+    svgs,
+    FabricExpandingV1Html,
+    merge,
+    addTrackingPixel,
+    Promise
+) {
+    var FabricExpandingV1 = function ($adSlot, params) {
+        this.$adSlot      = $adSlot;
+        this.params       = params;
+        this.isClosed     = true;
+
+        this.closedHeight = 250;
+        this.openedHeight = 500;
+    };
+
+    FabricExpandingV1.prototype.create = function () {
+        var videoHeight = this.openedHeight,
+            showmoreArrow = {
+                showArrow: (this.params.showMoreType === 'arrow-only' || this.params.showMoreType === 'plus-and-arrow') ?
+                '<button class="ad-exp__open-chevron ad-exp__open">' + svgs('arrowdownicon') + '</button>' : ''
+            },
+            showmorePlus = {
+                showPlus: (this.params.showMoreType === 'plus-only' || this.params.showMoreType === 'plus-and-arrow') ?
+                '<button class="ad-exp__close-button ad-exp__open">' + svgs('closeCentralIcon') + '</button>' : ''
+            },
+            videoSource = {
+                videoEmbed: (this.params.YoutubeVideoURL !== '') ?
+                '<iframe id="YTPlayer" width="100%" height="' + videoHeight + '" src="' + this.params.YoutubeVideoURL + '?showinfo=0&amp;rel=0&amp;controls=0&amp;fs=0&amp;title=0&amp;byline=0&amp;portrait=0" frameborder="0" class="expandable-video"></iframe>' : ''
+            },
+            $ExpandableVideo = $.create(template(FabricExpandingV1Html, { data: merge(this.params, showmoreArrow, showmorePlus, videoSource) })),
+            domPromise = new Promise(function (resolve) {
+                fastdom.write(function () {
+
+                    this.$ad = $('.ad-exp--expand', $ExpandableVideo).css('height', this.closedHeight);
+
+                    $('.ad-exp-collapse__slide', $ExpandableVideo).css('height', this.closedHeight);
+
+                    if (this.params.trackingPixel) {
+                        addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
+                    }
+                    $ExpandableVideo.appendTo(this.$adSlot);
+                    resolve();
+                }.bind(this));
+            }.bind(this));
+
+        bean.on(this.$adSlot[0], 'click', '.ad-exp__open', function () {
+            fastdom.write(function () {
+                var videoSrc = $('#YTPlayer').attr('src'),
+                    videoSrcAutoplay = videoSrc;
+                if (videoSrc.indexOf('autoplay') === -1) {
+                    videoSrcAutoplay = videoSrc + '&amp;autoplay=1';
+                } else {
+                    videoSrcAutoplay = videoSrcAutoplay.replace(this.isClosed ? 'autoplay=0' : 'autoplay=1', this.isClosed ? 'autoplay=1' : 'autoplay=0');
+                }
+                $('.ad-exp__close-button').toggleClass('button-spin');
+                $('.ad-exp__open-chevron').removeClass('chevron-up').toggleClass('chevron-down');
+                this.$ad.css('height', this.isClosed ? this.openedHeight : this.closedHeight);
+                $('.slide-video, .slide-video .ad-exp__layer', $(this.$adSlot[0])).css('height', this.isClosed ? this.openedHeight : this.closedHeight).toggleClass('slide-video__expand');
+                this.isClosed = !this.isClosed;
+                setTimeout(function () {
+                    $('#YTPlayer').attr('src', videoSrcAutoplay);
+                }, 1000);
+            }.bind(this));
+        }.bind(this));
+
+        return domPromise;
+    };
+
+    return FabricExpandingV1;
+
+});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fabric-v1.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fabric-v1.js
@@ -1,0 +1,116 @@
+define([
+    'qwery',
+    'bonzo',
+    'fastdom',
+    'common/utils/detect',
+    'common/utils/template',
+    'common/utils/mediator',
+    'common/modules/commercial/creatives/add-tracking-pixel',
+    'text!common/views/commercial/creatives/fabric-v1.html',
+    'text!common/views/commercial/creatives/iframe-video.html',
+    'text!common/views/commercial/creatives/scrollbg.html',
+    'lodash/objects/merge'
+], function (
+    $,
+    bonzo,
+    fastdom,
+    detect,
+    template,
+    mediator,
+    addTrackingPixel,
+    fabricV1Html,
+    iframeVideoStr,
+    scrollBgStr,
+    merge
+) {
+    var hasScrollEnabled = !detect.isIOS() && !detect.isAndroid();
+    var isEnhanced = detect.isEnhanced();
+    var isIE9OrLess = detect.getUserAgent.browser === 'MSIE' && (detect.getUserAgent.version === '9' || detect.getUserAgent.version === '8');
+
+    var fabricV1Tpl;
+    var iframeVideoTpl;
+    var scrollBgTpl;
+
+    // This is a hasty clone of fluid250.js
+
+    var FabricV1 = function ($adSlot, params) {
+        this.$adSlot = $adSlot;
+        this.params = params;
+    };
+
+    FabricV1.prototype.create = function () {
+        this.$adSlot.addClass('ad-slot__fabric-v1 content__mobile-full-width');
+
+        if (!fabricV1Tpl) {
+            fabricV1Tpl = template(fabricV1Html);
+            iframeVideoTpl = template(iframeVideoStr);
+            scrollBgTpl = template(scrollBgStr);
+        }
+
+        var videoPosition = {
+            position: this.params.videoPositionH === 'left' || this.params.videoPositionH === 'right' ?
+            this.params.videoPositionH + ':' + this.params.videoHorizSpace + 'px;' : ''
+        };
+
+        var templateOptions = {
+            showLabel: this.params.showAdLabel !== 'hide',
+            video: this.params.videoURL ? iframeVideoTpl(merge(this.params, videoPosition)) : '',
+            hasContainer: 'layerTwoAnimation' in this.params,
+            layerTwoBGPosition: this.params.layerTwoBGPosition && (
+                !this.params.layerTwoAnimation ||
+                this.params.layerTwoAnimation === 'disabled' ||
+                (!isEnhanced && this.params.layerTwoAnimation === 'enabled')
+            ) ?
+                this.params.layerTwoBGPosition :
+                '0% 0%',
+            scrollbg: this.params.backgroundImagePType && this.params.backgroundImagePType !== 'none' ?
+                scrollBgTpl(this.params) :
+                false
+        };
+
+        this.$adSlot.append(fabricV1Tpl({ data: merge(this.params, templateOptions) }));
+        if (templateOptions.scrollbg) {
+            this.scrollingBg = $('.ad-scrolling-bg', this.$adSlot[0]);
+            this.layer2 = $('.hide-until-tablet .fluid250_layer2', this.$adSlot[0]);
+
+            if (hasScrollEnabled) {
+                // update bg position
+                fastdom.read(this.updateBgPosition, this);
+                mediator.on('window:throttledScroll', this.updateBgPosition.bind(this));
+                // to be safe, also update on window resize
+                mediator.on('window:resize', this.updateBgPosition.bind(this));
+            }
+        }
+
+        if (this.params.trackingPixel) {
+            addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
+        }
+    };
+
+    FabricV1.prototype.updateBgPosition = function () {
+        if (this.params.backgroundImagePType === 'parallax') {
+            var scrollAmount = Math.ceil((window.pageYOffset - this.$adSlot.offset().top) * 0.3 * -1) + 20;
+            fastdom.write(function () {
+                bonzo(this.scrollingBg)
+                    .addClass('ad-scrolling-bg-parallax')
+                    .css('background-position', '50% ' + scrollAmount + '%');
+            }, this);
+        }
+
+        this.layer2Animation();
+    };
+
+    FabricV1.prototype.layer2Animation = function () {
+        var inViewB;
+        if (this.params.layerTwoAnimation === 'enabled' && isEnhanced && !isIE9OrLess) {
+            inViewB = (window.pageYOffset + bonzo.viewport().height) > this.$adSlot.offset().top;
+            fastdom.write(function () {
+                bonzo(this.layer2).addClass('ad-scrolling-text-hide' + (this.params.layerTwoAnimationPosition ? '-' + this.params.layerTwoAnimationPosition : ''));
+                if (inViewB) {
+                    bonzo(this.layer2).addClass('ad-scrolling-text-animate' + (this.params.layerTwoAnimationPosition ? '-' + this.params.layerTwoAnimationPosition : ''));
+                }
+            }, this);
+        }
+    };
+    return FabricV1;
+});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fabric-v1.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fabric-v1.js
@@ -112,5 +112,6 @@ define([
             }, this);
         }
     };
+
     return FabricV1;
 });

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -12,6 +12,8 @@ define([
     'common/modules/commercial/creatives/expandable-v3',
     'common/modules/commercial/creatives/expandable-video',
     'common/modules/commercial/creatives/expandable-video-v2',
+    'common/modules/commercial/creatives/fabric-v1',
+    'common/modules/commercial/creatives/fabric-expanding-v1',
     'common/modules/commercial/creatives/fluid250',
     'common/modules/commercial/creatives/fluid250GoogleAndroid',
     'common/modules/commercial/creatives/foundation-funded-logo',

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -35,7 +35,7 @@ define([
                 return false;
             }
 
-            var container, containerId, $adSlice, isFrontFirst,
+            var container, containerId, $adSlice, isFrontFirst, fabricAdSlot,
                 opts = defaults(
                     options || {},
                     {
@@ -43,19 +43,30 @@ define([
                         sliceSelector: '.js-fc-slice-mpu-candidate'
                     }
                 ),
-                // get all the containers
+            // get all the containers
                 containers   = qwery(opts.containerSelector),
                 index        = 0,
                 adSlices     = [],
                 containerGap = 1,
-                prefs        = userPrefs.get('container-states');
+                prefs        = userPrefs.get('container-states'),
+                addFabricAd  = (config.page.isFront && config.switches.fabricAdverts && detect.isBreakpoint({max : 'phablet'}));
+
+            // insert fabric advert at first container in lieu of a top slot
+            if (addFabricAd) {
+                fabricAdSlot = bonzo(createAdSlot('fabric', 'container-inline'));
+                fabricAdSlot.addClass('ad-slot--mobile');
+                fabricAdSlot.insertAfter(containers[0]);
+            }
+
+            // skip the initial containers if we've already added an advert to the first
+            index+= addFabricAd ? (1 + containerGap) : 0;
 
             // pull out ad slices which have at least x containers between them
             while (index < containers.length) {
                 container    = containers[index];
                 containerId  = bonzo(container).data('id');
                 $adSlice     = $(opts.sliceSelector, container);
-                // don't display ad in the first container on the fronts
+                // don't display ad in the first container on the network fronts
                 isFrontFirst = contains(['uk', 'us', 'au'], config.page.pageId) && index === 0;
 
                 if (config.page.showMpuInAllContainers) {

--- a/static/src/javascripts/projects/common/modules/commercial/sticky-top-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/sticky-top-banner.js
@@ -76,8 +76,11 @@ define([
         var $iframe = getAdIframe();
         var slotWidth = $iframe.attr('width');
         var slotHeight = $iframe.attr('height');
+        var slotSize = [slotWidth, slotHeight].join(',');
         // iframe may not have been injected at this point
-        var isFluidAd = $iframe.length > 0 && [slotWidth, slotHeight].join(',') === '88,70';
+        var isFluid250 = slotSize === '88,70';
+        var isFabricV1 = slotSize === '88,71';
+        var isFluidAd = $iframe.length > 0 && (isFluid250 || isFabricV1);
         // fluid ads are currently always 250px high. We can't just read the client height as fluid ads are
         // injected asynchronously, so we can't be sure when they will be in the dom
         var fluidAdInnerHeight = 250;

--- a/static/src/javascripts/projects/common/views/commercial/creatives/fabric-expanding-v1.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/fabric-expanding-v1.html
@@ -1,0 +1,50 @@
+<div class="creative--fabric-expanding-v1 <%=data.videoOptions%>">
+
+    <div class="ad-slot__label adFullWidth__label facia-container--layout-front" data-test-id="ad-slot-label">
+        <div class="facia-container__inner">Advertisement</div>
+    </div>
+
+    <div class="ad-exp--expand l-side-margins mobile-only" style="background-color: <%=data.backgroundColor%>">
+        <div class="slide-container" style="background: url('<%=data.backgroundImageM%>') <%=data.backgroundRepeatM%> <%=data.backgroundPositionM%>;">
+            <div class="ad-exp-collapse__slide slide-1" style="background: <%=data.slide1BGColor%> url('<%=data.slide1BGImageM%>') <%=data.slide1BGImageRepeatM%> <%=data.slide1BGImagePositionM%>;">
+                <div class="ad-exp__open">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('<%=data.slide1Layer1BGImageM%>') <%=data.slide1Layer1BGImageRepeatM%> <%=data.slide1Layer1BGImagePositionM%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('<%=data.slide1Layer2BGImageM%>') <%=data.slide1Layer2BGImageRepeatM%> <%=data.slide1Layer2BGImagePositionM%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background: url('<%=data.slide1Layer3BGImageM%>') <%=data.slide1Layer3BGImageRepeatM%> <%=data.slide1Layer3BGImagePositionM%>;"></div>
+                </div>
+            </div>
+            <div class="ad-exp-collapse__slide slide-2" style="background: <%=data.slide2BGColor%> url('<%=data.slide2BGImageM%>') <%=data.slide2BGImagePositionM%> <%=data.slide2BGImageRepeatM%>;">
+                <div class="ad-exp__layer ad-exp__layer1" style="background: url('<%=data.slide2Layer1BGImageM%>') <%=data.slide2Layer1BGImageRepeatM%> <%=data.slide2Layer1BGImagePositionM%>;"></div>
+                <div class="ad-exp__layer ad-exp__layer2" style="background: url('<%=data.slide2Layer2BGImageM%>') <%=data.slide2Layer2BGImageRepeatM%> <%=data.slide2Layer2BGImagePositionM%>;"></div>
+                <div class="ad-exp__layer ad-exp__layer3" style="background: url('<%=data.slide2Layer3BGImageM%>') <%=data.slide2Layer3BGImageRepeatM%> <%=data.slide2Layer3BGImagePositionM%>;"></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="ad-exp--expand l-side-margins hide-until-tablet" style="background-color: <%=data.backgroundColor%>">
+        <div class="slide-container" style="background: url('<%=data.backgroundImage%>') <%=data.backgroundRepeat%> <%=data.backgroundPosition%>;">
+            <div class="ad-exp-collapse__slide slide-1" style="background: <%=data.slide1BGColor%> url('<%=data.slide1BGImage%>') <%=data.slide1BGImageRepeat%> <%=data.slide1BGImagePosition%>;">
+                <div class="ad-exp__open">
+                    <div class="ad-exp__layer ad-exp__layer1" style="background: url('<%=data.slide1Layer1BGImage%>') <%=data.slide1Layer1BGImageRepeat%> <%=data.slide1Layer1BGImagePosition%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer2" style="background: url('<%=data.slide1Layer2BGImage%>') <%=data.slide1Layer2BGImageRepeat%> <%=data.slide1Layer2BGImagePosition%>;"></div>
+                    <div class="ad-exp__layer ad-exp__layer3" style="background : url('<%=data.slide1Layer3BGImage%>') <%=data.slide1Layer3BGImageRepeat%> <%=data.slide1Layer3BGImagePosition%>;"></div>
+                </div>
+            </div>
+            <div class="ad-exp-collapse__slide slide-2" style="background: <%=data.slide2BGColor%> url('<%=data.slide2BGImage%>') <%=data.slide2BGImagePosition%> <%=data.slide2BGImageRepeat%>;">
+                <div class="ad-exp__layer ad-exp__layer1" style="background: url('<%=data.slide2Layer1BGImage%>') <%=data.slide2Layer1BGImageRepeat%> <%=data.slide2Layer1BGImagePosition%>;"></div>
+                <div class="ad-exp__layer ad-exp__layer2" style="background: url('<%=data.slide2Layer2BGImage%>') <%=data.slide2Layer2BGImageRepeat%> <%=data.slide2Layer2BGImagePosition%>;"></div>
+                <div class="ad-exp__layer ad-exp__layer3" style="background: url('<%=data.slide2Layer3BGImage%>') <%=data.slide2Layer3BGImageRepeat%> <%=data.slide2Layer3BGImagePosition%>;"></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="slide-video" style="background: url('<%=data.videoBGImage%>') <%=data.videoBGImageRepeat%> <%=data.videoBGImagePosition%>;">
+        <div class="slide-container">
+            <div class="ad-exp__layer ad-exp__layer1" style="background: url('<%=data.videoLayer1BGImage%>') <%=data.videoLayer1BGImageRepeat%> <%=data.videoLayer1BGImagePosition%>;"></div>
+            <div class="video-container__inner"><%=data.videoEmbed%></div>
+        </div>
+    </div>
+
+    <%=data.showPlus%>
+    <%=data.showArrow%>
+</div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/fabric-v1-video.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/fabric-v1-video.html
@@ -1,0 +1,9 @@
+<iframe
+    width="409px"
+    height="230px"
+    src="<%=videoURL%>?rel=0&amp;controls=0&amp;showinfo=0&amp;title=0&amp;byline=0&amp;portrait=0"
+    frameborder="0"
+    class="fabric-v1_video fabric-v1_video--desktop fabric-v1_video--vert-pos-<%=videoPositionV%> fabric-v1_video--horiz-pos-<%=videoPositionH%>"
+    style="<%=position%>">
+</iframe>
+

--- a/static/src/javascripts/projects/common/views/commercial/creatives/fabric-v1.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/fabric-v1.html
@@ -4,7 +4,7 @@
     <div class="fc-container__inner">Advertisement</div>
 </div>
 <%}%>
-<div class="creative--fabric-v1 l-side-margins%>" style="
+<div class="creative--fabric-v1 l-side-margins hide-until-tablet" style="
     background-color: <%=data.backgroundColor%>;
     background-image: url(<%=data.backgroundImage%>);
     background-position: <%=data.backgroundPosition%>;
@@ -25,6 +25,29 @@
             <div class="fabric-v1_layer fabric-v1_layer3" style="
             background-image: url(<%=data.layerThreeBGImage%>);
             background-position: <%=data.layerThreeBGPosition%>;
+        "></div>
+        </div>
+    </a>
+</div>
+<div class="creative--fabric-v1 l-side-margins mobile-only" style="
+    background-color: <%=data.backgroundColor%>;
+    background-image: url(<%=data.backgroundImageM%>);
+    background-position: <%=data.backgroundPositionM%>;
+    background-repeat: <%=data.backgroundRepeatM%>;
+">
+    <a href="<%=data.link%>" target="_blank">
+        <div class="gs-container">
+            <div class="fabric-v1_layer fabric-v1_layer1" style="
+            background-image: url(<%=data.layerOneBGImageM%>);
+            background-position: <%=data.layerOneBGPositionM%>;
+        "></div>
+            <div class="fabric-v1_layer fabric-v1_layer1" style="
+            background-image: url(<%=data.layerTwoBGImageM%>);
+            background-position: <%=data.layerTwoBGPositionM%>;
+        "></div>
+            <div class="fabric-v1_layer fabric-v1_layer1" style="
+            background-image: url(<%=data.layerThreeBGImageM%>);
+            background-position: <%=data.layerThreeBGPositionM%>;
         "></div>
         </div>
     </a>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/fabric-v1.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/fabric-v1.html
@@ -1,0 +1,32 @@
+<%if (data.hasContainer) {%><div class="creative--fabric-v1-bg-container"><%}%>
+<%if (data.showLabel) {%>
+<div class="ad-slot__label creative--fabric-v1__label fc-container--layout-front" data-test-id="ad-slot-label">
+    <div class="fc-container__inner">Advertisement</div>
+</div>
+<%}%>
+<div class="creative--fabric-v1 l-side-margins%>" style="
+    background-color: <%=data.backgroundColor%>;
+    background-image: url(<%=data.backgroundImage%>);
+    background-position: <%=data.backgroundPosition%>;
+    background-repeat: <%=data.backgroundRepeat%>;
+">
+    <%if (data.scrollbg) {%><%=data.scrollbg%><%}%>
+    <a href="<%=data.clickMacro%><%=data.link%>" target="_blank">
+        <div class="gs-container">
+            <%=data.video%>
+            <div class="fabric-v1_layer fabric-v1_layer1" style="
+            background-image: url(<%=data.layerOneBGImage%>);
+            background-position: <%=data.layerOneBGPosition%>;
+        "></div>
+            <div class="fabric-v1_layer fabric-v1_layer2" style="
+            background-image: url(<%=data.layerTwoBGImage%>);
+            background-position: <%=data.layerTwoBGPosition%>;
+        "></div>
+            <div class="fabric-v1_layer fabric-v1_layer3" style="
+            background-image: url(<%=data.layerThreeBGImage%>);
+            background-position: <%=data.layerThreeBGPosition%>;
+        "></div>
+        </div>
+    </a>
+</div>
+<%if (data.hasContainer) {%></div><%}%>

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -408,6 +408,189 @@
 
 }
 
+.creative--fabric-expanding-v1 {
+
+    .ad-slot__label .facia-container__inner {
+        border-top: 0;
+        padding-top: 0;
+    }
+    .ad-slot__label--wrapper {
+        @include mq($until: tablet) {
+            width: auto;
+        }
+    }
+    .ad-slot__label {
+        text-align: left;
+    }
+
+    .ad-exp--expand {
+        height: 0;
+        position: relative;
+        overflow: hidden;
+        transition: height 1s;
+    }
+    .ad-exp--expand .facia-container__inner {
+        height: 100%;
+        position: relative;
+
+        @include mq($until: tablet) {
+            width: 100%;
+            margin-left: 0;
+            margin-right: 0;
+        }
+    }
+
+    .ad-exp__close-button {
+        position: absolute;
+        top: 34px;
+        right: 10px;
+        border-radius: 100px;
+        border: 1px solid #ffffff;
+        background-color: #000000;
+        margin: 5px;
+        padding: 0;
+        z-index: 3;
+        height: 32px;
+        width: 32px;
+        transform: rotate(45deg);
+        transition: all 1s ease;
+        box-shadow: 0 0 1px 0px #ffffff inset, 0 0 1px 0px #ffffff;
+
+        &:focus {
+            outline-color: transparent;
+            outline-style: none;
+        }
+        &.button-spin {
+            transform: rotate(360deg);
+        }
+    }
+
+    .ad-exp__open-chevron {
+        @include fs-textSans(1);
+        position: absolute;
+        z-index: 11;
+        bottom: -10px;
+        left: 50%;
+        border: 1px solid #ffffff;
+        border-width: 1px 1px 0;
+        background: $neutral-1;
+        color: #ffffff;
+        opacity: .75;
+        padding: $gs-baseline/2 0 0;
+        width: gs-span(1);
+        margin-left: $gs-gutter*-1.5;
+        text-align: center;
+        outline: none;
+        height: 39px;
+        border-radius: $gs-gutter $gs-gutter 0 0;
+        box-shadow: 0 0 1px 0px #ffffff inset, 0 0 1px 0px #ffffff;
+
+        .inline-arrow-down {
+            transition: all 1s ease;
+            display: block;
+            margin: -12px auto 2px;
+        }
+
+        &.chevron-down .inline-arrow-down {
+            transform: rotate(180deg);
+            transition: all 1s ease;
+        }
+
+        &.chevron-up {
+            animation: chevronanimation 3s ease-in-out 2;
+        }
+
+    }
+
+    .slide-container {
+        width: 100%;
+        margin: 0 auto;
+        position: relative;
+
+        @include mq(wide) {
+            width: 1300px;
+        }
+    }
+
+    &.full-width-video .slide-video .slide-container {
+        @include mq(wide) {
+            width: 100%;
+        }
+    }
+
+    .slide-video {
+        background: #000000;
+        position: absolute;
+        top: 24px;
+        width: 100%;
+        z-index: 3;
+        display: none;
+    }
+
+    .slide-video__expand {
+        transition: all 1s;
+        display: block;
+    }
+
+    &.right-aligned-video .video-container__inner {
+        width: 100%;
+        position: relative;
+
+        @include mq(1024px) {
+            width: 768px;
+            float: right;
+        }
+    }
+
+    .expandable-video {
+        position: absolute;
+        z-index: 10;
+        margin-left: -50%;
+        left: 50%;
+    }
+
+    &.full-width-video .expandable-video {
+        margin-left: -50%;
+        left: 50%;
+    }
+
+    &.right-aligned-video .expandable-video {
+        margin: 0;
+        left: auto;
+        right: 0;
+    }
+
+    .slide-1 {
+        z-index: 1;
+        overflow: hidden;
+    }
+
+    .ad-exp-collapse__slide {
+        position: relative;
+    }
+
+    .ad-exp__layer {
+        height: 100%;
+        width: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+
+        &.ad-exp__layer1 {
+            z-index: 1;
+        }
+
+        &.ad-exp__layer2 {
+            z-index: 2;
+        }
+
+        &.ad-exp__layer3 {
+            z-index: 3;
+        }
+    }
+
+}
+
 .creative--expandable-ga {
     $expandable-colour: #f3f3f3;
     .ad-exp-collapse__slide {
@@ -473,6 +656,150 @@
         .ad-exp-collapse__slide.slide-1 .ad-exp__logo {
             width: 22%;
         }
+    }
+}
+
+.ad-slot--dfp.ad-slot__fabric-v1 {
+    height: auto;
+    width: auto;
+    padding-left: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+
+    .ad-slot__label {
+        display: none;
+    }
+
+    .creative--fabric-v1__label {
+        width: 100%;
+        display: block;
+        text-align: left;
+        margin-top: 0;
+
+        .fc-container__inner {
+            padding-top: 0;
+            border-top: 0;
+        }
+    }
+}
+
+.creative--fabric-v1-bg-container {
+    position: relative;
+    overflow: hidden;
+    margin-bottom: 0 !important;
+
+    .ad-scrolling-bg {
+        position: absolute;
+        top: 0;
+        height: 500px;
+        width: 100%;
+        background-repeat: no-repeat;
+    }
+
+    .ad-scrolling-bg-parallax {
+        background-attachment: scroll;
+    }
+
+    .fabric-v1_layer {
+
+        .is-modern & {
+            &.ad-scrolling-text-hide {
+                background-position: 0 -250px;
+            }
+            &.ad-scrolling-text-hide-left {
+                background-position: left -250px;
+            }
+            &.ad-scrolling-text-hide-right {
+                background-position: right -250px;
+            }
+            &.ad-scrolling-text-hide-centre {
+                background-position: center -250px;
+            }
+            &.ad-scrolling-text-animate {
+                animation: textanimation 1.4s ease .4s;
+                animation-fill-mode: forwards;
+            }
+            &.ad-scrolling-text-animate-left {
+                animation: textanimation 1.4s ease .4s;
+                animation-fill-mode: forwards;
+            }
+            &.ad-scrolling-text-animate-right {
+                animation: textanimation-right 1.4s ease .4s;
+                animation-fill-mode: forwards;
+            }
+            &.ad-scrolling-text-animate-centre {
+                animation: textanimation-centre 1.4s ease .4s;
+                animation-fill-mode: forwards;
+            }
+        }
+    }
+
+    .ad-slot__label {
+        position: relative;
+        text-align: left;
+    }
+
+    .fc-container__inner {
+        padding-top: 0;
+        border-top: 0;
+    }
+}
+
+.creative--fabric-v1 {
+    height: 250px;
+
+    .gs-container {
+        height: 100%;
+    }
+
+    .fabric-v1_video {
+        position: absolute;
+        z-index: 10;
+        margin-left: 0;
+        margin-top: 0;
+
+        &.fabric-v1_video--vert-pos-top {
+            top: 0;
+        }
+        &.fabric-v1_video--vert-pos-center {
+            top: 50%;
+            /* Magic number of video height/2 */
+            margin-top: -115px;
+        }
+        &.fabric-v1_video--vert-pos-bottom {
+            top: auto;
+            bottom: 0;
+        }
+        &.fabric-v1_video--horiz-pos-left {
+            left: 0;
+        }
+        &.fabric-v1_video--horiz-pos-center {
+            /* Magic number of video width/2 */
+            margin-left: -205px;
+            left: 50%;
+        }
+        &.fabric-v1_video--horiz-pos-right {
+            left: auto;
+            right: 0;
+        }
+    }
+
+    .fabric-v1_layer {
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 1;
+        background-repeat: no-repeat;
+    }
+
+    .fabric-v1_layer2 {
+        z-index: 2;
+    }
+
+    .fabric-v1_layer3 {
+        z-index: 3;
     }
 }
 
@@ -635,7 +962,8 @@
 }
 
 @include mq(tablet) {
-    .top-banner-ad-container .ad-slot--top-banner-ad__fluid250 {
+    .top-banner-ad-container .ad-slot--top-banner-ad__fluid250,
+    .top-banner-ad-container .ad-slot--top-banner-ad__fabric-v1 {
         height: auto;
         padding: 0;
     }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -16,6 +16,8 @@
     // taking it off child elements and moving it here for DRY.
     // the intention is to move this to the global .gs-container definition
     // which requires the padding to be removed from all child elements
+
+    // You can break out of these margins with .content__mobile-full-width
     @include content-gutter();
     box-sizing: border-box;
 }
@@ -501,8 +503,11 @@
 }
 
 .content__mobile-full-width {
-    margin-left: -($gs-gutter/2);
-    margin-right: -($gs-gutter/2);
+    @include mq(mobile, tablet) {
+        width: auto;
+        margin-left: -($gs-gutter/2);
+        margin-right: -($gs-gutter/2);
+    }
 
     @include mq(mobileLandscape, tablet) {
         margin-left: -$gs-gutter;


### PR DESCRIPTION
In followup to #12665 ('revert-fabric-v1'), this PR restores the fabric-v1 templates, but without the behaviour to add fabric adverts to mobile article inlines, which had caused issues in production earlier today. It also re-adds the original layers that were in fluid250.html, so that creatives may use different backgrounds on mobile and desktop breakpoints.

@regiskuckaertz @tijanamiletic 
