### PR TITLE
Update us briefing check so it doesn't look at the article structure

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -98,8 +98,8 @@ define([
             return page.keywordExists(['Football']) && allowedArticleStructure();
         },
         usBriefing: function () {
-            return (config.page.section === 'us-news' || config.page.series === 'Guardian US briefing') &&
-                allowedArticleStructure();
+            return (config.page.section === 'us-news' && allowedArticleStructure()) ||
+                config.page.series === 'Guardian US briefing';
         },
         ausCampaignCatchup: function () {
             return page.keywordExists([


### PR DESCRIPTION
## What does this change?

Updates the us briefing sign-up page so it doesn't check the structure on the us briefing pages because they always end in a paragraph.
