### PR TITLE
Extend welcome banner switch date

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -118,7 +118,7 @@ trait ABTestSwitches {
     "ab-play-video-on-fronts",
     "Don't play video on fronts, but auto play when in article",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 25),
+    sellByDate = new LocalDate(2016, 6, 1),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Extends the expiry date for the welcome banner A/B test switch. It expires tonight and not changing it will break build. We are still keeping the switch because we will use it for the actual test (so far it has been used for a pretest).

@stephanfowler 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
