### PR TITLE
set videoDuration on article config

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -350,6 +350,10 @@ object Article {
     val fields = content.fields
     val bookReviewIsbn = content.isbn.map { i: String => Map("isbn" -> JsString(i)) }.getOrElse(Map())
 
+    // we don't serve pre-roll if there are multiple videos in an article
+    // `headOption` as the video could be main media or a regular embed, so just get the first video
+    val videoDuration = content.elements.videos.headOption.map { v => JsNumber(v.videos.duration) }.getOrElse(JsNull)
+
     val javascriptConfig: Map[String, JsValue] = Map(
       ("isLiveBlog", JsBoolean(content.tags.isLiveBlog)),
       ("inBodyInternalLinkCount", JsNumber(content.linkCounts.internal)),
@@ -359,7 +363,8 @@ object Article {
       ("lightboxImages", lightbox.javascriptConfig),
       ("hasMultipleVideosInPage", JsBoolean(content.hasMultipleVideosInPage)),
       ("isImmersive", JsBoolean(content.isImmersive)),
-      ("isSensitive", JsBoolean(fields.sensitive.getOrElse(false)))
+      ("isSensitive", JsBoolean(fields.sensitive.getOrElse(false))),
+      ("videoDuration" -> videoDuration)
     ) ++ bookReviewIsbn
 
     val opengraphProperties: Map[String, String] = Map(

--- a/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
+++ b/static/src/javascripts/projects/common/modules/commercial/build-page-targeting.js
@@ -170,7 +170,7 @@ define([
                 fr:      getVisitedValue(),
                 tn:      uniq(compact([page.sponsorshipType].concat(parseIds(page.tones)))),
                 // round video duration up to nearest 30 multiple
-                vl:      page.contentType === 'Video' ? (Math.ceil(page.videoDuration / 30.0) * 30).toString() : undefined
+                vl:      page.videoDuration ? (Math.ceil(page.videoDuration / 30.0) * 30).toString() : undefined
             }, audienceScienceGateway.getSegments());
 
         // filter out empty values


### PR DESCRIPTION
## What does this change?

Currently, we serve ads on embedded videos regardless of their duration. This allows the `vl` value to be sent to the ad-server to decide if pre-roll should be served on video.
## What is the value of this and can you measure success?
- No pre-roll on embedded videos < 30 seconds = better UX.
- We obey our own ad-rules.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

![screen shot 2016-05-27 at 14 53 53](https://cloud.githubusercontent.com/assets/836140/15610045/311a9dd6-241b-11e6-9865-3a0ee7b92a2f.jpeg)
## Request for comment

@kenlim @jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
