### PR TITLE
Labs v media

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -4,7 +4,7 @@
 @import views.support.TrailCssClasses.toneClass
 @import views.support.{ImgSrc, RenderClasses}
 
-<div class="l-side-margins l-side-margins--media">
+<div class="l-side-margins @if(!page.gallery.commercial.isAdvertisementFeature){l-side-margins--media}">
 
     <article id="article" class="@RenderClasses(
             Map("content--advertisement-feature" -> page.gallery.commercial.isAdvertisementFeature,

--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -6,7 +6,7 @@
 @import views.support.{RenderClasses, SeoOptimisedContentImage, StripHtmlTags, Video640}
 
 @defining(page.media, page.media match { case _: Audio => "audio" case _ => "video" }){ case (media, mediaType) =>
-<div class="l-side-margins l-side-margins--media">
+<div class="l-side-margins @if(!page.media.commercial.isAdvertisementFeature){l-side-margins--media}">
 
     <article id="article" class="@RenderClasses(
             Map(

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -454,35 +454,38 @@
         }
     }
 }
-.ad-slot--paid-for-badge--gallery {
-    border-top: 1px dotted $media-mute;
-    border-bottom: 0;
-    padding-top: $gs-baseline / 3;
 
-    @include mq(desktop) {
-        width: gs-span(3);
-        position: absolute;
-    }
+.content--media:not(.paid-content--advertisement-feature) {
+    .ad-slot--paid-for-badge--gallery {
+        border-top: 1px dotted $media-mute;
+        border-bottom: 0;
+        padding-top: $gs-baseline / 3;
 
-    .content__main-column > & {
         @include mq(desktop) {
-            top: 100%;
+            width: gs-span(3);
+            position: absolute;
         }
 
-        @include mq(leftCol) {
-            left: -160px;
+        .content__main-column > & {
+            @include mq(desktop) {
+                top: 100%;
+            }
+
+            @include mq(leftCol) {
+                left: -160px;
+            }
+
+            @include mq(wide) {
+                left: -240px;
+            }
         }
 
-        @include mq(wide) {
-            left: -240px;
+        .ad-slot--paid-for-badge__header {
+            font-weight: normal;
         }
-    }
-
-
-    .ad-slot--paid-for-badge__header {
-        font-weight: normal;
     }
 }
+
 .ad-slot--paid-for-badge--interactive {
     width: 140px;
     min-height: 135px;

--- a/static/src/stylesheets/module/commercial/_capi.scss
+++ b/static/src/stylesheets/module/commercial/_capi.scss
@@ -213,7 +213,7 @@
     &.tonal--tone-media .tonal__standfirst {
         .bullet:before,
         ul>li:before {
-            background-color: $media-mute;
+            background-color: $neutral-2;
         }
     }
 

--- a/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
+++ b/static/src/stylesheets/module/commercial/paidfor/_paidfor-content.scss
@@ -143,6 +143,10 @@
         svg {
             height: 24px;
             width: 75px;
+
+            path {
+                fill: $neutral-1;
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/content/_block-level-sharing.scss
+++ b/static/src/stylesheets/module/content/_block-level-sharing.scss
@@ -237,37 +237,39 @@
 
 // Gallery
 
-.block-share--gallery {
-    position: static;
+.content--media:not(.paid-content--advertisement-feature) {
+    .block-share--gallery {
+        position: static;
 
-    .block-share__item {
-        position: relative;
-        background-color: transparent;
-        border: 1px solid $neutral-2;
-        box-sizing: border-box;
-        transition: border-color .15s ease-out;
-        width: 32px;
-        height: 32px;
-
-        &:hover {
+        .block-share__item {
+            position: relative;
             background-color: transparent;
-            border-color: $neutral-6;
-        }
+            border: 1px solid $neutral-2;
+            box-sizing: border-box;
+            transition: border-color .15s ease-out;
+            width: 32px;
+            height: 32px;
 
-        .inline-icon {
-            fill: $neutral-3;
+            &:hover {
+                background-color: transparent;
+                border-color: $neutral-6;
+            }
 
-            // Directly referencing the sizes in _social.scss
-            svg {
-                height: 88%;
-                width: 88%;
-                vertical-align: middle;
-                position: absolute;
-                top: 0;
-                bottom: 0;
-                right: 0;
-                left: 0;
-                margin: auto;
+            .inline-icon {
+                fill: $neutral-3;
+
+                // Directly referencing the sizes in _social.scss
+                svg {
+                    height: 88%;
+                    width: 88%;
+                    vertical-align: middle;
+                    position: absolute;
+                    top: 0;
+                    bottom: 0;
+                    right: 0;
+                    left: 0;
+                    margin: auto;
+                }
             }
         }
     }

--- a/static/src/stylesheets/module/content/_content.scss
+++ b/static/src/stylesheets/module/content/_content.scss
@@ -669,6 +669,8 @@
 }
 
 .paid-content--advertisement-feature {
+    color: $neutral-1;
+
     &.content--article,
     &.content--interactive,
     &.tonal--tone-media {
@@ -747,14 +749,14 @@
             color: $neutral-1;
 
             .inline-icon {
-                fill: $neutral-1;
+                fill: $neutral-2;
             }
         }
 
         .most-viewed-container--media,
         .meta__number {
             .inline-icon {
-                fill: $neutral-1;
+                fill: $neutral-2;
             }
         }
 
@@ -771,12 +773,26 @@
         .byline,
         .meta__numbers .sharecount__heading,
         .meta__numbers .commentcount2__heading,
-        .tonal__main--tone-media .sharecount__value,
-        .tonal__main--tone-media .commentcount2__value,
         .content__dateline,
         .submeta__head,
         .content__series-label__link {
             color: $neutral-2-contrasted;
+        }
+
+        .tonal__main--tone-media .sharecount__value,
+        .tonal__main--tone-media .commentcount2__value {
+            color: $neutral-1;
+        }
+
+        .byline,
+        .content__dateline,
+        .submeta hr,
+        .commentcount,
+        .meta__numbers,
+        .meta__social,
+        .meta__save-for-later,
+        .meta__number:not(u-h) + .meta__number {
+            border-color: $neutral-3;
         }
 
         .byline {
@@ -785,6 +801,17 @@
                 &:hover {
                     color: $neutral-1;
                 }
+            }
+        }
+
+        .button--tone-media {
+            color: $neutral-1;
+            background-color: $neutral-6;
+            border-color: $neutral-6;
+
+            &:hover {
+                background-color: $neutral-3;
+                border-color: $neutral-3;
             }
         }
 
@@ -852,15 +879,15 @@
         .save-for-later__button--save,
         .save-for-later__button--saved {
             .inline-icon {
-                fill: #ffffff;
-                border-color: #ffffff;
-                background-color: $neutral-2-contrasted;
+                fill: $neutral-2-contrasted;
+                border-color: $neutral-2-contrasted;
+                background-color: $paid-article;
             }
             &:hover {
                 .inline-icon {
-                    background-color: #ffffff;
-                    fill: $neutral-2-contrasted;
+                    fill: $paid-article;
                     border-color: $neutral-2-contrasted;
+                    background-color: $neutral-2-contrasted;
                 }
             }
         }

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -23,21 +23,23 @@
         margin-bottom: 0;
     }
 
-    .social-icon {
-        overflow: visible; // opacity cuts borders off on chrome otherwise
-        background-color: transparent;
-        fill: $neutral-3;
-        border: 1px solid $neutral-2;
-        box-sizing: border-box;
-        transition: border-color .15s ease-out;
-
-        &:hover {
+     &:not(.paid-content--advertisement-feature) {
+        .social-icon {
+            overflow: visible; // opacity cuts borders off on chrome otherwise
             background-color: transparent;
-            border-color: $neutral-6;
-        }
-
-        .inline-icon {
             fill: $neutral-3;
+            border: 1px solid $neutral-2;
+            box-sizing: border-box;
+            transition: border-color .15s ease-out;
+
+            &:hover {
+                background-color: transparent;
+                border-color: $neutral-6;
+            }
+
+            .inline-icon {
+                fill: $neutral-3;
+            }
         }
     }
 

--- a/static/src/stylesheets/module/content/_media.global.scss
+++ b/static/src/stylesheets/module/content/_media.global.scss
@@ -23,7 +23,7 @@
         margin-bottom: 0;
     }
 
-     &:not(.paid-content--advertisement-feature) {
+    &:not(.paid-content--advertisement-feature) {
         .social-icon {
             overflow: visible; // opacity cuts borders off on chrome otherwise
             background-color: transparent;


### PR DESCRIPTION
Labs pages that also contain the media tone have some pretty weird styling. Some of this was due to new galleries and some elements were inheriting whatever tone the page was underneath. 

I have removed new gallery sharing tones and margins from labs pages. Also standardised some elements like save for later. These are a few changes and many more _could_ have been made if I had the time. 

Before:
![screen shot 2016-05-19 at 16 08 53](https://cloud.githubusercontent.com/assets/14570016/15398743/d46b9ab6-1ddc-11e6-9340-ccd4e6323dd3.png)

After:
![screen shot 2016-05-19 at 16 15 59](https://cloud.githubusercontent.com/assets/14570016/15398807/0b0961de-1ddd-11e6-97a7-f313218b6bb1.png)
