### PR TITLE
Change `req.latency` log field type to integer

### DIFF
--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -23,7 +23,7 @@ class RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
         "req.method" -> rh.method,
         "req.url" -> rh.uri,
         "req.id" -> pseudoId.toString,
-        "req.latency_ms" -> stopWatch.elapsed.toString
+        "req.latency_millis" -> stopWatch.elapsed
       )
       //TODO: add all/some request headers fields
       appendEntries(fields.asJava)


### PR DESCRIPTION
## What does this change?

Change `req.latency` log field type to integer. (it is a string right now)
## What is the value of this and can you measure success?

so we can do percentile aggregations in Kibana/ES
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
