### PR TITLE
[WIP, do not merge] Deploys radiator: include TeamCity build

### DIFF
--- a/admin/app/controllers/DeploysRadiatorController.scala
+++ b/admin/app/controllers/DeploysRadiatorController.scala
@@ -22,6 +22,10 @@ trait DeploysRadiatorController extends Controller with Logging with AuthLogging
     teamcity.getTeamCityBuild(number).map(ApiResults(_))
   }
 
+  def getBuilds(maybeProjectName: Option[String], maybeBuildTypeName: Option[String], maybePageSize: Option[Int]) = AuthActions.AuthActionTest.async {
+    teamcity.getTeamCityBuilds(maybeProjectName, maybeBuildTypeName, maybePageSize).map(ApiResults(_))
+  }
+
   def renderDeploysRadiator() = AuthActions.AuthActionTest {
     NoCache(Ok(views.html.deploysRadiator.main()))
   }

--- a/admin/app/model/deploys/Teamcity.scala
+++ b/admin/app/model/deploys/Teamcity.scala
@@ -24,8 +24,11 @@ case class TeamCityBuild(number: String,
                          state: String,
                          projectName: String,
                          parentNumber: Option[String],
-                         revision: String,
-                         commits: List[Commit]) {
+                         // Revision is sometimes missing on cancelled builds, e.g.
+                         // http://teamcity.gu-web.net:8111/guestAuth/app/rest/builds/id:8181
+                         revision: Option[String],
+                         commits: List[Commit]
+) {
 
   val isSuccess = (status == "SUCCESS")
   def committers() = commits.map(_.username).distinct
@@ -47,7 +50,7 @@ object TeamCityBuild {
       (__ \ "artifact-dependencies" \ "build").read(
         (__ \\ "number").readNullable[String]
       ) and
-      (__ \ "revisions" \ "revision" \\ "version").read[String] and
+      (__ \ "revisions" \ "revision" \\ "version").readNullable[String] and
       (__ \ "changes" \ "change").read[List[Commit]]
     )(TeamCityBuild.apply _)
 }

