### PR TITLE
Fabric-expandable video position should be mobile-only

### DIFF
--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -621,8 +621,11 @@
 }
 
 .creative--fabric-expanding-v1 {
-    .expandable_video {
-        bottom: $gs-row-height / 2;
+    @include mq($until: tablet) {
+        // Smaller video should not flush to container bottom
+        .expandable_video {
+            bottom: $gs-row-height / 2;
+        }
     }
 }
 


### PR DESCRIPTION
The side effect of [this](https://github.com/guardian/frontend/pull/12720) fix is that because videos are no longer flush to their container's lower edges, they peek out in the desktop view:

![image](https://cloud.githubusercontent.com/assets/3148617/14980911/705dffac-1123-11e6-907b-09e415e76075.png)

This PR limits the video's bottom margin - added for the sake of the mobile view - to mobile breakpoints exclusively.

![image](https://cloud.githubusercontent.com/assets/3148617/14980938/9f1d9ee2-1123-11e6-9adb-cc485faa3dea.png)
