### PR TITLE
Welcome message for first time users and dummy A/B test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -67,4 +67,13 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 7, 29),
     exposeClientSide = true
   )
+
+  val ABWelcomeHeader = Switch(
+    SwitchGroup.ABTests,
+    "ab-welcome-header",
+    "Welcome header for first time users test",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 5, 31),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -73,7 +73,7 @@ trait ABTestSwitches {
     "ab-welcome-header",
     "Welcome header for first time users test",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 14),
+    sellByDate = new LocalDate(2016, 5, 19),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -73,7 +73,7 @@ trait ABTestSwitches {
     "ab-welcome-header",
     "Welcome header for first time users test",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 13),
+    sellByDate = new LocalDate(2016, 5, 14),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -73,7 +73,7 @@ trait ABTestSwitches {
     "ab-welcome-header",
     "Welcome header for first time users test",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 31),
+    sellByDate = new LocalDate(2016, 5, 13),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -12,6 +12,7 @@ define([
     'common/modules/experiments/tests/minute',
     'common/modules/experiments/tests/participation-star-ratings',
     'common/modules/experiments/tests/clever-friend-brexit',
+    'common/modules/experiments/tests/welcome-header',
     'lodash/arrays/flatten',
     'lodash/arrays/zip',
     'lodash/collections/forEach',
@@ -39,6 +40,7 @@ define([
     Minute,
     ParticipationStarRatings,
     CleverFriendBrexit,
+    WelcomeHeader,
     flatten,
     zip,
     forEach,
@@ -61,7 +63,8 @@ define([
         new LoyalAdblockingSurvey(),
         new Minute(),
         new ParticipationStarRatings(),
-        new CleverFriendBrexit()
+        new CleverFriendBrexit(),
+        new WelcomeHeader()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -16,8 +16,8 @@ define([
             cookieVal = cookies.get(COOKIE_WELCOME_BANNER);
 
         this.id = 'WelcomeHeader';
-        this.start = '2016-05-12';
-        this.expiry = '2016-05-13';
+        this.start = '2016-05-13';
+        this.expiry = '2016-05-14';
         this.author = 'Maria Livia Chiorean';
         this.description = 'Show a welcome header for first time users.';
         this.audience = 1;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -1,6 +1,6 @@
 define([
     'common/utils/config',
-    'common/modules/ui/welcomeBanner',
+    'common/modules/ui/welcome-banner',
     'common/utils/detect',
     'common/utils/cookies'
 ], function (config, welcomeHeader, detect, cookies) {
@@ -27,12 +27,12 @@ define([
         this.variants = [{
             id: 'test1',
             test: function () {
-                cookies.add(COOKIE_WELCOME_BANNER, 1);
+
             }
         }, {
             id: 'test2',
             test: function () {
-                cookies.add(COOKIE_WELCOME_BANNER, 1);
+
             }
         }];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -16,8 +16,8 @@ define([
             cookieVal = cookies.get(COOKIE_WELCOME_BANNER);
 
         this.id = 'WelcomeHeader';
-        this.start = '2016-05-13';
-        this.expiry = '2016-05-14';
+        this.start = '2016-05-12';
+        this.expiry = '2016-05-18';
         this.author = 'Maria Livia Chiorean';
         this.description = 'Show a welcome header for first time users.';
         this.audience = 1;
@@ -27,9 +27,9 @@ define([
 
         this.canRun = function () {
             var firstTimeVisitor = false;
-            if (storage.local.isStorageAvailable()) {
+            if (!cookieVal && storage.local.isStorageAvailable()) {
                 var alreadyVisited = storage.local.get('gu.alreadyVisited');
-                if ((!alreadyVisited || alreadyVisited == 1) && !cookieVal) {
+                if (!alreadyVisited || alreadyVisited == 1) {
                     firstTimeVisitor = true;
                     cookies.add(COOKIE_WELCOME_BANNER, 1);
                 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -21,9 +21,7 @@ define([
         this.idealOutcome = 'People come back more after the first visit.';
 
         this.canRun = function () {
-            return !config.page.isFront &&
-                ((detect.isIOS() || detect.isAndroid()) && !detect.isFireFoxOSApp()) &&
-                !cookieVal;
+            return detect.isBreakpoint({max: 'mobile'}) && !cookieVal;
         };
 
         this.variants = [{

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -11,8 +11,8 @@ define([
             cookieVal = cookies.get(COOKIE_WELCOME_BANNER);
 
         this.id = 'WelcomeHeader';
-        this.start = '2016-03-21';
-        this.expiry = '2016-05-31';
+        this.start = '2016-05-12';
+        this.expiry = '2016-05-13';
         this.author = 'Maria Livia Chiorean';
         this.description = 'Show a welcome header for first time users.';
         this.audience = 1;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -2,11 +2,16 @@ define([
     'common/utils/config',
     'common/modules/ui/welcome-banner',
     'common/utils/detect',
-    'common/utils/cookies'
-], function (config, welcomeHeader, detect, cookies) {
-
+    'common/utils/cookies',
+    'common/utils/storage'
+], function (
+    config,
+    welcomeHeader,
+    detect,
+    cookies,
+    storage
+) {
     return function () {
-
         var COOKIE_WELCOME_BANNER = 'GU_WELCOMEBANNER',
             cookieVal = cookies.get(COOKIE_WELCOME_BANNER);
 
@@ -17,11 +22,19 @@ define([
         this.description = 'Show a welcome header for first time users.';
         this.audience = 1;
         this.audienceOffset = 0;
-        this.audienceCriteria = 'All users';
+        this.audienceCriteria = 'First time users';
         this.idealOutcome = 'People come back more after the first visit.';
 
         this.canRun = function () {
-            return detect.isBreakpoint({max: 'mobile'}) && !cookieVal;
+            var firstTimeVisitor = false;
+            if (storage.local.isStorageAvailable()) {
+                var alreadyVisited = storage.local.get('gu.alreadyVisited');
+                if ((!alreadyVisited || alreadyVisited == 1) && !cookieVal) {
+                    firstTimeVisitor = true;
+                    cookies.add(COOKIE_WELCOME_BANNER, 1);
+                }
+            }
+            return detect.isBreakpoint({max: 'mobile'}) && firstTimeVisitor;
         };
 
         this.variants = [{

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -1,0 +1,43 @@
+define([
+    'common/utils/config',
+    'common/modules/ui/welcomeBanner',
+    'common/utils/detect',
+    'common/utils/cookies'
+], function (config, welcomeHeader, detect, cookies) {
+
+    return function () {
+
+        var COOKIE_WELCOME_BANNER = 'GU_WELCOMEBANNER',
+            cookieVal = cookies.get(COOKIE_WELCOME_BANNER);
+
+        this.id = 'WelcomeHeader';
+        this.start = '2016-03-21';
+        this.expiry = '2016-05-31';
+        this.author = 'Maria Livia Chiorean';
+        this.description = 'Show a welcome header for first time users.';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.audienceCriteria = 'All users';
+        this.idealOutcome = 'People come back more after the first visit.';
+
+        this.canRun = function () {
+            return !config.page.isFront &&
+                ((detect.isIOS() || detect.isAndroid()) && !detect.isFireFoxOSApp()) &&
+                !cookieVal;
+        };
+
+        this.variants = [{
+            id: 'test1',
+            test: function () {
+                cookies.add(COOKIE_WELCOME_BANNER, 1);
+            }
+        }, {
+            id: 'test2',
+            test: function () {
+                cookies.add(COOKIE_WELCOME_BANNER, 1);
+            }
+        }];
+
+    };
+
+});

--- a/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
@@ -17,8 +17,8 @@ define([
      */
     var header = document.getElementById('header'),
         message1 = '<div class="banner-message"><%=HTML%></div>',
-        DATA = {
-            MESSAGE1: {
+        data = {
+            message1: {
                 HTML: '<span class="pull-left">news website</span><span class="pull-right">of the year</span>'
             }
         };
@@ -30,14 +30,14 @@ define([
     }
 
     function createAndSetHeader(messageNumber) {
-        var headerDiv = document.createElement('DIV'),
-            msg = template(message1, DATA[messageNumber.toUpperCase()]);
+        var headerDiv = document.createElement('div'),
+            msg = template(message1, data[messageNumber]);
 
-        headerDiv.setAttribute('id', 'welcomeBanner');
+        headerDiv.setAttribute('id', 'welcome-banner');
         headerDiv.setAttribute('style', 'height:' + header.offsetHeight + 'px;');
         headerDiv.innerHTML = msg;
 
-        header.getElementsByClassName('l-header-main')[0].setAttribute('style', 'z-index:1200;');
+        header.getElementsByClassName('l-header-main')[0].style.zIndex = 1200;
 
         header.appendChild(headerDiv);
     }

--- a/static/src/javascripts/projects/common/modules/ui/welcomeBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/welcomeBanner.js
@@ -15,7 +15,7 @@ define([
      * Rules:
      * 1st visit replace nav bar with banner
      */
-    var header = document.getElementById("header"),
+    var header = document.getElementById('header'),
         message1 = '<div class="banner-message"><%=HTML%></div>',
         DATA = {
             MESSAGE1: {
@@ -30,14 +30,14 @@ define([
     }
 
     function createAndSetHeader(messageNumber) {
-        var headerDiv = document.createElement("DIV"),
+        var headerDiv = document.createElement('DIV'),
             msg = template(message1, DATA[messageNumber.toUpperCase()]);
 
-        headerDiv.setAttribute("id", "welcomeBanner");
-        headerDiv.setAttribute("style", "height:" + header.offsetHeight + "px;");
+        headerDiv.setAttribute('id', 'welcomeBanner');
+        headerDiv.setAttribute('style', 'height:' + header.offsetHeight + 'px;');
         headerDiv.innerHTML = msg;
 
-        header.getElementsByClassName("l-header-main")[0].setAttribute("style", "z-index:1200;");
+        header.getElementsByClassName('l-header-main')[0].setAttribute('style', 'z-index:1200;');
 
         header.appendChild(headerDiv);
     }

--- a/static/src/javascripts/projects/common/modules/ui/welcomeBanner.js
+++ b/static/src/javascripts/projects/common/modules/ui/welcomeBanner.js
@@ -1,0 +1,48 @@
+define([
+    'fastdom',
+    'common/utils/$',
+    'common/utils/storage',
+    'common/utils/template',
+    'common/utils/load-css-promise'
+], function (
+    fastdom,
+    $,
+    storage,
+    template,
+    loadCssPromise
+) {
+    /**
+     * Rules:
+     * 1st visit replace nav bar with banner
+     */
+    var header = document.getElementById("header"),
+        message1 = '<div class="banner-message"><%=HTML%></div>',
+        DATA = {
+            MESSAGE1: {
+                HTML: '<span class="pull-left">news website</span><span class="pull-right">of the year</span>'
+            }
+        };
+
+    function showWelcomeMessage(messageNumber) {
+        loadCssPromise.then(function () {
+            createAndSetHeader(messageNumber);
+        });
+    }
+
+    function createAndSetHeader(messageNumber) {
+        var headerDiv = document.createElement("DIV"),
+            msg = template(message1, DATA[messageNumber.toUpperCase()]);
+
+        headerDiv.setAttribute("id", "welcomeBanner");
+        headerDiv.setAttribute("style", "height:" + header.offsetHeight + "px;");
+        headerDiv.innerHTML = msg;
+
+        header.getElementsByClassName("l-header-main")[0].setAttribute("style", "z-index:1200;");
+
+        header.appendChild(headerDiv);
+    }
+
+    return {
+        showWelcomeMessage: showWelcomeMessage
+    };
+});

--- a/static/src/stylesheets/head.content.scss
+++ b/static/src/stylesheets/head.content.scss
@@ -24,6 +24,7 @@
 @import 'module/_chapters';
 @import 'module/content/_article-immersive';
 @import 'module/content/_article-minute';
+@import 'module/test-welcome-header';
 
 
 /* ==========================================================================

--- a/static/src/stylesheets/module/_test-welcome-header.scss
+++ b/static/src/stylesheets/module/_test-welcome-header.scss
@@ -10,7 +10,7 @@
     width: 100%;
     font-size: 1.7rem;
     line-height: 1.65rem;
-    font-family: "Guardian Egyptian Web","Guardian Text Egyptian Web",Georgia,serif;
+    font-family: 'Guardian Egyptian Web', 'Guardian Text Egyptian Web', Georgia, serif;
     font-weight: 800;
 }
 

--- a/static/src/stylesheets/module/_test-welcome-header.scss
+++ b/static/src/stylesheets/module/_test-welcome-header.scss
@@ -1,0 +1,41 @@
+/* Test welcome header for first time users
+   ========================================================================== */
+
+#welcomeBanner {
+    color: rgb(170, 220, 230);
+    background: #005689;
+    position: absolute;
+    top: 0;
+    z-index: 1100;
+    width: 100%;
+    font-size: 1.7rem;
+    line-height: 1.65rem;
+    font-family: "Guardian Egyptian Web","Guardian Text Egyptian Web",Georgia,serif;
+    font-weight: 800;
+}
+
+#welcomeBanner .banner-message {
+    @include mq($until: tablet) {
+        margin: $gs-gutter/4 $gs-gutter/2;
+    }
+    @include mq(tablet, desktop) {
+        margin: $gs-gutter/4 $gs-gutter;
+    }
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+#welcomeBanner span {
+    width: 100%;
+    display: block;
+}
+
+#welcomeBanner .pull-left {
+    text-align: left;
+}
+
+#welcomeBanner .pull-right {
+    text-align: right;
+}

--- a/static/src/stylesheets/module/_test-welcome-header.scss
+++ b/static/src/stylesheets/module/_test-welcome-header.scss
@@ -1,7 +1,7 @@
 /* Test welcome header for first time users
    ========================================================================== */
 
-#welcomeBanner {
+#welcome-banner {
     color: rgb(170, 220, 230);
     background: #005689;
     position: absolute;
@@ -14,7 +14,7 @@
     font-weight: 800;
 }
 
-#welcomeBanner .banner-message {
+#welcome-banner .banner-message {
     @include mq($until: tablet) {
         margin: $gs-gutter/4 $gs-gutter/2;
     }
@@ -27,15 +27,15 @@
     bottom: 0;
 }
 
-#welcomeBanner span {
+#welcome-banner span {
     width: 100%;
     display: block;
 }
 
-#welcomeBanner .pull-left {
+#welcome-banner .pull-left {
     text-align: left;
 }
 
-#welcomeBanner .pull-right {
+#welcome-banner .pull-right {
     text-align: right;
 }


### PR DESCRIPTION
## What does this change?

Adds a new functionality for showing a welcome banner to first time users. The A/B tests added at the moment are dummy tests created to run for one day for all the people. The purpose of this is for the data team to measure how many new users we have in a day and what percentage we need for the real tests.
## Request for comment

@stephanfowler @zeftilldeath @harrysalmon 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
