### PR TITLE
DeploysRadiator: fix when github return commits info without author login

### DIFF
--- a/static/src/deploys-radiator/app/api.ts
+++ b/static/src/deploys-radiator/app/api.ts
@@ -43,7 +43,7 @@ export const getDifference = (base: string, head: string): Promise<List<GitHubCo
                         {
                             url: gitHubCommitJson.html_url,
                             authorName: gitHubCommitJson.commit.author.name,
-                            authorLogin: gitHubCommitJson.author.login,
+                            authorLogin: (gitHubCommitJson.author) ? gitHubCommitJson.author.login : 'Unknown',
                             message: gitHubCommitJson.commit.message
                         }
                     ))));
@@ -51,7 +51,7 @@ export const getDifference = (base: string, head: string): Promise<List<GitHubCo
                 return response.clone().json<GitHubErrorJson>()
                     // We need to re-assert the type for rejected promises
                     // https://github.com/Microsoft/TypeScript/issues/7588
-                    .then(json => Promise.reject<List<GitHubCommit>>(new Error('foo')));
+                    .then(json => Promise.reject<List<GitHubCommit>>(new Error(json.message)));
             }
         })
 );


### PR DESCRIPTION
## What does this change?

If author of a commit is not a known github account (happens if your gitconfig email doesn't match your github email for instance), github api return `null` for commit login. DeploysRadiator was not handling this case very well
## What is the value of this and can you measure success?

https://frontend.gutools.co.uk/deploys-radiator doesn't return a blank page in the case described above
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@NataliaLKB @lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
