### PR TITLE
Split brain

### DIFF
--- a/common/app/conf/switches/FaciaSwitches.scala
+++ b/common/app/conf/switches/FaciaSwitches.scala
@@ -60,4 +60,13 @@ trait FaciaSwitches {
     exposeClientSide = false
   )
 
+  val FaciaPressCrossAccountStorage = Switch(
+    SwitchGroup.Facia,
+    "facia-press-cross-account-storage",
+    "If this is switched on, facia press will access the bucket in cmsFronts account",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 21),
+    exposeClientSide = false
+  )
+
 }

--- a/common/app/fronts/FrontsApi.scala
+++ b/common/app/fronts/FrontsApi.scala
@@ -12,4 +12,10 @@ object FrontsApi extends ExecutionContexts {
     client.setEndpoint(AwsEndpoints.s3)
     ApiClient(Configuration.aws.bucket, Configuration.facia.stage.toUpperCase, AmazonSdkS3Client(client))
   }
+
+  val crossAccountClient: ApiClient = {
+    val client = new AmazonS3Client(Configuration.faciatool.crossAccountMandatoryCredentials)
+    client.setEndpoint(AwsEndpoints.s3)
+    ApiClient(Configuration.faciatool.crossAccountSourceBucket, Configuration.facia.stage.toUpperCase, AmazonSdkS3Client(client))
+  }
 }

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -2,9 +2,11 @@ package services
 
 import akka.util.Timeout
 import com.gu.facia.api.models.{CommercialPriority, EditorialPriority, FrontPriority, TrainingPriority}
+import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.{ConfigJson => Config, FrontJson => Front}
 import common._
 import conf.Configuration
+import conf.switches.Switches
 import fronts.FrontsApi
 import model.pressed.CollectionConfig
 import model.{FrontProperties, SeoDataJson}
@@ -21,8 +23,15 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
   implicit val alterTimeout: Timeout = Configuration.faciatool.configBeforePressTimeout.millis
   private lazy val configAgent = AkkaAgent[Option[Config]](None)
 
+  def getClient: ApiClient = {
+    if (Switches.FaciaPressCrossAccountStorage.isSwitchedOn)
+      FrontsApi.crossAccountClient
+    else
+      FrontsApi.amazonClient
+  }
+
   def refresh() = {
-    val futureConfig = FrontsApi.amazonClient.config
+    val futureConfig = getClient.config
     futureConfig.onComplete {
       case Success(config) => log.info(s"Successfully got config")
       case Failure(t) => log.error(s"Getting config failed with $t", t)
@@ -35,7 +44,7 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
   }
 
   def refreshAndReturn(): Future[Option[Config]] =
-    FrontsApi.amazonClient.config
+    getClient.config
       .flatMap(config => configAgent.alter{_ => Option(config)})
       .fallbackTo{
       log.warn("Falling back to current ConfigAgent contents on refreshAndReturn")

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -151,24 +151,6 @@ object S3FrontsApi extends S3 {
   def getDraftFapiPressedKeyForPath(path: String): String =
     s"$location/pressed/draft/$path/fapi/pressed.json"
 
-  def getSchema = get(s"$location/schema.json")
-  def getMasterConfig: Option[String] = get(s"$location/config/config.json")
-  def getBlock(id: String) = get(s"$location/collection/$id/collection.json")
-
-  private def getListing(prefix: String, dropText: String): List[String] = {
-    import scala.collection.JavaConversions._
-    val summaries = client.map(_.listObjects(bucket, prefix).getObjectSummaries.toList).getOrElse(Nil)
-    summaries
-      .map(_.getKey.split(prefix))
-      .filter(_.nonEmpty)
-      .map(_.last)
-      .filterNot(_.endsWith("/"))
-      .map(_.split(dropText).head)
-  }
-
-  def getConfigIds(prefix: String): List[String] = getListing(prefix, "/config.json")
-  def getCollectionIds(prefix: String): List[String] = getListing(prefix, "/collection.json")
-
   def putLivePressedJson(path: String, json: String) =
     putPrivateGzipped(getLivePressedKeyForPath(path), json, "application/json")
 


### PR DESCRIPTION
## What does this change?

Fronts tool lives in cmsFronts account but uses frontend S3 as data storage.

At the time of writing, fronts tool reads the master config from frontend and writes in both buckets. Ideally it would only write in cmsFronts.

This PR introduces a switch to use cmsFronts bucket as master config.

Changes:
- all reads (facia, press, admin ...) go through `ConfigAgent` which chooses the account / bucket depending on a feature switch.
- press writes with `S3FrontsApi` which always writes into frontend account
## What is the value of this and can you measure success?

I sleep better at night
## Does this affect other platforms - Amp, Apps, etc?

It affects most developers, they'll need cmsFronts credentials through Janus

It depends on cloudformation and platform updates
## Request for comment

@janua @johnduffell @anyone_in_the_team?
