### PR TITLE
Remove server-side A/B tests variants

### DIFF
--- a/admin/app/views/fragments/serverBasedTests.scala.html
+++ b/admin/app/views/fragments/serverBasedTests.scala.html
@@ -11,13 +11,11 @@
             <table class="table table-bordered ">
                 <thead>
                     <th colspan="4">Name</th>
-                    <th colspan="3">Allocated variants</th>
                 </thead>
                 <tbody>
                     @tests.map { test =>
                         <tr>
                             <td colspan="4">@test.name @status(test)</td>
-                            <td colspan="3">@{test.variants.map(_.name).sorted.mkString(", ")}</td>
                         </tr>
                     }
                     @if(tests.isEmpty) {

--- a/common/app/common/Edition.scala
+++ b/common/app/common/Edition.scala
@@ -165,9 +165,3 @@ object InternationalEdition {
     }
   }
 }
-
-object InternationalEditionVariant {
-
-  def apply(request: RequestHeader): Option[String] = request.headers.get("X-GU-International")
-
-}

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -1,7 +1,5 @@
 package mvt
 
-import MultiVariateTesting._
-import common.InternationalEditionVariant
 import conf.switches.{SwitchGroup, Switch}
 import org.joda.time.LocalDate
 import play.api.mvc.RequestHeader
@@ -19,78 +17,67 @@ import conf.switches.Switches.ServerSideTests
 // }
 
 object ABOpenGraphOverlay extends TestDefinition(
-  variants = Nil,
   name = "ab-open-graph-overlay",
   description = "Add a branded overlay to images cached by the Facebook crawler",
   sellByDate = new LocalDate(2016, 6, 29)
 ) {
   override def isParticipating(implicit request: RequestHeader): Boolean = {
-    request.queryString.get("page").exists(_.contains("facebookOverlayVariant")) && switch.isSwitchedOn && ServerSideTests.isSwitchedOn
+    request.queryString.get("page").exists(_.contains("facebookOverlayVariant")) && super.isParticipating(request)
   }
 }
 
 
 object ABHeadlinesTestVariant extends TestDefinition(
-  Nil,
   "headlines-ab-variant",
   "To test how much of a difference changing a headline makes (variant group)",
   new LocalDate(2016, 6, 10)
   ) {
   override def isParticipating(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-hlt").contains("hlt-V") && switch.isSwitchedOn && ServerSideTests.isSwitchedOn
-    }
+    request.headers.get("X-GU-hlt").contains("hlt-V") && super.isParticipating(request)
+  }
 }
 
 object ABNewHeaderVariant extends TestDefinition(
-  variants = Nil,
   name = "ab-new-header-variant",
   description = "Feature switch (0% test) for the new header",
   sellByDate = new LocalDate(2016, 6, 14)
 ) {
   override def isParticipating(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-new-header").contains("variant") && switch.isSwitchedOn && ServerSideTests.isSwitchedOn
+    request.headers.get("X-GU-ab-new-header").contains("variant") && super.isParticipating(request)
   }
 }
 
 object ABHeadlinesTestControl extends TestDefinition(
-  Nil,
   "headlines-ab-control",
   "To test how much of a difference changing a headline makes (control group)",
   new LocalDate(2016, 6, 10)
   ) {
   override def isParticipating(implicit request: RequestHeader): Boolean = {
-      request.headers.get("X-GU-hlt").contains("hlt-C") && switch.isSwitchedOn && ServerSideTests.isSwitchedOn
-    }
+    request.headers.get("X-GU-hlt").contains("hlt-C") && super.isParticipating(request)
+  }
 }
 
