### PR TITLE
add 2016 election to AU nav

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -47,6 +47,7 @@ trait Navigation {
   val uk = SectionLink("uk-news", "UK", "UK News", "/uk-news")
   val us = SectionLink("us-news", "US", "US News", "/us-news")
   val usElection2016 = SectionLink("us-elections-2016", "election 2016", "Election 2016", "/us-news/us-elections-2016")
+  val auElection2016 = SectionLink("au-elections-2016", "election 2016", "Election 2016", "/australia-news/australian-election-2016")
   val politics = SectionLink("politics", "politics", "Politics", "/politics")
   val technology = SectionLink("technology", "tech", "Technology", "/technology")
   val environment = SectionLink("environment", "environment", "Environment", "/environment")

--- a/common/app/common/editions/Au.scala
+++ b/common/app/common/editions/Au.scala
@@ -36,6 +36,7 @@ object Au extends Edition(
   override val navigation: Seq[NavItem] = {
     Seq(
       NavItem(home),
+      NavItem(auElection2016),
       NavItem(australia),
       NavItem(world, Seq(uk, us, asia, europeNews, americas, africa, middleEast)),
       NavItem(opinion),
@@ -57,6 +58,7 @@ object Au extends Edition(
 
   override val briefNav: Seq[NavItem] = Seq(
     NavItem(home),
+    NavItem(auElection2016),
     NavItem(australia),
     NavItem(world, Seq(uk, us, asia, europeNews, americas, africa, middleEast)),
     NavItem(opinion),
@@ -66,8 +68,9 @@ object Au extends Edition(
     NavItem(culture, cultureLocalNav),
     NavItem(lifeandstyle, Seq(foodanddrink, healthandwellbeing, loveAndSex, family, women)),
     NavItem(fashion),
-    NavItem(economy, economyLocalNav),
-    NavItem(travel, Seq(australasiaTravel, asiaTravel, uktravel, europetravel, usTravel)),
+    // add back when the AU election is over
+    // NavItem(economy, economyLocalNav),
+    // NavItem(travel, Seq(australasiaTravel, asiaTravel, uktravel, europetravel, usTravel)),
     NavItem(media),
     NavItem(environment, Seq(cities, globalDevelopment, ausustainablebusiness))
   )


### PR DESCRIPTION
## What does this change?

add _election 2016_ to au nav, removes _economy_ and _travel_ to make way for it.
## What is the value of this and can you measure success?

people can find the coverage more easily
## Does this affect other platforms - Amp, Apps, etc?

no, done already
## Screenshots

![screen shot 2016-05-05 at 14 18 28](https://cloud.githubusercontent.com/assets/867233/15044378/46d945f6-12cc-11e6-9b29-741aefe78a85.png)
![screen shot 2016-05-05 at 14 18 33](https://cloud.githubusercontent.com/assets/867233/15044379/4ac26b02-12cc-11e6-9a3d-1f09cd64d9d9.png)

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
