### PR TITLE
video embeds obey advertising rules of parent video

### DIFF
--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.contentapi.client.model.v1.{Content => ApiContent, ItemResponse}
+import com.gu.contentapi.client.model.v1.{ContentFields, ItemResponse, Content => ApiContent}
 import common._
 import contentapi.ContentApiClient
 import conf.switches.Switches
@@ -22,8 +22,8 @@ object MediaController extends Controller with RendersItemResponse with Logging 
 
   def renderInfoJson(path: String) = Action.async { implicit request =>
     lookup(path) map {
-      case Left(model)  => MediaInfo(expired = false)
-      case Right(other) => MediaInfo(expired = true)
+      case Left(model)  => MediaInfo(expired = false, shouldHideAdverts = model.media.content.shouldHideAdverts)
+      case Right(other) => MediaInfo(expired = true, shouldHideAdverts = true)
     } map { mediaInfo =>
       Cached(60)(JsonComponent(Json.toJson(mediaInfo).as[JsObject]))
     }
@@ -63,7 +63,7 @@ object MediaController extends Controller with RendersItemResponse with Logging 
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
 }
 
-case class MediaInfo(expired: Boolean)
+case class MediaInfo(expired: Boolean, shouldHideAdverts: Boolean)
 object MediaInfo {
   implicit val jsonFormats: Format[MediaInfo] = Json.format[MediaInfo]
 }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -179,20 +179,20 @@ define([
         var mediaType = el.tagName.toLowerCase(),
             $el = bonzo(el).addClass('vjs vjs-tech-' + videojs.options.techOrder[0]),
             mediaId = $el.attr('data-media-id'),
-            blockVideoAds = $el.attr('data-block-video-ads') === 'true',
             showEndSlate = $el.attr('data-show-end-slate') === 'true',
             endSlateUri = $el.attr('data-end-slate'),
             embedPath = $el.attr('data-embed-path'),
             // we need to look up the embedPath for main media videos
             canonicalUrl = $el.attr('data-canonical-url') || (embedPath ? '/' + embedPath : null),
             techPriority = techOrder(el),
-            withPreroll = shouldPreroll && !blockVideoAds,
             player,
             mouseMoveIdle,
             playerSetupComplete,
+            withPreroll,
+            blockVideoAds,
             isPlayerExpired;
 
-        isPlayerExpired = new Promise(function(resolve) {
+        var videoInfo = new Promise(function(resolve) {
             // We only have the canonical URL in videos embedded in articles / main media.
             if (!canonicalUrl) {
                 resolve(false);
@@ -200,10 +200,14 @@ define([
                 ajax({
                     url: canonicalUrl + '/info.json'
                 }).then(function(videoInfo) {
-                    resolve(videoInfo.expired);
+                    resolve(videoInfo);
                 });
             }
         });
+
+        isPlayerExpired = videoInfo.expired;
+        blockVideoAds = videoInfo.shouldHideAdverts;
+        withPreroll = shouldPreroll && !blockVideoAds;
 
         player = createVideoPlayer(el, {
             techOrder: techPriority,

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -189,8 +189,7 @@ define([
             mouseMoveIdle,
             playerSetupComplete,
             withPreroll,
-            blockVideoAds,
-            isPlayerExpired;
+            blockVideoAds;
 
         var videoInfo = new Promise(function(resolve) {
             // We only have the canonical URL in videos embedded in articles / main media.
@@ -205,9 +204,6 @@ define([
             }
         });
 
-        isPlayerExpired = videoInfo.expired;
-        blockVideoAds = videoInfo.shouldHideAdverts;
-        withPreroll = shouldPreroll && !blockVideoAds;
 
         player = createVideoPlayer(el, {
             techOrder: techPriority,
@@ -225,8 +221,8 @@ define([
             }
         });
 
-        isPlayerExpired.then(function(expired) {
-            if (expired) {
+        videoInfo.then(function(videoInfo) {
+            if (videoInfo.expired) {
                 player.ready(function() {
                     player.error({
                         code: 0,
@@ -238,6 +234,9 @@ define([
                     player.errorDisplay.open();
                 });
             } else {
+                blockVideoAds = videoInfo.shouldHideAdverts;
+                withPreroll = shouldPreroll && !blockVideoAds;
+
                 // Location of this is important.
                 events.bindErrorHandler(player);
                 player.guMediaType = mediaType;


### PR DESCRIPTION
## What does this change?

Before:
Video is published with pre-roll=true
Video is embedded
Video pre-roll is then changed to false
Embed still has pre-roll=true

(and vice-versa for video published with pre-roll=false)

After:
I've added a field to /info.json which is used to determine if advertising should be blocked on the video. Therefore, similar to how expiry is calculated, the embed follows the parent video.
## What is the value of this and can you measure success?

Video embeds obeys parent video. In order to achieve this before, the video had to be re-embedded.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

n/a
## Request for comment

@jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
