### PR TITLE
Re-enable sentry logging

### DIFF
--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -15,6 +15,15 @@ trait MonitoringSwitches {
     exposeClientSide = true
   )
 
+  val SentryReporting = Switch(
+    SwitchGroup.Monitoring,
+    "enable-sentry-reporting",
+    "If this switch is on, then js errors will be reported to Sentry.",
+    safeState = Off,
+    never,
+    exposeClientSide = true
+  )
+
   val GoogleAnalyticsSwitch = Switch(
     SwitchGroup.Monitoring,
     "google-analytics",

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -49,7 +49,7 @@ define([
         //
 
         raven.config(
-            'http://' + config.page.sentryPublicApiKey + '@' + config.page.sentryHost,
+            'https://' + config.page.sentryPublicApiKey + '@' + config.page.sentryHost,
             {
                 whitelistUrls: [
                     /localhost/, // will not actually log errors, but `shouldSendCallback` will be called

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -78,7 +78,7 @@ define([
                         }
                     }
 
-                    return config.switches.diagnosticsLogging &&
+                    return config.switches.enableSentryReporting &&
                         Math.random() < 0.2 &&
                         !isDev; // don't actually notify sentry in dev mode
                 }

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -49,7 +49,7 @@ define([
         //
 
         raven.config(
-            'https://' + config.page.sentryPublicApiKey + '@' + config.page.sentryHost,
+            'http://' + config.page.sentryPublicApiKey + '@' + config.page.sentryHost,
             {
                 whitelistUrls: [
                     /localhost/, // will not actually log errors, but `shouldSendCallback` will be called


### PR DESCRIPTION
The switch had been removed, but the raven configuration was still referencing it.
