### PR TITLE
request video content type for more in series

### DIFF
--- a/onward/app/controllers/MostViewedVideoController.scala
+++ b/onward/app/controllers/MostViewedVideoController.scala
@@ -16,6 +16,7 @@ object MostViewedVideoController extends Controller with Logging with ExecutionC
 
     getResponse(ContentApiClient.search(edition)
       .tag(series)
+      .contentType("video")
       .showTags("series")
       .showFields("headline")
       .page(page)


### PR DESCRIPTION
## What does this change?

More in series playlist only shows video.

The "How South Wales" item without a thumbnail below links to this article - http://www.theguardian.com/commentisfree/2012/may/03/credit-unions-evangelical-finance

![screen shot 2016-05-12 at 12 34 32](https://cloud.githubusercontent.com/assets/836140/15213193/95e65e38-183d-11e6-8464-7da5c4bf4545.jpeg)
## What is the value of this and can you measure success?

Better experience.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

n/a
## Request for comment

@jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
