### PR TITLE
Fabric ads in first slice

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -55,7 +55,7 @@ define([
                 }
 
                 if (hasFabricMobileAd && index === 0) {
-                    // It's mobile, so we needn't check for an adSlice
+                    // it's mobile, so we needn't check for an adSlice
                     return true;
                 }
 

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -32,12 +32,12 @@ define([
         }
 
         var adSlots;
-        var prefs          = userPrefs.get('container-states') || {};
-        var isMobile       = detect.getBreakpoint() === 'mobile';
-        var isNetworkFront = ['uk', 'us', 'au'].indexOf(config.page.pageId) !== -1;
-        var hasFabricAd    = (config.page.isFront && config.switches.fabricAdverts && detect.isBreakpoint({max : 'phablet'}));
+        var prefs               = userPrefs.get('container-states') || {};
+        var isMobile            = detect.getBreakpoint() === 'mobile';
+        var isNetworkFront      = ['uk', 'us', 'au'].indexOf(config.page.pageId) !== -1;
+        var hasFabricMobileAd   = (config.page.isFront && config.switches.fabricAdverts && detect.isBreakpoint({max : 'phablet'}));
         // We must keep a small bit of state in the filtering logic
-        var lastIndex      = -1;
+        var lastIndex           = -1;
 
         adSlots = qwery(containerSelector)
             // get all ad slices
@@ -51,6 +51,11 @@ define([
             // keeping containers only if they are $containerGap nodes apart
             .filter(function (item, index) {
                 if (config.page.showMpuInAllContainers) {
+                    return true;
+                }
+
+                if (hasFabricMobileAd && index === 0) {
+                    // It's mobile, so we needn't check for an adSlice
                     return true;
                 }
 
@@ -71,7 +76,7 @@ define([
             // create ad slots for the selected slices
             .map(function (item, index) {
                 var adName = 'inline' + (index + 1);
-                var adSlot = hasFabricAd && index === 0 ?
+                var adSlot = hasFabricMobileAd && index === 0 ?
                     createAdSlot('fabric', 'container-inline') :
                     createAdSlot(adName, 'container-inline');
 

--- a/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
@@ -40,7 +40,12 @@ define([
                 detect = arguments[3];
 
                 config.page = {
-                    pageId: 'uk/commentisfree'
+                    pageId: 'uk/commentisfree',
+                    isFront: true
+                };
+
+                config.switches = {
+                    fabricAdverts : false
                 };
 
                 detect.getBreakpoint = function () {
@@ -179,6 +184,36 @@ define([
                 expect(qwery('.fc-container-third .ad-slot', $fixtureContainer).length).toBe(1);
                 expect(qwery('.fc-container-fifth .ad-slot', $fixtureContainer).length).toBe(1);
                 done();
+            });
+        });
+
+        describe('Fabric ads', function () {
+            beforeEach(function () {
+                config.switches.fabricAdverts = true;
+            });
+
+            it('can be added on mobile', function (done) {
+                detect.isBreakpoint = function () {
+                    // expecting check for breakpoint <= phablet
+                    return true;
+                };
+                sliceAdverts.init();
+                fastdom.defer(function () {
+                    expect(qwery('.fc-container-first .ad-slot--fabric', $fixtureContainer).length).toBe(1);
+                    done();
+                });
+            });
+
+            it('is not added on desktop', function (done) {
+                detect.isBreakpoint = function () {
+                    // expecting check for breakpoint <= phablet
+                    return false;
+                };
+                sliceAdverts.init();
+                fastdom.defer(function () {
+                    expect(qwery('.fc-container-first .ad-slot--fabric', $fixtureContainer).length).toBe(0);
+                    done();
+                });
             });
         });
 


### PR DESCRIPTION
Fabric adverts should always appear in the first slot of mobile fronts - even if there's no slice candidate.

This PR also adds a unit test to verify the ad slot is being inserted.

@rich-nguyen - the way fabric works is a little implicit in the code at the moment. I'd like to rejig things, but I wouldn't mind getting a fix into code for Tijana.
