### PR TITLE
Add data-link-name to notifications sign-up button

### DIFF
--- a/static/src/javascripts/projects/common/views/ui/notifications-follow-link.html
+++ b/static/src/javascripts/projects/common/views/ui/notifications-follow-link.html
@@ -1,9 +1,9 @@
  <button class="button button--large button--tertiary js-notifications__button notifications__button notifications-follow-input--solo notifications__button--<%= isSubscribed ? 'subscribed' : 'unsubscribed' %>">
     <%= icon %>
      <% if (isSubscribed) { %>
-     <span class="live-notifications__label live-notifications__label--subscribed">Alerts on for this story</span>
+     <span class="live-notifications__label live-notifications__label--subscribed" data-link-name="live-blog-notifications-turned-off">Alerts on for this story</span>
      <% } else { %>
-     <span class="live-notifications__label live-notifications__label--unsubscribed">Get alerts for this story</span>
+     <span class="live-notifications__label live-notifications__label--unsubscribed" data-link-name="live-blog-notifications-turned-on">Get alerts for this story</span>
      <% } %>
 </button>
 


### PR DESCRIPTION
## What does this change?

Adds tracking for clicks on the liveblog notifications button.
## Request for comment

@NathanielBennett added this because @janua asked me nicely
