### PR TITLE
Revert gs-gutter to correct gutter width

### DIFF
--- a/static/src/stylesheets/_mixins.scss
+++ b/static/src/stylesheets/_mixins.scss
@@ -236,7 +236,7 @@
     padding-right: $gs-gutter/2;
 
     @include mq(mobileLandscape) {
-        padding-left: $gs-gutter/2;
-        padding-right: $gs-gutter/2;
+        padding-left: $gs-gutter;
+        padding-right: $gs-gutter;
     }
 }


### PR DESCRIPTION
4 days ago I did a stupid:
https://github.com/guardian/frontend/commit/c74e384880d8b4a25250583cec627b4c6e3770c7#diff-1318de042509dd3edb29e22650ffd6e1R235

Today is the day I undo that stupid. 

😒 
