### PR TITLE
Remove fixed top above slot (for now)

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -230,15 +230,6 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
-  val FixedTopAboveNavAdSlotSwitch = Switch(
-    SwitchGroup.Commercial,
-    "fixed-top-above-nav",
-    "Fixes size of top-above-nav ad slot on fronts.",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 5, 20),
-    exposeClientSide = false
-  )
-
   val KruxVideoTracking = Switch(
     SwitchGroup.Commercial,
     "krux-video-tracking",

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -50,17 +50,19 @@ object Commercial {
         "js-top-banner-above-nav")
 
       val sizeSpecificClass = {
-        if (FixedTopAboveNavAdSlotSwitch.isSwitchedOn && isBusinessFront(metaData)) {
-          if (hasAdOfSize(TopAboveNavSlot, leaderboardSize, metaData, edition, sizesOverride)) {
-            "top-banner-ad-container--small"
-          } else if (hasAdOfSize(TopAboveNavSlot, responsiveSize, metaData, edition, sizesOverride)) {
-            "top-banner-ad-container--responsive"
-          } else {
-            "top-banner-ad-container--large"
-          }
-        } else {
+        // Keeping this code for now since we'll be running another similar
+        // experiment in the near future:
+        // if (FixedTopAboveNavAdSlotSwitch.isSwitchedOn && isBusinessFront(metaData)) {
+        //   if (hasAdOfSize(TopAboveNavSlot, leaderboardSize, metaData, edition, sizesOverride)) {
+        //     "top-banner-ad-container--small"
+        //   } else if (hasAdOfSize(TopAboveNavSlot, responsiveSize, metaData, edition, sizesOverride)) {
+        //     "top-banner-ad-container--responsive"
+        //   } else {
+        //     "top-banner-ad-container--large"
+        //   }
+        // } else {
           "top-banner-ad-container--reveal"
-        }
+        // }
       }
 
       (classes :+ sizeSpecificClass) mkString " "

--- a/common/test/views/support/CommercialTest.scala
+++ b/common/test/views/support/CommercialTest.scala
@@ -22,10 +22,6 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
     topAboveNavSlot.adSizes(metaData, defaultEdition).get("desktop").value shouldBe sizes
   }
 
-  override protected def beforeEach(): Unit = {
-    FixedTopAboveNavAdSlotSwitch.switchOn()
-  }
-
   "topAboveNavSlot ad sizes" should "be variable for all pages" in {
     pageShouldRequestAdSizes("uk/culture")(
       Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250")
@@ -36,18 +32,20 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
       )
   }
 
-  "topAboveNavSlot css classes" should
-    "be large for 900x250 or 970x250 ad on UK business front" in {
-    topAboveNavSlot.cssClasses(metaDataFromId("uk/business"), defaultEdition, Seq(AdSize(900, 250))) should endWith("top-banner-ad-container--large")
-  }
-
-  they should "be small for 728x90 ad on AU business front" in {
-    topAboveNavSlot.cssClasses(metaDataFromId("au/business"), defaultEdition, Seq(leaderboardSize)) should endWith("top-banner-ad-container--small")
-  }
-
-  they should "be responsive for 88x70 ad on US business front" in {
-    topAboveNavSlot.cssClasses(metaDataFromId("us/business"), defaultEdition, Seq(responsiveSize)) should endWith("top-banner-ad-container--responsive")
-  }
+  // Keeping this code for now since we'll be running another similar
+  // experiment in the near future:
+  // "topAboveNavSlot css classes" should
+  //   "be large for 900x250 or 970x250 ad on UK business front" in {
+  //   topAboveNavSlot.cssClasses(metaDataFromId("uk/business"), defaultEdition, Seq(AdSize(900, 250))) should endWith("top-banner-ad-container--large")
+  // }
+  //
+  // they should "be small for 728x90 ad on AU business front" in {
+  //   topAboveNavSlot.cssClasses(metaDataFromId("au/business"), defaultEdition, Seq(leaderboardSize)) should endWith("top-banner-ad-container--small")
+  // }
+  //
+  // they should "be responsive for 88x70 ad on US business front" in {
+  //   topAboveNavSlot.cssClasses(metaDataFromId("us/business"), defaultEdition, Seq(responsiveSize)) should endWith("top-banner-ad-container--responsive")
+  // }
 
   they should "be default for any other page" in {
     topAboveNavSlot.cssClasses(metaDataFromId("uk/culture"), defaultEdition, Nil) should

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -115,12 +115,14 @@
         z-index: $zindex-popover;
     }
 }
-.top-banner-ad-container--small {
-    min-height: ($gs-row-height * 3) + 18;
-}
-.top-banner-ad-container--responsive {
-    min-height: ($gs-row-height * 7) + 16;
-}
+// Keeping this code for now since we'll be running another similar
+// experiment in the near future:
+// .top-banner-ad-container--small {
+//     min-height: ($gs-row-height * 3) + 18;
+// }
+// .top-banner-ad-container--responsive {
+//     min-height: ($gs-row-height * 7) + 16;
+// }
 .top-banner-ad-container--above-nav {
     @include mq(tablet) {
         .js-on & {
@@ -180,9 +182,9 @@
             text-align: left;
         }
     }
-    .top-banner-ad-container--large & {
-        min-height: 250px;
-    }
+    // .top-banner-ad-container--large & {
+    //     min-height: 250px;
+    // }
     .has-page-skin & {
         @include mq(wide) {
             width: auto !important;


### PR DESCRIPTION
There is an ongoing discussion around getting rid of any 728x90 ad in the top slot and the expanding animation, but nothing concrete yet. Removing this feature for now but keeping the logic for later re-use though.

cc @jbreckmckye @JonNorman 
