### PR TITLE
Stop tracking external links and download links as exit links

### DIFF
--- a/static/public/javascripts/vendor/omniture.js
+++ b/static/public/javascripts/vendor/omniture.js
@@ -12,8 +12,8 @@ s.charSet="UTF-8";
 /* Conversion Config */
 s.currencyCode="GBP";
 /* Link Tracking Config */
-s.trackDownloadLinks=true;
-s.trackExternalLinks=true;
+s.trackDownloadLinks=false;
+s.trackExternalLinks=false;
 s.trackInlineStats=true;
 s.linkDownloadFileTypes="exe,zip,wav,mp3,mov,mpg,avi,wmv,pdf,doc,docx,xls,xlsx,ppt,pptx";
 s.linkInternalFilters="javascript:,adinfo-guardian.co.uk,dating.guardian.co.uk,guardian.co.uk,guardian.greatgetaways.co.uk,guardian.lcplc-online.co.uk,guardian.oddschecker.com,guardian.pickthescore.co.uk,guardian.sportinglife.com,guardian.touch-line.com,guardian.unbiased.co.uk,guardianapis.com,guardianapps.co.uk,guardianbooks.co.uk,guardianbookshop.co.uk,guardiancottages.co.uk,guardiandigitalcomparison.co.uk,guardiandirectsubs.co.uk,guardianeatright.co.uk,guardianecostore.co.uk,guardianenergycomparison.co.uk,guardianenergycomparison.com,guardianfashionstore.co.uk,guardiangardencentre.co.uk,guardiangiftexperiences.co.uk,guardianholidayoffers.co.uk,guardianhomeexchange.co.uk,guardianhomeexchange.com,guardianinvesting.co.uk,guardianjobs.co.uk,guardianjobs.com,guardianjobs.mobi,guardianjobsrecruiter.co.uk,guardiannews.com,guardian-newspaper.com,guardianoffers.co.uk,guardianprofessional.co.uk,guardianpublic.co.uk,guardiansubscriptions.co.uk,guardiantickets.co.uk,guardianvouchercodes.co.uk,guardianweekly.co.uk,guardianweekly.com,id.guardian.co.uk,ivebeenthere.co.uk,jobs.guardian.co.uk,kable.co.uk,money-deals.co.uk,mps-expenses.guardian.co.uk,ogenterprises.co.uk,ogtravelinsurance.co.uk,sixsongsof.me,sixwordmemoirs.co.uk,smarthealthcare.com,sofacinema.co.uk,static.guim.co.uk,theguardian.co.uk,theguardian.com,traffic.outbrain.com,tvlistings.guardian.co.uk";
@@ -88,7 +88,7 @@ function s_doPlugins(s) {
 
     // Previous Site section
 	s.prop71 = s.getPreviousValue(s.channel,"s_prev_ch");
-	
+
 	s.prop50="D=User-Agent" // captures the user-agent string
     s.prop49="D=s_vi" // captures the s_vi (visitor ID) cookie value
 


### PR DESCRIPTION
## What does this change?

This stops us tracking external links and download links as exit links, which reduces the number of server calls we make to omniture
## What is the value of this and can you measure success?

Saves around £5k (£1K a month)
## Request for comment

@mkopka @desbo 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
