### PR TITLE
Adjust layout of commercial components on mobile

### DIFF
--- a/commercial/app/views/books/bookCard.scala.html
+++ b/commercial/app/views/books/bookCard.scala.html
@@ -1,7 +1,8 @@
 @(book: model.commercial.books.Book,
-  clickMacro: Option[String])
+  clickMacro: Option[String],
+  optClassNames: Option[Seq[String]] = None)
 
-<a class="advert advert--book" href="@clickMacro@book.buyUrl" data-link-name="merchandising-bookshop-v2_0_2014-10-15-medium-@{book.isbn}-@{book.author}-@{book.title}" itemscope itemtype="http://schema.org/Book">
+<a class="advert advert--book @optClassNames.map { classNames => @classNames.mkString(" ")}" href="@clickMacro@book.buyUrl" data-link-name="merchandising-bookshop-v2_0_2014-10-15-medium-@{book.isbn}-@{book.author}-@{book.title}" itemscope itemtype="http://schema.org/Book">
     <meta itemprop="isbn" content="@{book.isbn}">
     <h2 class="advert__title" itemprop="name">@book.title</h2>
     @book.jacketUrl.map { url =>

--- a/commercial/app/views/books/booksStandard.scala.html
+++ b/commercial/app/views/books/booksStandard.scala.html
@@ -4,7 +4,7 @@
   isProminent: Boolean = false)(implicit request: RequestHeader)
 
 @import conf.Configuration
-@import views.html.books.{bookCard, searchFormV2}
+@import views.html.books.{bookCard, searchForm}
 @import views.html.commercial.containerWrapper
 
 @containerWrapper(Seq("legacy", "books", "tone-books"),
@@ -31,15 +31,11 @@
         </div>
     }
 
-    <div class="adverts__row">
-
-    </div>
-
 }
 
 @actions = {
 
-    @searchFormV2()
+    @searchForm()
 
     <a class="button button--tertiary button--large" href="@clickMacro@Configuration.commercial.books_url" data-link-name="merchandising-bookshop-v2_0_2014-10-15-medium-visit-shop">
         @fragments.inlineSvg("arrow-right", "icon", List("i-right"))

--- a/commercial/app/views/books/booksStandard.scala.html
+++ b/commercial/app/views/books/booksStandard.scala.html
@@ -27,7 +27,8 @@
         </div>
     } else {
         <div class="adverts__row">
-        @books.map { book => @bookCard(book, clickMacro) }
+        @books.take(2).map { book => @bookCard(book, clickMacro) }
+        @books.slice(2, 4).map { book => @bookCard(book, clickMacro, optClassNames = Some(Seq("hide-until-tablet"))) }
         </div>
     }
 

--- a/commercial/app/views/books/searchForm.scala.html
+++ b/commercial/app/views/books/searchForm.scala.html
@@ -1,15 +1,6 @@
-@(version: String, date: String)
-
-<form class="commercial__search" action="http://bookshop.theguardian.com/catalogsearch/result/" method="POST" name="QuickSearchForm">
-    <div class="commercial__search__inner">
-        <label for="bookshop" class="u-h">Search bookshop:</label>
-        <input id="bookshop" name="q" class="commercial__search__input" type="text" placeholder="Search books" />
-        <button type="submit" class="u-button-reset commercial__search__submit" data-link-name="merchandising-bookshop-v@{version}_@{date}-low-search">
-            <i class="i i-search-grey-36"></i>
-            <span class="u-h">Search the Guardian Bookshop</span>
-        </button>
-        <input type="hidden" name="order" value="relevance" />
-        <input type="hidden" name="dir" value="desc" />
-        <input value="%JustOmnitureToken%" name="INTCMP" type="hidden" />
-    </div>
+<form class="search hide-until-desktop" action="http://bookshop.theguardian.com/catalogsearch/result/" method="POST" name="QuickSearchForm">
+    <label for="bookshop" class="u-h">Search bookshop:</label>
+    <input id="bookshop" name="q" class="search__input" type="text" placeholder="Search books">
+    <input type="hidden" name="order" value="relevance">
+    <input type="hidden" name="dir" value="desc">
 </form>

