### PR TITLE
don't show advertising on sponsored content

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -414,7 +414,8 @@ define([
         // The `hasMultipleVideosInPage` flag is temporary until the # will be fixed
         var shouldPreroll = commercialFeatures.videoPreRolls &&
             !config.page.hasMultipleVideosInPage &&
-            !config.page.isAdvertisementFeature;
+            !config.page.isAdvertisementFeature &&
+            !config.page.sponsorshipType;
 
         if (config.switches.enhancedMediaPlayer) {
             if (shouldPreroll) {


### PR DESCRIPTION
## What does this change?

Don't show preroll on content that is sponsored. They've paid for it after all.
## Does this affect other platforms - Amp, Apps, etc?

Nope.
## Screenshots

Nope.
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
