### PR TITLE
Update scala version to 2.11.8

### DIFF
--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -23,7 +23,7 @@ trait Prototypes {
       "-Xcheckinit", "-encoding", "utf8", "-feature", "-Yinline-warnings","-Xfatal-warnings"),
     doc in Compile <<= target.map(_ / "none"),
     incOptions := incOptions.value.withNameHashing(true),
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.8",
     initialize := {
       val _ = initialize.value
       assert(sys.props("java.specification.version") == "1.8",


### PR DESCRIPTION
## What does this change?

Update scala version to lastest stable one.
The [2.11.8 version](http://www.scala-lang.org/news/2.11.8/) fixes [44 issues](https://issues.scala-lang.org/browse/SI-9508?jql=project%20%3D%20SI%20AND%20resolution%20%3D%20Fixed%20AND%20fixVersion%20in%20%28%22Scala%202.11.8%22%29%20ORDER%20BY%20component%20ASC%2C%20priority%20DESC).
