### PR TITLE
add crosswords to whitelist

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-hide-half-of-comments.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-hide-half-of-comments.js
@@ -22,7 +22,11 @@ define([
         'lifeandstyle/series/how-to-eat',
         'commentisfree/series/you-tell-us',
         'football/series/footballweekly',
-        'australia-news/series/politics-live-with-katharine-murphy'
+        'australia-news/series/politics-live-with-katharine-murphy',
+        'crosswords/series/quick',
+        'crosswords/series/quiptic',
+        'crosswords/series/cryptic,',
+        'crosswords/series/speedy'
     ];
 
     var blogIds = [


### PR DESCRIPTION
## What does this change?

Glaring ommision from the whitelist here was crosswords: https://github.com/guardian/frontend/pull/12990. We know crossword users are a community and we probably don't wanna disrupt that. So don't hide comments on crosswords.
## What is the value of this and can you measure success?
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots
## Request for comment

@gtrufitt @gidsg 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
