### PR TITLE
Intermix packages stories only if more than one packages

### DIFF
--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -43,7 +43,7 @@ object GalleryController extends Controller with RendersItemResponse with Loggin
       .showFields("all")
     ).map { response =>
       val gallery = response.content.map(Content(_))
-      val model: Option[GalleryPage] = gallery collect { case g: Gallery => GalleryPage(g, RelatedContent(g, response), index, isTrail) }
+      val model: Option[GalleryPage] = gallery collect { case g: Gallery => GalleryPage(g, StoryPackages(g, response), index, isTrail) }
 
       ModelOrResult(model, response)
 

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -31,7 +31,7 @@ object InteractiveController extends Controller with RendersItemResponse with Lo
 
     val result = response map { response =>
       val interactive = response.content map {Interactive.make}
-      val page = interactive.map(i => InteractivePage(i, RelatedContent(i, response)))
+      val page = interactive.map(i => InteractivePage(i, StoryPackages(i, response)))
 
       ModelOrResult(page, response)
     }

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -40,7 +40,7 @@ object MediaController extends Controller with RendersItemResponse with Logging 
 
     val result = response map { response =>
       val mediaOption: Option[ContentType] = response.content.filter(isSupported).map(Content(_))
-      val model = mediaOption map { media => MediaPage(media, RelatedContent(media, response)) }
+      val model = mediaOption map { media => MediaPage(media, StoryPackages(media, response)) }
 
       ModelOrResult(model, response)
     }

--- a/applications/app/services/ImageQuery.scala
+++ b/applications/app/services/ImageQuery.scala
@@ -5,7 +5,7 @@ import common.{Edition, _}
 import contentapi.ContentApiClient
 import contentapi.ContentApiClient.getResponse
 import controllers.ImageContentPage
-import model.{ApiContent2Is, Content, ImageContent, RelatedContent}
+import model.{ApiContent2Is, Content, ImageContent, StoryPackages}
 import play.api.mvc.{RequestHeader, Result => PlayResult}
 
 import scala.concurrent.Future
@@ -18,7 +18,7 @@ trait ImageQuery extends ConciergeRepository {
     ) map { response: ItemResponse =>
         val mainContent = response.content.filter(_.isImageContent).map(Content(_))
         mainContent.map {
-          case content: ImageContent => Left(ImageContentPage(content, RelatedContent(content, response)))
+          case content: ImageContent => Left(ImageContentPage(content, StoryPackages(content, response)))
           case _ => Right(NotFound)
         }.getOrElse(Right(NotFound))
       }

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -181,21 +181,18 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
     val content: Either[PageWithStoryPackage, Result] = supportedContentResult.left.flatMap { content =>
       (content, page) match {
         case (minute: Article, None) if minute.isUSMinute =>
-          Left(MinutePage(minute, RelatedContent(minute, response)))
+          Left(MinutePage(minute, StoryPackages(minute, response)))
         case (liveBlog: Article, None/*no page param*/) if liveBlog.isLiveBlog =>
           createLiveBlogModel(liveBlog, response, None)
         case (liveBlog: Article, Some(Some(requiredBlockId))/*page param specified and valid format*/) if liveBlog.isLiveBlog =>
           createLiveBlogModel(liveBlog, response, Some(requiredBlockId))
         case (article: Article, None) =>
-          if(mvt.ABIntersperseMultipleStoryPackagesStories.isParticipating) {
-            Left(ArticlePage(article, StoryPackages(article, response)))
-          }
-          else if(mvt.ABOpenGraphOverlay.isParticipating) {
+          if(mvt.ABOpenGraphOverlay.isParticipating) {
             val newArticle = ArticleWithOpenGraphOverlay(article)
-            Left(ArticlePage(newArticle, RelatedContent(newArticle, response)))
+            Left(ArticlePage(newArticle, StoryPackages(newArticle, response)))
           }
           else {
-            Left(ArticlePage(article, RelatedContent(article, response)))
+            Left(ArticlePage(article, StoryPackages(article, response)))
           }
         case _ =>
           Right(NotFound)
@@ -235,7 +232,7 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
           content = liveBlog.content.copy(
             metadata = liveBlog.content.metadata.copy(
               cacheTime = cacheTime)))
-        Left(LiveBlogPage(liveBlogCache, pageModel, RelatedContent(liveBlog, response)))
+        Left(LiveBlogPage(liveBlogCache, pageModel, StoryPackages(liveBlog, response)))
       case None => Right(NotFound)
     }
 

--- a/common/app/model/RelatedContent.scala
+++ b/common/app/model/RelatedContent.scala
@@ -15,26 +15,9 @@ case class RelatedContentItem (
   faciaContent: PressedContent
 )
 
-case class RelatedContent ( items: Seq[RelatedContentItem], storyPackagesCount: Int = 0) {
+case class RelatedContent (items: Seq[RelatedContentItem]) {
   val hasStoryPackage: Boolean = items.nonEmpty
   val faciaItems: Seq[PressedContent] = items.map(_.faciaContent)
-}
-
-object RelatedContent {
-  def apply(parent: ContentType, response: ItemResponse): RelatedContent = {
-    // It's misleading to use storyPackage here rather than relatedContent. A tidy up should rename this object
-    val storyPackagesContent = response.packages.map { packages =>
-      packages.flatMap { p =>
-        p.articles.map(_.content)
-      }
-    }.getOrElse(List.empty)
-
-    val items = storyPackagesContent.map { item =>
-      val frontendContent = Content(item)
-      RelatedContentItem(frontendContent, FaciaContentConvert.contentToFaciaContent(item))
-    }
-    RelatedContent(items.filterNot(_.content.metadata.id == parent.metadata.id))
-  }
 }
 
 object StoryPackages {
@@ -52,6 +35,6 @@ object StoryPackages {
       val frontendContent = Content(item)
       RelatedContentItem(frontendContent, FaciaContentConvert.contentToFaciaContent(item))
     }
-    RelatedContent(items.filterNot(_.content.metadata.id == parent.metadata.id), response.packages.fold(0)(_.size))
+    RelatedContent(items.filterNot(_.content.metadata.id == parent.metadata.id))
   }
 }

--- a/common/app/model/RelatedContent.scala
+++ b/common/app/model/RelatedContent.scala
@@ -28,8 +28,10 @@ object StoryPackages {
       if(packages.size > 1) { //intermix packages only if more than one
         allContentsPerPackage
          .flatMap(_.zipWithIndex) // zip content with its position
+         .groupBy(_._1.id).map(_._2.head).toSeq // remove duplicates (Note: not using `distinct` here that would require
+                                                // hashing/comparing the whole ApiContent object but instead grouping based on `id`
+                                                // and then collecting the first element of each group of duplicates)
          .sortBy(_._2).map(_._1)  // sort by position and extract content
-         .distinct                // remove duplicates
       } else {
         allContentsPerPackage.flatten
       }

--- a/common/app/model/RelatedContent.scala
+++ b/common/app/model/RelatedContent.scala
@@ -22,13 +22,17 @@ case class RelatedContent (items: Seq[RelatedContentItem]) {
 
 object StoryPackages {
   def apply(parent: ContentType, response: ItemResponse): RelatedContent = {
-    val storyPackagesContent = response.packages.map { packages =>
-      packages.map { p =>
-        p.articles.map(_.content)
+
+    val storyPackagesContent: Seq[ApiContent] = response.packages.map { packages =>
+      val allContentsPerPackage: Seq[Seq[ApiContent]] = packages.map(_.articles.map(_.content))
+      if(packages.size > 1) { //intermix packages only if more than one
+        allContentsPerPackage
+         .flatMap(_.zipWithIndex) // zip content with its position
+         .sortBy(_._2).map(_._1)  // sort by position and extract content
+         .distinct                // remove duplicates
+      } else {
+        allContentsPerPackage.flatten
       }
-       .flatMap(_.zipWithIndex) // zip content with its position
-       .sortBy(_._2).map(_._1) // sort by position and extract content to intermix stories from all packages
-       .distinct // remove duplicates
     }.getOrElse(List.empty)
 
     val items = storyPackagesContent.map { item =>

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -63,27 +63,12 @@ object ABHeadlinesTestControl extends TestDefinition(
     }
 }
 
-object ABIntersperseMultipleStoryPackagesStories extends TestDefinition(
-  List(Variant8), // 1% of our audience
-  "intersperse-multiple-story-packages-stories",
-  "To test if mixing storyPackages stories (when article has more than one storyPackage) results in more clicks",
-  new LocalDate(2016, 5, 24)
-)
-object ABIntersperseMultipleStoryPackagesStoriesControl extends TestDefinition(
-  List(Variant9), // 1% of our audience
-  "intersperse-multiple-story-packages-stories-control",
-  "Control for the intersperse-multiple-story-packages-stories A/B test",
-  new LocalDate(2016, 5, 24)
-)
-
 object ActiveTests extends Tests {
   val tests: Seq[TestDefinition] = List(
     ABOpenGraphOverlay,
     ABNewHeaderVariant,
     ABHeadlinesTestControl,
-    ABHeadlinesTestVariant,
-    ABIntersperseMultipleStoryPackagesStories,
-    ABIntersperseMultipleStoryPackagesStoriesControl
+    ABHeadlinesTestVariant
   )
 
   def getJavascriptConfig(implicit request: RequestHeader): String = {
@@ -145,14 +130,7 @@ object MultiVariateTesting {
 
   sealed case class Variant(name: String)
 
-  // buckets 0-7 are removed because they cost $1000+ just in aws bandwidth every month, the rest
-  // will be removed once they're not in use.  In future server side ab tests will be added explicitly
-  // to target only the URLs needed for the time needed.
-  object Variant8 extends Variant("variant-8")
-  object Variant9 extends Variant("variant-9")
-
-  private val allVariants = List(
-    Variant8, Variant9)
+  private[mvt] val allVariants = List[Variant]()
 
   def getVariant(request: RequestHeader): Option[Variant] = {
     val cdnVariant: Option[String] = request.headers.get("X-GU-mvt-variant")

--- a/common/app/views/fragments/storyPackagePlaceholder.scala.html
+++ b/common/app/views/fragments/storyPackagePlaceholder.scala.html
@@ -11,10 +11,7 @@
 
 @defining(Seq("related") ++ (if(content.commercial.isAdvertisementFeature) Seq("fc-container--advertisement-feature") else Nil)) { classes =>
     @if(related.hasStoryPackage) {
-        <aside class="@classes.mkString(" ") more-on-this-story" role="complementary" aria-labelledby="related-content-head"
-            @if(mvt.ABIntersperseMultipleStoryPackagesStories.isParticipating && related.storyPackagesCount > 1){data-link-name="ab-multiple-story-packages"}
-            @if(mvt.ABIntersperseMultipleStoryPackagesStoriesControl.isParticipating && related.storyPackagesCount > 1){data-link-name="ab-multiple-story-packages-control"}
-        >
+        <aside class="@classes.mkString(" ") more-on-this-story" role="complementary" aria-labelledby="related-content-head">
             @container("more on this story", "more-on-this-story", href = None)
         </aside>
     } else {

--- a/common/test/common/MultiVariateTestingTest.scala
+++ b/common/test/common/MultiVariateTestingTest.scala
@@ -1,8 +1,5 @@
-package common
+package mvt
 
-import conf.switches.{Expiry, Switches}
-import mvt.MultiVariateTesting._
-import mvt.{TestDefinition, MultiVariateTesting, Tests}
 import org.joda.time.LocalDate
 import org.scalatest.{Matchers, FlatSpec}
 import test.TestRequest
@@ -16,16 +13,11 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
     variantsInUse.size should equal (variantsInUse.distinct.size)
   }
 
-  "a request with a valid test header" should "be assigned to the appropriate test" in {
-    TestCases.test1.switch.switchOn
-    val testRequest = TestRequest("/uk")
-      .withHeaders(
-        "X-GU-mvt-variant" -> "variant-9"
-      )
-    MultiVariateTesting.getVariant(testRequest) should be (Some(Variant9))
-    TestCases.isParticipatingInATest(testRequest) should be (true)
-    TestCases.getParticipatingTest(testRequest) should be (Some(TestCases.test1))
-    TestCases.test1.switch.switchOff
+  // TODO: refactor MultiVariateTesting to remove site-wide variants
+  // This test is only here to ensure nobody adds variants by accident before this refactoring happens
+  // Talk to Thomas Bonnin if you have any question
+  "MultiVariateTesting" should "have no variant" in {
+    MultiVariateTesting.allVariants.size should equal (0)
   }
 
   "a request with an invalid test header" should "be ignored" in {
@@ -44,14 +36,14 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
 
   object TestCases extends Tests {
     object test0 extends TestDefinition(
-      List(Variant8),
+      Nil,
       "test0",
       "an experiment test",
       new LocalDate(2100, 1, 1)
 
     )
     object test1 extends TestDefinition(
-      List(Variant8, Variant9),
+      Nil,
       "test1",
       "an experiment test",
       new LocalDate(2100, 1, 1)


### PR DESCRIPTION
## What does this change?

Second try at #12938. After deploying it the application and article instances latency went to the roof
The issue didn't seem to be with those change directly but with a problem with the capi client when hitting this line https://github.com/guardian/frontend/blob/tbonnin-remove-ABIntersperseMultipleStoryPackagesStories/common/app/model/RelatedContent.scala#L49
Logs of the issue can be found at http://kibana.gu-web.net/goto/16cb09613e0643ce1d95e00816f14db4

Before this change, the faulty code was only executed for people in the A/B test group which was 1% of readers. I guess the servers were able to recover since it was not happening this often.

This PR is dependent on capi client upgrade: https://github.com/guardian/frontend/pull/12971 :)

I also added an improvement where the zipping, sorting, removing duplicates only happens where there are more than one packages
## What is the value of this and can you measure success?

Removing a/b test
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
