### PR TITLE
Welcome header A/B test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -100,7 +100,7 @@ trait ABTestSwitches {
     "ab-welcome-header",
     "Welcome header for first time users test",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 1),
+    sellByDate = new LocalDate(2016, 6, 30),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -100,7 +100,7 @@ trait ABTestSwitches {
     "ab-welcome-header",
     "Welcome header for first time users test",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 19),
+    sellByDate = new LocalDate(2016, 6, 1),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -40,20 +40,9 @@ define([
         this.variants = [{
             id: 'control',
             test: function () {
-
-            }
-        }, {
-            id: 'liberal-newspaper',
-            test: function () {
-                welcomeHeader.showWelcomeMessage(this.id);
             }
         }, {
             id: 'award-winning',
-            test: function () {
-                welcomeHeader.showWelcomeMessage(this.id);
-            }
-        }, {
-            id: 'since-1821',
             test: function () {
                 welcomeHeader.showWelcomeMessage(this.id);
             }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -16,11 +16,11 @@ define([
             cookieVal = cookies.get(COOKIE_WELCOME_BANNER);
 
         this.id = 'WelcomeHeader';
-        this.start = '2016-05-12';
-        this.expiry = '2016-06-01';
+        this.start = '2016-05-18';
+        this.expiry = '2016-06-08';
         this.author = 'Maria Livia Chiorean';
         this.description = 'Show a welcome header for first time users.';
-        this.audience = 0;
+        this.audience = 1;
         this.audienceOffset = 0;
         this.audienceCriteria = 'First time users';
         this.idealOutcome = 'People come back more after the first visit.';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -17,7 +17,7 @@ define([
 
         this.id = 'WelcomeHeader';
         this.start = '2016-05-18';
-        this.expiry = '2016-05-23';
+        this.expiry = '2016-05-24';
         this.author = 'Maria Livia Chiorean';
         this.description = 'Show a welcome header for first time users.';
         this.audience = 1;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -45,19 +45,16 @@ define([
         }, {
             id: 'liberal-newspaper',
             test: function () {
-                console.log("liberal-newspaper");
                 welcomeHeader.showWelcomeMessage(this.id);
             }
         }, {
             id: 'award-winning',
             test: function () {
-                console.log("award-winning");
                 welcomeHeader.showWelcomeMessage(this.id);
             }
         }, {
             id: 'since-1821',
             test: function () {
-                console.log("since-1821");
                 welcomeHeader.showWelcomeMessage(this.id);
             }
         }];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -17,7 +17,7 @@ define([
 
         this.id = 'WelcomeHeader';
         this.start = '2016-05-12';
-        this.expiry = '2016-05-18';
+        this.expiry = '2016-06-01';
         this.author = 'Maria Livia Chiorean';
         this.description = 'Show a welcome header for first time users.';
         this.audience = 0;
@@ -34,7 +34,9 @@ define([
                     cookies.add(COOKIE_WELCOME_BANNER, 1);
                 }
             }
-            return detect.isBreakpoint({max: 'mobile'}) && firstTimeVisitor;
+            return detect.isBreakpoint({max: 'mobile'}) && firstTimeVisitor &&
+                !detect.isIOS() && detect.getUserAgent.browser !== 'Safari' &&
+                config.page.edition !== 'UK';
         };
 
         this.variants = [{

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -17,7 +17,7 @@ define([
 
         this.id = 'WelcomeHeader';
         this.start = '2016-05-18';
-        this.expiry = '2016-06-08';
+        this.expiry = '2016-05-23';
         this.author = 'Maria Livia Chiorean';
         this.description = 'Show a welcome header for first time users.';
         this.audience = 1;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -20,7 +20,7 @@ define([
         this.expiry = '2016-06-08';
         this.author = 'Maria Livia Chiorean';
         this.description = 'Show a welcome header for first time users.';
-        this.audience = 0;
+        this.audience = 1;
         this.audienceOffset = 0;
         this.audienceCriteria = 'First time users';
         this.idealOutcome = 'People come back more after the first visit.';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -20,7 +20,7 @@ define([
         this.expiry = '2016-05-18';
         this.author = 'Maria Livia Chiorean';
         this.description = 'Show a welcome header for first time users.';
-        this.audience = 1;
+        this.audience = 0;
         this.audienceOffset = 0;
         this.audienceCriteria = 'First time users';
         this.idealOutcome = 'People come back more after the first visit.';
@@ -38,14 +38,27 @@ define([
         };
 
         this.variants = [{
-            id: 'test1',
+            id: 'control',
             test: function () {
 
             }
         }, {
-            id: 'test2',
+            id: 'liberal-newspaper',
             test: function () {
-
+                console.log("liberal-newspaper");
+                welcomeHeader.showWelcomeMessage(this.id);
+            }
+        }, {
+            id: 'award-winning',
+            test: function () {
+                console.log("award-winning");
+                welcomeHeader.showWelcomeMessage(this.id);
+            }
+        }, {
+            id: 'since-1821',
+            test: function () {
+                console.log("since-1821");
+                welcomeHeader.showWelcomeMessage(this.id);
             }
         }];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/welcome-header.js
@@ -34,9 +34,9 @@ define([
                     cookies.add(COOKIE_WELCOME_BANNER, 1);
                 }
             }
-            return detect.isBreakpoint({max: 'mobile'}) && firstTimeVisitor &&
+            return detect.isBreakpoint({max: 'mobile'}) && !config.page.isFront && firstTimeVisitor &&
                 !detect.isIOS() && detect.getUserAgent.browser !== 'Safari' &&
-                config.page.edition !== 'UK';
+                config.page.edition === 'US';
         };
 
         this.variants = [{

--- a/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
@@ -35,28 +35,28 @@ define([
     }
 
     function createAndSetHeader(messageName) {
-        var headerDiv = document.createElement('button'),
+        var header = document.createElement('button'),
             msg = template(message1, data[messageName]),
             closeBtn = '<div class="banner-close-icon"><button class="js-welcome-message__item__close button button--tertiary u-faux-block-link__promote" aria-label="Dismiss" data-link-name="close button">' + svgs('closeCentralIcon') + '</button></div>';
 
-        headerDiv.id = 'welcome-banner';
-        headerDiv.style.height = header.offsetHeight + 'px';
-        headerDiv.innerHTML = closeBtn + msg;
-        headerDiv.className += 'u-faux-block-link__promote';
+        header.id = 'welcome-banner';
+        header.style.height = header.offsetHeight + 'px';
+        header.innerHTML = closeBtn + msg;
+        header.className += 'u-faux-block-link__promote';
 
-        headerDiv.setAttribute('data-link-name', 'welcome-banner');
+        header.setAttribute('data-link-name', 'welcome-banner');
 
-        bean.on($(headerDiv)[0], 'click', function () {
+        bean.on($(header)[0], 'click', function () {
             fastdom.write(function () {
-                headerDiv.style.display = 'none';
+                header.style.display = 'none';
             });
         });
 
         header.getElementsByClassName('l-header-main')[0].style.zIndex = 1200;
-        header.appendChild(headerDiv);
+        header.appendChild(header);
 
         setTimeout(function(){
-            headerDiv.style.opacity = 1;
+            header.style.opacity = 1;
         }, 0);
     }
 

--- a/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
@@ -40,11 +40,12 @@ define([
 
         var closeBtn = '<div class="banner-close-icon"><button class="js-welcome-message__item__close button button--tertiary u-faux-block-link__promote" aria-label="Dismiss" data-link-name="close button">' + svgs('closeCentralIcon') + '</button></div>';
 
-        headerDiv.setAttribute('id', 'welcome-banner');
-        headerDiv.setAttribute('data-link-name', 'welcome-banner');
-        headerDiv.setAttribute('style', 'height:' + header.offsetHeight + 'px;');
+        headerDiv.id = 'welcome-banner';
+        headerDiv.style.height = header.offsetHeight + 'px';
         headerDiv.innerHTML = closeBtn + msg;
         headerDiv.className += 'u-faux-block-link__promote';
+
+        headerDiv.setAttribute('data-link-name', 'welcome-banner');
 
         bean.on($(headerDiv)[0], 'click', function () {
             fastdom.write(function () {

--- a/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
@@ -20,10 +20,11 @@ define([
      * 1st visit replace nav bar with banner
      */
     var header = document.getElementById('header'),
-        message1 = '<div class="banner-message"><%=HTML%></div>',
+        message1 = '<div class="banner-message"><span class="line-1"><%=first%></span><span class="line-2"><%=second%></span></div>',
         data = {
             'award-winning': {
-                HTML: '<span class="line-1">award-winning news,</span><span class="line-2">sport and culture</span>'
+                'first': 'award-winning news,',
+                'second': 'sport and culture'
             }
         };
 
@@ -47,7 +48,7 @@ define([
 
         bean.on($(headerDiv)[0], 'click', function () {
             fastdom.write(function () {
-                headerDiv.style.opacity = 0;
+                headerDiv.style.display = 'none';
             });
         });
 

--- a/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
@@ -22,14 +22,8 @@ define([
     var header = document.getElementById('header'),
         message1 = '<div class="banner-message"><%=HTML%></div>',
         data = {
-            'liberal-newspaper': {
-                HTML: '<span class="pull-left">the world\'s leading</span><span class="pull-right">liberal newspaper</span>'
-            },
             'award-winning': {
-                HTML: '<span class="pull-left">award-winning</span><span class="pull-right">news, sport and culture</span>'
-            },
-            'since-1821': {
-                HTML: '<span class="pull-left">quality news</span><span class="pull-right">since 1821</span>'
+                HTML: '<span class="line-1">award-winning news,</span><span class="line-2">sport and culture</span>'
             }
         };
 

--- a/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
@@ -1,15 +1,19 @@
 define([
+    'bean',
     'fastdom',
     'common/utils/$',
     'common/utils/storage',
     'common/utils/template',
-    'common/utils/load-css-promise'
+    'common/utils/load-css-promise',
+    'common/views/svgs'
 ], function (
+    bean,
     fastdom,
     $,
     storage,
     template,
-    loadCssPromise
+    loadCssPromise,
+    svgs
 ) {
     /**
      * Rules:
@@ -18,28 +22,47 @@ define([
     var header = document.getElementById('header'),
         message1 = '<div class="banner-message"><%=HTML%></div>',
         data = {
-            message1: {
-                HTML: '<span class="pull-left">news website</span><span class="pull-right">of the year</span>'
+            'liberal-newspaper': {
+                HTML: '<span class="pull-left">the world\'s leading</span><span class="pull-right">liberal newspaper</span>'
+            },
+            'award-winning': {
+                HTML: '<span class="pull-left">award-winning</span><span class="pull-right">news, sport and culture</span>'
+            },
+            'since-1821': {
+                HTML: '<span class="pull-left">quality news</span><span class="pull-right">since 1821</span>'
             }
         };
 
-    function showWelcomeMessage(messageNumber) {
+    function showWelcomeMessage(messageName) {
         loadCssPromise.then(function () {
-            createAndSetHeader(messageNumber);
+            createAndSetHeader(messageName);
         });
     }
 
-    function createAndSetHeader(messageNumber) {
-        var headerDiv = document.createElement('div'),
-            msg = template(message1, data[messageNumber]);
+    function createAndSetHeader(messageName) {
+        var headerDiv = document.createElement('button'),
+            msg = template(message1, data[messageName]);
+
+        var closeBtn = '<div class="banner-close-icon"><button class="js-welcome-message__item__close button button--tertiary u-faux-block-link__promote" aria-label="Dismiss" data-link-name="close button">' + svgs('closeCentralIcon') + '</button></div>';
 
         headerDiv.setAttribute('id', 'welcome-banner');
+        headerDiv.setAttribute('data-link-name', 'welcome-banner');
         headerDiv.setAttribute('style', 'height:' + header.offsetHeight + 'px;');
-        headerDiv.innerHTML = msg;
+        headerDiv.innerHTML = closeBtn + msg;
+        headerDiv.className += 'u-faux-block-link__promote';
+
+        bean.on($(headerDiv)[0], 'click', function () {
+            fastdom.write(function () {
+                headerDiv.style.opacity = 0;
+            });
+        });
 
         header.getElementsByClassName('l-header-main')[0].style.zIndex = 1200;
-
         header.appendChild(headerDiv);
+
+        setTimeout(function(){
+            headerDiv.style.opacity = 1;
+        }, 0);
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
+++ b/static/src/javascripts/projects/common/modules/ui/welcome-banner.js
@@ -35,28 +35,28 @@ define([
     }
 
     function createAndSetHeader(messageName) {
-        var header = document.createElement('button'),
+        var newHeader = document.createElement('button'),
             msg = template(message1, data[messageName]),
             closeBtn = '<div class="banner-close-icon"><button class="js-welcome-message__item__close button button--tertiary u-faux-block-link__promote" aria-label="Dismiss" data-link-name="close button">' + svgs('closeCentralIcon') + '</button></div>';
 
-        header.id = 'welcome-banner';
-        header.style.height = header.offsetHeight + 'px';
-        header.innerHTML = closeBtn + msg;
-        header.className += 'u-faux-block-link__promote';
+        newHeader.id = 'welcome-banner';
+        newHeader.style.height = header.offsetHeight + 'px';
+        newHeader.innerHTML = closeBtn + msg;
+        newHeader.className += 'u-faux-block-link__promote';
 
-        header.setAttribute('data-link-name', 'welcome-banner');
+        newHeader.setAttribute('data-link-name', 'welcome-banner');
 
-        bean.on($(header)[0], 'click', function () {
+        bean.on($(newHeader)[0], 'click', function () {
             fastdom.write(function () {
-                header.style.display = 'none';
+                newHeader.style.display = 'none';
             });
         });
 
         header.getElementsByClassName('l-header-main')[0].style.zIndex = 1200;
-        header.appendChild(header);
+        header.appendChild(newHeader);
 
         setTimeout(function(){
-            header.style.opacity = 1;
+            newHeader.style.opacity = 1;
         }, 0);
     }
 

--- a/static/src/stylesheets/module/_test-welcome-header.scss
+++ b/static/src/stylesheets/module/_test-welcome-header.scss
@@ -8,7 +8,7 @@
     top: 0;
     z-index: 1100;
     width: 100%;
-    font-family: "Guardian Egyptian Web", "Guardian Text Egyptian Web" ,Georgia ,serif;
+    font-family: 'Guardian Egyptian Web', 'Guardian Text Egyptian Web', Georgia, serif;
     font-size: 1.75rem;
     line-height: 1.6rem;
     font-weight: 200;

--- a/static/src/stylesheets/module/_test-welcome-header.scss
+++ b/static/src/stylesheets/module/_test-welcome-header.scss
@@ -2,13 +2,13 @@
    ========================================================================== */
 
 #welcome-banner {
-    color: #AADCE6;
+    color: #aadce6;
     background: $guardian-brand;
     position: absolute;
     top: 0;
     z-index: 1100;
     width: 100%;
-    font-family: "Guardian Egyptian Web","Guardian Text Egyptian Web",Georgia,serif;
+    font-family: "Guardian Egyptian Web", "Guardian Text Egyptian Web" ,Georgia ,serif;
     font-size: 1.75rem;
     line-height: 1.6rem;
     font-weight: 200;

--- a/static/src/stylesheets/module/_test-welcome-header.scss
+++ b/static/src/stylesheets/module/_test-welcome-header.scss
@@ -11,24 +11,31 @@
     font-size: 1.7rem;
     line-height: 1.65rem;
     font-family: 'Guardian Egyptian Web', 'Guardian Text Egyptian Web', Georgia, serif;
-    font-weight: 800;
+    font-weight: 200;
+    letter-spacing: -1px;
+    opacity: 0;
+    transition: opacity 0.5s linear;
+    cursor: pointer;
+    border: 0;
+    margin: 0;
+    padding: 0;
 }
 
 #welcome-banner .banner-message {
-    @include mq($until: tablet) {
-        margin: $gs-gutter/4 $gs-gutter/2;
-    }
-    @include mq(tablet, desktop) {
-        margin: $gs-gutter/4 $gs-gutter;
-    }
+    margin: $gs-gutter/4 $gs-gutter/2;
     position: absolute;
     left: 0;
     right: 0;
     bottom: 0;
 }
 
+#welcome-banner .banner-close-icon {
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
 #welcome-banner span {
-    width: 100%;
     display: block;
 }
 
@@ -38,4 +45,15 @@
 
 #welcome-banner .pull-right {
     text-align: right;
+}
+
+#welcome-banner .button--tertiary {
+    padding: 0 !important;
+    border: 0;
+}
+
+@include mq($from: tablet) {
+    #welcome-banner {
+        display: none;
+    }
 }

--- a/static/src/stylesheets/module/_test-welcome-header.scss
+++ b/static/src/stylesheets/module/_test-welcome-header.scss
@@ -2,58 +2,100 @@
    ========================================================================== */
 
 #welcome-banner {
-    color: rgb(170, 220, 230);
-    background: #005689;
+    color: #AADCE6;
+    background: $guardian-brand;
     position: absolute;
     top: 0;
     z-index: 1100;
     width: 100%;
-    font-size: 1.7rem;
-    line-height: 1.65rem;
-    font-family: 'Guardian Egyptian Web', 'Guardian Text Egyptian Web', Georgia, serif;
+    font-family: "Guardian Egyptian Web","Guardian Text Egyptian Web",Georgia,serif;
+    font-size: 1.75rem;
+    line-height: 1.6rem;
     font-weight: 200;
-    letter-spacing: -1px;
     opacity: 0;
-    transition: opacity .5s linear;
+    transition: opacity .5s ease-in-out;
     cursor: pointer;
     border: 0;
     margin: 0;
     padding: 0;
-}
 
-#welcome-banner .banner-message {
-    margin: $gs-gutter/4 $gs-gutter/2;
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-}
-
-#welcome-banner .banner-close-icon {
-    position: absolute;
-    left: 0;
-    top: 0;
-}
-
-#welcome-banner span {
-    display: block;
-}
-
-#welcome-banner .pull-left {
-    text-align: left;
-}
-
-#welcome-banner .pull-right {
-    text-align: right;
-}
-
-#welcome-banner .button--tertiary {
-    padding: 0 !important;
-    border: 0;
-}
-
-@include mq($from: tablet) {
-    #welcome-banner {
+    @include mq($from: tablet) {
         display: none;
+    }
+
+    .banner-message {
+        position: absolute;
+        text-align: right;
+        bottom: $gs-baseline/1.7;
+        left: $gs-gutter;
+        right: $gs-gutter;
+
+        @include mq($until: mobileLandscape) {
+            left: $gs-gutter/2;
+            right: $gs-gutter/2;
+        }
+    }
+
+    .banner-close-icon {
+        position: absolute;
+        left: $gs-gutter;
+        top: $gs-baseline/3;
+
+        @include mq($until: mobileLandscape) {
+            left: $gs-gutter/2;
+        }
+
+        .button--tertiary {
+            padding: 0 !important;
+            height: 2rem;
+            width: 2rem;
+            border: 0;
+            background: $guardian-brand-dark;
+
+            .inline-icon {
+                margin-top: 1px;
+            }
+        }
+    }
+
+    span {
+        display: block;
+    }
+
+    .line-1 {
+        margin-right: $gs-gutter*2;
+
+        //Slide left animation
+        animation-name: slideleft;
+        animation-duration: 2s;
+        animation-timing-function: ease-out;
+
+        @keyframes slideleft {
+            from {margin-right: 0;}
+            to {margin-right: $gs-gutter*2;}
+        }
+
+        @include mq($until: 350px) {
+            margin-right: $gs-gutter*1.2;
+
+            @keyframes slideleft {
+                from {margin-right: 0;}
+                to {margin-right: $gs-gutter*1.2;}
+            }
+        }
+    }
+
+    .line-2 {
+        margin-right: 0;
+
+        //Slide right animation
+        animation-name: slideright;
+        animation-duration: 2s;
+        animation-timing-function: ease-out;
+    }
+
+    @keyframes slideright {
+        from {margin-right: $gs-gutter*2;}
+        to {margin-right: 0;}
     }
 }

--- a/static/src/stylesheets/module/_test-welcome-header.scss
+++ b/static/src/stylesheets/module/_test-welcome-header.scss
@@ -14,7 +14,7 @@
     font-weight: 200;
     letter-spacing: -1px;
     opacity: 0;
-    transition: opacity 0.5s linear;
+    transition: opacity .5s linear;
     cursor: pointer;
     border: 0;
     margin: 0;

--- a/static/src/stylesheets/module/_test-welcome-header.scss
+++ b/static/src/stylesheets/module/_test-welcome-header.scss
@@ -18,6 +18,7 @@
     border: 0;
     margin: 0;
     padding: 0;
+    outline: none;
 
     @include mq($from: tablet) {
         display: none;


### PR DESCRIPTION
## What does this change?

Adds the actual A/B test for the welcome header and a lot of styling.
The document with all the details can be found [here](https://docs.google.com/a/guardian.co.uk/document/d/1xNUdzFZAqfagkx9TBjMOfasjuFcMfSXA62LfsmB-8AQ/edit?usp=sharing).
To determine the audience we have been running a pretest for a day: https://github.com/guardian/frontend/pull/12859.
## What is the value of this and can you measure success?

We will analyse the returning rate of first time users who have been served the banner while their first visit.
## Screenshots

![welcome banner](https://cloud.githubusercontent.com/assets/5732563/15390407/8d7f1a02-1db3-11e6-9706-96348f740841.jpg)
## Request for comment

@stephanfowler @zeftilldeath 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission )?*
-->
