### PR TITLE
add test for playing videos on fronts

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -118,7 +118,7 @@ trait ABTestSwitches {
     "ab-play-video-on-fronts",
     "Don't play video on fronts, but auto play when in article",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 1),
+    sellByDate = new LocalDate(2016, 5, 31),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -146,7 +146,9 @@ define([
                         placeholder.removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
                         player.removeClass('media__container--hidden').addClass('media__container--active');
                         $el.removeClass('media__placeholder--active').addClass('media__placeholder--hidden');
-                        enhanceVideo($('video', player).get(0), true);
+                        var enhancedPlayer = enhanceVideo($('video', player).get(0), true);
+
+                        mediator.emit('ab:PlayVideoOnFronts:front-player-created', enhancedPlayer);
                     });
                 });
                 fastdom.write(function () {
@@ -166,7 +168,8 @@ define([
 
         fastdom.read(function () {
             $('.js-gu-media--enhance').each(function (el) {
-                enhanceVideo(el, false, withPreroll);
+                var enhancedPlayer = enhanceVideo(el, false, withPreroll);
+                mediator.emit('ab:PlayVideoOnFronts:in-article-video-created', enhancedPlayer);
             });
         });
 
@@ -351,6 +354,8 @@ define([
                 });
             }
         });
+
+        return player;
     }
 
     function initEndSlate(player, endSlatePath) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/play-video-on-fronts.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/play-video-on-fronts.js
@@ -14,12 +14,12 @@ define([
 
     return function () {
         this.id = 'PlayVideoOnFronts';
-        this.start = '2016-05-18';
-        this.expiry = '2016-05-25';
+        this.start = '2016-05-24';
+        this.expiry = '2016-05-31';
         this.author = 'James Gorrie';
         this.description = 'Test if autoplaying on fronts is bad.';
-        this.audience = 1;
-        this.audienceOffset = 0;
+        this.audience = 0.5;
+        this.audienceOffset = 0.39;
         this.successMeasure = '';
         this.audienceCriteria = 'Fronts that have cards with articles that have video as their main media';
         this.dataLinkNames = '';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/play-video-on-fronts.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/play-video-on-fronts.js
@@ -1,10 +1,17 @@
 define([
+    'bean',
     'common/utils/$',
-    'common/utils/config'
+    'common/utils/config',
+    'common/utils/mediator'
 ], function (
+    bean,
     $,
-    config
+    config,
+    mediator
 ) {
+    var autoplayHash = '#autoplay-main-media';
+    var hasAutoplayHash = window.location.hash.match(autoplayHash);
+
     return function () {
         this.id = 'PlayVideoOnFronts';
         this.start = '2016-05-18';
@@ -20,17 +27,58 @@ define([
 
         this.canRun = function () {
             // Only videos that are links to video pages have data-embed-paths
-            return config.page.isFront && $('.fc-item--has-video-main-media .js-video-play-button').length > 0;
+            // Or article pages that have been linked to from test-enhanced cards
+            return (config.page.isFront && $('.fc-item--has-video-main-media .js-video-play-button').length > 0) ||
+                (config.page.contentType === 'Article' && hasAutoplayHash);
         };
 
         this.variants = [
             {
-                id: 'baseline1',
-                test: function () {}
+                id: 'control',
+                test: function () {},
+                success: function(complete) {
+                    mediator.on('ab:PlayVideoOnFronts:front-player-created', function(player) {
+                        player.on('video:content:25', function() {
+                            complete();
+                        });
+                    });
+                }
             },
             {
-                id: 'baseline2',
-                test: function () {}
+                id: 'variant1',
+                test: function () {},
+                success: function(complete) {
+                    // On article page
+                    if (hasAutoplayHash) {
+                        var first = true;
+                        mediator.on('ab:PlayVideoOnFronts:in-article-video-created', function(player) {
+                            if (first) {
+                                first = false;
+                                player.play();
+                                player.on('video:content:25', function() {
+                                    complete();
+                                });
+                            }
+                        });
+                    }
+
+                    // This is for the front page
+                    $('.fc-item--has-video-main-media').each(function(el) {
+                        var link = $('.u-faux-block-link__overlay', el);
+                        var playButton = $('.js-video-play-button', el);
+
+                        if (playButton.length > 0) {
+                            link.attr('href', link.attr('href') + autoplayHash);
+
+                            bean.on(playButton[0], 'click', function(ev) {
+                                ev.preventDefault();
+                                ev.stopPropagation();
+                                link[0].click();
+                                return false;
+                            });
+                        }
+                    });
+                }
             }
         ];
     };


### PR DESCRIPTION
## What does this change?

Adding the test to play videos in article rather than on the front when an article has video main media.

There's a few changes to our main codebase, but just events being emitted to keep the code in the test.

What we are testing is: If we send you to the article and play the video there, are you more likely to get to 25%?
## What is the value of this and can you measure success?

Success is construct.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

Not-so-good:
![plomp](https://cloud.githubusercontent.com/assets/31692/15432607/dfb6bb7e-1ea6-11e6-8335-6866c8d4016a.gif)
## Request for comment

@akash1810 @harrysalmon @dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
