### PR TITLE
Move metrics into separate static object

### DIFF
--- a/commercial/app/commercial/CommercialLifecycle.scala
+++ b/commercial/app/commercial/CommercialLifecycle.scala
@@ -14,6 +14,16 @@ import scala.util.control.NonFatal
 
 import common.AkkaAgent
 
+private [commercial] object CommercialLifecycleMetrics {
+
+  val metricMap = Map(
+    "fetch-failure" -> AkkaAgent(0.0),
+    "fetch-success" -> AkkaAgent(0.0),
+    "parse-failure" -> AkkaAgent(0.0),
+    "parse-success" -> AkkaAgent(0.0)
+  )
+}
+
 trait CommercialLifecycle extends GlobalSettings with Logging with ExecutionContexts {
 
   private val refreshJobs: List[RefreshJob] = List(
@@ -23,24 +33,15 @@ trait CommercialLifecycle extends GlobalSettings with Logging with ExecutionCont
     MoneyBestBuysRefresh
   )
 
-
-  private lazy val metricMap = Map(
-    "fetch-failure" -> AkkaAgent(0.0),
-    "fetch-success" -> AkkaAgent(0.0),
-    "parse-failure" -> AkkaAgent(0.0),
-    "parse-success" -> AkkaAgent(0.0)
-  )
-
-  private def recordEvent(eventName:String, outcome:String):Unit = {
+  private def recordEvent(eventName:String, outcome:String): Unit = {
     val keyName = s"$eventName-$outcome"
-    metricMap
+    CommercialLifecycleMetrics.metricMap
       .get(keyName)
       .foreach(agent => agent.send(_ +1.0))
   }
 
-
   private def updateMetrics(): Unit = {
-    metricMap.foreach{
+    CommercialLifecycleMetrics.metricMap.foreach{
       case (metricName, agent) => {
         agent send {currentCount =>
           log.info(s"uploading $metricName with count of : $currentCount")


### PR DESCRIPTION
## What does this change?

Metric values where extrapolated outside of trait into separate static object due to a compiler error. Compiler was crashing trying to access private val within the trait. 
## Request for comment

@JonNorman 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
