### PR TITLE
Add us briefing email sign up to US news

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -86,6 +86,17 @@ define([
                 modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
+            usBriefing: {
+                listId: '',
+                listName: 'usBriefing',
+                campaignCode: '',
+                headline: 'Sign up for the Guardian US briefing',
+                description: '',
+                successHeadline: 'Thank you for signing up',
+                successDescription: '',
+                modClass: 'end-article',
+                insertMethod: insertBottomOfArticle
+            },
             theGuardianToday: {
                 listId: (function () {
                     switch (config.page.edition) {

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -87,13 +87,13 @@ define([
                 insertMethod: insertBottomOfArticle
             },
             usBriefing: {
-                listId: '',
+                listId: '1493',
                 listName: 'usBriefing',
-                campaignCode: '',
-                headline: 'Sign up for the Guardian US briefing',
-                description: '',
-                successHeadline: 'Thank you for signing up',
-                successDescription: '',
+                campaignCode: 'guardian_today_article_bottom',
+                headline: 'Want stories like this in your inbox?',
+                description: 'Sign up to The Guardian Today daily email and get the biggest headlines each morning.',
+                successHeadline: 'Thank you for signing up to the Guardian Today',
+                successDescription: 'We will send you our picks of the most important headlines tomorrow morning.',
                 modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
@@ -102,9 +102,6 @@ define([
                     switch (config.page.edition) {
                         default:
                             return '37';
-
-                        case 'US':
-                            return '1493';
 
                         case 'AU':
                             return '1506';

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -96,6 +96,9 @@ define([
         theFiver: function () {
             return page.keywordExists(['Football']) && allowedArticleStructure();
         },
+        usBriefing: function () {
+            return config.page.section === 'us-news' && allowedArticleStructure();
+        },
         ausCampaignCatchup: function () {
             return page.keywordExists([
                 'Australia news',


### PR DESCRIPTION
## What does this change?

Runs the us briefing as the priority email sign-up in us-news section.

_Todo_
- [x] Fill in the remaining values

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
