### PR TITLE
Use https for old interactives without a body

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -348,7 +348,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
   }
 
   object interactive {
-    lazy val url = "http://interactive.guim.co.uk/next-gen/"
+    lazy val url = "https://interactive.guim.co.uk/next-gen/"
   }
 
   object javascript {


### PR DESCRIPTION
2 years ago @theefer [added some logic to use a prefixed host](https://github.com/guardian/frontend/pull/2935/files) for some interactives. I don't know which interactives go to this code path but the host should be updated. However before merging I need to check that this is not breaking them.

@gklopper @JustinPinner do you know any interactives (or way to find them) I could test with those changes?
