### PR TITLE
Add check for clashing ab tests to email sign-up

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -11,6 +11,7 @@ define([
     'lodash/collections/contains',
     'common/modules/user-prefs',
     'common/modules/identity/api',
+    'common/modules/experiments/ab',
     'Promise'
 ], function (
     $,
@@ -25,18 +26,29 @@ define([
     contains,
     userPrefs,
     Id,
+    ab,
     Promise
 ) {
-    var emailInserted = false,
-        emailShown,
-        userListSubsChecked = false,
-        userListSubs = [];
+    var emailInserted = false;
+    var emailShown;
+    var userListSubsChecked = false;
+    var userListSubs = [];
 
     function pageHasBlanketBlacklist() {
         // Prevent the blanket emails from ever showing on certain keywords or sections
         return page.keywordExists(['US elections 2016', 'Football']) ||
             config.page.section === 'film' ||
             config.page.seriesId === 'world/series/guardian-morning-briefing';
+    }
+
+    function userIsInAClashingAbTest() {
+        var clashingTests = [
+            ['ParticipationStarRatings','star-rating']
+        ];
+
+        return some(clashingTests, function(test) {
+            return ab.isInVariant(test[0], test[1]);
+        });
     }
 
     function userHasRemoved(id, formType) {
@@ -145,6 +157,7 @@ define([
             !emailInserted &&
             !config.page.isFront &&
             config.switches.emailInArticle &&
+            !userIsInAClashingAbTest() &&
             storage.session.isAvailable() &&
             !userHasSeenThisSession() &&
             !(browser === 'MSIE' && contains(['7','8','9'], version + ''));


### PR DESCRIPTION
## What does this change?

Adds a check to the email sign-up to ensure that we're not in a test (initially star ratings) that will clash with the insertion of the form.
## Request for comment

@regiskuckaertz @sndrs Hi - I wondered if you two had a thought on this - seems a little kludgy and specific to add a check to the email sign-up module to check if we're in a particular ab tests.

The high-level problem here is having components, that are async lazy loaded taking priority over other components that are async lazy loaded - if we don't know when either component is going to be loaded the component that is the lower priority needs to know whether another component is ever going to load (probably with definitely, maybe, never values) - this may be via an ab test participation or it may be a proximity load or it may be based on a user's logged in status. I've done this with outbrain and email sign-up by exposing the the [email sign-ups](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/email/run-checks.js) `run-checks` so they can be [checked ahead of time by the Outbrain module](https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/commercial/third-party-tags/outbrain.js#L141).

Would creating some kind of generic `canRun` function with different levels of priority be sensible? Am I over thinking this completely? 

Anyway, this technique works here but something to think about.
