### PR TITLE
Remove the `retry-failed-accuweather-requests` switch

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -224,14 +224,4 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
-  // Owner: dotcom health (tbonnin)
-  val RetryFailedAccuWeatherApiRequests = Switch(
-    SwitchGroup.Performance,
-    "retry-failed-accuweather-requests",
-    "If this switch is ON then failed requests to the Accuweather would be retried 2 more times before failing",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 4, 27), //Wednesday
-    exposeClientSide = false
-  )
-
 }

--- a/onward/app/weather/WeatherApi.scala
+++ b/onward/app/weather/WeatherApi.scala
@@ -41,10 +41,8 @@ object WeatherApi extends ExecutionContexts with ResourcesHelper {
   private def getJson(url: String): Future[JsValue] = {
     if (Play.isTest) {
       Future(Json.parse(slurpOrDie(new URI(url).getPath.stripPrefix("/"))))
-    } else if(conf.switches.Switches.RetryFailedAccuWeatherApiRequests.isSwitchedOn) {
-      getJsonWithRetry(url)
     } else {
-      WS.url(url).get().filter(_.status == 200).map(_.json)
+      getJsonWithRetry(url)
     }
   }
 


### PR DESCRIPTION
## What does this change?

Lowering the timeout value of the requests to accuweather API and
retrying in case of timeout exceptions successfully resulted in lower
errors.
This patch is removing the flag and make the retrying permanent
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@johnduffell @jamespamplin 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
