### PR TITLE
Add low friction participation AB tests (initial segmentation)

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -64,7 +64,7 @@ trait ABTestSwitches {
     "ab-participation-low-fric-music",
     "AB test switch to insert low friction participation into music",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 11),
+    sellByDate = new LocalDate(2016, 6, 15),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -77,6 +77,15 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABParticipationLowFricRecipes = Switch(
+    SwitchGroup.ABTests,
+    "ab-participation-low-fric-recipes",
+    "AB test switch to insert low friction participation into recipes",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 15),
+    exposeClientSide = true
+  )
+
   val ABCleverFriend = Switch(
     SwitchGroup.ABTests,
     "ab-clever-friend-brexit",

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -86,6 +86,15 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABParticipationLowFricFashion = Switch(
+    SwitchGroup.ABTests,
+    "ab-participation-low-fric-fashion",
+    "AB test switch to insert low friction participation into fashion",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 15),
+    exposeClientSide = true
+  )
+
   val ABCleverFriend = Switch(
     SwitchGroup.ABTests,
     "ab-clever-friend-brexit",

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -59,6 +59,15 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABParticipationLowFricMusic = Switch(
+    SwitchGroup.ABTests,
+    "ab-participation-low-fric-music",
+    "AB test switch to insert low friction participation into music",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 11),
+    exposeClientSide = true
+  )
+
   val ABCleverFriend = Switch(
     SwitchGroup.ABTests,
     "ab-clever-friend-brexit",

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -68,6 +68,15 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABParticipationLowFricTv = Switch(
+    SwitchGroup.ABTests,
+    "ab-participation-low-fric-tv",
+    "AB test switch to insert low friction participation into tv",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 15),
+    exposeClientSide = true
+  )
+
   val ABCleverFriend = Switch(
     SwitchGroup.ABTests,
     "ab-clever-friend-brexit",

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -11,6 +11,7 @@ define([
     'common/modules/experiments/tests/loyal-adblocking-survey',
     'common/modules/experiments/tests/minute',
     'common/modules/experiments/tests/participation-star-ratings',
+    'common/modules/experiments/tests/participation-low-fric-music',
     'common/modules/experiments/tests/clever-friend-brexit',
     'lodash/arrays/flatten',
     'lodash/arrays/zip',
@@ -38,6 +39,7 @@ define([
     LoyalAdblockingSurvey,
     Minute,
     ParticipationStarRatings,
+    ParticipationLowFricMusic,
     CleverFriendBrexit,
     flatten,
     zip,
@@ -61,6 +63,7 @@ define([
         new LoyalAdblockingSurvey(),
         new Minute(),
         new ParticipationStarRatings(),
+        new ParticipationLowFricMusic(),
         new CleverFriendBrexit()
     ]);
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -12,6 +12,7 @@ define([
     'common/modules/experiments/tests/minute',
     'common/modules/experiments/tests/participation-star-ratings',
     'common/modules/experiments/tests/participation-low-fric-music',
+    'common/modules/experiments/tests/participation-low-fric-tv',
     'common/modules/experiments/tests/clever-friend-brexit',
     'lodash/arrays/flatten',
     'lodash/arrays/zip',
@@ -40,6 +41,7 @@ define([
     Minute,
     ParticipationStarRatings,
     ParticipationLowFricMusic,
+    ParticipationLowFricTv,
     CleverFriendBrexit,
     flatten,
     zip,
@@ -64,6 +66,7 @@ define([
         new Minute(),
         new ParticipationStarRatings(),
         new ParticipationLowFricMusic(),
+        new ParticipationLowFricTv(),
         new CleverFriendBrexit()
     ]);
 

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -13,6 +13,7 @@ define([
     'common/modules/experiments/tests/participation-star-ratings',
     'common/modules/experiments/tests/participation-low-fric-music',
     'common/modules/experiments/tests/participation-low-fric-tv',
+    'common/modules/experiments/tests/participation-low-fric-recipes',
     'common/modules/experiments/tests/clever-friend-brexit',
     'common/modules/experiments/tests/welcome-header',
     'lodash/arrays/flatten',
@@ -43,6 +44,7 @@ define([
     ParticipationStarRatings,
     ParticipationLowFricMusic,
     ParticipationLowFricTv,
+    ParticipationLowFricRecipes,
     CleverFriendBrexit,
     WelcomeHeader,
     flatten,
@@ -69,6 +71,7 @@ define([
         new ParticipationStarRatings(),
         new ParticipationLowFricMusic(),
         new ParticipationLowFricTv(),
+        new ParticipationLowFricRecipes(),
         new CleverFriendBrexit(),
         new WelcomeHeader()
     ]);

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -14,6 +14,7 @@ define([
     'common/modules/experiments/tests/participation-low-fric-music',
     'common/modules/experiments/tests/participation-low-fric-tv',
     'common/modules/experiments/tests/participation-low-fric-recipes',
+    'common/modules/experiments/tests/participation-low-fric-fashion',
     'common/modules/experiments/tests/clever-friend-brexit',
     'common/modules/experiments/tests/welcome-header',
     'lodash/arrays/flatten',
@@ -45,6 +46,7 @@ define([
     ParticipationLowFricMusic,
     ParticipationLowFricTv,
     ParticipationLowFricRecipes,
+    ParticipationLowFricFashion,
     CleverFriendBrexit,
     WelcomeHeader,
     flatten,
@@ -72,6 +74,7 @@ define([
         new ParticipationLowFricMusic(),
         new ParticipationLowFricTv(),
         new ParticipationLowFricRecipes(),
+        new ParticipationLowFricFashion(),
         new CleverFriendBrexit(),
         new WelcomeHeader()
     ]);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-fashion.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-fashion.js
@@ -1,0 +1,74 @@
+define([
+    'common/utils/config',
+    'common/utils/mediator',
+    'Promise'
+], function (
+    config,
+    mediator,
+    Promise
+) {
+
+    var omniture;
+
+    /**
+     * The omniture module depends on common/modules/experiments/ab, so trying to
+     * require omniture directly inside an AB test gives you a circular dependency.
+     *
+     * This is a workaround to load omniture without making it a dependency of
+     * this module, which is required by an AB test.
+     */
+    function getOmniture() {
+        return new Promise(function (resolve) {
+            if (omniture) {
+                return resolve(omniture);
+            }
+
+            require('common/modules/analytics/omniture', function (omnitureM) {
+                omniture = omnitureM;
+                resolve(omniture);
+            });
+        });
+    }
+
+    return function () {
+        this.id = 'ParticipationLowFricFashion';
+        this.start = '2016-05-11';
+        this.expiry = '2016-06-15';
+        this.author = 'Gareth Trufitt - Participation';
+        this.description = 'Initial user segmentation to ensure statistical significance';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = '';
+        this.audienceCriteria = 'Users on fashion pages that have comments turned on';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            // Commentable, fashion pages
+            return config.page.section === 'fashion' &&
+                config.page.commentable;
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {},
+                success: function (complete) {
+                    mediator.on('discussion:commentbox:post:success', function (){
+                        // Data lake
+                        complete();
+
+                        // Omniture
+                        getOmniture().then(function (omniture) {
+                            omniture.trackLinkImmediate('ab | ParticipationLowFricFashion | control | complete');
+                        });
+                    });
+                }
+            },
+            {
+                id: 'variant-1',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-fashion.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-fashion.js
@@ -36,7 +36,7 @@ define([
         this.expiry = '2016-06-15';
         this.author = 'Gareth Trufitt - Participation';
         this.description = 'Initial user segmentation to ensure statistical significance';
-        this.audience = 1;
+        this.audience = 0.1;
         this.audienceOffset = 0;
         this.successMeasure = '';
         this.audienceCriteria = 'Users on fashion pages that have comments turned on';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-music.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-music.js
@@ -33,7 +33,7 @@ define([
     return function () {
         this.id = 'ParticipationLowFricMusic';
         this.start = '2016-05-11';
-        this.expiry = '2016-06-11';
+        this.expiry = '2016-06-15';
         this.author = 'Gareth Trufitt - Participation';
         this.description = 'Initial user segmentation to ensure statistical significance';
         this.audience = 1;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-music.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-music.js
@@ -36,7 +36,7 @@ define([
         this.expiry = '2016-06-15';
         this.author = 'Gareth Trufitt - Participation';
         this.description = 'Initial user segmentation to ensure statistical significance';
-        this.audience = 1;
+        this.audience = 0.1;
         this.audienceOffset = 0;
         this.successMeasure = '';
         this.audienceCriteria = 'Users on music review pages that have comments turned on';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-music.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-music.js
@@ -45,7 +45,10 @@ define([
 
         this.canRun = function () {
             // Commentable, album reviews
-            return config.page.section === 'music' && config.page.toneIds.indexOf('tone/albumreview') !== -1 && config.page.commentable;
+            return config.page.section === 'music' &&
+                config.page.toneIds &&
+                config.page.toneIds.indexOf('tone/albumreview') !== -1 &&
+                config.page.commentable;
         };
 
         this.variants = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-music.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-music.js
@@ -1,0 +1,73 @@
+define([
+    'common/utils/config',
+    'common/utils/mediator',
+    'Promise'
+], function (
+    config,
+    mediator,
+    Promise
+) {
+
+    var omniture;
+
+    /**
+     * The omniture module depends on common/modules/experiments/ab, so trying to
+     * require omniture directly inside an AB test gives you a circular dependency.
+     *
+     * This is a workaround to load omniture without making it a dependency of
+     * this module, which is required by an AB test.
+     */
+    function getOmniture() {
+        return new Promise(function (resolve) {
+            if (omniture) {
+                return resolve(omniture);
+            }
+
+            require('common/modules/analytics/omniture', function (omnitureM) {
+                omniture = omnitureM;
+                resolve(omniture);
+            });
+        });
+    }
+
+    return function () {
+        this.id = 'ParticipationLowFricMusic';
+        this.start = '2016-05-11';
+        this.expiry = '2016-06-11';
+        this.author = 'Gareth Trufitt - Participation';
+        this.description = 'Initial user segmentation to ensure statistical significance';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = '';
+        this.audienceCriteria = 'Users on music review pages that have comments turned on';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            // Commentable, album reviews
+            return config.page.section === 'music' && config.page.toneIds.indexOf('tone/albumreview') !== -1 && config.page.commentable;
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {},
+                success: function (complete) {
+                    mediator.on('discussion:commentbox:post:success', function (){
+                        // Data lake
+                        complete();
+
+                        // Omniture
+                        getOmniture().then(function (omniture) {
+                            omniture.trackLinkImmediate('ab | ParticipationLowFricMusic | control | complete');
+                        });
+                    });
+                }
+            },
+            {
+                id: 'variant-1',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-recipes.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-recipes.js
@@ -45,8 +45,8 @@ define([
 
         this.canRun = function () {
             // Commentable, recipes
-            return guardian.config.page.toneIds &&
-                guardian.config.page.toneIds.indexOf('tone/recipes') !== -1 &&
+            return config.page.toneIds &&
+                config.page.toneIds.indexOf('tone/recipes') !== -1 &&
                 config.page.commentable;
         };
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-recipes.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-recipes.js
@@ -36,7 +36,7 @@ define([
         this.expiry = '2016-06-15';
         this.author = 'Gareth Trufitt - Participation';
         this.description = 'Initial user segmentation to ensure statistical significance';
-        this.audience = 1;
+        this.audience = 0.1;
         this.audienceOffset = 0;
         this.successMeasure = '';
         this.audienceCriteria = 'Users on recipe pages that have comments turned on';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-recipes.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-recipes.js
@@ -1,0 +1,75 @@
+define([
+    'common/utils/config',
+    'common/utils/mediator',
+    'Promise'
+], function (
+    config,
+    mediator,
+    Promise
+) {
+
+    var omniture;
+
+    /**
+     * The omniture module depends on common/modules/experiments/ab, so trying to
+     * require omniture directly inside an AB test gives you a circular dependency.
+     *
+     * This is a workaround to load omniture without making it a dependency of
+     * this module, which is required by an AB test.
+     */
+    function getOmniture() {
+        return new Promise(function (resolve) {
+            if (omniture) {
+                return resolve(omniture);
+            }
+
+            require('common/modules/analytics/omniture', function (omnitureM) {
+                omniture = omnitureM;
+                resolve(omniture);
+            });
+        });
+    }
+
+    return function () {
+        this.id = 'ParticipationLowFricRecipes';
+        this.start = '2016-05-11';
+        this.expiry = '2016-06-15';
+        this.author = 'Gareth Trufitt - Participation';
+        this.description = 'Initial user segmentation to ensure statistical significance';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = '';
+        this.audienceCriteria = 'Users on recipe pages that have comments turned on';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            // Commentable, recipes
+            return guardian.config.page.toneIds &&
+                guardian.config.page.toneIds.indexOf('tone/recipes') !== -1 &&
+                config.page.commentable;
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {},
+                success: function (complete) {
+                    mediator.on('discussion:commentbox:post:success', function (){
+                        // Data lake
+                        complete();
+
+                        // Omniture
+                        getOmniture().then(function (omniture) {
+                            omniture.trackLinkImmediate('ab | ParticipationLowFricRecipes | control | complete');
+                        });
+                    });
+                }
+            },
+            {
+                id: 'variant-1',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-tv.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-tv.js
@@ -36,7 +36,7 @@ define([
         this.expiry = '2016-06-15';
         this.author = 'Gareth Trufitt - Participation';
         this.description = 'Initial user segmentation to ensure statistical significance';
-        this.audience = 1;
+        this.audience = 0.1;
         this.audienceOffset = 0;
         this.successMeasure = '';
         this.audienceCriteria = 'Users on tv review pages that have comments turned on';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-tv.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-tv.js
@@ -46,7 +46,7 @@ define([
         this.canRun = function () {
             // Commentable, episode by episode reviews
             return config.page.section === 'tv-and-radio' &&
-                config.page.nonKeywordTagIds && config.page.keywordIds &&
+                (config.page.nonKeywordTagIds || config.page.keywordIds) &&
                 (config.page.nonKeywordTagIds.indexOf('episode-by-episode') !== -1 || config.page.keywordIds.indexOf('episode-by-episode') !== -1) &&
                 config.page.commentable;
         };

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-tv.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-tv.js
@@ -1,0 +1,76 @@
+define([
+    'common/utils/config',
+    'common/utils/mediator',
+    'Promise'
+], function (
+    config,
+    mediator,
+    Promise
+) {
+
+    var omniture;
+
+    /**
+     * The omniture module depends on common/modules/experiments/ab, so trying to
+     * require omniture directly inside an AB test gives you a circular dependency.
+     *
+     * This is a workaround to load omniture without making it a dependency of
+     * this module, which is required by an AB test.
+     */
+    function getOmniture() {
+        return new Promise(function (resolve) {
+            if (omniture) {
+                return resolve(omniture);
+            }
+
+            require('common/modules/analytics/omniture', function (omnitureM) {
+                omniture = omnitureM;
+                resolve(omniture);
+            });
+        });
+    }
+
+    return function () {
+        this.id = 'ParticipationLowFricTv';
+        this.start = '2016-05-11';
+        this.expiry = '2016-06-15';
+        this.author = 'Gareth Trufitt - Participation';
+        this.description = 'Initial user segmentation to ensure statistical significance';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = '';
+        this.audienceCriteria = 'Users on tv review pages that have comments turned on';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            // Commentable, episode by episode reviews
+            return config.page.section === 'tv-and-radio' &&
+                config.page.nonKeywordTagIds && config.page.keywordIds &&
+                (config.page.nonKeywordTagIds.indexOf('episode-by-episode') !== -1 || config.page.keywordIds.indexOf('episode-by-episode') !== -1) &&
+                config.page.commentable;
+        };
+
+        this.variants = [
+            {
+                id: 'control',
+                test: function () {},
+                success: function (complete) {
+                    mediator.on('discussion:commentbox:post:success', function (){
+                        // Data lake
+                        complete();
+
+                        // Omniture
+                        getOmniture().then(function (omniture) {
+                            omniture.trackLinkImmediate('ab | ParticipationLowFricTv | control | complete');
+                        });
+                    });
+                }
+            },
+            {
+                id: 'variant-1',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-tv.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-low-fric-tv.js
@@ -47,7 +47,9 @@ define([
             // Commentable, episode by episode reviews
             return config.page.section === 'tv-and-radio' &&
                 (config.page.nonKeywordTagIds || config.page.keywordIds) &&
-                (config.page.nonKeywordTagIds.indexOf('episode-by-episode') !== -1 || config.page.keywordIds.indexOf('episode-by-episode') !== -1) &&
+                (config.page.nonKeywordTagIds.indexOf('episode-by-episode') !== -1 ||
+                config.page.keywordIds.indexOf('episode-by-episode') !== -1 ||
+                config.page.nonKeywordTagIds.indexOf('lastnightstv') !== -1) &&
                 config.page.commentable;
         };
 


### PR DESCRIPTION
## What does this change?

Adds A/B tests for Music (album reviews), Tv (episode by episode articles), all Recipes and all Fashion  **(FASHION FAB or FASHION FAIL)** articles. Initially testing the commenting so that we can put out at the right percentage.
## Request for comment

@crifmulholland @nicl 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
