### PR TITLE
Remove the handling of filters from the "global" of each individual micro service

### DIFF
--- a/admin-jobs/app/Global.scala
+++ b/admin-jobs/app/Global.scala
@@ -1,15 +1,13 @@
 import common.Logback.Logstash
 import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
-import conf.{AdminJobsHealthCheckLifeCycle, Filters, SwitchboardLifecycle}
+import conf.{AdminJobsHealthCheckLifeCycle, SwitchboardLifecycle}
 import contentapi.SectionsLookUpLifecycle
 import dev.DevParametersLifecycle
 import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
-import play.api.mvc.WithFilters
 import services.ConfigAgentLifecycle
 
-object Global extends WithFilters(Filters.common: _*)
-with ConfigAgentLifecycle
+object Global extends ConfigAgentLifecycle
 with DevParametersLifecycle
 with CloudWatchApplicationMetrics
 with SurgingContentAgentLifecycle

--- a/admin-jobs/conf/application.conf
+++ b/admin-jobs/conf/application.conf
@@ -33,6 +33,10 @@ play {
     ws {
         compressionEnabled: true
     }
+
+    http {
+        filters: "conf.CommonFilters"
+    }
 }
 
 guardian: {

--- a/admin/app/Global.scala
+++ b/admin/app/Global.scala
@@ -1,19 +1,18 @@
 import common.CloudWatchApplicationMetrics
 import common.Logback.Logstash
 import common.dfp.DfpAgentLifecycle
-import conf.{Gzipper, SwitchboardLifecycle}
+import conf.SwitchboardLifecycle
 import controllers.AdminHealthCheckLifeCycle
 import dfp.DfpDataCacheLifecycle
 import model.AdminLifecycle
 import ophan.SurgingContentAgentLifecycle
-import play.api.mvc.{RequestHeader, Results, WithFilters}
+import play.api.mvc._
 import purge.SoftPurge
 import services.ConfigAgentLifecycle
 
 import scala.concurrent.Future
 
-object Global extends WithFilters(Gzipper)
-  with AdminLifecycle
+object Global extends AdminLifecycle
   with ConfigAgentLifecycle
   with SwitchboardLifecycle
   with CloudWatchApplicationMetrics

--- a/admin/conf/application.conf
+++ b/admin/conf/application.conf
@@ -39,6 +39,10 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "conf.CommonGzipFilter"
+  }
 }
 
 guardian: {

--- a/applications/app/Global.scala
+++ b/applications/app/Global.scala
@@ -1,17 +1,15 @@
 import common.Logback.Logstash
 import common.dfp.DfpAgentLifecycle
 import common.{CloudWatchApplicationMetrics, ContentApiMetrics, EmailSubsciptionMetrics}
-import conf.{ApplicationsHealthCheckLifeCycle, CorsErrorHandler, Filters, SwitchboardLifecycle}
+import conf.{ApplicationsHealthCheckLifeCycle, CorsErrorHandler, SwitchboardLifecycle}
 import contentapi.SectionsLookUpLifecycle
 import dev.DevParametersLifecycle
 import jobs.SiteMapLifecycle
 import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
-import play.api.mvc.WithFilters
 import services.{ConfigAgentLifecycle, IndexListingsLifecycle}
 
-object Global extends WithFilters(Filters.common: _*)
-  with ConfigAgentLifecycle
+object Global extends ConfigAgentLifecycle
   with DevParametersLifecycle
   with CloudWatchApplicationMetrics
   with DfpAgentLifecycle

--- a/applications/conf/application.conf
+++ b/applications/conf/application.conf
@@ -33,6 +33,10 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "conf.CommonFilters"
+  }
 }
 
 guardian: {

--- a/archive/app/Global.scala
+++ b/archive/app/Global.scala
@@ -1,12 +1,10 @@
 import common.CloudWatchApplicationMetrics
 import common.Logback.Logstash
-import conf.{ArchiveHealthCheckLifeCycle, CorsErrorHandler, Filters, SwitchboardLifecycle}
+import conf.{ArchiveHealthCheckLifeCycle, CorsErrorHandler, SwitchboardLifecycle}
 import dev.DevParametersLifecycle
-import play.api.mvc.WithFilters
 import services.ArchiveMetrics
 
-object Global extends WithFilters(Filters.common: _*)
-  with DevParametersLifecycle
+object Global extends DevParametersLifecycle
   with CloudWatchApplicationMetrics
   with ArchiveMetrics
   with CorsErrorHandler

--- a/archive/conf/application.conf
+++ b/archive/conf/application.conf
@@ -33,6 +33,10 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "conf.CommonFilters"
+  }
 }
 
 guardian: {

--- a/article/app/Global.scala
+++ b/article/app/Global.scala
@@ -1,16 +1,14 @@
 import common.Logback.Logstash
 import common.dfp.DfpAgentLifecycle
 import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
-import conf.{ArticleHealthCheckLifeCycle, CorsErrorHandler, Filters, SwitchboardLifecycle}
+import conf.{ArticleHealthCheckLifeCycle, CorsErrorHandler, SwitchboardLifecycle}
 import dev.DevParametersLifecycle
 import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
-import play.api.mvc.WithFilters
 import services.NewspaperBooksAndSectionsAutoRefresh
 
 object Global
-  extends WithFilters(Filters.common: _*)
-  with NewspaperBooksAndSectionsAutoRefresh
+  extends NewspaperBooksAndSectionsAutoRefresh
   with DevParametersLifecycle
   with DfpAgentLifecycle
   with CloudWatchApplicationMetrics

--- a/article/conf/application.conf
+++ b/article/conf/application.conf
@@ -33,6 +33,10 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "conf.CommonFilters"
+  }
 }
 
 guardian: {

--- a/commercial/app/Global.scala
+++ b/commercial/app/Global.scala
@@ -1,18 +1,16 @@
 import commercial.CommercialLifecycle
 import common.Logback.Logstash
 import common._
-import conf.{CommercialHealthCheckLifeCycle, CorsErrorHandler, Filters, SwitchboardLifecycle}
+import conf.{CommercialHealthCheckLifeCycle, CorsErrorHandler, SwitchboardLifecycle}
 import dev.DevParametersLifecycle
 import metrics.MetricUploader
-import play.api.mvc.WithFilters
 
 package object CommercialMetrics {
 
   val metrics = MetricUploader("Commercial")
 }
 
-object Global extends WithFilters(Filters.common: _*)
-  with CommercialLifecycle
+object Global extends CommercialLifecycle
   with DevParametersLifecycle
   with SwitchboardLifecycle
   with CloudWatchApplicationMetrics

--- a/commercial/conf/application.conf
+++ b/commercial/conf/application.conf
@@ -45,6 +45,10 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "conf.CommonFilters"
+  }
 }
 
 guardian: {

--- a/common/app/conf/Filters.scala
+++ b/common/app/conf/Filters.scala
@@ -3,15 +3,16 @@ package conf
 import cache.SurrogateKey
 import common.ExecutionContexts
 import filters.RequestLoggingFilter
+import play.api.http.HttpFilters
 import implicits.Responses._
 import play.api.mvc.{EssentialFilter, Filter, RequestHeader, Result}
 import play.filters.gzip.GzipFilter
 
 import scala.concurrent.Future
 
-object Gzipper extends GzipFilter(shouldGzip = (_, resp) => !resp.isImage)
+class Gzipper extends GzipFilter(shouldGzip = (_, result) => !result.isImage)
 
-object JsonVaryHeadersFilter extends Filter with ExecutionContexts with implicits.Requests {
+class JsonVaryHeadersFilter extends Filter with ExecutionContexts with implicits.Requests {
 
   private val varyFields = List("Origin", "Accept")
   private val defaultVaryFields = varyFields.mkString(",")
@@ -33,7 +34,7 @@ object JsonVaryHeadersFilter extends Filter with ExecutionContexts with implicit
 }
 
 // this lets the CDN log the exact part of the backend this response came from
-object BackendHeaderFilter extends Filter with ExecutionContexts {
+class BackendHeaderFilter extends Filter with ExecutionContexts {
 
   private lazy val backendHeader = "X-Gu-Backend-App" -> conf.Configuration.environment.projectName
 
@@ -43,7 +44,7 @@ object BackendHeaderFilter extends Filter with ExecutionContexts {
 }
 
 // See https://www.fastly.com/blog/surrogate-keys-part-1/
-object SurrogateKeyFilter extends Filter with ExecutionContexts {
+class SurrogateKeyFilter extends Filter with ExecutionContexts {
 
   private val SurrogateKeyHeader = "Surrogate-Key"
 
@@ -57,7 +58,7 @@ object SurrogateKeyFilter extends Filter with ExecutionContexts {
   }
 }
 
-object AmpFilter extends Filter with ExecutionContexts with implicits.Requests {
+class AmpFilter extends Filter with ExecutionContexts with implicits.Requests {
   override def apply(nextFilter: (RequestHeader) => Future[Result])(request: RequestHeader): Future[Result] = {
     if (request.isAmp) {
       val domain = request.headers.get("Origin").getOrElse("https://" + request.domain)
@@ -74,13 +75,21 @@ object AmpFilter extends Filter with ExecutionContexts with implicits.Requests {
 object Filters {
   // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
   // which effectively means "JsonVaryHeaders goes around Gzipper"
-  lazy val common: List[EssentialFilter] = List(
-    PanicSheddingFilter,
-    JsonVaryHeadersFilter,
-    Gzipper,
-    BackendHeaderFilter,
-    RequestLoggingFilter,
-    SurrogateKeyFilter,
-    AmpFilter
+  def common: List[EssentialFilter] = List(
+    new PanicSheddingFilter,
+    new JsonVaryHeadersFilter,
+    new Gzipper,
+    new BackendHeaderFilter,
+    new RequestLoggingFilter,
+    new SurrogateKeyFilter,
+    new AmpFilter
   )
+}
+
+class CommonFilters extends HttpFilters {
+  val filters = Filters.common
+}
+
+class CommonGzipFilter extends HttpFilters {
+  val filters = Seq(new Gzipper)
 }

--- a/common/app/conf/PanicSheddingFilter.scala
+++ b/common/app/conf/PanicSheddingFilter.scala
@@ -12,7 +12,7 @@ import play.api.mvc.{Result, RequestHeader, Filter}
 import scala.concurrent.Future
 
 // this turns requests away with 5xx errors if we are too busy
-object PanicSheddingFilter extends Filter with Logging {
+class PanicSheddingFilter extends Filter with Logging {
 
   import scala.concurrent.ExecutionContext.Implicits.global
   import scala.concurrent.duration._

--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -7,7 +7,7 @@ import scala.concurrent.Future
 import scala.util.{Failure, Random, Success}
 import conf.switches.Switches
 
-object RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
+class RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
   override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
     val stopWatch = new StopWatch
 
@@ -31,7 +31,7 @@ object RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
   }
 }
 
-object DiscussionRequestLoggingFilter extends Filter with Logging with ExecutionContexts {
+class DiscussionRequestLoggingFilter extends Filter with Logging with ExecutionContexts {
   override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
 
     val requestId = Random.nextInt(Integer.MAX_VALUE)

--- a/diagnostics/app/Global.scala
+++ b/diagnostics/app/Global.scala
@@ -1,11 +1,9 @@
-
 import common.Logback.Logstash
 import common.{CloudWatchApplicationMetrics, DiagnosticsLifecycle}
-import conf.{DiagnosticsHealthCheckLifeCycle, Gzipper, SwitchboardLifecycle}
-import play.api.mvc.WithFilters
+import conf.{DiagnosticsHealthCheckLifeCycle, SwitchboardLifecycle}
 
-object Global extends WithFilters(Gzipper)
-  with DiagnosticsLifecycle
+object Global
+  extends DiagnosticsLifecycle
   with SwitchboardLifecycle
   with CloudWatchApplicationMetrics
   with Logstash

--- a/diagnostics/conf/application.conf
+++ b/diagnostics/conf/application.conf
@@ -33,6 +33,10 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "conf.CommonGzipFilter"
+  }
 }
 
 guardian: {

--- a/discussion/app/Global.scala
+++ b/discussion/app/Global.scala
@@ -17,12 +17,12 @@ class DiscussionFilters extends HttpFilters {
   // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
   // which effectively means "JsonVaryHeaders goes around Gzipper"
   lazy val filters: List[EssentialFilter] = List(
+    new PanicSheddingFilter,
     new JsonVaryHeadersFilter,
     new Gzipper,
     new BackendHeaderFilter,
     new DiscussionRequestLoggingFilter,
     new SurrogateKeyFilter,
-    new AmpFilter,
-    new PanicSheddingFilter
+    new AmpFilter
   )
 }

--- a/discussion/app/Global.scala
+++ b/discussion/app/Global.scala
@@ -1,11 +1,11 @@
 import common.CloudWatchApplicationMetrics
 import common.Logback.Logstash
 import conf._
-import filters.{DiscussionRequestLoggingFilter, RequestLoggingFilter}
-import play.api.mvc.{EssentialFilter, WithFilters}
+import filters.DiscussionRequestLoggingFilter
+import play.api.http.HttpFilters
+import play.api.mvc.EssentialFilter
 
-object Global extends WithFilters(DiscussionFilters.allFilters : _*)
-  with CloudWatchApplicationMetrics
+object Global extends CloudWatchApplicationMetrics
   with CorsErrorHandler
   with SwitchboardLifecycle
   with Logstash
@@ -13,16 +13,16 @@ object Global extends WithFilters(DiscussionFilters.allFilters : _*)
   override lazy val applicationName = "frontend-discussion"
 }
 
-object DiscussionFilters {
+class DiscussionFilters extends HttpFilters {
   // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
   // which effectively means "JsonVaryHeaders goes around Gzipper"
-  lazy val allFilters: List[EssentialFilter] = List(
-    JsonVaryHeadersFilter,
-    Gzipper,
-    BackendHeaderFilter,
-    DiscussionRequestLoggingFilter,
-    SurrogateKeyFilter,
-    AmpFilter,
-    PanicSheddingFilter
+  lazy val filters: List[EssentialFilter] = List(
+    new JsonVaryHeadersFilter,
+    new Gzipper,
+    new BackendHeaderFilter,
+    new DiscussionRequestLoggingFilter,
+    new SurrogateKeyFilter,
+    new AmpFilter,
+    new PanicSheddingFilter
   )
 }

--- a/discussion/conf/application.conf
+++ b/discussion/conf/application.conf
@@ -39,6 +39,10 @@ play {
     ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "DiscussionFilters"
+  }
 }
 
 guardian: {

--- a/facia/app/Global.scala
+++ b/facia/app/Global.scala
@@ -1,16 +1,14 @@
 import common.Logback.Logstash
 import common._
 import common.dfp.FaciaDfpAgentLifecycle
-import conf.{FaciaHealthCheckLifeCycle, Filters, SwitchboardLifecycle}
+import conf.{FaciaHealthCheckLifeCycle, SwitchboardLifecycle}
 import crosswords.TodaysCrosswordGridLifecycle
 import dev.DevParametersLifecycle
 import headlines.ABHeadlinesLifecycle
 import ophan.SurgingContentAgentLifecycle
-import play.api.mvc.WithFilters
 import services.{ConfigAgentLifecycle, IndexListingsLifecycle}
 
-object Global extends WithFilters(Filters.common: _*)
-  with ConfigAgentLifecycle
+object Global extends ConfigAgentLifecycle
   with DevParametersLifecycle
   with CloudWatchApplicationMetrics
   with FaciaDfpAgentLifecycle

--- a/facia/conf/application.conf
+++ b/facia/conf/application.conf
@@ -36,6 +36,10 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "conf.CommonFilters"
+  }
 }
 
 guardian: {

--- a/identity/app/Global.scala
+++ b/identity/app/Global.scala
@@ -1,19 +1,15 @@
-import com.google.inject.Guice
 import common.CloudWatchApplicationMetrics
 import common.Logback.Logstash
 import conf._
-import filters.{StrictTransportSecurityHeaderFilter, HeaderLoggingFilter}
 import play.api.Play.current
 import play.api._
 import play.api.mvc._
 import play.api.mvc.Results._
-import play.api.inject._
 import play.api.inject.guice._
 import scala.concurrent.Future
 import utils.SafeLogging
 
-object Global extends WithFilters(HeaderLoggingFilter :: StrictTransportSecurityHeaderFilter :: conf.Filters.common: _*)
-  with SafeLogging
+object Global extends SafeLogging
   with CloudWatchApplicationMetrics
   with IdentityLifecycle
   with SwitchboardLifecycle

--- a/identity/app/conf/IdentityFilters.scala
+++ b/identity/app/conf/IdentityFilters.scala
@@ -1,0 +1,9 @@
+package conf
+
+import filters.{HeaderLoggingFilter, StrictTransportSecurityHeaderFilter}
+import play.api.http.HttpFilters
+
+class IdentityFilters extends HttpFilters {
+
+  val filters = new HeaderLoggingFilter :: new StrictTransportSecurityHeaderFilter :: conf.Filters.common
+}

--- a/identity/app/filters/HeaderLoggingFilter.scala
+++ b/identity/app/filters/HeaderLoggingFilter.scala
@@ -5,8 +5,7 @@ import utils.SafeLogging
 import common.ExecutionContexts
 import scala.concurrent.Future
 
-
-object HeaderLoggingFilter extends Filter with SafeLogging with ExecutionContexts {
+class HeaderLoggingFilter extends Filter with SafeLogging with ExecutionContexts {
   def logHeaders(rh: RequestHeader) {
     val keys: Set[String] = rh.headers.keys filterNot { name =>
       "Cookie" == name || "User-Agent" == name || "Authorization" == name

--- a/identity/app/filters/StrictTransportSecurityHeaderFilter.scala
+++ b/identity/app/filters/StrictTransportSecurityHeaderFilter.scala
@@ -5,7 +5,7 @@ import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.Future
 
-object StrictTransportSecurityHeaderFilter extends Filter with ExecutionContexts {
+class StrictTransportSecurityHeaderFilter extends Filter with ExecutionContexts {
 
   private val OneYearInSeconds = 31536000
   private val Header = "Strict-Transport-Security" -> s"max-age=$OneYearInSeconds; preload"

--- a/identity/conf/application.conf
+++ b/identity/conf/application.conf
@@ -41,6 +41,8 @@ play {
     session {
       secure=true
     }
+
+    filters: "conf.IdentityFilters"
   }
 
   filters {

--- a/identity/test/filters/StrictTransportSecurityHeaderFilterTest.scala
+++ b/identity/test/filters/StrictTransportSecurityHeaderFilterTest.scala
@@ -14,7 +14,7 @@ class StrictTransportSecurityHeaderFilterTest extends FunSuite with Matchers {
     val request = FakeRequest()
     def action(req: RequestHeader): Future[Result] = Future.successful(Ok)
 
-    val result = StrictTransportSecurityHeaderFilter(action _)(request)
+    val result = new StrictTransportSecurityHeaderFilter().apply(action _)(request)
 
     Await.result(result, 1.second).header.headers("Strict-Transport-Security") should equal("max-age=31536000; preload")
   }

--- a/onward/app/Global.scala
+++ b/onward/app/Global.scala
@@ -1,14 +1,12 @@
 import business.StocksDataLifecycle
 import common.Logback.Logstash
 import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
-import conf.{CorsErrorHandler, Filters, OnwardHealthCheckLifeCycle, SwitchboardLifecycle}
+import conf.{CorsErrorHandler, OnwardHealthCheckLifeCycle, SwitchboardLifecycle}
 import dev.DevParametersLifecycle
 import feed.{MostPopularFacebookAutoRefreshLifecycle, MostReadLifecycle, OnwardJourneyLifecycle}
 import metrics.FrontendMetric
-import play.api.mvc.WithFilters
 
-object Global extends WithFilters(Filters.common: _*)
-  with OnwardJourneyLifecycle
+object Global extends OnwardJourneyLifecycle
   with DevParametersLifecycle
   with CloudWatchApplicationMetrics
   with MostReadLifecycle

--- a/onward/conf/application.conf
+++ b/onward/conf/application.conf
@@ -42,6 +42,10 @@ play {
         request: 2000ms
     }
   }
+
+  http {
+    filters: "conf.CommonFilters"
+  }
 }
 
 guardian: {

--- a/preview/conf/application.conf
+++ b/preview/conf/application.conf
@@ -48,6 +48,7 @@ play {
 
   http {
     errorHandler: "PreviewErrorHandler"
+    filters: "conf.StandaloneFilters"
   }
 
 }

--- a/rss/app/Global.scala
+++ b/rss/app/Global.scala
@@ -1,15 +1,13 @@
 import common.Logback.Logstash
 import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
-import conf.{Filters, RssHealthCheckLifeCycle, SwitchboardLifecycle}
+import conf._
 import contentapi.SectionsLookUpLifecycle
 import dev.DevParametersLifecycle
 import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
-import play.api.mvc.WithFilters
 import services.ConfigAgentLifecycle
 
-object Global extends WithFilters(Filters.common: _*)
-  with ConfigAgentLifecycle
+object Global extends ConfigAgentLifecycle
   with DevParametersLifecycle
   with CloudWatchApplicationMetrics
   with SurgingContentAgentLifecycle

--- a/rss/conf/application.conf
+++ b/rss/conf/application.conf
@@ -33,6 +33,10 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "conf.CommonFilters"
+  }
 }
 
 guardian: {

--- a/sport/app/Global.scala
+++ b/sport/app/Global.scala
@@ -3,11 +3,9 @@ import common.Logback.Logstash
 import conf._
 import dev.DevParametersLifecycle
 import ophan.SurgingContentAgentLifecycle
-import play.api.mvc.WithFilters
 import rugby.conf.RugbyLifecycle
 
-object Global extends WithFilters(Filters.common: _*)
-  with DevParametersLifecycle
+object Global extends DevParametersLifecycle
   with CloudWatchApplicationMetrics
   with SurgingContentAgentLifecycle
   with SwitchboardLifecycle

--- a/sport/conf/application.conf
+++ b/sport/conf/application.conf
@@ -33,6 +33,10 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "conf.CommonFilters"
+  }
 }
 
 guardian: {

--- a/standalone/app/StandaloneGlobal.scala
+++ b/standalone/app/StandaloneGlobal.scala
@@ -1,0 +1,26 @@
+import com.gu.googleauth.{FilterExemption, UserIdentity}
+import commercial.CommercialLifecycle
+import common.ExecutionContexts
+import common.Logback.Logstash
+import common.dfp.FaciaDfpAgentLifecycle
+import conf._
+import controllers.AuthCookie
+import feed.OnwardJourneyLifecycle
+import play.Play
+import play.api.mvc.Results._
+import play.api.mvc._
+import play.api.mvc.{Filters => PlayFilters}
+import rugby.conf.RugbyLifecycle
+import services.ConfigAgentLifecycle
+
+import scala.concurrent.Future
+
+class StandaloneGlobal extends CommercialLifecycle
+  with OnwardJourneyLifecycle
+  with ConfigAgentLifecycle
+  with FaciaDfpAgentLifecycle
+  with SwitchboardLifecycle
+  with FootballLifecycle
+  with CricketLifecycle
+  with RugbyLifecycle
+  with Logstash

--- a/training-preview/conf/application.conf
+++ b/training-preview/conf/application.conf
@@ -39,6 +39,10 @@ play {
   ws {
     compressionEnabled: true
   }
+
+  http {
+    filters: "conf.StandaloneFilters"
+  }
 }
 
 guardian: {


### PR DESCRIPTION
## What does this change?

This change extracts the filters out of `Global`s states of each micro service.
It is back ported from my play-2.5.3 branch and adapted to play 2.4
Filters are transformed from object to classes as they will need to be injected with a akka.stream.Materializer in play 2.5
## What is the value of this and can you measure success?

It keeps the play-2.5.3 branch to human readable size and prepares the project to support dependency injection
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @TBonnin 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
