### PR TITLE
eu-referendum tag disabled

### DIFF
--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -13,7 +13,7 @@ object Badges {
   val euRealityCheck = Badge("politics/series/eu-referendum-reality-check", Static("images/EU_Ref_Logo.svg").path)
   
 
-  val allBadges = Seq(usElection, ausElection, euElection, euRealityCheck)
+  val allBadges = Seq(usElection, ausElection, euRealityCheck)
 
   def badgeFor(c: ContentType) = allBadges.find(badge => c.tags.tags.exists(tag => tag.id == badge.seriesTag))
   def badgeFor(fc: FaciaContainer) = fc.href.flatMap(href => allBadges.find(badge => href == badge.seriesTag))

--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -8,7 +8,8 @@ case class Badge(seriesTag: String, imageUrl: String)
 object Badges {
   val usElection = Badge("us-news/us-elections-2016", Static("images/USElectionlogooffset.png").path)
   val ausElection = Badge("australia-news/australian-election-2016", Static("images/AUSElectionBadge.png").path)
-  val euElection = Badge("politics/eu-referendum", Static("images/EU_Ref_Logo.svg").path)
+  // Temporarily Disabled until Editorial confirm
+  /* val euElection = Badge("politics/eu-referendum", Static("images/EU_Ref_Logo.svg").path) */
   val euRealityCheck = Badge("politics/series/eu-referendum-reality-check", Static("images/EU_Ref_Logo.svg").path)
   
 


### PR DESCRIPTION
Editorial want to hold off on the badging on all EU content for now and just have EU reality check tagged.

@desbo 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
