### PR TITLE
Extend plista switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -37,7 +37,7 @@ trait FeatureSwitches {
     "plista-for-outbrain-au",
     "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition (for web only).",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 5),
+    sellByDate = new LocalDate(2016, 8, 9),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
This switch is used by the AU team to balance the meeting of Outbrain and Plista targets. It needs to be present for the foreseeable future.
