### PR TITLE
Release the Guardian Frame

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/frame.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/frame.js
@@ -1,0 +1,51 @@
+define([
+    'common/utils/fastdom-promise',
+    'common/utils/template',
+    'common/views/svgs',
+    'common/modules/ui/toggles',
+    'common/modules/commercial/creatives/add-tracking-pixel',
+    'text!common/views/commercial/creatives/frame.html',
+    'text!common/views/commercial/gustyle/label.html'
+], function (
+    fastdom,
+    template,
+    svgs,
+    Toggles,
+    addTrackingPixel,
+    frameStr,
+    labelStr
+) {
+
+    var Frame = function ($adSlot, params) {
+        this.$adSlot = $adSlot;
+        this.params  = params;
+    };
+
+    Frame.prototype.create = function () {
+        this.params.externalLinkIcon = svgs('externalLink', ['gu-external-icon']);
+        this.params.target = this.params.newWindow === 'yes' ? '_blank' : '_self';
+
+        var frameMarkup = template(frameStr, { data: this.params });
+        var labelMarkup = template(labelStr, { data: {
+            buttonTitle: 'Ad',
+            infoTitle: 'Advertising on the Guardian',
+            infoText: 'is created and paid for by third parties and link to an external site.',
+            infoLinkText: 'Learn more about how advertising supports the Guardian.',
+            infoLinkUrl: 'https://www.theguardian.com/advertising-on-the-guardian',
+            icon: svgs('arrowicon', ['gu-comlabel__icon']),
+            dataAttr: this.$adSlot[0].id
+        }});
+        return fastdom.write(function () {
+            this.$adSlot[0].insertAdjacentHTML('beforeend', frameMarkup);
+            this.$adSlot[0].lastElementChild.insertAdjacentHTML('afterbegin', labelMarkup);
+            this.$adSlot.addClass('ad-slot--frame');
+            if (this.params.trackingPixel) {
+                addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
+            }
+            new Toggles(this.$adSlot[0]).init();
+        }, this);
+    };
+
+    return Frame;
+
+});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/gu-style-comcontent.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/gu-style-comcontent.js
@@ -1,5 +1,5 @@
 define([
-    'fastdom',
+    'common/utils/fastdom-promise',
     'common/utils/$',
     'common/utils/detect',
     'common/utils/mediator',
@@ -41,14 +41,16 @@ define([
                 isHostedBottom: this.params.adType === 'gu-style-hosted-bottom'
             };
         var templateToLoad = this.params.adType === 'gu-style' ? gustyleComcontentTpl : gustyleHostedTpl;
+        var markup = template(templateToLoad, { data: merge(this.params, templateOptions) });
+        var gustyle = new GuStyle(this.$adSlot, this.params);
 
-        $.create(template(templateToLoad, { data: merge(this.params, templateOptions) })).appendTo(this.$adSlot);
-        new GuStyle(this.$adSlot, this.params).addLabel();
+        return fastdom.write(function () {
+            this.$adSlot[0].insertAdjacentHTML('beforeend', markup);
 
-        if (this.params.trackingPixel) {
-            addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
-        }
-
+            if (this.params.trackingPixel) {
+                addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
+            }
+        }, this).then(gustyle.addLabel.bind(gustyle));
     };
 
     return GustyleComcontent;

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -34,48 +34,40 @@ define([
      * This can be set on the DFP creative.
      */
     function breakoutIFrame(iFrame, $slot) {
-        return new Promise(function (resolve, reject) {
-            /*eslint-disable no-eval*/
-            var $iFrame = bonzo(iFrame);
-            var iFrameBody = iFrame.contentDocument.body;
-            var $breakoutEl;
+        /*eslint-disable no-eval*/
+        var $iFrame = bonzo(iFrame);
+        var iFrameBody = iFrame.contentDocument.body;
+        var $breakoutEl;
 
-            if (!iFrameBody) {
-                reject();
-            }
+        $breakoutEl = $('.breakout__html, .breakout__script', iFrameBody);
 
-            $breakoutEl = $('.breakout__html, .breakout__script', iFrameBody);
-
-            if ($breakoutEl.hasClass('breakout__html')) {
-                resolve(fastdom.write(function () {
-                    $iFrame.hide();
-                    $breakoutEl.detach();
-                    $slot.append($breakoutEl[0].innerHTML);
-                }));
-            } else if ($breakoutEl.hasClass('breakout__script')) {
-                fastdom.write(function () {
-                    $iFrame.hide();
-                }).then(function () {
-                    var breakoutContent = $breakoutEl.html();
-                    if ($breakoutEl.attr('type') === 'application/json') {
-                        var creativeConfig = JSON.parse(breakoutContent);
-                        if (creativeConfig.name === 'fluid250-v4' || creativeConfig.name === 'fluid250-v3') {
-                            creativeConfig.name = 'fluid250';
-                        }
-                        require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
-                            new Creative($slot, creativeConfig.params, creativeConfig.opts).create();
-                        });
-                        resolve(creativeConfig.params.adType || '');
-                    } else {
-                        // evil, but we own the returning js snippet
-                        eval(breakoutContent);
-                        resolve();
+        if ($breakoutEl.hasClass('breakout__html')) {
+            return fastdom.write(function () {
+                $iFrame.hide();
+                $breakoutEl.detach();
+                $slot.append($breakoutEl[0].innerHTML);
+            });
+        } else if ($breakoutEl.hasClass('breakout__script')) {
+            return fastdom.write(function () {
+                $iFrame.hide();
+            }).then(function () {
+                var breakoutContent = $breakoutEl.html();
+                if ($breakoutEl.attr('type') === 'application/json') {
+                    var creativeConfig = JSON.parse(breakoutContent);
+                    if (creativeConfig.name === 'fluid250-v4' || creativeConfig.name === 'fluid250-v3') {
+                        creativeConfig.name = 'fluid250';
                     }
-                });
-            } else {
-                resolve();
-            }
-        });
+                    return new Promise(function(resolve) {
+                        require(['common/modules/commercial/creatives/' + creativeConfig.name], function (Creative) {
+                            resolve(new Creative($slot, creativeConfig.params, creativeConfig.opts).create());
+                        });
+                    });
+                } else {
+                    // evil, but we own the returning js snippet
+                    eval(breakoutContent);
+                }
+            });
+        }
     }
 
     return breakoutIFrame;

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/breakout-iframe.js
@@ -7,6 +7,7 @@ define([
 
     'common/modules/commercial/creatives/commercial-component',
     'common/modules/commercial/creatives/gu-style-comcontent',
+    'common/modules/commercial/creatives/frame',
     'common/modules/commercial/creatives/expandable',
     'common/modules/commercial/creatives/expandable-v2',
     'common/modules/commercial/creatives/expandable-v3',

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -407,7 +407,9 @@ define([
     }
 
     function shouldRenderLabel($adSlot) {
-        return $adSlot.data('label') !== false && qwery('.ad-slot__label', $adSlot[0]).length === 0;
+        return !$adSlot.hasClass('ad-slot--frame') &&
+            !$adSlot.hasClass('gu-style') &&
+            ($adSlot.data('label') !== false && qwery('.ad-slot__label', $adSlot[0]).length === 0);
     }
 
     function lazyLoad() {
@@ -713,10 +715,8 @@ define([
             });
 
             // Check if creative is a new gu style creative and place labels accordingly
-            dfp.checkForBreakout($adSlot).then(function (adType) {
-                if (!/gu-style/.test(adType)) {
-                    addLabel($adSlot);
-                }
+            dfp.checkForBreakout($adSlot).then(function () {
+                addLabel($adSlot);
 
                 size = event.size.join(',');
                 // is there a callback for this size

--- a/static/src/javascripts/projects/common/modules/commercial/gustyle/gustyle.js
+++ b/static/src/javascripts/projects/common/modules/commercial/gustyle/gustyle.js
@@ -1,5 +1,5 @@
 define([
-    'fastdom',
+    'common/utils/fastdom-promise',
     'common/utils/$',
     'common/utils/config',
     'common/utils/template',
@@ -35,7 +35,7 @@ define([
                 dataAttr: this.$slot.attr('id')
             };
 
-        fastdom.write(function () {
+        return fastdom.write(function () {
             var classList = 'gu-style' + ((this.isContentPage) ? ' gu-style--unboxed' : '');
 
             this.$slot.addClass(classList);
@@ -43,7 +43,7 @@ define([
 
             toggles = new Toggles(this.$slot[0]);
             toggles.init();
-        }.bind(this));
+        }, this);
     };
 
     return Gustyle;

--- a/static/src/javascripts/projects/common/views/commercial/creatives/frame.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/frame.html
@@ -1,0 +1,17 @@
+<aside class="frame" data-link-name="creative | frame">
+    <div class="frame__background">
+        <img class="frame__background-image" src="<%=data.backgroundImage%>">
+    </div>
+    <div class="frame__foreground">
+        <a class="frame__logo frame__logo--<%=data.brandLogoPosition%>" href="<%=data.brandUrl%>" data-link-name="logo" target="<%=data.target%>">
+            <img class="frame__logo__image" src="<%=data.brandLogo%>">
+        </a>
+        <a style="color: <%=data.contentColour%>" class="frame__content frame__content--<%=data.contentVerticalPosition%> frame__content--<%=data.contentHorizontalPosition%>" href="<%=data.clickMacro%><%=data.destinationUrl%>" target="<%=data.target%>">
+            <h2 style="font-size: <%=data.headerFontSize%>px" class="frame__content-title"><%=data.header%></h2>
+            <p style="font-size: <%=data.textFontSize%>px" class="frame__content-text"><%=data.text%></p>
+        </a>
+        <a href="<%=data.clickMacro%><%=data.callToActionUrl%>" class="frame__cta frame__link button button--tertiary button--medium" data-link-name="call to action" target="<%=data.target%>">
+            <%=data.callToAction%><%=data.externalLinkIcon%>
+        </a>
+    </div>
+</aside>

--- a/static/src/stylesheets/module/commercial/_commercial.scss
+++ b/static/src/stylesheets/module/commercial/_commercial.scss
@@ -54,3 +54,6 @@
 
 /* Glabs Awesome component */
 @import 'glabs/_hosted.scss';
+
+/* Guardian frame */
+@import '_frame';

--- a/static/src/stylesheets/module/commercial/_frame.scss
+++ b/static/src/stylesheets/module/commercial/_frame.scss
@@ -1,0 +1,84 @@
+.frame {
+    position: relative;
+}
+
+.frame__background-image {
+    display: block;
+    width: 100%;
+}
+
+.frame__foreground {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: $gs-baseline / 2 $gs-gutter / 2;
+
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.frame__logo--bottom {
+    position: absolute;
+    bottom: $gs-baseline / 2;
+    right: $gs-gutter / 2;
+}
+
+.frame__content {
+    @include f-headlineSans;
+    align-self: stretch;
+}
+
+@include mq(gs-span(5) + $gs-gutter, phablet) {
+    .frame__foreground {
+        padding: $gs-baseline * 1.5 $gs-gutter;
+    }
+
+    .frame__content {
+        max-width: 18em;
+    }
+
+    .frame__logo--bottom {
+        bottom: $gs-baseline * 1.5;
+        right: $gs-gutter;
+    }
+}
+
+.frame__content--left   {
+    align-self: flex-start;
+    text-align: left;
+}
+.frame__content--center {
+    align-self: center;
+    text-align: center;
+}
+.frame__content--right  {
+    align-self: flex-end;
+    text-align: right;
+}
+
+.frame__content--top    {
+    margin-bottom: auto;
+}
+.frame__content--middle {
+    margin-bottom: auto;
+    margin-top: auto;
+}
+.frame__content--bottom {
+    margin-top: auto;
+}
+
+.frame__content-title {
+    font-weight: normal;
+    line-height: 1.2;
+}
+
+.frame__link {
+    color: inherit;
+}
+
+.frame__cta {
+    color: #fff;
+}

--- a/static/src/stylesheets/module/commercial/_frame.scss
+++ b/static/src/stylesheets/module/commercial/_frame.scss
@@ -20,15 +20,22 @@
     align-items: flex-start;
 }
 
+.frame__logo--top {
+    margin-bottom: $gs-baseline;
+}
+
 .frame__logo--bottom {
     position: absolute;
     bottom: $gs-baseline / 2;
     right: $gs-gutter / 2;
 }
 
+.frame__logo-image {
+    display: block;
+}
+
 .frame__content {
     @include f-headlineSans;
-    align-self: stretch;
 }
 
 @include mq(gs-span(5) + $gs-gutter, phablet) {
@@ -81,4 +88,57 @@
 
 .frame__cta {
     color: #fff;
+}
+
+.has-no-flex {
+    .frame__logo,
+    .frame__content,
+    .frame__cta {
+        position: absolute;
+    }
+
+    .frame__logo--top {
+        top: $gs-baseline / 2;
+        left: $gs-gutter / 2;
+    }
+
+    .frame__logo--bottom {
+        bottom: $gs-baseline / 2;
+        right: $gs-gutter / 2;
+    }
+
+    .frame__cta {
+        bottom: $gs-baseline / 2;
+        left: $gs-gutter / 2;
+    }
+
+    .frame__content--top {
+        top: $gs-baseline * 5;
+    }
+
+    .frame__content--bottom {
+        bottom: $gs-baseline * 5;
+    }
+
+    .frame__content--middle {
+        top: 50%;
+        transform: translate(0, -50%);
+    }
+
+    .frame__content--left {
+        left: $gs-gutter / 2;
+    }
+
+    .frame__content--right {
+        right: $gs-gutter / 2;
+    }
+
+    .frame__content--center {
+        left: 50%;
+        transform: translate(-50%, 0);
+    }
+
+    .frame__content--middle.frame__content--center {
+        transform: translate(-50%, -50%);
+    }
 }

--- a/static/src/stylesheets/module/commercial/_frame.scss
+++ b/static/src/stylesheets/module/commercial/_frame.scss
@@ -87,7 +87,7 @@
 }
 
 .frame__cta {
-    color: #fff;
+    color: #ffffff;
 }
 
 .has-no-flex {

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -140,6 +140,7 @@
 $mobile-max-container-width: gs-span(8);
 @include mq-add-breakpoint(containerWidestMobile, $mobile-max-container-width + $gs-gutter * 2);
 
+.ad-slot--frame,
 .gu-style {
     width: auto;
     border-top: #fedd79 1px solid;

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comlabel.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comlabel.scss
@@ -26,6 +26,16 @@
         &:after {
             display: none;
         }
+
+        @include mq(gs-span(5) + $gs-gutter, phablet) {
+            top: $gs-baseline * 1.5;
+            right: $gs-gutter;
+            padding: 10px 10px 5px;
+
+            &.is-active::before {
+                top: 38px;
+            }
+        }
     }
 }
 

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-compopup.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-compopup.scss
@@ -8,7 +8,13 @@
     right: $gs-baseline / 2;
     z-index: $zindex-modal;
     text-align: left;
+    max-width: 16em;
     background-color: $gustyle-tone;
+
+    @include mq(gs-span(5) + $gs-gutter, phablet) {
+        padding: $gs-baseline $gs-gutter / 4 * 3;
+        top: 62px;
+    }
 }
 
 .gu-compopup__title {

--- a/static/test/javascripts/spec/common/commercial/creatives/gu-style-comcontent.spec.js
+++ b/static/test/javascripts/spec/common/commercial/creatives/gu-style-comcontent.spec.js
@@ -34,105 +34,115 @@ define([
             expect(gustyleComcontent).toBeDefined();
         });
 
-        it('ad slot should have text and header at the bottom', function () {
+        it('ad slot should have text and header at the bottom', function (done) {
             $fixturesContainer = fixtures.render(fixturesConfig);
 
             new GustyleComcontent($('.ad-slot', $fixturesContainer), {
                 adType: 'gu-style',
                 articleContentPosition: 'bottom'
-            }).create();
-            expect(qwery('.gu-display__content-position--bottom', '.ad-slot').length).toBe(1);
+            }).create().then(function () {
+                expect(qwery('.gu-display__content-position--bottom', '.ad-slot').length).toBe(1);
+            }).then(done);
         });
 
-        it('ad slot should have text and header on top', function () {
+        it('ad slot should have text and header on top', function (done) {
             $fixturesContainer = fixtures.render(fixturesConfig);
 
             new GustyleComcontent($('.ad-slot', $fixturesContainer), {
                 adType: 'gu-style',
                 articleContentPosition: 'top'
-            }).create();
-            expect(qwery('.gu-display__content-position--top', '.ad-slot').length).toBe(1);
+            }).create().then(function () {
+                expect(qwery('.gu-display__content-position--top', '.ad-slot').length).toBe(1);
+            }).then(done);
         });
 
-        it('ad slot should have bright font colour', function () {
+        it('ad slot should have bright font colour', function (done) {
             $fixturesContainer = fixtures.render(fixturesConfig);
 
             new GustyleComcontent($('.ad-slot', $fixturesContainer), {
                 adType: 'gu-style',
                 articleContentColor: 'bright'
-            }).create();
-            expect(qwery('.gu-display__content-color--bright', '.ad-slot').length).toBe(4);
+            }).create().then(function () {
+                expect(qwery('.gu-display__content-color--bright', '.ad-slot').length).toBe(4);
+            }).then(done);
         });
 
-        it('ad slot should have dark font colour', function () {
+        it('ad slot should have dark font colour', function (done) {
             $fixturesContainer = fixtures.render(fixturesConfig);
 
             new GustyleComcontent($('.ad-slot', $fixturesContainer), {
                 adType: 'gu-style',
                 articleContentColor: 'dark'
-            }).create();
-            expect(qwery('.gu-display__content-color--dark', '.ad-slot').length).toBe(4);
+            }).create().then(function () {
+                expect(qwery('.gu-display__content-color--dark', '.ad-slot').length).toBe(4);
+            }).then(done);
         });
 
-        it('ad slot should have regular font size header', function () {
+        it('ad slot should have regular font size header', function (done) {
             $fixturesContainer = fixtures.render(fixturesConfig);
 
             new GustyleComcontent($('.ad-slot', $fixturesContainer), {
                 adType: 'gu-style',
                 articleHeaderFontSize: 'regular'
-            }).create();
-            expect(qwery('.gu-display__content-size--regular', '.ad-slot').length).toBe(1);
+            }).create().then(function () {
+                expect(qwery('.gu-display__content-size--regular', '.ad-slot').length).toBe(1);
+            }).then(done);
         });
 
-        it('ad slot should have big font size header', function () {
+        it('ad slot should have big font size header', function (done) {
             $fixturesContainer = fixtures.render(fixturesConfig);
 
             new GustyleComcontent($('.ad-slot', $fixturesContainer), {
                 adType: 'gu-style',
                 articleHeaderFontSize: 'big'
-            }).create();
-            expect(qwery('.gu-display__content-size--big', '.ad-slot').length).toBe(1);
+            }).create().then(function () {
+                expect(qwery('.gu-display__content-size--big', '.ad-slot').length).toBe(1);
+            }).then(done);
         });
 
-        it('ad slot should have small font size text', function () {
+        it('ad slot should have small font size text', function (done) {
             $fixturesContainer = fixtures.render(fixturesConfig);
 
             new GustyleComcontent($('.ad-slot', $fixturesContainer), {
                 adType: 'gu-style',
                 articleTextFontSize: 'small'
-            }).create();
-            expect(qwery('.gu-display__content-size--small', '.ad-slot').length).toBe(1);
+            }).create().then(function () {
+                expect(qwery('.gu-display__content-size--small', '.ad-slot').length).toBe(1);
+            }).then(done);
         });
 
-        it('ad slot should have big font size text and header', function () {
+        it('ad slot should have big font size text and header', function (done) {
             $fixturesContainer = fixtures.render(fixturesConfig);
 
             new GustyleComcontent($('.ad-slot', $fixturesContainer), {
                 adType: 'gu-style',
                 articleTextFontSize: 'big',
                 articleHeaderFontSize: 'big'
-            }).create();
-            expect(qwery('.gu-display__content-size--big', '.ad-slot').length).toBe(2);
+            }).create().then(function () {
+                expect(qwery('.gu-display__content-size--big', '.ad-slot').length).toBe(2);
+            }).then(done);
         });
 
-        it('ad slot should have logo in the top left corner', function () {
+        it('ad slot should have logo in the top left corner', function (done) {
             $fixturesContainer = fixtures.render(fixturesConfig);
 
             new GustyleComcontent($('.ad-slot', $fixturesContainer), {
                 adType: 'gu-style',
                 brandLogoPosition: 'top-left'
-            }).create();
-            expect(qwery('.gu-display__logo-pos--top-left', '.ad-slot').length).toBe(1);
+            }).create().then(function () {
+                expect(qwery('.gu-display__logo-pos--top-left', '.ad-slot').length).toBe(1);
+            }).then(done);
         });
 
-        it('ad slot should have logo in the bottom right corner', function () {
+        it('ad slot should have logo in the bottom right corner', function (done) {
             $fixturesContainer = fixtures.render(fixturesConfig);
 
             new GustyleComcontent($('.ad-slot', $fixturesContainer), {
                 adType: 'gu-style',
                 brandLogoPosition: 'bottom-right'
-            }).create();
-            expect(qwery('.gu-display__logo-pos--bottom-right', '.ad-slot').length).toBe(1);
+            }).create().then(function () {
+                expect(qwery('.gu-display__logo-pos--bottom-right', '.ad-slot').length).toBe(1);
+            }).then(done);
         });
 
     });

--- a/static/test/javascripts/spec/common/commercial/dfp/dfp-api.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/dfp-api.spec.js
@@ -28,7 +28,7 @@ define([
                     <div id="dfp-ad-script-slot" class="js-ad-slot" data-name="script-slot" data-mobile="300,50|320,50" data-refresh="false"></div>\
                     <div id="dfp-ad-already-labelled" class="js-ad-slot ad-label--showing" data-name="already-labelled" data-mobile="300,50|320,50"  data-tablet="728,90"></div>\
                     <div id="dfp-ad-dont-label" class="js-ad-slot" data-label="false" data-name="dont-label" data-mobile="300,50|320,50"  data-tablet="728,90" data-desktop="728,90|900,250|970,250"></div>\
-                    <div id="dfp-ad-gu-style" data-name="gu-style" data-mobile="300,250" data-desktop="300,250"></div>'
+                    <div id="dfp-ad-gu-style" class="gu-style" data-name="gu-style" data-mobile="300,250" data-desktop="300,250"></div>'
                 ]
             },
             makeFakeEvent = function (id, isEmpty) {


### PR DESCRIPTION
Feedback from the creative team led to the creation of a new template in DFP to handle the recently announced Guardian Frame.

![picture 1](https://cloud.githubusercontent.com/assets/629976/15216152/d9025d10-184d-11e6-9d3e-2add049f48d9.jpg)

I have left `gu-comcontent` (its original name) there for now because it is used in another context; I just made minor tweaks regarding the AD popup. I also refactored how we deal with the breakout iframe alg, to make sure the overarching promise resolved when the creative was rendered.

cc @uplne @Calanthe @jbreckmckye 
