### PR TITLE
Rename MAX_INT constant to something more meaningful

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/mvt-cookie.js
+++ b/static/src/javascripts/projects/common/modules/analytics/mvt-cookie.js
@@ -9,7 +9,7 @@ define([
         // The full mvt ID interval is [1, 1000000]
         // Server side mvt IDs occupy [9000000, 1000000)
         // So the client-side mvt interval is [1, 899999]
-        MAX_INT = 899999;
+        MAX_CLIENT_MVT_ID = 899999;
 
     function overwriteMvtCookie(testId) {
         // For test purposes only.
@@ -41,7 +41,7 @@ define([
     }
 
     function getMvtNumValues() {
-        return MAX_INT;
+        return MAX_CLIENT_MVT_ID;
     }
 
     return {
@@ -49,6 +49,6 @@ define([
         getMvtValue: getMvtValue,
         getMvtNumValues: getMvtNumValues,
         overwriteMvtCookie: overwriteMvtCookie,
-        MAX_INT: MAX_INT
+        MAX_CLIENT_MVT_ID: MAX_CLIENT_MVT_ID
     };
 });


### PR DESCRIPTION
## What does this change?

Renames MAX_INT to MAX_CLIENT_MVT_ID
## What is the value of this and can you measure success?

Makes MVT code less confusing for new devs
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

n/a
## Request for comment
