### PR TITLE
Reduce frequency of CSP reports

### DIFF
--- a/diagnostics/app/controllers/DiagnosticsController.scala
+++ b/diagnostics/app/controllers/DiagnosticsController.scala
@@ -9,6 +9,8 @@ import model.diagnostics.csp.CSP
 import model.TinyResponse
 
 object DiagnosticsController extends Controller with Logging {
+  val r = scala.util.Random
+
   def acceptBeaconOptions = postOptions
 
   def acceptBeacon = Action { implicit request =>
@@ -41,7 +43,7 @@ object DiagnosticsController extends Controller with Logging {
   }
 
   def csp = Action(jsonParser) { implicit request =>
-    if (conf.switches.Switches.CspReporting.isSwitchedOn) {
+    if (conf.switches.Switches.CspReporting.isSwitchedOn && r.nextInt(100) == 1) {
       CSP.report(request.body)
     }
 


### PR DESCRIPTION
## What does this change?

Limits CSP reporting to every 1 in 100 rather than every request.
## What is the value of this and can you measure success?

We'll be able to turn on CSP reporting for longer to gain more insight into where errors are coming from.
## Request for comment

@TBonnin 
