### PR TITLE
Remove dev-build route for sponsored-containers

### DIFF
--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -309,7 +309,6 @@ GET            /commercial/surging                                              
 GET            /commercial/inline-merchandising                                                                                  controllers.admin.CommercialController.renderInlineMerchandisingTargetedTags()
 GET            /commercial/high-merchandising                                                                                    controllers.admin.CommercialController.renderHighMerchandisingTargetedTags()
 GET            /commercial/templates                                                                                             controllers.admin.CommercialController.renderCreativeTemplates()
-GET            /commercial/sponsored-containers                                                                                  controllers.admin.CommercialController.sponsoredContainers()
 GET            /commercial/adunits/toapprove                                                                                     controllers.admin.CommercialAdUnitController.renderToApprove()
 POST           /commercial/adunits/toapprove                                                                                     controllers.admin.CommercialAdUnitController.approve()
 GET            /commercial/fluid250                                                                                              controllers.admin.CommercialController.renderFluidAds()


### PR DESCRIPTION
## What does this change?

Removes missed route on dev-build to fix local
## What is the value of this and can you measure success?

Stops things breaking
## Does this affect other platforms - Amp, Apps, etc?

n/a
## Screenshots
## Request for comment

@johnduffell @JonNorman 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