--- a/commercial/app/views/books/searchFormV2.scala.html
+++ b/commercial/app/views/books/searchFormV2.scala.html
@@ -1,6 +1,0 @@
-<form class="search" action="http://bookshop.theguardian.com/catalogsearch/result/" method="POST" name="QuickSearchForm">
-    <label for="bookshop" class="u-h">Search bookshop:</label>
-    <input id="bookshop" name="q" class="search__input" type="text" placeholder="Search books">
-    <input type="hidden" name="order" value="relevance">
-    <input type="hidden" name="dir" value="desc">
-</form>

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -50,7 +50,7 @@
             useCardBranding = false)
 
         @for(moreButton <- optCapiReadMoreText) {
-            <a href="@clickMacro@optCapiReadMoreUrl" class="hide-on-mobile button button--primary button--large button--legacy-single" data-link-name="merchandising-single-more">
+            <a href="@clickMacro@optCapiReadMoreUrl" class="hide-until-mobile-landscape button button--primary button--large button--legacy-single" data-link-name="merchandising-single-more">
                 @moreButton
                 @fragments.inlineSvg("arrow-right", "icon", List("i-right"))
             </a>

--- a/commercial/app/views/jobs/jobCard.scala.html
+++ b/commercial/app/views/jobs/jobCard.scala.html
@@ -1,7 +1,8 @@
 @(job: model.commercial.jobs.Job,
-  clickMacro: Option[String])
+  clickMacro: Option[String],
+  optClassNames: Option[Seq[String]] = None)
 
-<a class="advert advert--job" href="@clickMacro@job.listingUrl" data-link-name="merchandising-jobs-v0_2_2014-04-30-low-job-@{job.id}">
+<a class="advert advert--job @optClassNames.map { classNames => @classNames.mkString(" ")}" href="@clickMacro@job.listingUrl" data-link-name="merchandising-jobs-v0_2_2014-04-30-low-job-@{job.id}">
     <h2 class="advert__title" itemprop="name">@job.title</h2>
     <div class="advert__image-container">
         <img class="advert__image" src="@job.recruiterLogoUrl">

--- a/commercial/app/views/jobs/jobs.scala.html
+++ b/commercial/app/views/jobs/jobs.scala.html
@@ -28,7 +28,8 @@
             <li><a class="job-sector__all" href="@{clickMacro}http://jobs.theguardian.com/" data-link-name="merchandising-jobs-v0_2_2014-04-30-low-sector-all">All sectors</a></li>
         </ul>
 
-        @jobs.map { job => @jobCard(job, clickMacro) }
+        @jobs.take(1).map { job => @jobCard(job, clickMacro) }
+        @jobs.slice(1, 2).map { job => @jobCard(job, clickMacro, optClassNames = Some(Seq("hide-until-tablet"))) }
     </div>
 
 }

--- a/commercial/app/views/masterclasses/masterclassCard.scala.html
+++ b/commercial/app/views/masterclasses/masterclassCard.scala.html
@@ -1,7 +1,8 @@
 @(event: model.commercial.events.Masterclass,
-  clickMacro: Option[String])
+  clickMacro: Option[String],
+  optClassNames: Option[Seq[String]] = None)
 
-<a class="advert advert--masterclass" href="@clickMacro@event.url" data-link-name="merchandising-masterclasses-s-v1_0_2014-05-23-low-@event.name">
+<a class="advert advert--masterclass @optClassNames.map { classNames => @classNames.mkString(" ")}" href="@clickMacro@event.url" data-link-name="merchandising-masterclasses-s-v1_0_2014-05-23-low-@event.name">
     <h2 class="advert__title">@event.name</h2>
     @event.mainPicture.map { picture =>
         @Item300.bestFor(picture.images).map { url =>

--- a/commercial/app/views/masterclasses/masterclasses.scala.html
+++ b/commercial/app/views/masterclasses/masterclasses.scala.html
@@ -21,7 +21,8 @@
 }{
 
     <div class="adverts__row">
-        @events.map { event => @masterclassCard(event, clickMacro) }
+        @events.take(2).map { event => @masterclassCard(event, clickMacro) }
+        @events.slice(2, 4).map { event => @masterclassCard(event, clickMacro, optClassNames = Some(Seq("hide-until-tablet"))) }
     </div>
 
 }

--- a/commercial/app/views/soulmates/soulmateCard.scala.html
+++ b/commercial/app/views/soulmates/soulmateCard.scala.html
@@ -1,7 +1,8 @@
 @(soulmate: model.commercial.soulmates.Member,
-  clickMacro: Option[String])
+  clickMacro: Option[String],
+  optClassNames: Option[Seq[String]] = None)
 
