### PR TITLE
add ec2 instance and request info to logs

### DIFF
--- a/common/app/common/Logback/Logstash.scala
+++ b/common/app/common/Logback/Logstash.scala
@@ -1,6 +1,7 @@
 package common.Logback
 
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.util.EC2MetadataUtils
 import common.ManifestData
 import conf.switches.Switches
 import conf.Configuration
@@ -29,7 +30,8 @@ object Logstash {
     "app" -> Configuration.environment.projectName,
     "stage" -> Configuration.environment.stage.toUpperCase,
     "build" -> ManifestData.build,
-    "revision" -> ManifestData.revision
+    "revision" -> ManifestData.revision,
+    "ec2_instance" -> Option(EC2MetadataUtils.getInstanceId).getOrElse("Not running on ec2")
   )
 
   val config = for {

--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -1,59 +1,112 @@
 package filters
 
+import java.util.UUID
+
 import common.{ExecutionContexts, Logging, StopWatch}
-import play.api.mvc.{Result, RequestHeader, Filter}
+import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.Future
 import scala.util.{Failure, Random, Success}
 import conf.switches.Switches
+import net.logstash.logback.marker.LogstashMarker
+import net.logstash.logback.marker.Markers._
+import play.api.Logger
+
+import scala.collection.JavaConverters._
 
 class RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
+
+  case class RequestLogger(rh: RequestHeader)(implicit internalLogger: Logger, stopWatch: StopWatch) {
+    private lazy val pseudoId = Random.nextInt(Integer.MAX_VALUE)
+    private def customFieldsMarkers(): LogstashMarker = {
+      val fields = Map(
+        "req.method" -> rh.method,
+        "req.url" -> rh.uri,
+        "req.id" -> pseudoId.toString,
+        "req.latency_ms" -> stopWatch.elapsed.toString
+      )
+      //TODO: add all/some request headers fields
+      appendEntries(fields.asJava)
+    }
+
+    def info(message: String): Unit = {
+      internalLogger.logger.info(customFieldsMarkers, message)
+    }
+    def warn(message: String, error: Throwable): Unit = {
+      internalLogger.logger.warn(customFieldsMarkers, message, error)
+    }
+    def error(message: String, error: Throwable): Unit = {
+      internalLogger.logger.error(customFieldsMarkers, message, error)
+    }
+  }
+
   override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
-    val stopWatch = new StopWatch
 
+    implicit val stopWatch = new StopWatch
     val result = next(rh)
-
+    val requestLogger = RequestLogger(rh)
     result onComplete {
       case Success(response) =>
         response.header.headers.get("X-Accel-Redirect") match {
           case Some(internalRedirect) =>
-            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and redirected to $internalRedirect")
-
+            requestLogger.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and redirected to $internalRedirect")
           case None =>
-            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and returned ${response.header.status}")
+            requestLogger.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and returned ${response.header.status}")
         }
 
       case Failure(error) =>
-        log.warn(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed} ms", error)
+        requestLogger.warn(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed} ms", error)
     }
-
     result
   }
 }
 
 class DiscussionRequestLoggingFilter extends Filter with Logging with ExecutionContexts {
-  override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
 
-    val requestId = Random.nextInt(Integer.MAX_VALUE)
-
-    if(Switches.LogAllDiscussionIncomingRequests.isSwitchedOn) {
-      log.info(s"Start handling ${rh.method} ${rh.uri} (requestID: ${requestId})")
+  case class RequestLogger(rh: RequestHeader)(implicit internalLogger: Logger, stopWatch: StopWatch) {
+    private lazy val pseudoId = Random.nextInt(Integer.MAX_VALUE)
+    private def customFieldsMarkers(): LogstashMarker = {
+      val fields = Map(
+        "req.method" -> rh.method,
+        "req.url" -> rh.uri,
+        "req.uuid" -> pseudoId.toString,
+        "req.latency_ms" -> stopWatch.elapsed.toString
+      )
+      appendEntries(fields.asJava)
     }
 
-    val stopWatch = new StopWatch
+    def info(message: String): Unit = {
+      internalLogger.logger.info(customFieldsMarkers, message)
+    }
+    def warn(message: String, error: Throwable): Unit = {
+      internalLogger.logger.warn(customFieldsMarkers, message, error)
+    }
+    def error(message: String, error: Throwable): Unit = {
+      internalLogger.logger.error(customFieldsMarkers, message, error)
+    }
+  }
+
+  override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
+
+    implicit val stopWatch = new StopWatch
+    val requestLogger = RequestLogger(rh)
+
+    if(Switches.LogAllDiscussionIncomingRequests.isSwitchedOn) {
+      requestLogger.info(s"Start handling ${rh.method} ${rh.uri}")
+    }
+
     val result = next(rh)
     result onComplete {
       case Success(response) =>
         response.header.headers.get("X-Accel-Redirect") match {
           case Some(internalRedirect) =>
-            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and redirected to $internalRedirect (requestID: ${requestId})")
-
+            requestLogger.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and redirected to $internalRedirect")
           case None =>
-            log.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and returned ${response.header.status} (requestID: ${requestId})")
+            requestLogger.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and returned ${response.header.status}")
         }
 
       case Failure(error) =>
-        log.warn(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed} ms (requestID: ${requestId})", error)
+        requestLogger.warn(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed} ms", error)
     }
     result
   }


### PR DESCRIPTION
## What does this change?

Add additional fields to server-side logs (ec2 instance id, request url, request method, request id, request latency)
## What is the value of this and can you measure success?

We can look into the logs by ec2 instance as well as querying by those new request fields
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
