### PR TITLE
Add EU referendum badge switch

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -343,6 +343,15 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val EuReferendumBadgeSwitch = Switch(
+    SwitchGroup.Feature,
+    "eu-referendum-badge",
+    "When ON, a badge will be applied to all EU Referendum articles",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 7, 1),
+    exposeClientSide = false
+  )
+
   // Owner: Dotcom loyalty
   val EmailInArticleGtodaySwitch = Switch(
     SwitchGroup.Feature,

--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -1,5 +1,6 @@
 package model
 
+import conf.switches.Switches
 import conf.{Configuration, Static}
 import layout.FaciaContainer
 
@@ -8,12 +9,13 @@ case class Badge(seriesTag: String, imageUrl: String)
 object Badges {
   val usElection = Badge("us-news/us-elections-2016", Static("images/USElectionlogooffset.png").path)
   val ausElection = Badge("australia-news/australian-election-2016", Static("images/AUSElectionBadge.png").path)
-  // Temporarily Disabled until Editorial confirm
-  /* val euElection = Badge("politics/eu-referendum", Static("images/EU_Ref_Logo.svg").path) */
+  val euElection = Badge("politics/eu-referendum", Static("images/EU_Ref_Logo.svg").path)
   val euRealityCheck = Badge("politics/series/eu-referendum-reality-check", Static("images/EU_Ref_Logo.svg").path)
-  
 
-  val allBadges = Seq(usElection, ausElection, euRealityCheck)
+  val allBadges = Seq(usElection, ausElection, euRealityCheck) ++ {
+    if (Switches.EuReferendumBadgeSwitch.isSwitchedOn) Seq(euElection)
+    else Seq()
+  }
 
   def badgeFor(c: ContentType) = allBadges.find(badge => c.tags.tags.exists(tag => tag.id == badge.seriesTag))
   def badgeFor(fc: FaciaContainer) = fc.href.flatMap(href => allBadges.find(badge => href == badge.seriesTag))


### PR DESCRIPTION
...so we can turn on the badge for eu-referendum articles late on Friday (editorial request) without having to deploy.
