### PR TITLE
Add Fabric dependency

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -14,6 +14,7 @@ define([
     'common/modules/commercial/creatives/expandable-video-v2',
     'common/modules/commercial/creatives/fabric-v1',
     'common/modules/commercial/creatives/fabric-expanding-v1',
+    'common/modules/commercial/creatives/fabric-expandable-video-v1',
     'common/modules/commercial/creatives/fluid250',
     'common/modules/commercial/creatives/fluid250GoogleAndroid',
     'common/modules/commercial/creatives/foundation-funded-logo',


### PR DESCRIPTION
We have to specify creative templates as dependencies in breakout-iframe.js, else the _require_ for them in the iframe parser will break in prod - they're not available on any bundle.

This adds the new fabric expandable video.

@regiskuckaertz
