### PR TITLE
Add correct class names to containers and items

### DIFF
--- a/common/app/views/commercial/containers/fixedLargeSlowXIV.scala.html
+++ b/common/app/views/commercial/containers/fixedLargeSlowXIV.scala.html
@@ -8,18 +8,20 @@
         card,
         cardType = cards.ThreeQuarters,
         omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
-        optAdvertClassNames = Some(Seq("large--1x2")),
+        optAdvertClassNames = Some(Seq("paidfor", "large--1x2")),
         useCardBranding = !containerModel.isSingleSponsorContainer
     ))
     @containerModel.content.initialCards.slice(1, 2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>
 <div class="adverts__row hide-until-tablet">
     @containerModel.content.initialCards.slice(2, 6).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>
 <div class="adverts__row hide-until-tablet">
@@ -27,24 +29,28 @@
         @containerModel.content.initialCards.slice(6, 8).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                                optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
     <div class="adverts__column">
         @containerModel.content.initialCards.slice(8, 10).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                                optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
     <div class="adverts__column">
         @containerModel.content.initialCards.slice(10, 12).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                                optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
     <div class="adverts__column">
         @containerModel.content.initialCards.slice(12, 14).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                                optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
 </div>

--- a/common/app/views/commercial/containers/fixedMediumFastXI.scala.html
+++ b/common/app/views/commercial/containers/fixedMediumFastXI.scala.html
@@ -8,15 +8,18 @@
                             card,
                             cardType = cards.Half,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     @containerModel.content.initialCards.slice(1, 2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     @containerModel.content.initialCards.slice(2, 3).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                             optClassNames = Some(Seq("hide-until-tablet")),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>
 <div class="adverts__row hide-until-tablet">
@@ -24,24 +27,28 @@
         @containerModel.content.initialCards.slice(3, 5).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                                optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
     <div class="adverts__column">
         @containerModel.content.initialCards.slice(3, 5).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                                optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
     <div class="adverts__column">
         @containerModel.content.initialCards.slice(3, 5).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                                optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
     <div class="adverts__column">
         @containerModel.content.initialCards.slice(3, 5).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                                optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
 </div>

--- a/common/app/views/commercial/containers/fixedMediumFastXII.scala.html
+++ b/common/app/views/commercial/containers/fixedMediumFastXII.scala.html
@@ -7,10 +7,12 @@
     @containerModel.content.initialCards.take(2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     @containerModel.content.initialCards.slice(2, 4).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             optClassNames = Some(Seq("hide-until-tablet")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>

--- a/common/app/views/commercial/containers/fixedMediumSlowVI.scala.html
+++ b/common/app/views/commercial/containers/fixedMediumSlowVI.scala.html
@@ -8,16 +8,18 @@
                             card,
                             cardType = cards.ThreeQuarters,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
-                            optAdvertClassNames = Some(Seq("large--1x2")),
+                            optAdvertClassNames = Some(Seq("large--1x2", "paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     @containerModel.content.initialCards.slice(1, 2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>
 <div class="adverts__row hide-until-tablet">
     @containerModel.content.initialCards.slice(2, 6).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>

--- a/common/app/views/commercial/containers/fixedMediumSlowVII.scala.html
+++ b/common/app/views/commercial/containers/fixedMediumSlowVII.scala.html
@@ -8,14 +8,17 @@
                             card,
                             cardType = cards.Half,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel,card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     @containerModel.content.initialCards.slice(1, 2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel,card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     @containerModel.content.initialCards.slice(2, 3).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             optClassNames = Some(Seq("hide-until-tablet")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>
@@ -23,5 +26,6 @@
     @containerModel.content.initialCards.slice(3, 7).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>

--- a/common/app/views/commercial/containers/fixedSmallFastVIII.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallFastVIII.scala.html
@@ -7,11 +7,13 @@
     @containerModel.content.initialCards.take(2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     <div class="adverts__column adverts__2cols">
         @containerModel.content.initialCards.slice(2, 8).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                                optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
 </div>

--- a/common/app/views/commercial/containers/fixedSmallSlowI.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallSlowI.scala.html
@@ -7,7 +7,7 @@
     @containerModel.content.initialCards.take(1).map(card => views.html.commercial.cards.itemLargeCard(
                             card,
                             cardType = cards.FullMedia75,
-                            optAdvertClassNames = Some(Seq("large--1x3")),
+                            optAdvertClassNames = Some(Seq("large--1x3", "paidfor")),
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>

--- a/common/app/views/commercial/containers/fixedSmallSlowIII.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallSlowIII.scala.html
@@ -8,14 +8,17 @@
                             card,
                             cardType = cards.Half,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     @containerModel.content.initialCards.slice(1, 2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     @containerModel.content.initialCards.slice(2, 3).map(card => views.html.commercial.cards.itemCard(
                             card,
                             optClassNames = Some(Seq("hide-until-tablet")),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>

--- a/common/app/views/commercial/containers/fixedSmallSlowIV.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallSlowIV.scala.html
@@ -7,10 +7,12 @@
     @containerModel.content.initialCards.take(2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     @containerModel.content.initialCards.slice(2, 4).map(card => views.html.commercial.cards.itemCard(
                             card,
                             optClassNames = Some(Seq("hide-until-tablet")),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>

--- a/common/app/views/commercial/containers/fixedSmallSlowVHalf.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallSlowVHalf.scala.html
@@ -7,13 +7,13 @@
     <div class="adverts__column">
         @containerModel.content.initialCards.take(2).map(card => views.html.commercial.cards.itemLargeCard(
             card,
-            optAdvertClassNames = Some(Seq("inverse", "thumbnail")),
+            optAdvertClassNames = Some(Seq("inverse", "thumbnail", "paidfor")),
             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
             useCardBranding = !containerModel.isSingleSponsorContainer
         ))
         @containerModel.content.initialCards.slice(2, 4).map(card => views.html.commercial.cards.itemLargeCard(
             card,
-            optAdvertClassNames = Some(Seq("inverse", "thumbnail")),
+            optAdvertClassNames = Some(Seq("inverse", "thumbnail", "paidfor")),
             optClassNames = Some(Seq("hide-until-tablet")),
             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
             useCardBranding = !containerModel.isSingleSponsorContainer
@@ -23,6 +23,7 @@
         card,
         cardType = cards.Half,
         optClassNames = Some(Seq("hide-until-tablet")),
+        optAdvertClassNames = Some(Seq("paidfor")),
         omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
         useCardBranding = !containerModel.isSingleSponsorContainer
     ))

--- a/common/app/views/commercial/containers/fixedSmallSlowVThird.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallSlowVThird.scala.html
@@ -7,11 +7,12 @@
     @containerModel.content.initialCards.take(2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
+                            optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
     <div class="adverts__column hide-until-tablet">
         @containerModel.content.initialCards.slice(2, 5).map(card => views.html.commercial.cards.itemLargeCard(
             card,
-            optAdvertClassNames = Some(Seq("inverse", "thumbnail")),
+            optAdvertClassNames = Some(Seq("inverse", "thumbnail", "paidfor")),
             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
             useCardBranding = !containerModel.isSingleSponsorContainer
         ))

--- a/common/app/views/commercial/containers/paidContainerV2.scala.html
+++ b/common/app/views/commercial/containers/paidContainerV2.scala.html
@@ -17,7 +17,7 @@
     }
     >
     @containerWrapper(
-        Seq("legacy", "capi", "tone-capi"),
+        Seq("legacy", "capi", "paidfor", "tone-paidfor"),
         optKicker = Some(fragments.commercial.paidForMeta(Some(containerModel.id))),
         optStamp = Some(stamp),
         optBadge = if(containerModel.isSingleSponsorContainer){ Some(logoSlot) } else { None }
@@ -53,6 +53,7 @@
                 <div class="adverts__row adverts__row--wrap adverts__3cols">
                     @containerModel.content.showMoreCards.map(card => views.html.commercial.cards.itemSmallCard(
                                             card,
+                                            optAdvertClassNames = Some(Seq("paidfor")),
                                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                                             useCardBranding = !containerModel.isSingleSponsorContainer))
                 </div>


### PR DESCRIPTION
Fixes a bug where the paid for containers did not have the correct class names following the changes in #12687

cc @JonNorman 
