### PR TITLE
Video container will match "video" as well as "videos"

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/videoContainer.scala.html
@@ -25,7 +25,7 @@
         <li class="video-playlist__item video-title video-title--leftcol fc-container__header__title">
             <a class="video-title__link" href="@containerDefinition.href" data-link-name="video-container-title @containerDefinition.displayName">
                 @containerDefinition.displayName match {
-                    case Some("videos") => {
+                    case Some("video") | Some("videos") => {
                         @fragments.inlineSvg("guardian-video-logo", "logo")
                     }
 


### PR DESCRIPTION
## What does this change?

Makes it so the video container also matches the word "video" as well as "videos" to put the custom logo in place.
## Does this affect other platforms - Amp, Apps, etc?

Nah
## Request for comment

@jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
