### PR TITLE
pass in the 'ids' field for the travel component call

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/commercial-component.js
@@ -40,7 +40,7 @@ define([
         jobs:           complexUrlBuilder('jobs', 'jobIds', true),
         masterclasses:  complexUrlBuilder('masterclasses', 'ids', true),
         liveevents:     complexUrlBuilder('liveevents/event', 'id', true),
-        travel:         complexUrlBuilder('travel/offers', '', true),
+        travel:         complexUrlBuilder('travel/offers', 'ids', true),
         multi:          complexUrlBuilder('multi', '', true),
         book:           bookUrlBuilder('books/book'),
         soulmatesGroup: soulmatesGroupUrlBuilder('soulmates/')


### PR DESCRIPTION
The travel component was ignoring the Vibe IDs passed through from the DFP template.

/@kelvin-chappell 
