### PR TITLE
Add fake series tests

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -13,6 +13,24 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABFakeSeriesShowSensitive = Switch(
+    SwitchGroup.ABTests,
+    "ab-fake-series-show-sensitive",
+    "A fake test to target series content that's shown on sensitive articles",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 5, 2),
+    exposeClientSide = true
+  )
+
+  val ABFakeSeriesHideSensitive = Switch(
+    SwitchGroup.ABTests,
+    "ab-fake-series-hide-sensitive",
+    "A fake test to target series content that's hidden on sensitive articles",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 5, 2),
+    exposeClientSide = true
+  )
+
   // Owner: Dotcom Reach
   val ABFrontsOnArticles2 = Switch(
     SwitchGroup.ABTests,

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -6,6 +6,8 @@ define([
     'common/utils/storage',
     'common/modules/analytics/mvt-cookie',
     'common/modules/experiments/tests/dummy-test',
+    'common/modules/experiments/tests/fake-series-hide-sensitive',
+    'common/modules/experiments/tests/fake-series-show-sensitive',
     'common/modules/experiments/tests/fronts-on-articles2',
     'common/modules/experiments/tests/identity-register-membership-standfirst',
     'common/modules/experiments/tests/live-blog-chrome-notifications-internal',
@@ -36,6 +38,8 @@ define([
     store,
     mvtCookie,
     DummyTest,
+    FakeSeriesHideSensitive,
+    FakeSeriesShowSensitive,
     FrontsOnArticles2,
     IdentityRegisterMembershipStandfirst,
     LiveBlogChromeNotificationsInternal,
@@ -70,7 +74,9 @@ define([
         new Membership(),
         new LoyalAdblockingSurvey(),
         new Minute(),
-        new VideoSeriesPage()
+        new VideoSeriesPage(),
+        new FakeSeriesHideSensitive(),
+        new FakeSeriesShowSensitive()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/fake-series-hide-sensitive.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/fake-series-hide-sensitive.js
@@ -1,0 +1,31 @@
+define([], function () {
+    return function () {
+        this.id = 'FakeSeriesHideSensitive';
+        this.start = '2016-04-28';
+        this.expiry = '2016-04-30';
+        this.author = 'Sam Desborough';
+        this.description = 'A fake test to target series content that\'s hidden on sensitive articles';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = '';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+        this.showForSensitive = false;
+
+        this.canRun = function () {
+            return !!window.guardian.config.page.seriesId;
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {}
+            },
+            {
+                id: 'variant',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/fake-series-hide-sensitive.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/fake-series-hide-sensitive.js
@@ -1,8 +1,8 @@
 define([], function () {
     return function () {
         this.id = 'FakeSeriesHideSensitive';
-        this.start = '2016-04-28';
-        this.expiry = '2016-04-30';
+        this.start = '2016-04-27';
+        this.expiry = '2016-04-29';
         this.author = 'Sam Desborough';
         this.description = 'A fake test to target series content that\'s hidden on sensitive articles';
         this.audience = 1;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/fake-series-show-sensitive.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/fake-series-show-sensitive.js
@@ -1,0 +1,31 @@
+define([], function () {
+    return function () {
+        this.id = 'FakeSeriesShowSensitive';
+        this.start = '2016-04-28';
+        this.expiry = '2016-04-30';
+        this.author = 'Sam Desborough';
+        this.description = 'A fake test to target series content that\'s shown on sensitive articles';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = '';
+        this.audienceCriteria = 'All users';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+        this.showForSensitive = true;
+
+        this.canRun = function () {
+            return !!window.guardian.config.page.seriesId;
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {}
+            },
+            {
+                id: 'variant',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/fake-series-show-sensitive.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/fake-series-show-sensitive.js
@@ -1,8 +1,8 @@
 define([], function () {
     return function () {
         this.id = 'FakeSeriesShowSensitive';
-        this.start = '2016-04-28';
-        this.expiry = '2016-04-30';
+        this.start = '2016-04-27';
+        this.expiry = '2016-04-29';
         this.author = 'Sam Desborough';
         this.description = 'A fake test to target series content that\'s shown on sensitive articles';
         this.audience = 1;


### PR DESCRIPTION
A couple of tests that don't actually do anything, but cover 100% of our audience and only run on series pages. The only difference is whether they should run on sensitive content or not. 

We'll use them see how well the current A/B framework supports queries about visitor habits.
