### PR TITLE
add pagination to more-in-series

### DIFF
--- a/onward/app/controllers/MostViewedVideoController.scala
+++ b/onward/app/controllers/MostViewedVideoController.scala
@@ -11,11 +11,16 @@ object MostViewedVideoController extends Controller with Logging with ExecutionC
 
   // Move this out of here if the test is successful
   def renderInSeries(series: String) = Action.async { implicit request =>
+    val page = (request.getQueryString("page") getOrElse "1").toInt
     val edition = Edition(request)
+    val nextPage = Some(page + 1)
+    val prevPage = if (page > 1) Some(page - 1) else None
+
     getResponse(ContentApiClient.search(edition)
       .tag(series)
       .showTags("all")
       .showFields("all")
+      .page(page)
       .pageSize(6)
     ).map { response =>
       val videos = response.results.toList.map(apiContent => {
@@ -29,7 +34,7 @@ object MostViewedVideoController extends Controller with Logging with ExecutionC
 
       Cached(900) {
         JsonComponent(
-          "html" -> views.html.fragments.videosInSeries(videos, seriesTitle)
+          "html" -> views.html.fragments.videosInSeries(videos, seriesTitle, series, nextPage, prevPage)
         )
       }
     }

--- a/onward/app/views/fragments/videosInSeries.scala.html
+++ b/onward/app/views/fragments/videosInSeries.scala.html
@@ -1,4 +1,4 @@
-@(videos: List[model.Video], seriesTitle: Option[String])(implicit request: RequestHeader)
+@(videos: List[model.Video], seriesTitle: Option[String], series: String, nextPage: Option[Int], prevPage: Option[Int])(implicit request: RequestHeader)
 
 @import views.support.Seq2zipWithRowInfo
 
@@ -8,7 +8,7 @@ data-component="most-viewed-video">
     <div class="most-viewed-container__header">
         <h3 class="most-viewed-container__heading u-cf">
             <div class="most-viewed__more-from">More from</div>
-            @seriesTitle.getOrElse("More in this series")
+               @seriesTitle.getOrElse("More in this series")
         </h3>
     </div>
     <ul class="u-cf u-unstyled most-viewed--media most-viewed--video items--media items--video items--playlist" data-link-name="Most viewed video">
@@ -16,5 +16,18 @@ data-component="most-viewed-video">
         @fragments.mediaItem(video, row.rowNum)
     }
     </ul>
-
+    <div class="u-cf most-viewed-navigation" data-link-name="most-viewed-navigation">
+            <!-- TODO: reverse routing - do we support it? -->
+            <!-- TODO: Buttons here, not really links, but it's easy for styling -->
+        @prevPage.map{ p =>
+            <a class="most-viewed-navigation__link most-viewed-navigation__link--prev" data-page="@p" data-link-name="prev" href="">
+            @fragments.inlineSvg("arrow-left", "icon")
+            </a>
+        }
+        @nextPage.map{ p =>
+            <a class="most-viewed-navigation__link most-viewed-navigation__link--next" data-page="@p" data-link-name="next" href="">
+            @fragments.inlineSvg("chevron-right", "icon")
+            </a>
+        }
+    </div>
 </div>

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -393,7 +393,7 @@ define([
 
         var mediaType  = config.page.contentType.toLowerCase(),
             mostViewed = new Component(),
-            isInSeriesTest = ab.isInVariant('VideoSeriesPage', 'variant'),
+            isInSeriesTest = true || ab.isInVariant('VideoSeriesPage', 'variant'),
             attachTo   = $(mediaType === 'video' ? '.js-video-components-container' : '.js-media-popular')[0],
             endpoint   = isInSeriesTest ? '/video/in-series/' + config.page.seriesId + '.json' :
                          '/' + (config.page.isPodcast ? 'podcast' : mediaType) + '/most-viewed.json';
@@ -403,6 +403,22 @@ define([
 
         mostViewed.fetch(attachTo, 'html').then(function () {
             mediator.emit('page:new-content');
+
+            if (isInSeriesTest) {
+                // TODO: This is only for the test - please don't get this close to prod
+                bean.on(attachTo, 'click', '.most-viewed-navigation__link', function(ev) {
+                    var page = ev.currentTarget.getAttribute('data-page');
+                    var endpoint = mostViewed.endpoint.replace(/\?page=\d/, '') + '?page=' + page;
+
+                    mostViewed = new Component();
+                    mostViewed.manipulationType = mediaType === 'video' ? 'append' : 'html';
+                    mostViewed.endpoint = endpoint;
+                    attachTo.innerHTML = '';
+                    mostViewed.fetch(attachTo, 'html');
+                    ev.preventDefault();
+                    return false;
+                });
+            }
         });
     }
 

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -393,7 +393,7 @@ define([
 
         var mediaType  = config.page.contentType.toLowerCase(),
             mostViewed = new Component(),
-            isInSeriesTest = true || ab.isInVariant('VideoSeriesPage', 'variant'),
+            isInSeriesTest = ab.isInVariant('VideoSeriesPage', 'variant'),
             attachTo   = $(mediaType === 'video' ? '.js-video-components-container' : '.js-media-popular')[0],
             endpoint   = isInSeriesTest ? '/video/in-series/' + config.page.seriesId + '.json' :
                          '/' + (config.page.isPodcast ? 'podcast' : mediaType) + '/most-viewed.json';

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -227,10 +227,10 @@
         text-align: center;
         border-radius: 24px;
         background: #ffbb00;
-        color: #333;
+        color: #333333;
 
         svg {
-            fill: #333;
+            fill: #333333;
             position: relative;
             top: 1px;
         }

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -216,4 +216,29 @@
     .most-viewed-container__header {
         height: auto !important;
     }
+
+    .most-viewed-navigation {
+        margin-top: $gs-baseline;
+    }
+    .most-viewed-navigation__link {
+        display: block;
+        width: 24px;
+        height: 24px;
+        text-align: center;
+        border-radius: 24px;
+        background: #ffbb00;
+        color: #333;
+
+        svg {
+            fill: #333;
+            position: relative;
+            top: 1px;
+        }
+    }
+    .most-viewed-navigation__link--prev {
+        float: left;
+    }
+    .most-viewed-navigation__link--next {
+        float: right;
+    }
 }


### PR DESCRIPTION
## What does this change?

Adding pagination to the test as, without fail, if we went with it, it would have pagination, and adds a lot to the value of what this container might be, so seems a better indication of whether it's useful to our audience.

I know there are a few things that we don't cater for i.e
- What happens when we run out of pages
- Clicking through to a video won't keep your place in the pagination
- etc - it's a week test, so should be okay.
## What is the value of this and can you measure success?

Same as the test before, we will be looking at who goes from a video in a series, to another.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

![more-in-pagination](https://cloud.githubusercontent.com/assets/31692/14858659/c9befc52-0c98-11e6-8294-ef05cf182134.png)
## Request for comment

@akash1810 @blongden73 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
