### PR TITLE
Mobile fix for the hosted page header

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -242,13 +242,17 @@ $hosted-video-height: 540px;
 .hosted__meta {
     position: absolute;
     left: 20px;
-    bottom: 60px;
     width: 100%;
     color: #ffffff;
 
     @include mq($until: tablet) {
         right: $gs-gutter;
         width: auto;
+        bottom: 48px;
+    }
+
+    @include mq(tablet) {
+        bottom: 60px;
     }
 
     @include mq(desktop) {


### PR DESCRIPTION
## Screenshots

Before:
![screen shot 2016-05-26 at 11 07 29](https://cloud.githubusercontent.com/assets/489567/15571439/9fec112a-2332-11e6-8536-afdac40bb16a.png)

After:
![screen shot 2016-05-26 at 11 06 55](https://cloud.githubusercontent.com/assets/489567/15571443/a62ad35a-2332-11e6-83a9-d037dd70aeac.png)

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
