### PR TITLE
Update faciaVersion to 1.6.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val seleniumVersion = "2.44.0"
   val slf4jVersion = "1.7.5"
   val awsVersion = "1.10.58"
-  val faciaVersion = "1.6.1"
+  val faciaVersion = "1.6.2"
 
   val akkaAgent = "com.typesafe.akka" %% "akka-agent" % "2.3.4"
   val akkaContrib = "com.typesafe.akka" %% "akka-contrib" % "2.3.5"


### PR DESCRIPTION
This updates `faciaJson` and `fapiClient` to `1.6.2`.

This fixes an issue of new types getting added to `faciaJson`/`fapiClient` breaking older clients.

See https://github.com/guardian/facia-scala-client/pull/166 for more information.

@piuccio @kelvin-chappell 
