### PR TITLE
Lower sample rate for sentry errors

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -275,6 +275,15 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
+  val reportEmptyDfpResponsesSwitch = Switch(
+    SwitchGroup.Commercial,
+    "report-empty-dfp-responses",
+    "If on, the client will report empty dfp ad responses.",
+    safeState = Off,
+    sellByDate = new LocalDate(2016,6,8),
+    exposeClientSide = true
+  )
+
   val hostedEpisode1Content = Switch(
     SwitchGroup.Commercial,
     "hosted-episode1-content",

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -83,7 +83,7 @@ define([
                     }
 
                     return config.switches.enableSentryReporting &&
-                        Math.random() < 0.2 &&
+                        Math.random() < 0.1 &&
                         !isDev; // don't actually notify sentry in dev mode
                 }
             }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -524,17 +524,20 @@ define([
 
             // This empty slot could be caused by a targeting problem,
             // let's report these and diagnose the problem in sentry.
-            var adUnitPath = event.slot.getAdUnitPath();
-            var adTargetingMap = event.slot.getTargetingMap();
-            var adTargetingKValues = adTargetingMap ? adTargetingMap['k'] : [];
-            var adKeywords = adTargetingKValues ? adTargetingKValues.join(', ') : '';
+            // Keep the sample rate low, otherwise we'll get rate-limited (report-error will also sample down)
+            if (config.switches.reportEmptyDfpResponses && Math.random() < 0.001) {
+                var adUnitPath = event.slot.getAdUnitPath();
+                var adTargetingMap = event.slot.getTargetingMap();
+                var adTargetingKValues = adTargetingMap ? adTargetingMap['k'] : [];
+                var adKeywords = adTargetingKValues ? adTargetingKValues.join(', ') : '';
 
-            reportError(new Error('dfp returned an empty ad response'), {
-                feature: 'commercial',
-                adUnit: adUnitPath,
-                adSlot: adSlotId,
-                adKeywords: adKeywords
-            }, false);
+                reportError(new Error('dfp returned an empty ad response'), {
+                    feature: 'commercial',
+                    adUnit: adUnitPath,
+                    adSlot: adSlotId,
+                    adKeywords: adKeywords
+                }, false);
+            }
         } else {
             $adSlot = $('#' + adSlotId);
 


### PR DESCRIPTION
Reduces the number of errors being sent to sentry, because we are being rate-limited.

![giphy](https://cloud.githubusercontent.com/assets/4549425/15544636/4feed442-2291-11e6-9975-03b445cbaa44.gif)
