### PR TITLE
Read the series Id from the keywordIds value

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -68,7 +68,7 @@ define([
                 return seriesIdFromKeywords[0].split('/')[1];
             }
 
-            return seriesIdFromUrl === null ? '' : seriesIdFromUrl[1];
+            return null;
         },
         parseIds = function (ids) {
             if (!ids) {

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -61,11 +61,13 @@ define([
                 return seriesIdFromUrl[1];
             }
 
-            var seriesIdFromKeywords = page.keywordIds.split(',').filter(function (keyword) {
-                return keyword.indexOf('series/') === 0;
-            }).slice(0, 1);
-            if (seriesIdFromKeywords.length) {
-                return seriesIdFromKeywords[0].split('/')[1];
+            if (page.keywordIds) {
+                var seriesIdFromKeywords = page.keywordIds.split(',').filter(function (keyword) {
+                    return keyword.indexOf('series/') === 0;
+                }).slice(0, 1);
+                if (seriesIdFromKeywords.length) {
+                    return seriesIdFromKeywords[0].split('/')[1];
+                }
             }
 
             return null;

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -57,6 +57,16 @@ define([
                 return parseId(page.seriesId);
             }
             var seriesIdFromUrl = /\/series\/(.+)$/.exec(page.pageId);
+            if (seriesIdFromUrl) {
+                return seriesIdFromUrl[1];
+            }
+
+            var seriesIdFromKeywords = page.keywordIds.split(',').filter(function (keyword) {
+                return keyword.indexOf('series/') === 0;
+            }).slice(0, 1);
+            if (seriesIdFromKeywords.length) {
+                return seriesIdFromKeywords[0].split('/')[1];
+            }
 
             return seriesIdFromUrl === null ? '' : seriesIdFromUrl[1];
         },


### PR DESCRIPTION
Sponsored series fronts don't have a `seriesId` value, so instead we are looking into `keywordIds` for a  matching keyword starting with `series/`.

cc @JonNorman @rich-nguyen @kenlim 
