### PR TITLE
Extending out-pf-page-slot-always switch

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -28,7 +28,7 @@ trait ABTestSwitches {
     "ab-identity-register-membership-standfirst",
     "Membership registration page variant for Identity",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 4),
+    sellByDate = new LocalDate(2016, 5, 12),
     exposeClientSide = true
   )
 
@@ -49,7 +49,7 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 6, 1),
     exposeClientSide = true
   )
-  
+
   val ABLoyalAdblockingSurvey = Switch(
     SwitchGroup.ABTests,
     "ab-loyal-adblocking-survey",

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -289,7 +289,7 @@ trait CommercialSwitches {
     "request-out-of-page-slot-always",
     "If on, the out of page slot (1x1) will be added to each page, regardless of pageskins, surveys or other dependent features",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 4),
+    sellByDate = new LocalDate(2016, 5, 12),
     exposeClientSide =  false
   )
 }


### PR DESCRIPTION
Will discuss with Ad Ops as to when we can remove this switch this morning, but will extend for now.
