### PR TITLE
A fabric layer two animation must be not be positioned

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/fabric-v1.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/fabric-v1.js
@@ -68,10 +68,21 @@ define([
                 false
         };
 
-        this.$adSlot.append(fabricV1Tpl({ data: merge(this.params, templateOptions) }));
+        fastdom.write(function () {
+            this.$adSlot.append(fabricV1Tpl({data: merge(this.params, templateOptions)}));
+
+            this.layer2 = $('.hide-until-tablet .fabric-v1_layer2', this.$adSlot[0]);
+
+            // layer two animations must not have a background position, otherwise the background will
+            // be visible before the animation has been initiated.
+            if (this.params.layerTwoAnimation === 'enabled' && isEnhanced && !isIE9OrLess) {
+                bonzo(this.layer2).css('background-position', '');
+            }
+        }, this);
+
         if (templateOptions.scrollbg) {
             this.scrollingBg = $('.ad-scrolling-bg', this.$adSlot[0]);
-            this.layer2 = $('.hide-until-tablet .fabric-v1_layer2', this.$adSlot[0]);
+
 
             if (hasScrollEnabled) {
                 // update bg position


### PR DESCRIPTION
This fixes a visual issue where the fabric layer two animation is visible in it's final position before the animation begins. We do need to keep the inline `background-position` in some cases, so it has to be removed conditionally.
