### PR TITLE
Passing healthcheck refresh interval as config param

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -78,6 +78,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val urls = properties map { property =>
       configuration.getStringProperty(property).get
     }
+    lazy val updateIntervalInSecs: Int = configuration.getIntegerProperty("healthcheck.updateIntervalInSecs").getOrElse(5)
   }
 
   object debug {

--- a/common/conf/env/CODE.properties
+++ b/common/conf/env/CODE.properties
@@ -107,4 +107,5 @@ guardian.page.dfp.facebookIaAdUnitRoot=facebook-instant-articles
 notifications.latest_message.url=https://notifications.gu-web.net/messages
 notifications.subscriptions_table=frontend-notifications
 
-
+#HealthCheck refresh interval (0 = no update on regular schedule)
+healthcheck.updateIntervalInSecs=5

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -109,3 +109,6 @@ notifications.subscriptions_table=frontend-notifications-DEV
 
 # Deploys-radiator
 deploys-notify.api.key=this-is-the-dev-api-key
+
+#HealthCheck refresh interval (0 = no update on regular schedule)
+healthcheck.updateIntervalInSecs=0

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -106,3 +106,6 @@ guardian.page.dfp.mobileAppsAdUnitRoot=beta-guardian-app
 #Browser Notifications
 notifications.latest_message.url=https://notifications.gu-web.net/messages
 notifications.subscriptions_table=frontend-notifications
+
+#HealthCheck refresh interval (0 = no update on regular schedule)
+healthcheck.updateIntervalInSecs=5


### PR DESCRIPTION
## What does this change?

Passing healthcheck refresh interval as config param
## What is the value of this and can you measure success?

Healthcheck is only used by ELB and it could be annoying when debugging
in dev locally.
Passing the interval value as a config variable allows to have different
value depending on the STAGE and even disabling it if necessary
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