-<a class="advert advert--soulmate" href="@clickMacro@soulmate.profileUrl" data-link-name="merchandising-soulmates-v2_2_2014-03-28-profile-@{soulmate.gender}">
+<a class="advert advert--soulmate @optClassNames.map { classNames => @classNames.mkString(" ")}" href="@clickMacro@soulmate.profileUrl" data-link-name="merchandising-soulmates-v2_2_2014-03-28-profile-@{soulmate.gender}">
     <h2 class="advert__title u-text-hyphenate" itemprop="name">@soulmate.username</h2>
     <div class="advert__image-container">
         <img class="advert__image" src="@soulmate.profilePhoto">

--- a/commercial/app/views/soulmates/soulmateForm.scala.html
+++ b/commercial/app/views/soulmates/soulmateForm.scala.html
@@ -1,4 +1,4 @@
-<form class="search" action="@Configuration.commercial.soulmates_url/find" method="get">
+<form class="search hide-until-tablet" action="@Configuration.commercial.soulmates_url/find" method="get">
     <div class="search__field">
         <label for="my_gender" class="search__label">I am a</label>
         <select id="my_gender" name="my_gender" class="search__dropdown">

--- a/commercial/app/views/soulmates/soulmates.scala.html
+++ b/commercial/app/views/soulmates/soulmates.scala.html
@@ -20,7 +20,8 @@
 }{
 
     <div class="adverts__row">
-        @members.map { member => @soulmateCard(member, clickMacro) }
+        @members.take(6).map { member => @soulmateCard(member, clickMacro) }
+        @members.drop(6).map { member => @soulmateCard(member, clickMacro, optClassNames = Some(Seq("hide-until-tablet"))) }
         @soulmateForm()
     </div>
 

--- a/commercial/app/views/travel/travel.scala.html
+++ b/commercial/app/views/travel/travel.scala.html
@@ -26,7 +26,8 @@
         </div>
     } else {
         <div class="adverts__row">
-            @offers.map { offer => @travelCard(offer, clickMacro) }
+            @offers.take(2).map { offer => @travelCard(offer, clickMacro) }
+            @offers.slice(2, 4).map { offer => @travelCard(offer, clickMacro, optClassNames = Some(Seq("hide-until-tablet"))) }
         </div>
     }
 

--- a/commercial/app/views/travel/travelCard.scala.html
+++ b/commercial/app/views/travel/travelCard.scala.html
@@ -1,7 +1,8 @@
 @(offer: model.commercial.travel.TravelOffer,
-  clickMacro: Option[String])
+  clickMacro: Option[String],
+  optClassNames: Option[Seq[String]] = None)
 
-<a class="advert advert--travel" href="@clickMacro@offer.offerUrl" data-link-name="merchandising-travel-v2_1_2014-07-04-low-@{offer.title}">
+<a class="advert advert--travel @optClassNames.map { classNames => @classNames.mkString(" ")}" href="@clickMacro@offer.offerUrl" data-link-name="merchandising-travel-v2_1_2014-07-04-low-@{offer.title}">
     <h2 class="advert__title" itemprop="name">@offer.title</h2>
     <div class="advert__image-container">
         <img class="advert__image" src="@offer.imageUrl">

--- a/static/src/javascripts/projects/common/views/commercial/creatives/manual-container-button.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/manual-container-button.html
@@ -1,4 +1,4 @@
-<a href="<%=clickMacro%><%=baseUrl%>" class="hide-on-mobile button button--primary button--large button--legacy-single" data-link-name="viewall">
+<a href="<%=clickMacro%><%=baseUrl%>" class="hide-until-mobile-landscape button button--primary button--large button--legacy-single" data-link-name="viewall">
     <%=offerLinkText%>
     <%=arrowRight%>
 </a>

--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -101,8 +101,11 @@
 .advert__image-container {
     order: -1;
     margin-bottom: $gs-baseline / 2;
-    height: 11 * $gs-baseline;
     width: 100%;
+
+    @include mq(tablet) {
+        height: 11 * $gs-baseline;
+    }
 
     .has-no-flex & {
         position: absolute;

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -4,6 +4,18 @@
     }
 }
 
