### PR TITLE
Fix media query for high DPR images

### DIFF
--- a/applications/app/views/fragments/newGalleryBody.scala.html
+++ b/applications/app/views/fragments/newGalleryBody.scala.html
@@ -81,7 +81,7 @@
                         GalleryMedia.inline
                     }) { widths =>
                         @widths.breakpoints.map { breakpointWidth =>
-                            <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+                            <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
                             sizes="@breakpointWidth.width"
                             srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(imageElement.images), hidpi = true)" />
                             <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"

--- a/common/app/views/fragments/img.scala.html
+++ b/common/app/views/fragments/img.scala.html
@@ -111,7 +111,7 @@
         @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
         <!--[if IE 9]><video style="display: none;"><![endif]-->
         @widths.breakpoints.map { breakpointWidth =>
-            <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+            <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
                     sizes="@breakpointWidth.width"
                     srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath = None, maybeImageMedia = Some(picture), hidpi = true)" />
             <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"

--- a/common/app/views/fragments/items/elements/facia_cards/image.scala.html
+++ b/common/app/views/fragments/items/elements/facia_cards/image.scala.html
@@ -5,7 +5,7 @@
     @* IE 9 needs this workaround as per https://scottjehl.github.io/picturefill/ *@
     <!--[if IE 9]><video style="display: none;"><![endif]-->
     @widths.breakpoints.map { breakpointWidth =>
-        <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
+        <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (-webkit-min-device-pixel-ratio: 1.25), (min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px) and (min-resolution: 120dpi)"
                 sizes="@breakpointWidth.width"
                 srcset="@ImgSrc.srcsetForBreakpoint(breakpointWidth, widths.breakpoints, maybePath, maybeImageMedia, hidpi = true)" />
         <source media="(min-width: @breakpointWidth.breakpoint.minWidth.getOrElse("0")px)"


### PR DESCRIPTION
We are currently serving desktop images to all high DPR devices, regardless of screen width. This is because the `min-width` in our media query is not being taken into effect.

As an example, on a high DPR device of any screen width, the following media query returns `true`:

``` js
window.matchMedia('(min-width: 980px) and (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)').matches
// => true
```

Our intention is that this media query should only return true if the screen is 980px or wider _and resolution is deemed high DPR_, but this is not happening.

That is because the precedence is wrong: the media query is interpreted as `(x and y) or z` where `x` is our `min-width`, when we want it to be interpreted as `x and (y or z)`.

It seems you can't use parentheses to control precedence in media queries, so I've worked around this by duplicating the `min-width` media query, resulting in a media query of the form `(x and y) or (x and z)`.
# Before

![image](https://cloud.githubusercontent.com/assets/921609/14821557/18fa752a-0bc3-11e6-9dfd-113324b0943d.png)

`w=620&dpr=2` resulting in an image 1240px wide (too big)
# After

![image](https://cloud.githubusercontent.com/assets/921609/14821576/2854d4ac-0bc3-11e6-8037-3c5b7678792f.png)

`w=465&dpr=2` resulting in an image 930px wide (correct)

/cc @paperboyo @sndrs 
