### PR TITLE
Play 2.5 environment

### DIFF
--- a/admin-jobs/app/Global.scala
+++ b/admin-jobs/app/Global.scala
@@ -1,5 +1,5 @@
 import common.Logback.Logstash
-import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
+import common.{ApplicationMode, CloudWatchApplicationMetrics, ContentApiMetrics}
 import conf.{Filters, SwitchboardLifecycle}
 import contentapi.SectionsLookUpLifecycle
 import dev.DevParametersLifecycle
@@ -9,13 +9,14 @@ import play.api.mvc.WithFilters
 import services.ConfigAgentLifecycle
 
 object Global extends WithFilters(Filters.common: _*)
-with ConfigAgentLifecycle
-with DevParametersLifecycle
-with CloudWatchApplicationMetrics
-with SurgingContentAgentLifecycle
-with SectionsLookUpLifecycle
-with SwitchboardLifecycle
-with Logstash {
+  with ApplicationMode
+  with ConfigAgentLifecycle
+  with DevParametersLifecycle
+  with CloudWatchApplicationMetrics
+  with SurgingContentAgentLifecycle
+  with SectionsLookUpLifecycle
+  with SwitchboardLifecycle
+  with Logstash {
   override lazy val applicationName = "frontend-admin-jobs"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ List(

--- a/admin/app/Global.scala
+++ b/admin/app/Global.scala
@@ -1,4 +1,4 @@
-import common.CloudWatchApplicationMetrics
+import common.{ApplicationMode, CloudWatchApplicationMetrics}
 import common.Logback.Logstash
 import common.dfp.DfpAgentLifecycle
 import conf.{Gzipper, SwitchboardLifecycle}
@@ -12,6 +12,7 @@ import services.ConfigAgentLifecycle
 import scala.concurrent.Future
 
 object Global extends WithFilters(Gzipper)
+  with ApplicationMode
   with AdminLifecycle
   with ConfigAgentLifecycle
   with SwitchboardLifecycle

--- a/applications/app/Global.scala
+++ b/applications/app/Global.scala
@@ -1,6 +1,6 @@
 import common.Logback.Logstash
 import common.dfp.DfpAgentLifecycle
-import common.{CloudWatchApplicationMetrics, ContentApiMetrics, EmailSubsciptionMetrics}
+import common.{ApplicationMode, CloudWatchApplicationMetrics, ContentApiMetrics, EmailSubsciptionMetrics}
 import conf.{CorsErrorHandler, Filters, SwitchboardLifecycle}
 import contentapi.SectionsLookUpLifecycle
 import dev.DevParametersLifecycle
@@ -11,6 +11,7 @@ import play.api.mvc.WithFilters
 import services.{ConfigAgentLifecycle, IndexListingsLifecycle}
 
 object Global extends WithFilters(Filters.common: _*)
+  with ApplicationMode
   with ConfigAgentLifecycle
   with DevParametersLifecycle
   with CloudWatchApplicationMetrics

--- a/archive/app/Global.scala
+++ b/archive/app/Global.scala
@@ -1,4 +1,4 @@
-import common.CloudWatchApplicationMetrics
+import common.{ApplicationMode, CloudWatchApplicationMetrics}
 import common.Logback.Logstash
 import conf.{SwitchboardLifecycle, CorsErrorHandler, Filters}
 import dev.DevParametersLifecycle
@@ -6,6 +6,7 @@ import play.api.mvc.WithFilters
 import services.ArchiveMetrics
 
 object Global extends WithFilters(Filters.common: _*)
+  with ApplicationMode
   with DevParametersLifecycle
   with CloudWatchApplicationMetrics
   with ArchiveMetrics

--- a/article/app/Global.scala
+++ b/article/app/Global.scala
@@ -1,6 +1,6 @@
 import common.Logback.Logstash
 import common.dfp.DfpAgentLifecycle
-import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
+import common.{ApplicationMode, CloudWatchApplicationMetrics, ContentApiMetrics}
 import conf.{CorsErrorHandler, Filters, SwitchboardLifecycle}
 import dev.DevParametersLifecycle
 import metrics.FrontendMetric
@@ -10,6 +10,7 @@ import services.NewspaperBooksAndSectionsAutoRefresh
 
 object Global
   extends WithFilters(Filters.common: _*)
+  with ApplicationMode
   with NewspaperBooksAndSectionsAutoRefresh
   with DevParametersLifecycle
   with DfpAgentLifecycle

--- a/commercial/app/Global.scala
+++ b/commercial/app/Global.scala
@@ -12,6 +12,7 @@ package object CommercialMetrics {
 }
 
 object Global extends WithFilters(Filters.common: _*)
+  with ApplicationMode
   with CommercialLifecycle
   with DevParametersLifecycle
   with SwitchboardLifecycle

--- a/common/app/assets/assets.scala
+++ b/common/app/assets/assets.scala
@@ -1,14 +1,15 @@
 package common.Assets
 
 import java.net.URL
-import common.{Logging, RelativePathEscaper}
+
+import common.{ApplicationMode, Logging, RelativePathEscaper}
 import conf.Configuration
 import org.apache.commons.io.IOUtils
 import play.api.libs.json._
 import play.api.{Mode, Play}
 import play.api.Play.current
 
-import scala.collection.concurrent.{Map => ConcurrentMap, TrieMap}
+import scala.collection.concurrent.{TrieMap, Map => ConcurrentMap}
 import scala.util.control.NonFatal
 
 case class Asset(path: String) {
@@ -106,7 +107,7 @@ class Assets(base: String) extends Logging {
       val url = AssetFinder(resourceName)
 
       // Reload css on every access in DEV
-      if (Play.current.mode == Mode.Dev) {
+      if (ApplicationMode.mode == Mode.Dev) {
         memoizedCss.remove(url)
       }
 

--- a/common/app/common/ApplicationMode.scala
+++ b/common/app/common/ApplicationMode.scala
@@ -15,5 +15,6 @@ trait ApplicationMode extends GlobalSettings with Logging {
   override def onStart(app: Application): Unit = {
     log.info(s"Setting the application mode to ${app.mode}")
     ApplicationMode.setMode(app.mode)
+    super.onStart(app)
   }
 }

--- a/common/app/common/ApplicationMode.scala
+++ b/common/app/common/ApplicationMode.scala
@@ -1,0 +1,19 @@
+package common
+
+import play.api.{Application, GlobalSettings}
+import play.api.Mode._
+
+object ApplicationMode {
+  private var theMode = Prod
+  def mode: Mode = theMode
+  def setMode(theMode: Mode) = {
+    this.theMode = theMode
+  }
+}
+
+trait ApplicationMode extends GlobalSettings with Logging {
+  override def onStart(app: Application): Unit = {
+    log.info(s"Setting the application mode to ${app.mode}")
+    ApplicationMode.setMode(app.mode)
+  }
+}

--- a/common/app/conf/AllGoodHealthcheckController.scala
+++ b/common/app/conf/AllGoodHealthcheckController.scala
@@ -2,8 +2,8 @@ package conf
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import common.ExecutionContexts
-import play.api.{Mode, Play}
+import common.{ApplicationMode, ExecutionContexts}
+import play.api.Mode
 import play.api.libs.ws.WS
 import play.api.mvc._
 
@@ -15,7 +15,7 @@ trait HealthcheckController extends Controller with Results with ExecutionContex
   def testPort: Int
 
   lazy val port = {
-    Play.current.mode match {
+    ApplicationMode.mode match {
       case Mode.Test => testPort
       case _ => 9000
     }

--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -65,7 +65,7 @@ private[conf] trait HealthCheckFetcher extends ExecutionContexts with Logging {
   protected def fetchResults(testPort: Int, paths: String*): Future[Seq[HealthCheckResult]] = {
     val defaultPort = 9000
     val port = {
-      Play.current.mode match {
+      ApplicationMode.mode match {
         case Mode.Test => testPort
         case _ => defaultPort
       }

--- a/common/app/crosswords/TodaysCrosswordGridLifecycle.scala
+++ b/common/app/crosswords/TodaysCrosswordGridLifecycle.scala
@@ -1,11 +1,12 @@
 package crosswords
 
-import play.api.{Application, GlobalSettings, Play, Mode}
+import common.ApplicationMode
+import play.api.{Application, GlobalSettings, Mode}
 
 trait TodaysCrosswordGridLifecycle extends GlobalSettings {
   override def onStart(app: Application): Unit = {
     super.onStart(app)
-    if(Play.current.mode != Mode.Test) {
+    if(ApplicationMode.mode != Mode.Test) {
       TodaysCrosswordGrid.start()
     }
   }

--- a/dev-build/app/Global.scala
+++ b/dev-build/app/Global.scala
@@ -1,6 +1,6 @@
 import commercial.CommercialLifecycle
 import common.dfp.FaciaDfpAgentLifecycle
-import common.{CanonicalLink, DiagnosticsLifecycle, ExecutionContexts}
+import common.{ApplicationMode, CanonicalLink, DiagnosticsLifecycle, ExecutionContexts}
 import conf._
 import contentapi.SectionsLookUpLifecycle
 import dev.DevParametersLifecycle
@@ -58,6 +58,7 @@ object DevJsonExtensionFilter extends EssentialFilter with ExecutionContexts wit
 
 
 object Global extends WithFilters(DevJsonExtensionFilter :: DevCacheWarningFilter :: Filters.common: _*)
+  with ApplicationMode
   with DevParametersLifecycle
   with AdminLifecycle
   with DiagnosticsLifecycle

--- a/diagnostics/app/Global.scala
+++ b/diagnostics/app/Global.scala
@@ -1,10 +1,10 @@
-
 import common.Logback.Logstash
-import common.{CloudWatchApplicationMetrics, DiagnosticsLifecycle}
+import common.{ApplicationMode, CloudWatchApplicationMetrics, DiagnosticsLifecycle}
 import conf.{SwitchboardLifecycle, Gzipper}
 import play.api.mvc.WithFilters
 
 object Global extends WithFilters(Gzipper)
+  with ApplicationMode
   with DiagnosticsLifecycle
   with SwitchboardLifecycle
   with CloudWatchApplicationMetrics

--- a/discussion/app/Global.scala
+++ b/discussion/app/Global.scala
@@ -1,9 +1,10 @@
-import common.CloudWatchApplicationMetrics
+import common.{ApplicationMode, CloudWatchApplicationMetrics}
 import common.Logback.Logstash
 import conf.{SwitchboardLifecycle, CorsErrorHandler, Filters}
 import play.api.mvc.{WithFilters}
 
 object Global extends WithFilters(Filters.common : _*)
+  with ApplicationMode
   with CloudWatchApplicationMetrics
   with CorsErrorHandler
   with SwitchboardLifecycle

--- a/facia-press/app/Global.scala
+++ b/facia-press/app/Global.scala
@@ -6,6 +6,7 @@ import play.api.GlobalSettings
 import services.ConfigAgentLifecycle
 
 object Global extends GlobalSettings
+  with ApplicationMode
   with ConfigAgentLifecycle
   with SwitchboardLifecycle
   with CloudWatchApplicationMetrics

--- a/facia/app/Global.scala
+++ b/facia/app/Global.scala
@@ -10,6 +10,7 @@ import play.api.mvc.WithFilters
 import services.{ConfigAgentLifecycle, IndexListingsLifecycle}
 
 object Global extends WithFilters(Filters.common: _*)
+  with ApplicationMode
   with ConfigAgentLifecycle
   with DevParametersLifecycle
   with CloudWatchApplicationMetrics

--- a/identity/app/Global.scala
+++ b/identity/app/Global.scala
@@ -1,5 +1,5 @@
 import com.google.inject.Guice
-import common.CloudWatchApplicationMetrics
+import common.{ApplicationMode, CloudWatchApplicationMetrics}
 import common.Logback.Logstash
 import conf._
 import filters.{StrictTransportSecurityHeaderFilter, HeaderLoggingFilter}
@@ -13,6 +13,7 @@ import scala.concurrent.Future
 import utils.SafeLogging
 
 object Global extends WithFilters(HeaderLoggingFilter :: StrictTransportSecurityHeaderFilter :: conf.Filters.common: _*)
+  with ApplicationMode
   with SafeLogging
   with CloudWatchApplicationMetrics
   with IdentityLifecycle
@@ -23,7 +24,7 @@ object Global extends WithFilters(HeaderLoggingFilter :: StrictTransportSecurity
 
   override def onError(request: RequestHeader, ex: Throwable) = {
     logger.error("Serving error page", ex)
-    if (Play.mode == Mode.Prod) {
+    if (ApplicationMode.mode == Mode.Prod) {
       Future.successful(InternalServerError(views.html.errors._50x()))
     } else {
       super.onError(request, ex)
@@ -32,7 +33,7 @@ object Global extends WithFilters(HeaderLoggingFilter :: StrictTransportSecurity
 
   override def onHandlerNotFound(request: RequestHeader) = {
     logger.info(s"Serving 404, no handler found for ${request.path}")
-    if (Play.mode == Mode.Prod) {
+    if (ApplicationMode.mode == Mode.Prod) {
       Future.successful(NotFound(views.html.errors._404()))
     } else {
       super.onHandlerNotFound(request)
@@ -41,7 +42,7 @@ object Global extends WithFilters(HeaderLoggingFilter :: StrictTransportSecurity
 
   override def onBadRequest(request: RequestHeader, error: String) = {
     logger.info(s"Serving 400, could not bind request to handler for ${request.uri}")
-    if (Play.mode == Mode.Prod) {
+    if (ApplicationMode.mode == Mode.Prod) {
       Future.successful(BadRequest("Bad Request: " + error))
     } else {
       super.onBadRequest(request, error)

--- a/onward/app/Global.scala
+++ b/onward/app/Global.scala
@@ -1,6 +1,6 @@
 import business.StocksDataLifecycle
 import common.Logback.Logstash
-import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
+import common.{ApplicationMode, CloudWatchApplicationMetrics, ContentApiMetrics}
 import conf.{CorsErrorHandler, Filters, SwitchboardLifecycle}
 import dev.DevParametersLifecycle
 import feed.{MostPopularFacebookAutoRefreshLifecycle, MostReadLifecycle, OnwardJourneyLifecycle}
@@ -8,6 +8,7 @@ import metrics.FrontendMetric
 import play.api.mvc.WithFilters
 
 object Global extends WithFilters(Filters.common: _*)
+  with ApplicationMode
   with OnwardJourneyLifecycle
   with DevParametersLifecycle
   with CloudWatchApplicationMetrics

--- a/rss/app/Global.scala
+++ b/rss/app/Global.scala
@@ -1,5 +1,5 @@
 import common.Logback.Logstash
-import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
+import common.{ApplicationMode, CloudWatchApplicationMetrics, ContentApiMetrics}
 import conf.{Filters, SwitchboardLifecycle}
 import contentapi.SectionsLookUpLifecycle
 import dev.DevParametersLifecycle
@@ -9,6 +9,7 @@ import play.api.mvc.WithFilters
 import services.ConfigAgentLifecycle
 
 object Global extends WithFilters(Filters.common: _*)
+  with ApplicationMode
   with ConfigAgentLifecycle
   with DevParametersLifecycle
   with CloudWatchApplicationMetrics

--- a/sport/app/Global.scala
+++ b/sport/app/Global.scala
@@ -1,4 +1,4 @@
-import common.CloudWatchApplicationMetrics
+import common.{ApplicationMode, CloudWatchApplicationMetrics}
 import common.Logback.Logstash
 import conf._
 import dev.DevParametersLifecycle
@@ -7,6 +7,7 @@ import play.api.mvc.WithFilters
 import rugby.conf.RugbyLifecycle
 
 object Global extends WithFilters(Filters.common: _*)
+  with ApplicationMode
   with DevParametersLifecycle
   with CloudWatchApplicationMetrics
   with SurgingContentAgentLifecycle

--- a/standalone/app/Global.scala
+++ b/standalone/app/Global.scala
@@ -1,6 +1,6 @@
 import com.gu.googleauth.{FilterExemption, UserIdentity}
 import commercial.CommercialLifecycle
-import common.ExecutionContexts
+import common.{ApplicationMode, ExecutionContexts}
 import common.Logback.Logstash
 import common.dfp.FaciaDfpAgentLifecycle
 import conf._
@@ -63,6 +63,7 @@ object Global extends WithFilters(
     new PreviewAuthFilters.AuthFilterWithExemptions(
     FilterExemptions.loginExemption,
     FilterExemptions.exemptions):: NoCacheFilter :: conf.Filters.common: _*)
+  with ApplicationMode
   with CommercialLifecycle
   with OnwardJourneyLifecycle
   with ConfigAgentLifecycle


### PR DESCRIPTION
## What does this change?

This change is a first step towards play 2.5. It gets rid of `play.current.mode` as this will be deprecated.
The implementation works around the problem by introducing a global state, please let me know if that's causing you any worry.
## What is the value of this and can you measure success?

The value is an up-to-date codebase, no measure of success
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

N/A
## Request for comment

@rich-nguyen @johnduffell @mchv @TBonnin @jamespamplin 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
