### PR TITLE
Remove out-of-page-slot switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -284,15 +284,6 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val requestOutOfPageSlotAlways = Switch(
-    SwitchGroup.Commercial,
-    "request-out-of-page-slot-always",
-    "If on, the out of page slot (1x1) will be added to each page, regardless of pageskins, surveys or other dependent features",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 12),
-    exposeClientSide =  false
-  )
-
   val highMerchandisingComponentSwitch = Switch(
     SwitchGroup.Commercial,
     "render-commercial-high-slot-always",

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -131,7 +131,7 @@
 
         @fragments.analytics.base(page)
 
-        @if(requestOutOfPageSlotAlways.isSwitchedOn || page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
+        @if(page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
             @fragments.commercial.pageSkin()
         }
 


### PR DESCRIPTION
Adops no longer server surveys through this out-of-page slot and so we no longer need this switch.
