### PR TITLE
hide cursor when inactive over video

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -68,6 +68,10 @@ $ima-controls-height: 70px;
     &.gu-media--video { // aspect ratio fix (this element gets given a fixed height by video.js)
         height: auto !important;
         cursor: pointer;
+        
+        &.vjs-user-inactive {
+            cursor: none;
+        }
     }
     &.gu-media--audio {
         position: relative;


### PR DESCRIPTION
## What does this change?

cursor can be distracting when watching video
## What is the value of this and can you measure success?

less distraction = better UX.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

Before
![before](https://cloud.githubusercontent.com/assets/836140/15580353/493861ca-2360-11e6-8801-c2cad8dc0c06.gif)

After
![after](https://cloud.githubusercontent.com/assets/836140/15580372/602978ec-2360-11e6-96ed-bf489ff21fdc.gif)
## Request for comment

@jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
