### PR TITLE
Fix logo position in sponsored galleries

### DIFF
--- a/common/app/views/fragments/headTonal.scala.html
+++ b/common/app/views/fragments/headTonal.scala.html
@@ -6,9 +6,9 @@
 <header class="content__head tonal__head tonal__head--@toneClass(item)
     @if(item.content.hasTonalHeaderByline && item.tags.hasLargeContributorImage) { content__head--byline-pic}">
 
-    <div class="content__header tonal__header u-cf">
+    <div class="content__header tonal__header">
         <div class="gs-container">
-            <div class="content__main-column">
+            <div class="content__main-column u-cf">
 
                 @if(showMeta) {
                     @fragments.meta.metaInline(item, amp)

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -501,6 +501,21 @@
         position: absolute;
     }
 
+    .content__main-column > & {
+        @include mq(desktop) {
+            top: 100%;
+        }
+
+        @include mq(leftCol) {
+            left: -160px;
+        }
+
+        @include mq(wide) {
+            left: -240px;
+        }
+    }
+
+
     .ad-slot--paid-for-badge__header {
         font-weight: normal;
     }


### PR DESCRIPTION
## What does this change?

Correctly positions the logo in sponsored galleries.

Before:
![picture 4](https://cloud.githubusercontent.com/assets/629976/14990397/4b61423c-1154-11e6-88fd-636bf4f326a6.jpg)

After:
![picture 3](https://cloud.githubusercontent.com/assets/629976/14990399/4eda79a6-1154-11e6-9b9c-2d808a8959db.jpg)

cc @JonNorman @jbreckmckye 
