### PR TITLE
Reduce the size of the commercial js asset

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/hosted-video.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-video.js
@@ -8,7 +8,6 @@ define([
     'common/utils/defer-to-analytics',
     'common/modules/video/events',
     'common/modules/video/supportedBrowsers',
-    'bootstraps/enhanced/media/video-player',
     'text!common/views/ui/loading.html'
 ], function (
     bean,
@@ -16,7 +15,6 @@ define([
     deferToAnalytics,
     events,
     supportedBrowsers,
-    videojs,
     loadingTmpl
 ) {
 
@@ -49,26 +47,31 @@ define([
             return;
         }
 
-        var mediaId = $videoEl.attr('data-media-id');
+        require(['bootstraps/enhanced/media/main'], function () {
+            require(['bootstraps/enhanced/media/video-player'], function(videojs){
 
-        player = videojs($videoEl.get(0), {
-            controls: true,
-            autoplay: false,
-            preload: 'metadata'
-        });
+                var mediaId = $videoEl.attr('data-media-id');
 
-        player.ready(function () {
-            deferToAnalytics(function () {
-                events.initOmnitureTracking(player);
-                events.initOphanTracking(player, mediaId);
+                player = videojs($videoEl.get(0), {
+                    controls: true,
+                    autoplay: false,
+                    preload: 'metadata'
+                });
 
-                events.bindGlobalEvents(player);
-                events.bindContentEvents(player);
+                player.ready(function () {
+                    deferToAnalytics(function () {
+                        events.initOmnitureTracking(player);
+                        events.initOphanTracking(player, mediaId);
+
+                        events.bindGlobalEvents(player);
+                        events.bindContentEvents(player);
+                    });
+
+                    initLoadingSpinner(player);
+                    upgradeVideoPlayerAccessibility(player);
+                    supportedBrowsers(player);
+                });
             });
-
-            initLoadingSpinner(player);
-            upgradeVideoPlayerAccessibility(player);
-            supportedBrowsers(player);
         });
     }
 


### PR DESCRIPTION
The changes in https://github.com/guardian/frontend/pull/12860 mean that we build the javascript bootstrap for commercial, and include all the modules used by the `media/video-player` module. This meant commercial had ballooned to 455KB, and was acting in a similar way to the old `enhanced-vendor` optimisation, holding module definitions for lots of downstream bootstraps.

This modifies the behaviour of hosted-video so that this no longer happens.

Aside:
I've investigated the impact this issue had on my previous change, which removed `enhanced-vendor`, claiming it was only 2KB [here](https://github.com/guardian/frontend/pull/12815). Despite the misunderstanding, I still think this is a valid thing to do. The `enhanced-vendor` file hides all our videojs problems. If I use this PR as a baseline, and reintroduce `enhanced-vendor`, here are the asset build sizes:
1. `enhanced-vendor`, with all third-party js: 266KB. This leaves `media` bootstrap at 10KB.
2. `enhanced-vendor`, with most third-party js, excluding video: 2KB. This leaves `media` bootstrap at 273KB.

So it is still wise to consider `enhanced-vendor` a 2KB optimisation file. This means that we defer loading any video content until we actually choose to execute the media bootstrap.
