### PR TITLE
Redisplay membership banners

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -37,7 +37,7 @@ define([
             campaign:      'MEMBERSHIP_SUPPORTER_BANNER_UK',
             // increment the number at the end of the code to redisplay banners
             // to everyone who has previously closed them
-            code:          'membership-message-uk-2',
+            code:          'membership-message-uk-2016-05-13',
             minVisited:    10,
             data: {
                 messageText: [
@@ -49,7 +49,7 @@ define([
         },
         US: {
             campaign:      'MEMBERSHIP_SUPPORTER_BANNER_US',
-            code:          'membership-message-us-1',
+            code:          'membership-message-us-2016-05-13',
             minVisited:    10,
             data: {
                 messageText: 'Support open, independent journalism. Become a Supporter for just $4.99 per month',
@@ -58,7 +58,7 @@ define([
         },
         INT: {
             campaign:      'MEMBERSHIP_SUPPORTER_BANNER_INT',
-            code:          'membership-message-int-1',
+            code:          'membership-message-int-2016-05-13',
             minVisited:    10,
             data: {
                 messageText: [

--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -37,7 +37,7 @@ define([
             campaign:      'MEMBERSHIP_SUPPORTER_BANNER_UK',
             // increment the number at the end of the code to redisplay banners
             // to everyone who has previously closed them
-            code:          'membership-message-uk-1',
+            code:          'membership-message-uk-2',
             minVisited:    10,
             data: {
                 messageText: [
@@ -49,7 +49,7 @@ define([
         },
         US: {
             campaign:      'MEMBERSHIP_SUPPORTER_BANNER_US',
-            code:          'membership-message-us',
+            code:          'membership-message-us-1',
             minVisited:    10,
             data: {
                 messageText: 'Support open, independent journalism. Become a Supporter for just $4.99 per month',
@@ -58,7 +58,7 @@ define([
         },
         INT: {
             campaign:      'MEMBERSHIP_SUPPORTER_BANNER_INT',
-            code:          'membership-message-int',
+            code:          'membership-message-int-1',
             minVisited:    10,
             data: {
                 messageText: [


### PR DESCRIPTION
## What does this change?

This change triggers a re-display of the membership supporter banners (to people who have previously closed it). These appear on the footer of articles for any non-member who visits at least 10 different articles.

The Membership marketing team ask us to do this approximately twice per quarter.
## What is the value of this and can you measure success?

There is usually an uplift of supporter signups when this is done.
## Does this affect other platforms - Amp, Apps, etc?

No, only theguardian.com web users.
## Screenshots

![picture 87](https://cloud.githubusercontent.com/assets/1515970/15247654/83762730-190d-11e6-847d-f4af12c1eb70.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
