### PR TITLE
If advertisement feature, don't show new gallery design

### DIFF
--- a/applications/app/views/gallery.scala.html
+++ b/applications/app/views/gallery.scala.html
@@ -1,9 +1,7 @@
 @(page: model.GalleryPage)(implicit request: RequestHeader)
 
-@import conf.switches.Switches.galleryRedesign
-
 @main(page){ }{
-    @if(galleryRedesign.isSwitchedOn) {
+    @if(page.gallery.showNewGalleryDesign) {
         @fragments.newGalleryBody(page)
     } else {
         @fragments.galleryBody(page)

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -8,7 +8,7 @@ import com.gu.facia.client.models.TrailMetaData
 import common._
 import common.dfp.DfpAgent
 import conf.Configuration
-import conf.switches.Switches.{FacebookShareUseTrailPicFirstSwitch, LongCacheSwitch}
+import conf.switches.Switches.{FacebookShareUseTrailPicFirstSwitch, LongCacheSwitch, galleryRedesign}
 import cricketPa.CricketTeams
 import layout.ContentWidths.GalleryMedia
 import model.content.{Atoms, Quiz}
@@ -80,6 +80,7 @@ final case class Content(
   lazy val shortUrlPath = shortUrlId
   lazy val discussionId = Some(shortUrlPath)
   lazy val isImmersive = fields.displayHint.contains("immersive") || metadata.contentType.toLowerCase == "gallery"
+  lazy val showNewGalleryDesign = galleryRedesign.isSwitchedOn && metadata.contentType.toLowerCase == "gallery" && !trail.commercial.isAdvertisementFeature
 
   lazy val hasSingleContributor: Boolean = {
     (tags.contributors.headOption, trail.byline) match {
@@ -650,6 +651,7 @@ final case class Gallery(
   lightboxProperties: GalleryLightboxProperties) extends ContentType {
 
   val lightbox = GalleryLightbox(content.elements, content.tags, lightboxProperties)
+  val showNewGalleryDesign: Boolean = content.showNewGalleryDesign
   def apply(index: Int): ImageAsset = lightbox.galleryImages(index).images.largestImage.get
 }
 

--- a/common/app/views/fragments/contentMeta.scala.html
+++ b/common/app/views/fragments/contentMeta.scala.html
@@ -11,7 +11,7 @@
 }
 
 @metaBody() = {
-    @if(!(galleryRedesign.isSwitchedOn && item.tags.isGallery)) {
+    @if(!item.content.showNewGalleryDesign) {
         @if(!item.content.hasTonalHeaderByline) {
             @byline()
         }
@@ -33,7 +33,7 @@
     @if(showExtras) {
         <div class="meta__extras">
             <div class="meta__social" data-component="share">
-                @fragments.social(item.sharelinks.pageShares, "top", isGallery = galleryRedesign.isSwitchedOn && item.tags.isGallery)
+                @fragments.social(item.sharelinks.pageShares, "top", isGallery = item.content.showNewGalleryDesign)
                 @if(item.content.tags.tags.exists(_.id == "tone/news")) {
                     @fragments.contentAgeNotice(ContentOldAgeDescriber(item.content))
                 }
@@ -47,7 +47,7 @@
                 }">
                 </div>
             </div>
-            @if(SaveForLaterSwitch.isSwitchedOn && !(galleryRedesign.isSwitchedOn && item.tags.isGallery)) {
+            @if(SaveForLaterSwitch.isSwitchedOn && !item.content.showNewGalleryDesign) {
                 <div class="meta__save-for-later js-save-for-later" data-position="top"></div>
             }
         </div>

--- a/common/app/views/fragments/meta/metaInline.scala.html
+++ b/common/app/views/fragments/meta/metaInline.scala.html
@@ -7,7 +7,7 @@
     USElectionSwitch.isSwitchedOn &&
     item.content.tags.tags.exists(_.id == "us-news/us-elections-2016")
 ){ isUSElection =>
-    <div class="content__labels @if(isUSElection) {content__labels--us-election} @if(galleryRedesign.isSwitchedOn && item.tags.isGallery) {content__labels--gallery}">
+    <div class="content__labels @if(isUSElection) {content__labels--us-election} @if(item.content.showNewGalleryDesign) {content__labels--gallery}">
 
         @if(isUSElection) {
             <div class="badge-slot badge-slot--us-election">

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -87,7 +87,7 @@
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
         @page match {
-            case page: model.GalleryPage if galleryRedesign.isSwitchedOn => {
+            case page: model.GalleryPage if page.gallery.showNewGalleryDesign => {
                 <div class="immersive-header-container">
                     @headerAndTopAds(showAdverts, edition, adBelowNav)
 


### PR DESCRIPTION
## What does this change?

The new gallery design affects paid advertisement features, which we were not aware of (sorry 😞 ). They are supposed to look like:

![image](https://cloud.githubusercontent.com/assets/8774970/15111344/5ee6edbe-15de-11e6-8839-fbb2ac6685af.png)

And right now look like:
![image](https://cloud.githubusercontent.com/assets/8774970/15111362/73159fec-15de-11e6-92c2-22d15fd10724.png)

The main problems are the tonal changes, the lack of a badge, and the paid for content bar. 

At the moment we are not sure whether we should modify them to use the new design, or if we should keep the old template and styles around just for them.

Until that is decided this PR makes them use the old design and template again.
## Screenshots

They should look the same as they used to, except for the slim header. Like this:

![image](https://cloud.githubusercontent.com/assets/8774970/15111411/c63cb9d0-15de-11e6-8446-460abdd5d748.png)
## Request for comment

cc @regiskuckaertz do you have time to take a look at this?
