### PR TITLE
Remove eTags switch

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -60,15 +60,6 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
-  val CheckETagsSwitch = Switch(
-    SwitchGroup.Performance,
-    "check-etags",
-    "If this switch is on, empty 304 not modified responses will be returned for requests with the correct etag",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 20),
-    exposeClientSide = false
-  )
-
   val CircuitBreakerSwitch = Switch(
     SwitchGroup.Performance,
     "circuit-breaker",

--- a/common/app/model/Cached.scala
+++ b/common/app/model/Cached.scala
@@ -96,7 +96,7 @@ object Cached extends implicits.Dates {
 
     val (etagHeaderString, validatedResult): (String, Result) = maybeHash.map { case (hash, maybeHashToMatch) =>
       val etag = s"""W/"hash${hash.string}""""
-      if (Switches.CheckETagsSwitch.isSwitchedOn && maybeHashToMatch.contains(etag)) {
+      if (maybeHashToMatch.contains(etag)) {
         (etag, Results.NotModified)
       } else {
         (etag, result)

--- a/common/test/model/CachedTest.scala
+++ b/common/test/model/CachedTest.scala
@@ -102,7 +102,6 @@ class CachedTest extends FlatSpec with Matchers with Results with implicits.Date
 
   it should "etag should be added" in {
     DoubleCacheTimesSwitch.switchOff()
-    Switches.CheckETagsSwitch.switchOn()
 
     val result = Cached(5, RevalidatableResult(Ok("foo"), "A"), None)
     val headers = result.header.headers
@@ -114,7 +113,6 @@ class CachedTest extends FlatSpec with Matchers with Results with implicits.Date
 
   it should "wrong etag should be ignored" in {
     DoubleCacheTimesSwitch.switchOff()
-    Switches.CheckETagsSwitch.switchOn()
 
     val result = Cached(5, RevalidatableResult(Ok("foo"), "A"), Some("""W/"hasheroo""""))
     val headers = result.header.headers
@@ -126,7 +124,6 @@ class CachedTest extends FlatSpec with Matchers with Results with implicits.Date
 
   it should "correct etag should not be ignored" in {
     DoubleCacheTimesSwitch.switchOff()
-    Switches.CheckETagsSwitch.switchOn()
 
     val result = Cached(5, RevalidatableResult(Ok("foo"), "A"), Some("""W/"hash96""""))
     val headers = result.header.headers


### PR DESCRIPTION
Etags are working really well, and noone has complained of caching issues since we shipped them.  As such it seems sensible to remove the switch rather than making it unlimited, as there's not a high chance we'll need to turn it off.  Leaving switches unnecessarily would clutter up the switchboard.
