### PR TITLE
Show capi-driven logos on facia fronts

### DIFF
--- a/common/app/common/commercial/BrandHunter.scala
+++ b/common/app/common/commercial/BrandHunter.scala
@@ -1,26 +1,34 @@
 package common.commercial
 
 import common.Edition
-import model.{Branding, Section, Tag, Tags}
+import model._
 import org.joda.time.DateTime
 
 object BrandHunter {
 
+  private def findBranding(activeBrandings: Option[Seq[Branding]],
+                           publicationDate: Option[DateTime],
+                           edition: Edition): Option[Branding] = {
+    activeBrandings flatMap (_ find (_.isTargeting(publicationDate, edition)))
+  }
+
   def findSectionBranding(section: Section, publicationDate: Option[DateTime], edition: Edition): Option[Branding] = {
-    section.activeBrandings flatMap { brandings =>
-      brandings find (_.isTargeting(publicationDate, edition))
-    }
+    findBranding(section.activeBrandings, publicationDate, edition)
   }
 
   def findTagBranding(tag: Tag, publicationDate: Option[DateTime], edition: Edition): Option[Branding] = {
-    tag.properties.activeBrandings flatMap (_ find (_.isTargeting(publicationDate, edition)))
+    findBranding(tag.properties.activeBrandings, publicationDate, edition)
+  }
+
+  def findFrontBranding(frontProps: FrontProperties, edition: Edition): Option[Branding] = {
+    findBranding(frontProps.activeBrandings, publicationDate = None, edition)
   }
 
   // difficult to find content's section at the moment so this param is temporarily optional
-  def findBranding(section: Option[Section],
-                   tags: Tags,
-                   publicationDate: Option[DateTime],
-                   edition: Edition): Option[Branding] = {
+  def findContentBranding(section: Option[Section],
+                          tags: Tags,
+                          publicationDate: Option[DateTime],
+                          edition: Edition): Option[Branding] = {
     lazy val brandingBySection = section flatMap (findSectionBranding(_, publicationDate, edition))
     lazy val brandingByTags = tags.tags.flatMap(findTagBranding(_, publicationDate, edition)).headOption
     brandingBySection orElse brandingByTags

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -267,7 +267,7 @@ trait CommercialSwitches {
   )
 
   val cardsDecidePaidContainerBranding = Switch(
-    SwitchGroup.CommercialRefactoring,
+    SwitchGroup.Commercial,
     "cards-decide-paid-container-branding",
     "DON'T TURN THIS ON! If on, the cards will decide the branding of their container",
     safeState = Off,

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -19,9 +19,6 @@ object SwitchGroup {
                             Some("The expiry date of these switches does NOT affect the expiry of the AB tests; " +
                                  "these switches serve only to quickly enable/disable said tests."))
   val Commercial = SwitchGroup("Commercial")
-  val CommercialRefactoring = SwitchGroup("Commercial: Refactoring",
-                            Some("All commercial containers have been refactored, these switches enable the " +
-                                 "refactored components."))
   val CommercialFeeds = SwitchGroup("Commercial: Feeds",
                             Some("These switches enable the fetching and parsing of the commercial merchandising components."))
   val Facia = SwitchGroup("Facia")

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -1,5 +1,6 @@
 package model
 
+import campaigns.PersonalInvestmentsCampaign
 import com.gu.facia.api.models._
 import common.Edition
 import common.dfp.DfpAgent
@@ -8,7 +9,6 @@ import conf.Configuration.commercial.showMpuInAllContainersPageId
 import contentapi.Paths
 import model.facia.PressedCollection
 import play.api.libs.json.{JsBoolean, JsString, JsValue}
-import campaigns.PersonalInvestmentsCampaign
 
 import scala.language.postfixOps
 
@@ -116,6 +116,8 @@ case class PressedPage (
   val navSection: String = metadata.section
 
   val keywordIds: Seq[String] = frontKeywordIds(id)
+
+  override def branding(edition: Edition): Option[Branding] = frontProperties.branding(edition)
 
   def sponsorshipType: Option[String] = {
     if (isSponsored(None)) {

--- a/common/app/model/facia.scala
+++ b/common/app/model/facia.scala
@@ -1,5 +1,6 @@
 package model
 
+import common.commercial.BrandHunter
 import common.{Edition, ExecutionContexts, Logging}
 import play.api.libs.json.Json
 
@@ -54,13 +55,15 @@ case class FrontProperties(
   imageHeight: Option[String],
   isImageDisplayed: Boolean,
   editorialType: Option[String],
-  branding: Option[Branding]
-)
+  activeBrandings: Option[Seq[Branding]]
+) {
+  def branding(edition: Edition): Option[Branding] = BrandHunter.findFrontBranding(this, edition)
+}
 
 object FrontProperties {
   implicit val jsonFormat = Json.format[FrontProperties]
 
   val empty = FrontProperties(None, None, None, None, false, None, None)
 
-  def fromBranding(branding: Branding): FrontProperties = empty.copy(branding = Some(branding))
+  def fromBranding(branding: Branding): FrontProperties = empty.copy(activeBrandings = Some(Seq(branding)))
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -380,7 +380,7 @@ trait ContentPage extends Page {
     metadata.twitterPropertiesOverrides
 
   override def branding(edition: Edition): Option[Branding] = {
-    BrandHunter.findBranding(
+    BrandHunter.findContentBranding(
       section = None,
       item.tags,
       publicationDate = Some(item.trail.webPublicationDate),

--- a/common/app/services/ConfigAgentTrait.scala
+++ b/common/app/services/ConfigAgentTrait.scala
@@ -131,7 +131,7 @@ trait ConfigAgentTrait extends ExecutionContexts with Logging {
       imageHeight = frontOption.flatMap(_.imageHeight).map(_.toString),
       isImageDisplayed = frontOption.flatMap(_.isImageDisplayed).getOrElse(false),
       editorialType = None, // value found in Content API
-      branding = None // value found in Content API
+      activeBrandings = None // value found in Content API
     )
   }
 

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -1,13 +1,14 @@
 @(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
-@import common.Localisation
+@import common.{Edition, Localisation}
+@import conf.switches.Switches.staticBadgesSwitch
 @import views.html.fragments.commercial.contentLogo
 @import views.html.fragments.containers.facia_cards.{containerHeader, showMore, showMoreButton, slice}
 @import views.support.RenderClasses
 
 @containerHeader(containerDefinition, frontProperties)
 
-@if(containerDefinition.index == 0) {
-    @for(branding <- frontProperties.branding) {
+@if(containerDefinition.index == 0 && staticBadgesSwitch.isSwitchedOn) {
+    @for(branding <- frontProperties.branding(Edition(request))) {
         @contentLogo(branding)
     }
 }

--- a/facia-press/app/frontpress/FapiFrontPress.scala
+++ b/facia-press/app/frontpress/FapiFrontPress.scala
@@ -217,7 +217,15 @@ trait FapiFrontPress extends Logging with ExecutionContexts {
         .orElse(SeoData.descriptionFromWebTitle(webTitle))
 
       val frontProperties: FrontProperties = ConfigAgent.fetchFrontProperties(path)
-        .copy(editorialType = itemResp.flatMap(_.tag).map(_.`type`.name))
+        .copy(
+          editorialType = itemResp.flatMap(_.tag).map(_.`type`.name),
+          activeBrandings = itemResp.flatMap { response =>
+            val sectionBrandings = response.section.flatMap(_.activeSponsorships.map(_.map(Branding.make)))
+            val tagBrandings = response.tag.flatMap(_.activeSponsorships.map(_.map(Branding.make)))
+            val brandings = sectionBrandings.toList.flatten ++ tagBrandings.toList.flatten
+            if (brandings.isEmpty) None else Some(brandings)
+          }
+        )
 
       val seoData: SeoData = SeoData(path, navSection, webTitle, title, description)
       (seoData, frontProperties)

--- a/facia/app/views/fragments/brandedFrontBody.scala.html
+++ b/facia/app/views/fragments/brandedFrontBody.scala.html
@@ -1,0 +1,61 @@
+@(faciaPage: model.PressedPage)(implicit request: RequestHeader)
+@import common.Edition
+@import common.commercial.ContainerModel
+@import model.{PaidContent, Sponsored}
+@import views.support.RenderClasses
+
+@faciaPage.branding(Edition(request)) match {
+
+    case Some(branding) => {
+        @if(faciaPage.collections.nonEmpty) {
+            <div class="l-side-margins">
+                <div class="@RenderClasses(Map(
+                    "fc-container--sponsored" -> (branding.sponsorshipType == Sponsored),
+                    "fc-container--advertisement-feature paid-content--advertisement-feature" -> (branding.sponsorshipType == PaidContent)
+                ), "facia-page")"
+                data-link-name="Front | @request.path"
+                role="main">
+
+                    @if(branding.sponsorshipType == PaidContent){ @fragments.guBand() }
+
+                    @defining(layout.Front.fromPressedPage(faciaPage, Edition(request)).containers) { collections =>
+                        @collections.map { containerDefinition =>
+                            @fragments.containers.facia_cards.container(
+                                containerDefinition,
+                                faciaPage.frontProperties,
+                                Some(faciaPage.id),
+                                branding.sponsorshipType == PaidContent,
+                                faciaPage.collections.find {
+                                    _.id == containerDefinition.dataId
+                                }.map {
+                                    ContainerModel.fromPressedCollection
+                                }
+                            )
+                        }
+
+                        @defining(layout.Front.makeLinkedData(faciaPage.metadata.url, collections)) { linkedData =>
+                            <script data-schema="@{linkedData.`@type`}" type="application/ld+json">
+                                @Html(model.meta.LinkedData.toJson(linkedData))
+                            </script>
+                        }
+
+                    }
+
+                    <div class="js-front-bottom"></div>
+
+                    @fragments.trendingTopics(faciaPage.allItems, faciaPage.id, faciaPage.allPath)
+
+                    @if(branding.sponsorshipType != PaidContent) {
+                        <div class="fc-container fc-container--commercial">
+                        @fragments.commercial.commercialComponent()
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+    }
+
+    case None => {
+        @fragments.frontBody(faciaPage)
+    }
+}

--- a/facia/app/views/front.scala.html
+++ b/facia/app/views/front.scala.html
@@ -1,7 +1,12 @@
 @(page: model.PressedPage)(implicit request: RequestHeader)
+@import conf.switches.Switches.staticBadgesSwitch
 
 @main(page, projectName = Option("facia")){
     @fragments.frontHead(page)
 }{
-    @fragments.frontBody(page)
+    @if(staticBadgesSwitch.isSwitchedOn) {
+        @fragments.brandedFrontBody(page)
+    } else {
+        @fragments.frontBody(page)
+    }
 }


### PR DESCRIPTION
This change will show logos from capi on facia fronts, instead of logos from DFP, when switch is on.

The logo data is stored in `FrontProperties` so that it gets pressed with the front.

/cc @steppenwells 
