### PR TITLE
Changing Omniture report suite id for code

### DIFF
--- a/article/test/AnalyticsFeatureTest.scala
+++ b/article/test/AnalyticsFeatureTest.scala
@@ -29,7 +29,7 @@ import conf.Configuration
         Then("the Omniture webbug should record my visit")
         val webbug = findFirst("#omnitureNoScript img")
 
-        webbug.getAttribute("src") should startWith("https://hits-secure.theguardian.com/b/ss/guardiangu-network-dev/1/H.25.3/")
+        webbug.getAttribute("src") should startWith("https://hits-secure.theguardian.com/b/ss/guardiangudev-code/1/H.25.3/")
 
         // test a few token properties in the web bug
         webbug.getAttribute("src") should include("c11=sport")

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -49,7 +49,7 @@ open.cta.apiRoot=http://opencontent.code.dev-guardianapis.com/discussion-api
 #properties that start with guardian.page will be exposed via JavaScript
 #if you create one make sure that is what you intend
 guardian.page.omnitureAmpAccount=guardiangudev-code
-guardian.page.omnitureAccount=guardiangu-network-dev
+guardian.page.omnitureAccount=guardiangudev-code
 guardian.page.googleSearchId=007466294097402385199:m2ealvuxh1i
 guardian.page.fbAppId=157221981065719
 guardian.page.host=http://m.code.dev-theguardian.com

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -45,7 +45,7 @@ open.cta.apiRoot=http://opencontent.code.dev-guardianapis.com/discussion-api
 # properties that start with guardian.page will be exposed via JavaScript
 # if you create one make sure that is what you intend
 guardian.page.omnitureAmpAccount=guardiangudev-code
-guardian.page.omnitureAccount=guardiangu-network-dev
+guardian.page.omnitureAccount=guardiangudev-code
 guardian.page.googleSearchId=007466294097402385199:m2ealvuxh1i
 guardian.page.fbAppId=202314643182694
 guardian.page.idApiJsClientToken=frontend-dev-js-client-token

--- a/common/conf/env/DEVINFRA.properties
+++ b/common/conf/env/DEVINFRA.properties
@@ -38,7 +38,7 @@ open.cta.apiRoot=http://opencontent.code.dev-guardianapis.com/discussion-api
 #properties that start with guardian.page will be exposed via JavaScript
 #if you create one make sure that is what you intend
 guardian.page.omnitureAmpAccount=guardiangudev-code
-guardian.page.omnitureAccount=guardiangu-network-dev
+guardian.page.omnitureAccount=guardiangudev-code
 guardian.page.googleSearchId=007466294097402385199:m2ealvuxh1i
 guardian.page.fbAppId=202314643182694
 guardian.page.idApiJsClientToken=frontend-dev-js-client-token


### PR DESCRIPTION
## What does this change?

This changes the omniture report suite id for our code environment to point to the correct one.
## What is the value of this and can you measure success?

This allows us to test analytics changes in code
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots
## Request for comment

@rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

…ight location
