### PR TITLE
expired switches now turn red, rather than orange

### DIFF
--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -37,7 +37,7 @@
         <ul id="sell-by-date">
             @switches.map{ switch =>
                 @Switch.expiry(switch).daysToExpiry.map { days =>
-                    <li class="Expiring expiry-days-@days" title="@switch.name - expires in @days days">
+                    <li class="Expiring expiry-days-@days @if(Switch.expiry(switch).hasExpired){expired}">" title="@switch.name - expires in @days days">
                         @switch.name
                     </li>
                 }

--- a/admin/app/views/switchboard.scala.html
+++ b/admin/app/views/switchboard.scala.html
@@ -34,8 +34,11 @@
                     @switches.map { switch =>
                         @defining(Switch.expiry(switch)) { expiry =>
                             <div class="checkbox">
-                                <label for="switch-@switch.name" @if(Switch.expiry(switch).expiresSoon) {
-                                    class="Expiring expiry-days-@expiry.daysToExpiry"}>
+                                <label for="switch-@switch.name"
+                                    @if(Switch.expiry(switch).expiresSoon) {
+                                        class="Expiring @if(expiry.hasExpired){expired} else {expiry-days-@expiry.daysToExpiry}"
+                                    }
+                                >
                                     <input id="switch-@switch.name" name="@switch.name" type="checkbox" @if(switch.isSwitchedOn) {
                                         checked="checked" }/>
                                     <strong>@switch.name</strong>

--- a/admin/public/css/radiator.css
+++ b/admin/public/css/radiator.css
@@ -61,7 +61,7 @@ ul {
     background-color: #21fa41;
 }
 
-.expiry-days-0, .expiry-days-1, .expiry-days-2 {
+.expired, .expiry-days-0, .expiry-days-1, .expiry-days-2 {
     background-color: red;
 }
 
@@ -133,11 +133,11 @@ a {
         width: 50%;
         float: left;
     }
-    
+
     .charts-full {
         width: 100%;
     }
-    
+
     .pingdom-wrapper {
         width: 100%;
     }


### PR DESCRIPTION
Currently when a switch is actually expired, the colour goes back to orange. Whilst this doesn't answer the broader question around how we manage our switches, it at least keeps the visual cue of "this switch needs immediate attention" that is otherwise missing (expired switches are currently coloured orange).

**before**
![image](https://cloud.githubusercontent.com/assets/1821099/15044464/b02c5674-12cc-11e6-86a6-87e5b4f515d0.png)
**after**
![image](https://cloud.githubusercontent.com/assets/1821099/15044395/56d4b454-12cc-11e6-93b0-f75d1555ae72.png)
