### PR TITLE
fix icon positioning in carousel

### DIFF
--- a/static/src/stylesheets/module/facia/_container--video.scss
+++ b/static/src/stylesheets/module/facia/_container--video.scss
@@ -107,7 +107,7 @@ $video-width-desktop: 700px;
     overflow: hidden;
 
     @include mq(desktop, leftCol) {
-        background-color: darken($media-background, 5%); 
+        background-color: darken($media-background, 5%);
     }
 }
 
@@ -350,8 +350,8 @@ $video-width-desktop: 700px;
         }
     }
 
-    .inline-video-icon {
-        display: none;
+    .inline-icon svg {
+        position: relative;
     }
 
     .fc-item__title--quoted .inline-quote {


### PR DESCRIPTION
## What does this change?

Fixes icons in carousel. Currently, the video icon is hidden and if the quote icon is shown, it isn't positioned correctly. This shows the video icon and renders all icons in the correct position.
## What is the value of this and can you measure success?

Icons make the world go round
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

Before
![screen shot 2016-05-05 at 16 32 53](https://cloud.githubusercontent.com/assets/836140/15048013/6a9fc9ac-12df-11e6-8f71-1be0b358ea7b.jpeg)

After
![screen shot 2016-05-05 at 16 32 36](https://cloud.githubusercontent.com/assets/836140/15048019/6fd8a61e-12df-11e6-9a37-2d0493534ef0.jpeg)
## Request for comment

@blongden73 @desbo 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
