### PR TITLE
New gallery styling changes at smaller breakpoints

### DIFF
--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -234,8 +234,11 @@
 
 .new-gallery__divider {
     border-top: 1px solid $neutral-1;
-    padding-top: $gs-baseline / 2;
     margin-top: $gs-baseline;
+
+    @include mq(desktop) {
+        padding-top: $gs-baseline / 2;
+    }
 }
 
 // TODO: When the time comes, remove `.new-gallery` class completely and remove old gallery styling
@@ -535,8 +538,15 @@
         @include mq($until: desktop) {
             margin-left: -$gs-gutter;
             margin-right: -$gs-gutter;
+            padding-top: $gs-baseline / 2;
+            border-top: 1px solid $neutral-1;
+
+            &:first-of-type {
+                border-top: 0;
+            }
 
             &.gallery__item--advert {
+                border-top: 0;
                 margin-left: 0;
                 margin-right: 0;
             }
@@ -635,6 +645,14 @@
 
         @include mq(desktop) {
             padding-bottom: 2.5rem;
+        }
+
+        @include mq($until: desktop) {
+            text-align: center;
+
+            img {
+                display: inline-block;
+            }
         }
     }
 

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -259,9 +259,9 @@
         margin-right: auto;
         padding-bottom: $gs-baseline*2;
 
-        @include mq(tablet) {
+        @include mq(desktop) {
             margin-left: gs-span(3) + $gs-gutter;
-            margin-right: -$gs-gutter/2;
+            margin-right: -$gs-gutter;
         }
     }
 
@@ -508,7 +508,7 @@
         margin: 0;
         position: relative;
 
-        @include mq(tablet) {
+        @include mq(desktop) {
             &:before {
                 content: '';
                 position: absolute;
@@ -527,7 +527,7 @@
         }
 
         // On mobile the images should be 100% of the width of the screen
-        @include mq($until: phablet) {
+        @include mq($until: desktop) {
             margin-left: -$gs-gutter;
             margin-right: -$gs-gutter;
         }
@@ -537,7 +537,7 @@
             margin-right: -$gs-gutter / 2;
         }
 
-        @include mq(tablet) {
+        @include mq(desktop) {
             position: relative;
             border-top: 0;
             padding: 0;
@@ -558,17 +558,17 @@
 
         @include mq($until: desktop) {
             margin-bottom: $gs-baseline * 2;
-        }
-
-        @include mq($until: phablet) {
-            padding: $gs-gutter;
+            padding-top: $gs-baseline / 2;
+            padding-left: $gs-gutter;
+            padding-right: $gs-gutter;
         }
 
         @include mq($until: mobileLandscape) {
-            padding: $gs-gutter / 2;
+            padding-left: $gs-gutter / 2;
+            padding-right: $gs-gutter / 2;
         }
 
-        @include mq(tablet) {
+        @include mq(desktop) {
             @include fs-textSans(2, true);
             position: absolute;
             width: gs-span(3);
@@ -582,7 +582,7 @@
         color: $neutral-4;
         margin-bottom: 0;
 
-        @include mq(tablet) {
+        @include mq(desktop) {
             padding-right: $gs-gutter / 2;
         }
 
@@ -615,7 +615,7 @@
     .gallery__credit {
         color: $neutral-2;
 
-        @include mq(tablet) {
+        @include mq(desktop) {
             padding-right: $gs-gutter / 2;
         }
     }
@@ -623,7 +623,7 @@
     .gallery__img-container {
         background-color: $multimedia-support-5;
 
-        @include mq(tablet) {
+        @include mq(desktop) {
             padding-bottom: 2.5rem;
         }
     }

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -245,13 +245,18 @@
     }
 
     .ad-slot__label {
-        text-align: left;
+        @include mq(desktop) {
+            text-align: left;
+            padding-left: 0;
+        }
     }
 
     // TODO: Update _adslot.scss with this change
-    .ad-slot--gallery-inline > div:not(.ad-slot__label) {
-        margin-left: 0;
-        margin-right: auto;
+    @include mq(desktop) {
+        .ad-slot--gallery-inline > div:not(.ad-slot__label) {
+            margin-left: 0;
+            margin-right: auto;
+        }
     }
 
     .content__main-column--gallery {
@@ -526,10 +531,15 @@
             flex-direction: column-reverse;
         }
 
-        // On mobile the images should be 100% of the width of the screen
+        // On mobile/tablet the images should be 100% of the width of the screen
         @include mq($until: desktop) {
             margin-left: -$gs-gutter;
             margin-right: -$gs-gutter;
+
+            &.gallery__item--advert {
+                margin-left: 0;
+                margin-right: 0;
+            }
         }
 
         @include mq($until: mobileLandscape) {

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -365,7 +365,6 @@
     &.tonal--tone-media {
         background-color: $multimedia-support-5;
 
-
         // TODO: Move this to the proper place once changes are live
         .meta__twitter,
         .meta__email {
@@ -384,12 +383,6 @@
                     fill: $neutral-3;
                 }
             }
-        }
-
-        // TODO: Make this the default for all media tones once changes are live
-        .fc-container__inner,
-        .fc-slice__item+.fc-slice__item:before {
-            border-color: $neutral-1;
         }
 
         // Overwriting media tone header so that you can see the image instead
@@ -665,6 +658,16 @@
 }
 
 .l-side-margins--new-gallery {
+    // TODO: Make this the default for all media tones once changes are live
+    .tonal--tone-media {
+        background-color: $multimedia-support-5;
+
+        .fc-container__inner,
+        .fc-slice__item+.fc-slice__item:before {
+            border-color: $neutral-1;
+        }
+    }
+
     // TODO: Make this the default for all media tones once changes are live
     &.l-side-margins--media {
         @include mq(tablet) {

--- a/static/src/stylesheets/module/content/_gallery.scss
+++ b/static/src/stylesheets/module/content/_gallery.scss
@@ -250,7 +250,6 @@
     .ad-slot__label {
         @include mq(desktop) {
             text-align: left;
-            padding-left: 0;
         }
     }
 
@@ -544,12 +543,6 @@
             &:first-of-type {
                 border-top: 0;
             }
-
-            &.gallery__item--advert {
-                border-top: 0;
-                margin-left: 0;
-                margin-right: 0;
-            }
         }
 
         @include mq($until: mobileLandscape) {
@@ -565,6 +558,14 @@
             figure {
                 flex-direction: row;
             }
+        }
+    }
+
+    .gallery__item--advert {
+        @include mq($until: desktop) {
+            border-top: 0;
+            margin-left: 0;
+            margin-right: 0;
         }
     }
 


### PR DESCRIPTION
Main change being; images are centered at small breakpoint now. Have added additional rule work to divide them comfortably.

![screen shot 2016-05-03 at 16 38 00](https://cloud.githubusercontent.com/assets/14570016/14988823/79e9d6a2-114d-11e6-8be9-5be1fff348cb.png)

Commits should make sense (For once). 
