### PR TITLE
Fix #12828

### DIFF
--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -2,70 +2,81 @@ package football.controllers
 
 import common.Edition
 import feed.Competitions
-import play.api.mvc.{AnyContent, Action}
+import play.api.mvc.{AnyContent, Action, Result}
 import org.joda.time.LocalDate
 import model._
 import football.model._
 import pa.FootballTeam
 import model.Competition
 
-
 object ResultsController extends MatchListController with CompetitionResultFilters {
 
-  private def results(date: LocalDate) = new ResultsList(date, Competitions())
-  private val page = new FootballPage("football/results", "football", "All results", "GFE:Football:automatic:results")
-
-  def allResultsForJson(year: String, month: String, day: String) = allResultsFor(year, month, day)
-  def allResultsFor(year: String, month: String, day: String): Action[AnyContent] =
-    renderAllResults(createDate(year, month, day))
-
-  def allResultsJson() = allResults()
-  def allResults(): Action[AnyContent] =
-    renderAllResults(LocalDate.now(Edition.defaultEdition.timezone))
-
-  def moreResultsFor(year: String, month: String, day: String): Action[AnyContent] =
-    renderMoreResults(createDate(year, month, day))
-
-  def moreResultsForJson(year: String, month: String, day: String) = moreResultsFor(year, month, day)
-
-
-  private def renderAllResults(date: LocalDate) = Action { implicit request =>
-    renderMatchList(page, results(date), filters)
+  private def competitionOrTeam(tag: String): Option[Either[Competition, FootballTeam]] = {
+    lookupCompetition(tag).map(Left(_))
+      .orElse(lookupTeam(tag).map(Right(_)))
   }
 
-  private def renderMoreResults(date: LocalDate) = Action { implicit request =>
-    renderMoreMatches(page, results(date), filters)
-  }
-
-  def tagResultsJson(tag: String) = tagResults(tag)
-  def tagResults(tag: String): Action[AnyContent] =
-    renderTagResults(LocalDate.now(Edition.defaultEdition.timezone), tag)
-
-  def tagResultsForJson(year: String, month: String, day: String, tag: String) = tagResultsFor(year, month, day, tag)
-  def tagResultsFor(year: String, month: String, day: String, tag: String): Action[AnyContent] =
-    renderTagResults(createDate(year, month, day), tag)
-
-  private def renderTagResults(date: LocalDate, tag: String): Action[AnyContent] = {
-    lookupCompetition(tag).map { comp =>
-      renderCompetitionResults(tag, comp, date)
-    }.orElse {
-      lookupTeam(tag).map(renderTeamResults(tag, _, date))
-    }.getOrElse {
-      Action(NotFound)
+  private def byType[A](ifAll: => A)(ifCompetition: Competition => A)(ifTeam: FootballTeam => A)(tag: Option[String]): Option[A] = {
+    tag.fold(Option(ifAll)) {
+      competitionOrTeam(_).map {
+        _ match {
+          case Left(competition) => ifCompetition(competition)
+          case Right(team) => ifTeam(team)
+        }
+      }
     }
   }
 
-  private def renderCompetitionResults(competitionName: String, competition: Competition, date: LocalDate) = Action { implicit request =>
-    val results = new CompetitionResultsList(date, Competitions(), competition.id)
-    val page = new FootballPage(s"football/$competitionName/results", "football", s"${competition.fullName} results",
-      "GFE:Football:automatic:competition results")
-    renderMatchList(page, results, filters)
+  private def results(date: LocalDate, tag: Option[String] = None): Option[Results] = {
+    def allResults = ResultsList(date, Competitions())
+    def competitionResults = (competition: Competition) => CompetitionResultsList(date, Competitions(), competition.id)
+    def teamResults = (team: FootballTeam) => TeamResultsList(date, Competitions(), team.id, TeamUrl(team))
+    byType[Results](allResults)(competitionResults)(teamResults)(tag)
   }
 
-  private def renderTeamResults(teamName: String, team: FootballTeam, date: LocalDate) = Action { implicit request =>
-    val results = new TeamResultsList(date, Competitions(), team.id)
-    val page = new FootballPage(s"/football/$teamName/results", "football", s"${team.name} results",
-      "GFE:Football:automatic:team results")
-    renderMatchList(page, results, filters)
+  private def page(tag: Option[String] = None): Option[FootballPage] = {
+    def allPage = new FootballPage("football/results", "football", "All results", "GFE:Football:automatic:results")
+    def competitionPage = (competition: Competition) => new FootballPage(s"${competition.url}/results", "football", s"${competition.fullName} results", "GFE:Football:automatic:competition results")
+    def teamPage = (team: FootballTeam) => new FootballPage(s"/football/$tag/results", "football", s"${tag} results", "GFE:Football:automatic:team results")
+    byType[FootballPage](allPage)(competitionPage)(teamPage)(tag)
   }
+
+  private def renderWith(renderFunction:(FootballPage, Results, Map[String, Seq[CompetitionFilter]]) => Result)
+                        (date: LocalDate, tag: Option[String] = None) = {
+    val result = for {
+      p <- page(tag)
+      r <- results(date, tag)
+    } yield {
+      renderFunction(p, r, filters)
+    }
+    result.getOrElse(NotFound("No results"))
+  }
+
+  private def renderForDate(date: LocalDate, tag: Option[String] = None) = Action { implicit request =>
+    renderWith(renderMatchList)(date, tag)
+  }
+
+  private def renderMoreForDate(date: LocalDate, tag: Option[String] = None) = Action { implicit request =>
+    renderWith(renderMoreMatches)(date, tag)
+  }
+
+  /* Public methods */
+
+  def allResults(): Action[AnyContent] = renderForDate(LocalDate.now(Edition.defaultEdition.timezone))
+  def allResultsJson() = allResults()
+
+  def allResultsFor(year: String, month: String, day: String): Action[AnyContent] = renderForDate(createDate(year, month, day))
+  def allResultsForJson(year: String, month: String, day: String) = allResultsFor(year, month, day)
+
+  def moreResultsFor(year: String, month: String, day: String): Action[AnyContent] = renderMoreForDate(createDate(year, month, day))
+  def moreResultsForJson(year: String, month: String, day: String) = moreResultsFor(year, month, day)
+
+  def tagResults(tag: String): Action[AnyContent] = renderForDate(LocalDate.now(Edition.defaultEdition.timezone), Some(tag))
+  def tagResultsJson(tag: String) = tagResults(tag)
+
+  def tagResultsFor(year: String, month: String, day: String, tag: String): Action[AnyContent] = renderForDate(createDate(year, month, day), Some(tag))
+  def tagResultsForJson(year: String, month: String, day: String, tag: String) = tagResultsFor(year, month, day, tag)
+
+  def moreTagResultsFor(year: String, month: String, day: String, tag: String): Action[AnyContent] = renderMoreForDate(createDate(year, month, day), Some(tag))
+  def moreTagResultsForJson(year: String, month: String, day: String, tag: String) = moreTagResultsFor(year, month, day, tag)
 }

--- a/sport/app/football/model/matches.scala
+++ b/sport/app/football/model/matches.scala
@@ -125,6 +125,7 @@ case class ResultsList(date: LocalDate, competitions: CompetitionSupport) extend
     fMatch.isResult
 }
 case class CompetitionResultsList(date: LocalDate, competitions: CompetitionSupport, competitionId: String) extends Results with CompetitionList {
+  override val baseUrl: String = competition.fold("/football/results")(_.url + "/results")
   override val daysToDisplay = 20
   override def filterMatches(fMatch: FootballMatch, competition: Competition): Boolean =
     competition.id == competitionId && fMatch.isResult
@@ -135,7 +136,8 @@ object TeamResultsList {
     TeamResultsList(LocalDate.now(Edition.defaultEdition.timezone), Competitions(), teamId)
 }
 
-case class TeamResultsList(date: LocalDate, competitions: CompetitionSupport, teamId: String) extends Results with TeamList {
+case class TeamResultsList(date: LocalDate, competitions: CompetitionSupport, teamId: String, teamUrl:Option[String] = None) extends Results with TeamList {
+  override val baseUrl: String = teamUrl.fold("/football/results")(url => s"${url}/results")
   override val daysToDisplay = 20
   override def filterMatches(fMatch: FootballMatch, competition: Competition): Boolean =
     fMatch.isResult && fMatch.hasTeam(teamId)

--- a/sport/conf/routes
+++ b/sport/conf/routes
@@ -29,6 +29,8 @@ GET        /football/results                                                    
 GET        /football/results.json                                                              football.controllers.ResultsController.allResultsJson()
 GET        /football/:tag/results/:year/:month/:day.json                                       football.controllers.ResultsController.tagResultsForJson(year, month, day, tag)
 GET        /football/:tag/results/:year/:month/:day                                            football.controllers.ResultsController.tagResultsFor(year, month, day, tag)
+GET        /football/:tag/results/more/:year/:month/:day.json                                  football.controllers.ResultsController.moreTagResultsForJson(year, month, day, tag)
+GET        /football/:tag/results/more/:year/:month/:day                                       football.controllers.ResultsController.moreTagResultsFor(year, month, day, tag)
 GET        /football/:tag/results                                                              football.controllers.ResultsController.tagResults(tag)
 GET        /football/:tag/results.json                                                         football.controllers.ResultsController.tagResultsJson(tag)
 

--- a/sport/test/FootballTestData.scala
+++ b/sport/test/FootballTestData.scala
@@ -3,9 +3,8 @@ package test
 import org.scala_tools.time.Imports._
 import org.joda.time.DateTime
 import pa._
-import model.Competition
+import model.{Competition, Tag, TagProperties, TeamMap}
 import feed.Competitions
-
 
 trait FootballTestData {
 
@@ -71,6 +70,14 @@ trait FootballTestData {
     )
   )
 
+  val teamTags: Map[String, Tag] = Map(
+      "Liverpool" -> Tag(
+        TagProperties("football/liverpool", "/football/liverpool", "Keyword", "football", "Football", "Liverpool",
+          "https://www.theguardian.com/football/liverpool", None, None, None, None, None, None, None, Seq(), None),
+        None,
+        None,
+        None)
+    )
 
 
   private def liveMatch(homeName: String, awayName: String, homeScore: Int, awayScore: Int, date: DateTime) = matchDay.copy(
@@ -107,6 +114,9 @@ trait FootballTestData {
           agent.addMatches(comp.matches)
         }
       }
+    }
+    if (TeamMap.teamAgent.get.isEmpty) {
+      TeamMap.teamAgent.send(old => old ++ teamTags)
     }
   }
 }

--- a/sport/test/controllers/ResultsControllerTest.scala
+++ b/sport/test/controllers/ResultsControllerTest.scala
@@ -1,0 +1,119 @@
+package controllers
+
+import football.controllers.ResultsController
+import org.scalatest.{DoNotDiscover, Matchers, WordSpec}
+import play.api.libs.json.JsValue
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import test.ConfiguredTestSuite
+import scala.concurrent.Future
+
+@DoNotDiscover class ResultsControllerTest extends WordSpec with Matchers with ConfiguredTestSuite {
+
+  "GET all results" should {
+    val request = FakeRequest(method = "GET", path = "/football/results.json")
+    val action = ResultsController.allResultsJson()
+    lazy val response: Future[Result] = call(action, request)
+    "200" in {
+      status(response) should be(200)
+    }
+  }
+  "GET all results for a specific date" when {
+    "date is correct" should {
+      val request = FakeRequest(method = "GET", path = "/football/results/2016/May/3.json")
+      val action = ResultsController.allResultsForJson("2016", "May", "3")
+      lazy val response: Future[Result] = call(action, request)
+      "200" in {
+        status(response) should be(200)
+
+      }
+    }
+  }
+  "GET more results for a specific date" should {
+    val request = FakeRequest(method = "GET", path = "/football/results/more/2016/May/3.json")
+    val action = ResultsController.moreResultsForJson("2016", "May", "3")
+    lazy val response: Future[Result] = call(action, request)
+    "200" in {
+      status(response) should be(200)
+    }
+  }
+  "GET results for a specific tag" when {
+    "tag (competition) exists" should {
+      val request = FakeRequest(method = "GET", path = "/football/premierleague/results.json")
+      val action = ResultsController.tagResultsJson("premierleague")
+      lazy val response: Future[Result] = call(action, request)
+      "200" in {
+        status(response) should be(200)
+      }
+    }
+    "tag (team) exists" should {
+      val request = FakeRequest(method = "GET", path = "/football/liverpool/results.json")
+      val action = ResultsController.tagResultsJson("liverpool")
+      lazy val response: Future[Result] = call(action, request)
+      "200" in {
+        status(response) should be(200)
+      }
+    }
+    "tag doesn't exist" should {
+      val request = FakeRequest(method = "GET", path = "/football/DONOTEXIST/results.json")
+      val action = ResultsController.tagResultsJson("DONOTEXIST")
+      lazy val response: Future[Result] = call(action, request)
+      "404" in {
+        status(response) should be(404)
+      }
+    }
+  }
+  "GET results for a specific tag and date" when {
+    "tag (competition) exists" should {
+      val request = FakeRequest(method = "GET", path = "/football/premierleague/results.json")
+      val action = ResultsController.tagResultsForJson("2016", "May", "3", "premierleague")
+      lazy val response: Future[Result] = call(action, request)
+      "200" in {
+        status(response) should be(200)
+      }
+    }
+    "tag (team) exists" should {
+      val request = FakeRequest(method = "GET", path = "/football/liverpool/results.json")
+      val action = ResultsController.tagResultsForJson("2016", "May", "3", "liverpool")
+      lazy val response: Future[Result] = call(action, request)
+      "200" in {
+        status(response) should be(200)
+      }
+    }
+    "tag doesn't exist" should {
+      val request = FakeRequest(method = "GET", path = "/football/DONOTEXIST/results.json")
+      val action = ResultsController.moreTagResultsForJson("2016", "May", "3", "DONOTEXIST")
+      lazy val response: Future[Result] = call(action, request)
+      "404" in {
+        status(response) should be(404)
+      }
+    }
+  }
+  "GET more results for a specific tag" when {
+    "tag (competition) exists" should {
+      val request = FakeRequest(method = "GET", path = "/football/premierleague/results.json")
+      val action = ResultsController.moreTagResultsForJson("2016", "May", "3", "premierleague")
+      lazy val response: Future[Result] = call(action, request)
+      "200" in {
+        status(response) should be(200)
+      }
+    }
+    "tag (team) exists" should {
+      val request = FakeRequest(method = "GET", path = "/football/liverpool/results.json")
+      val action = ResultsController.moreTagResultsForJson("2016", "May", "3", "liverpool")
+      lazy val response: Future[Result] = call(action, request)
+      "200" in {
+        status(response) should be(200)
+      }
+    }
+    "tag doesn't exist" should {
+      val request = FakeRequest(method = "GET", path = "/football/DONOTEXIST/results.json")
+      val action = ResultsController.moreTagResultsForJson("2016", "May", "3", "DONOTEXIST")
+      lazy val response: Future[Result] = call(action, request)
+      "404" in {
+        status(response) should be(404)
+      }
+    }
+  }
+}

--- a/sport/test/football/model/ResultsListTest.scala
+++ b/sport/test/football/model/ResultsListTest.scala
@@ -145,7 +145,7 @@ import test.ConfiguredTestSuite
       matchDates should equal(matchDates.sortWith((match1Date, match2Date) => match1Date.isAfter(match2Date)))
     }
 
-    "should only show fixtures" in {
+    "should only show results" in {
       results.relevantMatches.foreach(checkIsResult)
     }
 


### PR DESCRIPTION
## What does this change?

Fix #12828:
- Add 'more' endpoints for football tag results
- Refactor ResultsController to avoid duplication of code
- Add tests for ResultsController
## What is the value of this and can you measure success?

One can go through paginated results when a competition or team filter is selected
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@JustinPinner 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
