### PR TITLE
The .adverts class renaming

### DIFF
--- a/commercial/app/views/books/booksStandard.scala.html
+++ b/commercial/app/views/books/booksStandard.scala.html
@@ -11,7 +11,7 @@
                   dataLinkName = omnitureId.map(id => s"merchandising | books standard | ${id}"),
                   optActions = Some(actions)){
 
-    <a class="adverts__logo" href="@{clickMacro}http://www.guardianbookshop.co.uk/" data-link-name="merchandising-bookshop-v2_0_2014-10-15-medium-visit-shop">
+    <a class="commodel__logo" href="@{clickMacro}http://www.guardianbookshop.co.uk/" data-link-name="merchandising-bookshop-v2_0_2014-10-15-medium-visit-shop">
         @fragments.inlineSvg("marque-54", "icon")
         @fragments.inlineSvg("logo-guardian", "logo")
         @fragments.inlineSvg("logo-bookshop", "commercial", List("inline-commercial-brand"))
@@ -21,12 +21,12 @@
 }{
 
     @if(isProminent) {
-        <div class="adverts__row adverts__row--2x1x1">
+        <div class="commodel__row commodel__row--2x1x1">
             @books.take(1).map { book => @bookLargeCard(book, clickMacro, optAdvertClassNames = Some(Seq("inverse", "large--1x2"))) }
             @books.slice(1, 3).map { book => @bookCard(book, clickMacro) }
         </div>
     } else {
-        <div class="adverts__row">
+        <div class="commodel__row">
         @books.take(2).map { book => @bookCard(book, clickMacro) }
         @books.slice(2, 4).map { book => @bookCard(book, clickMacro, optClassNames = Some(Seq("hide-until-tablet"))) }
         </div>

--- a/commercial/app/views/contentapi/item.scala.html
+++ b/commercial/app/views/contentapi/item.scala.html
@@ -35,14 +35,14 @@
                   }){
 
     @optCapiLink.map { linkUrl =>
-        <a href="@clickMacro@linkUrl" class="adverts__logo u-text-hyphenate" data-link-name="header link">@optCapiTitle</a>
+        <a href="@clickMacro@linkUrl" class="commodel__logo u-text-hyphenate" data-link-name="header link">@optCapiTitle</a>
     }.getOrElse {
         <span class="u-text-hyphenate">@optCapiTitle</span>
     }
 
 }{
 
-    <div class="adverts__row adverts__row--single">
+    <div class="commodel__row commodel__row--single">
         @itemLargeCard(
             card,
             omnitureId,
@@ -74,12 +74,12 @@
 @badge = {
 
     @optSponsorLabel
-    <a class="adverts__badge__link" href="@clickMacro@optCapiLink" data-link-name="logo link">
-        @for(logoUrl <- optLogo) {<img class="adverts__badge__logo" src="@logoUrl" alt="">}
+    <a class="commodel__badge__link" href="@clickMacro@optCapiLink" data-link-name="logo link">
+        @for(logoUrl <- optLogo) {<img class="commodel__badge__logo" src="@logoUrl" alt="">}
     </a>
     @for(sponsorType <- optSponsorType if sponsorType != PaidFor;
          aboutLinkUrl <- optCapiAbout) {
-        <a href="@clickMacro@aboutLinkUrl" class="adverts__badge__help" data-link-name="about link">About this content</a>
+        <a href="@clickMacro@aboutLinkUrl" class="commodel__badge__help" data-link-name="about link">About this content</a>
     }
 
 }

--- a/commercial/app/views/contentapi/items.scala.html
+++ b/commercial/app/views/contentapi/items.scala.html
@@ -33,14 +33,14 @@
                   }){
 
     @optCapiLink.map { linkUrl =>
-        <a href="@clickMacro@linkUrl" class="adverts__logo u-text-hyphenate" data-link-name="header link">@optCapiTitle</a>
+        <a href="@clickMacro@linkUrl" class="commodel__logo u-text-hyphenate" data-link-name="header link">@optCapiTitle</a>
     }.getOrElse {
         <span class="u-text-hyphenate">@optCapiTitle</span>
     }
 
 }{
 
-    <div class="adverts__row">
+    <div class="commodel__row">
         @cards.take(2).map { card => @itemCard(
             card,
             omnitureId,
@@ -75,12 +75,12 @@
 @badge = {
 
     @optSponsorLabel
-    <a class="adverts__badge__link" href="@clickMacro@optCapiLink" data-link-name="logo link">
-        @for(logoUrl <- optLogo) {<img class="adverts__badge__logo" src="@logoUrl" alt="">}
+    <a class="commodel__badge__link" href="@clickMacro@optCapiLink" data-link-name="logo link">
+        @for(logoUrl <- optLogo) {<img class="commodel__badge__logo" src="@logoUrl" alt="">}
     </a>
     @for(sponsorType <- optSponsorType if sponsorType != PaidFor;
          aboutLinkUrl <- optCapiAbout) {
-        <a href="@clickMacro@aboutLinkUrl" class="adverts__badge__help" data-link-name="about link">About this content</a>
+        <a href="@clickMacro@aboutLinkUrl" class="commodel__badge__help" data-link-name="about link">About this content</a>
     }
 
 }

--- a/commercial/app/views/debugger/allcreatives.scala.html
+++ b/commercial/app/views/debugger/allcreatives.scala.html
@@ -143,12 +143,12 @@
                     var $palette    = $('#dfp-palette'),
                         toneClasses = ['brand', 'subscriptions', 'membership', 'live', 'jobs', 'networks', 'books', 'masterclasses', 'travel', 'shop', 'money', 'gardening', 'soulmates']
                             .map(function (tone) {
-                                return 'adverts--tone-' + tone;
+                                return 'commodel--tone-' + tone;
                             });
                     bean.on($palette[0], 'change', function () {
-                        $('#multiple1 > .adverts, #manual1 > .adverts, .commercial--v-high')
+                        $('#multiple1 > .commodel, #manual1 > .commodel, .commercial--v-high')
                             .removeClass(toneClasses.join(' '))
-                            .addClass('adverts--tone-' + $palette.val());
+                            .addClass('commodel--tone-' + $palette.val());
                     });
 
                     var blendedStyle = document.getElementById('blended-style'),

--- a/commercial/app/views/jobs/jobs.scala.html
+++ b/commercial/app/views/jobs/jobs.scala.html
@@ -11,7 +11,7 @@
                   omnitureId.map(id => s"merchandising | jobs | ${id}"),
                   optActions = Some(actions)){
 
-    <a class="adverts__logo" href="@{clickMacro}http://jobs.theguardian.com/" data-link-name="merchandising-jobs-v0_2_2014-04-30-low-browse-all-jobs">
+    <a class="commodel__logo" href="@{clickMacro}http://jobs.theguardian.com/" data-link-name="merchandising-jobs-v0_2_2014-04-30-low-browse-all-jobs">
         @fragments.inlineSvg("marque-54", "icon")
         @fragments.inlineSvg("logo-guardian", "logo")
         @fragments.inlineSvg("logo-jobs", "commercial", List("inline-commercial-brand"))
@@ -20,7 +20,7 @@
 
 }{
 
-    <div class="adverts__row adverts__row--2x1x1">
+    <div class="commodel__row commodel__row--2x1x1">
         <ul class="jobs-sectors">
             @for(sector <- jobSectors) {
                 <li><a href="@{clickMacro}http://jobs.theguardian.com/@{sector.path}" data-link-name="merchandising-jobs-v0_2_2014-04-30-low-sector-@{sector.path}">@{sector.name}</a></li>

--- a/commercial/app/views/masterclasses/masterclasses.scala.html
+++ b/commercial/app/views/masterclasses/masterclasses.scala.html
@@ -11,7 +11,7 @@
                   optBlurb = Some(Html("Courses from the Guardian")),
                   optActions = Some(actions)){
 
-    <a class="adverts__logo" href="@clickMacro@Configuration.commercial.masterclasses_url" data-link-name="merchandising-masterclasses-s-v1_0_2014-05-23-low-browse-all-masterclasses">
+    <a class="commodel__logo" href="@clickMacro@Configuration.commercial.masterclasses_url" data-link-name="merchandising-masterclasses-s-v1_0_2014-05-23-low-browse-all-masterclasses">
         @fragments.inlineSvg("marque-54", "icon")
         @fragments.inlineSvg("logo-guardian", "logo")
         @fragments.inlineSvg("logo-masterclasses", "commercial", List("inline-commercial-brand"))
@@ -20,7 +20,7 @@
 
 }{
 
-    <div class="adverts__row">
+    <div class="commodel__row">
         @events.take(2).map { event => @masterclassCard(event, clickMacro) }
         @events.slice(2, 4).map { event => @masterclassCard(event, clickMacro, optClassNames = Some(Seq("hide-until-tablet"))) }
     </div>

--- a/commercial/app/views/multi.scala.html
+++ b/commercial/app/views/multi.scala.html
@@ -5,14 +5,14 @@
 @containerWrapper(Seq("legacy", "blended", "tone-brand"),
                   omnitureId.map(id => s"creative | blended component | ${id}")){
 
-    <span class="adverts__logo">
+    <span class="commodel__logo">
         @fragments.inlineSvg("marque-54", "icon")
     </span>
     from across the guardian
 
 }{
 
-    <div class="adverts__row">
+    <div class="commodel__row">
         @components
     </div>
 

--- a/commercial/app/views/soulmates/soulmates.scala.html
+++ b/commercial/app/views/soulmates/soulmates.scala.html
@@ -11,7 +11,7 @@
                   optBlurb = Some(blurb),
                   optActions = Some(actions)){
 
-    <a class="adverts__logo" href="@clickMacro@Configuration.commercial.soulmates_url" data-link-name="merchandising-soulmates-v2_2_2014-03-28-join-now">
+    <a class="commodel__logo" href="@clickMacro@Configuration.commercial.soulmates_url" data-link-name="merchandising-soulmates-v2_2_2014-03-28-join-now">
         @fragments.inlineSvg("marque-54", "icon")
         @fragments.inlineSvg("logo-soulmates", "commercial")
         <span class="u-h">The Guardian Soulmates</span>
@@ -19,7 +19,7 @@
 
 }{
 
-    <div class="adverts__row">
+    <div class="commodel__row">
         @members.take(6).map { member => @soulmateCard(member, clickMacro) }
         @members.drop(6).map { member => @soulmateCard(member, clickMacro, optClassNames = Some(Seq("hide-until-tablet"))) }
         @soulmateForm()

--- a/commercial/app/views/static/guardianHostedPage.scala.html
+++ b/commercial/app/views/static/guardianHostedPage.scala.html
@@ -12,7 +12,7 @@
     </div>
     <div class="l-side-margins hosted__side">
         <section class="hosted-tone--dark">
-            <div class="adverts hosted__container--full">
+            <div class="commodel hosted__container--full">
                 <div class="hostedbadge hosted-tone-bg--renault">
                     <p class="hostedbadge__info">Advertiser content</p>
                     <img class="hostedbadge__logo" src="@Static("images/commercial/logo_renault.jpg")">
@@ -40,8 +40,8 @@
                 </div>
             </div>
         </section>
-        <section class="adverts adverts--legacy hosted__container">
-            <header class="adverts__header">
+        <section class="commodel commodel--legacy hosted__container">
+            <header class="commodel__header">
                 <div class="meta__social hosted__social" data-component="share">
                     <ul class="social social--top u-unstyled u-cf" data-component="social">
                         <li class="social__item social__item--facebook" data-link-name="facebook">
@@ -87,14 +87,14 @@
                     </ul>
                 </div>
             </header>
-            <div class="adverts__body">
+            <div class="commodel__body">
                 <div class="hosted__standfirst">
                     <p class="hosted__text">ZOE integrates the most advanced electric technology. More than 60 patents have been filed under design, innovations in service autonomy, ease of use and connectivity. ZOE is fitted with a "Range Optimizer" system which enhances the battery life, whatever the driving conditions.</p>
                     <p class="hosted__terms">This content was paid for and produced by Renault. For more information see our <a href="" class="hosted__link">Because I rock it doesn't mean my heart is made of stone.</a></p>
                 </div>
             </div>
         </section>
-        <section class="adverts hosted__container--full">
+        <section class="commodel hosted__container--full">
             <div class="hosted__banner" style="background-image: url(@Static("images/commercial/zoe-1.jpg"));">
                 <div class="hostedbadge hostedbadge--pushdown hosted-tone-bg--renault">
                     <p class="hostedbadge__info">Advertiser content</p>

--- a/commercial/app/views/travel/travel.scala.html
+++ b/commercial/app/views/travel/travel.scala.html
@@ -10,7 +10,7 @@
                   dataLinkName = omnitureId.map(id => s"commercial-low | travel | ${id}"),
                   optActions = Some(actions)) {
 
-    <a class="adverts__logo" href="@{clickMacro}https://holidays.theguardian.com/" data-link-name="merchandising-travel-v2_1_2014-07-04-low-title">
+    <a class="commodel__logo" href="@{clickMacro}https://holidays.theguardian.com/" data-link-name="merchandising-travel-v2_1_2014-07-04-low-title">
         @fragments.inlineSvg("marque-54", "icon")
         @fragments.inlineSvg("logo-guardian", "logo")
         @fragments.inlineSvg("logo-holidayoffers", "commercial", List("inline-commercial-brand"))
@@ -20,12 +20,12 @@
 }{
 
     @if(isProminent) {
-        <div class="adverts__row adverts__row--2x1x1">
+        <div class="commodel__row commodel__row--2x1x1">
             @offers.take(1).map { offer => @travelLargeCard(offer, clickMacro, Some(Seq("inverse", "large--1x2"))) }
             @offers.slice(1, 3).map { offer => @travelCard(offer, clickMacro) }
         </div>
     } else {
-        <div class="adverts__row">
+        <div class="commodel__row">
             @offers.take(2).map { offer => @travelCard(offer, clickMacro) }
             @offers.slice(2, 4).map { offer => @travelCard(offer, clickMacro, optClassNames = Some(Seq("hide-until-tablet"))) }
         </div>

--- a/common/app/views/commercial/containerWrapper.scala.html
+++ b/common/app/views/commercial/containerWrapper.scala.html
@@ -10,23 +10,23 @@
   optBadge: Option[Html] = None
  )(title: Html)(innards: Html)
 
-<aside class="adverts @classNames.map(c => s"adverts--$c").mkString(" ")"
+<aside class="commodel @classNames.map(c => s"commodel--$c").mkString(" ")"
     @for(dln <- dataLinkName){data-link-name="@dln"}
     >
-    <header class="adverts__header">
-        @for(kicker   <- optKicker)  {<div class="adverts__kicker">@kicker</div>}
-        <h1 class="adverts__title">@title</h1>
+    <header class="commodel__header">
+        @for(kicker   <- optKicker)  {<div class="commodel__kicker">@kicker</div>}
+        <h1 class="commodel__title">@title</h1>
         @if(badgeInHeader) {
-            @for(badge        <- optBadge)   {<div class="adverts__badge adverts__badge--alt js-badge">@badge</div>}
+            @for(badge        <- optBadge)   {<div class="commodel__badge commodel__badge--alt js-badge">@badge</div>}
         }
-        @for(blurb    <- optBlurb)   {<div class="adverts__blurb">@blurb</div>}
-        @for(actions  <- optActions) {<div class="adverts__ctas">@actions</div>}
-        @for(stamp    <- optStamp)   {<div class="adverts__stamp">@stamp</div>}
+        @for(blurb    <- optBlurb)   {<div class="commodel__blurb">@blurb</div>}
+        @for(actions  <- optActions) {<div class="commodel__ctas">@actions</div>}
+        @for(stamp    <- optStamp)   {<div class="commodel__stamp">@stamp</div>}
     </header>
-    <div class="adverts__body">
+    <div class="commodel__body">
         @innards
         @if(!badgeInHeader) {
-            @for(badge        <- optBadge)   {<div class="adverts__badge js-badge">@badge</div>}
+            @for(badge        <- optBadge)   {<div class="commodel__badge js-badge">@badge</div>}
         }
     </div>
 </aside>

--- a/common/app/views/commercial/containers/fixedLargeSlowXIV.scala.html
+++ b/common/app/views/commercial/containers/fixedLargeSlowXIV.scala.html
@@ -3,7 +3,7 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row adverts__row--3x1">
+<div class="commodel__row commodel__row--3x1">
     @containerModel.content.initialCards.take(1).map(card => views.html.commercial.cards.itemLargeCard(
         card,
         cardType = cards.ThreeQuarters,
@@ -17,36 +17,36 @@
                             optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>
-<div class="adverts__row hide-until-tablet">
+<div class="commodel__row hide-until-tablet">
     @containerModel.content.initialCards.slice(2, 6).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                             optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>
-<div class="adverts__row hide-until-tablet">
-    <div class="adverts__column">
+<div class="commodel__row hide-until-tablet">
+    <div class="commodel__column">
         @containerModel.content.initialCards.slice(6, 8).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                                 optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
-    <div class="adverts__column">
+    <div class="commodel__column">
         @containerModel.content.initialCards.slice(8, 10).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                                 optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
-    <div class="adverts__column">
+    <div class="commodel__column">
         @containerModel.content.initialCards.slice(10, 12).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                                 optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
-    <div class="adverts__column">
+    <div class="commodel__column">
         @containerModel.content.initialCards.slice(12, 14).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),

--- a/common/app/views/commercial/containers/fixedMediumFastXI.scala.html
+++ b/common/app/views/commercial/containers/fixedMediumFastXI.scala.html
@@ -3,7 +3,7 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row adverts__row--2x1x1">
+<div class="commodel__row commodel__row--2x1x1">
     @containerModel.content.initialCards.take(1).map(card => views.html.commercial.cards.itemCard(
                             card,
                             cardType = cards.Half,
@@ -22,29 +22,29 @@
                             optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>
-<div class="adverts__row hide-until-tablet">
-    <div class="adverts__column">
+<div class="commodel__row hide-until-tablet">
+    <div class="commodel__column">
         @containerModel.content.initialCards.slice(3, 5).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                                 optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
-    <div class="adverts__column">
+    <div class="commodel__column">
         @containerModel.content.initialCards.slice(3, 5).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                                 optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
-    <div class="adverts__column">
+    <div class="commodel__column">
         @containerModel.content.initialCards.slice(3, 5).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                                 optAdvertClassNames = Some(Seq("paidfor")),
                                 useCardBranding = !containerModel.isSingleSponsorContainer))
     </div>
-    <div class="adverts__column">
+    <div class="commodel__column">
         @containerModel.content.initialCards.slice(3, 5).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),

--- a/common/app/views/commercial/containers/fixedMediumFastXII.scala.html
+++ b/common/app/views/commercial/containers/fixedMediumFastXII.scala.html
@@ -3,7 +3,7 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row">
+<div class="commodel__row">
     @containerModel.content.initialCards.take(2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),

--- a/common/app/views/commercial/containers/fixedMediumSlowVI.scala.html
+++ b/common/app/views/commercial/containers/fixedMediumSlowVI.scala.html
@@ -3,7 +3,7 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row adverts__row--3x1">
+<div class="commodel__row commodel__row--3x1">
     @containerModel.content.initialCards.take(1).map(card => views.html.commercial.cards.itemLargeCard(
                             card,
                             cardType = cards.ThreeQuarters,
@@ -16,7 +16,7 @@
                             optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>
-<div class="adverts__row hide-until-tablet">
+<div class="commodel__row hide-until-tablet">
     @containerModel.content.initialCards.slice(2, 6).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),

--- a/common/app/views/commercial/containers/fixedMediumSlowVII.scala.html
+++ b/common/app/views/commercial/containers/fixedMediumSlowVII.scala.html
@@ -3,7 +3,7 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row adverts__row--2x1x1">
+<div class="commodel__row commodel__row--2x1x1">
     @containerModel.content.initialCards.take(1).map(card => views.html.commercial.cards.itemCard(
                             card,
                             cardType = cards.Half,
@@ -22,7 +22,7 @@
                             optClassNames = Some(Seq("hide-until-tablet")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
 </div>
-<div class="adverts__row hide-until-tablet">
+<div class="commodel__row hide-until-tablet">
     @containerModel.content.initialCards.slice(3, 7).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),

--- a/common/app/views/commercial/containers/fixedSmallFastVIII.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallFastVIII.scala.html
@@ -3,13 +3,13 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row adverts__row--1x1x2">
+<div class="commodel__row commodel__row--1x1x2">
     @containerModel.content.initialCards.take(2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                             optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
-    <div class="adverts__column adverts__2cols">
+    <div class="commodel__column commodel__2cols">
         @containerModel.content.initialCards.slice(2, 8).map(card => views.html.commercial.cards.itemSmallCard(
                                 card,
                                 omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),

--- a/common/app/views/commercial/containers/fixedSmallSlowI.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallSlowI.scala.html
@@ -3,7 +3,7 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row">
+<div class="commodel__row">
     @containerModel.content.initialCards.take(1).map(card => views.html.commercial.cards.itemLargeCard(
                             card,
                             cardType = cards.FullMedia75,

--- a/common/app/views/commercial/containers/fixedSmallSlowIII.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallSlowIII.scala.html
@@ -3,7 +3,7 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row adverts__row--2x1x1">
+<div class="commodel__row commodel__row--2x1x1">
     @containerModel.content.initialCards.take(1).map(card => views.html.commercial.cards.itemCard(
                             card,
                             cardType = cards.Half,

--- a/common/app/views/commercial/containers/fixedSmallSlowIV.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallSlowIV.scala.html
@@ -3,7 +3,7 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row">
+<div class="commodel__row">
     @containerModel.content.initialCards.take(2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),

--- a/common/app/views/commercial/containers/fixedSmallSlowVHalf.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallSlowVHalf.scala.html
@@ -3,8 +3,8 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row">
-    <div class="adverts__column">
+<div class="commodel__row">
+    <div class="commodel__column">
         @containerModel.content.initialCards.take(2).map(card => views.html.commercial.cards.itemLargeCard(
             card,
             optAdvertClassNames = Some(Seq("inverse", "thumbnail", "paidfor")),

--- a/common/app/views/commercial/containers/fixedSmallSlowVThird.scala.html
+++ b/common/app/views/commercial/containers/fixedSmallSlowVThird.scala.html
@@ -3,13 +3,13 @@
   containerIndex: Int,
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
-<div class="adverts__row adverts__row--1x1x2">
+<div class="commodel__row commodel__row--1x1x2">
     @containerModel.content.initialCards.take(2).map(card => views.html.commercial.cards.itemCard(
                             card,
                             omnitureId = mkInteractionTrackingCode(frontId, containerIndex, containerModel, card),
                             optAdvertClassNames = Some(Seq("paidfor")),
                             useCardBranding = !containerModel.isSingleSponsorContainer))
-    <div class="adverts__column hide-until-tablet">
+    <div class="commodel__column hide-until-tablet">
         @containerModel.content.initialCards.slice(2, 5).map(card => views.html.commercial.cards.itemLargeCard(
             card,
             optAdvertClassNames = Some(Seq("inverse", "thumbnail", "paidfor")),

--- a/common/app/views/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/commercial/containers/paidContainer.scala.html
@@ -23,7 +23,7 @@
         optBadge = if(containerModel.isSingleSponsorContainer){ Some(logoSlot) } else { None }
     ){
 
-        <a class="adverts__logo u-text-hyphenate" href="/@containerModel.content.targetUrl">@containerModel.content.title</a>
+        <a class="commodel__logo u-text-hyphenate" href="/@containerModel.content.targetUrl">@containerModel.content.title</a>
 
     }{
 
@@ -44,13 +44,13 @@
         }
 
         @if(containerModel.content.showMoreCards.nonEmpty){
-            <details class="adverts__more">
+            <details class="commodel__more">
                 <summary class="button button--medium button--primary button--show-more" data-text="@containerModel.content.title">
                     @fragments.inlineSvg("plus", "icon")
                     @fragments.inlineSvg("minus", "icon")
                     <span class="js-button__label">More @containerModel.content.title</span>
                 </summary>
-                <div class="adverts__row adverts__row--wrap adverts__3cols">
+                <div class="commodel__row commodel__row--wrap commodel__3cols">
                     @containerModel.content.showMoreCards.map(card => views.html.commercial.cards.itemSmallCard(
                                             card,
                                             optAdvertClassNames = Some(Seq("paidfor")),

--- a/static/src/javascripts/projects/common/modules/commercial/adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adverts.js
@@ -15,7 +15,7 @@ define([
             bean.on(document, 'keypress', 'summary', onKeyPress(onClick));
         }
 
-        var showMores = qwery('.adverts__more > summary');
+        var showMores = qwery('.commodel__more > summary');
         bean.on(document, 'click', showMores, onOpenClick);
         bean.on(document, 'click', showMores, onKeyPress(onOpenClick));
     }

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/template-preprocessor.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/template-preprocessor.js
@@ -116,7 +116,7 @@ define([
         manualContainerButtonTpl || (manualContainerButtonTpl = template(manualContainerButtonStr));
         manualCardTpls[tpl.params.creativeCard] || (manualCardTpls[tpl.params.creativeCard] = template(manualCardStrs[tpl.params.creativeCard]));
         manualCardCtaTpl || (manualCardCtaTpl = template(manualCardCtaStr));
-        tpl.params.classNames = ['manual'].concat(tpl.params.classNames).map(function (cn) { return 'adverts--' + cn; }).join(' ');
+        tpl.params.classNames = ['manual'].concat(tpl.params.classNames).map(function (cn) { return 'commodel--' + cn; }).join(' ');
         tpl.params.title || (tpl.params.title = '');
 
         if (tpl.params.isSoulmates) {

--- a/static/src/javascripts/projects/common/views/commercial/creatives/manual-container.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/manual-container.html
@@ -1,15 +1,15 @@
-<aside class="adverts <%=classNames%>" data-link-name="creative | ad <%=type%> manual | <%=omnitureId%>">
-    <header class="adverts__header">
-        <h1 class="adverts__title">
-            <a class="adverts__logo" href="<%=clickMacro%><%=baseUrl%>" data-link-name="title">
+<aside class="commodel <%=classNames%>" data-link-name="creative | ad <%=type%> manual | <%=omnitureId%>">
+    <header class="commodel__header">
+        <h1 class="commodel__title">
+            <a class="commodel__logo" href="<%=clickMacro%><%=baseUrl%>" data-link-name="title">
                 <%=title%>
             </a>
         </h1>
-        <div class="adverts__blurb"><%=blurb%></div>
-        <div class="adverts__ctas"><%=ctas%></div>
+        <div class="commodel__blurb"><%=blurb%></div>
+        <div class="commodel__ctas"><%=ctas%></div>
     </header>
-    <div class="adverts__body">
-        <div class="adverts__row">
+    <div class="commodel__body">
+        <div class="commodel__row">
             <%=innards%>
         </div>
     </div>

--- a/static/src/stylesheets/module/commercial/_adverts-blended.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-blended.scss
@@ -1,6 +1,6 @@
-.adverts--blended {
+.commodel--blended {
     @include mq($until: tablet) {
-        .adverts__row > :nth-child(2) ~ * {
+        .commodel__row > :nth-child(2) ~ * {
             display: none;
         }
     }

--- a/static/src/stylesheets/module/commercial/_adverts-books.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-books.scss
@@ -1,5 +1,5 @@
-.adverts--books {
-    > .adverts__header {
+.commodel--books {
+    > .commodel__header {
         .search {
             position: relative;
         }
@@ -39,8 +39,8 @@
 
 }
 
-.adverts--tone-books {
-    > .adverts__header {
+.commodel--tone-books {
+    > .commodel__header {
         background: $features-main-1;
     }
 }
@@ -51,7 +51,7 @@
     }
 }
 
-.adverts--tone-books .button--legacy-single,
+.commodel--tone-books .button--legacy-single,
 .advert--book .button {
     @include button-colour(
         $features-main-2,
@@ -72,7 +72,7 @@
     }
 }
 
-.adverts--tone-books .button--legacy-single {
+.commodel--tone-books .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts-brand.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-brand.scss
@@ -1,10 +1,10 @@
-.adverts--tone-brand {
-    > .adverts__header {
+.commodel--tone-brand {
+    > .commodel__header {
         background: $news-support-2;
     }
 }
 
-.adverts--tone-brand .button--legacy-single,
+.commodel--tone-brand .button--legacy-single,
 .advert--brand .button {
     @include button-colour(
         $news-main-2,
@@ -25,7 +25,7 @@
     }
 }
 
-.adverts--tone-brand .button--legacy-single {
+.commodel--tone-brand .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts-capi.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-capi.scss
@@ -1,49 +1,49 @@
-.adverts--capi {
-    .adverts__title {
+.commodel--capi {
+    .commodel__title {
         font-size: get-font-size(headline, 3);
     }
 }
 
-.adverts--paidfor {
+.commodel--paidfor {
     @include mq(mobileLandscape, desktop) {
-        > .adverts__header {
+        > .commodel__header {
             flex-wrap: wrap;
         }
 
-        .adverts__kicker {
+        .commodel__kicker {
             flex-basis: 100%;
         }
     }
 }
 
-.adverts--tone-paidfor {
+.commodel--tone-paidfor {
     background-color: $neutral-6;
 
-    > .adverts__header {
+    > .commodel__header {
         background: $paidfor-background;
     }
 
-    .adverts__title {
+    .commodel__title {
         @include f-headlineSans;
     }
 
-    .adverts__logo {
+    .commodel__logo {
         color: #ffffff;
     }
 
-    .adverts__stamp {
+    .commodel__stamp {
         text-align: right;
     }
 
-    .adverts__row > * + *::before,
-    .adverts__row--legacy > .advert::after,
-    .adverts__2cols::after,
-    .adverts__3cols::before,
-    .adverts__3cols::after {
+    .commodel__row > * + *::before,
+    .commodel__row--legacy > .advert::after,
+    .commodel__2cols::after,
+    .commodel__3cols::before,
+    .commodel__3cols::after {
         background: $paid-article-subheader-bg;
     }
 
-    .adverts__more > summary {
+    .commodel__more > summary {
         background: $paidfor-background;
         border-color: $paidfor-background;
 
@@ -61,7 +61,7 @@
         }
     }
 
-    .adverts__more[open] > summary {
+    .commodel__more[open] > summary {
         background: none;
         border-color: $neutral-4;
         color: $neutral-1;
@@ -84,7 +84,7 @@
     }
 }
 
-.adverts--tone-supported {
+.commodel--tone-supported {
     background: none;
 
     &::before {
@@ -113,11 +113,11 @@
         }
     }
 
-    .adverts__logo {
+    .commodel__logo {
         color: $guardian-brand-dark;
     }
 
-    .adverts__badge__help {
+    .commodel__badge__help {
         color: $neutral-2-contrasted;
     }
 }
@@ -203,7 +203,7 @@
     }
 
 
-    .adverts--legacy-single & {
+    .commodel--legacy-single & {
         background: none;
         border-top: 0;
 

--- a/static/src/stylesheets/module/commercial/_adverts-gardening.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-gardening.scss
@@ -1,13 +1,13 @@
-.adverts--gardening {
+.commodel--gardening {
 }
 
-.adverts--tone-gardening {
-    > .adverts__header {
+.commodel--tone-gardening {
+    > .commodel__header {
         background: $maps-main-1;
     }
 }
 
-.adverts--tone-gardening .button--legacy-single,
+.commodel--tone-gardening .button--legacy-single,
 .advert--gardening .button {
     @include button-colour(
         $maps-support-2,
@@ -28,7 +28,7 @@
     }
 }
 
-.adverts--tone-gardening .button--legacy-single {
+.commodel--tone-gardening .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts-jobs.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-jobs.scss
@@ -1,4 +1,4 @@
-.adverts--jobs {
+.commodel--jobs {
     .advert__image-container {
         height: $gs-baseline * 10;
     }
@@ -34,7 +34,7 @@
     }
 }
 
-.adverts--tone-jobs .button--legacy-single,
+.commodel--tone-jobs .button--legacy-single,
 .advert--job .button {
     @include button-colour(
         $news-main-1,
@@ -55,7 +55,7 @@
     }
 }
 
-.adverts--tone-jobs .button--legacy-single {
+.commodel--tone-jobs .button--legacy-single {
     &:hover,
     &:focus,
     &:active {
@@ -71,8 +71,8 @@
     padding-bottom: 4px;
 }
 
-.adverts--tone-jobs {
-    > .adverts__header {
+.commodel--tone-jobs {
+    > .commodel__header {
         background: $news-support-2;
     }
 }

--- a/static/src/stylesheets/module/commercial/_adverts-live.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-live.scss
@@ -1,13 +1,13 @@
-.adverts--live {
+.commodel--live {
 }
 
-.adverts--tone-live {
-    > .adverts__header {
+.commodel--tone-live {
+    > .commodel__header {
         background: $live-main-1;
     }
 }
 
-.adverts--tone-live .button--legacy-single,
+.commodel--tone-live .button--legacy-single,
 .advert--live .button {
     @include button-colour(
         $live-main-1,
@@ -28,7 +28,7 @@
     }
 }
 
-.adverts--tone-live .button--legacy-single {
+.commodel--tone-live .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts-masterclasses.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-masterclasses.scss
@@ -1,8 +1,8 @@
-.adverts--masterclasses {
+.commodel--masterclasses {
 }
 
-.adverts--tone-masterclasses {
-    > .adverts__header {
+.commodel--tone-masterclasses {
+    > .commodel__header {
         background: $multimedia-main-1;
 
         .button {
@@ -22,7 +22,7 @@
     }
 }
 
-.adverts--tone-masterclasses .button--legacy-single,
+.commodel--tone-masterclasses .button--legacy-single,
 .advert--masterclass .button {
     @include button-colour(
         $multimedia-main-2,
@@ -43,7 +43,7 @@
     }
 }
 
-.adverts--tone-masterclasses .button--legacy-single {
+.commodel--tone-masterclasses .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts-membership.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-membership.scss
@@ -1,10 +1,10 @@
-.adverts--tone-membership {
-    > .adverts__header {
+.commodel--tone-membership {
+    > .commodel__header {
         background: $membership-default;
     }
 }
 
-.adverts--tone-membership .button--legacy-single,
+.commodel--tone-membership .button--legacy-single,
 .advert--membership .button {
     @include button-colour(
         $membership-default,
@@ -25,7 +25,7 @@
     }
 }
 
-.adverts--tone-membership .button--legacy-single {
+.commodel--tone-membership .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts-money.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-money.scss
@@ -1,13 +1,13 @@
-.adverts--money {
+.commodel--money {
 }
 
-.adverts--tone-money {
-    > .adverts__header {
+.commodel--tone-money {
+    > .commodel__header {
         background: $news-main-2;
     }
 }
 
-.adverts--tone-money .button--legacy-single,
+.commodel--tone-money .button--legacy-single,
 .advert--money .button {
     @include button-colour(
         $news-support-2,
@@ -28,7 +28,7 @@
     }
 }
 
-.adverts--tone-money .button--legacy-single {
+.commodel--tone-money .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts-networks.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-networks.scss
@@ -1,13 +1,13 @@
-.adverts--networks {
+.commodel--networks {
 }
 
-.adverts--tone-networks {
-    > .adverts__header {
+.commodel--tone-networks {
+    > .commodel__header {
         background: $news-support-4;
     }
 }
 
-.adverts--tone-networks .button--legacy-single,
+.commodel--tone-networks .button--legacy-single,
 .advert--network .button {
     @include button-colour(
         $news-main-1,
@@ -28,7 +28,7 @@
     }
 }
 
-.adverts--tone-networks .button--legacy-single {
+.commodel--tone-networks .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts-shop.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-shop.scss
@@ -1,13 +1,13 @@
-.adverts--shop {
+.commodel--shop {
 }
 
-.adverts--tone-shop {
-    > .adverts__header {
+.commodel--tone-shop {
+    > .commodel__header {
         background: $features-main-1;
     }
 }
 
-.adverts--tone-shop .button--legacy-single,
+.commodel--tone-shop .button--legacy-single,
 .advert--shop .button {
     @include button-colour(
         $features-support-4,
@@ -33,7 +33,7 @@
     }
 }
 
-.adverts--tone-shop .button--legacy-single {
+.commodel--tone-shop .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts-soulmates.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-soulmates.scss
@@ -1,8 +1,8 @@
-.adverts--soulmates {
+.commodel--soulmates {
     @include mq($until: tablet) {
         // In the soulmates component, we want to show rows of 3 profiles
         // on mobile. Except if this is a manual component.
-        &:not(.adverts--manual) .adverts__row {
+        &:not(.commodel--manual) .commodel__row {
             > * {
                 flex-basis: calc(33.33% - #{$gs-gutter});
                 &:nth-child(even)::before {
@@ -19,13 +19,13 @@
             }
         }
 
-        > .adverts__header {
+        > .commodel__header {
             flex-direction: row;
             justify-content: space-between;
         }
     }
 
-    > .adverts__header .inline-logo-soulmates > svg {
+    > .commodel__header .inline-logo-soulmates > svg {
         width: 100px;
         height: 21px;
 
@@ -41,11 +41,11 @@
         }
     }
 
-    .adverts__blurb {
+    .commodel__blurb {
         margin-bottom: $gs-baseline;
     }
 
-    .adverts__ctas {
+    .commodel__ctas {
         .button {
             display: flex;
             align-items: center;
@@ -87,14 +87,14 @@
     }
 }
 
-.adverts--tone-soulmates {
+.commodel--tone-soulmates {
     background: $soulmates-background;
 
-    > .adverts__header {
+    > .commodel__header {
         background: $soulmates-colour;
     }
 
-    .adverts__blurb {
+    .commodel__blurb {
         @include fs-headline(2);
         font-weight: bold;
 
@@ -108,7 +108,7 @@
         }
     }
 
-    .adverts__ctas {
+    .commodel__ctas {
         .button {
             background: none;
             border: 0;

--- a/static/src/stylesheets/module/commercial/_adverts-subscriptions.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-subscriptions.scss
@@ -1,13 +1,13 @@
-.adverts--subscriptions {
+.commodel--subscriptions {
 }
 
-.adverts--tone-subscriptions {
-    > .adverts__header {
+.commodel--tone-subscriptions {
+    > .commodel__header {
         background: $news-support-2;
     }
 }
 
-.adverts--tone-subscriptions .button--legacy-single,
+.commodel--tone-subscriptions .button--legacy-single,
 .advert--subscription .button {
     @include button-colour(
         $news-main-2,
@@ -28,7 +28,7 @@
     }
 }
 
-.adverts--tone-subscriptions .button--legacy-single {
+.commodel--tone-subscriptions .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts-travel.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-travel.scss
@@ -1,5 +1,5 @@
-.adverts--travel {
-    > .adverts__header {
+.commodel--travel {
+    > .commodel__header {
         .search {
             position: relative;
         }
@@ -58,13 +58,13 @@
 
 }
 
-.adverts--tone-travel {
-    > .adverts__header {
+.commodel--tone-travel {
+    > .commodel__header {
         background: $maps-support-3;
     }
 }
 
-.adverts--tone-travel .button--legacy-single,
+.commodel--tone-travel .button--legacy-single,
 .advert--travel .button {
     @include button-colour(
         $maps-support-4,
@@ -85,7 +85,7 @@
     }
 }
 
-.adverts--tone-travel .button--legacy-single {
+.commodel--tone-travel .button--legacy-single {
     &:hover,
     &:focus,
     &:active {

--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -9,7 +9,7 @@
     background: $colour;
 }
 
-.adverts {
+.commodel {
     padding: 0 $gs-gutter / 2;
     position: relative;
 
@@ -38,13 +38,13 @@
     }
 }
 
-.adverts--legacy {
+.commodel--legacy {
     @include mq($until: tablet) {
         padding: 0;
     }
 
     @include mq(mobileLandscape, desktop) {
-        > .adverts__header {
+        > .commodel__header {
             flex-direction: row;
             justify-content: space-between;
         }
@@ -53,13 +53,13 @@
     @include mq(leftCol) {
         display: flex;
 
-        > .adverts__header {
+        > .commodel__header {
             box-sizing: border-box;
             padding: $gs-baseline $gs-gutter / 5 * 2;
             width: 160px;
         }
 
-        > .adverts__body {
+        > .commodel__body {
             flex: 1;
         }
 
@@ -68,8 +68,8 @@
 
             &::before,
             &::after,
-            > .adverts__body,
-            > .adverts__header {
+            > .commodel__body,
+            > .commodel__header {
                 display: table-cell;
                 vertical-align: top;
             }
@@ -77,18 +77,18 @@
     }
 
     @include mq(wide) {
-        > .adverts__header {
+        > .commodel__header {
             padding: $gs-baseline $gs-gutter;
             width: 240px;
         }
 
-        .adverts__ctas {
+        .commodel__ctas {
             margin-left: (-1 * $gs-gutter / 2);
             margin-right: (-1 * $gs-gutter / 2);
         }
     }
 
-    > .adverts__header {
+    > .commodel__header {
         .inline-logo-guardian {
             @include mq(leftCol) {
                 display: none;
@@ -104,7 +104,7 @@
         }
     }
 
-    > .adverts__body {
+    > .commodel__body {
         @include mq(mobileLandscape) {
             box-sizing: border-box;
             max-width: gs-span(8) + ($gs-gutter * 2);
@@ -118,12 +118,12 @@
         }
     }
 
-    .adverts__title {
+    .commodel__title {
         color: #ffffff;
         @include fs-header(2);
     }
 
-    .adverts__logo {
+    .commodel__logo {
         color: #ffffff;
         display: flex;
 
@@ -160,7 +160,7 @@
         }
     }
 
-    .adverts__ctas {
+    .commodel__ctas {
         @include mq($until: tablet) {
             margin-top: $gs-baseline / 3;
         }
@@ -179,7 +179,7 @@
         position: relative;
     }
 
-    .adverts__row {
+    .commodel__row {
         padding: $gs-baseline / 2 0;
         display: flex;
 
@@ -272,7 +272,7 @@
         }
     }
 
-    .adverts__row--wrap {
+    .commodel__row--wrap {
         position: relative;
         padding-top: 0;
 
@@ -283,7 +283,7 @@
         }
     }
 
-    .adverts__2cols {
+    .commodel__2cols {
         @include mq(tablet) {
             > * {
                 position: relative;
@@ -296,7 +296,7 @@
         }
     }
 
-    .adverts__3cols {
+    .commodel__3cols {
         @include mq(tablet) {
             > * {
                 position: relative;
@@ -314,7 +314,7 @@
     }
 }
 
-.adverts--legacy-single {
+.commodel--legacy-single {
     .advert {
         flex-basis: calc(100% - #{$gs-gutter});
     }
@@ -330,16 +330,16 @@
             margin-right: 0;
         }
 
-        .adverts__row > .advert::after {
+        .commodel__row > .advert::after {
             @include separator($neutral-4, 100%, $gs-gutter / 2);
         }
 
-        .adverts__row > .button {
+        .commodel__row > .button {
             flex-basis: auto;
             flex-grow: 1;
         }
 
-        .adverts__row > .button::before {
+        .commodel__row > .button::before {
             content: none;
         }
     }
@@ -355,7 +355,7 @@
     }
 }
 
-.adverts__header {
+.commodel__header {
     display: flex;
     flex-direction: column;
 
@@ -364,7 +364,7 @@
     }
 }
 
-.adverts__kicker {
+.commodel__kicker {
     .paidfor-meta__label {
         padding-left: 0;
     }
@@ -373,16 +373,16 @@
     }
 }
 
-.adverts__title {
+.commodel__title {
     @include fs-headline(4, true);
 }
 
-.adverts__ctas,
-.adverts__stamp {
+.commodel__ctas,
+.commodel__stamp {
     margin-top: auto;
 }
 
-.adverts__ctas {
+.commodel__ctas {
     display: flex;
     flex-direction: column;
 
@@ -392,15 +392,15 @@
     }
 }
 
-.adverts__ctas + .adverts__stamp {
+.commodel__ctas + .commodel__stamp {
     margin-top: 0;
 }
 
-.adverts__body {
+.commodel__body {
     position: relative;
 }
 
-.adverts__row {
+.commodel__row {
     @include mq($until: tablet) {
         /* http://alistapart.com/article/axiomatic-css-and-lobotomized-owls */
         > * + * {
@@ -419,13 +419,13 @@
 
 }
 
-.adverts__row--wrap {
+.commodel__row--wrap {
     @include mq(tablet) {
         flex-wrap: wrap;
     }
 }
 
-.adverts__2cols {
+.commodel__2cols {
     > * {
         flex-basis: calc(50% - #{$gs-gutter / 2});
     }
@@ -438,7 +438,7 @@
         margin-top: $gs-baseline;
     }
 
-    .has-no-flex .adverts--legacy & {
+    .has-no-flex .commodel--legacy & {
         > * {
             float: left;
             width: calc(50% - #{$gs-gutter / 2});
@@ -454,7 +454,7 @@
     }
 }
 
-.adverts__3cols {
+.commodel__3cols {
     > * {
         flex-basis: calc(33.33% - #{$gs-gutter});
     }
@@ -463,7 +463,7 @@
         margin-top: $gs-baseline;
     }
 
-    .has-no-flex .adverts--legacy & {
+    .has-no-flex .commodel--legacy & {
         > * {
             float: left;
             width: calc(33.33% - #{$gs-gutter});
@@ -476,9 +476,9 @@
 }
 
 @include mq(tablet) {
-    .adverts__row--2x1x1 > :nth-child(1),
-    .adverts__row--1x2x1 > :nth-child(2),
-    .adverts__row--1x1x2 > :nth-child(3) {
+    .commodel__row--2x1x1 > :nth-child(1),
+    .commodel__row--1x2x1 > :nth-child(2),
+    .commodel__row--1x1x2 > :nth-child(3) {
         flex-basis: calc(50% - #{$gs-gutter} - 1px);
         flex-grow: 0;
 
@@ -487,8 +487,8 @@
         }
     }
 
-    .adverts__row--3x1 > :nth-child(1),
-    .adverts__row--1x3 > :nth-child(2) {
+    .commodel__row--3x1 > :nth-child(1),
+    .commodel__row--1x3 > :nth-child(2) {
         flex-basis: calc(75% - #{$gs-gutter});
         flex-grow: 0;
 
@@ -498,18 +498,18 @@
     }
 }
 
-.adverts__column {
+.commodel__column {
     display: flex;
     flex-wrap: wrap;
 
-    &:not(.adverts__2cols) {
+    &:not(.commodel__2cols) {
         > * + * {
             margin-top: $gs-baseline;
         }
     }
 }
 
-.adverts__badge {
+.commodel__badge {
     @include fs-textSans(1);
     color: $neutral-2;
     font-weight: bold;
@@ -517,7 +517,7 @@
     padding-right: $gs-gutter;
     text-align: right;
 
-    .adverts__more + & {
+    .commodel__more + & {
         margin-top: 0;
     }
 
@@ -526,39 +526,39 @@
     }
 }
 
-.adverts__badge--alt {
+.commodel__badge--alt {
     border-top: 1px dotted $neutral-5;
     margin-top: $gs-baseline / 3;
     padding-top: $gs-baseline / 6;
     text-align: left;
 
-    > .adverts__badge__link,
-    .adverts__badge__logo {
+    > .commodel__badge__link,
+    .commodel__badge__logo {
         display: block;
     }
 
-    .adverts__badge__logo {
+    .commodel__badge__logo {
         max-height: 6 * $gs-baseline;
         margin: 0;
     }
 
-    > .adverts__badge__link {
+    > .commodel__badge__link {
         border-bottom: 1px dotted $neutral-5;
         margin: 3 / 4 * $gs-baseline 0 $gs-baseline / 3;
     }
 
-    > .adverts__badge__help {
+    > .commodel__badge__help {
         @include font-size(11);
     }
 }
 
-.adverts__badge__logo {
+.commodel__badge__logo {
     max-height: $gs-baseline * 5;
     margin-left: $gs-gutter / 2;
     vertical-align: middle;
 }
 
-.adverts__more {
+.commodel__more {
     @include mq(tablet) {
         margin: $gs-baseline 0;
     }
@@ -597,14 +597,14 @@
 
 
 /* Theming */
-.adverts--legacy {
+.commodel--legacy {
     background: #eaeaea;
 
-    > .adverts__header .button {
+    > .commodel__header .button {
         color: #ffffff;
     }
 
-    .adverts__blurb {
+    .commodel__blurb {
         @include fs-headline(1);
         color: #ffffff;
 
@@ -622,7 +622,7 @@
     }
 }
 
-.adverts--framed {
+.commodel--framed {
     @include mq(tablet) {
         &::before,
         &::after {
@@ -661,7 +661,7 @@
 }
 
 /* Let's remove this shit when we revamp badges: */
-.adverts {
+.commodel {
     .ad-slot--paid-for-badge--front {
         border: 0;
         clear: none;

--- a/static/src/stylesheets/module/commercial/_commercial.scss
+++ b/static/src/stylesheets/module/commercial/_commercial.scss
@@ -41,7 +41,7 @@
 /* Surveys */
 @import 'surveys/_survey';
 
-/* New adverts component */
+/* New commodel component */
 @import '_advert';
 @import '_adverts';
 

--- a/static/test/javascripts/spec/common/commercial/creatives/template.spec.js
+++ b/static/test/javascripts/spec/common/commercial/creatives/template.spec.js
@@ -166,7 +166,7 @@ define([
                 clickMacro: '%%CLICK_URL_ESC%%'
             };
             new Template(slot, params).create().then(function () {
-                expect(document.querySelector('.adverts', slot)).not.toBe(null);
+                expect(document.querySelector('.commodel', slot)).not.toBe(null);
             });
         });
 


### PR DESCRIPTION
## What does this change?

The hosted page (https://github.com/guardian/frontend/pull/12832) is entirely blocked by an adblock because we named the main css class as `adverts`. My proposition is to rename the `adverts` into `commodel` (because it's a box model for the commercial content). The test page, glabs page and unit tests seem to work fine. I don't know what else should I test.  
## What is the value of this and can you measure success?

The hosted page won't be blocked by adblock.
## Does this affect other platforms - Amp, Apps, etc?

no
## Request for comment

@uplne @regiskuckaertz @jbreckmckye 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