--- a/admin/conf/routes
+++ b/admin/conf/routes
@@ -115,6 +115,7 @@ GET         /radiator/commit/*hash                                              
 
 GET         /deploys-radiator/api/deploys                                                           controllers.admin.DeploysRadiatorController.getDeploys(pageSize: Option[String], projectName: Option[String], stage: Option[String])
 GET         /deploys-radiator/api/builds/:number                                                    controllers.admin.DeploysRadiatorController.getBuild(number)
+GET         /deploys-radiator/api/builds                                                            controllers.admin.DeploysRadiatorController.getBuilds(projectName: Option[String], buildTypeName: Option[String], pageSize: Option[Int])
 GET         /deploys-radiator                                                                       controllers.admin.DeploysRadiatorController.renderDeploysRadiator()
 
 POST        /deploys-notify/api/builds/:number/notify                                               controllers.admin.DeploysNotifyController.notifyStep(number)

--- a/static/src/deploys-radiator/app/api.ts
+++ b/static/src/deploys-radiator/app/api.ts
@@ -37,7 +37,7 @@ export const getBuild = (build: number): Promise<BuildRecord> => (
 );
 
 export const getBuilds = (): Promise<List<BuildRecord>> => (
-    fetch(`${apiPath}/builds?projectName=dotcom&buildTypeName=master&pageSize=5`, { credentials: 'same-origin' })
+    fetch(`${apiPath}/builds?projectName=dotcom&buildTypeName=master`, { credentials: 'same-origin' })
         .then((response): Promise<BuildsJson> => response.json())
         .then(buildsJson => buildsJson.response)
         .then(buildsJsonResponse => List(buildsJsonResponse.map(buildJsonResponseToBuild)))

--- a/static/src/deploys-radiator/app/helpers.ts
+++ b/static/src/deploys-radiator/app/helpers.ts
@@ -1,0 +1,3 @@
+import { Option } from 'monapt';
+
+export const headOption = <A>(array: Array<A>): Option<A> => Option(array[0]);

--- a/static/src/deploys-radiator/app/main.ts
+++ b/static/src/deploys-radiator/app/main.ts
@@ -1,3 +1,15 @@
+// TODO: No recent deploys of router so it doesn't appear!! Increase history
+// size or filter exact matches only
+// TODO: Deal with error JSON
+// TODO: Show status if updates fail
+// TODO: Show build ID beside merge commits.
+// - We currently only request the build for the most recent CODE/PROD deploys.
+// We would have to request all builds in the range
+// http://teamcity.gu-web.net:8111/guestAuth/app/rest/buildTypes/id:dotcom_master/builds?locator=sinceBuild:(number:1205),untilBuild:(number:1209)&fields=build(number,buildType(name,projectName),revisions(revision(version)),changes(change(username,comment,version)),artifact-dependencies(build(number)))
+// TODO: Show failed deploys. Update status to say so
+// TODO: Show upcoming deploys? Flow chart?
+// Draw out requests
+
 /// <reference path="../typings/tsd.d.ts" />
 /// <reference path="../manual-typings/vdom-virtualize.d.ts" />
 /// <reference path="../manual-typings/immutable.d.ts" />

--- a/static/src/deploys-radiator/app/main.ts
+++ b/static/src/deploys-radiator/app/main.ts
@@ -71,7 +71,7 @@ const run = (): Promise<void> => {
             .sortBy(deploy => deploy.build)
             .first();
 
-        return [ latestCodeDeploy, oldestProdDeploy ];
+        return [ latestCodeDeploy, oldestProdDeploy ] as [ DeployRecord, DeployRecord ];
     });
 
     const buildsPromise = latestDeploysPromise.then(([ latestCodeDeploy, oldestProdDeploy ]) => (

--- a/static/src/deploys-radiator/app/model.ts
+++ b/static/src/deploys-radiator/app/model.ts
@@ -26,6 +26,8 @@ export interface Build {
     number: number;
     // TODO: This is confusing, same name as deploy.projectName
     projectName: string;
+    status: string;
+    state: string;
     revision: string;
     commits: Array<Commit>
 }
@@ -40,6 +42,10 @@ export type BuildRecord = Record.IRecord<Build>;
 export const createBuildRecord = Record<Build>({
     number: undefined,
     projectName: undefined,
+    // SUCCESS/FAILURE/ERROR(?)
+    status: undefined,
+    // running/finished
+    state: undefined,
     revision: undefined,
     commits: undefined,
 }, 'Build');
@@ -69,16 +75,23 @@ export interface DeploysJson {
     response: Array<DeployJson>;
 }
 
-interface BuildResponseJson {
+export interface BuildJsonResponse {
     number: string;
     projectName: string;
     revision: string;
+    status: string;
+    state: string;
     commits: Array<CommitJson>
 }
 
 export interface BuildJson {
     status: string;
-    response: BuildResponseJson;
+    response: BuildJsonResponse;
+}
+
+export interface BuildsJson {
+    status: string;
+    response: Array<BuildJsonResponse>;
 }
 
 interface CommitJson {

--- a/static/src/deploys-radiator/app/render.ts
+++ b/static/src/deploys-radiator/app/render.ts
@@ -118,18 +118,13 @@ const renderGroupDeployListNode = (deploys: List<DeployRecord>) => {
     ]);
 };
 
-const renderPage: (
-    deploysPair: [ List<DeployRecord>, List<DeployRecord> ],
-    deployPair: [ DeployRecord, DeployRecord ],
-    commits: List<GitHubCommit>,
-    maybeLatestSuccessfulBuild: Option<BuildRecord>
-) => VirtualDOM.VNode =
+const renderPage =
     (
-        [ codeDeploys, prodDeploys ],
-        [ latestCodeDeploy, oldestProdDeploy ],
-        commits,
-        maybeLatestSuccessfulBuild
-    ) => {
+        [ codeDeploys, prodDeploys ]: [ List<DeployRecord>, List<DeployRecord> ],
+        [ latestCodeDeploy, oldestProdDeploy ]: [ DeployRecord, DeployRecord ],
+        commits: List<GitHubCommit>,
+        maybeLatestSuccessfulBuild: Option<BuildRecord>
+    ): VirtualDOM.VNode => {
         const isInSync = oldestProdDeploy.build === latestCodeDeploy.build;
         return h('.row#root', {}, [
             h('h1', [

--- a/static/src/deploys-radiator/app/render.ts
+++ b/static/src/deploys-radiator/app/render.ts
@@ -123,13 +123,13 @@ const renderPage: (
     // TODO: Use tuple instead
     deployPair: Array<DeployRecord>,
     commits: List<GitHubCommit>,
-    maybeLatestBuild: Option<BuildRecord>
+    maybeLatestSuccessfulBuild: Option<BuildRecord>
 ) => VirtualDOM.VNode =
     (
         [ codeDeploys, prodDeploys ],
         [ latestCodeDeploy, oldestProdDeploy ],
         commits,
-        maybeLatestBuild
+        maybeLatestSuccessfulBuild
     ) => {
         const isInSync = oldestProdDeploy.build === latestCodeDeploy.build;
         return h('.row#root', {}, [
@@ -137,17 +137,21 @@ const renderPage: (
                 `Status: ${isInSync ? 'in sync. Ship it!' : 'out of sync.'}`
             ]),
             h('hr', {}, []),
-            maybeLatestBuild
-                .map(latestBuild => h('h2', {}, `Latest build: ${latestBuild.number}, ${latestBuild.state}, ${latestBuild.status}`))
+            maybeLatestSuccessfulBuild
+                .map(build => h('h2', {}, `Latest successful build: ${build.number}`))
                 .getOrElse(() => undefined),
             exp(commits.size > 0) && h('.col', [
-                h('h1', [
-                    'Difference (',
-                    h('span', { title: 'Oldest PROD deploy' }, `${oldestProdDeploy.build}`),
-                    '...',
-                    h('span', { title: 'Latest CODE deploy' }, `${latestCodeDeploy.build}`),
-                    ')'
-                ]),
+                maybeLatestSuccessfulBuild
+                    .map(build => (
+                        h('h1', [
+                            'Difference (',
+                            h('span', { title: 'Build of oldest PROD deploy' }, `${oldestProdDeploy.build}`),
+                            '...',
+                            h('span', { title: 'Latest successful build' }, `${build.number}`),
+                            ')'
+                        ])
+                    ))
+                    .getOrElse(() => undefined),
                 ih('ul', {}, (
                     commits
                         .groupBy(commit => commit.authorLogin)

--- a/static/src/deploys-radiator/app/render.ts
+++ b/static/src/deploys-radiator/app/render.ts
@@ -120,8 +120,7 @@ const renderGroupDeployListNode = (deploys: List<DeployRecord>) => {
 
 const renderPage: (
     deploysPair: [ List<DeployRecord>, List<DeployRecord> ],
-    // TODO: Use tuple instead
-    deployPair: Array<DeployRecord>,
+    deployPair: [ DeployRecord, DeployRecord ],
     commits: List<GitHubCommit>,
     maybeLatestSuccessfulBuild: Option<BuildRecord>
 ) => VirtualDOM.VNode =


### PR DESCRIPTION
A few months ago I made a branch that added TeamCity builds to the dashboard, but never got round to merging it. I think it's pretty much done though.

With this change the diff is now between TeamCity master and PROD as opposed to CODE and PROD.

I won't be able to merge this as today is my last day, but it's here if you want it 😄 

/cc @TBonnin 

![image](https://cloud.githubusercontent.com/assets/921609/15070731/1f461c78-137e-11e6-90c9-6ca0038b0777.png)
