### PR TITLE
remove server side ab buckets

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -69,6 +69,15 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
+  val ServerSideBucketsSwitch = Switch(
+    SwitchGroup.Performance,
+    "server-side-buckets",
+    "When this switch expires, we should have decided whether permanently running server side ab testing affects caching/costs too much",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 5, 10),
+    exposeClientSide = false
+  )
+
   val AutoRefreshSwitch = Switch(
     SwitchGroup.Performance,
     "auto-refresh",

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -149,20 +149,13 @@ object MultiVariateTesting {
 
   sealed case class Variant(name: String)
 
-  object Variant0 extends Variant("variant-0")
-  object Variant1 extends Variant("variant-1")
-  object Variant2 extends Variant("variant-2")
-  object Variant3 extends Variant("variant-3")
-  object Variant4 extends Variant("variant-4")
-  object Variant5 extends Variant("variant-5")
-  object Variant6 extends Variant("variant-6")
-  object Variant7 extends Variant("variant-7")
+  // buckets 0-7 are removed during testing whether having a permanently running server side ab test framework
+  // affects our caching too much - I'll put them back or come up with a new solution once I have some data! John
   object Variant8 extends Variant("variant-8")
   object Variant9 extends Variant("variant-9")
 
   private val allVariants = List(
-    Variant0, Variant1, Variant2, Variant3, Variant4,
-    Variant5, Variant6, Variant7, Variant8, Variant9)
+    Variant8, Variant9)
 
   def getVariant(request: RequestHeader): Option[Variant] = {
     val cdnVariant: Option[String] = request.headers.get("X-GU-mvt-variant")

--- a/common/test/common/MultiVariateTestingTest.scala
+++ b/common/test/common/MultiVariateTestingTest.scala
@@ -20,9 +20,9 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
     TestCases.test1.switch.switchOn
     val testRequest = TestRequest("/uk")
       .withHeaders(
-        "X-GU-mvt-variant" -> "variant-2"
+        "X-GU-mvt-variant" -> "variant-9"
       )
-    MultiVariateTesting.getVariant(testRequest) should be (Some(Variant2))
+    MultiVariateTesting.getVariant(testRequest) should be (Some(Variant9))
     TestCases.isParticipatingInATest(testRequest) should be (true)
     TestCases.getParticipatingTest(testRequest) should be (Some(TestCases.test1))
     TestCases.test1.switch.switchOff
@@ -44,14 +44,14 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
 
   object TestCases extends Tests {
     object test0 extends TestDefinition(
-      List(Variant0),
+      List(Variant8),
       "test0",
       "an experiment test",
       new LocalDate(2100, 1, 1)
 
     )
     object test1 extends TestDefinition(
-      List(Variant1, Variant2),
+      List(Variant8, Variant9),
       "test1",
       "an experiment test",
       new LocalDate(2100, 1, 1)


### PR DESCRIPTION
As suggested by @TBonnin in https://github.com/guardian/fastly-edge-cache/pull/615 I have temporarily removed the unused server side ab test buckets.  See that PR for more details on why.
