### PR TITLE
Ensure that adKeywords don't join an undefined array

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -690,7 +690,8 @@ define([
             // let's report these and diagnose the problem in sentry.
             var adUnitPath = event.slot.getAdUnitPath(),
                 adTargetingMap = event.slot.getTargetingMap(),
-                adKeywords = adTargetingMap ? adTargetingMap['k'].join(', ') : '';
+                adTargetingKValues = adTargetingMap ? adTargetingMap['k'] : [],
+                adKeywords = adTargetingKValues ? adTargetingKValues.join(', ') : '';
 
             reportError(new Error('dfp returned an empty ad response'), {
                 feature: 'commercial',


### PR DESCRIPTION
I introduced a bug with dfp response reporting. It was joining an undefined array.