-object ActiveTests extends Tests {
+trait ServerSideABTests {
+  val tests: Seq[TestDefinition]
+
+  def getJavascriptConfig(implicit request: RequestHeader): String = {
+    tests
+      .filter(_.isParticipating)
+      .map { test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}""" }
+      .mkString(",")
+  }
+}
+
+object ActiveTests extends ServerSideABTests {
   val tests: Seq[TestDefinition] = List(
     ABOpenGraphOverlay,
     ABNewHeaderVariant,
     ABHeadlinesTestControl,
     ABHeadlinesTestVariant
   )
-
-  def getJavascriptConfig(implicit request: RequestHeader): String = {
-
-    val headlineTests = List(ABHeadlinesTestControl, ABHeadlinesTestVariant).filter(_.isParticipating)
-                          .map{ test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}"""}
-    val newHeaderTests = List(ABNewHeaderVariant).filter(_.isParticipating)
-                          .map{ test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}"""}
-    val internationalEditionTests = List(InternationalEditionVariant(request)
-                                      .map{ international => s""""internationalEditionVariant" : "$international" """}).flatten
-
-    val activeTest = List(ActiveTests.getParticipatingTest(request)
-                        .map{ test => s""""${CamelCase.fromHyphenated(test.name)}" : ${test.switch.isSwitchedOn}"""}).flatten
-
-    val configEntries = activeTest ++ internationalEditionTests ++ headlineTests ++ newHeaderTests
-
-    configEntries.mkString(",")
-  }
 }
 
 case class TestDefinition (
-  variants: Seq[Variant],
   name: String,
   description: String,
   sellByDate: LocalDate
@@ -103,40 +90,5 @@ case class TestDefinition (
     sellByDate,
     exposeClientSide = true
   )
-
-  def isParticipating(implicit request: RequestHeader): Boolean = {
-    ActiveTests.getParticipatingTest(request).contains(this)
-  }
-}
-
-trait Tests {
-
-  protected def tests: Seq[TestDefinition]
-
-  def getParticipatingTest(request: RequestHeader): Option[TestDefinition] = {
-    getVariant(request).flatMap { variant =>
-      tests.find { test =>
-        test.variants.contains(variant) &&
-        test.switch.isSwitchedOn &&
-        ServerSideTests.isSwitchedOn
-      }
-    }
-  }
-
-  def isParticipatingInATest(request: RequestHeader): Boolean = getParticipatingTest(request).isDefined
-}
-
-object MultiVariateTesting {
-
-  sealed case class Variant(name: String)
-
-  private[mvt] val allVariants = List[Variant]()
-
-  def getVariant(request: RequestHeader): Option[Variant] = {
-    val cdnVariant: Option[String] = request.headers.get("X-GU-mvt-variant")
-
-    cdnVariant.flatMap( variantName => {
-      allVariants.find(_.name == variantName)
-    })
-  }
+  def isParticipating(implicit request: RequestHeader): Boolean = switch.isSwitchedOn && ServerSideTests.isSwitchedOn
 }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -21,8 +21,8 @@ object ABOpenGraphOverlay extends TestDefinition(
   description = "Add a branded overlay to images cached by the Facebook crawler",
   sellByDate = new LocalDate(2016, 6, 29)
 ) {
-  override def isParticipating(implicit request: RequestHeader): Boolean = {
-    request.queryString.get("page").exists(_.contains("facebookOverlayVariant")) && super.isParticipating(request)
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.queryString.get("page").exists(_.contains("facebookOverlayVariant"))
   }
 }
 
@@ -32,8 +32,8 @@ object ABHeadlinesTestVariant extends TestDefinition(
   "To test how much of a difference changing a headline makes (variant group)",
   new LocalDate(2016, 6, 10)
   ) {
-  override def isParticipating(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-hlt").contains("hlt-V") && super.isParticipating(request)
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-hlt").contains("hlt-V")
   }
 }
 
@@ -42,8 +42,8 @@ object ABNewHeaderVariant extends TestDefinition(
   description = "Feature switch (0% test) for the new header",
   sellByDate = new LocalDate(2016, 6, 14)
 ) {
-  override def isParticipating(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-ab-new-header").contains("variant") && super.isParticipating(request)
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-ab-new-header").contains("variant")
   }
 }
 
@@ -52,8 +52,8 @@ object ABHeadlinesTestControl extends TestDefinition(
   "To test how much of a difference changing a headline makes (control group)",
   new LocalDate(2016, 6, 10)
   ) {
-  override def isParticipating(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-hlt").contains("hlt-C") && super.isParticipating(request)
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-hlt").contains("hlt-C")
   }
 }
 
@@ -77,7 +77,7 @@ object ActiveTests extends ServerSideABTests {
   )
 }
 
-case class TestDefinition (
+abstract case class TestDefinition (
   name: String,
   description: String,
   sellByDate: LocalDate
@@ -90,5 +90,10 @@ case class TestDefinition (
     sellByDate,
     exposeClientSide = true
   )
-  def isParticipating(implicit request: RequestHeader): Boolean = switch.isSwitchedOn && ServerSideTests.isSwitchedOn
+
+  private def isSwitchedOn: Boolean = switch.isSwitchedOn && ServerSideTests.isSwitchedOn
+
+  def canRun(implicit request: RequestHeader): Boolean
+  def isParticipating(implicit request: RequestHeader): Boolean = isSwitchedOn && canRun(request)
+
 }

--- a/common/test/common/MultiVariateTestingTest.scala
+++ b/common/test/common/MultiVariateTestingTest.scala
@@ -41,14 +41,16 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
       "test0",
       "an experiment test",
       new LocalDate(2100, 1, 1)
-    )
+    ) {
+      def canRun(implicit request: RequestHeader): Boolean = true
+    }
     object test1 extends TestDefinition(
       "test1",
       "another experiment test",
       new LocalDate(2100, 1, 1)
     ) {
-      override def isParticipating(implicit request: RequestHeader): Boolean = {
-        request.headers.get("X-GU-Test1").contains("test1variant") && super.isParticipating(request)
+      def canRun(implicit request: RequestHeader): Boolean = {
+        request.headers.get("X-GU-Test1").contains("test1variant")
       }
     }
     object test2 extends TestDefinition(
@@ -56,8 +58,8 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
       "still another experiment test",
       new LocalDate(2100, 1, 1)
     ) {
-      override def isParticipating(implicit request: RequestHeader): Boolean = {
-        request.headers.get("X-GU-Test2").contains("test2variant") && super.isParticipating(request)
+      def canRun(implicit request: RequestHeader): Boolean = {
+        request.headers.get("X-GU-Test2").contains("test2variant")
       }
     }
 

--- a/common/test/common/MultiVariateTestingTest.scala
+++ b/common/test/common/MultiVariateTestingTest.scala
@@ -1,54 +1,78 @@
 package mvt
 
 import org.joda.time.LocalDate
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.{FlatSpec, Matchers}
+import play.api.mvc.RequestHeader
 import test.TestRequest
 
 class MultiVariateTestingTest extends FlatSpec with Matchers {
 
   conf.switches.Switches.ServerSideTests.switchOn
 
-  "active mvt tests" should "not have duplicate variants" in {
-    val variantsInUse = mvt.ActiveTests.tests.flatMap(_.variants)
-    variantsInUse.size should equal (variantsInUse.distinct.size)
-  }
-
-  // TODO: refactor MultiVariateTesting to remove site-wide variants
-  // This test is only here to ensure nobody adds variants by accident before this refactoring happens
-  // Talk to Thomas Bonnin if you have any question
-  "MultiVariateTesting" should "have no variant" in {
-    MultiVariateTesting.allVariants.size should equal (0)
-  }
-
-  "a request with an invalid test header" should "be ignored" in {
-    val testRequest = TestRequest("/uk")
-      .withHeaders(
-        "X-GU-mvt-variant" -> "variant-invalid"
-      )
-    MultiVariateTesting.getVariant(testRequest) should be (None)
-    TestCases.isParticipatingInATest(testRequest) should be (false)
-    TestCases.getParticipatingTest(testRequest) should be (None)
-  }
-
   "a test definition" should "have a default switch state to off" in {
     TestCases.test0.switch.isSwitchedOff should be (true)
   }
 
-  object TestCases extends Tests {
+  "A test definition" should "know if a given request is participating" in EnabledTests {
+    val testRequest = TestRequest("/uk")
+      .withHeaders(
+        "X-GU-Test1" -> "test1variant"
+      )
+    TestCases.test0.isParticipating(testRequest) should be (true)
+    TestCases.test1.isParticipating(testRequest) should be (true)
+    TestCases.test2.isParticipating(testRequest) should be (false)
+  }
+
+  "ActiveTests" should "returns proper javascript config" in EnabledTests {
+    object AllAbTests extends ServerSideABTests {
+      val tests: Seq[TestDefinition] = TestCases.tests
+    }
+    val testRequest = TestRequest("/myPage")
+      .withHeaders(
+        "X-GU-Test2" -> "test2variant"
+      )
+    val jsConfig = AllAbTests.getJavascriptConfig(testRequest)
+    jsConfig should be("\"test0\" : true,\"test2\" : true")
+
+  }
+
+  object TestCases {
     object test0 extends TestDefinition(
-      Nil,
       "test0",
       "an experiment test",
       new LocalDate(2100, 1, 1)
-
     )
     object test1 extends TestDefinition(
-      Nil,
       "test1",
-      "an experiment test",
+      "another experiment test",
       new LocalDate(2100, 1, 1)
-    )
+    ) {
+      override def isParticipating(implicit request: RequestHeader): Boolean = {
+        request.headers.get("X-GU-Test1").contains("test1variant") && super.isParticipating(request)
+      }
+    }
+    object test2 extends TestDefinition(
+      "test2",
+      "still another experiment test",
+      new LocalDate(2100, 1, 1)
+    ) {
+      override def isParticipating(implicit request: RequestHeader): Boolean = {
+        request.headers.get("X-GU-Test2").contains("test2variant") && super.isParticipating(request)
+      }
+    }
 
-    val tests = List(test0, test1)
+    val tests = List(test0, test1, test2)
   }
+
+  trait EnabledTests {
+
+    def apply[T](block: => T): T = {
+      TestCases.tests.foreach(_.switch.switchOn)
+      val result = block
+      TestCases.tests.foreach(_.switch.switchOff)
+      result
+    }
+  }
+
+  object EnabledTests extends EnabledTests
 }


### PR DESCRIPTION
## What does this change?

We used to have 10 variants (each of the representing 1% of our traffic)
which you can assign server-side a/b tests to.
However this was creating 10 CDN 'buckets' for each url and therefore
reduced our cache/hit ratio and cost us a lot of money.
We are moving away from this system: this patch is removing the
remaining variants and refactor slightly the MultiVariateTesting file

I guess this server-side code can disappear fully once the current tests has been run and the new a/b test framework Dom, Sam, etc... are working on

A PR to fastly-edge-cache will follow. :)
## What is the value of this and can you measure success?

Removing all variants CDN-side as well as making the code less confusing regarding what it is allowed and what it is not.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell 
FYI @desbo @dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
