### PR TITLE
quick switch logic and description change and

### DIFF
--- a/common/app/common/dfp/HighMerchandiseComponentAgent.scala
+++ b/common/app/common/dfp/HighMerchandiseComponentAgent.scala
@@ -8,7 +8,7 @@ trait HighMerchandiseComponentAgent {
   protected def highMerchandisingTargetedTags: HighMerchandisingTargetedTagSet
 
   def hasHighMerchandisingTarget(tags: Seq[Tag]): Boolean = {
-    highMerchandisingComponentSwitch.isSwitchedOn ||
+    highMerchandisingComponentSwitch.isSwitchedOff ||
       (tags exists highMerchandisingTargetedTags.hasTag)
   }
 }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -296,7 +296,7 @@ trait CommercialSwitches {
   val highMerchandisingComponentSwitch = Switch(
     SwitchGroup.Commercial,
     "render-commercial-high-slot-always",
-    "If on, the commercial-high slot will always render on pageload",
+    "If on, wil be a server side check of page keywords with high-merchandising keywords, before high-merch slot render.",
     safeState = Off,
     sellByDate = new LocalDate(2016,6,8),
     exposeClientSide = false

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -296,7 +296,7 @@ trait CommercialSwitches {
   val highMerchandisingComponentSwitch = Switch(
     SwitchGroup.Commercial,
     "render-commercial-high-slot-always",
-    "If on, wil be a server side check of page keywords with high-merchandising keywords, before high-merch slot render.",
+    "If on, server will check tags for high-merchandising target before rendering high-merch slot.",
     safeState = Off,
     sellByDate = new LocalDate(2016,6,8),
     exposeClientSide = false


### PR DESCRIPTION
## What does this change?

Quick change to High-Merch-Slot pul request that changes the logic and description of switch. Switch logic is now reversed so that feature is switched ON with the switch turning on.  

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
