### PR TITLE
Add invalid email message

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -228,6 +228,10 @@ CommentBox.prototype.submitPostComment = function(e) {
     this.postComment();
 };
 
+CommentBox.prototype.invalidEmailError = function () {
+   this.error('EMAIL_NOT_VALIDATED');
+   ValidationEmail.init();
+};
 
 CommentBox.prototype.postComment = function() {
     var self = this,
@@ -260,11 +264,6 @@ CommentBox.prototype.postComment = function() {
         }
     };
 
-    var invalidEmailError = function () {
-        self.error('EMAIL_NOT_VALIDATED');
-        ValidationEmail.init();
-    };
-
     if (!self.getUserData().emailVerified) {
         // Cookie could be stale so lets refresh and check from the api
         var createdDate = new Date(self.getUserData().accountCreatedDate);
@@ -273,7 +272,7 @@ CommentBox.prototype.postComment = function() {
                 if (response.user.statusFields.userEmailValidated === true) {
                     validEmailCommentSubmission();
                 } else {
-                    invalidEmailError();
+                    self.invalidEmailError();
                 }
             });
         } else {
@@ -339,6 +338,8 @@ CommentBox.prototype.fail = function(xhr) {
 
     if (xhr.status == 0) {
         this.error('API_CORS_BLOCKED');
+    } else if (response.errorCode === 'EMAIL_NOT_VALIDATED') {
+        this.invalidEmailError();
     } else if (this.errorMessages[response.errorCode]) {
         this.error(response.errorCode);
     } else {


### PR DESCRIPTION
Ensures the resend email verification link works correctly in all cases when attempting to comment with an unverified email address.

This is the fix for this revert: https://github.com/guardian/frontend/pull/12674
