### PR TITLE
Discussion bug #12678 #10471 - Comment Permalinks

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -199,6 +199,10 @@ Comments.prototype.goToPermalink = function(commentId) {
     if (commentId) {
         this.showHiddenComments();
         $('.d-discussion__show-all-comments').addClass('u-h');
+        // First we have to clear the existing # as replacing
+        // it with the same one doesn't trigger the hashchange event
+        // Using location.replace prevents changing history
+        window.location.replace('#');
         window.location.replace('#comment-' + commentId);
     }
 };


### PR DESCRIPTION
## What does this change?

Fixes the issue where if a user follows a permalink to a comment, the page doesn't jump to the comment.

Issues #12678 #10471
## Request for comment

@nicl @gidsg 
