### PR TITLE
Badge - Update to https asset

### DIFF
--- a/static/src/stylesheets/module/content/_badging.scss
+++ b/static/src/stylesheets/module/content/_badging.scss
@@ -50,12 +50,12 @@
 
     &.us-election {
         .content__header .gs-container {
-            background-image: url('http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615039/uselectionliveblogon.jpg');
+            background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615039/uselectionliveblogon.jpg');
         }
 
         &.tonal__head--tone-dead {
             .content__header .gs-container {
-                background-image: url('http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615570/uselectionliveblogoff.jpg');
+                background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615570/uselectionliveblogoff.jpg');
             }
         }
     }


### PR DESCRIPTION
US elections liveblogs should not see a mixed-content warning when moving to https
