### PR TITLE
Asset metrics dashboard: show size and size change for all js/css files

### DIFF
--- a/admin/app/controllers/metrics/MetricsController.scala
+++ b/admin/app/controllers/metrics/MetricsController.scala
@@ -10,6 +10,8 @@ import conf.Configuration
 import tools.CloudWatch._
 import play.api.Play.current
 
+import scala.concurrent.Future
+
 object MetricsController extends Controller with Logging with AuthLogging with ExecutionContexts {
   // We only do PROD metrics
 
@@ -54,7 +56,7 @@ object MetricsController extends Controller with Logging with AuthLogging with E
   }
 
   def renderAssets() = AuthActions.AuthActionTest.async { implicit request =>
-    AssetMetrics.assets.map(metrics => NoCache(Ok(views.html.staticAssets(stage, metrics))))
+    Future.successful(NoCache(Ok(views.html.staticAssets(stage, AssetMetricsCache.sizes))))
   }
 
   def renderAfg() = AuthActions.AuthActionTest.async { implicit request =>

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -10,7 +10,7 @@ import football.feed.MatchDayRecorder
 import jobs._
 import play.api.GlobalSettings
 import services.EmailService
-import tools.{CloudWatch, LoadBalancer}
+import tools.{AssetMetricsCache, CloudWatch, LoadBalancer}
 
 import scala.concurrent.Future
 
@@ -93,6 +93,10 @@ trait AdminLifecycle extends GlobalSettings with Logging {
       VideoEncodingsJob.run()
     }
 
+    Jobs.scheduleEveryNMinutes("AssetMetricsCache", 60 * 6) {
+      AssetMetricsCache.run()
+    }
+
   }
 
   private def descheduleJobs(): Unit = {
@@ -112,6 +116,7 @@ trait AdminLifecycle extends GlobalSettings with Logging {
     Jobs.deschedule("ExpiringAdFeaturesEmailJob")
     Jobs.deschedule("VideoEncodingsJob")
     Jobs.deschedule("ExpiringSwitchesEmailJob")
+    Jobs.deschedule("AssetMetricsCache")
   }
 
   override def onStart(app: play.api.Application): Unit = {
@@ -122,6 +127,7 @@ trait AdminLifecycle extends GlobalSettings with Logging {
     AkkaAsync {
       RebuildIndexJob.run()
       VideoEncodingsJob.run()
+      AssetMetricsCache.run()
     }
   }
 

--- a/admin/app/tools/charts/charts.scala
+++ b/admin/app/tools/charts/charts.scala
@@ -128,11 +128,12 @@ class AwsLineChart(
       .getOrElse(throw new IllegalStateException(s"Don't know how to get a value for $dataPoint"))
 
   protected def toLabel(date: DateTime): String = date.withZone(format.timezone).toString("HH:mm")
+
+  lazy val latest = dataset.lastOption.flatMap(_.values.headOption).getOrElse(0.0)
 }
 
 class AwsDailyLineChart(name: String, labels: Seq[String], format: ChartFormat, charts: GetMetricStatisticsResult*) extends AwsLineChart(name, labels, format, charts:_*) {
   override def toLabel(date: DateTime): String = date.withZone(format.timezone).toString("dd/MM")
-  lazy val latest = dataset.lastOption.flatMap(_.values.headOption).getOrElse(0.0)
 }
 
 class ABDataChart(name: String, ablabels: Seq[String], format: ChartFormat, charts: GetMetricStatisticsResult*) extends AwsLineChart(name, ablabels, format, charts:_*) {

--- a/admin/app/views/staticAssets.scala.html
+++ b/admin/app/views/staticAssets.scala.html
@@ -1,83 +1,7 @@
-@(env: String, assets: Seq[tools.AssetData])(implicit request: RequestHeader)
+@(env: String, metrics: Seq[tools.AssetMetric])(implicit request: RequestHeader)
 
-@chart(chart: tools.AwsDailyLineChart) = {
-    <div id="@chart.id" class="chart @chart.format.cssClass"></div>
-
-    <script type="text/javascript">
-    new google.visualization.LineChart(document.getElementById('@chart.id'))
-    .draw(google.visualization.arrayToDataTable(@Html(chart.asDataset)), {
-        curveType: 'function',
-        colors: [@Html(chart.format.colours.map(c => s"'$c'").mkString(","))],
-        chartArea: {
-            width: "98%"
-        },
-        vAxis: {
-            title: 'Kb',
-            textPosition: 'in',
-            viewWindowMode: 'pretty'
-        },
-        fontName : 'Helvetica'
-    });
-    </script>
-}
-
-@data(asset: tools.AssetData, index: Int) = {
-    <h4 id="asset-@index"><i class="glyphicon glyphicon-file"></i> @asset.name</h4>
-    <hr />
-    <div class="row">
-        <div class="col-md-8">
-            <table class="table table-bordered table--asset">
-                <thead>
-                    <tr>
-                        <th class="table__head" colspan="4">GZipped size in Kb (last 14 days)</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td colspan="4">@chart(asset.zipped)</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        <div class="col-md-4">
-            <table class="table table-bordered table--asset">
-                <tbody>
-                    <tr>
-                        <th class="table__head" colspan="3">Size</th>
-                    </tr>
-                    <tr>
-                        <th>Current size (Raw)</th>
-                        <th>Current size (GZip)</th>
-                        <th>Week-on-week Change</th>
-                    </tr>
-                    <tr>
-                        <td>@asset.raw.latest.floor Kb</td>
-                        <td>@asset.zipped.latest.floor Kb</td>
-                        <td>@change(asset)</td>
-                    </tr>
-                    @if(asset.isCSS) {
-                        <tr>
-                            <th class="table__head" colspan="3">Metrics</th>
-                        </tr>
-                        <tr>
-                            <th>Rules</th>
-                            <th>Total Selectors</th>
-                            <th>Average Selectors</th>
-                        </tr>
-                        <tr>
-                            <td>@asset.rules.latest.toInt</td>
-                            <td>@asset.selectors.latest.toInt</td>
-                            <td>@{ "%.2f".format(asset.selectors.latest / asset.rules.latest) }</td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
-        </div>
-    </div>
-}
-
-@change(asset: tools.AssetData) = {
-    @defining(asset.rawChange) { change =>
+@change(metric: tools.AssetMetric) = {
+    @defining(metric.change) { change =>
         <span class="label label-@change match {
                 case c if c < 0 => {success}
                 case c if c > 0 => {danger}
@@ -91,43 +15,43 @@
                     case c if c > 0 => {arrow-up}
                     case _ => {}
                 }"></i>
-                @{"%.2f".format(asset.rawChange)} Kb
+                @{"%.2f".format(metric.change)} Kb
             }
         </span>
     }
 }
 
-@admin_main("Dashboard", env, isAuthed = true, hasCharts = true) {
+@sizeSummary(title: String, metrics: Seq[tools.AssetMetric]) = {
 
-    <h1 class="page-header">Static assets</h1>
-
-    <h3>Summary</h3>
+    <h3>@title</h3>
 
     <table class="table table-bordered table-striped table--asset">
         <thead>
             <tr>
                 <th class="table__head">Asset filename</th>
-                <th class="table__head">Current size (Raw)</th>
-                <th class="table__head">Current size (GZip)</th>
+                <th class="table__head">Current size (Gzipped)</th>
                 <th class="table__head">Week-on-week Change</th>
             </tr>
         </thead>
         <tbody>
-            @assets.filter(_.combined.hasData).zipWithIndex.map{ case (asset, index) =>
-                <tr>
-                    <td>
-                        <a href="#asset-@index">
-                            <strong>@asset.name</strong>
-                        </a>
-                    <td>@{"%.2f".format(asset.raw.latest)} Kb</td>
-                    <td>@{"%.2f".format(asset.zipped.latest)} Kb</td>
-                    <td>@change(asset)</td>
-                </tr>
-            }
+        @metrics.filter(_.chart.hasData).zipWithIndex.map{ case (metric, index) =>
+        <tr>
+            <td>
+                <strong>@metric.name</strong>
+        <td>@{"%.2f".format(metric.chart.latest)} Kb</td>
+        <td>@change(metric)</td>
+        </tr>
+        }
         </tbody>
     </table>
 
-    @assets.filter(_.combined.hasData).zipWithIndex.map{ case (asset, index) =>
-        @data(asset, index)
-    }
+}
+
+
+@admin_main("Dashboard", env, isAuthed = true, hasCharts = true) {
+
+    <h1 class="page-header">Static assets</h1>
+
+    @sizeSummary("Javascript Files", metrics.filter(_.name.endsWith(".js")))
+    @sizeSummary("CSS Files", metrics.filter(_.name.endsWith(".css")))
 }


### PR DESCRIPTION
## What does this change?

This is the first step of fixing the Asset Metrics admin dashboard
https://frontend.gutools.co.uk/metrics/assets

The dashboard now shows two lists of files (js and css) with each file' size
and size evolution during the time period (14 days)

The 2nd step objective would be to show a graph when a file is clicked
that would give a more detailled overview of this file size evolution
## What is the value of this and can you measure success?

Tracking the size of all js/css files overtime
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![screen shot 2016-04-25 at 15 53 32](https://cloud.githubusercontent.com/assets/233326/14787971/dcc438b8-0afd-11e6-894c-b94541759a4d.png)
## Request for comment

@sndrs @johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
