### PR TITLE
Serve hosted by container logo from dfp, and adjust the text positioning

### DIFF
--- a/static/src/javascripts/projects/common/views/commercial/creatives/hosted-thrasher.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/hosted-thrasher.html
@@ -29,7 +29,7 @@
         </div>
         <div class="hostedbadge hosted-tone-bg--renault">
             <p class="hostedbadge__info">Advertiser content</p>
-            <img class="hostedbadge__logo" src="/assets/images/commercial/logo_renault.jpg">
+            <img class="hostedbadge__logo" src="<%=data.logo%>">
         </div>
     </div>
 </div>

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -384,6 +384,8 @@ $hosted-stripe: 28px;
         @include mq(desktop) {
             font-size: 46px;
             line-height: 46px;
+            margin-top: -12px;
+            margin-bottom: 10px;
         }
     }
 


### PR DESCRIPTION
## What does this change?

Use a logo from dfp instead of the static one. Move the text a bit.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
