### PR TITLE
add baselining to videos on fronts test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -103,4 +103,13 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 5, 19),
     exposeClientSide = true
   )
+
+  val ABPlayVideoOnFronts = Switch(
+    SwitchGroup.ABTests,
+    "ab-play-video-on-fronts",
+    "Don't play video on fronts, but auto play when in article",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 5, 19),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -109,7 +109,7 @@ trait ABTestSwitches {
     "ab-play-video-on-fronts",
     "Don't play video on fronts, but auto play when in article",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 19),
+    sellByDate = new LocalDate(2016, 5, 25),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/play-video-on-fronts.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/play-video-on-fronts.js
@@ -1,0 +1,37 @@
+define([
+    'qwery',
+    'common/utils/config'
+], function (
+    qwery,
+    config
+) {
+    return function () {
+        this.id = 'PlayVideoOnFronts';
+        this.start = '2016-05-18';
+        this.expiry = '2016-06-25';
+        this.author = 'James Gorrie';
+        this.description = 'Test if autoplaying on fronts is bad.';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = '';
+        this.audienceCriteria = 'Fronts that have cards with articles that have video as their main media';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            // Only videos that are links to video pages have data-embed-paths
+            return config.page.isFront && qwery('video:not([data-embed-path])').length > 0;
+        };
+
+        this.variants = [
+            {
+                id: 'baseline1',
+                test: function () {}
+            },
+            {
+                id: 'baseline2',
+                test: function () {}
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/play-video-on-fronts.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/play-video-on-fronts.js
@@ -20,7 +20,7 @@ define([
 
         this.canRun = function () {
             // Only videos that are links to video pages have data-embed-paths
-            return config.page.isFront && qwery('video:not([data-embed-path])').length > 0;
+            return config.page.isFront && qwery('.fc-item--has-video-main-media').length > 0;
         };
 
         this.variants = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/play-video-on-fronts.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/play-video-on-fronts.js
@@ -8,7 +8,7 @@ define([
     return function () {
         this.id = 'PlayVideoOnFronts';
         this.start = '2016-05-18';
-        this.expiry = '2016-06-25';
+        this.expiry = '2016-05-25';
         this.author = 'James Gorrie';
         this.description = 'Test if autoplaying on fronts is bad.';
         this.audience = 1;


### PR DESCRIPTION
## What does this change?

Adding the baselining to see how long we would have to run a test with videos on fronts to make a statistical difference.
## What is the value of this and can you measure success?

We see numbers go ⬆️ .
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@harrysalmon @akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
