### PR TITLE
Changing video og tags to 'og:type = article'

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -524,10 +524,13 @@ object Video {
 
     val optionalOpengraphProperties = if(content.metadata.webUrl.startsWith("https://")) Map("og:video:secure_url" -> content.metadata.webUrl) else Nil
     val opengraphProperties = Map(
-      "og:type" -> "video",
-      "og:video:type" -> "text/html",
-      "og:video" -> content.metadata.webUrl,
-      "video:tag" -> content.tags.keywords.map(_.name).mkString(",")
+      // Not using the og:video properties here because we want end-users to visit the guardian website
+      // when they click the thumbnail in the FB feed rather than playing the video "in-place"
+      "og:type" -> "article",
+      "article:published_time" -> content.trail.webPublicationDate.toString,
+      "article:modified_time" -> content.fields.lastModified.toString,
+      "article:section" -> content.trail.sectionName,
+      "article:tag" -> content.tags.keywords.map(_.name).mkString(",")
     ) ++ optionalOpengraphProperties
 
     val metadata = content.metadata.copy(


### PR DESCRIPTION
## What does this change?

James Murray confirmed that video shared on FB used to behave like any other articles. ie: clicking on the thumbnail would open a guardian.com video page.

Possible assumption: Something might have changed on FB side and even though we were specifying it was a video (`og:type =  video`) they were still loading the html we passed in the (`og:video`) property. Maybe they are now more strict about that. ie: it is declared as a video (`og:type = video`) so they try to play the file supposedly passed in the `og:video` property. Since it is a html doc and not a mp4/swf file it fails.

With this patch, I am trying to recreate the previous behaviour by declaring video page to be normal article. 

I don't think we want to play the video directly on Facebook without evaluating the impact it could have on our traffic.
## What is the value of this and can you measure success?

No more blank page when clicking on a shared video on FB
## Does this affect other platforms - Amp, Apps, etc?

Good question. I am not sure. Does Twitter uses the og tags? This might have more impact than I am aware off. Let me know what do you think
## Request for comment

@JustinPinner @johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
