### PR TITLE
Gallery as feature switch

### DIFF
--- a/applications/app/views/gallery.scala.html
+++ b/applications/app/views/gallery.scala.html
@@ -1,7 +1,9 @@
 @(page: model.GalleryPage)(implicit request: RequestHeader)
 
+@import conf.switches.Switches.galleryRedesign
+
 @main(page){ }{
-    @if(mvt.ABGalleryRedesignVariant.shouldShow(page.gallery.metadata.contentType)) {
+    @if(galleryRedesign.isSwitchedOn) {
         @fragments.newGalleryBody(page)
     } else {
         @fragments.galleryBody(page)

--- a/applications/test/GalleryTemplateTest.scala
+++ b/applications/test/GalleryTemplateTest.scala
@@ -12,17 +12,17 @@ import scala.collection.JavaConversions._
 
   it should "render captions" in goTo("/news/gallery/2012/may/02/picture-desk-live-kabul-burma") { browser =>
     import browser._
-    $("p.gallery2__caption").getTexts.firstNonEmpty.get should include("A TV grab from state-owned French television station France 2 showing the debate between Francois Hollande and Nicolas Sarkozy for the 2012 French presidential election campaign")
+    $("p.gallery__caption").getTexts.firstNonEmpty.get should include("A TV grab from state-owned French television station France 2 showing the debate between Francois Hollande and Nicolas Sarkozy for the 2012 French presidential election campaign")
   }
 
   it should "render all images in the gallery" in goTo("/news/gallery/2012/may/02/picture-desk-live-kabul-burma") { browser =>
     import browser._
-    $(".gallery2__item:not(.gallery2__item--advert)").length should be (22)
+    $(".gallery__item:not(.gallery__item--advert)").length should be (22)
   }
 
   it should "render adverts" in goTo("/news/gallery/2012/may/02/picture-desk-live-kabul-burma") { browser =>
     import browser._
-    val ads = $(".gallery2__item--advert")
+    val ads = $(".gallery__item--advert")
     ads.length should be (2)
     ads.get(0).find("#dfp-ad--inline1").length should be (1)
     ads.get(1).find("#dfp-ad--inline2").length should be (1)

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -305,7 +305,7 @@ trait FeatureSwitches {
   )
 
   val AmpSwitch = Switch(
-    SwitchGroup.ServerSideABTests,
+    SwitchGroup.Feature,
     "amp-switch",
     "If this switch is on, link to amp pages will be in the metadata for articles",
     safeState = On,

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -313,6 +313,17 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  // Owner: First impressions
+  val galleryRedesign = Switch(
+    SwitchGroup.Feature,
+    "gallery-redesign-switch",
+    "If this switch is on, the new gallery redesign displays",
+    safeState = On,
+    // Tuesday
+    sellByDate = new LocalDate(2016, 5, 31),
+    exposeClientSide = false
+  )
+
   val R2PagePressServiceSwitch = Switch(
     SwitchGroup.Feature,
     "r2-page-press-service",

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -15,6 +15,7 @@ import org.joda.time.DateTime
 import org.scala_tools.time.Imports._
 import play.api.libs.json.{JsBoolean, JsString, JsValue}
 import play.api.mvc.RequestHeader
+import conf.switches.Switches.galleryRedesign
 
 object Commercial {
 
@@ -270,7 +271,7 @@ final case class MetaData (
     conf.switches.Switches.MembersAreaSwitch.isSwitchedOn && membershipAccess.nonEmpty && url.contains("/membership/")
   }
 
-  val hasSlimHeader: Boolean = contentType == "Interactive" || section == "identity"
+  val hasSlimHeader: Boolean = contentType == "Interactive" || section == "identity" || (galleryRedesign.isSwitchedOn && contentType == "gallery")
 
   // Special means "Next Gen platform only".
   private val special = id.contains("-sp-")

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -40,33 +40,6 @@ object ABNewHeaderVariant extends TestDefinition(
   }
 }
 
-object ABGalleryRedesignVariant extends TestDefinition(
-  variants = Nil,
-  name = "ab-gallery-redesign-variant",
-  description = "Gallery redesign ab test (variant group)",
-  sellByDate = new LocalDate(2016, 5, 10)
-) {
-  override def isParticipating(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-gallery-redesign").contains("variant") && switch.isSwitchedOn && ServerSideTests.isSwitchedOn
-  }
-  def shouldShow(contentType: String)(implicit request: RequestHeader): Boolean = {
-     isParticipating && contentType.toLowerCase == "gallery"
-  }
-}
-
-object ABGalleryRedesignControl extends TestDefinition(
-  variants = Nil,
-  name = "ab-gallery-redesign-control",
-  description = "Gallery redesign ab test (control group)",
-  sellByDate = new LocalDate(2016, 5, 10)
-) {
-  override def isParticipating(implicit request: RequestHeader): Boolean = {
-    val doesNotContainGalleryHeader = !request.headers.get("X-GU-ab-gallery-redesign").isDefined
-
-    doesNotContainGalleryHeader && switch.isSwitchedOn && ServerSideTests.isSwitchedOn
-  }
-}
-
 object ABHeadlinesTestControl extends TestDefinition(
   Nil,
   "headlines-ab-control",
@@ -94,8 +67,6 @@ object ABIntersperseMultipleStoryPackagesStoriesControl extends TestDefinition(
 object ActiveTests extends Tests {
   val tests: Seq[TestDefinition] = List(
     ABNewHeaderVariant,
-    ABGalleryRedesignVariant,
-    ABGalleryRedesignControl,
     ABHeadlinesTestControl,
     ABHeadlinesTestVariant,
     ABIntersperseMultipleStoryPackagesStories,
@@ -108,15 +79,13 @@ object ActiveTests extends Tests {
                           .map{ test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}"""}
     val newHeaderTests = List(ABNewHeaderVariant).filter(_.isParticipating)
                           .map{ test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}"""}
-    val galleryRedesignTests = List(ABGalleryRedesignControl, ABGalleryRedesignVariant).filter(_.isParticipating)
-                          .map{ test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}"""}
     val internationalEditionTests = List(InternationalEditionVariant(request)
                                       .map{ international => s""""internationalEditionVariant" : "$international" """}).flatten
 
     val activeTest = List(ActiveTests.getParticipatingTest(request)
                         .map{ test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}"""}).flatten
 
-    val configEntries = activeTest ++ internationalEditionTests ++ headlineTests ++ newHeaderTests ++ galleryRedesignTests
+    val configEntries = activeTest ++ internationalEditionTests ++ headlineTests ++ newHeaderTests
 
     configEntries.mkString(",")
   }

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -1,5 +1,5 @@
 @(item: model.ContentType, page: model.Page, showBadge: Boolean = true, showExtras: Boolean = true)(implicit request: RequestHeader)
-@import conf.switches.Switches.SaveForLaterSwitch
+@import conf.switches.Switches.{SaveForLaterSwitch, galleryRedesign}
 @import model._
 @import views.support.ContentOldAgeDescriber
 
@@ -11,7 +11,7 @@
 }
 
 @metaBody() = {
-    @if(!mvt.ABGalleryRedesignVariant.shouldShow(item.metadata.contentType)) {
+    @if(!(galleryRedesign.isSwitchedOn && item.tags.isGallery)) {
         @if(!item.content.hasTonalHeaderByline) {
             @byline()
         }
@@ -33,7 +33,7 @@
     @if(showExtras) {
         <div class="meta__extras">
             <div class="meta__social" data-component="share">
-                @fragments.social(item.sharelinks.pageShares, "top", isGallery = mvt.ABGalleryRedesignVariant.shouldShow(item.metadata.contentType))
+                @fragments.social(item.sharelinks.pageShares, "top", isGallery = galleryRedesign.isSwitchedOn && item.tags.isGallery)
                 @if(item.content.tags.tags.exists(_.id == "tone/news")) {
                     @fragments.contentAgeNotice(ContentOldAgeDescriber(item.content))
                 }
@@ -47,7 +47,7 @@
                 }">
                 </div>
             </div>
-            @if(SaveForLaterSwitch.isSwitchedOn && !mvt.ABGalleryRedesignVariant.shouldShow(item.metadata.contentType)) {
+            @if(SaveForLaterSwitch.isSwitchedOn && !(galleryRedesign.isSwitchedOn && item.tags.isGallery)) {
                 <div class="meta__save-for-later js-save-for-later" data-position="top"></div>
             }
         </div>

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -3,7 +3,6 @@
 @import common.{LinkTo, Edition, SubscribeLink}
 @import common.editions._
 @import conf.Configuration
-@import views.support.URLEncode
 
 @if(mvt.ABNewHeaderVariant.isParticipating) {
     @fragments.newHeader()

--- a/common/app/views/fragments/header.scala.html
+++ b/common/app/views/fragments/header.scala.html
@@ -9,7 +9,7 @@
     @fragments.newHeader()
 } else {
     <header id="header"
-            class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} @if(mvt.ABGalleryRedesignVariant.shouldShow(page.metadata.contentType)){l-header--is-slim l-header--no-navigation} js-header"
+            class="l-header u-cf @if(page.metadata.hasSlimHeader) {l-header--is-slim l-header--no-navigation} js-header"
             role="banner"
             data-link-name="global navigation: header">
         <div class="js-navigation-header navigation-container navigation-container--collapsed">
@@ -105,7 +105,7 @@
                     } else {
                         <a href="@LinkTo{/}" data-link-name="site logo" id="logo" class="logo-wrapper" data-component="logo">
                             <span class="u-h">The Guardian</span>
-                            @if(page.metadata.hasSlimHeader || (mvt.ABGalleryRedesignVariant.shouldShow(page.metadata.contentType))) {
+                            @if(page.metadata.hasSlimHeader) {
                                 @* CRAZY HACK TO FIX IE8 RENDERING ISSUE WITH LOGO SVG MARKUP *@
                                 <!--[if (gt IE 8)|(IEMobile)]><!-->
                                     @fragments.inlineSvg("guardian-logo-160", "logo")
@@ -128,7 +128,7 @@
                             }
                         </a>
                     }
-                    @if(page.metadata.hasSlimHeader || (mvt.ABGalleryRedesignVariant.shouldShow(page.metadata.contentType))) {
+                    @if(page.metadata.hasSlimHeader) {
                         @fragments.nav.navigationToggle()
                     }
                 </div>

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -7,7 +7,7 @@
     USElectionSwitch.isSwitchedOn &&
     item.content.tags.tags.exists(_.id == "us-news/us-elections-2016")
 ){ isUSElection =>
-    <div class="content__labels @if(isUSElection) {content__labels--us-election} @if(mvt.ABGalleryRedesignVariant.shouldShow(item.metadata.contentType)) {content__labels--gallery}">
+    <div class="content__labels @if(isUSElection) {content__labels--us-election} @if(galleryRedesign.isSwitchedOn && item.tags.isGallery) {content__labels--gallery}">
 
         @if(isUSElection) {
             <div class="badge-slot badge-slot--us-election">

--- a/common/app/views/fragments/nav/navigation.scala.html
+++ b/common/app/views/fragments/nav/navigation.scala.html
@@ -35,7 +35,7 @@
                     </nav>
                 </div>
                 @* Don't show navigation toggle if slimHeader, or participating in the gallery redesign test*@
-                @if(!page.metadata.hasSlimHeader && (!mvt.ABGalleryRedesignVariant.shouldShow(page.metadata.contentType))) {
+                @if(!page.metadata.hasSlimHeader) {
                     @fragments.nav.navigationToggle()
                 }
             </div>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -87,7 +87,7 @@
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
         @page match {
-            case page: model.GalleryPage if mvt.ABGalleryRedesignVariant.isParticipating => {
+            case page: model.GalleryPage if galleryRedesign.isSwitchedOn => {
                 <div class="immersive-header-container">
                     @headerAndTopAds(showAdverts, edition, adBelowNav)
 


### PR DESCRIPTION
This takes the new gallery design out of the mvt testing framework and turns it into a feature switch instead.

The test between old galleries and new was only on for just over 24 hours. Today it needs to go fully live 🎉 

I will keep the switch and the old design around for another week or so and then delete all the old gallery styling and templates.
