### PR TITLE
AB test https

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -13,6 +13,15 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABHttpsTest = Switch(
+    SwitchGroup.ABTests,
+    "ab-https-test",
+    "AB test site-wide https",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 5, 26),
+    exposeClientSide = true
+  )
+
   val ABFakeSeriesShowSensitive = Switch(
     SwitchGroup.ABTests,
     "ab-fake-series-show-sensitive",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -6,6 +6,7 @@ define([
     'common/utils/storage',
     'common/modules/analytics/mvt-cookie',
     'common/modules/experiments/tests/dummy-test',
+    'common/modules/experiments/tests/https_test',
     'common/modules/experiments/tests/fake-series-hide-sensitive',
     'common/modules/experiments/tests/fake-series-show-sensitive',
     'common/modules/experiments/tests/fronts-on-articles2',
@@ -38,6 +39,7 @@ define([
     store,
     mvtCookie,
     DummyTest,
+    Https,
     FakeSeriesHideSensitive,
     FakeSeriesShowSensitive,
     FrontsOnArticles2,
@@ -66,6 +68,7 @@ define([
 
     var TESTS = flatten([
         new DummyTest(),
+        new Https(),
         new FrontsOnArticles2(),
         new IdentityRegisterMembershipStandfirst(),
         new LiveBlogChromeNotificationsInternal(),

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -6,7 +6,7 @@ define([
     'common/utils/storage',
     'common/modules/analytics/mvt-cookie',
     'common/modules/experiments/tests/dummy-test',
-    'common/modules/experiments/tests/https_test',
+    'common/modules/experiments/tests/https-test',
     'common/modules/experiments/tests/fake-series-hide-sensitive',
     'common/modules/experiments/tests/fake-series-show-sensitive',
     'common/modules/experiments/tests/fronts-on-articles2',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/https-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/https-test.js
@@ -18,7 +18,7 @@ define([
         function getCookieValue(cookieName) {
             var cookieArray = document.cookie.split(';'),
                 cookieVal;
-            for(i = 0; i < cookieArray.length; i++) {
+            for(var i = 0; i < cookieArray.length; i++) {
                 var c = cookieArray[i].split('='),
                     n = c[0].trim(),
                     v = c[1].trim();
@@ -38,8 +38,8 @@ define([
             {
                 id: 'mvt-https',
                 test: function () {
-                    if(document.location.href.startsWith("http:")) {
-                        document.cookie = "https_opt_in=true; expires=Thu, 26 May 2016 22:59:59 GMT";
+                    if(document.location.href.startsWith('http:')) {
+                        document.cookie = 'https_opt_in=true; expires=Thu, 26 May 2016 22:59:59 GMT';
                         document.location = document.location.href.replace('http:','https:');
                     }
                 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/https-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/https-test.js
@@ -4,7 +4,7 @@ define([
     cookies
 ) {
     return function () {
-        this.id = 'https-test';
+        this.id = 'HttpsTest';
         this.start = '2016-04-28';
         this.expiry = '2016-05-26';
         this.author = 'Justin Pinner';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/https-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/https-test.js
@@ -1,0 +1,49 @@
+define([
+], function (
+) {
+    return function () {
+        this.id = 'https-test';
+        this.start = '2016-04-28';
+        this.expiry = '2016-05-26';
+        this.author = 'Justin Pinner';
+        this.description = 'Test how users get on with https site-wide (0% initially)';
+        this.audience = 0;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Pages are served over https';
+        this.audienceCriteria = 'Small percentage of users';
+        this.dataLinkNames = '';
+        this.idealOutcome = 'Nobody reports that things are broken';
+        this.hypothesis = 'We believe that most of our content should serve successfully over https, with a few known exceptions.';
+
+        function getCookieValue(cookieName) {
+            var cookieArray = document.cookie.split(';'),
+                cookieVal;
+            for(i = 0; i < cookieArray.length; i++) {
+                var c = cookieArray[i].split('='),
+                    n = c[0].trim(),
+                    v = c[1].trim();
+                if(n === cookieName) {
+                    cookieVal = v;
+                    break;
+                }
+            }
+            return cookieVal;
+        }
+
+        this.canRun = function () {
+            return !getCookieValue('https_opt_in');
+        };
+
+        this.variants = [
+            {
+                id: 'mvt-https',
+                test: function () {
+                    if(document.location.href.startsWith("http:")) {
+                        document.cookie = "https_opt_in=true; expires=Thu, 26 May 2016 22:59:59 GMT";
+                        document.location = document.location.href.replace('http:','https:');
+                    }
+                }
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/https-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/https-test.js
@@ -1,5 +1,7 @@
 define([
+    'common/utils/cookies'
 ], function (
+    cookies
 ) {
     return function () {
         this.id = 'https-test';
@@ -15,23 +17,8 @@ define([
         this.idealOutcome = 'Nobody reports that things are broken';
         this.hypothesis = 'We believe that most of our content should serve successfully over https, with a few known exceptions.';
 
-        function getCookieValue(cookieName) {
-            var cookieArray = document.cookie.split(';'),
-                cookieVal;
-            for(var i = 0; i < cookieArray.length; i++) {
-                var c = cookieArray[i].split('='),
-                    n = c[0].trim(),
-                    v = c[1].trim();
-                if(n === cookieName) {
-                    cookieVal = v;
-                    break;
-                }
-            }
-            return cookieVal;
-        }
-
         this.canRun = function () {
-            return !getCookieValue('https_opt_in');
+            return !cookies.get('https_opt_in');
         };
 
         this.variants = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/https-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/https-test.js
@@ -18,17 +18,21 @@ define([
         this.hypothesis = 'We believe that most of our content should serve successfully over https, with a few known exceptions.';
 
         this.canRun = function () {
-            return !cookies.get('https_opt_in');
+            return document.location.href.startsWith('http:') && !cookies.get('https_opt_in');
         };
 
         this.variants = [
             {
-                id: 'mvt-https',
+                id: 'mvt-https-in',
                 test: function () {
-                    if(document.location.href.startsWith('http:')) {
-                        document.cookie = 'https_opt_in=true; expires=Thu, 26 May 2016 22:59:59 GMT';
-                        document.location = document.location.href.replace('http:','https:');
-                    }
+                    document.cookie = 'https_opt_in=true; expires=Thu, 26 May 2016 22:59:59 GMT';
+                    document.location = document.location.href.replace('http:','https:');
+                }
+            },
+            {
+                id: 'mvt-https-out',
+                test: function () {
+                    document.cookie = 'https_opt_in=false; expires=Thu, 26 May 2016 22:59:59 GMT';
                 }
             }
         ];


### PR DESCRIPTION
## What does this change?

Sets up an (initially 0%) AB test for site-wide https.
## What is the value of this and can you measure success?

Lets us discover if there are any areas that need further work before https can be enabled universally.
## Does this affect other platforms - Amp, Apps, etc?

No. Or at least it _shouldn't_.
## Screenshots

One thing at a time! I just want to get it running without breaking anything first.
## Request for comment

@sndrs @desbo and anyone else who's an AB veteran.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
