### PR TITLE
Fabric: replace top slot adverts with an inline fabric ad

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -97,7 +97,9 @@ define([
 
         function insertInlineAd(paras) {
             bodyAds += 1;
-            insertAdAtPara(paras[0], 'inline' + bodyAds, 'inline');
+            var isFabricTopReplacement = (bodyAds === 1) && detect.isBreakpoint({max: 'phablet'});
+            var adDefinition = isFabricTopReplacement ? 'inline-fabric-top' : ('inline' + bodyAds);
+            insertAdAtPara(paras[0], adDefinition, 'inline');
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -97,8 +97,9 @@ define([
 
         function insertInlineAd(paras) {
             bodyAds += 1;
-            var isFabricTopReplacement = (bodyAds === 1) && detect.isBreakpoint({max: 'phablet'});
+            var isFabricTopReplacement = config.switches.fabricAdverts && (bodyAds === 1) && detect.isBreakpoint({max: 'phablet'});
             var adDefinition = isFabricTopReplacement ? 'inline-fabric-top' : ('inline' + bodyAds);
+
             insertAdAtPara(paras[0], adDefinition, 'inline');
         }
     }

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -13,8 +13,8 @@ define([
     isArray,
     transform
 ) {
-    var fabricMapping = '88,71';
-    var fabricMappingSwitch = config.switches.fabricAdverts ? ('|' + fabricMapping) : '';
+    var fabricTopSlot = '88,71';
+    var fabricMappingSwitch = config.switches.fabricAdverts ? ('|' + fabricTopSlot) : '';
     var adSlotDefinitions = {
         right: {
             sizeMappings: {
@@ -101,7 +101,12 @@ define([
         },
         'fabric': {
             sizeMappings: {
-                mobile: fabricMapping
+                mobile: fabricTopSlot
+            }
+        },
+        'inline-fabric-top': {
+            sizeMappings: {
+                mobile: ('1,1|300,250|' + fabricTopSlot)
             }
         }
     };


### PR DESCRIPTION
Fabric takeovers include full-width adverts in the navigation top slot, but mobile breakpoints don't include such a position. In these cases, the advert should appear in the first inline position instead. This pull request makes this work on articles.

Fabric top slots are requested under the size 88x71, so all we need to do is request that size in addition to ordinary MPUs in the first article body advert. If the page has a takeover, its sponsorship priority will force the slot to show the fabric creative. If not, we fall back to a standard 300x250 MPU.

Existing styles then make this replacement ad display in a flush layout:

![image](https://cloud.githubusercontent.com/assets/3148617/15250350/4b7369e2-191c-11e6-900c-4da0807da338.png)
