### PR TITLE
Add extra logging to the discussion app

### DIFF
--- a/common/app/conf/Filters.scala
+++ b/common/app/conf/Filters.scala
@@ -159,7 +159,6 @@ object PanicSheddingFilter extends Filter with Logging {
       requestsInProgressCounter.send(InProgressRequestMonitor.requestComplete)
       startCompleteRatio.send(StartCompleteRatioMonitor.requestComplete)
       averageLatency.send(LatencyMonitor.updateLatency(DateTime.now.getMillis - startTime)_)
-      log.info(s"request complete in: ${DateTime.now.getMillis - startTime}")
     }
     startedResult
   }

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -259,4 +259,14 @@ trait PerformanceSwitches {
     sellByDate = new LocalDate(2016, 8, 5),
     exposeClientSide = false
   )
+
+  // Owner: tbonnin
+  val LogAllDiscussionIncomingRequests = Switch(
+    SwitchGroup.Performance,
+    "log-all-discussion-incoming-requests",
+    "If this switch is on then log all incoming discussion requests",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 2),
+    exposeClientSide = false
+  )
 }

--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -4,7 +4,8 @@ import common.{ExecutionContexts, Logging, StopWatch}
 import play.api.mvc.{Result, RequestHeader, Filter}
 
 import scala.concurrent.Future
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Random, Success}
+import conf.switches.Switches
 
 object RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
   override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
@@ -26,6 +27,34 @@ object RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
         log.warn(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed} ms", error)
     }
 
+    result
+  }
+}
+
+object DiscussionRequestLoggingFilter extends Filter with Logging with ExecutionContexts {
+  override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
+
+    val requestId = Random.nextInt(Integer.MAX_VALUE)
+
+    if(Switches.LogAllDiscussionIncomingRequests.isSwitchedOn) {
+      log.info(s"Start handling ${rh.method} ${rh.uri} (requestID: ${requestId})")
+    }
+
+    val stopWatch = new StopWatch
+    val result = next(rh)
+    result onComplete {
+      case Success(response) =>
+        response.header.headers.get("X-Accel-Redirect") match {
+          case Some(internalRedirect) =>
+            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and redirected to $internalRedirect (requestID: ${requestId})")
+
+          case None =>
+            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and returned ${response.header.status} (requestID: ${requestId})")
+        }
+
+      case Failure(error) =>
+        log.warn(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed} ms (requestID: ${requestId})", error)
+    }
     result
   }
 }

--- a/discussion/app/Global.scala
+++ b/discussion/app/Global.scala
@@ -1,13 +1,28 @@
 import common.CloudWatchApplicationMetrics
 import common.Logback.Logstash
-import conf.{CorsErrorHandler, DiscussionHealthCheckLifeCycle, Filters, SwitchboardLifecycle}
-import play.api.mvc.WithFilters
+import conf._
+import filters.{DiscussionRequestLoggingFilter, RequestLoggingFilter}
+import play.api.mvc.{EssentialFilter, WithFilters}
 
-object Global extends WithFilters(Filters.common : _*)
+object Global extends WithFilters(DiscussionFilters.allFilters : _*)
   with CloudWatchApplicationMetrics
   with CorsErrorHandler
   with SwitchboardLifecycle
   with Logstash
   with DiscussionHealthCheckLifeCycle {
   override lazy val applicationName = "frontend-discussion"
+}
+
+object DiscussionFilters {
+  // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
+  // which effectively means "JsonVaryHeaders goes around Gzipper"
+  lazy val allFilters: List[EssentialFilter] = List(
+    JsonVaryHeadersFilter,
+    Gzipper,
+    BackendHeaderFilter,
+    DiscussionRequestLoggingFilter,
+    SurrogateKeyFilter,
+    AmpFilter,
+    PanicSheddingFilter
+  )
 }

--- a/discussion/app/discussion/util/Http.scala
+++ b/discussion/app/discussion/util/Http.scala
@@ -1,20 +1,20 @@
 package discussion.util
 
 import play.api.libs.ws.{WS, WSResponse}
-import play.api.libs.json.{Json, JsValue}
-import common.Logging
-import scala.concurrent._
-import ExecutionContext.Implicits.global
+import play.api.libs.json.{JsValue, Json}
+import common.{ExecutionContexts, Logging, StopWatch}
+import scala.concurrent.Future
 
-trait Http extends Logging {
+trait Http extends Logging with ExecutionContexts {
 
   protected def getJsonOrError(url: String, onError: (WSResponse) => String, headers: (String, String)*): Future[JsValue] = {
+    val stopWatch = new StopWatch
     GET(url, headers: _*) map {
       response =>
         response.status match {
           case 200 =>
+            log.info(s"DAPI responded successfully in ${stopWatch.elapsed} ms for url: ${url}")
             Json.parse(response.body)
-
           case _ =>
             log.error(onError(response))
             throw new RuntimeException(onError(response))
@@ -24,7 +24,6 @@ trait Http extends Logging {
 
   protected def GET(url: String, headers: (String, String)*): Future[WSResponse] = {
     import play.api.Play.current
-    log.debug(s"GET $url")
     WS.url(url).withHeaders(headers: _*).withRequestTimeout(2000).get()
   }
 


### PR DESCRIPTION
## What does this change?

Add extra logging to the Discussion app in order to better understand what happens when the discussion app latency goes up
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
