### PR TITLE
Fix srcset for high DPR images

### DIFF
--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -153,7 +153,7 @@ object ImgSrc extends Logging with implicits.Strings {
   }
 
   def srcset(imageContainer: ImageMedia, widths: WidthsByBreakpoint): String = {
-    widths.profiles.map { profile => srcsetForProfile(profile, imageContainer) } mkString ", "
+    widths.profiles.map { profile => srcsetForProfile(profile, imageContainer, hidpi = false) } mkString ", "
   }
 
   def srcsetForBreakpoint(breakpointWidth: BreakpointWidth, breakpointWidths: Seq[BreakpointWidth], maybePath: Option[String] = None, maybeImageMedia: Option[ImageMedia] = None, hidpi: Boolean = false) = {
@@ -162,23 +162,23 @@ object ImgSrc extends Logging with implicits.Strings {
       .map(browserWidth => Profile(width = Some(browserWidth), hidpi = hidpi, isPng = isPng))
       .map { profile => {
         maybePath
-          .map(url => srcsetForProfile(profile, url))
-          .orElse(maybeImageMedia.map(imageContainer => srcsetForProfile(profile, imageContainer)))
+          .map(url => srcsetForProfile(profile, url, hidpi))
+          .orElse(maybeImageMedia.map(imageContainer => srcsetForProfile(profile, imageContainer, hidpi)))
           .getOrElse("")
       } }
       .mkString(", ")
   }
 
-  def srcsetForProfile(profile: Profile, imageContainer: ImageMedia): String = {
+  def srcsetForProfile(profile: Profile, imageContainer: ImageMedia, hidpi: Boolean): String = {
     if(ImageServerSwitch.isSwitchedOn) {
-      s"${findLargestSrc(imageContainer, profile).get} ${profile.width.get}w"
+      s"${findLargestSrc(imageContainer, profile).get} ${profile.width.get * (if (hidpi) 2 else 1)}w"
     } else {
-      s"${findNearestSrc(imageContainer, profile).get} ${profile.width.get}w"
+      s"${findNearestSrc(imageContainer, profile).get} ${profile.width.get * (if (hidpi) 2 else 1)}w"
     }
   }
 
-  def srcsetForProfile(profile: Profile, path: String): String = {
-    s"${ImgSrc(path, profile)} ${profile.width.get}w"
+  def srcsetForProfile(profile: Profile, path: String, hidpi: Boolean): String = {
+    s"${ImgSrc(path, profile)} ${profile.width.get * (if (hidpi) 2 else 1)}w"
   }
 
   def getFallbackUrl(ImageElement: ImageMedia): Option[String] = {


### PR DESCRIPTION
High DPR devices are currently downloading larger images than intended because of an error in our `srcset`. Explanation below.

Given:

``` html
<source sizes="100vw" srcset="
  foo.jpg?w=300&dpr=2 300w,
  foo.jpg?w=600&dpr=2 600w
">
```

On a device 300px wide, this will fetch `foo.jpg?w=600&dpr=2` (1200px) because the width descriptor (`600vw`) matches `size * dpr = 300 * 2`. However, we want it to fetch the smaller image (but still big enough): `foo.jpg?w=300&dpr=2` (600px).

We can make the browser download the correct image by updating the width descriptor to reflect the actual size of the high DPR image, e.g. for `foo.jpg?w=300&dpr=2` the width descriptor should be `600w` not `300w`:

``` html
<source sizes="100vw" srcset="
  foo.jpg?w=300&dpr=2 600w,
  foo.jpg?w=600&dpr=2 1200w
">
```

I ran a quick test on the network front. The total size of all downloaded images on an iPhone 5 (high DPR):

Before
648KB

After
459KB

/cc @paperboyo @sndrs 
