### PR TITLE
Show capi-sourced logos in branded containers

### DIFF
--- a/common/app/common/commercial/BrandHunter.scala
+++ b/common/app/common/commercial/BrandHunter.scala
@@ -24,13 +24,11 @@ object BrandHunter {
     findBranding(frontProps.activeBrandings, publicationDate = None, edition)
   }
 
-  // difficult to find content's section at the moment so this param is temporarily optional
-  def findContentBranding(section: Option[Section],
-                          tags: Tags,
-                          publicationDate: Option[DateTime],
-                          edition: Edition): Option[Branding] = {
-    lazy val brandingBySection = section flatMap (findSectionBranding(_, publicationDate, edition))
-    lazy val brandingByTags = tags.tags.flatMap(findTagBranding(_, publicationDate, edition)).headOption
-    brandingBySection orElse brandingByTags
+  def findContentBranding(content: ContentType, edition: Edition): Option[Branding] = {
+    // TODO: incorporate branding by section - needs capi change to get section element in content results
+    val tags = content.tags
+    val publicationDate = Some(content.trail.webPublicationDate)
+    val brandingByTags = tags.tags.flatMap(findTagBranding(_, publicationDate, edition)).headOption
+    brandingByTags
   }
 }

--- a/common/app/common/commercial/ContainerModel.scala
+++ b/common/app/common/commercial/ContainerModel.scala
@@ -1,6 +1,8 @@
 package common.commercial
 
+import common.Edition
 import conf.switches.Switches
+import model.Branding
 import model.facia.PressedCollection
 import views.support.{Commercial, SponsorDataAttributes}
 
