### PR TITLE
add classes to explain video cards better

### DIFF
--- a/common/app/layout/Sublink.scala
+++ b/common/app/layout/Sublink.scala
@@ -295,6 +295,13 @@ case class ContentCard(
   val analyticsPrefix = s"${cardStyle.toneString} | group-$group${if(displaySettings.isBoosted) "+" else ""}"
 
   val hasInlineSnapHtml = snapStuff.exists(_.embedHtml.isDefined)
+
+  val isMediaLink = mediaType.nonEmpty
+
+  val hasVideoMainMedia = displayElement match {
+    case Some(a: InlineVideo) if (!isMediaLink) => true
+    case _ => false
+  }
 }
 
 case class HtmlBlob(html: Html, customCssClasses: Seq[String], cardTypes: ItemClasses) extends FaciaCard

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -44,7 +44,6 @@
             @kicker(item.header, List("fc-item__kicker--dreamsnap", "fc-item__kicker--dreamsnap-list"))
         }
 
-
         @item.displayElement.filter(const(item.showDisplayElement)) match {
             case Some(InlineVideo(videoElement, title, endSlatePath, fallback)) if item.cardTypes.showVideoPlayer => {
                 @defining(VideoPlayer(
@@ -59,7 +58,7 @@
                     // ID is actually pointing to the article, which is wrong. It would be nice to have the ID on the
                     // ContentCard, but we don't for now. Annoyingly this doesn't allow us to check for if we should
                     // play ads or if the video is expired, but as fronts change really often, this is a non-problem.
-                    item.mediaType.flatMap(_ => item.id)
+                    if (item.isMediaLink) item.id else None
                 )) { player =>
                     <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player">
                         <div class="fc-item__video-container">

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -29,7 +29,9 @@ object GetClasses {
       ("fc-item--has-metadata",
         item.timeStampDisplay.isDefined || item.discussionSettings.isCommentable || SaveForLaterSwitch.isSwitchedOn),
       ("fc-item--has-timestamp", item.timeStampDisplay.isDefined),
-      ("fc-item--is-commentable", item.discussionSettings.isCommentable)
+      ("fc-item--is-commentable", item.discussionSettings.isCommentable),
+      ("fc-item--is-media-link", item.isMediaLink),
+      ("fc-item--has-video-main-media", item.hasVideoMainMedia)
     ) ++ item.snapStuff.map(_.cssClasses.map(_ -> true).toMap).getOrElse(Map.empty)
       ++ mediaTypeClass(item).map(_ -> true)
     )


### PR DESCRIPTION
## What does this change?

This will help us differentiate between cards to video pages and articles with main media that is video.
## What is the value of this and can you measure success?

It will help us with some tests we'd like to run on fronts.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

![fact](https://cloud.githubusercontent.com/assets/31692/15360944/8a1c5520-1d07-11e6-9c0e-66f6cfb05b9b.png)
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
