### PR TITLE
get some basic stats in cloudwatch for offlinepage views (if possible)

### DIFF
--- a/applications/app/views/offlinePage.scala.html
+++ b/applications/app/views/offlinePage.scala.html
@@ -22,6 +22,16 @@
     our own paths *@
 
     @fragments.analytics.omnitureScript(Some(offlinePage.metadata))
+    @if(OfflinePageView.isSwitchedOn) {
+    <script>
+        try {
+            var offlineViews = parseInt(localStorage.getItem('gu.offlineViews')) || 0;
+            localStorage.setItem('gu.offlineViews', offlineViews + 1)
+        } catch (e) {
+            // do nothing
+        }
+    </script>
+    }
 
     @* NOTE the order of these includes is important  *@
     <script>

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -6,6 +6,15 @@ import org.joda.time.LocalDate
 trait MonitoringSwitches {
   // Monitoring
 
+  val OfflinePageView = Switch(
+    SwitchGroup.Monitoring,
+    "offline-page-view",
+    "If this switch is on, views of the offline page will be beaconed to cloudwatch when you come online again",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 3),
+    exposeClientSide = true
+  )
+
   val OphanSwitch = Switch(
     SwitchGroup.Monitoring,
     "ophan",

--- a/common/app/templates/inlineJS/blocking/cloudwatchBeacons.scala.js
+++ b/common/app/templates/inlineJS/blocking/cloudwatchBeacons.scala.js
@@ -1,6 +1,18 @@
 @(item: model.MetaData)(implicit request: RequestHeader)
 @import conf.switches.Switches._
 
+@if(OfflinePageView.isSwitchedOn) {
+    try {
+        var offlineViews = parseInt(localStorage.getItem('gu.offlineViews'));
+        for (var i = 0; i < offlineViews; i++) {
+            (new Image()).src = window.guardian.config.page.beaconUrl + '/count/offline-page-view.gif';
+        }
+        localStorage.removeItem('gu.offlineViews');
+    } catch (e) {
+        // do nothing
+    }
+}
+
 @if(IphoneConfidence.isSwitchedOn && Seq("uk", "us", "au").contains(item.id)) {
 
     (function (window, navigator) {

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -13,6 +13,7 @@ object Metric extends Logging {
     ("pv", CountMetric("kpis-page-views", "raw page views - simple <img> in body, no javascript involved")),
     ("pva", CountMetric("kpis-analytics-page-views", "page view fires after analytics")),
     ("omniture-pageview-error", CountMetric("omniture-pageview-error", "omniture-pageview-error")),
+    ("offline-page-view", CountMetric("offline-page-view", "offline page views after returning")),
 
     ("ads-blocked", CountMetric("ads-blocked", "ads-blocked")),
     ("ad-render", CountMetric("first-ad-rendered", "first-ad-rendered")),


### PR DESCRIPTION
## What does this change?

adds cloudwatch metric for offline page views
## What is the value of this and can you measure success?

should give some kind of indication of how much people see the offline page
## Does this affect other platforms - Amp, Apps, etc?

no 
## Request for comment

@OliverJAsh @rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
