### PR TITLE
Add badges to immersives

### DIFF
--- a/article/app/views/fragments/articleBodyImmersive.scala.html
+++ b/article/app/views/fragments/articleBodyImmersive.scala.html
@@ -34,6 +34,11 @@
 
                         <div class="content__article-body from-content-api js-article__body" itemprop="@if(article.tags.isReview){reviewBody} else {articleBody}"
                             data-test-id="article-review-body">
+
+                            @if(article.commercial.isAdvertisementFeature || article.commercial.isSponsored(None) || article.commercial.isFoundationSupported) {
+                                @fragments.commercial.badge(article)
+                            }
+
                             @BodyCleaner(article, article.fields.body, amp = amp)
                         </div>
 

--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -1,4 +1,4 @@
-@(article: model.Article, showBadge: Boolean = false)(implicit request: RequestHeader)
+@(article: model.Article)(implicit request: RequestHeader)
 
 @import views.support.TrailCssClasses.toneClass
 

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -479,6 +479,17 @@
     .content--media--video & {
         min-height: 0;
     }
+
+    .content--immersive & {
+        @include mq(leftCol) {
+            float: left;
+            margin-left: -158px;
+        }
+
+        @include mq(wide) {
+            margin-left: -238px;
+        }
+    }
 }
 .ad-slot--paid-for-badge--gallery {
     border-top: 1px dotted $neutral-1;


### PR DESCRIPTION
## What does this change?

Immersive templates don't inject adbadges into the page for sponsored content, now they do.
## Screenshots

![image](https://cloud.githubusercontent.com/assets/1821099/14981282/f81b493e-1125-11e6-8473-3137c8d1713e.png)
## Request for comment

/@regiskuckaertz 
