### PR TITLE
resolve with object that has properties

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -195,16 +195,21 @@ define([
 
         var videoInfo = new Promise(function(resolve) {
             // We only have the canonical URL in videos embedded in articles / main media.
+            var defaultVideoInfo = {
+                expired: false,
+                shouldHideAdverts: false
+            };
+
             if (!canonicalUrl) {
-                resolve({
-                    expired: false,
-                    shouldHideAdverts: false
-                });
+                resolve(defaultVideoInfo);
             } else {
                 ajax({
                     url: canonicalUrl + '/info.json'
                 }).then(function(videoInfo) {
                     resolve(videoInfo);
+                }, function() {
+                    // if this fails, don't stop, keep going.
+                    resolve(defaultVideoInfo);
                 });
             }
         });

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -196,7 +196,10 @@ define([
         var videoInfo = new Promise(function(resolve) {
             // We only have the canonical URL in videos embedded in articles / main media.
             if (!canonicalUrl) {
-                resolve(false);
+                resolve({
+                    expired: false,
+                    shouldHideAdverts: false
+                });
             } else {
                 ajax({
                     url: canonicalUrl + '/info.json'


### PR DESCRIPTION
## What does this change

Being more explicit about the object that we can't et as we don't always have the canonical URL.
Doing this because we potentially have some tracking issues. 

There were no errors thrown as, apparently, you can have `false.whatever` or even `false.true` in JS and  all is well.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
