### PR TITLE
Add the email sign-up form for Aus campaign catchup

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -75,6 +75,17 @@ define([
                 modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
+            ausCampaignCatchup: {
+                listId: '3689',
+                listName: 'ausCampaignCatchup',
+                campaignCode: 'AU_campaign_signup_page',
+                headline: 'Sign up for the Campaign catchup',
+                description: 'Get the day\'s top election news and commentary coverage delivered to your inbox every afternoon',
+                successHeadline: 'Thank you for signing up',
+                successDescription: 'We will send you the latest Campaign catchup every weekday afternoon',
+                modClass: 'end-article',
+                insertMethod: insertBottomOfArticle
+            },
             theGuardianToday: {
                 listId: (function () {
                     switch (config.page.edition) {

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -96,6 +96,15 @@ define([
         theFiver: function () {
             return page.keywordExists(['Football']) && allowedArticleStructure();
         },
+        ausCampaignCatchup: function () {
+            return page.keywordExists([
+                'Australia news',
+                'Australian politics',
+                'Australian election 2016',
+                'Guardian Australia\'s Morning Mail',
+                'Australian election briefing'
+            ]);
+        },
         theGuardianToday: function () {
             return config.switches.emailInArticleGtoday &&
                 !pageHasBlanketBlacklist() &&


### PR DESCRIPTION
To pull in email sign-ups from related keywords to the Australian election campaign.
## Request for comment

@crifmulholland 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
