### PR TITLE
Allow the Member's Area redirect to apply on all parts of the site

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -284,7 +284,7 @@ final case class MetaData (
   val isSurging: Seq[Int] = SurgingContentAgent.getSurgingLevelsFor(id)
 
   val requiresMembershipAccess: Boolean = {
-    conf.switches.Switches.MembersAreaSwitch.isSwitchedOn && membershipAccess.nonEmpty && url.contains("/membership/")
+    conf.switches.Switches.MembersAreaSwitch.isSwitchedOn && membershipAccess.nonEmpty
   }
 
   val hasSlimHeader: Boolean = contentType == "Interactive" || section == "identity" || (galleryRedesign.isSwitchedOn && contentType.toLowerCase == "gallery")

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -121,25 +121,11 @@ class ContentTest extends FlatSpec with Matchers with OneAppPerSuite with implic
 
     conf.switches.Switches.MembersAreaSwitch.switchOn()
 
-    val membershipArticle = ApiContent(id = "membership/2015/jan/01/foo",
-      sectionId = None,
-      sectionName = None,
-      webPublicationDate = Some(new DateTime().toCapiDateTime),
-      webTitle = "Some article",
-      webUrl = "http://www.guardian.co.uk/membership/2015/jan/01/foo",
-      apiUrl = "http://content.guardianapis.com/membership/2015/jan/01/foo",
-      tags = List(tag("type/article")),
-      fields = Some(ContentFields(membershipAccess = Some(MembershipTier.MembersOnly))),
-      elements = None
-    )
-
-    Content(membershipArticle).metadata.requiresMembershipAccess should be(true)
-
     val noAccess = article.copy(fields = None)
     Content(noAccess).metadata.requiresMembershipAccess should be(false)
 
-    val outsideMembership = article.copy(fields = Some(ContentFields(membershipAccess = Some(MembershipTier.MembersOnly))))
-    Content(outsideMembership).metadata.requiresMembershipAccess should be(false)
+    val membershipArticle = article.copy(fields = Some(ContentFields(membershipAccess = Some(MembershipTier.MembersOnly))))
+    Content(membershipArticle).metadata.requiresMembershipAccess should be(true)
 
   }
 


### PR DESCRIPTION
## What does this change?

Previously, only articles that had `/membership/` in the url - like this one:

http://www.theguardian.com/membership/2015/apr/27/the-spin-london-cycle-festival-save-mop

...would actually have the [Member's Area restriction](https://docs.google.com/a/guardian.co.uk/document/d/1oQhe3PwhcJdmmm_q6_9issBqOA69vE0hMcT28WztQsA/edit?usp=sharing) take effect - the setting wouldn't affect articles under theguardian.com/film, for instance. This change gets rid of that `/membership/` restriction.

Currently, these are the only three articles that would be affected by this change:
- https://www.theguardian.com/news/2016/feb/12/guardian-bookshop-an-exclusive-offer
- https://www.theguardian.com/news/2015/oct/07/exclusive-to-guardian-members-buy-half-price-tickets-american-idiots-mop
- https://www.theguardian.com/news/2016/apr/29/looking-back-archaeology - marked as _paid-members-only_
## What is the value of this and can you measure success?

We're planning to use the Member's Area on a wider basis around the site, and also apply it to the Mobile Apps premium content, so this '/membership/' restriction (initially in place to reduce possible editorial accidents) needs to go.
## Does this affect other platforms - Amp, Apps, etc?

Eventually the Mobile Apps will apply the Member's Area restriction as well, but currently the dotcom web site is the only place where this takes effect.

cc @DiegoVazquezNanini @rcrphillips @mchv @paulbrown1982 
