### PR TITLE
Changing optimal image widths for galleries

### DIFF
--- a/common/app/layout/WidthsByBreakpoint.scala
+++ b/common/app/layout/WidthsByBreakpoint.scala
@@ -236,10 +236,13 @@ object ContentWidths {
 
   object GalleryMedia {
     val inline = WidthsByBreakpoint(
-      mobile          = Some(445.px),
-      mobileLandscape = Some(610.px),
-      phablet =         Some(620.px),
-      tablet =          Some(700.px)) // desktop, leftCol, and wide are also 700px
+      mobile          = Some(480.px),
+      mobileLandscape = Some(660.px),
+      phablet =         Some(700.px),
+      tablet =          Some(700.px), // TODO: Change to 480 when new galleries is merged
+      desktop =         Some(720.px),
+      leftCol =         Some(880.px),
+      wide =            Some(1010.px))
 
     val lightbox = WidthsByBreakpoint(
       mobile =          Some(465.px),


### PR DESCRIPTION
## What does this change?

For the new gallery design, images appear bigger on most breakpoints. This change means that the correct image width will be available. 

Downside: Images for the old galleries will be requested too big on desktop breakpoints. However, this will only be for a week until Galleries are fully replaced.

cc @OliverJAsh 
