### PR TITLE
Add contentType to standard js configuration

### DIFF
--- a/commercial/app/controllers/commercial/CreativeTestPage.scala
+++ b/commercial/app/controllers/commercial/CreativeTestPage.scala
@@ -1,9 +1,9 @@
 package controllers.commercial
 
-import model.{MetaData, GuardianContentTypes, NoCache, Cached}
+import conf.Configuration
+import model.{GuardianContentTypes, MetaData}
 import play.api.libs.json.{JsString, JsValue}
 import play.api.mvc._
-import conf.Configuration
 
 case class TestPage(specifiedKeywords : List[String] = Nil) extends model.StandalonePage {
 
@@ -17,8 +17,7 @@ case class TestPage(specifiedKeywords : List[String] = Nil) extends model.Standa
 
   val newMetaData: Map[String, JsValue] = Map(
     "keywords" -> JsString(capitalisedKeywords),
-    "keywordIds" -> JsString(lowerCaseKeywords),
-    "contentType" -> JsString(contentType)
+    "keywordIds" -> JsString(lowerCaseKeywords)
   )
 
   override val metadata = MetaData.make(

--- a/common/app/model/PressedPage.scala
+++ b/common/app/model/PressedPage.scala
@@ -35,7 +35,6 @@ object PressedPage {
       "keywords" -> JsString(seoData.webTitle.capitalize),
       "keywordIds" -> JsString(keywordIds.mkString(",")),
       "hasSuperStickyBanner" -> JsBoolean(PersonalInvestmentsCampaign.isRunning(keywordIds)),
-      "contentType" -> JsString(contentType),
       "isAdvertisementFeature" -> JsBoolean(isAdvertisementFeature)
     ) ++ (if (showMpuInAllContainers) Map("showMpuInAllContainers" -> JsBoolean(true)) else Nil)
 

--- a/common/app/model/Section.scala
+++ b/common/app/model/Section.scala
@@ -21,7 +21,6 @@ object Section {
         "keywords" -> JsString(webTitle),
         "keywordIds" -> JsString(keywordIds.mkString(",")),
         "hasSuperStickyBanner" -> JsBoolean(PersonalInvestmentsCampaign.isRunning(keywordIds)),
-        "contentType" -> JsString("Section"),
         "isAdvertisementFeature" -> JsBoolean(keywordSponsorship.isAdvertisementFeature)
       )
 
@@ -34,6 +33,7 @@ object Section {
       webTitle = webTitle,
       analyticsName = s"GFE:$sectionName",
       adUnitSuffix = adUnitSuffix,
+      contentType = "Section",
       isFront = true,
       rssPath = Some(s"/$id/rss"),
       iosType = sectionName match {

--- a/common/app/model/Tag.scala
+++ b/common/app/model/Tag.scala
@@ -18,7 +18,6 @@ object Tag {
     val javascriptConfigOverrides: Map[String, JsValue] = Map(
       ("keywords", JsString(tag.webTitle)),
       ("keywordIds", JsString(tag.id)),
-      ("contentType", JsString("Tag")),
       ("references", JsArray(tag.references.map(ref => Reference.toJavaScript(ref.id))))
     )
 
@@ -43,6 +42,7 @@ object Tag {
       adUnitSuffix = AdSuffixHandlingForFronts.extractAdUnitSuffixFrom(tag.id, tag.sectionId),
       description = tag.description,
       pagination = pagination,
+      contentType = "Tag",
       isFront = true,
       rssPath = Some(s"/${tag.id}/rss"),
       iosType = tag.sectionId match {

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -843,8 +843,7 @@ object CrosswordContent {
       analyticsName = crossword.id,
       webTitle = crossword.name,
       contentType = contentType,
-      iosType = None,
-      javascriptConfigOverrides = Map("contentType" -> JsString(contentType))
+      iosType = None
     )
 
     val contentOverrides = content.content.copy(metadata = metadata)

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -479,7 +479,6 @@ object Audio {
     val id = content.metadata.id
     val section = content.metadata.section
     val javascriptConfig: Map[String, JsValue] = Map(
-      "contentType" -> JsString(contentType),
       "isPodcast" -> JsBoolean(content.tags.isPodcast))
 
     val metadata = content.metadata.copy(

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -351,7 +351,6 @@ object Article {
     val bookReviewIsbn = content.isbn.map { i: String => Map("isbn" -> JsString(i)) }.getOrElse(Map())
 
     val javascriptConfig: Map[String, JsValue] = Map(
-      ("contentType", JsString(contentType)),
       ("isLiveBlog", JsBoolean(content.tags.isLiveBlog)),
       ("inBodyInternalLinkCount", JsNumber(content.linkCounts.internal)),
       ("inBodyExternalLinkCount", JsNumber(content.linkCounts.external)),

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -585,7 +585,6 @@ object Gallery {
       standfirst = fields.standfirst)
     val lightbox = GalleryLightbox(elements, tags, lightboxProperties)
     val javascriptConfig: Map[String, JsValue] = Map(
-      "contentType" -> JsString(contentType),
       "gallerySize" -> JsNumber(lightbox.size),
       "lightboxImages" -> lightbox.javascriptConfig
     )

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -807,7 +807,6 @@ object ImageContent {
       standfirst = fields.standfirst)
     val lightbox = GenericLightbox(content.elements, content.fields, content.trail, lightboxProperties)
     val javascriptConfig: Map[String, JsValue] = Map(
-      "contentType" -> JsString(contentType),
       "lightboxImages" -> lightbox.javascriptConfig
     )
     val metadata = content.metadata.copy(

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -781,7 +781,6 @@ object Interactive {
       contentType = contentType,
       analyticsName = s"GFE:$section:$contentType:${id.substring(id.lastIndexOf("/") + 1)}",
       adUnitSuffix = section + "/" + contentType.toLowerCase,
-      javascriptConfigOverrides = Map("contentType" -> JsString(contentType)),
       twitterPropertiesOverrides = twitterProperties
     )
     val contentOverrides = content.copy(

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -517,7 +517,6 @@ object Video {
     val source: Option[String] = elements.videos.find(_.properties.isMain).flatMap(_.videos.source)
 
     val javascriptConfig: Map[String, JsValue] = Map(
-      "contentType" -> JsString(contentType),
       "isPodcast" -> JsBoolean(content.tags.isPodcast),
       "source" -> JsString(source.getOrElse("")),
       "embeddable" -> JsBoolean(elements.videos.find(_.properties.isMain).map(_.videos.embeddable).getOrElse(false)),

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -7,6 +7,7 @@ import common.commercial.BrandHunter
 import common.dfp._
 import common.{Edition, ManifestData, NavItem, Pagination}
 import conf.Configuration
+import conf.switches.Switches.galleryRedesign
 import cricketPa.CricketTeams
 import model.liveblog.BodyBlock
 import model.meta.{Guardian, LinkedData, PotentialAction, WebPage}
@@ -15,7 +16,6 @@ import org.joda.time.DateTime
 import org.scala_tools.time.Imports._
 import play.api.libs.json.{JsBoolean, JsString, JsValue}
 import play.api.mvc.RequestHeader
-import conf.switches.Switches.galleryRedesign
 
 object Commercial {
 
@@ -308,7 +308,8 @@ final case class MetaData (
     ("analyticsName", JsString(analyticsName)),
     ("isFront", JsBoolean(isFront)),
     ("isSurging", JsString(isSurging.mkString(","))),
-    ("videoJsFlashSwf", JsString(conf.Static("flash/components/video-js-swf/video-js.swf").path))
+    ("videoJsFlashSwf", JsString(conf.Static("flash/components/video-js-swf/video-js.swf").path)),
+    ("contentType", JsString(contentType))
   )
 
   def opengraphProperties: Map[String, String] = {

--- a/identity/app/model/IdentityPage.scala
+++ b/identity/app/model/IdentityPage.scala
@@ -11,7 +11,6 @@ case class IdentityPage(
   omnitureEvent: Option[String] = None) extends StandalonePage {
 
   private val javascriptConfig = Seq(
-    Some("contentType" -> JsString("userid")), // For the no js omniture tracking
     returnUrl.map("returnUrl" -> JsString(_)),
     registrationType.map("registrationType" -> JsString(_)),
     omnitureEvent.map("omnitureEvent" -> JsString(_))
@@ -22,5 +21,6 @@ case class IdentityPage(
     section = "identity",
     webTitle = webTitle,
     analyticsName = analyticsName,
+    contentType = "userid", // For the no js omniture tracking
     javascriptConfigOverrides = javascriptConfig)
 }


### PR DESCRIPTION
Puts content-type value from metadata into js config by default, to avoid having to always add it with js config overrides.
