### PR TITLE
created switch to force 1x1px pageskin creation

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -364,10 +364,10 @@ trait FeatureSwitches {
   )
 
   //Owner: Dotcom Commercial
-  val forceOneByOnePxSlotSwitch = Switch(
+  val ForceOneByOnePxSlotSwitch = Switch(
     SwitchGroup.Feature,
     "1x1px-slot",
-    "When ON, we will force the creation of the 1x1px adSlot for pageskins",
+    "When ON, we will force the creation of the 1x1px adSlot for surveys and pageskins globally",
     safeState = On,
     sellByDate = new LocalDate(2016, 8, 25),
     exposeClientSide = true

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -368,7 +368,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "1x1px-slot",
     "When ON, we will force the creation of the 1x1px adSlot for surveys and pageskins globally",
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2016, 8, 25),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -368,7 +368,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "1x1px-slot",
     "When ON, we will force the creation of the 1x1px adSlot for surveys and pageskins globally",
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2016, 8, 25),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -363,4 +363,14 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  //Owner: Dotcom Commercial
+  val forceOneByOnePxSlotSwitch = Switch(
+    SwitchGroup.Feature,
+    "1x1px-slot",
+    "When ON, we will force the creation of the 1x1px adSlot for pageskins",
+    safeState = On,
+    sellByDate = new LocalDate(2016, 8, 25),
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -131,7 +131,7 @@
 
         @fragments.analytics.base(page)
 
-        @if(forceOneByOnePxSlotSwitch.isSwitchedOn || page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
+        @if(ForceOneByOnePxSlotSwitch.isSwitchedOn || page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
             @fragments.commercial.pageSkin()
         }
 

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -131,7 +131,7 @@
 
         @fragments.analytics.base(page)
 
-        @if(page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
+        @if(forceOneByOnePxSlotSwitch.isSwitchedOn || page.metadata.hasPageSkinOrAdTestPageSkin(edition)) {
             @fragments.commercial.pageSkin()
         }
 


### PR DESCRIPTION
## What does this change?

Adds a switch to forces the 1x1px adslot fragment to be created. 
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots
## Request for comment

@kenlim 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
