### PR TITLE
Instances will stop trying as hard when they're overloaded

### DIFF
--- a/common/app/conf/Filters.scala
+++ b/common/app/conf/Filters.scala
@@ -1,12 +1,16 @@
 package conf
 
+import akka.agent.Agent
 import cache.SurrogateKey
 import common.ExecutionContexts
 import filters.RequestLoggingFilter
-import org.apache.commons.codec.digest.DigestUtils
-import play.api.mvc.{EssentialFilter, Result, RequestHeader, Filter}
-import play.filters.gzip.GzipFilter
 import implicits.Responses._
+import org.joda.time.DateTime
+import play.api.mvc.{EssentialFilter, Filter, RequestHeader, Result}
+import play.filters.gzip.GzipFilter
+import play.api.mvc.Results.ServiceUnavailable
+
+import scala.collection.immutable.Queue
 import scala.concurrent.Future
 
 object Gzipper extends GzipFilter(shouldGzip = (_, resp) => !resp.isImage)
@@ -71,6 +75,79 @@ object AmpFilter extends Filter with ExecutionContexts with implicits.Requests {
   }
 }
 
+// this turns requests away with 5xx errors if we are too busy
+object PanicSheddingFilter extends Filter {
+
+  import scala.concurrent.duration._
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  val LATENCY_LIMIT = 1.second
+
+  val averageLatency = Agent(LatencyMonitor.initialLatency)
+  val inFlightLatency = Agent(InFlightLatencyMonitor.initialLatency)
+
+  def alreadyBusy =
+    inFlightLatency.get.latency(DateTime.now.getMillis) > LATENCY_LIMIT.toMillis ||
+    averageLatency.get.latency > LATENCY_LIMIT.toMillis
+
+  override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
+    val startTime = DateTime.now.getMillis
+    val result = if (alreadyBusy) Future.successful(ServiceUnavailable) else nextFilter(request)
+    inFlightLatency.send(InFlightLatencyMonitor.requestStarted(startTime)_)
+    result.onComplete { _ =>
+      inFlightLatency.send(InFlightLatencyMonitor.requestComplete(startTime)_)
+      averageLatency.send(LatencyMonitor.updateLatency(DateTime.now.getMillis - startTime)_)
+    }
+    result
+  }
+
+}
+
+object InFlightLatencyMonitor extends ExecutionContexts {
+
+  case class InFlightLatency(requestStarts: Long, lastUpdateTime: Long, totalLatency: Long) {
+    def latency(now: Long) = ((now - lastUpdateTime) * requestStarts) + (if (requestStarts == 0) 0 else totalLatency / requestStarts)
+  }
+
+  val initialLatency = InFlightLatency(requestStarts = 0, lastUpdateTime = 0, totalLatency = 0)
+
+  def requestStarted(startTime: Long)(inFlightLatency: InFlightLatency) = {
+    val InFlightLatency(requestStarts, lastUpdateTime, total) = inFlightLatency
+    val newTotal = total + ((startTime - lastUpdateTime) * requestStarts)
+    InFlightLatency(requestStarts + 1, startTime, newTotal)
+  }
+
+  def requestComplete(startTime: Long)(inFlightLatency: InFlightLatency) = {
+    val InFlightLatency(requestStarts, lastUpdateTime, total) = inFlightLatency
+    InFlightLatency(requestStarts - 1, lastUpdateTime, total - (lastUpdateTime - startTime))
+  }
+
+}
+
+object LatencyMonitor extends ExecutionContexts {
+
+  case class AverageLatency(latencies: Queue[Long], total: Long) {
+    def latency = total / latencies.length
+  }
+
+  val initialLatency = AverageLatency(Queue(), 0)
+
+  val LATENCY_MAX_SAMPLES = 1000
+
+  def updateLatency(thisRequestLatencyMs: Long)(averageLatency: AverageLatency): AverageLatency = {
+    val AverageLatency(latencies, total) = averageLatency
+    val newLatencies = latencies.enqueue(thisRequestLatencyMs)
+    val newTotal = total + thisRequestLatencyMs
+    val newLatency = if (newLatencies.length > LATENCY_MAX_SAMPLES) {
+      val (removed, removedQueue) = newLatencies.dequeue
+      AverageLatency(removedQueue, newTotal - removed)
+    } else {
+      AverageLatency(newLatencies, newTotal)
+    }
+    newLatency
+  }
+}
+
 object Filters {
   // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
   // which effectively means "JsonVaryHeaders goes around Gzipper"
@@ -80,6 +157,7 @@ object Filters {
     BackendHeaderFilter,
     RequestLoggingFilter,
     SurrogateKeyFilter,
-    AmpFilter
+    AmpFilter,
+    PanicSheddingFilter
   )
 }

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -105,6 +105,15 @@ trait PerformanceSwitches {
     exposeClientSide = true
   )
 
