### PR TITLE
Set the correct audience segment size for hiding clever friend

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/clever-friend-brexit.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/clever-friend-brexit.js
@@ -6,13 +6,13 @@ define([
         this.start = '2016-05-09';
         this.expiry = '2016-07-31';
         this.author = 'Anne Byrne';
-        this.description = 'Segmentation to target users with Clever Friend';
-        this.audience = 0.0;
+        this.description = 'Only expose the clever friend embed to 10% of people, by removing it for 90%';
+        this.audience = 0.9;
         this.audienceOffset = 0.0;
-        this.successMeasure = 'We want to segment users, so that only 1% are targeted with Clever Friend - the Brexit Companion.';
+        this.successMeasure = 'Not really an a/b test, just using the audience segmentation for a soft launch';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';
-        this.idealOutcome = 'We want a sample of users, 1% of our audience, to see Clever Friend on Brexit news articles.';
+        this.idealOutcome = '';
 
         this.canRun = function () {
             return true;


### PR DESCRIPTION
Turning on the "test" (more of soft launch really) added in #12857, exposing the clever friend interactive to just 10% of people by removing it for 90%. Also amended the description to make it clearer what we're doing here.
