### PR TITLE
Hosted content - small mobile screen style changes

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -24,8 +24,15 @@ $hosted-stripe: 28px;
 
 .hosted__header {
     width: 100%;
-    height: 58px;
     background-color: $neutral-1;
+
+    @include mq(mobile) {
+        height: 48px;
+    }
+
+    @include mq(tablet) {
+        height: 58px;
+    }
 }
 
 .hosted__side {
@@ -62,8 +69,6 @@ $hosted-stripe: 28px;
 
     svg {
         fill: #ffffff;
-        width: 135px;
-        height: 50px;
     }
 
     .inline-logo {
@@ -71,9 +76,17 @@ $hosted-stripe: 28px;
         margin-top: -5px;
     }
 
+    @include mq(mobile) {
+        svg {
+            width: 115px;
+            height: 40px
+        }
+    }
+
     @include mq(tablet) {
         svg {
             width: 185px;
+            height: 50px;
         }
     }
 }
@@ -451,9 +464,16 @@ $hosted-stripe: 28px;
 .hosted__label {
     float: left;
     margin-left: 110px;
-    margin-top: 29px;
     color: #ffffff;
     border: 0;
+
+    @include mq(mobile) {
+        margin-top: 20px;
+    }
+
+    @include mq(tablet) {
+        margin-top: 29px;
+    }
 
     @include mq(desktop) {
         margin-left: 160px;


### PR DESCRIPTION
Looks much better now.

<img width="354" alt="screen shot 2016-05-18 at 16 52 58" src="https://cloud.githubusercontent.com/assets/2579465/15365699/1cc5ad98-1d19-11e6-9295-7f1fc91ba826.png">

@regiskuckaertz 
