### PR TITLE
Hosted campaign tracking and metadata

### DIFF
--- a/common/app/common/commercial/HostedPage.scala
+++ b/common/app/common/commercial/HostedPage.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.JsString
 case object HostedPage extends StandalonePage {
 
   override val metadata: MetaData = {
-    val title = "Designing the car of the future - video"
+    val title = "Advertiser content hosted by the Guardian: Designing the car of the future - video"
     val description =
       "Who better to dream up the transport of tomorrow than the people who'll be buying them? Follow a group of students as they work on designing the interior of self-driving cars"
     val toneId = "tone/hosted-content"

--- a/common/app/common/commercial/HostedPage.scala
+++ b/common/app/common/commercial/HostedPage.scala
@@ -32,8 +32,9 @@ case object HostedPage extends StandalonePage {
       opengraphPropertiesOverrides = Map(
         "og:url" ->
           "http://theguardian.com/commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser",
-        "og:title" -> title,
-        "og:description" -> description,
+        "og:title" -> "Designing the car of the future - video",
+        "og:description" ->
+          "ADVERTISER CONTENT FROM RENAULT HOSTED BY THE GUARDIAN | Who better to dream up the transport of tomorrow than the people who'll be buying them? Follow a group of students as they work on designing the interior of self-driving cars",
         "og:image" ->
           "https://aws-frontend-static.s3.amazonaws.com/PROD/frontend-static/images/commercial/038c373fd249e5a2f4b6ae02e7cf3a93/renault-video-poster.jpg",
         "fb:app_id" -> "180444840287"

--- a/common/app/views/support/commercial/TrackingCodeBuilder.scala
+++ b/common/app/views/support/commercial/TrackingCodeBuilder.scala
@@ -28,7 +28,7 @@ object TrackingCodeBuilder extends implicits.Requests {
   def paidCard(articleTitle: String)(implicit request: RequestHeader): String = {
     def param(name: String) = request.getParameter(name) getOrElse "unknown"
     val section = param("s")
-    val sponsor = param("sponsor")
+    val sponsor = param("brand")
     s"GLabs-native-traffic-card | ${Edition(request).id} | $section | $articleTitle | $sponsor"
   }
 }

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/gu-style-comcontent.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/gu-style-comcontent.js
@@ -3,6 +3,7 @@ define([
     'common/utils/$',
     'common/utils/detect',
     'common/utils/mediator',
+    'common/utils/config',
     'common/utils/template',
     'common/views/svgs',
     'common/modules/commercial/gustyle/gustyle',
@@ -15,6 +16,7 @@ define([
     $,
     detect,
     mediator,
+    config,
     template,
     svgs,
     GuStyle,
@@ -41,6 +43,15 @@ define([
                 isHostedBottom: this.params.adType === 'gu-style-hosted-bottom'
             };
         var templateToLoad = this.params.adType === 'gu-style' ? gustyleComcontentTpl : gustyleHostedTpl;
+
+        var title = this.params.articleHeaderText || 'unknown';
+        var sponsor = 'Renault';
+        this.params.linkTracking = 'Labs hosted native traffic card' +
+            ' | ' + config.page.edition +
+            ' | ' + config.page.section +
+            ' | ' + title +
+            ' | ' + sponsor;
+
         var markup = template(templateToLoad, { data: merge(this.params, templateOptions) });
         var gustyle = new GuStyle(this.$adSlot, this.params);
 

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/hosted-thrasher.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/hosted-thrasher.js
@@ -26,7 +26,7 @@ define([
         fastdom.write(function () {
             var title = this.params.header2 || 'unknown';
             var sponsor = 'Renault';
-            this.params.linkTracking = 'GLabs-hosted-container' +
+            this.params.linkTracking = 'Labs hosted container' +
                 ' | ' + config.page.edition +
                 ' | ' + config.page.section +
                 ' | ' + title +

--- a/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-comcontent.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-comcontent.html
@@ -1,19 +1,19 @@
-<div class="gu-display" data-link-name="creative | gu style commercial display content">
+<div class="gu-display">
     <div class="gu-display__image-layer inlined-image">
         <img class="gu-display__image" src="<%=data.articleImage%>">
     </div>
     <div class="gu-mutable gu-display__content <%=data.articleContentPosition%>">
-        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link <%=data.articleContentColor%>" data-link-name="header text" target="_blank">
+        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link <%=data.articleContentColor%>" data-link-name="<%=data.linkTracking%>" target="_blank">
             <h2 class="gu-display__content-title <%=data.articleContentColor%> <%=data.articleHeaderFontSize%>"><%=data.articleHeaderText%></h2>
         </a>
-        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link <%=data.articleContentColor%>" data-link-name="text" target="_blank">
+        <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link <%=data.articleContentColor%>" data-link-name="<%=data.linkTracking%>" target="_blank">
             <p class="gu-display__content-text <%=data.articleContentColor%> <%=data.articleTextFontSize%>"><%=data.articleText%></p>
         </a>
     </div>
-    <a href="<%=data.clickMacro%><%=data.callToActionLink%>" class="gu-mutable gu-display__cta gu-display__link button button--tertiary button--medium" data-link-name="call to action" target="_blank">
+    <a href="<%=data.clickMacro%><%=data.callToActionLink%>" class="gu-mutable gu-display__cta gu-display__link button button--tertiary button--medium" data-link-name="<%=data.linkTracking%>" target="_blank">
         <%=data.callToAction%><%=data.externalLinkIcon%>
     </a>
-    <a href="<%=data.brandLink%>" class="gu-mutable gu-display__logo-link <%=data.brandLogoPosition%>" data-link-name="logo" target="_blank">
+    <a href="<%=data.brandLink%>" class="gu-mutable gu-display__logo-link <%=data.brandLogoPosition%>" data-link-name="<%=data.linkTracking%>" target="_blank">
         <img class="gu-display__logo" src="<%=data.brandLogo%>">
     </a>
 </div>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-hosted.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/gu-style-hosted.html
@@ -1,29 +1,29 @@
 <% if (data.isHostedBottom) { %>
-    <div class="gu-display gu-display--hostedbottom" data-link-name="creative | gu style commercial display content">
+    <div class="gu-display gu-display--hostedbottom">
         <div class="gu-display__image-layer inlined-image">
             <img class="gu-display__image" src="<%=data.articleImage%>">
         </div>
         <div class="gu-display__content gu-display__content--hosted">
-            <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link" data-link-name="header text" target="_blank">
+            <a href="<%=data.clickMacro%><%=data.articleUrl%>" class="gu-display__link" data-link-name="<%=data.linkTracking%>" target="_blank">
                 <h2 class="gu-display__content-title gu-display__content-title--hosted"><%=data.articleHeaderText%></h2>
             </a>
-            <a href="<%=data.brandLink%>" class="gu-mutable <%=data.brandLogoPosition%> hostedbadge" style="background-color: <%=data.brandColor%>" data-link-name="logo" target="_blank">
+            <a href="<%=data.brandLink%>" class="gu-mutable <%=data.brandLogoPosition%> hostedbadge" style="background-color: <%=data.brandColor%>" data-link-name="<%=data.linkTracking%>" target="_blank">
                 <p class="hostedbadge__info">Advertiser Content</p>
                 <img class="hostedbadge__logo" src="<%=data.brandLogo%>">
             </a>
         </div>
     </div>
 <% } else { %>
-    <div class="gu-display" data-link-name="creative | gu style commercial display content">
+    <div class="gu-display" data-link-name="<%=data.linkTracking%>">
         <div class="gu-display__image-layer inlined-image">
             <img class="gu-display__image" src="<%=data.articleImage%>">
         </div>
         <div class="gu-mutable gu-display__content gu-display__content--hosted">
-            <a href="<%=data.clickMacro%><%=data.articleUrl%>" style="color: <%=data.brandColor%>" class="gu-display__link" data-link-name="header text" target="_blank">
+            <a href="<%=data.clickMacro%><%=data.articleUrl%>" style="color: <%=data.brandColor%>" class="gu-display__link" data-link-name="<%=data.linkTracking%>" target="_blank">
                 <h2 class="gu-display__content-title gu-display__content-title--hosted" style="color: <%=data.brandColor%>"><%=data.articleHeaderText%></h2>
             </a>
         </div>
-        <a href="<%=data.brandLink%>" class="gu-mutable <%=data.brandLogoPosition%> hostedbadge" style="background-color: <%=data.brandColor%>" data-link-name="logo" target="_blank">
+        <a href="<%=data.brandLink%>" class="gu-mutable <%=data.brandLogoPosition%> hostedbadge" style="background-color: <%=data.brandColor%>" data-link-name="<%=data.linkTracking%>" target="_blank">
             <p class="hostedbadge__info">Advertiser Content</p>
             <img class="hostedbadge__logo" src="<%=data.brandLogo%>">
         </a>


### PR DESCRIPTION
This has two effects:  
1. Change name of page to:
`Advertiser content hosted by the Guardian: Designing the car of the future - video | Renault-car-of-the-future | The Guardian`
2. Add tracking to traffic drivers.  Populate v37:
![image](https://cloud.githubusercontent.com/assets/1722550/15430637/1a670ebc-1e9e-11e6-89a0-2ae4f4bcb132.png)
