### PR TITLE
Hover state and image width in refactored components

### DIFF
--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -143,12 +143,12 @@
                     var $palette    = $('#dfp-palette'),
                         toneClasses = ['brand', 'subscriptions', 'membership', 'live', 'jobs', 'networks', 'books', 'masterclasses', 'travel', 'shop', 'money', 'gardening', 'soulmates']
                             .map(function (tone) {
-                                return 'commercial--tone-' + tone;
+                                return 'adverts--tone-' + tone;
                             });
                     bean.on($palette[0], 'change', function () {
-                        $('#multiple1, .commercial--dfp-single, .commercial--v-high')
+                        $('#multiple1 > .adverts, #manual1 > .adverts, .commercial--v-high')
                             .removeClass(toneClasses.join(' '))
-                            .addClass('commercial--tone-' + $palette.val());
+                            .addClass('adverts--tone-' + $palette.val());
                     });
 
                     var blendedStyle = document.getElementById('blended-style'),

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -117,6 +117,14 @@
 
 .advert--capi {
     border-top: 1px solid;
+    transition: background .1s;
+
+    &:hover,
+    &:focus {
+        .advert__title {
+            text-decoration: none;
+        }
+    }
 
     .advert__title,
     .advert__meta,
@@ -173,6 +181,11 @@
     background: $paid-article-subheader;
     border-top-color: $paid-article-brand;
 
+    &:hover,
+    &:focus {
+        background: darken($paid-article-subheader, 7%);
+    }
+
     .advert__title {
         @include f-headlineSans;
         font-weight: 400;
@@ -200,12 +213,22 @@
 .advert--supported {
     &.advert--text {
         border-top-color: $news-main-2;
+
+        &:hover,
+        &:focus {
+            background: $neutral-6;
+        }
     }
 
     &.advert--media {
         border-top-color: $multimedia-main-2;
         background: $multimedia-main-1;
         color: #ffffff;
+
+        &:hover,
+        &:focus {
+            background: darken($media-background, 7.5%);
+        }
 
         .advert__title {
             > .inline-icon svg {

--- a/static/src/stylesheets/module/commercial/_adverts-soulmates.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-soulmates.scss
@@ -149,7 +149,7 @@
 
     .adverts--manual & {
         .advert__image-container {
-            height: 11 * $gs-baseline;
+            height: auto;
         }
     }
 }


### PR DESCRIPTION
## What does this change?
1. The hover/focus states for paidfor/supportedby containers is now in line with normal articles (i.e. no underline but a darker shade for the background)
2. The image for the soulmates component with 3 cards now occupies 100% of the card width (by removing the height constraint)

Before:
![picture 2](https://cloud.githubusercontent.com/assets/629976/14987274/34e986fc-1147-11e6-9c8d-f1330801aa29.jpg)

After:
![picture 1](https://cloud.githubusercontent.com/assets/629976/14987277/387febb2-1147-11e6-9820-c921112f38bd.jpg)

@uplne 
