### PR TITLE
Call super.onStart in CachedHealthCheckLifeCycle onStart override

### DIFF
--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -121,6 +121,7 @@ trait CachedHealthCheckLifeCycle extends GlobalSettings {
   val healthCheckController: CachedHealthCheckController
 
   override def onStart(app: PlayApp) = {
+    super.onStart(app)
     Jobs.deschedule("HealthCheckFetch")
     Jobs.scheduleEveryNSeconds("HealthCheckFetch", healthCheckRequestFrequencyInSec) {
       healthCheckController.runChecks


### PR DESCRIPTION
## What does this change?

Fix missing call to super.onStart in CachedHealthCheckLifeCycle
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
