### PR TITLE
Make travel offer IDs keep their order

### DIFF
--- a/commercial/app/controllers/commercial/package.scala
+++ b/commercial/app/controllers/commercial/package.scala
@@ -20,7 +20,7 @@ package object commercial {
   }
 
   def specificId(implicit request: RequestHeader): Option[String] = request.queryString.get("t").map(_.head)
-  def specificIds(implicit request: RequestHeader): Seq[String] = request.queryString.getOrElse("t", Nil).reverse
+  def specificIds(implicit request: RequestHeader): Seq[String] = request.queryString.getOrElse("t", Nil)
 
   trait Relevance[T] {
     def view(ads: Seq[T])(implicit request: RequestHeader): Html

--- a/commercial/app/model/commercial/travel/TravelOffersAgent.scala
+++ b/commercial/app/model/commercial/travel/TravelOffersAgent.scala
@@ -15,14 +15,7 @@ object TravelOffersAgent extends MerchandiseAgent[TravelOffer] with ExecutionCon
   }
 
   def specificTravelOffers(offerIdStrings: Seq[String]): Seq[TravelOffer] = {
-
-    def sortByRequestOrder(a: TravelOffer, b: TravelOffer) = {
-
-      def getOriginalPositionOfId(offer: TravelOffer) = offerIdStrings.indexOf(offer.id)
-      getOriginalPositionOfId(a) < getOriginalPositionOfId(b)
-    }
-
-    available filter (offer => offerIdStrings contains offer.id) sortWith sortByRequestOrder
+    offerIdStrings flatMap (offerId => available find (_.id == offerId))
   }
 
   def refresh(feedMetaData: FeedMetaData, feedContent: => Option[String]): Future[ParsedFeed[TravelOffer]] = {

--- a/commercial/app/model/commercial/travel/TravelOffersAgent.scala
+++ b/commercial/app/model/commercial/travel/TravelOffersAgent.scala
@@ -15,7 +15,14 @@ object TravelOffersAgent extends MerchandiseAgent[TravelOffer] with ExecutionCon
   }
 
   def specificTravelOffers(offerIdStrings: Seq[String]): Seq[TravelOffer] = {
-    available filter (offer => offerIdStrings contains offer.id)
+
+    def sortByRequestOrder(a: TravelOffer, b: TravelOffer) = {
+
+      def getOriginalPositionOfId(offer: TravelOffer) = offerIdStrings.indexOf(offer.id)
+      getOriginalPositionOfId(a) < getOriginalPositionOfId(b)
+    }
+
+    available filter (offer => offerIdStrings contains offer.id) sortWith sortByRequestOrder
   }
 
   def refresh(feedMetaData: FeedMetaData, feedContent: => Option[String]): Future[ParsedFeed[TravelOffer]] = {


### PR DESCRIPTION
## What does this change?

Currently, when travel offer IDs are provided within the DFP travel offer creative, the ordering is ignored and the merchandising container will render them (probably) alphabetically. This normally doesn't matter, but in the case of a _prominent_ travel offer component, it is necessary to be able to specify which offer should be prominent.
## What is the value of this and can you measure success?

Ad Ops and others that use this component can specify the order by which travel offers are rendered in a merchandising container.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

**before -> after**
![image](https://cloud.githubusercontent.com/assets/1821099/15222647/a5fd77fe-1868-11e6-830a-fc40ea27c1b4.png)
