### PR TITLE
add timeout to contrib-ads on video to be larger than IMA timeout

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -293,8 +293,14 @@ define([
                                         player.ima({
                                             id: mediaId,
                                             adTagUrl: getAdUrl(),
-                                            prerollTimeout: 1000
+                                            prerollTimeout: 1000,
+                                            contribAdsSettings: {
+                                                // This is higher than the `prerollTimeout` to so as not to
+                                                // trigger the `adtimeout` before the `prerollTimeout`.
+                                                timeout: 2000
+                                            }
                                         });
+
                                         player.ima.requestAds();
 
                                         // Video analytics event.
@@ -305,10 +311,6 @@ define([
                             } else {
                                 resolve();
                             }
-
-
-
-
                         } else {
                             player.playlist({
                                 mediaType: 'audio',
@@ -335,7 +337,7 @@ define([
                 });
 
                 playerSetupComplete.then(function () {
-                    if (autoplay) {
+                    if (true) {
                         player.play();
                     }
                 });

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -337,7 +337,7 @@ define([
                 });
 
                 playerSetupComplete.then(function () {
-                    if (true) {
+                    if (autoplay) {
                         player.play();
                     }
                 });


### PR DESCRIPTION
## What does this change?

This helps negate against the play => content-play => ad-play situation we are in at the moment.

We have two timeouts, one being `adtimeout` & `prerollTimeout` which are set by [videojs-contrib-ads](https://github.com/videojs/videojs-contrib-ads) and [videojs-ima](https://github.com/googleads/videojs-ima) respectively. 

At the moment we have `adsready?` => `adtimeout` => `contentplay` => `adsplay` as the adtimeout is set to the default (100ms) which is less than the ima `prerollTimeout`.

Now we will have `adready` => `adplay` => `contentplay`.

**Next**
Find out how to serve a blank frame as the first frame as we will currently serve the first frame before the ad, which is the same as the [IMA example](https://googleads.github.io/videojs-ima/examples/simple/).
## What is the value of this and can you measure success?

People stop reporting the crap UX we give them.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
