### PR TITLE
Extend commercial high server check further

### DIFF
--- a/admin/app/views/commercial/highMerchandisingTargetedTags.scala.html
+++ b/admin/app/views/commercial/highMerchandisingTargetedTags.scala.html
@@ -33,7 +33,7 @@
                         }</td>
                         @if(lineItem.editions.isEmpty){
                         <td>none</td>} else {
-                        <td>@{lineItem.editions.distinct}</td>}
+                        <td>@{lineItem.editions}</td>}
                     </tr>
                 }
             </tbody>

--- a/common/app/common/dfp/HighMerchandiseComponentAgent.scala
+++ b/common/app/common/dfp/HighMerchandiseComponentAgent.scala
@@ -7,8 +7,8 @@ trait HighMerchandiseComponentAgent {
 
   protected def targetedHighMerchandisingLineItems: Seq[HighMerchandisingLineItem]
 
-  def hasHighMerchAdAndTagandEdition(adUnitSuffix:String, tags: Seq[Tag],edition:String) = {
+  def isTargetedByHighMerch(adUnitSuffix:String, tags: Seq[Tag],edition:String) = {
     highMerchandisingComponentSwitch.isSwitchedOff ||
-    targetedHighMerchandisingLineItems.exists(_.matchesAdUnitAndTagAndEdition(adUnitSuffix, tags,edition))
+    targetedHighMerchandisingLineItems.exists(_.matchesPageTargeting(adUnitSuffix, tags, edition))
   }
 }

--- a/common/app/common/dfp/HighMerchandiseComponentAgent.scala
+++ b/common/app/common/dfp/HighMerchandiseComponentAgent.scala
@@ -1,5 +1,6 @@
 package common.dfp
 
+import common.Edition
 import model.Tag
 import conf.switches.Switches._
 

--- a/common/app/common/dfp/HighMerchandiseComponentAgent.scala
+++ b/common/app/common/dfp/HighMerchandiseComponentAgent.scala
@@ -8,8 +8,8 @@ trait HighMerchandiseComponentAgent {
 
   protected def targetedHighMerchandisingLineItems: Seq[HighMerchandisingLineItem]
 
-  def hasHighMerchAdAndTag(adUnitSuffix:String, tags: Seq[Tag]) = {
+  def hasHighMerchAdAndTag(adUnitSuffix:String, tags: Seq[Tag],edition:String) = {
     highMerchandisingComponentSwitch.isSwitchedOff ||
-    targetedHighMerchandisingLineItems.exists(_.matchesAdUnitAndTag(adUnitSuffix, tags))
+    targetedHighMerchandisingLineItems.exists(_.matchesAdUnitAndTag(adUnitSuffix, tags,edition))
   }
 }

--- a/common/app/common/dfp/HighMerchandiseComponentAgent.scala
+++ b/common/app/common/dfp/HighMerchandiseComponentAgent.scala
@@ -8,8 +8,8 @@ trait HighMerchandiseComponentAgent {
 
   protected def targetedHighMerchandisingLineItems: Seq[HighMerchandisingLineItem]
 
-  def hasHighMerchAdAndTag(adUnitSuffix:String, tags: Seq[Tag],edition:String) = {
+  def hasHighMerchAdAndTagandEdition(adUnitSuffix:String, tags: Seq[Tag],edition:String) = {
     highMerchandisingComponentSwitch.isSwitchedOff ||
-    targetedHighMerchandisingLineItems.exists(_.matchesAdUnitAndTag(adUnitSuffix, tags,edition))
+    targetedHighMerchandisingLineItems.exists(_.matchesAdUnitAndTagandEdition(adUnitSuffix, tags,edition))
   }
 }

--- a/common/app/common/dfp/HighMerchandiseComponentAgent.scala
+++ b/common/app/common/dfp/HighMerchandiseComponentAgent.scala
@@ -1,6 +1,5 @@
 package common.dfp
 
-import common.Edition
 import model.Tag
 import conf.switches.Switches._
 

--- a/common/app/common/dfp/HighMerchandiseComponentAgent.scala
+++ b/common/app/common/dfp/HighMerchandiseComponentAgent.scala
@@ -9,6 +9,6 @@ trait HighMerchandiseComponentAgent {
 
   def hasHighMerchAdAndTagandEdition(adUnitSuffix:String, tags: Seq[Tag],edition:String) = {
     highMerchandisingComponentSwitch.isSwitchedOff ||
-    targetedHighMerchandisingLineItems.exists(_.matchesAdUnitAndTagandEdition(adUnitSuffix, tags,edition))
+    targetedHighMerchandisingLineItems.exists(_.matchesAdUnitAndTagAndEdition(adUnitSuffix, tags,edition))
   }
 }

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -82,12 +82,14 @@ case class HighMerchandisingLineItem(
   customTargetSet: Seq[CustomTargetSet]
   ) {
   val customTargets = customTargetSet.map(_.targets)
-  val editions = customTargets.flatMap(sequence => sequence.filter((target) => target.name == "edition")).map(target => target.values)
+  val editions = customTargets.flatMap(sequence => sequence.filter((target) => target.name == "edition")).map(_.values)
 
 
-  def matchesAdUnitAndTag (adUnitSuffix: String, pageTags:Seq[Tag],edition:String): Boolean = {
+  def matchesAdUnitAndTagandEdition (adUnitSuffix: String, pageTags:Seq[Tag],edition:String): Boolean = {
 
-    println(edition)
+    val cleansedHighMerchEdition = editions.flatMap(_.distinct)
+
+    val cleansedPageEdition = edition.split(" ", 2)(0).toLowerCase
 
     val tagNames = pageTags map (_.name) map (_.replaceAll(" ","-").toLowerCase)
 
@@ -95,7 +97,9 @@ case class HighMerchandisingLineItem(
 
     lazy val matchesAdUnit: Boolean = adUnits.exists(_.path contains adUnitSuffix)
 
-    matchesTag && matchesAdUnit
+    lazy val matchesEdition: Boolean = cleansedHighMerchEdition.contains(cleansedPageEdition)
+
+    matchesTag && matchesAdUnit && matchesEdition
   }
 }
 

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -1,6 +1,6 @@
 package common.dfp
 
-import common.Logging
+import common.{Edition, Logging}
 import model.Tag
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
@@ -92,7 +92,7 @@ case class HighMerchandisingLineItem(
     val matchesTag: Boolean = tagNames.exists(tags.contains)
 
     lazy val matchesAdUnit: Boolean = adUnits.exists(_.path contains adUnitSuffix)
-
+    
     matchesTag && matchesAdUnit
   }
 }

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -85,7 +85,7 @@ case class HighMerchandisingLineItem(
   val editions = customTargets.flatMap(sequence => sequence.filter((target) => target.name == "edition")).map(_.values)
 
 
-  def matchesAdUnitAndTagandEdition (adUnitSuffix: String, pageTags:Seq[Tag],edition:String): Boolean = {
+  def matchesAdUnitAndTagAndEdition (adUnitSuffix: String, pageTags:Seq[Tag],edition:String): Boolean = {
 
     val cleansedHighMerchEdition = editions.flatMap(_.distinct)
 

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -85,14 +85,16 @@ case class HighMerchandisingLineItem(
   val editions = customTargets.flatMap(sequence => sequence.filter((target) => target.name == "edition")).map(target => target.values)
 
 
-  def matchesAdUnitAndTag (adUnitSuffix: String, pageTags:Seq[Tag]): Boolean = {
+  def matchesAdUnitAndTag (adUnitSuffix: String, pageTags:Seq[Tag],edition:String): Boolean = {
+
+    println(edition)
 
     val tagNames = pageTags map (_.name) map (_.replaceAll(" ","-").toLowerCase)
 
     val matchesTag: Boolean = tagNames.exists(tags.contains)
 
     lazy val matchesAdUnit: Boolean = adUnits.exists(_.path contains adUnitSuffix)
-    
+
     matchesTag && matchesAdUnit
   }
 }

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -97,7 +97,7 @@ case class HighMerchandisingLineItem(
 
     lazy val matchesAdUnit: Boolean = adUnits.exists(_.path contains adUnitSuffix)
 
-    lazy val matchesEdition: Boolean = cleansedHighMerchEdition.contains(cleansedPageEdition)
+    lazy val matchesEdition: Boolean = cleansedHighMerchEdition.isEmpty || cleansedHighMerchEdition.contains(cleansedPageEdition)
 
     matchesTag && matchesAdUnit && matchesEdition
   }

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -81,23 +81,22 @@ case class HighMerchandisingLineItem(
   adUnits: Seq[GuAdUnit],
   customTargetSet: Seq[CustomTargetSet]
   ) {
+
   val customTargets = customTargetSet.map(_.targets)
-  val editions = customTargets.flatMap(sequence => sequence.filter((target) => target.name == "edition")).map(_.values)
+  val editions = customTargets.flatMap(_.filter( _.name == "edition")).map(_.values).distinct
 
+  def matchesPageTargeting (adUnitSuffix: String, pageTags:Seq[Tag], edition:String): Boolean = {
 
-  def matchesAdUnitAndTagAndEdition (adUnitSuffix: String, pageTags:Seq[Tag],edition:String): Boolean = {
+    // edition comes in the form "UK edition" and "US edition"
+    val cleansedPageEdition = edition.split(" ", 2).head.toLowerCase
 
-    val cleansedHighMerchEdition = editions.flatMap(_.distinct)
+    val cleansedPageTagNames = pageTags map (_.name) map (_.replaceAll(" ","-").toLowerCase)
 
-    val cleansedPageEdition = edition.split(" ", 2)(0).toLowerCase
-
-    val tagNames = pageTags map (_.name) map (_.replaceAll(" ","-").toLowerCase)
-
-    val matchesTag: Boolean = tagNames.exists(tags.contains)
+    val matchesTag: Boolean = cleansedPageTagNames.exists(tags.contains)
 
     lazy val matchesAdUnit: Boolean = adUnits.exists(_.path contains adUnitSuffix)
 
-    lazy val matchesEdition: Boolean = cleansedHighMerchEdition.isEmpty || cleansedHighMerchEdition.contains(cleansedPageEdition)
+    lazy val matchesEdition: Boolean = editions.isEmpty || editions.flatten.contains(cleansedPageEdition)
 
     matchesTag && matchesAdUnit && matchesEdition
   }

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -103,24 +103,14 @@ final case class Commercial(
   def isSponsored(maybeEdition: Option[Edition]): Boolean =
     DfpAgent.isSponsored(tags.tags, Some(metadata.section), maybeEdition)
 
-  def needsHighMerchandisingSlot: Boolean = {
-    DfpAgent.hasHighMerchAdAndTag(metadata.adUnitSuffix,tags.tags)
+  def needsHighMerchandisingSlot(edition:String): Boolean = {
+    DfpAgent.hasHighMerchAdAndTag(metadata.adUnitSuffix,tags.tags,edition)
   }
 
-  def conditionalConfig: Map[String, JsValue] = {
-    val highMerchandisingMeta = if (needsHighMerchandisingSlot) {
-      Some("hasHighMerchandisingTarget", JsBoolean(needsHighMerchandisingSlot))
-    } else None
-
-    val meta: List[Option[(String, JsValue)]] = List(
-      highMerchandisingMeta
-    )
-    meta.flatten.toMap
-  }
 
   def javascriptConfig: Map[String, JsValue] = Map(
     ("isAdvertisementFeature", JsBoolean(isAdvertisementFeature))
-  ) ++ conditionalConfig
+  )
 
 }
 /**

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -104,7 +104,7 @@ final case class Commercial(
     DfpAgent.isSponsored(tags.tags, Some(metadata.section), maybeEdition)
 
   def needsHighMerchandisingSlot(edition:String): Boolean = {
-    DfpAgent.hasHighMerchAdAndTagandEdition(metadata.adUnitSuffix,tags.tags,edition)
+    DfpAgent.isTargetedByHighMerch(metadata.adUnitSuffix,tags.tags,edition)
   }
 
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -104,7 +104,7 @@ final case class Commercial(
     DfpAgent.isSponsored(tags.tags, Some(metadata.section), maybeEdition)
 
   def needsHighMerchandisingSlot(edition:String): Boolean = {
-    DfpAgent.hasHighMerchAdAndTag(metadata.adUnitSuffix,tags.tags,edition)
+    DfpAgent.hasHighMerchAdAndTagandEdition(metadata.adUnitSuffix,tags.tags,edition)
   }
 
 

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -21,7 +21,6 @@
         <div class="js-fronts-network-2" data-link-name="fronts-on-articles | network-front | block-2"></div>
     } {
         @if(content.commercial.needsHighMerchandisingSlot(Edition(request).displayName)) {
-            @Edition(request).displayName
             <div class="fc-container fc-container--commercial-high">@fragments.commercial.commercialComponentHigh()</div>
         }
     } {

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -1,5 +1,6 @@
 @(content: model.ContentType, related: model.RelatedContent, cssClass: String = "")(implicit request: RequestHeader)
 @import views.support.ContentFooterContainersLayout
+@import common.Edition
 
 <div class="content-footer @if(cssClass){content-footer--@cssClass}">
     @fragments.discussionFooter(content.content, content.trail.isCommentable, content.trail.isClosedForComments, content.content.shortUrlId)
@@ -20,6 +21,7 @@
         <div class="js-fronts-network-2" data-link-name="fronts-on-articles | network-front | block-2"></div>
     } {
         @if(content.commercial.needsHighMerchandisingSlot) {
+            @Edition(request).displayName
             <div class="fc-container fc-container--commercial-high">@fragments.commercial.commercialComponentHigh()</div>
         }
     } {

--- a/common/app/views/fragments/contentFooter.scala.html
+++ b/common/app/views/fragments/contentFooter.scala.html
@@ -20,7 +20,7 @@
     } {
         <div class="js-fronts-network-2" data-link-name="fronts-on-articles | network-front | block-2"></div>
     } {
-        @if(content.commercial.needsHighMerchandisingSlot) {
+        @if(content.commercial.needsHighMerchandisingSlot(Edition(request).displayName)) {
             @Edition(request).displayName
             <div class="fc-container fc-container--commercial-high">@fragments.commercial.commercialComponentHigh()</div>
         }


### PR DESCRIPTION
## What does this change?

Adds one more filter into server side check for commercial-High adSlot. Now filter by Edition as well as adUnit and tags.
## What is the value of this and can you measure success?

Should further decrease errors reported to Sentry regarding empty ad slots being served. 
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@kelvin-chappell @JonNorman @rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
