### PR TITLE
OpenGraph: pass video file info into the og:video parameters

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -514,21 +514,27 @@ object Video {
     val elements = content.elements
     val section = content.metadata.section
     val id = content.metadata.id
-    val source: Option[String] = elements.videos.find(_.properties.isMain).flatMap(_.videos.source)
+    val mainVideo: Option[VideoElement] = elements.videos.find(_.properties.isMain)
+    val source: Option[String] = mainVideo.flatMap(_.videos.source)
 
     val javascriptConfig: Map[String, JsValue] = Map(
       "isPodcast" -> JsBoolean(content.tags.isPodcast),
       "source" -> JsString(source.getOrElse("")),
-      "embeddable" -> JsBoolean(elements.videos.find(_.properties.isMain).map(_.videos.embeddable).getOrElse(false)),
-      "videoDuration" -> elements.videos.find(_.properties.isMain).map{ v => JsNumber(v.videos.duration)}.getOrElse(JsNull))
+      "embeddable" -> JsBoolean(mainVideo.map(_.videos.embeddable).getOrElse(false)),
+      "videoDuration" -> mainVideo.map{ v => JsNumber(v.videos.duration)}.getOrElse(JsNull))
 
-    val optionalOpengraphProperties = if(content.metadata.webUrl.startsWith("https://")) Map("og:video:secure_url" -> content.metadata.webUrl) else Nil
-    val opengraphProperties = Map(
-      "og:type" -> "video",
-      "og:video:type" -> "text/html",
-      "og:video" -> content.metadata.webUrl,
-      "video:tag" -> content.tags.keywords.map(_.name).mkString(",")
-    ) ++ optionalOpengraphProperties
+    val opengraphProperties = mainVideo.flatMap { _.videos.largestVideo }.map { videoAsset =>
+      val videoAssetUrl = videoAsset.url.getOrElse("")
+      val optionalOpengraphProperties = if(content.metadata.webUrl.startsWith("https://")) Map("og:video:secure_url" -> videoAssetUrl) else Nil
+      Map(
+        "og:type" -> "video",
+        "og:video" -> videoAssetUrl,
+        "og:video:type" -> videoAsset.mimeType.getOrElse(""),
+        "og:video:width" -> videoAsset.width.toString,
+        "og:video:height" -> videoAsset.height.toString,
+        "video:tag" -> content.tags.keywords.map(_.name).mkString(",")
+      ) ++ optionalOpengraphProperties
+    }.getOrElse(Map.empty)
 
     val metadata = content.metadata.copy(
       contentType = contentType,


### PR DESCRIPTION
## What does this change?

Video shared on FB don't play currently. 
See https://www.facebook.com/annemarie.conlon.75?pnref=story  and try to play the video

So far we were passing the page url into og:video
This patch passes the video asset/file url in the og:video as well as adding og:video:width,
og:video:height and og:video:type as recommended in opengraph documentation https://developers.facebook.com/docs/sharing/webmasters#markup
## What is the value of this and can you measure success?

Video shared on FB are actually playable
## Does this affect other platforms - Amp, Apps, etc?

No, it only affects video shared on FB
## Request for comment

@JustinPinner @katebee 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
