### PR TITLE
Spacefinder: wait for interactives to load

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -91,7 +91,7 @@ define([
             return !(iframe.length && isIframeLoaded(iframe[0]));
         });
 
-        return notLoaded.length === 0 ?
+        return notLoaded.length === 0 || !('MutationObserver' in window) ?
             true :
             Promise.all(notLoaded.map(function (interactive) {
                 return new Promise(function (resolve) {

--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -63,7 +63,7 @@ define([
         });
 
         return notLoaded.length === 0 ?
-            Promise.resolve(true) :
+            true :
             new Promise(function (resolve) {
                 var loadedCount = 0;
                 bean.on(body, 'load', notLoaded, function onImgLoaded() {
@@ -79,10 +79,52 @@ define([
 
     function onRichLinksUpgraded(body) {
         return qwery('.element-rich-link--not-upgraded', body).length === 0 ?
-            Promise.resolve(true) :
+            true :
             new Promise(function (resolve) {
                 mediator.once('rich-link:loaded', resolve);
             });
+    }
+
+    function onInteractivesLoaded(body) {
+        var notLoaded = qwery('.element-interactive', body).filter(function (interactive) {
+            var iframe = qwery(interactive.children).filter(isIframe);
+            return !(iframe.length && isIframeLoaded(iframe[0]));
+        });
+
+        return notLoaded.length === 0 ?
+            true :
+            Promise.all(notLoaded.map(function (interactive) {
+                return new Promise(function (resolve) {
+                    new MutationObserver(function (records, instance) {
+                        if (!(records.length > 0 &&
+                            records[0].addedNodes.length > 0 &&
+                            isIframe(records[0].addedNodes[0]))
+                        ) {
+                            return;
+                        }
+
+                        var iframe = records[0].addedNodes[0];
+                        if (isIframeLoaded(iframe)) {
+                            resolve();
+                        } else {
+                            iframe.addEventListener('load', function () {
+                                instance.disconnect();
+                                resolve();
+                            });
+                        }
+                    }).observe(interactive, { childList: true });
+                });
+            }));
+
+        function isIframe(node) {
+            return node.nodeName === 'IFRAME';
+        }
+
+        function isIframeLoaded(iframe) {
+            return iframe.contentWindow &&
+                iframe.contentWindow.document &&
+                iframe.contentWindow.document.readyState === 'complete';
+        }
     }
 
     // test one element vs another for the given rules
@@ -159,7 +201,7 @@ define([
         if (config.switches.viewability) {
             return Promise.race([
                 new Promise(expire),
-                Promise.all([onImagesLoaded(body), onRichLinksUpgraded(body)])
+                Promise.all([onImagesLoaded(body), onRichLinksUpgraded(body), onInteractivesLoaded(body)])
             ]);
         }
 


### PR DESCRIPTION
When an article contains interactives, spacefinder may get geometry wrong if the interactives haven't been loaded yet and therefore think there is space enough for inline slots:

![picture 2](https://cloud.githubusercontent.com/assets/629976/15015895/4f4fccbc-1206-11e6-880b-cda84575522d.jpg)

Alas, there is no way of knowing if an interactive has been "enhanced" unless we wait for the load event of the containing iframe... which may not even exist when spacefinder is running. Event delegation is a no go, so I had to use a `MutationObserver`, which was kind of fun.

![picture 1](https://cloud.githubusercontent.com/assets/629976/15015993/e85e2430-1206-11e6-8a0e-b5a3aa541f1d.jpg)

@uplne 
