### PR TITLE
Move interactive bootstraps to the top of the JS app.

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -24,6 +24,15 @@ trait PerformanceSwitches {
     exposeClientSide = true
   )
 
+  val BootInteractivesFromMainSwitch = Switch(
+    SwitchGroup.Performance,
+    "boot-interactives-from-main",
+    "If this switch is on then interactive bootstraps will be booted from main.js for perf and stability reasons",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 8),
+    exposeClientSide = true
+  )
+
   val TagPageSizeSwitch = Switch(
     SwitchGroup.Performance,
     "tag-page-size",

--- a/static/src/javascripts/bootstraps/enhanced/trail.js
+++ b/static/src/javascripts/bootstraps/enhanced/trail.js
@@ -125,7 +125,10 @@ define([
     }
 
     function augmentInteractive() {
-        if (/Article|Interactive|LiveBlog/.test(config.page.contentType)) {
+        if (
+            !config.switches.bootInteractivesFromMain &&
+            /Article|Interactive|LiveBlog/.test(config.page.contentType)
+        ) {
             $('figure.interactive').each(function (el) {
                 fastdom.defer(function () {
                     enhancer.render(el, document, config, mediator);

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -110,6 +110,27 @@ define([
             }
         });
 
+        /*
+         *  Interactive bootstraps.
+         *
+         *  Interactives are content, we want them booting as soon (and as stable) as possible.
+         */
+
+        if (
+            config.switches.bootInteractivesFromMain &&
+            /Article|Interactive|LiveBlog/.test(config.page.contentType)
+        ) {
+            $('figure.interactive').each(function (el) {
+                require($(el).attr('data-interactive'), function (interactive) {
+                    fastdom.defer(function () {
+                        robust.catchErrorsAndLog('interactive-bootstrap', function () {
+                            interactive.boot(el, document, config, mediator);
+                        });
+                    });
+                });
+            });
+        }
+
         //
         // A/B tests
         //


### PR DESCRIPTION
## What does this change?

Interactives are content. This pull request prioritises their rendering which should do two things.
1. Make them more stable. The earlier they run the less likely it is something else will interfere with them.
2. Make them render quicker.

This is not quite as ambitious as I hoped, and at one point I had the rendering down to < 1000ms, but I'm not confident that would work properly in PROD.
## What is the value of this and can you measure success?

On my local machine the bootstraps are initialised in 1/2 the time once they are in main.js. Measured by taking the time in a script at the top of the page, and then again immediately after the `interactive.boot(...)` function is called.

![boot](https://cloud.githubusercontent.com/assets/76709/15151821/c0c64e16-16ca-11e6-868c-c9b98102de4c.png)
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
