### PR TITLE
Remove some redundant commercial container code

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -1,149 +1,58 @@
 @(containerType: slices.CommercialContainerType, container: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
 @import common.{Edition, LinkTo}
-@import conf.switches.Switches
-@import layout.{ColumnAndCards, ContentCard, FaciaCardAndIndex}
 @import model.InlineImage
-@import slices.{MultiCampaign, SingleCampaign}
-@import views.html.fragments.containers.facia_cards.{showMore, showMoreButton, standardContainer}
 @import views.html.fragments.inlineSvg
 @import views.html.fragments.items.elements.facia_cards.{itemImage, title}
-@import views.support.{Commercial, RemoveOuterParaHtml, RenderClasses}
+@import views.support.{Commercial, RemoveOuterParaHtml}
 
-    @containerType match {
-
-    case SingleCampaign(_) => {
-        <div class="@RenderClasses(Map(
-                        ("fc-show-more--hidden", container.addShowMoreClasses),
-                        ("js-container--fc-show-more", container.addShowMoreClasses),
-                        ("fc-show-more--mobile-only", container.hasMobileOnlyShowMore)
-                    )) fc-container fc-container--commercial fc-container--rolled-up-hide" data-id="@container.dataId">
-            <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component">
-                <div class="commercial commercial--paidfor commercial--tone-paidfor commercial--paidfor-single">
-                    <div class="commercial__inner">
-                        <div class="commercial__header">
-                            @fragments.commercial.paidForMeta(Some(container.dataId))
-                            <h3 class="commercial__title">@container.displayName</h3>
-                            <a class="commercial__cta"
-                                @if(Edition(request).id == "AU") {
-                                    href="@LinkTo("/guardian-labs-australia")"
-                                } else {
-                                    href="@LinkTo("/guardian-labs")"
-                                    }
-                            >
-                                @inlineSvg("glabs-logo", "logo")
-                                <span class='u-h'>Guardian Labs</span>
-                            </a>
-                        </div>
-                        <div class="commercial__body">
-                            @for(layout <- container.containerLayout) {
-                                @for(slice <- layout.slices) {
-                                    <ul class="lineitems l-row l-row--cols-@math.min(Commercial.container.numberOfItems(container), 4)">
-                                    @for(ColumnAndCards(_, cards) <- slice.columns) {
-                                        @for(FaciaCardAndIndex(_, card, hideUpTo) <- cards) {
-                                            @card match {
-                                                case contentCard: ContentCard => {
-                                                    <li class="lineitem l-row__item l-row__item--span-1">
-                                                        <div class="rich-link tone-paidfor--item">
-                                                            <div class="rich-link__container">
-                                                                @for(displayElement <- contentCard.displayElement) {
-                                                                    @displayElement match {
-                                                                        case InlineVideo(videoElement, _, _, _) => { @itemImage(videoElement.images) }
-                                                                        case InlineImage(images) => { @itemImage(images) }
-                                                                        case _ => { }
-                                                                    }
-                                                                }
-                                                            <div class="rich-link__header">
-                                                            @title(contentCard.header, 0, container.index)
-                                                            </div>
-                                                            <div class="rich-link__standfirst u-cf">@for(text <- contentCard.trailText) {@Html(text)}</div>
-                                                            <a class="rich-link__link u-faux-block-link__overlay" @Html(contentCard.header.url.hrefWithRel)>@RemoveOuterParaHtml(contentCard.header.headline)</a>
-                                                            </div>
-                                                        </div>
-                                                    </li>
-
-                                                }
-                                                case _ => {}
-                                            }
-                                        }
-                                    }
-                                    </ul>
-                                }
+<div class="fc-container fc-container--commercial">
+    <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component">
+        <div class="commercial commercial--paidfor commercial--tone-paidfor commercial--paidfor-multi">
+            <div class="commercial__inner">
+                <div class="commercial__header">
+                    @fragments.commercial.paidForMeta(Some(container.dataId))
+                    <h3 class="commercial__title">@container.displayName</h3>
+                    <a class="commercial__cta"
+                        @if(Edition(request).id == "AU") {
+                            href="@LinkTo("/guardian-labs-australia")"
+                        } else {
+                            href="@LinkTo("/guardian-labs")"
                             }
-                            <div class="commercial__show-mores">
-                                @if(container.hasShowMore && container.hasShowMoreEnabled) {
-                                    @if(container.useShowMore) {
-                                        <div class="js-show-more-placeholder"></div>
-                                        @showMoreButton(container.displayName getOrElse "")
-                                    } else {
-                                        @showMore(
-                                            container.containerLayout.map(_.remainingCards).getOrElse(Nil),
-                                            container.index
-                                        )
-                                    }
-                                }
-                                <div class="js-badge-placeholder"></div>
-                            </div>
-                        </div>
-                    </div>
+                    >
+                        @inlineSvg("glabs-logo", "logo")
+                        <span class='u-h'>Guardian Labs</span>
+                    </a>
                 </div>
-            </div>
-        </div>
-    }
-
-    case MultiCampaign(_) => {
-        <div class="fc-container fc-container--commercial">
-            <div class="ad-slot ad-slot--dfp ad-slot--merchandising ad-slot--commercial-component">
-                <div class="commercial commercial--paidfor commercial--tone-paidfor commercial--paidfor-multi">
-                    <div class="commercial__inner">
-                        <div class="commercial__header">
-                            @fragments.commercial.paidForMeta(Some(container.dataId))
-                            <h3 class="commercial__title">@container.displayName</h3>
-                            <a class="commercial__cta"
-                                @if(Edition(request).id == "AU") {
-                                    href="@LinkTo("/guardian-labs-australia")"
-                                } else {
-                                    href="@LinkTo("/guardian-labs")"
+                <div class="commercial__body">
+                    @defining(Commercial.containerCard.mkCardsWithSponsorDataAttributes(container, 4)) { items =>
+                        <ul class="lineitems l-row l-row--cols-@math.min(items.length, 4)">
+                            @for(cardWithSponsorData <- items) {
+                                <li class="lineitem l-row__item l-row__item--span-1 js-sponsored-container"
+                                    @for(sponsorData <- cardWithSponsorData.sponsorData) {
+                                        @for(sponsor <- sponsorData.sponsor) { data-sponsor="@sponsor" }
+                                        data-sponsorship="@sponsorData.sponsorshipType"
+                                        @for(seriesId <- sponsorData.seriesId) { data-series="@seriesId" }
+                                        @for(keywordId <- sponsorData.keywordId) { data-keywords="@keywordId" }
                                     }
-                            >
-                                @inlineSvg("glabs-logo", "logo")
-                                <span class='u-h'>Guardian Labs</span>
-                            </a>
-                        </div>
-                        <div class="commercial__body">
-                            @defining(Commercial.containerCard.mkCardsWithSponsorDataAttributes(container, 4)) { items =>
-                                <ul class="lineitems l-row l-row--cols-@math.min(items.length, 4)">
-                                    @*
-                                    Taking first 4 cards as a temporary fix until container can show a 'more' CTA
-                                    *@
-                                    @for(cardWithSponsorData <- items) {
-                                        <li class="lineitem l-row__item l-row__item--span-1 js-sponsored-container"
-                                            @for(sponsorData <- cardWithSponsorData.sponsorData) {
-                                                @for(sponsor <- sponsorData.sponsor) { data-sponsor="@sponsor" }
-                                                data-sponsorship="@sponsorData.sponsorshipType"
-                                                @for(seriesId <- sponsorData.seriesId) { data-series="@seriesId" }
-                                                @for(keywordId <- sponsorData.keywordId) { data-keywords="@keywordId" }
+                                >
+                                    <div class="rich-link tone-paidfor--item">
+                                        <div class="rich-link__container js-container__header">
+                                            @for( InlineImage(images) <- cardWithSponsorData.card.displayElement) {
+                                                @itemImage(images)
                                             }
-                                        >
-                                            <div class="rich-link tone-paidfor--item">
-                                                <div class="rich-link__container js-container__header">
-                                                    @for( InlineImage(images) <- cardWithSponsorData.card.displayElement) {
-                                                        @itemImage(images)
-                                                    }
-                                                    <div class="rich-link__header">
-                                                        @title(cardWithSponsorData.card.header, 0, container.index)
-                                                    </div>
-                                                    <div class="rich-link__standfirst u-cf">@for( text <- cardWithSponsorData.card.trailText) {@Html(text)}</div>
-                                                    <a class="rich-link__link u-faux-block-link__overlay" @Html(cardWithSponsorData.card.header.url.hrefWithRel)>@RemoveOuterParaHtml(cardWithSponsorData.card.header.headline)</a>
-                                                </div>
+                                            <div class="rich-link__header">
+                                                @title(cardWithSponsorData.card.header, 0, container.index)
                                             </div>
-                                        </li>
-                                    }
-                                </ul>
+                                            <div class="rich-link__standfirst u-cf">@for( text <- cardWithSponsorData.card.trailText) {@Html(text)}</div>
+                                            <a class="rich-link__link u-faux-block-link__overlay" @Html(cardWithSponsorData.card.header.url.hrefWithRel)>@RemoveOuterParaHtml(cardWithSponsorData.card.header.headline)</a>
+                                        </div>
+                                    </div>
+                                </li>
                             }
-                        </div>
-                    </div>
+                        </ul>
+                    }
                 </div>
             </div>
         </div>
-    }
-}
+    </div>
+</div>

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -2,7 +2,7 @@
 @import common.dfp.{Keyword, Series}
 @import conf.switches.Switches
 @import layout.MetaDataHeader
-@import slices.{CommercialContainerType, Dynamic, Fixed, MostPopular, NavList, NavMediaList, SingleCampaign, Video}
+@import slices.{Dynamic, Fixed, MostPopular, NavList, NavMediaList, Video}
 @import views.html.commercial.containers.paidContainer
 @import views.html.fragments.containers.facia_cards._
 @import views.support.Commercial.container.shouldRenderAsPaidContainer
@@ -13,12 +13,6 @@
   frontId: Option[String] = None,
   isPaidFront: Boolean = false,
   maybeContainerModel: Option[ContainerModel] = None)(implicit request: RequestHeader)
-
-@renderCommercialContainer(containerType: CommercialContainerType) = {
-    <div class="fc-container__inner--full-span fc-container__inner--paidfor fc-container__inner">
-    @commercialContainer(containerType, containerDefinition, frontProperties)
-    </div>
-}
 
 @renderBrandingDataAttributes() = {
     @if(Switches.cardsDecidePaidContainerBranding.isSwitchedOn) {
@@ -55,7 +49,7 @@
     @containerDefinition.container match {
         case _: model.MostPopular if isPaidFront => {}
 
-        case _: Fixed if shouldRenderAsPaidContainer(isPaidFront, containerDefinition, maybeContainerModel) => {
+        case Fixed(_) if shouldRenderAsPaidContainer(isPaidFront, containerDefinition, maybeContainerModel) => {
             @maybeContainerModel match {
                 case Some(containerModel) => {
                     @paidContainer(frontId.getOrElse(""), containerDefinition.index, containerModel)
@@ -88,10 +82,6 @@
 
             @containerDefinition.container match {
 
-                case Fixed(definition) if shouldRenderAsPaidContainer(isPaidFront, containerDefinition, None) => {
-                    @renderCommercialContainer(SingleCampaign(definition))
-                }
-
                 case _: Dynamic | _: Fixed => {
                     <div class="fc-container__inner">
                         @standardContainer(containerDefinition, frontProperties)
@@ -122,8 +112,10 @@
                     </div>
                 }
 
-                case slices.Commercial(container) => {
-                    @renderCommercialContainer(container)
+                case slices.Commercial(container) if Switches.cardsDecidePaidContainerBranding.isSwitchedOff => {
+                    <div class="fc-container__inner--full-span fc-container__inner--paidfor fc-container__inner">
+                        @commercialContainer(container, containerDefinition, frontProperties)
+                    </div>
                 }
             }
         </section>


### PR DESCRIPTION
We no longer need a special single-sponsor commercial container.

The multiple-sponsor commercial container can go when we've switched on the `cardsDecideContainerBranding` switch.

/cc @regiskuckaertz @JonNorman 
