### PR TITLE
Fabric slice adverts should support 300x250 MPUs

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/create-ad-slot.js
@@ -99,11 +99,6 @@ define([
                 desktop: '1,1|88,70|728,90|940,230|900,250|970,250' + fabricMappingSwitch
             }
         },
-        'fabric': {
-            sizeMappings: {
-                mobile: fabricTopSlot
-            }
-        },
         'inline1-fabric': {
             sizeMappings: {
                 mobile: ('1,1|300,250|' + fabricTopSlot)

--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -35,7 +35,9 @@ define([
         var prefs               = userPrefs.get('container-states') || {};
         var isMobile            = detect.getBreakpoint() === 'mobile';
         var isNetworkFront      = ['uk', 'us', 'au'].indexOf(config.page.pageId) !== -1;
-        var hasFabricMobileAd   = (config.page.isFront && config.switches.fabricAdverts && detect.isBreakpoint({max : 'phablet'}));
+        // Mobile doesn't have a top slot, so we substitute a slot that accepts both ordinary MPUs and the 'fabric' ads
+        // that take the top slot in responsive takeovers.
+        var replaceTopSlot      = (config.page.isFront && config.switches.fabricAdverts && detect.isBreakpoint({max : 'phablet'}));
         // We must keep a small bit of state in the filtering logic
         var lastIndex           = -1;
 
@@ -54,8 +56,9 @@ define([
                     return true;
                 }
 
-                if (hasFabricMobileAd && index === 0) {
+                if (replaceTopSlot && index === 0) {
                     // it's mobile, so we needn't check for an adSlice
+                    lastIndex = index;
                     return true;
                 }
 
@@ -76,8 +79,8 @@ define([
             // create ad slots for the selected slices
             .map(function (item, index) {
                 var adName = 'inline' + (index + 1);
-                var adSlot = hasFabricMobileAd && index === 0 ?
-                    createAdSlot('fabric', 'container-inline') :
+                var adSlot = replaceTopSlot && index === 0 ?
+                    createAdSlot('inline1-fabric', 'container-inline') :
                     createAdSlot(adName, 'container-inline');
 
                 adSlot.className += ' ' + (isMobile ? 'ad-slot--mobile' : 'container-inline');

--- a/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
@@ -187,19 +187,22 @@ define([
             });
         });
 
-        describe('Fabric ads', function () {
+        describe('Top slot replacement', function () {
             beforeEach(function () {
                 config.switches.fabricAdverts = true;
+                // Remove the first container's candidate, so we're sure any slots are inserted by our replacement logic,
+                // not at the behest of the markup.
+                bonzo(qwery('.fc-container-first .js-fc-slice-mpu-candidate', $fixtureContainer)).remove();
             });
 
-            it('can be added on mobile', function (done) {
+            it('is added on mobile', function (done) {
                 detect.isBreakpoint = function () {
                     // expecting check for breakpoint <= phablet
                     return true;
                 };
                 sliceAdverts.init();
                 fastdom.defer(function () {
-                    expect(qwery('.fc-container-first .ad-slot--fabric', $fixtureContainer).length).toBe(1);
+                    expect(qwery('.fc-container-first .ad-slot--inline1', $fixtureContainer).length).toBe(1);
                     done();
                 });
             });
@@ -211,7 +214,7 @@ define([
                 };
                 sliceAdverts.init();
                 fastdom.defer(function () {
-                    expect(qwery('.fc-container-first .ad-slot--fabric', $fixtureContainer).length).toBe(0);
+                    expect(qwery('.fc-container-first .ad-slot--inline1', $fixtureContainer).length).toBe(0);
                     done();
                 });
             });

--- a/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/slice-adverts.spec.js
@@ -190,9 +190,9 @@ define([
         describe('Top slot replacement', function () {
             beforeEach(function () {
                 config.switches.fabricAdverts = true;
-                // Remove the first container's candidate, so we're sure any slots are inserted by our replacement logic,
-                // not at the behest of the markup.
-                bonzo(qwery('.fc-container-first .js-fc-slice-mpu-candidate', $fixtureContainer)).remove();
+                // To be sure that any slots added are top slot replacements, we set the page to a network front,
+                // where adverts will normally never appear on the first container.
+                config.page.pageId = 'uk';
             });
 
             it('is added on mobile', function (done) {
@@ -200,9 +200,13 @@ define([
                     // expecting check for breakpoint <= phablet
                     return true;
                 };
+                detect.getBreakpoint = function () {
+                    return 'mobile';
+                };
+
                 sliceAdverts.init();
                 fastdom.defer(function () {
-                    expect(qwery('.fc-container-first .ad-slot--inline1', $fixtureContainer).length).toBe(1);
+                    expect(qwery('.fc-container-first + .ad-slot--inline1', $fixtureContainer).length).toBe(1);
                     done();
                 });
             });
@@ -211,6 +215,9 @@ define([
                 detect.isBreakpoint = function () {
                     // expecting check for breakpoint <= phablet
                     return false;
+                };
+                detect.getBreakpoint = function () {
+                    return 'desktop';
                 };
                 sliceAdverts.init();
                 fastdom.defer(function () {


### PR DESCRIPTION
This is becoming a bit of a saga, now.

We want the Fabric slots we insert into fronts (on the first container) to support 300x250 MPUs. I've patched `slice-adverts` to use the `inline1-fabric` ad type, which handles both these sizes. It also uses the 'inline1' name, which means the slot should integrate with any existing passback behaviour.

The real solution to this problem, however, is to change `dfp-api` so that sizes specified for mobile breakpoints are not automatically reused in larger configurations. If that happens, we can remove the 'inline1-fabric' adtype entirely, and just specify 88x71 as a mobile size for `inline1`. This is something I'm doing in another branch.