@@ -8,9 +10,14 @@ case class ContainerModel(
                            id: String,
                            layoutName: String,
                            content: ContainerContent,
-                           brandingAttributes: Option[SponsorDataAttributes]
-                         ){
-  val isSingleSponsorContainer: Boolean = brandingAttributes.isDefined
+                           brandingAttributes: Option[SponsorDataAttributes],
+                           branding: Option[Branding]
+                         ) {
+  val isSingleSponsorContainer: Boolean = {
+    if (Switches.staticBadgesSwitch.isSwitchedOn) {
+      branding.isDefined
+    } else brandingAttributes.isDefined
+  }
 }
 
 case class ContainerContent(
@@ -23,7 +30,7 @@ case class ContainerContent(
 
 object ContainerModel {
 
-  def fromPressedCollection(collection: PressedCollection): ContainerModel = {
+  def fromPressedCollection(edition: Edition)(collection: PressedCollection): ContainerModel = {
 
     val cards = collection.curatedPlusBackfillDeduplicated map CardContent.fromPressedContent
     val layoutName = collection.collectionType
@@ -76,7 +83,8 @@ object ContainerModel {
       id = collection.id,
       layoutName,
       content,
-      branding
+      brandingAttributes = Commercial.container.mkSponsorDataAttributes(collection.config),
+      branding = collection.branding(edition)
     )
   }
 }

--- a/common/app/common/commercial/ContainerModel.scala
+++ b/common/app/common/commercial/ContainerModel.scala
@@ -8,9 +8,9 @@ case class ContainerModel(
                            id: String,
                            layoutName: String,
                            content: ContainerContent,
-                           branding: Option[SponsorDataAttributes]
+                           brandingAttributes: Option[SponsorDataAttributes]
                          ){
-  val isSingleSponsorContainer: Boolean = branding.isDefined
+  val isSingleSponsorContainer: Boolean = brandingAttributes.isDefined
 }
 
 case class ContainerContent(

--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -1,7 +1,9 @@
 package model.facia
 
 import com.gu.facia.api.{models => fapi}
+import common.Edition
 import implicits.CollectionsOps._
+import model.Branding
 import model.pressed._
 import org.joda.time.DateTime
 import services.CollectionConfigWithId
@@ -29,7 +31,16 @@ case class PressedCollection(
 
   lazy val collectionConfigWithId = CollectionConfigWithId(id, config)
 
-  lazy val curatedPlusBackfillDeduplicated = (curated ++ backfill).distinctBy(c => c.properties.maybeContentId.getOrElse(c.card.id))
+  lazy val curatedPlusBackfillDeduplicated = (curated ++ backfill).distinctBy { c =>
+    c.properties.maybeContentId.getOrElse(c.card.id)
+  }
+
+  def branding(edition: Edition): Option[Branding] = {
+    val brandings = curatedPlusBackfillDeduplicated flatMap(_.branding(edition))
+    if (brandings.size == 1) {
+      brandings.headOption
+    } else None
+  }
 }
 
 object PressedCollection {

--- a/common/app/model/facia/PressedCollection.scala
+++ b/common/app/model/facia/PressedCollection.scala
@@ -36,9 +36,15 @@ case class PressedCollection(
   }
 
   def branding(edition: Edition): Option[Branding] = {
-    val brandings = curatedPlusBackfillDeduplicated flatMap(_.branding(edition))
-    if (brandings.size == 1) {
-      brandings.headOption
+
+    // TODO: replace this placeholder with value from fapi
+    val shouldBeBranded = true
+
+    if (shouldBeBranded) {
+      val brandings = curatedPlusBackfillDeduplicated flatMap (_.branding(edition))
+      if (brandings.nonEmpty && brandings.forall(_ == brandings.head)) {
+        brandings.headOption
+      } else None
     } else None
   }
 }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -396,14 +396,7 @@ trait ContentPage extends Page {
     item.content.twitterProperties ++
     metadata.twitterPropertiesOverrides
 
-  override def branding(edition: Edition): Option[Branding] = {
-    BrandHunter.findContentBranding(
-      section = None,
-      item.tags,
-      publicationDate = Some(item.trail.webPublicationDate),
-      edition
-    )
-  }
+  override def branding(edition: Edition): Option[Branding] = BrandHunter.findContentBranding(item, edition)
 }
 case class SimpleContentPage(content: ContentType) extends ContentPage {
   override lazy val item: ContentType = content

--- a/common/app/model/pressedContent.scala
+++ b/common/app/model/pressedContent.scala
@@ -3,7 +3,9 @@ package model.pressed
 import com.gu.facia.api.utils.FaciaContentUtils
 import com.gu.facia.api.{models => fapi, utils => fapiutils}
 import com.gu.facia.client.models.{Backfill, CollectionConfigJson}
-import model.{ContentType, SupportedUrl}
+import common.Edition
+import common.commercial.BrandHunter
+import model.{Branding, ContentType, SupportedUrl}
 import org.joda.time.DateTime
 
 object CollectionConfig {
@@ -157,7 +159,11 @@ final case class PressedProperties(
   maybeFrontPublicationDate: Option[Long],
   href: Option[String],
   webUrl: Option[String]
-)
+) {
+  def branding(edition: Edition): Option[Branding] = {
+    maybeContent map (BrandHunter.findContentBranding(_, edition)) getOrElse None
+  }
+}
 
 object PressedCardHeader {
   def make(content: fapi.FaciaContent): PressedCardHeader = {
@@ -276,6 +282,8 @@ sealed trait PressedContent {
   def card: PressedCard
   def discussion: PressedDiscussionSettings
   def display: PressedDisplaySettings
+
+  def branding(edition: Edition): Option[Branding] = properties.branding(edition)
 }
 sealed trait Snap extends PressedContent
 

--- a/common/app/views/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/commercial/containers/paidContainer.scala.html
@@ -3,17 +3,19 @@
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
 @import common.{Edition, LinkTo}
+@import conf.switches.Switches.staticBadgesSwitch
 @import views.html.commercial.containerWrapper
 @import views.html.commercial.containers._
+@import views.html.fragments.commercial.contentLogo
 @import views.html.fragments.inlineSvg
 @import views.support.commercial.TrackingCodeBuilder.mkInteractionTrackingCode
 
 <div data-id="@containerModel.id" class="fc-container@if(containerModel.isSingleSponsorContainer){ js-sponsored-container}"
-    @for(branding <- containerModel.brandingAttributes){
-        data-sponsorship="@branding.sponsorshipType"
-        @for(sponsor <- branding.sponsor){ data-sponsor="@sponsor" }
-        @for(keywordId <- branding.keywordId){ data-keywords="@keywordId" }
-        @for(seriesId <- branding.seriesId){ data-series="@seriesId"}
+    @for(brandingAttributes <- containerModel.brandingAttributes){
+        data-sponsorship="@brandingAttributes.sponsorshipType"
+        @for(sponsor <- brandingAttributes.sponsor){ data-sponsor="@sponsor" }
+        @for(keywordId <- brandingAttributes.keywordId){ data-keywords="@keywordId" }
+        @for(seriesId <- brandingAttributes.seriesId){ data-series="@seriesId"}
     }
     >
     @containerWrapper(
@@ -77,4 +79,12 @@
 
 }
 
-@logoSlot = {<div class="js-badge-placeholder"></div>}
+@logoSlot = {
+    @if(staticBadgesSwitch.isSwitchedOn) {
+        @for(branding <- containerModel.branding) {
+            @contentLogo(branding)
+        }
+    } else {
+        <div class="js-badge-placeholder"></div>
+    }
+}

--- a/common/app/views/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/commercial/containers/paidContainer.scala.html
@@ -9,7 +9,7 @@
 @import views.support.commercial.TrackingCodeBuilder.mkInteractionTrackingCode
 
 <div data-id="@containerModel.id" class="fc-container@if(containerModel.isSingleSponsorContainer){ js-sponsored-container}"
-    @for(branding <- containerModel.branding){
+    @for(branding <- containerModel.brandingAttributes){
         data-sponsorship="@branding.sponsorshipType"
         @for(sponsor <- branding.sponsor){ data-sponsor="@sponsor" }
         @for(keywordId <- branding.keywordId){ data-keywords="@keywordId" }

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -100,7 +100,7 @@
 
                 case _: Dynamic | _: Fixed => {
                     <div class="fc-container__inner">
-                        @standardContainer(containerDefinition, frontProperties)
+                        @standardContainer(containerDefinition, frontProperties, maybeContainerModel)
                     </div>
                 }
 

--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -17,7 +17,7 @@
 @renderBrandingDataAttributes() = {
     @if(Switches.cardsDecidePaidContainerBranding.isSwitchedOn) {
         @for(container <- maybeContainerModel) {
-            @for(branding <- container.branding) {
+            @for(branding <- container.brandingAttributes) {
                 @for(sponsor <- branding.sponsor){data-sponsor="@sponsor"}
                 @for(seriesId <- branding.seriesId) { data-series="@seriesId" }
                 @for(keywordId <- branding.keywordId) { data-keywords="@keywordId" }

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -1,15 +1,26 @@
-@(containerDefinition: layout.FaciaContainer, frontProperties: model.FrontProperties)(implicit request: RequestHeader)
+@import common.commercial.ContainerModel
 @import common.{Edition, Localisation}
 @import conf.switches.Switches.staticBadgesSwitch
 @import views.html.fragments.commercial.contentLogo
 @import views.html.fragments.containers.facia_cards.{containerHeader, showMore, showMoreButton, slice}
 @import views.support.RenderClasses
+@(containerDefinition: layout.FaciaContainer,
+  frontProperties: model.FrontProperties,
+  maybeContainerModel: Option[ContainerModel])(implicit request: RequestHeader)
 
 @containerHeader(containerDefinition, frontProperties)
 
-@if(containerDefinition.index == 0 && staticBadgesSwitch.isSwitchedOn) {
-    @for(branding <- frontProperties.branding(Edition(request))) {
-        @contentLogo(branding)
+@if(staticBadgesSwitch.isSwitchedOn) {
+    @if(containerDefinition.index == 0) {
+        @for(frontBranding <- frontProperties.branding(Edition(request))) {
+            @contentLogo(frontBranding)
+        }
+    } else {
+        @for(containerModel <- maybeContainerModel) {
+            @for(containerBranding <- containerModel.branding) {
+                @contentLogo(containerBranding)
+            }
+        }
     }
 }
 

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -93,7 +93,7 @@ object Commercial {
         val content = container.content
         val paidCards = content.initialCards.filter(card => isPaid(card.branding))
 
-        isPaid(container.branding) || paidCards.nonEmpty
+        isPaid(container.brandingAttributes) || paidCards.nonEmpty
       }
 
       !isPaidFront &&

--- a/common/app/views/support/commercial/TrackingCodeBuilder.scala
+++ b/common/app/views/support/commercial/TrackingCodeBuilder.scala
@@ -10,7 +10,7 @@ object TrackingCodeBuilder {
                                 containerIndex: Int,
                                 container: ContainerModel,
                                 card: CardContent)(implicit request: RequestHeader): String = {
-    val sponsor = container.branding.flatMap(_.sponsor) orElse card.branding.flatMap(_.sponsor) getOrElse ""
+    val sponsor = container.brandingAttributes.flatMap(_.sponsor) orElse card.branding.flatMap(_.sponsor) getOrElse ""
     val cardIndex =
       (container.content.initialCards ++ container.content.showMoreCards).indexWhere(_.headline == card.headline)
     Seq(

--- a/common/test/common/commercial/ContainerModelTest.scala
+++ b/common/test/common/commercial/ContainerModelTest.scala
@@ -1,6 +1,7 @@
 package common.commercial
 
 import common.commercial.FixtureBuilder._
+import common.editions.Uk
 import model.facia.PressedCollection
 import model.pressed.{CollectionConfig, PressedContent}
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
@@ -58,52 +59,56 @@ class ContainerModelTest extends FlatSpec with Matchers with OptionValues {
     )
   }
 
+  def fromUkPressedCollection: (PressedCollection) => ContainerModel = {
+    ContainerModel.fromPressedCollection(Uk)
+  }
+
   "fromPressedCollection" should "populate id" in {
     val pressedCollection = mkPressedCollection("fixed/small/slow-I")
-    val container = ContainerModel.fromPressedCollection(pressedCollection)
+    val container = fromUkPressedCollection(pressedCollection)
     container.id shouldBe "test-collection-id"
   }
 
   it should "populate title" in {
     val pressedCollection = mkPressedCollection("fixed/small/slow-I")
-    val container = ContainerModel.fromPressedCollection(pressedCollection)
+    val container = fromUkPressedCollection(pressedCollection)
     container.content.title shouldBe "test-collection-displayName"
   }
 
   it should "populate description" in {
     val pressedCollection = mkPressedCollection("fixed/small/slow-I")
-    val container = ContainerModel.fromPressedCollection(pressedCollection)
+    val container = fromUkPressedCollection(pressedCollection)
     container.content.description.value shouldBe "desc"
   }
 
   it should "populate targetUrl" in {
     val pressedCollection = mkPressedCollection("fixed/small/slow-I")
-    val container = ContainerModel.fromPressedCollection(pressedCollection)
+    val container = fromUkPressedCollection(pressedCollection)
     container.content.targetUrl.value shouldBe
       "/am-resorts-partner-zone/2016/jan/20/be-a-hero-on-the-half-shell-release-baby-turtles-on-your-next-vacation"
   }
 
   it should "populate layoutName" in {
     val pressedCollection = mkPressedCollection("fixed/small/slow-I")
-    val container = ContainerModel.fromPressedCollection(pressedCollection)
+    val container = fromUkPressedCollection(pressedCollection)
     container.layoutName shouldBe "fixed/small/slow-I"
   }
 
   it should "populate initial cards in a fixed container" in {
     val pressedCollection = mkPressedCollection("fixed/medium/fast-XII")
-    val model = ContainerModel.fromPressedCollection(pressedCollection)
+    val model = fromUkPressedCollection(pressedCollection)
     model.content.initialCards.size shouldBe 4
   }
 
   it should "populate show-more cards" in {
     val pressedCollection = mkPressedCollection("fixed/small/slow-I")
-    val model = ContainerModel.fromPressedCollection(pressedCollection)
+    val model = fromUkPressedCollection(pressedCollection)
     model.content.showMoreCards.size shouldBe 4
   }
 
   it should "leave show-more cards empty if hideShowMore property is set" in {
     val pressedCollection = mkPressedCollection("fixed/small/slow-I", hideShowMore = true)
-    val model = ContainerModel.fromPressedCollection(pressedCollection)
+    val model = fromUkPressedCollection(pressedCollection)
     model.content.showMoreCards shouldBe empty
   }
 }

--- a/common/test/views/support/commercial/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/commercial/TrackingCodeBuilderTest.scala
@@ -25,7 +25,7 @@ class TrackingCodeBuilderTest extends FlatSpec with Matchers {
     branding
   )
 
-  def mkContainerModel(branding: Option[SponsorDataAttributes] = None) = {
+  def mkContainerModel(brandingAttributes: Option[SponsorDataAttributes] = None) = {
 
     def mkContainerContent() = ContainerContent(
       title = "container-title",
@@ -49,7 +49,8 @@ class TrackingCodeBuilderTest extends FlatSpec with Matchers {
       id = "",
       layoutName = "",
       mkContainerContent(),
-      branding
+      brandingAttributes,
+      branding = None
     )
   }
 
@@ -57,7 +58,7 @@ class TrackingCodeBuilderTest extends FlatSpec with Matchers {
     val code = TrackingCodeBuilder.mkInteractionTrackingCode(
       frontId = "front-id",
       containerIndex = 2,
-      container = mkContainerModel(branding = Some(mkBranding("sponsor-name"))),
+      container = mkContainerModel(brandingAttributes = Some(mkBranding("sponsor-name"))),
       card = mkCardContent(5)
     )(request = FakeRequest().withHeaders("X-Gu-Edition" -> "US"))
     code shouldBe
@@ -79,7 +80,7 @@ class TrackingCodeBuilderTest extends FlatSpec with Matchers {
     val code = TrackingCodeBuilder.mkInteractionTrackingCode(
       frontId = "front-id",
       containerIndex = 2,
-      container = mkContainerModel(branding = Some(mkBranding("sponsor-name"))),
+      container = mkContainerModel(brandingAttributes = Some(mkBranding("sponsor-name"))),
       card = mkCardContent(5)
     )(request = FakeRequest().withHeaders("X-Gu-Edition" -> "US"))
     code shouldBe

--- a/facia/app/views/fragments/brandedFrontBody.scala.html
+++ b/facia/app/views/fragments/brandedFrontBody.scala.html
@@ -28,7 +28,7 @@
                                 faciaPage.collections.find {
                                     _.id == containerDefinition.dataId
                                 }.map {
-                                    ContainerModel.fromPressedCollection
+                                    ContainerModel.fromPressedCollection(Edition(request))
                                 }
                             )
                         }

--- a/facia/app/views/fragments/frontBody.scala.html
+++ b/facia/app/views/fragments/frontBody.scala.html
@@ -37,7 +37,7 @@
                             faciaPage.collections.find {
                                 _.id == containerDefinition.dataId
                             }.map {
-                                ContainerModel.fromPressedCollection
+                                ContainerModel.fromPressedCollection(Edition(request))
                             }
                         )
                     }


### PR DESCRIPTION
Eg.

![image](https://cloud.githubusercontent.com/assets/1722550/15213199/9baf9f5a-183d-11e6-80cd-3d8c384b9086.png)

When switch is on, logo will be served directly in template.  Otherwise it will be served from DFP as now.

/cc @steppenwells 
