### PR TITLE
Lower healthcheck timeout

### DIFF
--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -46,7 +46,7 @@ private[conf] trait HealthCheckFetcher extends ExecutionContexts with Logging {
   protected def fetchResult(baseUrl: String, path: String): Future[HealthCheckResult] = {
     WS.url(s"$baseUrl$path")
       .withHeaders("User-Agent" -> "GU-HealthChecker", "X-Gu-Management-Healthcheck" -> "true")
-      .withRequestTimeout(10000).get()
+      .withRequestTimeout(4.seconds.toMillis).get()
       .map {
         response: WSResponse =>
           val result = response.status match {


### PR DESCRIPTION
## What does this change?

Lower the healthcheck timeout from 10 seconds to 4s
## What is the value of this and can you measure success?

Services are fetching healthcheck every 5 seconds.
It doesn't make sense to have timeout to be greater than this value.
If it fails it would be retried soon after
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
