### PR TITLE
add baseline for showing controls on main media

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -122,4 +122,13 @@ trait ABTestSwitches {
     exposeClientSide = true
   )
 
+  val ABVideoControlsOnMainMedia = Switch(
+    SwitchGroup.ABTests,
+    "ab-video-controls-on-main-media",
+    "Show video controls on main media.",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 5, 26),
+    exposeClientSide = true
+  )
+
 }

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -17,6 +17,8 @@ define([
     'common/modules/experiments/tests/participation-low-fric-fashion',
     'common/modules/experiments/tests/clever-friend-brexit',
     'common/modules/experiments/tests/welcome-header',
+    'common/modules/experiments/tests/play-video-on-fronts',
+    'common/modules/experiments/tests/video-controls-on-main-media',
     'lodash/arrays/flatten',
     'lodash/arrays/zip',
     'lodash/collections/forEach',
@@ -49,6 +51,8 @@ define([
     ParticipationLowFricFashion,
     CleverFriendBrexit,
     WelcomeHeader,
+    PlayVideoOnFronts,
+    VideoControlsOnMainMedia,
     flatten,
     zip,
     forEach,
@@ -76,7 +80,9 @@ define([
         new ParticipationLowFricRecipes(),
         new ParticipationLowFricFashion(),
         new CleverFriendBrexit(),
-        new WelcomeHeader()
+        new WelcomeHeader(),
+        new PlayVideoOnFronts(),
+        new VideoControlsOnMainMedia()
     ]);
 
     var participationsKey = 'gu.ab.participations';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-controls-on-main-media.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-controls-on-main-media.js
@@ -1,0 +1,37 @@
+define([
+    'qwery',
+    'common/utils/config'
+], function (
+    qwery,
+    config
+) {
+    return function () {
+        this.id = 'VideoControlsOnMainMedia';
+        this.start = '2016-05-19';
+        this.expiry = '2016-05-26';
+        this.author = 'James Gorrie';
+        this.description = 'Showing controls on main media.';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = '';
+        this.audienceCriteria = 'Landing on an article with main media';
+        this.dataLinkNames = '';
+        this.idealOutcome = '';
+
+        this.canRun = function () {
+            return config.page.contentType === 'Article' && qwery('[data-component-type="main video"]').length > 0;
+        };
+
+        this.variants = [
+            {
+                id: 'baseline1',
+                test: function () {}
+            },
+            {
+                id: 'baseline2',
+                test: function () {}
+            }
+        ];
+    };
+});
+


### PR DESCRIPTION
## What does this change?

Running a baseline to see how many people we need to run a test with showing the video controls to on the main media.

It appears we actually set a class on it called `gu-media--show-controls-at-start`, which does nothing, but instead of just adding it, I wouldn't mind testing it.
## What is the value of this and can you measure success?

🔢 
## Request for comment

@akash1810 @harrysalmon

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
