### PR TITLE
Hosted page - mobile header size fix

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -284,8 +284,13 @@ $hosted-video-height: 540px;
     @include f-headlineSans;
 
     margin: 0;
-    font-size: 26px;
-    line-height: 26px;
+    font-size: 22px;
+    line-height: 24px;
+
+    @include mq(tablet) {
+        font-size: 26px;
+        line-height: 26px;
+    }
 
     @include mq(desktop) {
         font-size: 36px;


### PR DESCRIPTION
## What does this change?

The header size on mobile (Iphone 5 especially)
## Screenshots

Before:
![screen shot 2016-05-25 at 17 27 01](https://cloud.githubusercontent.com/assets/489567/15547968/2ff57710-229e-11e6-91ad-0a2f1a228108.png)

After:
![screen shot 2016-05-25 at 17 29 49](https://cloud.githubusercontent.com/assets/489567/15547980/36cd6dfe-229e-11e6-8350-b1b43581cec1.png)

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
