### PR TITLE
Send CSP reports to elasticsearch instead of DynamoDB

### DIFF
--- a/diagnostics/app/controllers/DiagnosticsController.scala
+++ b/diagnostics/app/controllers/DiagnosticsController.scala
@@ -43,7 +43,7 @@ object DiagnosticsController extends Controller with Logging {
   }
 
   def csp = Action(jsonParser) { implicit request =>
-    if (conf.switches.Switches.CspReporting.isSwitchedOn && r.nextInt(100) == 1) {
+    if (conf.switches.Switches.CspReporting.isSwitchedOn) {
       CSP.report(request.body)
     }
 

--- a/diagnostics/app/model/diagnostics/DynamoDbReport.scala
+++ b/diagnostics/app/model/diagnostics/DynamoDbReport.scala
@@ -52,27 +52,3 @@ object CSSDynamoDbReport extends DynamoDbReport[CssReport] {
     }
   }
 }
-
-object CSPDynamoDbReport extends DynamoDbReport[CSPReport] {
-  def report(r: CSPReport): Unit = {
-    val keys: Map[String, AttributeValue] = Map(
-      "documentUri" -> new AttributeValue().withS(r.documentUri),
-      "blockedUri" -> new AttributeValue().withS(r.blockedUri)
-    )
-
-    val count: Map[String, AttributeValueUpdate] = Map(
-      "count" -> new AttributeValueUpdate()
-        .withAction(AttributeAction.ADD)
-        .withValue(new AttributeValue().withN("1"))
-    )
-
-    val update = new UpdateItemRequest()
-      .withTableName("cspReport")
-      .withKey(keys.asJava)
-      .withAttributeUpdates(count.asJava)
-
-    client.updateItemFuture(update) onFailure {
-      case error: Throwable => log.error(s"Failed to log CSP report to DynamoDB: $error", error)
-    }
-  }
-}

--- a/diagnostics/app/model/diagnostics/csp/CSP.scala
+++ b/diagnostics/app/model/diagnostics/csp/CSP.scala
@@ -1,24 +1,42 @@
 package model.diagnostics.csp
 
-import model.diagnostics.CSPDynamoDbReport
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import common.Logging
+import net.logstash.logback.marker.Markers._
 
 case class CSPReport(
+  documentUri: String,
+  referrer: String,
   blockedUri: String,
-  documentUri: String)
+  violatedDirective: String,
+  effectiveDirective: String,
+  originalPolicy: String)
 
 object CSPReport {
   implicit val jsonReads: Reads[CSPReport] = (
-    (__ \ "blocked-uri").read[String] and
-      (__ \ "document-uri").read[String]
+    (__ \ "document-uri").read[String] and
+      (__ \ "referrer").read[String] and
+      (__ \ "blocked-uri").read[String] and
+      (__ \ "violated-directive").read[String] and
+      (__ \ "effective-directive").read[String] and
+      (__ \ "original-policy").read[String]
     )(CSPReport.apply _)
+
+  implicit val jsonWrites: Writes[CSPReport] = (
+    (__ \ "document-uri").write[String] and
+      (__ \ "referrer").write[String] and
+      (__ \ "blocked-uri").write[String] and
+      (__ \ "violated-directive").write[String] and
+      (__ \ "effective-directive").write[String] and
+      (__ \ "original-policy").write[String]
+    )(unlift(CSPReport.unapply))
 }
 
-object CSP {
+object CSP extends Logging {
   def report(requestBody: JsValue): Unit = {
     (requestBody \ "csp-report").validate[CSPReport] match {
-      case JsSuccess(report, _) => CSPDynamoDbReport.report(report)
+      case JsSuccess(report, _) => log.logger.info(appendRaw("csp", Json.toJson(report).toString()), "csp report")
       case JsError(e) => throw new Exception(JsError.toJson(e).toString())
     }
   }

--- a/diagnostics/app/model/diagnostics/csp/CSP.scala
+++ b/diagnostics/app/model/diagnostics/csp/CSP.scala
@@ -1,6 +1,5 @@
 package model.diagnostics.csp
 
-import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import common.Logging
 import net.logstash.logback.marker.Markers._
@@ -14,23 +13,8 @@ case class CSPReport(
   originalPolicy: String)
 
 object CSPReport {
-  implicit val jsonReads: Reads[CSPReport] = (
-    (__ \ "document-uri").read[String] and
-      (__ \ "referrer").read[String] and
-      (__ \ "blocked-uri").read[String] and
-      (__ \ "violated-directive").read[String] and
-      (__ \ "effective-directive").read[String] and
-      (__ \ "original-policy").read[String]
-    )(CSPReport.apply _)
-
-  implicit val jsonWrites: Writes[CSPReport] = (
-    (__ \ "document-uri").write[String] and
-      (__ \ "referrer").write[String] and
-      (__ \ "blocked-uri").write[String] and
-      (__ \ "violated-directive").write[String] and
-      (__ \ "effective-directive").write[String] and
-      (__ \ "original-policy").write[String]
-    )(unlift(CSPReport.unapply))
+  implicit val jsonReads = Json.reads[CSPReport]
+  implicit val jsonWrites = Json.writes[CSPReport]
 }
 
 object CSP extends Logging {

--- a/diagnostics/app/model/diagnostics/csp/CSP.scala
+++ b/diagnostics/app/model/diagnostics/csp/CSP.scala
@@ -1,5 +1,6 @@
 package model.diagnostics.csp
 
+import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import common.Logging
 import net.logstash.logback.marker.Markers._
@@ -13,8 +14,23 @@ case class CSPReport(
   originalPolicy: String)
 
 object CSPReport {
-  implicit val jsonReads = Json.reads[CSPReport]
-  implicit val jsonWrites = Json.writes[CSPReport]
+  implicit val jsonReads: Reads[CSPReport] = (
+    (__ \ "document-uri").read[String] and
+      (__ \ "referrer").read[String] and
+      (__ \ "blocked-uri").read[String] and
+      (__ \ "violated-directive").read[String] and
+      (__ \ "effective-directive").read[String] and
+      (__ \ "original-policy").read[String]
+    )(CSPReport.apply _)
+
+  implicit val jsonWrites: Writes[CSPReport] = (
+    (__ \ "document-uri").write[String] and
+      (__ \ "referrer").write[String] and
+      (__ \ "blocked-uri").write[String] and
+      (__ \ "violated-directive").write[String] and
+      (__ \ "effective-directive").write[String] and
+      (__ \ "original-policy").write[String]
+    )(unlift(CSPReport.unapply))
 }
 
 object CSP extends Logging {


### PR DESCRIPTION
A second attempt at storing these. Dynamo was too restrictive for the type of queries we want to do.

@TBonnin 
