### PR TITLE
Verbose logging in config agent

### DIFF
--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -24,10 +24,13 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
   private lazy val configAgent = AkkaAgent[Option[Config]](None)
 
   def getClient: ApiClient = {
-    if (Switches.FaciaPressCrossAccountStorage.isSwitchedOn)
+    if (Switches.FaciaPressCrossAccountStorage.isSwitchedOn) {
+      log.info("Config agent is using cross account client")
       FrontsApi.crossAccountClient
-    else
+    } else {
+      log.info("Config agent is using same account client")
       FrontsApi.amazonClient
+    }
   }
 
   def refresh() = {


### PR DESCRIPTION
The trait now logs which client is in use, otherwise there's no way to check that cross account communication is actually working
