### PR TITLE
Control player components in JS

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -215,10 +215,22 @@ define([
             }
         });
 
-
         player = createVideoPlayer(el, {
             techOrder: techPriority,
             controls: true,
+            textTrackDisplay: false,
+            textTrackSettings: false,
+            controlBar: {
+                children: [
+                    'playToggle',
+                    'currentTimeDisplay',
+                    'timeDivider',
+                    'durationDisplay',
+                    'progressControl',
+                    'fullscreenToggle',
+                    'volumeMenuButton'
+                ]
+            },
             // `autoplay` is always set to false.
             // If you are going to set autoplay to any other value, note it breaks
             // `preload="auto"` on < Chrome 35 and `preload="metadata"` on old Safari

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -238,17 +238,6 @@ $ima-controls-height: 70px;
     }
 }
 
-.vjs-custom-control-spacer,
-.vjs-live-control,
-.vjs-remaining-time,
-.vjs-playback-rate,
-.vjs-subtitles-button,
-.vjs-captions-button,
-.vjs-chapters-button,
-.vjs-caption-settings {
-    display: none;
-}
-
 .vjs-control-text {
     overflow: hidden !important; // some control texts have pseudo elements for icons, so they cannot use u-h.
     display: inline-block;


### PR DESCRIPTION
## What does this change?

We control the components in JS. This has the added benefit that the DOM of all the other gumpf is not created.

The fullscreen button is also where it should be, especially on fronts where it is hidden on mobile, making our teeny tiny videos massively unappealing.
## What is the value of this and can you measure success?

@paperboyo gives me something.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

**NOW!**
![now-player](https://cloud.githubusercontent.com/assets/31692/15544197/c115ba3e-228f-11e6-80a1-a5bb0d0c44c9.png)

**THEN!**
![then-player](https://cloud.githubusercontent.com/assets/31692/15544194/beeddaa2-228f-11e6-866c-fa6a651fe8fc.png)
## Request for comment

@akash1810 @paperboyo

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
