### PR TITLE
Only allow http(s) URLs in CSP reports

### DIFF
--- a/diagnostics/app/model/diagnostics/csp/CSP.scala
+++ b/diagnostics/app/model/diagnostics/csp/CSP.scala
@@ -12,7 +12,8 @@ case class CSPReport(
   violatedDirective: Option[String],
   effectiveDirective: Option[String],
   originalPolicy: Option[String]) {
-  val shouldReport = blockedUri.exists(_.startsWith("http")) && documentUri.exists(_.startsWith("http"))
+  // used to filter reports consisting of about:blank, safari-extension:// etc urls
+  val isHTTP = blockedUri.exists(_.startsWith("http")) && documentUri.exists(_.startsWith("http"))
 }
 
 object CSPReport {
@@ -38,7 +39,7 @@ object CSPReport {
 object CSP extends Logging {
   def report(requestBody: JsValue): Unit = {
     (requestBody \ "csp-report").validate[CSPReport] match {
-      case JsSuccess(report, _) => if (report.shouldReport) log.logger.info(appendRaw("csp", Json.toJson(report).toString()), "csp report")
+      case JsSuccess(report, _) => if (report.isHTTP) log.logger.info(appendRaw("csp", Json.toJson(report).toString()), "csp report")
       case JsError(e) => throw new Exception(JsError.toJson(e).toString())
     }
   }

--- a/diagnostics/app/model/diagnostics/csp/CSP.scala
+++ b/diagnostics/app/model/diagnostics/csp/CSP.scala
@@ -11,7 +11,9 @@ case class CSPReport(
   blockedUri: Option[String],
   violatedDirective: Option[String],
   effectiveDirective: Option[String],
-  originalPolicy: Option[String])
+  originalPolicy: Option[String]) {
+  val shouldReport = blockedUri.exists(_.startsWith("http")) && documentUri.exists(_.startsWith("http"))
+}
 
 object CSPReport {
   implicit val jsonReads: Reads[CSPReport] = (
@@ -36,7 +38,7 @@ object CSPReport {
 object CSP extends Logging {
   def report(requestBody: JsValue): Unit = {
     (requestBody \ "csp-report").validate[CSPReport] match {
-      case JsSuccess(report, _) => log.logger.info(appendRaw("csp", Json.toJson(report).toString()), "csp report")
+      case JsSuccess(report, _) => if (report.shouldReport) log.logger.info(appendRaw("csp", Json.toJson(report).toString()), "csp report")
       case JsError(e) => throw new Exception(JsError.toJson(e).toString())
     }
   }


### PR DESCRIPTION
This prevents things like `about:blank`,`safari-extension://` getting into the reports.
