### PR TITLE
Fix the download link for mp3s

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -501,7 +501,7 @@ object Audio {
 final case class Audio (override val content: Content) extends ContentType {
 
   lazy val downloadUrl: Option[String] = elements.mainAudio
-    .flatMap(_.audio.encodings.find(_.format == "audio/mpeg").map(_.url.replace("static.guim", "download.guardian")))
+    .flatMap(_.audio.encodings.find(_.format == "audio/mpeg").map(_.url))
 
   private lazy val podcastTag: Option[Tag] = tags.tags.find(_.properties.podcast.nonEmpty)
   lazy val iTunesSubscriptionUrl: Option[String] = podcastTag.flatMap(_.properties.podcast.flatMap(_.subscriptionUrl))


### PR DESCRIPTION
We changed the first part of the link in this old commit: https://github.com/guardian/frontend/commit/c94e43a4333ef5703c718f3026787ec325162773#diff-cddbf1a20ebe144ec9aa35d41a46dbb4R462
Not sure why, but that server doesn't have a valid http cert anyway, so updating it to use the new url.

@mchv @JustinPinner 
