### PR TITLE
add page-skin class to video container

### DIFF
--- a/static/src/stylesheets/module/facia/_container--video.scss
+++ b/static/src/stylesheets/module/facia/_container--video.scss
@@ -15,6 +15,10 @@ $video-width-desktop: 700px;
 
         @include mq(leftCol) {
             display: none;
+
+            .has-page-skin & {
+                display: block;
+            }
         }
     }
 
@@ -108,6 +112,10 @@ $video-width-desktop: 700px;
 
     @include mq(desktop, leftCol) {
         background-color: darken($media-background, 5%);
+
+        .has-page-skin & {
+            background-color: transparent;
+        }
     }
 }
 
@@ -171,10 +179,18 @@ $video-width-desktop: 700px;
 
     @include mq(leftCol) {
         width: gs-span(2) + $gs-gutter * 2;
+
+        .has-page-skin & {
+            width: gs-span(2);
+        }
     }
 
     @include mq(wide) {
         width: gs-span(3) + $gs-gutter * 2;
+
+        .has-page-skin & {
+            width: gs-span(2);
+        }
     }
 
     .video-playlist__icon {
@@ -191,10 +207,18 @@ $video-width-desktop: 700px;
 
     @include mq(leftCol) {
         width: gs-span(3) + $gs-gutter * 2;
+
+        .has-page-skin & {
+            width: gs-span(2);
+        }
     }
 
     @include mq(wide) {
         width: gs-span(4) + $gs-gutter * 2;
+
+        .has-page-skin & {
+            width: gs-span(2);
+        }
     }
 
     .video-playlist__icon {
@@ -246,10 +270,18 @@ $video-width-desktop: 700px;
 .video-playlist__item--first {
     @include mq(desktop, leftCol) {
         margin-left: gs-span(2);
+
+        .has-page-skin & {
+            margin-left: 0;
+        }
     }
 
     @include mq(leftCol) {
         margin-left: 0;
+
+        .has-page-skin & {
+            margin-left: 0;
+        }
     }
 }
 
@@ -281,6 +313,10 @@ $video-width-desktop: 700px;
 
     @include mq(wide) {
         width: gs-span(3) + $gs-gutter * 2;
+
+        .has-page-skin & {
+            width: gs-span(2) + $gs-gutter * 2;
+        }
     }
 
     .inline-guardian-video-logo svg {
@@ -291,6 +327,10 @@ $video-width-desktop: 700px;
             fill: #ffffff;
         }
     }
+
+    .has-page-skin & {
+        display: none;
+    }
 }
 
 .video-playlist__item--first {
@@ -300,6 +340,10 @@ $video-width-desktop: 700px;
 
     @include mq(leftCol) {
         margin-left: 0;
+
+        .has-page-skin & {
+            margin-left: gs-span(2);
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?

Making sure the video container responds to page skings.
Not the best fix, but all I can think of for now and it's broken on the Network front.
## Does this affect other platforms - Amp, Apps, etc?

Nope.
## Screenshots

![video-container-with-skin](https://cloud.githubusercontent.com/assets/31692/15108393/98688f90-15cd-11e6-8683-51b0fa4662c9.png)
## Request for comment

@akash1810 @sammorrisdesign 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
