### PR TITLE
Fix IE11 display bugs in the soulmates component

### DIFF
--- a/static/src/stylesheets/module/commercial/_advert.scss
+++ b/static/src/stylesheets/module/commercial/_advert.scss
@@ -98,8 +98,10 @@
     }
 }
 
+/* [1] Prevents IE11 bug where the image container's height would go ballooney */
 .advert__image-container {
     order: -1;
+    overflow: auto; /* [1] */
     margin-bottom: $gs-baseline / 2;
     width: 100%;
 

--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -179,6 +179,13 @@
         position: relative;
     }
 
+    /* [1] Forces text wrap in IE11 */
+    .advert__title,
+    .advert__standfirst,
+    .advert__meta {
+        max-width: 100%; /* [1] */
+    }
+
     .adverts__row {
         padding: $gs-baseline / 2 0;
         display: flex;


### PR DESCRIPTION
Fixes two display bugs where IE11 doesn't handle (1) the intrinsic height of wrapper elements and (2) the text wrapping in flex containers.

![unnamed](https://cloud.githubusercontent.com/assets/629976/15287850/be22668a-1b5d-11e6-9023-f42518ce53ae.png)

cc @JonNorman 
