### PR TITLE
Enchilada ads for hosted content updates

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/gustyle/gustyle.js
+++ b/static/src/javascripts/projects/common/modules/commercial/gustyle/gustyle.js
@@ -39,12 +39,10 @@ define([
             var classList = 'gu-style' + ((this.isContentPage) ? ' gu-style--unboxed' : '');
 
             this.$slot.addClass(classList);
-            // Temporary taking this off as we need to some big updates but it needs some proper thinking time and these ads needs to run today. Haha I know what you think.
-            // But seriously we will do it. Eventually. Maybe. We will.
-            // this.$slot.prepend($.create(template(labelTpl, { data: merge(templateOptions) })));
+            this.$slot.prepend($.create(template(labelTpl, { data: merge(templateOptions) })));
 
-            // toggles = new Toggles(this.$slot[0]);
-            // toggles.init();
+            toggles = new Toggles(this.$slot[0]);
+            toggles.init();
         }, this);
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/gustyle/gustyle.js
+++ b/static/src/javascripts/projects/common/modules/commercial/gustyle/gustyle.js
@@ -39,10 +39,12 @@ define([
             var classList = 'gu-style' + ((this.isContentPage) ? ' gu-style--unboxed' : '');
 
             this.$slot.addClass(classList);
-            this.$slot.prepend($.create(template(labelTpl, { data: merge(templateOptions) })));
+            // Temporary taking this off as we need to some big updates but it needs some proper thinking time and these ads needs to run today. Haha I know what you think.
+            // But seriously we will do it. Eventually. Maybe. We will.
+            // this.$slot.prepend($.create(template(labelTpl, { data: merge(templateOptions) })));
 
-            toggles = new Toggles(this.$slot[0]);
-            toggles.init();
+            // toggles = new Toggles(this.$slot[0]);
+            // toggles.init();
         }, this);
     };
 

--- a/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-hosted.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-hosted.html
@@ -8,7 +8,7 @@
                 <h2 class="gu-display__content-title gu-display__content-title--hosted"><%=data.articleHeaderText%></h2>
             </a>
             <a href="<%=data.brandLink%>" class="gu-mutable <%=data.brandLogoPosition%> hostedbadge" style="background-color: <%=data.brandColor%>" data-link-name="logo" target="_blank">
-                <p class="hostedbadge__info">Advertiser Content</p>
+                <p class="hostedbadge__info">Advertiser content</p>
                 <img class="hostedbadge__logo" src="<%=data.brandLogo%>">
             </a>
         </div>
@@ -24,7 +24,7 @@
             </a>
         </div>
         <a href="<%=data.brandLink%>" class="gu-mutable <%=data.brandLogoPosition%> hostedbadge" style="background-color: <%=data.brandColor%>" data-link-name="logo" target="_blank">
-            <p class="hostedbadge__info">Advertiser Content</p>
+            <p class="hostedbadge__info">Advertiser content</p>
             <img class="hostedbadge__logo" src="<%=data.brandLogo%>">
         </a>
     </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-hosted.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-hosted.html
@@ -15,7 +15,7 @@
     </div>
 <% } else { %>
     <div class="gu-display" data-link-name="creative | gu style commercial display content">
-        <div class="gu-display__image-layer inlined-image">
+        <div class="gu-display__image-layer inlined-image gu-display__image-fadeout">
             <img class="gu-display__image" src="<%=data.articleImage%>">
         </div>
         <div class="gu-mutable gu-display__content gu-display__content--hosted">

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -518,7 +518,7 @@ $hosted-stripe: 28px;
         bottom: 0;
         position: absolute;
         background-image: linear-gradient(to bottom, rgba(238, 238, 238, 0), rgba(0, 0, 0, .4));
-        border-top: 2px solid transparent;
+        border-top: 1px solid transparent;
     }
 
     .play-button {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -549,7 +549,7 @@ $hosted-stripe: 28px;
         right: 0;
         bottom: 0;
         position: absolute;
-        background-image: linear-gradient(to bottom, rgba(238, 238, 238, 0), rgba(0, 0, 0, .4));
+        background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, .4));
         border-top: 1px solid transparent;
     }
 

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -37,6 +37,10 @@
 
 .gu-display__link {
     color: #ffffff;
+
+    &:hover {
+        text-decoration: none;
+    }
 }
 
 .content--immersive-article .from-content-api .gu-display__content-title,

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comcontent.scss
@@ -18,6 +18,19 @@
     display: block;
 }
 
+.gu-display__image-fadeout {
+    &:after {
+        content: '';
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+        z-index: 0;
+        background: linear-gradient(transparent 80px, rgba(0, 0, 0, .5));
+    }
+}
+
 .gu-mutable {
     display: block;
     position: absolute;
@@ -201,7 +214,7 @@ $mobile-max-container-width: gs-span(8);
 .gu-display--hostedbottom {
     .gu-display__logo-pos--bottom-right {
         top: auto;
-        bottom: 49px;
+        bottom: 50px;
     }
 
     .gu-display__content {

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comlabel.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comlabel.scss
@@ -1,4 +1,6 @@
 .gu-comlabel {
+    // Temporary hidding this. We need to update texts etc but it needs to be live today.
+    display: none;
     color: $neutral-1;
 
     .gu-comlabel__btn {


### PR DESCRIPTION
Again. Fixing some stylings. The bigger change is that we are hiding label for now. There needs to be some updates but that is low priority for now so the quick hack is to just hide it. quick hacks ftw. what can go wrong.

<img width="305" alt="screen shot 2016-05-20 at 12 32 17" src="https://cloud.githubusercontent.com/assets/2579465/15426487/e9ab03e4-1e86-11e6-97b2-efb69345c5ad.png">

@regiskuckaertz @lps88 
