### PR TITLE
Make passbacks work with fabric ads

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -98,7 +98,7 @@ define([
         function insertInlineAd(paras) {
             bodyAds += 1;
             var isFabricTopReplacement = config.switches.fabricAdverts && (bodyAds === 1) && detect.isBreakpoint({max: 'phablet'});
-            var adDefinition = isFabricTopReplacement ? 'inline-fabric-top' : ('inline' + bodyAds);
+            var adDefinition = isFabricTopReplacement ? 'inline1-fabric' : ('inline' + bodyAds);
 
             insertAdAtPara(paras[0], adDefinition, 'inline');
         }

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -98,6 +98,9 @@ define([
         function insertInlineAd(paras) {
             bodyAds += 1;
             var isFabricTopReplacement = config.switches.fabricAdverts && (bodyAds === 1) && detect.isBreakpoint({max: 'phablet'});
+
+            // Note that the names 'inline1' to 'inline8' are used by passbacks for retargeting -
+            // check with adOps before changing these labels
             var adDefinition = isFabricTopReplacement ? 'inline1-fabric' : ('inline' + bodyAds);
 
             insertAdAtPara(paras[0], adDefinition, 'inline');

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -108,7 +108,9 @@ define([
             sizeMappings: {
                 mobile: ('1,1|300,250|' + fabricTopSlot)
             },
-            name : 'inline1' // needed for third party passbacks
+            // This label is used so that passbacks can retarget the slot, and so that in-reads (which always appear in
+            // the first slot) can be limited to this ad.
+            name : 'inline1'
         }
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -107,7 +107,8 @@ define([
         'inline-fabric-top': {
             sizeMappings: {
                 mobile: ('1,1|300,250|' + fabricTopSlot)
-            }
+            },
+            name : 'inline1' // needed for third party passbacks
         }
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -104,7 +104,7 @@ define([
                 mobile: fabricTopSlot
             }
         },
-        'inline-fabric-top': {
+        'inline1-fabric': {
             sizeMappings: {
                 mobile: ('1,1|300,250|' + fabricTopSlot)
             },


### PR DESCRIPTION
When we're on a mobile article, there's no top nav slot, so we need to make the first inline slot request a Fabric 88x71 advert. To do this, I created a new adslot definition, _inline-fabric-top_.

However, this breaks passbacks, which it appear require a particular set of names ('inline', 'inline1' ... 'inline8') for retargeting. It may also break inreads, which need a `dfp-ad--inline1` slot ID.

To fix this in the short term, I've added a `name` override for the fabric definition.

A longer-term fix might be to change the `inline-1` definition to target 88x71s in mobile specifically, and fix dfp-api's `buildSizeMapping` to only use slot sizes on the largest matching breakpoint. I'd need to do a little sniffing to see if this would break anything else in turn first, though.