+.adverts--paidfor {
+    @include mq(mobileLandscape, desktop) {
+        > .adverts__header {
+            flex-wrap: wrap;
+        }
+
+        .adverts__kicker {
+            flex-basis: 100%;
+        }
+    }
+}
+
 .adverts--tone-paidfor {
     background-color: $neutral-6;
 

--- a/static/src/stylesheets/module/commercial/_adverts-soulmates.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-soulmates.scss
@@ -1,4 +1,16 @@
 .adverts--soulmates {
+    @include mq($until: tablet) {
+        > .adverts__header {
+            flex-direction: row;
+            justify-content: space-between;
+        }
+
+        .adverts__row > :nth-child(3),
+        .adverts__row > :nth-child(4) {
+            display: flex;
+        }
+    }
+
     > .adverts__header .inline-logo-soulmates > svg {
         width: 100px;
         height: 21px;
@@ -96,6 +108,7 @@
 
 .advert-blended--soulmates {
     background: $soulmates-background;
+    box-sizing: border-box;
     padding: 0 $gs-gutter / 4;
 
     .inline-logo-soulmates {

--- a/static/src/stylesheets/module/commercial/_adverts-soulmates.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-soulmates.scss
@@ -1,13 +1,25 @@
 .adverts--soulmates {
     @include mq($until: tablet) {
+        .adverts__row {
+            > * {
+                flex-basis: calc(33.33% - #{$gs-gutter});
+                &:nth-child(even)::before {
+                    content: none;
+                }
+                &:nth-child(3n+2)::before,
+                &:nth-child(3n+3)::before {
+                    @include separator($neutral-4, $gs-gutter / -2);
+                }
+            }
+
+            > :nth-child(3) {
+                margin-top: 0;
+            }
+        }
+
         > .adverts__header {
             flex-direction: row;
             justify-content: space-between;
-        }
-
-        .adverts__row > :nth-child(3),
-        .adverts__row > :nth-child(4) {
-            display: flex;
         }
     }
 

--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -43,6 +43,13 @@
         padding: 0;
     }
 
+    @include mq(mobileLandscape, desktop) {
+        > .adverts__header {
+            flex-direction: row;
+            justify-content: space-between;
+        }
+    }
+
     @include mq(leftCol) {
         display: flex;
 
@@ -104,6 +111,7 @@
         }
         @include mq(tablet) {
             max-width: gs-span(9) + ($gs-gutter * 2);
+            padding-bottom: $gs-baseline;
         }
         @include mq(desktop) {
             max-width: gs-span(12) + ($gs-gutter * 2);
@@ -118,11 +126,31 @@
     .adverts__logo {
         color: #ffffff;
         display: flex;
-        flex-direction: column;
 
-        /* http://alistapart.com/article/axiomatic-css-and-lobotomized-owls */
-        > * + * {
-            margin-top: $gs-baseline / 2;
+        @include mq($until: desktop) {
+            align-items: center;
+
+            .inline-marque-54 {
+                margin-right: $gs-gutter / 2;
+            }
+
+            .inline-marque-54 > svg {
+                width: 36px;
+                height: 36px;
+            }
+
+            .inline-logo-guardian {
+                margin-right: $gs-gutter / 4;
+            }
+        }
+
+        @include mq(desktop) {
+            flex-direction: column;
+
+            /* http://alistapart.com/article/axiomatic-css-and-lobotomized-owls */
+            > * + * {
+                margin-top: $gs-baseline / 2;
+            }
         }
 
         svg {
@@ -133,6 +161,10 @@
     }
 
     .adverts__ctas {
+        @include mq($until: tablet) {
+            margin-top: $gs-baseline / 3;
+        }
+
         .button--tertiary {
             border-color: rgba(255, 255, 255, .3);
 
@@ -148,29 +180,26 @@
     }
 
     .adverts__row {
-        padding: $gs-baseline $gs-gutter / 2;
+        padding: $gs-baseline / 2 0;
+        display: flex;
 
-        @include mq(mobileLandscape) {
-            display: flex;
+        > * {
+            margin: 0 $gs-gutter / 2;
 
-            > * {
-                margin: 0 $gs-gutter / 2;
-
-                /* In Firefox, flex items have a min-width: auto, which prevents
-                   them from shrinking when they have an image larger than the
-                   size the item would normally fill. The only workaround to
-                   solve this is to overwrite min-width on the flex item.
-                   Additionnally, we put a max-width constraint on the container
-                   otherwise it will overflow.
-                   See https://bugzilla.mozilla.org/show_bug.cgi?id=1139931 */
-                min-width: 0;
-                > .advert__image-container {
-                    max-width: 100%;
-                }
+            /* In Firefox, flex items have a min-width: auto, which prevents
+               them from shrinking when they have an image larger than the
+               size the item would normally fill. The only workaround to
+               solve this is to overwrite min-width on the flex item.
+               Additionnally, we put a max-width constraint on the container
+               otherwise it will overflow.
+               See https://bugzilla.mozilla.org/show_bug.cgi?id=1139931 */
+            min-width: 0;
+            > .advert__image-container {
+                max-width: 100%;
             }
         }
 
-        @include mq(mobileLandscape, $until: tablet) {
+        @include mq($until: tablet) {
             flex-flow: row wrap;
 
             > * {
@@ -178,7 +207,7 @@
             }
 
             > :nth-child(2) ~ * {
-                margin-top: $gs-baseline;
+                display: none;
             }
 
             > * + * {
@@ -191,6 +220,8 @@
         }
 
         @include mq(tablet) {
+            padding: $gs-baseline $gs-gutter / 2;
+
             > * + * {
                 position: relative;
 
@@ -219,6 +250,22 @@
                 > :first-child:nth-last-child(2),
                 > :nth-child(2):last-child {
                     width: calc(50% - #{$gs-gutter});
+                }
+            }
+        }
+
+        @supports(scroll-snap-type: mandatory) {
+            @include mq($until: tablet) {
+                display: flex;
+                scroll-snap-type: mandatory;
+
+                > * {
+                    width: min-content;
+                }
+
+                > * + * {
+                    margin-top: 0;
+                    margin-left: $gs-gutter;
                 }
             }
         }
@@ -268,21 +315,32 @@
 
 .adverts--legacy-single {
     .advert {
-        flex-basis: calc(75% - #{$gs-gutter});
-        flex-grow: 0;
+        flex-basis: calc(100% - #{$gs-gutter});
     }
 
-    .advert--inverse > .advert__image-container {
-        flex-basis: calc(33.33% - #{$gs-gutter / 2});
-        margin-right: 0;
-    }
+    @include mq(mobileLandscape) {
+        .advert {
+            flex-basis: calc(75% - #{$gs-gutter});
+            flex-grow: 0;
+        }
 
-    .adverts__row > .advert::after {
-        @include separator($neutral-4, 100%, $gs-gutter / 2);
-    }
+        .advert--inverse > .advert__image-container {
+            flex-basis: calc(33.33% - #{$gs-gutter / 2});
+            margin-right: 0;
+        }
 
-    .adverts__row > .button::before {
-        content: none;
+        .adverts__row > .advert::after {
+            @include separator($neutral-4, 100%, $gs-gutter / 2);
+        }
+
+        .adverts__row > .button {
+            flex-basis: auto;
+            flex-grow: 1;
+        }
+
+        .adverts__row > .button::before {
+            content: none;
+        }
     }
 
     .has-no-flex & {
@@ -339,7 +397,6 @@
 
 .adverts__body {
     position: relative;
-    padding-bottom: $gs-baseline;
 }
 
 .adverts__row {
@@ -549,6 +606,10 @@
     .adverts__blurb {
         @include fs-headline(1);
         color: #ffffff;
+
+        @include mq($until: desktop) {
+            display: none;
+        }
 
         @include mq(leftCol) {
             @include fs-headline(2);

--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -207,7 +207,7 @@
             }
 
             > :nth-child(2) ~ * {
-                display: none;
+                margin-top: $gs-baseline;
             }
 
             > * + * {
@@ -261,6 +261,7 @@
 
                 > * {
                     width: min-content;
+                    scroll-snap-align: start;
                 }
 
                 > * + * {


### PR DESCRIPTION
Essentially made sure components fit in a 400px high window by hiding and moving elements around:
![picture 2](https://cloud.githubusercontent.com/assets/629976/15068709/237df7e6-1371-11e6-9042-6d180d62d384.jpg)

Now
![picture 1](https://cloud.githubusercontent.com/assets/629976/15068712/27b33394-1371-11e6-87a5-4c309ce6b7e7.jpg)

@uplne @piuccio 
