### PR TITLE
Link preconnect

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -224,4 +224,12 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
+  val UseLinkPreconnect = Switch(
+    SwitchGroup.Performance,
+    "use-link-preconnect",
+    "If this switch is on then link preconnect hints will be on the page",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 8, 5),
+    exposeClientSide = false
+  )
 }

--- a/common/app/views/fragments/analytics/omniture.scala.html
+++ b/common/app/views/fragments/analytics/omniture.scala.html
@@ -2,13 +2,12 @@
 
 @import common.AnalyticsHost
 @import views.support.OmnitureAnalyticsData
-@import common.InlineJs
 @import conf.Configuration
 @import conf.Static
 
 @fragments.analytics.omnitureScript(Some(page.metadata))
 
-<script>
+<script id="gu-analytics">
         // analytics code
         @Html(Static.js.analyticsJs)
 </script>

--- a/common/app/views/fragments/analytics/omnitureScript.scala.html
+++ b/common/app/views/fragments/analytics/omnitureScript.scala.html
@@ -4,7 +4,7 @@
 @import views.support.OmnitureAnalyticsAccount
 
 @item.map{ item =>
-    <script>
+    <script id="omniture">
         @* must always be set before the Omniture file is parsed *@
         window.s_account = '@OmnitureAnalyticsAccount(item)';
         @Html(Static.js.omnitureJs)

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -7,7 +7,7 @@
 @import play.api.Play
 @import play.api.Play.current
 @import views.support.{SeoThumbnail, StripHtmlTags}
-@import conf.switches.Switches.AmpSwitch
+@import conf.switches.Switches.{AmpSwitch, UseLinkPreconnect, GoogleAnalyticsSwitch}
 
 @* Critical meta data that have an impact on rendering speed *@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
@@ -24,6 +24,24 @@
     <link rel="dns-prefetch" href="//j.ophan.co.uk" />
     <link rel="dns-prefetch" href="//ophan.theguardian.com" />
     <link rel="dns-prefetch" href="@Configuration.debug.beaconUrl" />
+
+    @if(GoogleAnalyticsSwitch.isSwitchedOn) {
+        <link rel="dns-prefetch" href="//www.google-analytics.com" />
+    }
+
+    @if(UseLinkPreconnect.isSwitchedOn) {
+        <link rel="preconnect" crossorigin href="@Configuration.assets.path" />
+        <link rel="preconnect" crossorigin href="@Configuration.images.path" />
+        <link rel="preconnect" crossorigin href="@Configuration.ajax.url" />
+        <link rel="preconnect" crossorigin href="@AnalyticsHost()" />
+        <link rel="preconnect" crossorigin href="//j.ophan.co.uk" />
+        <link rel="preconnect" crossorigin href="//ophan.theguardian.com" />
+        <link rel="preconnect" crossorigin href="@Configuration.debug.beaconUrl" />
+
+        @if(GoogleAnalyticsSwitch.isSwitchedOn) {
+            <link rel="preconnect" crossorigin href="//www.google-analytics.com" />
+        }
+    }
 
     <link rel="apple-touch-icon" sizes="152x152" href="@Static("images/favicons/152x152.png")" />
     <link rel="apple-touch-icon" sizes="144x144" href="@Static("images/favicons/144x144.png")" />

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -23,7 +23,6 @@
     <link rel="dns-prefetch" href="@AnalyticsHost()" />
     <link rel="dns-prefetch" href="//j.ophan.co.uk" />
     <link rel="dns-prefetch" href="//ophan.theguardian.com" />
-    <link rel="dns-prefetch" href="//oas.theguardian.com" />
     <link rel="dns-prefetch" href="@Configuration.debug.beaconUrl" />
 
     <link rel="apple-touch-icon" sizes="152x152" href="@Static("images/favicons/152x152.png")" />

--- a/static/src/javascripts/projects/common/modules/analytics/analytics.js
+++ b/static/src/javascripts/projects/common/modules/analytics/analytics.js
@@ -64,6 +64,7 @@
 
         s.trackingServer = 'hits.theguardian.com';
         s.trackingServerSecure = 'hits-secure.theguardian.com';
+        s.ssl = true;
 
         /* Omniture library version */
         s.prop62    = 'Guardian JS-1.4.1 20140914';


### PR DESCRIPTION
We've got pretty good coverage of `<link rel="preconnect">` now, which should allow us to hint to the browser that we want to open a connection. The aim is to reduce delays caused by opening connections during the critical path.

Currently, we use `dns-prefetch`, which has marginally better browser support, but doesn't pre-emptively perform the tcp connection (in orange, below), or the ssl negotiation (in purple). I want to see if `preconnect` saves us time, as increasingly move more things to TLS.

I've also made omniture always-ssl. The server was assuming this, but the client needs to be specifically targeting ssl. Without always-ssl, the dns-prefetch/preconnect was redundant.

![screen shot 2016-05-17 at 11 56 35](https://cloud.githubusercontent.com/assets/4549425/15320209/3a6f198a-1c27-11e6-9377-292fa0a3663f.png)

More info [here](https://www.igvita.com/2015/08/17/eliminating-roundtrips-with-preconnect/)
