### PR TITLE
Respect order of tags when selecting a badge

### DIFF
--- a/common/app/model/Badges.scala
+++ b/common/app/model/Badges.scala
@@ -17,6 +17,9 @@ object Badges {
     else Seq()
   }
 
-  def badgeFor(c: ContentType) = allBadges.find(badge => c.tags.tags.exists(tag => tag.id == badge.seriesTag))
+  def badgeFor(c: ContentType) = c.tags.tags.map(_.id).foldLeft(None: Option[Badge]) { (maybeBadge, tag) =>
+      maybeBadge orElse allBadges.find(b => b.seriesTag == tag)
+  }
+
   def badgeFor(fc: FaciaContainer) = fc.href.flatMap(href => allBadges.find(badge => href == badge.seriesTag))
 }


### PR DESCRIPTION
## What does this change?

Article badges will be selected according to the order of tags, so the first tag with a matching badge is used.
## What is the value of this and can you measure success?

fixes a bug 
## Screenshots

before: 
![screen shot 2016-05-27 at 14 59 39](https://cloud.githubusercontent.com/assets/1064734/15610144/ad746240-241b-11e6-99b4-f884308f1666.png)

after:
![screen shot 2016-05-27 at 14 58 39](https://cloud.githubusercontent.com/assets/1064734/15610154/ba5dcfa0-241b-11e6-9965-aaebd2870048.png)
## Request for comment

@stephanfowler 
