### PR TITLE
add tracking component name to video playlist

### DIFF
--- a/common/app/fronts/FrontsApi.scala
+++ b/common/app/fronts/FrontsApi.scala
@@ -13,7 +13,7 @@ object FrontsApi extends ExecutionContexts {
     ApiClient(Configuration.aws.bucket, Configuration.facia.stage.toUpperCase, AmazonSdkS3Client(client))
   }
 
-  val crossAccountClient: ApiClient = {
+  lazy val crossAccountClient: ApiClient = {
     val client = new AmazonS3Client(Configuration.faciatool.crossAccountMandatoryCredentials)
     client.setEndpoint(AwsEndpoints.s3)
     ApiClient(Configuration.faciatool.crossAccountSourceBucket, Configuration.facia.stage.toUpperCase, AmazonSdkS3Client(client))

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -12,7 +12,8 @@
 </div>
 
 <div class="video-playlist video-playlist--start js-video-playlist"
-     data-number-of-videos="@(containerDefinition.collectionEssentials.items.zipWithIndex.length - 1)">
+     data-number-of-videos="@(containerDefinition.collectionEssentials.items.zipWithIndex.length - 1)"
+     data-component="video-playlist">
     <div class="video-playlist__control video-playlist__control--prev js-video-playlist-prev" data-link-name="video-container-prev">
         @fragments.inlineSvg("chevron-left", "icon", Seq("video-playlist__icon"))
     </div>
@@ -53,7 +54,7 @@
                                 </div>
                             </div>
                             <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
-                                <div class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
+                                <div data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
                                 <div class="fc-item__media-wrapper">
                                     <div class="fc-item__image-container u-responsive-ratio inlined-image">
                                     @InlineImage.fromFaciaContent(item).map { fallbackImage =>

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -63,7 +63,7 @@
                     </div>
                 @fallback.map { fallbackImage =>
                     <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
-                        <div class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
+                        <div data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
                         @itemImage(
                             fallbackImage.imageMedia,
                             inlineImage = containerIndex == 0 && index < 4,


### PR DESCRIPTION
## What does this change?

Adding better tracking to the new video playlist.
We now the following when tracking a click on the play button:

```
clickComponent: "video-playlist"
clickLinkNames: ["video-play-button-overlay","container-2 | videos","Front | /video"]
```
## What is the value of this and can you measure success?

That we can measure success
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Icecreamshots

🍨 
## Request for comment

@akash1810 @harrysalmon

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