+  val PanicSheddingSwitch = Switch(
+    SwitchGroup.Performance,
+    "panic-shedding",
+    "If this switch is on, we try to keep response times below 1s by returning Service Unavailable errors if we're busy",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 8),
+    exposeClientSide = false
+  )
+
   val RichLinkSwitch = Switch(
     SwitchGroup.Performance,
     "rich-links",

--- a/common/test/conf/PanicSheddingFilterTest.scala
+++ b/common/test/conf/PanicSheddingFilterTest.scala
@@ -1,0 +1,55 @@
+package conf
+
+import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+
+import scala.collection.immutable.Queue
+
+class LatencyMonitorTest extends FlatSpec with Matchers with AppendedClues {
+
+  import LatencyMonitor._
+
+  "LatencyMonitor" should "have 2 latency after a single request" in {
+    updateLatency(2)(initialLatency) should be(AverageLatency(Queue(2), 2))
+  }
+
+  "LatencyMonitor" should "have 6 latency after (2, 4) request" in {
+    updateLatency(4)(updateLatency(2)(initialLatency)) should be(AverageLatency(Queue(2, 4), 6))
+  }
+
+  "LatencyMonitor" should "have 10000 latency after a 1001 req" in {
+    val one = updateLatency(0)(initialLatency)
+    val result = (0 to 1000).foldLeft(one)({ (prev, _) => updateLatency(10)(prev) })
+    result.copy(latencies = Queue()) should be(AverageLatency(Queue(), 10000))
+  }
+
+}
+
+class InFlightLatencyMonitorTest extends FlatSpec with Matchers with AppendedClues {
+
+  import InFlightLatencyMonitor._
+
+  "LatencyMonitor" should "have 2 latency after a single request" in {
+    val added = requestStarted(2)(initialLatency)
+    added should be(InFlightLatency(requestStarts = 1, lastUpdateTime = 2, totalLatency = 0))
+    added.latency(2) should be(0)
+    added.latency(4) should be(2)
+    val removed = requestComplete(2)(added)
+    removed should be(InFlightLatency(requestStarts = 0, lastUpdateTime = 2, totalLatency = 0))
+    removed.latency(4) should be(0)
+    removed.latency(6) should be(0)
+  }
+
+  "LatencyMonitor" should "be able to add 2 and remove 2" in {
+    val added = requestStarted(2)(initialLatency)
+    added should be(InFlightLatency(requestStarts = 1, lastUpdateTime = 2, totalLatency = 0))
+    val addedAgain = requestStarted(4)(added)
+    addedAgain should be(InFlightLatency(requestStarts = 2, lastUpdateTime = 4, totalLatency = 2))
+    addedAgain.latency(4) should be(1)
+    addedAgain.latency(6) should be(5)
+    val removed = requestComplete(4)(addedAgain)
+    removed should be(InFlightLatency(requestStarts = 1, lastUpdateTime = 4, totalLatency = 2))
+    val removedAgain = requestComplete(2)(removed)
+    removedAgain should be(InFlightLatency(requestStarts = 0, lastUpdateTime = 4, totalLatency = 0))
+  }
+
+}

--- a/common/test/conf/PanicSheddingFilterTest.scala
+++ b/common/test/conf/PanicSheddingFilterTest.scala
@@ -18,8 +18,8 @@ class LatencyMonitorTest extends FlatSpec with Matchers with AppendedClues {
 
   "LatencyMonitor" should "have 10000 latency after a 1001 req" in {
     val one = updateLatency(0)(initialLatency)
-    val result = (0 to 1000).foldLeft(one)({ (prev, _) => updateLatency(10)(prev) })
-    result.copy(latencies = Queue()) should be(AverageLatency(Queue(), 10000))
+    val result = (0 to LATENCY_MAX_SAMPLES).foldLeft(one)({ (prev, _) => updateLatency(10)(prev) })
+    result.copy(latencies = Queue()) should be(AverageLatency(Queue(), LATENCY_MAX_SAMPLES*10))
   }
 
 }


### PR DESCRIPTION
This is to allow our servers to survive if they get overwhelmed by traffic.

It works by limiting the amount of work the server will take on to the amount it can complete within a reasonable time.

It makes our servers monitor the latency so far of outstanding requests and also the latency of completed requests.  If either of those go above 1 second, it will limit the number of concurrent requests to a nominal amount to allow recovery.

This does include health checks, so in this state it might fail healthchecks and be taken out of service anyway.  This is intentional as the box isn't coping, but hopefully it can recover in time for the next health check.

Latency is only a proxy for how well the box is coping, as if the upstream has latency issues our boxes will stop serving some requests.  This might need tweaking so it doesn't cause too big problems, maybe 1 second should be longer.

I thought about limiting concurrent requests or by CPU, but since our apps are so different I would have to choose appropriate values for other services.

We could terminate in progress requests if they take too long, this might help the instance become healthy.

None of this detracts from the fact that our apps shouldn't use so many resources and also new instances should come up quicker.  But at least they can come up one at a time without dying again.

The benefit of this is the system will be able to come up under load.  This is especially important when we have had issues which have lost the instances.

@cb372 @markjamesbutler @adamnfish @TBonnin 

I'm going to do a little more testing with JMeter to make sure it behaves as I want before I put it out, as it could all go horribly wrong in prod!
