### PR TITLE
force *something* out if a quiz has an image question with no text

### DIFF
--- a/common/app/views/fragments/atoms/quiz.scala.html
+++ b/common/app/views/fragments/atoms/quiz.scala.html
@@ -32,7 +32,11 @@
 
 @renderQuestion(question: Question, field: play.api.data.Field, maybeUserAnswer: Option[Answer]) = {
     <fieldset class="atom-quiz__question">
-        <legend class="atom-quiz__question-text">@question.text</legend>
+        <legend class="atom-quiz__question-text">@if(question.text.trim.isEmpty()) {
+            &nbsp;
+        } else {
+            @question.text
+        }</legend>
 
         @question.imageMedia.map { image =>
             <div class="atom-quiz__question-image">


### PR DESCRIPTION
## What does this change?

quiz questions with images but no text had the image cinching up over the question number, because the space normally taken up by the question text was collapsing. 

![screen shot 2016-05-12 at 15 43 53](https://cloud.githubusercontent.com/assets/867233/15218645/cc0a8e88-1858-11e6-9310-4f103ba56d6b.png)

this will force an `&nbsp;` out if its empty
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

![screen shot 2016-05-12 at 15 43 44](https://cloud.githubusercontent.com/assets/867233/15218659/d3a4d82e-1858-11e6-8a24-f452eef15d60.png)
## Request for comment

@rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
