### PR TITLE
Fix results page title for football team results

### DIFF
--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -37,7 +37,7 @@ object ResultsController extends MatchListController with CompetitionResultFilte
   private def page(tag: Option[String] = None): Option[FootballPage] = {
     def allPage = new FootballPage("football/results", "football", "All results", "GFE:Football:automatic:results")
     def competitionPage = (competition: Competition) => new FootballPage(s"${competition.url}/results", "football", s"${competition.fullName} results", "GFE:Football:automatic:competition results")
-    def teamPage = (team: FootballTeam) => new FootballPage(s"/football/$tag/results", "football", s"${tag} results", "GFE:Football:automatic:team results")
+    def teamPage = (team: FootballTeam) => new FootballPage(s"/football/${tag.getOrElse("")}/results", "football", s"${team.name} results", "GFE:Football:automatic:team results")
     byType[FootballPage](allPage)(competitionPage)(teamPage)(tag)
   }
 


### PR DESCRIPTION
## What does this change?

Fix the results page title for football team results
## What is the value of this and can you measure success?

Currently the page title (displayed in the browser tab) displays `Some(leicestercity) results | Football ...`
This patch change the page title to `Leicester results | Football ...`

Ex: https://www.theguardian.com/football/leicestercity/results
## Does this affect other platforms - Amp, Apps, etc..

No
## Request for comment

@JustinPinner 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
