### PR TITLE
Card's AD button text changed

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/frame.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/frame.js
@@ -29,7 +29,7 @@ define([
         var labelMarkup = template(labelStr, { data: {
             buttonTitle: 'Ad',
             infoTitle: 'Advertising on the Guardian',
-            infoText: 'is created and paid for by third parties and link to an external site.',
+            infoText: 'is created and paid for by third parties.',
             infoLinkText: 'Learn more about how advertising supports the Guardian.',
             infoLinkUrl: 'https://www.theguardian.com/advertising-on-the-guardian',
             icon: svgs('arrowicon', ['gu-comlabel__icon']),

--- a/static/src/javascripts/projects/common/modules/commercial/gustyle/gustyle.js
+++ b/static/src/javascripts/projects/common/modules/commercial/gustyle/gustyle.js
@@ -28,7 +28,7 @@ define([
             templateOptions = {
                 buttonTitle: 'Ad',
                 infoTitle: 'Advertising on the Guardian',
-                infoText: 'is created and paid for by third parties and link to an external site.',
+                infoText: 'is created and paid for by third parties.',
                 infoLinkText: 'Learn more about how advertising supports the Guardian.',
                 infoLinkUrl: 'https://www.theguardian.com/advertising-on-the-guardian',
                 icon: svgs('arrowicon', ['gu-comlabel__icon']),

--- a/static/src/stylesheets/module/commercial/gustyle/_gu-comlabel.scss
+++ b/static/src/stylesheets/module/commercial/gustyle/_gu-comlabel.scss
@@ -1,6 +1,4 @@
 .gu-comlabel {
-    // Temporary hidding this. We need to update texts etc but it needs to be live today.
-    display: none;
     color: $neutral-1;
 
     .gu-comlabel__btn {


### PR DESCRIPTION
## What does this change?

The 'AD' rounded button (on Card ads) is visible again - but with the shorted text.
## Screenshots

![screen shot 2016-05-23 at 14 59 25](https://cloud.githubusercontent.com/assets/489567/15473474/29585456-20f8-11e6-8214-d73aab82772a.png)
