### PR TITLE
don't show poster image in carousel

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -50,7 +50,7 @@
                         )) { player =>
                             <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player">
                                 <div class="fc-item__video-container">
-                                    @video(player, false, false, showOverlay = true)
+                                    @video(player, false, false, showOverlay = true, showPoster = false)
                                 </div>
                             </div>
                             <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">


### PR DESCRIPTION
## What does this change?

Stops loading poster image for videos in a carousel.

Following from https://github.com/guardian/frontend/pull/12375 and https://github.com/guardian/frontend/pull/12384
## What is the value of this and can you measure success?

Less bandwidth cost.
## Does this affect other platforms - Amp, Apps, etc?

No.
## ~~Screenshots~~ GIFs!
### Before

![poster](https://cloud.githubusercontent.com/assets/836140/15043194/7bd9c55a-12c2-11e6-8c65-9e79b9869422.gif)
### After

![no-poster](https://cloud.githubusercontent.com/assets/836140/15043186/6de0b30a-12c2-11e6-86f1-110bb32eb733.gif)
## Request for comment

@jamesgorrie @paperboyo 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
