### PR TITLE
Revert "Revert "add timeout to contrib-ads on video to be larger than IMA timeout""

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -303,8 +303,14 @@ define([
                                         player.ima({
                                             id: mediaId,
                                             adTagUrl: getAdUrl(),
-                                            prerollTimeout: 1000
+                                            prerollTimeout: 1000,
+                                            contribAdsSettings: {
+                                                // This is higher than the `prerollTimeout` to so as not to
+                                                // trigger the `adtimeout` before the `prerollTimeout`.
+                                                timeout: 2000
+                                            }
                                         });
+
                                         player.ima.requestAds();
 
                                         // Video analytics event.
@@ -315,10 +321,6 @@ define([
                             } else {
                                 resolve();
                             }
-
-
-
-
                         } else {
                             player.playlist({
                                 mediaType: 'audio',


### PR DESCRIPTION
Reverts guardian/frontend#12913

We've confirmed that this doesn't affect the tracking, and does help with the problem.

@akash1810 
