### PR TITLE
move onward journey for videos to own component

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -22,6 +22,7 @@ define([
     'common/modules/video/tech-order',
     'common/modules/video/video-container',
     'common/modules/video/onward-container',
+    'common/modules/video/more-in-series-container',
     // This must be the full path because we use curl config to change it based
     // on env
     'bootstraps/enhanced/media/video-player',
@@ -50,6 +51,7 @@ define([
     techOrder,
     videoContainer,
     onwardContainer,
+    moreInSeriesContainer,
     videojs,
     loadingTmpl
 ) {
@@ -362,33 +364,22 @@ define([
         });
     }
 
+    function getMediaType() {
+        return config.page.contentType.toLowerCase();
+    }
+
     function initMoreInSection() {
         if (!config.isMedia || !config.page.showRelatedContent) {
             return;
         }
 
-        var mediaType = config.page.contentType.toLowerCase(),
-            section   = new Component(),
-            attachTo  = $('.js-onward')[0],
-            endpoint  = '/' + mediaType + '/section/' + config.page.section;
-
-        if ('seriesId' in config.page) {
-            endpoint += '/' + config.page.seriesId;
-        }
-
-        endpoint += '.json?shortUrl=' + config.page.shortUrl;
-
-        // exclude professional network content from video pages
-        if (mediaType === 'video') {
-            endpoint += '&exclude-tag=guardian-professional/guardian-professional';
-        }
-
-        section.endpoint = endpoint;
-
-        section.fetch(attachTo).then(function () {
-            mediator.emit('page:media:moreinloaded', attachTo);
-            mediator.emit('page:new-content', attachTo);
-        });
+        var el  = $('.js-onward')[0];
+        moreInSeriesContainer.init(
+            el, getMediaType(),
+            config.page.section,
+            config.page.shortUrl,
+            config.page.seriesId
+        );
     }
 
     function initOnwardContainer() {
@@ -396,9 +387,8 @@ define([
             return;
         }
 
-        var mediaType = config.page.contentType.toLowerCase();
+        var mediaType = getMediaType();
         var el = $(mediaType === 'video' ? '.js-video-components-container' : '.js-media-popular')[0];
-
         onwardContainer.init(el, mediaType);
     }
 

--- a/static/src/javascripts/projects/common/modules/video/more-in-series-container.js
+++ b/static/src/javascripts/projects/common/modules/video/more-in-series-container.js
@@ -1,0 +1,26 @@
+define([
+    'common/modules/component',
+    'common/utils/mediator'
+], function(
+    Component,
+    mediator
+) {
+
+    function init(el, mediaType, section, shortUrl, series) {
+        var component = new Component();
+        var endpoint  = '/' + mediaType + '/section/' + section +
+                        (series ? '/' + series : '') +
+                        '.json?shortUrl=' + shortUrl +
+                        // exclude professional network content from video pages
+                        (mediaType === 'video' ? '&exclude-tag=guardian-professional/guardian-professional' : '');
+
+        component.endpoint = endpoint;
+
+        component.fetch(el).then(function () {
+            mediator.emit('page:media:moreinloaded', el);
+            mediator.emit('page:new-content', el);
+        });
+    }
+
+    return { init: init };
+})

--- a/static/src/javascripts/projects/common/modules/video/more-in-series-container.js
+++ b/static/src/javascripts/projects/common/modules/video/more-in-series-container.js
@@ -23,4 +23,4 @@ define([
     }
 
     return { init: init };
-})
+});


### PR DESCRIPTION
## What does this change?

While trying to figure out what the devil is slowing things down with ads, I keep coming up against not really knowing what's going on in this file.

I am going to try break it into a more coherent structure and flow.

We will need to break this up at some stage as having a new player would not remove the need to have all the furniture, so this isn't wasted effort (I hope 🙏).
## What is the value of this and can you measure success?

I can actually do some work on the player.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

See site, they're the same
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
