### PR TITLE
temporary reprieve for server side ab testing framework

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -72,9 +72,9 @@ trait PerformanceSwitches {
   val ServerSideBucketsSwitch = Switch(
     SwitchGroup.Performance,
     "server-side-buckets",
-    "When this switch expires, we should have decided whether permanently running server side ab testing affects caching/costs too much",
+    "When this switch expires, remove the remaining predefined server side testing buckets",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 10),
+    sellByDate = new LocalDate(2016, 5, 20),
     exposeClientSide = false
   )
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -132,8 +132,9 @@ object MultiVariateTesting {
 
   sealed case class Variant(name: String)
 
-  // buckets 0-7 are removed during testing whether having a permanently running server side ab test framework
-  // affects our caching too much - I'll put them back or come up with a new solution once I have some data! John
+  // buckets 0-7 are removed because they cost $1000+ just in aws bandwidth every month, the rest
+  // will be removed once they're not in use.  In future server side ab tests will be added explicitly
+  // to target only the URLs needed for the time needed.
   object Variant8 extends Variant("variant-8")
   object Variant9 extends Variant("variant-9")
 


### PR DESCRIPTION
The stats for server side mvt test showed that 8 of the buckets alone were costing $1k+ per month just in bandwidth, so I'm going to remove the rest and we can just add tests specifically for the time they're needed and only against the URLs that are in the tests.

There are a couple of tests ending on 17th so I'll wait for them to finish before updating everything to explain how to do them in future.
