### PR TITLE
Backporting play 2.5 test refactoring

### DIFF
--- a/identity/test/controllers/SignoutControllerTest.scala
+++ b/identity/test/controllers/SignoutControllerTest.scala
@@ -1,17 +1,15 @@
 package controllers
 
-import org.scalatest.path
+import org.scalatest.{Matchers => ShouldMatchers, WordSpec}
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{Matchers => ShouldMatchers}
+import org.scalatestplus.play.OneAppPerSuite
 import services._
 import org.mockito.Mockito._
 import org.mockito.Matchers._
 import conf.IdentityConfiguration
-import idapiclient.{UserCookie, IdApiClient, TrackingData}
-import play.api.test.Helpers._
+import idapiclient.IdApiClient
 import play.api.test._
 import client.Auth
-import idapiclient.responses.{CookieResponse, CookiesResponse}
 import scala.concurrent.Future
 import org.joda.time.DateTime
 import play.api.mvc._
@@ -22,9 +20,10 @@ import services.IdentityRequest
 import idapiclient.responses.CookiesResponse
 import idapiclient.TrackingData
 import play.api.mvc.Cookie
+import play.api.test.Helpers._
 
 
-class SignoutControllerTest extends path.FreeSpec with ShouldMatchers with MockitoSugar{
+class SignoutControllerTest extends WordSpec with OneAppPerSuite with ShouldMatchers with MockitoSugar{
 
   val returnUrlVerifier = mock[ReturnUrlVerifier]
   val conf = new IdentityConfiguration
@@ -37,33 +36,31 @@ class SignoutControllerTest extends path.FreeSpec with ShouldMatchers with Mocki
   val identityRequest = IdentityRequest(trackingData, Some("http://example.com/return"), None, None, Some(false), false)
   when(idRequestParser.apply(anyObject())).thenReturn(identityRequest)
 
-  "the signout method" - {
-    "with a valid API response" - {
-       val fakeRequest = FakeRequest(GET, "/signout").withCookies(Cookie("SC_GU_U","testscguuval"))
-       when(returnUrlVerifier.getVerifiedReturnUrl(fakeRequest)).thenReturn(Some("http://example.com/return"))
+  "the signout method" should {
+    val fakeRequest = FakeRequest(GET, "/signout").withCookies(Cookie("SC_GU_U","testscguuval"))
+    when(returnUrlVerifier.getVerifiedReturnUrl(fakeRequest)).thenReturn(Some("http://example.com/return"))
 
-      "if api call succeeds" - {
-         when(api.unauth(any[Auth], same(trackingData))).thenReturn(Future.successful(Right(CookiesResponse(DateTime.now, List(CookieResponse("test_gu_so", "testVal"))))))
-         "should call the api with the secure cookie data" in Fake {
-           signoutController.signout()(fakeRequest)
-           verify(api).unauth(UserCookie("testscguuval"),trackingData)
-         }
+    when(api.unauth(any[Auth], same(trackingData))).thenReturn(Future.successful(Right(CookiesResponse(DateTime.now, List(CookieResponse("test_gu_so", "testVal"))))))
+    "call the api with the secure cookie data" in Fake {
+      signoutController.signout()(fakeRequest)
+      verify(api).unauth(UserCookie("testscguuval"),trackingData)
+    }
 
-         "should redirect the user to the returnUrl" in Fake {
-            val result = signoutController.signout()(fakeRequest)
-            status(result) should equal(FOUND)
-            redirectLocation(result).get should equal("http://example.com/return")
-         }
+    "redirect the user to the returnUrl" in Fake {
+      val result = signoutController.signout()(fakeRequest)
+      status(result) should equal(FOUND)
+      redirectLocation(result).get should equal("http://example.com/return")
+    }
 
-         "should set the signout cookie on the response" in Fake {
-            val result = signoutController.signout()(fakeRequest)
-            val responseCookies : Cookies = cookies(result)
-            val testSignOutCookie = responseCookies.get("test_gu_so").get
-            testSignOutCookie should have('value("testVal"))
-            testSignOutCookie should have('secure(false))
-            testSignOutCookie should have('httpOnly(false))
-         }
-       }
+    "set the signout cookie on the response" in Fake {
+      running(app) {
+        val result = signoutController.signout()(fakeRequest)
+        val responseCookies: Cookies = cookies(result)
+        val testSignOutCookie = responseCookies.get("test_gu_so").get
+        testSignOutCookie should have('value ("testVal"))
+        testSignOutCookie should have('secure (false))
+        testSignOutCookie should have('httpOnly (false))
+      }
     }
   }
 }


### PR DESCRIPTION
_Nota: this PR looks big because the indentation was changed, the net number of modified line is much lower than the ~400 something you can see. (don't be too scared). To see this PR ignoring the whitespaces, follow this link: https://github.com/guardian/frontend/pull/13022/files?w=1_
## What does this change?

It prepares the migration to play 2.5 as on my play2.5 branch I had to solve csrf related problem on these three tests.
Refactoring the tests by using OneAppPerSuite and forcing the app to start using running(app) solved my csrf issue.
This PR focuses only on the refactoring part, leaving the csrf changes to the play 2.5 branch.
## What is the value of this and can you measure success?

Test are still passing
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

No
## Request for comment

@johnduffell @TBonnin, optionally @adamnfish if you remember touching these tests ?

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
