### PR TITLE
video teaser

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -109,7 +109,7 @@ trait ABTestSwitches {
     "ab-video-teaser",
     "Show video teaser",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 8),
+    sellByDate = new LocalDate(2016, 6, 17),
     exposeClientSide = true
   )
 }

--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -48,7 +48,7 @@
                             autoPlay = false,
                             showControlsAtStart = false
                         )) { player =>
-                            <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player">
+                            <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player video-playlist__item__player">
                                 <div class="fc-item__video-container">
                                     @video(player, false, false, showOverlay = true, showPoster = false)
                                 </div>

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -170,10 +170,55 @@ define([
             });
         });
 
+        initVideoTeaser();
+
         initPlayButtons(document.body);
 
         mediator.on('modules:related:loaded', initPlayButtons);
         mediator.on('page:media:moreinloaded', initPlayButtons);
+    }
+
+    function initVideoTeaser() {
+        fastdom.read(function () {
+            $('.js-video-player', document.body).each(function (el) {
+                var $el = bonzo(el);
+                var clone = el.cloneNode(true);
+                var $clone = bonzo(clone);
+                var teaserVideo = $('video', $clone).get(0);
+                var teaserLength = 5; //seconds
+
+                $clone.removeClass('media__container--hidden').addClass('media__container--active');
+                $('.js-video-placeholder', $el.parent()).addClass('media__container--hidden');
+
+                // teaser should be muted with no chrome
+                teaserVideo.muted = true;
+                teaserVideo.controls = false;
+
+                el.parentNode.insertBefore(clone, el);
+
+                teaserVideo.addEventListener('timeupdate', function () {
+                    if (teaserVideo.currentTime >= teaserLength) {
+                        teaserVideo.pause();
+
+                        // HACK around https://bugs.chromium.org/p/chromium/issues/detail?id=593273
+                        setTimeout(function () {
+                            teaserVideo.currentTime = 0;
+                            teaserVideo.play();
+                        }, 100);
+                    }
+                });
+
+                clone.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    teaserVideo.pause();
+                    $el.removeClass('media__container--hidden').addClass('media__container--active');
+                    enhanceVideo($('video', $el).get(0), true, false);
+                    $clone.remove();
+                });
+
+                teaserVideo.play();
+            });
+        });
     }
 
     function enhanceVideo(el, autoplay, shouldPreroll) {

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -180,7 +180,7 @@ define([
 
     function initVideoTeaser() {
         fastdom.read(function () {
-            $('.js-video-player', document.body).each(function (el) {
+            $('.js-video-player:not(.video-playlist__item__player)', document.body).each(function (el) {
                 var $el = bonzo(el);
                 var clone = el.cloneNode(true);
                 var $clone = bonzo(clone);

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -16,6 +16,7 @@ define([
     'common/modules/commercial/build-page-targeting',
     'common/modules/commercial/commercial-features',
     'common/modules/component',
+    'common/modules/experiments/ab',
     'common/modules/video/events',
     'common/modules/video/fullscreener',
     'common/modules/video/tech-order',
@@ -45,6 +46,7 @@ define([
     buildPageTargeting,
     commercialFeatures,
     Component,
+    ab,
     events,
     fullscreener,
     techOrder,
@@ -170,7 +172,9 @@ define([
             });
         });
 
-        initVideoTeaser();
+        if(ab.isInVariant('VideoTeaser', 'variant')) {
+            initVideoTeaser();
+        }
 
         initPlayButtons(document.body);
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-teaser.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-teaser.js
@@ -25,11 +25,11 @@ define([
 
         this.variants = [
             {
-                id: 'baseline1',
+                id: 'control',
                 test: function () {}
             },
             {
-                id: 'baseline2',
+                id: 'variant',
                 test: function () {}
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-teaser.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-teaser.js
@@ -5,13 +5,13 @@ define([
 ) {
     return function () {
         this.id = 'VideoTeaser';
-        this.start = '2016-06-03';
-        this.expiry = '2016-06-08';
+        this.start = '2016-06-07';
+        this.expiry = '2016-06-17';
         this.author = 'Akash Askoolum';
         this.description = 'Test if video teasing leads to more plays';
         this.showForSensitive = true;
-        this.audience = 1;
-        this.audienceOffset = 0;
+        this.audience = 0.18;
+        this.audienceOffset = 0.12;
         this.successMeasure = '';
         this.audienceCriteria = 'Videos not in a carousel';
         this.dataLinkNames = '';


### PR DESCRIPTION
## What does this change?

Adds a 5 second, muted, control-less, looping video in place of a poster image on fronts.
## What is the value of this and can you measure success?

Make video more obvious and enticing. Success = ⬆️ in starts on fronts.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

![teaser](https://cloud.githubusercontent.com/assets/836140/15539075/396cda66-2278-11e6-97a5-94341d4fd9e3.gif)
## Request for comment

@jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
