### PR TITLE
Rename offline-page to offline-crossword

### DIFF
--- a/applications/app/controllers/WebAppController.scala
+++ b/applications/app/controllers/WebAppController.scala
@@ -11,12 +11,12 @@ import play.api.libs.json.{JsArray, JsString, JsObject}
 
 import scala.concurrent.Future
 
-case class OfflinePage(crossword: CrosswordData) extends StandalonePage {
+case class OfflineCrossword(crossword: CrosswordData) extends StandalonePage {
 
   override val metadata = MetaData.make(
-      id = "offline-page",
+      id = "offline-crossword",
       section = "",
-      analyticsName = "offline-page",
+      analyticsName = "offline-crossword",
       webTitle = "Unable to connect to the Internet")
 }
 
@@ -44,9 +44,9 @@ object WebAppController extends Controller with ExecutionContexts with Logging {
     }
   }
 
-  def offlinePage() = Action.async { implicit request =>
+  def offlineCrossword() = Action.async { implicit request =>
     withCrossword("quick") { crossword =>
-      val crosswordHtml = views.html.offlinePage(OfflinePage(CrosswordData.fromCrossword(crossword)))
+      val crosswordHtml = views.html.offlineCrossword(OfflineCrossword(CrosswordData.fromCrossword(crossword)))
       Cached(60)(JsonComponent(JsObject(Map(
         "html" -> JsString(crosswordHtml.body),
         "assets" -> JsArray(Seq(

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -27,7 +27,7 @@ var cachePageAndAssetResponses = function (jsonResponse, assetResponses) {
     var cacheName = [getISODate(), staticCacheName].join('-');
     return caches.open(cacheName).then(function (cache) {
         return jsonResponse.clone().json().then(function (jsonResponseJson) {
-            var pageRequest = new Request('/offline-page');
+            var pageRequest = new Request('/offline-crossword');
             var pageResponse = new Response(jsonResponseJson.html, { headers: { 'Content-Type': 'text/html' } });
             return Promise.all([
                 cache.put(pageRequest, pageResponse)
@@ -42,10 +42,10 @@ var cachePageAndAssetResponses = function (jsonResponse, assetResponses) {
 };
 
 // The JSON contains the HTML and asset versions. We cache the assets at
-// their specified URLs and the page HTML as '/offline-page'.
+// their specified URLs and the page HTML as '/offline-crossword'.
 var updateCache = function () {
     // Fetch page and all assets. Iff all responses are OK then cache all assets and page.
-    return fetch('/offline-page.json').then(function (jsonResponse) {
+    return fetch('/offline-crossword.json').then(function (jsonResponse) {
         if (jsonResponse.ok) {
             return jsonResponse.clone().json().then(function (json) {
                 return fetchAll(json.assets).then(function (assetResponses) {
@@ -128,7 +128,7 @@ this.addEventListener('fetch', function (event) {
         event.respondWith(
             fetch(request)
                 .catch(function () {
-                    return caches.match('/offline-page');
+                    return caches.match('/offline-crossword');
                 })
         );
     } else if (isAssetRequest) {

--- a/applications/app/templates/serviceWorker.scala.js
+++ b/applications/app/templates/serviceWorker.scala.js
@@ -6,9 +6,6 @@
 /*global self*/
 /*global clients*/
 
-//
-// Offline page
-//
 "use strict";
 
 var staticCacheName = 'static';
@@ -23,7 +20,7 @@ var fetchAll = function (inputs) {
     }));
 };
 
-var cachePageAndAssetResponses = function (jsonResponse, assetResponses) {
+var cacheOfflineCrosswordAndAssetResponses = function (jsonResponse, assetResponses) {
     var cacheName = [getISODate(), staticCacheName].join('-');
     return caches.open(cacheName).then(function (cache) {
         return jsonResponse.clone().json().then(function (jsonResponseJson) {
@@ -43,7 +40,7 @@ var cachePageAndAssetResponses = function (jsonResponse, assetResponses) {
 
 // The JSON contains the HTML and asset versions. We cache the assets at
 // their specified URLs and the page HTML as '/offline-crossword'.
-var updateCache = function () {
+var updateOfflineCrosswordCache = function () {
     // Fetch page and all assets. Iff all responses are OK then cache all assets and page.
     return fetch('/offline-crossword.json').then(function (jsonResponse) {
         if (jsonResponse.ok) {
@@ -52,7 +49,7 @@ var updateCache = function () {
                     var allAssetResponsesOk = assetResponses.every(function (response) { return response.ok; });
 
                     if (allAssetResponsesOk) {
-                        return cachePageAndAssetResponses(jsonResponse, assetResponses);
+                        return cacheOfflineCrosswordAndAssetResponses(jsonResponse, assetResponses);
                     }
                 });
             });
@@ -89,7 +86,7 @@ var isCacheUpdated = function () {
 };
 
 self.addEventListener('install', function (event) {
-    event.waitUntil(updateCache());
+    event.waitUntil(updateOfflineCrosswordCache());
 });
 
 var needCredentialsWorkaround = function (url) {
@@ -105,7 +102,7 @@ this.addEventListener('fetch', function (event) {
     if (doesRequestAcceptHtml(request)) {
         isCacheUpdated().then(function (isUpdated) {
             if (!isUpdated) {
-                updateCache().then(deleteOldCaches);
+                updateOfflineCrosswordCache().then(deleteOldCaches);
             }
         });
     }
@@ -124,7 +121,7 @@ this.addEventListener('fetch', function (event) {
     // https://github.com/guardian/frontend/issues/10936
     var isRequestToDeveloperBlog = url.pathname.match(/^\/info\/developer-blog($|\/.*$)/);
     if (isRootRequest && isRequestToDeveloperBlog && doesRequestAcceptHtml(request)) {
-        // HTML pages fallback to offline page
+        // HTML pages fallback to offline crossword
         event.respondWith(
             fetch(request)
                 .catch(function () {

--- a/applications/app/views/offlineCrossword.scala.html
+++ b/applications/app/views/offlineCrossword.scala.html
@@ -22,16 +22,6 @@
     our own paths *@
 
     @fragments.analytics.omnitureScript(Some(offlineCrossword.metadata))
-    @if(OfflineCrosswordView.isSwitchedOn) {
-    <script>
-        try {
-            var offlineViews = parseInt(localStorage.getItem('gu.offlineViews')) || 0;
-            localStorage.setItem('gu.offlineViews', offlineViews + 1)
-        } catch (e) {
-            // do nothing
-        }
-    </script>
-    }
 
     @* NOTE the order of these includes is important  *@
     <script>

--- a/applications/app/views/offlineCrossword.scala.html
+++ b/applications/app/views/offlineCrossword.scala.html
@@ -1,4 +1,4 @@
-@(offlinePage: controllers.OfflinePage)(implicit request: RequestHeader)
+@(offlineCrossword: controllers.OfflineCrossword)(implicit request: RequestHeader)
 
 @import play.api.libs.json._
 @import conf.switches.Switches._
@@ -11,9 +11,9 @@
 
 <head>
     <meta charset="utf-8" />
-    <title>@views.support.Title(offlinePage)</title>
+    <title>@views.support.Title(offlineCrossword)</title>
 
-    @fragments.metaData(offlinePage)
+    @fragments.metaData(offlineCrossword)
 
     @* get the stylesheets downloading ASAP *@
     @fragments.stylesheets(None)
@@ -21,8 +21,8 @@
     @* We don't use the inlineJSBlocking template because we need to specify
     our own paths *@
 
-    @fragments.analytics.omnitureScript(Some(offlinePage.metadata))
-    @if(OfflinePageView.isSwitchedOn) {
+    @fragments.analytics.omnitureScript(Some(offlineCrossword.metadata))
+    @if(OfflineCrosswordView.isSwitchedOn) {
     <script>
         try {
             var offlineViews = parseInt(localStorage.getItem('gu.offlineViews')) || 0;
@@ -70,10 +70,10 @@
         @Html(polyfills().body)
 
         // determine whether to run enhanced JS
-        @InlineJs(shouldEnhance(offlinePage.metadata).body, "shouldEnhance.js")
+        @InlineJs(shouldEnhance(offlineCrossword.metadata).body, "shouldEnhance.js")
 
         // page config
-        @Html(config(offlinePage).body)
+        @Html(config(offlineCrossword).body)
 
         // apply render conditions
         @InlineJs(applyRenderConditions().body, "applyRenderConditions.js")
@@ -90,7 +90,7 @@
         }
 
         // cloudwatch beacons
-        @InlineJs(cloudwatchBeacons(offlinePage.metadata).body, "cloudwatchBeacons.js")
+        @InlineJs(cloudwatchBeacons(offlineCrossword.metadata).body, "cloudwatchBeacons.js")
     </script>
 </head>
     <body
@@ -99,7 +99,7 @@
 
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
-        @fragments.header(offlinePage)
+        @fragments.header(offlineCrossword)
 
         <div class="l-side-margins">
             <article id="crossword" class="content content--article tonal tonal--tone-news" role="main">
@@ -111,9 +111,9 @@
                             <button class="button js-open-crossword-btn">Open crossword</button>
                         </div>
                         <div class="js-crossword-container is-hidden u-baseline-top">
-                            <h2><a href="/crosswords/@offlinePage.crossword.id">@offlinePage.crossword.name</a></h2>
+                            <h2><a href="/crosswords/@offlineCrossword.crossword.id">@offlineCrossword.crossword.name</a></h2>
                             <div class="js-crossword"
-                                data-crossword-data="@Json.stringify(Json.toJson(offlinePage.crossword))">
+                                data-crossword-data="@Json.stringify(Json.toJson(offlineCrossword.crossword))">
                             </div>
                         </div>
                     </div>
@@ -121,11 +121,11 @@
             </article>
         </div>
 
-        @fragments.footer(offlinePage)
+        @fragments.footer(offlineCrossword)
 
         @fragments.inlineJSNonBlocking()
 
-        @fragments.analytics.base(offlinePage)
+        @fragments.analytics.base(offlineCrossword)
 
     </body>
 </html>

--- a/applications/app/views/offlineCrossword.scala.html
+++ b/applications/app/views/offlineCrossword.scala.html
@@ -78,9 +78,6 @@
             // borrows *heavily* from https://github.com/filamentgroup/loadCSS.
             @InlineJs(enableStylesheets().body, "enableStylesheets.js")
         }
-
-        // cloudwatch beacons
-        @InlineJs(cloudwatchBeacons(offlineCrossword.metadata).body, "cloudwatchBeacons.js")
     </script>
 </head>
     <body

--- a/applications/conf/routes
+++ b/applications/conf/routes
@@ -55,7 +55,7 @@ GET        /new-header/optout                                                   
 GET        /opt/$choice<in|out>/:feature                                        controllers.OptInController.handle(feature, choice)
 
 # Web App paths
-GET        /offline-page.json                                                   controllers.WebAppController.offlinePage()
+GET        /offline-crossword.json                                              controllers.WebAppController.offlineCrossword()
 GET        /service-worker.js                                                   controllers.WebAppController.serviceWorker()
 GET        /2015-06-24-manifest.json                                            controllers.WebAppController.manifest()
 

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -6,10 +6,10 @@ import org.joda.time.LocalDate
 trait MonitoringSwitches {
   // Monitoring
 
-  val OfflinePageView = Switch(
+  val OfflineCrosswordView = Switch(
     SwitchGroup.Monitoring,
-    "offline-page-view",
-    "If this switch is on, views of the offline page will be beaconed to cloudwatch when you come online again",
+    "offline-crossword-view",
+    "If this switch is on, views of the offline crossword will be beaconed to cloudwatch when you come online again",
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 3),
     exposeClientSide = true

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -6,15 +6,6 @@ import org.joda.time.LocalDate
 trait MonitoringSwitches {
   // Monitoring
 
-  val OfflineCrosswordView = Switch(
-    SwitchGroup.Monitoring,
-    "offline-crossword-view",
-    "If this switch is on, views of the offline crossword will be beaconed to cloudwatch when you come online again",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 3),
-    exposeClientSide = true
-  )
-
   val OphanSwitch = Switch(
     SwitchGroup.Monitoring,
     "ophan",

--- a/common/app/templates/inlineJS/blocking/cloudwatchBeacons.scala.js
+++ b/common/app/templates/inlineJS/blocking/cloudwatchBeacons.scala.js
@@ -1,14 +1,2 @@
 @(item: model.MetaData)(implicit request: RequestHeader)
 @import conf.switches.Switches._
-
-@if(OfflineCrosswordView.isSwitchedOn) {
-    try {
-        var offlineViews = parseInt(localStorage.getItem('gu.offlineViews'));
-        for (var i = 0; i < offlineViews; i++) {
-            (new Image()).src = window.guardian.config.page.beaconUrl + '/count/offline-crossword-view.gif';
-        }
-        localStorage.removeItem('gu.offlineViews');
-    } catch (e) {
-        // do nothing
-    }
-}

--- a/common/app/templates/inlineJS/blocking/cloudwatchBeacons.scala.js
+++ b/common/app/templates/inlineJS/blocking/cloudwatchBeacons.scala.js
@@ -1,11 +1,11 @@
 @(item: model.MetaData)(implicit request: RequestHeader)
 @import conf.switches.Switches._
 
-@if(OfflinePageView.isSwitchedOn) {
+@if(OfflineCrosswordView.isSwitchedOn) {
     try {
         var offlineViews = parseInt(localStorage.getItem('gu.offlineViews'));
         for (var i = 0; i < offlineViews; i++) {
-            (new Image()).src = window.guardian.config.page.beaconUrl + '/count/offline-page-view.gif';
+            (new Image()).src = window.guardian.config.page.beaconUrl + '/count/offline-crossword-view.gif';
         }
         localStorage.removeItem('gu.offlineViews');
     } catch (e) {

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -352,7 +352,7 @@ GET            /series/*path.json                                               
 # Applications (must come before wildcard)
 GET            /sitemaps/news.xml                                                                                                controllers.SiteMapController.renderNewsSiteMap()
 GET            /sitemaps/video.xml                                                                                               controllers.SiteMapController.renderVideoSiteMap()
-GET            /offline-page.json                                                                                                controllers.WebAppController.offlinePage()
+GET            /offline-crossword.json                                                                                                controllers.WebAppController.offlineCrossword()
 GET            /service-worker.js                                                                                                controllers.WebAppController.serviceWorker()
 
 #Notifications Store

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -13,7 +13,7 @@ object Metric extends Logging {
     ("pv", CountMetric("kpis-page-views", "raw page views - simple <img> in body, no javascript involved")),
     ("pva", CountMetric("kpis-analytics-page-views", "page view fires after analytics")),
     ("omniture-pageview-error", CountMetric("omniture-pageview-error", "omniture-pageview-error")),
-    ("offline-page-view", CountMetric("offline-page-view", "offline page views after returning")),
+    ("offline-crossword-view", CountMetric("offline-crossword-view", "offline crossword views after returning")),
 
     ("ads-blocked", CountMetric("ads-blocked", "ads-blocked")),
     ("ad-render", CountMetric("first-ad-rendered", "first-ad-rendered")),

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -134,7 +134,7 @@ define([
             initialiseStickyAdBanner: function () {
                 if (config.switches.viewability
                     && !(config.switches.disableStickyAdBannerOnMobile && detect.getBreakpoint() === 'mobile')
-                    && config.page.pageId !== 'offline-page'
+                    && config.page.pageId !== 'offline-crossword'
                     && !config.page.shouldHideAdverts
                     && config.page.section !== 'childrens-books-site'
                     && !config.tests.abNewHeaderVariant

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -67,7 +67,7 @@ define([
             }
         }
 
-        if (config.page.contentType === 'Crossword' || config.page.pageId === 'offline-page') {
+        if (config.page.contentType === 'Crossword' || config.page.pageId === 'offline-crossword') {
             require(['bootstraps/enhanced/crosswords'], function (crosswords) {
                 bootstrapContext('crosswords', crosswords);
             });
@@ -148,7 +148,7 @@ define([
             }
         }
 
-        if (config.page.pageId === 'offline-page') {
+        if (config.page.pageId === 'offline-crossword') {
             var $button = $('.js-open-crossword-btn');
             bean.on($button[0], 'click', function () {
                 fastdom.write(function () {


### PR DESCRIPTION
## What does this change?

prepares space for alternative offline offering (for now, a simple cloudwatch ping for the rest of the site)

_update_
some context for this: getting metrics from the current offline page (by stroring a view in localstorage and pinging cloudwatch if we detect it again) limits us to users of the dev blog, who go offline, then come back to another secure page on the guardian subsequently. 

this clears out the old metrics stuff (which didn't work) and makes space for a metrics-only offline page that can be served regardless of the section, but which can leave the current crossword in place for dev blog
## What is the value of this and can you measure success?

makes it easier to add more than one offline treatment
## Request for comment

@OliverJAsh @rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
