### PR TITLE
Add build number and revision to logs fields

### DIFF
--- a/common/app/common/Logback/Logstash.scala
+++ b/common/app/common/Logback/Logstash.scala
@@ -1,6 +1,7 @@
 package common.Logback
 
 import com.amazonaws.auth.AWSCredentialsProvider
+import common.ManifestData
 import conf.switches.Switches
 import conf.Configuration
 import play.api.{Logger => PlayLogger, Application => PlayApp, GlobalSettings}
@@ -26,7 +27,9 @@ object Logstash {
   val customFields = Map(
     "stack" -> "frontend",
     "app" -> Configuration.environment.projectName,
-    "stage" -> Configuration.environment.stage.toUpperCase
+    "stage" -> Configuration.environment.stage.toUpperCase,
+    "build" -> ManifestData.build,
+    "revision" -> ManifestData.revision
   )
 
   val config = for {


### PR DESCRIPTION
## What does this change?

Add build number and revision to logs fields
## What is the value of this and can you measure success?

Allows to query logs for a specific build or revision
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@jamespamplin @rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
