### PR TITLE
Interactives don't have a tonal header, so they need some help

### DIFF
--- a/static/src/stylesheets/module/content/tones/_tone-feature.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-feature.scss
@@ -18,21 +18,17 @@
 .tonal--tone-feature {
     // Interactives need help because their headers are not tonal
     &.content--interactive {
-        .commentcount i {
-            @extend %i-comment--tone-feature;
-
-            @if $svg-support {
-                .svg & {
-                    @extend %svg-i-comment--tone-feature;
-                }
-            }
+        .content__headline {
+            font-weight: normal;
+            color: $neutral-1;
         }
-
         .tone-colour,
         .content__section-label__link {
             color: $feature-default;
         }
-
+        .content__series-label__link {
+            color: $neutral-2;
+        }
         .u-underline {
             color: $feature-default;
             border-bottom-color: rgba($feature-default, .3);

--- a/static/src/stylesheets/module/content/tones/_tone-news.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-news.scss
@@ -17,17 +17,5 @@
     .tone-accent-border {
         border-color: $news-accent;
     }
-
-    // Interactives need help because their headers are not tonal
-    &.content--interactive {
-        .commentcount i {
-            @extend %i-comment--tone-news;
-
-            @if $svg-support {
-                .svg & {
-                    @extend %svg-i-comment--tone-news;
-                }
-            }
-        }
-    }
 }
+

--- a/static/src/stylesheets/module/content/tones/_tone-special-report.scss
+++ b/static/src/stylesheets/module/content/tones/_tone-special-report.scss
@@ -18,17 +18,15 @@
 .tonal--tone-special-report {
     // Interactives need help because their headers are not tonal
     &.content--interactive {
-        .commentcount i {
-            @extend %i-comment--tone-neutral2;
-
-            @if $svg-support {
-                .svg & {
-                    @extend %svg-i-comment--tone-neutral2;
-                }
-            }
+        .content__headline {
+            font-weight: normal;
+            color: $neutral-1;
         }
 
-        .tone-colour,
+        .content__series-label__link {
+            color: $neutral-2;
+        }
+
         .content__section-label__link {
             color: $special-report-accent;
         }


### PR DESCRIPTION
After #12706  interactives with tones applied appeared to be without a headline. 

It turns out that interactives with tones already have some overrides to help them out. They have them because even though they have the tones, they don't have the tonal header. 

I have deleted the unnecessary overrides, and included a couple that are needed for headlines to appear correctly.
## Screenshots

Before:

![image](https://cloud.githubusercontent.com/assets/8774970/15248418/ffda36d2-1911-11e6-930f-8258d6604b04.png)

![image](https://cloud.githubusercontent.com/assets/8774970/15248429/0f38939e-1912-11e6-9bb0-4b34752ae590.png)

After:

![image](https://cloud.githubusercontent.com/assets/8774970/15248444/265ac114-1912-11e6-81e0-641d368e16fc.png)

![image](https://cloud.githubusercontent.com/assets/8774970/15248448/2e82b05e-1912-11e6-90bf-79e663356c4f.png)

cc @sndrs 
