### PR TITLE
fix switch date

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -109,7 +109,7 @@ trait ABTestSwitches {
     "ab-participation-hide-half-of-comments",
     "We are going to hide comments on a random half of articles",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 6),
+    sellByDate = new LocalDate(2016, 6, 21),
     exposeClientSide = true
   )
 


### PR DESCRIPTION
## What does this change?

Changes the expirry date of the switch introduced here: https://github.com/guardian/frontend/pull/12990 to match the expiry date of the abtest (also created by 12980)
## What is the value of this and can you measure success?
## Does this affect other platforms - Amp, Apps, etc?
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
