### PR TITLE
Expect explicit targeted high merch

### DIFF
--- a/admin/app/views/commercial/highMerchandisingTargetedTags.scala.html
+++ b/admin/app/views/commercial/highMerchandisingTargetedTags.scala.html
@@ -9,10 +9,10 @@
 
     <p>Article page will render a high-merchandising slot in the contentFooter when following conditions are met :</p>
     <ol>
-        <li>There is an available Line item that is targeting the <em>merchandising-high</em> slot <b>AND</b> has:</li>
-        <li>A keyword target that matches one of the page keyword tags (or no targeted tags)</li>
-        <li>An edition target that matches the page Edition (or no edition target)</li>
-        <li>A url target that matches the page url (or no url target)</li>
+        <li>There is an available Line item that is targeting the <em>merchandising-high</em> slot <b>AND</b> at least one of:</li>
+        <li>A tag target that matches one of the page tags</li>
+        <li>An edition target that matches the page Edition</li>
+        <li>A url target that matches the page url</li>
         <li>An adUnit target that matches the page adUnit</li>
     </ol>
 
@@ -24,25 +24,34 @@
                 <tr>
                     <th class="col-md-3">Name</th>
                     <th class="col-md-1">DFP link</th>
-                    <th class="col-md-4">Tags</th>
-                    <th class="col-md-3">DFP adUnits</th>
+                    <th class="col-md-2">Tags</th>
+                    <th class="col-md-3">AdUnits</th>
                     <th class="col-md-1">Editions</th>
+                    <th class="col-md-2">Urls</th>
                 </tr>
             </thead>
             <tbody>
                 @for(lineItem <- report.lineItems.sortedItems) {
                     <tr>
-                        <td>@{lineItem.name}</td>
+                        <td>@{lineItem.name}
+                            @if(lineItem.hasUnknownTarget){
+                                <span class="label label-danger">no targeting</span>
+                            }
+                        </td>
                         <td><a href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a></td>
                         <td>@{lineItem.tags.mkString(", ")}</td>
-                        <td>@for(adUnit <- lineItem.adUnits) {
-                            <div>
-                                <a href="@DfpLink.adUnit(adUnit.id)">@{adUnit.fullPath}</a>
-                            </div>
-                        }</td>
-                        @if(lineItem.editions.isEmpty){
-                        <td>none</td>} else {
-                        <td>@{lineItem.editions}</td>}
+                        <td>
+                            @for(adUnit <- lineItem.adUnits) {
+                                <div>
+                                    <a href="@DfpLink.adUnit(adUnit.id)">@{adUnit.fullPath}</a>
+                                </div>
+                            }
+                            @if(lineItem.isRunOfNetwork) {
+                                <div class="alert alert-warning">Run of network</div>
+                            }
+                        </td>
+                        <td>@{lineItem.editions.mkString(", ")}</td>
+                        <td>@{lineItem.urls.mkString(", ")}</td>
                     </tr>
                 }
             </tbody>

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -92,19 +92,16 @@ case class HighMerchandisingLineItem(
   def matchesPageTargeting (adUnitSuffix: String, pageTags:Seq[Tag], edition:Edition, pagePath:String): Boolean = {
 
     val cleansedPageEdition = edition.id.toLowerCase
-
     val cleansedPageTagNames = pageTags map (_.name.replaceAll(" ","-").toLowerCase)
 
-    val matchesTag: Boolean = cleansedPageTagNames.exists(tags.contains)
+    val matchesAdUnit = adUnits.isEmpty || adUnits.exists(_.path contains adUnitSuffix)
+    val matchesTag = cleansedPageTagNames.isEmpty || cleansedPageTagNames.exists(tags.contains)
+    val matchesEdition = editions.isEmpty || editions.contains(cleansedPageEdition)
+    val matchesUrl = urls.isEmpty || urls.contains(pagePath)
 
-    // This does not accept run of network. High merch line items must be explicitly targeted.
-    val matchesAdUnit: Boolean = adUnits.exists(_.path contains adUnitSuffix)
-
-    val matchesEdition: Boolean = editions.contains(cleansedPageEdition)
-
-    val matchesUrl: Boolean = urls.contains(pagePath)
-
-    matchesTag || matchesAdUnit || matchesEdition || matchesUrl
+    // High-merch line items must be explicitly targeted to something, so if there is no kind of targeting,
+    // then the match fails.
+    matchesAdUnit && matchesTag && matchesEdition && matchesUrl && !hasUnknownTarget
   }
 }
 


### PR DESCRIPTION
Tweaks the high merch slot decision making, so that we only render a high merch slot when we find a line item that explicit matches the page requested. This means that if a line item does not target anything, it doesn't match all the pages on our site. DFP would consider this situation to be run-of-network, but we don't roll high merch across the whole site.

Also updated the admin page so we can easily spot high merch line items that don't have any targeting.
