### PR TITLE
Fix potential race condition in CachedHealthCheckTest

### DIFF
--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -81,9 +81,8 @@ private[conf] trait HealthCheckCache extends HealthCheckFetcher {
   protected val cache = AkkaAgent[List[HealthCheckResult]](List[HealthCheckResult]())
   def get() = cache.get()
 
-  def fetchPaths(testPort: Int, paths: String*): Future[Unit] = {
-    log.info("Fetching HealthChecks...")
-    fetchResults(testPort, paths:_*).map(allResults => cache.send(allResults.toList))
+  def fetchPaths(testPort: Int, paths: String*): Future[List[HealthCheckResult]] = {
+    fetchResults(testPort, paths:_*).flatMap(allResults => cache.alter(allResults.toList))
   }
 
 }
@@ -125,7 +124,7 @@ class CachedHealthCheck(policy: HealthCheckPolicy, testPort: Int, paths: String*
     }
   }
 
-  def runChecks: Future[Unit] = cache.fetchPaths(testPort, paths:_*)
+  def runChecks: Future[Unit] = cache.fetchPaths(testPort, paths:_*).map(_ => Nil)
 }
 
 case class AllGoodCachedHealthCheck(testPort: Int, paths: String*)


### PR DESCRIPTION
## What does this change?

Tests wait for the Future returned by `runChecks` to be completed before
to execute the tests. However since the cache value is dispatched to the
AkkaAgent, it was possible for the initial Future to complete without
the AkkaAgent to be fully updated
This patch ensures this doesn't happen
## What is the value of this and can you measure success?

Make sure CachedHealthCheckTest do not randomly fail
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

No
## Request for comment

@alexduf

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
