### PR TITLE
Only send video id to player if mediaType is present on fronts

### DIFF
--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -44,6 +44,7 @@
             @kicker(item.header, List("fc-item__kicker--dreamsnap", "fc-item__kicker--dreamsnap-list"))
         }
 
+
         @item.displayElement.filter(const(item.showDisplayElement)) match {
             case Some(InlineVideo(videoElement, title, endSlatePath, fallback)) if item.cardTypes.showVideoPlayer => {
                 @defining(VideoPlayer(
@@ -54,7 +55,11 @@
                     showControlsAtStart = false,
                     endSlatePath,
                     Some(false),
-                    item.id
+                    // We only pass in the ID if this is a video or audio block, as if it's a mainMedia video, the
+                    // ID is actually pointing to the article, which is wrong. It would be nice to have the ID on the
+                    // ContentCard, but we don't for now. Annoyingly this doesn't allow us to check for if we should
+                    // play ads or if the video is expired, but as fronts change really often, this is a non-problem.
+                    item.mediaType.flatMap(_ => item.id)
                 )) { player =>
                     <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player">
                         <div class="fc-item__video-container">


### PR DESCRIPTION
## What does this change?

At present we send the article ID through to the `video` snippet, which is wrong as we expect the video page ID. 

Unfortunately this isn't present on the `ContentCard`, so we don't send it through unless we have `mediaType` proving that this is a card for video.

This should stop the current click-twice-to-play video, but also start pushing through stats, which are not working at the moment.
## What is the value of this and can you measure success?

Click once - get video.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
