### PR TITLE
Unleash the fluid ads

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -257,6 +257,15 @@ trait CommercialSwitches {
     exposeClientSide = true
   )
 
+  val FluidAdverts = Switch(
+    SwitchGroup.Commercial,
+    "fluid-adverts",
+    "Request fluid adverts from DFP",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 30),
+    exposeClientSide = false
+  )
+
   val staticBadgesSwitch = Switch(
     SwitchGroup.Commercial,
     "static-badges",

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -35,9 +35,10 @@ object Commercial {
 
     def adSizes(metaData: MetaData, edition: Edition): Map[String, Seq[String]] = {
       val fabricAdvertsTop = if (FabricAdverts.isSwitchedOn) Some("88,71") else None
+      val fluidAdvertsTop = if (FluidAdverts.isSwitchedOn) Some("fluid") else None
       Map(
-        "mobile" -> (Seq("1,1", "88,70", "728,90") ++ fabricAdvertsTop),
-        "desktop" -> (Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250") ++ fabricAdvertsTop)
+        "mobile" -> (Seq("1,1", "88,70", "728,90") ++ fabricAdvertsTop ++ fluidAdvertsTop),
+        "desktop" -> (Seq("1,1", "88,70", "728,90", "940,230", "900,250", "970,250") ++ fabricAdvertsTop ++ fluidAdvertsTop)
       )
     }
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -458,6 +458,7 @@ define([
      */
 
     var callbacks = {
+        '0,0': isFluid250('ad-slot--top-banner-ad'),
         '300,251': function (event, $adSlot) {
             stickyMpu($adSlot);
         },

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -697,8 +697,8 @@ define([
      * Multiple sizes - `data-mobile="300,50|320,50"`
      */
     function createSizeMapping(attr) {
-        return map(attr.split('|'), function (size) {
-            return map(size.split(','), Number);
+        return attr.split('|').map(function (size) {
+            return size === 'fluid' ? 'fluid' : size.split(',').map(Number);
         });
     }
 


### PR DESCRIPTION
Google has added us to their alpha testers of fluid ads. Quite simply:
- we advertise our slots accept fluid ads using the `data-` attributes
- fluids ads returned by DFP use the 0x0 size

cc @jbreckmckye @kenlim @kelvin-chappell @Calanthe 
