### PR TITLE
rss -  use https for links and fixed guid

### DIFF
--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -106,7 +106,7 @@ object TrailsToRss extends implicits.Collections {
       entry.setTitle(stripInvalidXMLCharacters(trail.fields.linkText))
       entry.setLink(trail.metadata.webUrl)
       /* set http intentionally to not break existing guid */
-      entry,setUri("http://www.theguardian.com/" + trail.metadata.id)
+      entry.setUri("http://www.theguardian.com/" + trail.metadata.id)
       
       entry.setDescription(description)
       entry.setCategories(categories)

--- a/common/app/common/TrailsToRss.scala
+++ b/common/app/common/TrailsToRss.scala
@@ -28,10 +28,10 @@ object TrailsToRss extends implicits.Collections {
   val image: SyndImageImpl = {
     // Feed: image
     val image = new SyndImageImpl
-    image.setLink("http://www.theguardian.com")
+    image.setLink("https://www.theguardian.com")
 
     // This image fits this spec. - https://support.google.com/news/publisher/answer/1407682
-    image.setUrl("http://assets.guim.co.uk/images/guardian-logo-rss.c45beb1bafa34b347ac333af2e6fe23f.png")
+    image.setUrl("https://assets.guim.co.uk/images/guardian-logo-rss.c45beb1bafa34b347ac333af2e6fe23f.png")
     image.setTitle("The Guardian")
     image
   }
@@ -47,7 +47,7 @@ object TrailsToRss extends implicits.Collections {
     feed.setFeedType("rss_2.0")
     feed.setTitle(feedTitle)
     feed.setDescription(description.getOrElse("Latest news and features from theguardian.com, the world's leading liberal voice"))
-    feed.setLink("http://www.theguardian.com" + url.getOrElse(""))
+    feed.setLink("https://www.theguardian.com" + url.getOrElse(""))
     feed.setLanguage("en-gb")
     feed.setCopyright(s"Guardian News and Media Limited or its affiliated companies. All rights reserved. ${DateTime.now.getYear}")
     feed.setImage(image)
@@ -105,6 +105,9 @@ object TrailsToRss extends implicits.Collections {
       val entry = new SyndEntryImpl
       entry.setTitle(stripInvalidXMLCharacters(trail.fields.linkText))
       entry.setLink(trail.metadata.webUrl)
+      /* set http intentionally to not break existing guid */
+      entry,setUri("http://www.theguardian.com/" + trail.metadata.id)
+      
       entry.setDescription(description)
       entry.setCategories(categories)
       entry.setModules(new java.util.ArrayList(mediaModules ++ Seq(dc)))
@@ -149,7 +152,7 @@ object TrailsToRss extends implicits.Collections {
     feed.setFeedType("rss_2.0")
     feed.setTitle(webTitle)
     feed.setDescription(description.getOrElse("Latest news and features from theguardian.com, the world's leading liberal voice"))
-    feed.setLink("http://www.theguardian.com" + url)
+    feed.setLink("https://www.theguardian.com" + url)
     feed.setLanguage("en-gb")
     feed.setCopyright(s"Guardian News and Media Limited or its affiliated companies. All rights reserved. ${DateTime.now.getYear}")
     feed.setImage(image)


### PR DESCRIPTION
## What does this change?

The rss returned for sections and container will have `https` links and `guid` independent of the protocol used, for instance [`tv-and-radio` section](http://www.theguardian.com/tv-and-radio/rss) currently returns:

``` xml
<channel>
<title>Television & radio | The Guardian</title>
<link>http://www.theguardian.com/tv-and-radio</link>
...
<pubDate>Mon, 09 May 2016 06:31:41 GMT</pubDate>
<guid>
http://www.theguardian.com/tv-and-radio/2016/may/08/wolf-hall-director-says-bbc-is-under-threat
</guid>
<media:content width="140" url="https://i.guim.co.uk/img/media/4de5681da4abf47ec2e925f71ee732341860b01c/0_103_3000_1801/3000.jpg?w=140&q=55&auto=format&usm=12&fit=max&s=16a34672a00a40ae223323cc9434d9e4">
```

and will return after this change:

``` xml
<channel>
<title>Television & radio | The Guardian</title>
<link>https://www.theguardian.com/tv-and-radio</link>
...
<pubDate>Mon, 09 May 2016 06:31:41 GMT</pubDate>
<guid>
http://www.theguardian.com/tv-and-radio/2016/may/08/wolf-hall-director-says-bbc-is-under-threat
</guid>
<media:content width="140" url="https://i.guim.co.uk/img/media/4de5681da4abf47ec2e925f71ee732341860b01c/0_103_3000_1801/3000.jpg?w=140&q=55&auto=format&usm=12&fit=max&s=16a34672a00a40ae223323cc9434d9e4">
```
## What is the value of this and can you measure success?

Without the associated changes, when we migrate a section to https, rss readers including some of our social accounts integration will detect old articles as new ones.
## Does this affect other platforms - Amp, Apps, etc?

This affect our social accounts integration.
