### PR TITLE
Refactor CachedHealthCheck

### DIFF
--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -81,49 +81,64 @@ private[conf] trait HealthCheckCache extends HealthCheckFetcher {
   protected val cache = AkkaAgent[List[HealthCheckResult]](List[HealthCheckResult]())
   def get() = cache.get()
 
-  def allSuccessful: Boolean = {
-    get() match {
-      case Nil => false
-      case nonEmpty => nonEmpty.forall(_.recentlySucceed)
-    }
-  }
-  def anySuccessful: Boolean = get().exists(_.recentlySucceed)
-
   def fetchPaths(testPort: Int, paths: String*): Future[Unit] = {
     log.info("Fetching HealthChecks...")
     fetchResults(testPort, paths:_*).map(allResults => cache.send(allResults.toList))
   }
+
 }
 
-trait CachedHealthCheckController extends Controller with Results with ExecutionContexts with Logging {
+sealed trait Policy
+object HealthCheckPolicy {
+  case object All extends Policy
+  case object Any extends Policy
+}
 
-  val paths: Seq[String]
-  val testPort: Int
-
+trait HealthCheckGenericController extends Controller {
   def healthCheck(): Action[AnyContent]
+}
+
+class CachedHealthCheck(policy: Policy, testPort: Int, paths: String*) extends HealthCheckGenericController with Results with ExecutionContexts with Logging {
+
   private[conf] val cache: HealthCheckCache = new HealthCheckCache {}
 
-  def runChecks: Future[Unit] = cache.fetchPaths(testPort, paths:_*)
+  private def allSuccessful(results: List[HealthCheckResult]): Boolean = {
+    results match {
+      case Nil => false
+      case nonEmpty => nonEmpty.forall(_.recentlySucceed)
+    }
+  }
+  private def anySuccessful(results: List[HealthCheckResult]): Boolean = results.exists(_.recentlySucceed)
+  private def successful(results: List[HealthCheckResult]): Boolean = policy match {
+    case HealthCheckPolicy.All => allSuccessful(results)
+    case HealthCheckPolicy.Any => anySuccessful(results)
+  }
 
-  private def healthCheckResponse(condition: => Boolean): Action[AnyContent] = Action.async {
+  def healthCheck(): Action[AnyContent] = Action.async {
     Future.successful {
-      val response = cache.get().map {
+      val results = cache.get
+      val response = results.map {
         case r: HealthCheckResult => s"GET ${r.url} '${r.formattedResult}' '${r.formattedDate}'"
       }
         .mkString("\n")
-      if(condition) Ok(response) else ServiceUnavailable(response)
+      if(successful(results)) Ok(response) else ServiceUnavailable(response)
     }
   }
 
-  def healthCheckAll(): Action[AnyContent] = healthCheckResponse(cache.allSuccessful)
-  def healthCheckAny(): Action[AnyContent] = healthCheckResponse(cache.anySuccessful)
+  def runChecks: Future[Unit] = cache.fetchPaths(testPort, paths:_*)
 }
+
+case class AllGoodCachedHealthCheck(testPort: Int, paths: String*)
+  extends CachedHealthCheck(HealthCheckPolicy.All, testPort, paths:_*)
+
+case class AnyGoodCachedHealthCheck(testPort: Int, paths: String*)
+  extends CachedHealthCheck(HealthCheckPolicy.Any, testPort, paths:_*)
 
 trait CachedHealthCheckLifeCycle extends GlobalSettings {
 
   private val healthCheckRequestFrequencyInSec = 5
 
-  val healthCheckController: CachedHealthCheckController
+  val healthCheckController: CachedHealthCheck
 
   override def onStart(app: PlayApp) = {
     super.onStart(app)

--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -88,17 +88,17 @@ private[conf] trait HealthCheckCache extends HealthCheckFetcher {
 
 }
 
-sealed trait Policy
+sealed trait HealthCheckPolicy
 object HealthCheckPolicy {
-  case object All extends Policy
-  case object Any extends Policy
+  case object All extends HealthCheckPolicy
+  case object Any extends HealthCheckPolicy
 }
 
 trait HealthCheckGenericController extends Controller {
   def healthCheck(): Action[AnyContent]
 }
 
-class CachedHealthCheck(policy: Policy, testPort: Int, paths: String*) extends HealthCheckGenericController with Results with ExecutionContexts with Logging {
+class CachedHealthCheck(policy: HealthCheckPolicy, testPort: Int, paths: String*) extends HealthCheckGenericController with Results with ExecutionContexts with Logging {
 
   private[conf] val cache: HealthCheckCache = new HealthCheckCache {}
 

--- a/common/test/conf/CachedHealthCheckTest.scala
+++ b/common/test/conf/CachedHealthCheckTest.scala
@@ -24,7 +24,7 @@ class CachedHealthCheckTest extends WordSpec with Matchers with SingleServerSuit
   }
 
   // Test helper method
-  def getHealthCheck(mockResults: List[HealthCheckResult], policy: Policy)(testBlock: Future[Result] => Unit) = {
+  def getHealthCheck(mockResults: List[HealthCheckResult], policy: HealthCheckPolicy)(testBlock: Future[Result] => Unit) = {
 
     // Create a CachedHealthCheck controller with mock results
     val mockPaths: Seq[String] = mockResults.map(_.url)

--- a/common/test/conf/CachedHealthCheckTest.scala
+++ b/common/test/conf/CachedHealthCheckTest.scala
@@ -3,7 +3,7 @@ package conf
 import common.ExecutionContexts
 import org.joda.time.DateTime
 import org.scalatest.{WordSpec, Matchers}
-import play.api.mvc.{AnyContent, Action, Result}
+import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import test.SingleServerSuite
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random
 
-class CachedHealthCheckControllerTest extends WordSpec with Matchers with SingleServerSuite with ScalaFutures with ExecutionContexts {
+class CachedHealthCheckTest extends WordSpec with Matchers with SingleServerSuite with ScalaFutures with ExecutionContexts {
 
   //Helper method to construct mock Results
   def mockResult(statusCode: Int, date: DateTime = DateTime.now, expiration: Duration = 10.seconds): HealthCheckResult = {
@@ -23,34 +23,26 @@ class CachedHealthCheckControllerTest extends WordSpec with Matchers with Single
     }
   }
 
-  sealed trait HealthCheckType
-  object HealthCheckTypes {
-    object All extends HealthCheckType
-    object Any extends HealthCheckType
-  }
   // Test helper method
-  def getHealthCheck(mockResults: List[HealthCheckResult], `type`: HealthCheckType)(testBlock: Future[Result] => Unit) = {
+  def getHealthCheck(mockResults: List[HealthCheckResult], policy: Policy)(testBlock: Future[Result] => Unit) = {
 
-    // Create a CachedHealthCheckController with mock results
-    val controller = new CachedHealthCheckController {
-      override val paths: Seq[String] = mockResults.map(_.url)
-      override val testPort: Int = 9008
-      override def healthCheck(): Action[AnyContent] = `type` match {
-        case HealthCheckTypes.All => healthCheckAll()
-        case HealthCheckTypes.Any => healthCheckAny()
-      }
+    // Create a CachedHealthCheck controller with mock results
+    val mockPaths: Seq[String] = mockResults.map(_.url)
+    val mockTestPort: Int = 9100
+    val controller = new CachedHealthCheck(policy, mockTestPort, mockPaths:_*) {
       override val cache = new HealthCheckCache {
         override def fetchResults(testPort: Int, paths: String*): Future[Seq[HealthCheckResult]] = {
           Future.successful(mockResults)
         }
       }
     }
-    // 2. Run the fetch to populate the cache and wait for it to finish
+
+    // Populate the cache and wait for it to finish
     whenReady(controller.runChecks) { _ =>
-      // 3. Call the /_healthcheck endpoint on this controller
+      // Call the /_healthcheck endpoint on this controller
       val healthCheckRequest = FakeRequest(method = "GET", path = "/_healthcheck")
       val response = call(controller.healthCheck(), healthCheckRequest)
-      // 4. Pass the response to the testBlock
+      // Pass the response to the testBlock
       testBlock(response)
     }
   }
@@ -59,7 +51,7 @@ class CachedHealthCheckControllerTest extends WordSpec with Matchers with Single
     "all requests must be successful" when {
       "cache result is empty" should {
         "503" in {
-          getHealthCheck(List(), HealthCheckTypes.All) { response =>
+          getHealthCheck(List(), HealthCheckPolicy.All) { response =>
             status(response) should be(503)
           }
         }
@@ -69,7 +61,7 @@ class CachedHealthCheckControllerTest extends WordSpec with Matchers with Single
           val expiration = 5.seconds
           val date = DateTime.now.minus(expiration.toMillis + 1)
           val mockResults = List(mockResult(200, date, expiration))
-          getHealthCheck(mockResults, HealthCheckTypes.All) { response =>
+          getHealthCheck(mockResults, HealthCheckPolicy.All) { response =>
             status(response) should be (503)
           }
         }
@@ -77,7 +69,7 @@ class CachedHealthCheckControllerTest extends WordSpec with Matchers with Single
       "only one cached result is successful" should {
         "503" in {
           val mockResults = List(mockResult(500), mockResult(200))
-          getHealthCheck(mockResults, HealthCheckTypes.All) { response =>
+          getHealthCheck(mockResults, HealthCheckPolicy.All) { response =>
             status(response) should be(503)
           }
         }
@@ -85,7 +77,7 @@ class CachedHealthCheckControllerTest extends WordSpec with Matchers with Single
       "cached results are all successful" should {
         "200" in {
           val mockResults = List(mockResult(200), mockResult(200))
-          getHealthCheck(mockResults, HealthCheckTypes.All) { response =>
+          getHealthCheck(mockResults, HealthCheckPolicy.All) { response =>
             status(response) should be (200)
           }
         }
@@ -94,7 +86,7 @@ class CachedHealthCheckControllerTest extends WordSpec with Matchers with Single
     "at least one request must be successful" when {
       "cache result is empty" should {
         "503" in {
-          getHealthCheck(List(), HealthCheckTypes.Any) { response =>
+          getHealthCheck(List(), HealthCheckPolicy.Any) { response =>
             status(response) should be(503)
           }
         }
@@ -104,7 +96,7 @@ class CachedHealthCheckControllerTest extends WordSpec with Matchers with Single
           val expiration = 5.seconds
           val date = DateTime.now.minus(expiration.toMillis + 1)
           val mockResults = List(mockResult(200, date, expiration), mockResult(404))
-          getHealthCheck(mockResults, HealthCheckTypes.Any) { response =>
+          getHealthCheck(mockResults, HealthCheckPolicy.Any) { response =>
             status(response) should be(503)
           }
         }
@@ -112,7 +104,7 @@ class CachedHealthCheckControllerTest extends WordSpec with Matchers with Single
       "no cached result is successful" should {
         "503" in {
           val mockResults = List(mockResult(400), mockResult(500))
-          getHealthCheck(mockResults, HealthCheckTypes.Any) { response =>
+          getHealthCheck(mockResults, HealthCheckPolicy.Any) { response =>
             status(response) should be(503)
           }
         }
@@ -120,7 +112,7 @@ class CachedHealthCheckControllerTest extends WordSpec with Matchers with Single
       "one cached result is successful" should {
         "200" in {
           val mockResults = List(mockResult(200), mockResult(404))
-          getHealthCheck(mockResults, HealthCheckTypes.Any) { response =>
+          getHealthCheck(mockResults, HealthCheckPolicy.Any) { response =>
             status(response) should be(200)
           }
         }

--- a/facia/app/conf/HealthCheck.scala
+++ b/facia/app/conf/HealthCheck.scala
@@ -1,11 +1,7 @@
 package conf
 
-object HealthCheckController extends CachedHealthCheckController {
-  override val paths = Seq("/uk/business")
-  override val testPort = 9008
-  override def healthCheck() = healthCheckAll()
-}
+object HealthCheck extends AllGoodCachedHealthCheck(9008, "/uk/business")
 
 trait FaciaHealthCheckLifeCycle extends CachedHealthCheckLifeCycle {
-  override val healthCheckController = HealthCheckController
+  override val healthCheckController = HealthCheck
 }

--- a/facia/conf/routes
+++ b/facia/conf/routes
@@ -6,8 +6,8 @@
 # For dev machines
 GET        /assets/*path                                                            dev.DevAssetsController.at(path)
 
-GET        /_healthcheck                                                            conf.HealthCheckController.healthCheck()
-GET        /_fronts_cdn_healthcheck                                                 conf.HealthCheckController.healthCheck()
+GET        /_healthcheck                                                            conf.HealthCheck.healthCheck()
+GET        /_fronts_cdn_healthcheck                                                 conf.HealthCheck.healthCheck()
 
 GET        /_agentcontents                                                          controllers.FaciaController.renderAgentContents
 

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -51,5 +51,5 @@ class FaciaTestSuite extends Suites (
   new FaciaControllerTest,
   new metadata.FaciaMetaDataTest
 ) with SingleServerSuite {
-  override lazy val port: Int = conf.HealthCheckController.testPort
+  override lazy val port: Int = conf.HealthCheck.testPort
 }


### PR DESCRIPTION
## What does this change?

While looking into applying cached healthcheck to the other services, I
figured out I could simplify the way CachedHealthCheck is structured.
See benefits below

A PR that moves all services to cached healthcheck will follow
## What is the value of this and can you measure success?

This patch has the following benefits:
- Create abstract Trait so services like facia-press can define their own healthcheck custom logic
- Avoid overriding trait vals
- Easier to define service's own healthcheck controller object
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
