### PR TITLE
Improve portrait picture sources for immersive main media

### DIFF
--- a/applications/app/views/fragments/newGalleryBody.scala.html
+++ b/applications/app/views/fragments/newGalleryBody.scala.html
@@ -79,7 +79,7 @@
                     @*
                      * This ensures that the image height never goes above 96vh
                      *@
-                    style="max-width: calc(@image.width.toFloat/@image.height * 96vh)"
+                    style="max-width: calc(@image.ratioDouble * 96vh)"
                     href="@LinkTo{@page.item.metadata.url#img-@rowNum}"
                     data-link-name="Launch Gallery Lightbox" data-is-ajax>
                     @fragments.image(

--- a/common/app/model/Asset.scala
+++ b/common/app/model/Asset.scala
@@ -55,7 +55,8 @@ case class ImageAsset(
 
   val width: Int = fields.get("width").map(_.toInt).getOrElse(1)
   val height: Int = fields.get("height").map(_.toInt).getOrElse(1)
-  lazy val ratio: Int = width/height
+  lazy val ratioWholeNumber: Int = width/height
+  lazy val ratioDouble: Double = width.toDouble/height
   val role: Option[String] = fields.get("role")
   val orientation: Orientation = Orientation.fromDimensions(width, height)
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -717,7 +717,7 @@ case class GenericLightbox(
   properties: GenericLightboxProperties
 ) {
   lazy val mainFiltered = elements.mainPicture
-    .filter(_.images.largestEditorialCrop.map(_.ratio).getOrElse(0) > 0.7)
+    .filter(_.images.largestEditorialCrop.map(_.ratioWholeNumber).getOrElse(0) > 0.7)
     .filter(_.images.largestEditorialCrop.map(_.width).getOrElse(1) > properties.lightboxableCutoffWidth).toSeq
   lazy val bodyFiltered: Seq[ImageElement] = elements.bodyImages.filter(_.images.largestEditorialCrop.map(_.width).getOrElse(1) > properties.lightboxableCutoffWidth).toSeq
 

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -16,7 +16,8 @@
     } else {
         (orientation: portrait)
     }"
-    sizes="@{100 * (largestImage.width.toDouble / largestImage.height.toDouble)}vh"
+
+    sizes="@{100 * largestImage.ratioDouble}vh"
     srcset="@{(500 to 4000 by 250)
         .toList
         .map(width => ImgSrc.srcsetForProfile(views.support.Profile(width = Some(width)), picture, hidpi))

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -40,8 +40,8 @@
 
     @if(isImmersiveMainMedia) {
         @picture.largestImage.map { largestImage =>
-          @immersivePortraitSource(largestImage)
             @immersivePortraitSource(largestImage, hidpi = true)
+            @immersivePortraitSource(largestImage)
         }
     }
 

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -18,6 +18,7 @@
     }"
 
     sizes="@{100 * largestImage.ratioDouble}vh"
+    @* This adds 15 src options to the srcset from 500 to 4000 incrementing by 250px *@
     srcset="@{(500 to 4000 by 250)
         .toList
         .map(width => ImgSrc.srcsetForProfile(views.support.Profile(width = Some(width)), picture, hidpi))

--- a/common/app/views/fragments/image.scala.html
+++ b/common/app/views/fragments/image.scala.html
@@ -18,8 +18,8 @@
     }"
 
     sizes="@{100 * largestImage.ratioDouble}vh"
-    @* This adds 15 src options to the srcset from 500 to 4000 incrementing by 250px *@
-    srcset="@{(500 to 4000 by 250)
+    @* This adds 15 src options to the srcset from 500 to the largest image width incrementing by 250px *@
+    srcset="@{(500 to largestImage.width by 250)
         .toList
         .map(width => ImgSrc.srcsetForProfile(views.support.Profile(width = Some(width)), picture, hidpi))
         .mkString(", ")}" />


### PR DESCRIPTION
This makes come improvements to https://github.com/guardian/frontend/pull/12811

There were some really helpful suggestions by @rich-nguyen and @paperboyo. Fixes and corresponding comment links below:
- [Adding a ratioDouble to imageAsset](https://github.com/guardian/frontend/pull/12811/files#r62668080)) 
- Making sure hidpi sources are rendered first. Fixes: https://github.com/guardian/frontend/pull/12811#issuecomment-218150887
- [instead of ending the widths at 4000px, use the largest image width](https://github.com/guardian/frontend/pull/12811/files#r62706973)
## Request for comment

@rich-nguyen @paperboyo @OliverJAsh 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
