### PR TITLE
Get correct id from shortUrl regardless of the scheme

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -76,9 +76,9 @@ final case class Content(
   lazy val isFromTheObserver: Boolean = publication == "The Observer"
   lazy val primaryKeyWordTag: Option[Tag] = tags.tags.find(!_.isSectionTag)
   lazy val keywordTags: Seq[Tag] = tags.keywords.filter(tag => !tag.isSectionTag)
-  lazy val shortUrlId = fields.shortUrl.replace("http://gu.com", "")
+  lazy val shortUrlId = fields.shortUrlId
   lazy val shortUrlPath = shortUrlId
-  lazy val discussionId = Some(shortUrlPath)
+  lazy val discussionId = Some(shortUrlId)
   lazy val isImmersive = fields.displayHint.contains("immersive") || metadata.contentType.toLowerCase == "gallery"
   lazy val showNewGalleryDesign = galleryRedesign.isSwitchedOn && metadata.contentType.toLowerCase == "gallery" && !trail.commercial.isAdvertisementFeature
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -159,7 +159,14 @@ final case class Fields(
   sensitive: Option[Boolean],
   legallySensitive: Option[Boolean]
 ){
-  def javascriptConfig: Map[String, JsValue] = Map(("shortUrl", JsString(shortUrl)))
+  lazy val shortUrlId = shortUrl.replaceFirst("^[a-zA-Z]+://gu.com", "") //removing scheme://gu.com
+
+  def javascriptConfig: Map[String, JsValue] = {
+    Map(
+      "shortUrl" -> JsString(shortUrl),
+      "shortUrlId" -> JsString(shortUrlId)
+    )
+  }
 }
 
 object MetaData {

--- a/common/test/model/ContentTest.scala
+++ b/common/test/model/ContentTest.scala
@@ -129,6 +129,15 @@ class ContentTest extends FlatSpec with Matchers with OneAppPerSuite with implic
 
   }
 
+  it should "returns the correct shortUrlId" in {
+
+    def contentWithShortUrl(shortUrl: String) = Content(article.copy(fields =  Some(ContentFields(shortUrl = Some(shortUrl)))))
+
+    contentWithShortUrl("http://gu.com/p/3r1b5").fields.shortUrlId should be("/p/3r1b5")
+    contentWithShortUrl("https://gu.com/p/4t2c6").fields.shortUrlId should be("/p/4t2c6")
+  }
+
+
   private def tag(id: String = "/id", tagType: TagType = TagType.Keyword, name: String = "", url: String = "") = {
     ApiTag(id = id, `type` = tagType, webTitle = name,
       sectionId = None, sectionName = None, webUrl = url, apiUrl = "apiurl", references = Nil)

--- a/identity/app/services/PlaySavedArticlesService.scala
+++ b/identity/app/services/PlaySavedArticlesService.scala
@@ -35,9 +35,9 @@ class PlaySavedArticlesService @Inject()(api: IdApiClient) extends SafeLogging w
 
     val sanitizedArticles = savedArticles.articles map {
       article =>
-        val id = article.id.replace("http://www.theguardian.com/","")
-        val shortUrl = article.shortUrl.replace("http://gu.com","")
-        SavedArticle(id, shortUrl, article.date, article.read, article.platform)
+        val id = article.id.replaceFirst("^[a-zA-Z]+://www.theguardian.com/","")
+        val shortUrlId = article.shortUrl.replaceFirst("^[a-zA-Z]+://gu.com","")
+        SavedArticle(id, shortUrlId, article.date, article.read, article.platform)
     }
     SavedArticles(savedArticles.version, sanitizedArticles)
   }

--- a/static/src/javascripts/bootstraps/enhanced/article-liveblog-common.js
+++ b/static/src/javascripts/bootstraps/enhanced/article-liveblog-common.js
@@ -27,7 +27,7 @@ define([
     function initOpenCta() {
         if (config.switches.openCta && config.page.commentable) {
             var openCta = new OpenCta(mediator, {
-                discussionKey: config.page.shortUrl.replace('http://gu.com/', '')
+                discussionKey: config.page.shortUrlId || ''
             });
 
             $.create('<div class="open-cta"></div>').each(function (el) {

--- a/static/src/javascripts/projects/common/modules/save-for-later.js
+++ b/static/src/javascripts/projects/common/modules/save-for-later.js
@@ -74,7 +74,7 @@ define([
     }
 
     var bookmarkSvg = svgs('bookmark', ['rounded-icon']),
-        shortUrl = (config.page.shortUrl || '').replace('http://gu.com', ''),
+        shortUrl = config.page.shortUrlId || '',
         savedPlatformAnalytics = 'web:' + detect.getUserAgent.browser + ':' + detect.getBreakpoint();
 
     var getCustomEventProperties = function (contentId) {


### PR DESCRIPTION
## What does this change?

Properly get the id from a short url regardless of the scheme
## What is the value of this and can you measure success?

CAPI can start returning short urls with https
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@mchv @johnduffell @sndrs 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
