### PR TITLE
Revert "add timeout to contrib-ads on video to be larger than IMA timeout"

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -295,14 +295,8 @@ define([
                                         player.ima({
                                             id: mediaId,
                                             adTagUrl: getAdUrl(),
-                                            prerollTimeout: 1000,
-                                            contribAdsSettings: {
-                                                // This is higher than the `prerollTimeout` to so as not to
-                                                // trigger the `adtimeout` before the `prerollTimeout`.
-                                                timeout: 2000
-                                            }
+                                            prerollTimeout: 1000
                                         });
-
                                         player.ima.requestAds();
 
                                         // Video analytics event.
@@ -313,6 +307,10 @@ define([
                             } else {
                                 resolve();
                             }
+
+
+
+
                         } else {
                             player.playlist({
                                 mediaType: 'audio',


### PR DESCRIPTION
Reverts guardian/frontend#12896

It seems tracking might have taken a hit, although I can't see as to why.
