### PR TITLE
Add Euro 2016 to the list of football competitions ⚽ 

### DIFF
--- a/admin/app/football/model/PA.scala
+++ b/admin/app/football/model/PA.scala
@@ -36,8 +36,8 @@ object PA extends Collections {
   val approvedCompetitions = List(
     "100", "500", "510", "300", "301", "101", "102",
     "103", "400", "120", "121", "122", "123", "320",
-    "321", "700", "721", "650", "620", "625", "635",
-    "870"
+    "321", "700", "721", "750", "650", "620", "625",
+    "635", "870"
   )
 
   def filterCompetitions(competitions: List[Season]): List[Season] = {

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -20,6 +20,7 @@ case class TablesPage(
 object LeagueTableController extends Controller with Logging with CompetitionTableFilters with ExecutionContexts {
 
     val tableOrder = Seq(
+        "Euro 2016",
         "Premier League",
         "La Liga",
         "Bundesliga",

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -120,6 +120,7 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
     Competition("121", "/football/scottish-championship", "Scottish Championship", "Scottish Championship", "Scottish", showInTeamsList = true, tableDividers = List(1, 8, 9)),
     Competition("122", "/football/scottish-league-one", "Scottish League One", "Scottish League One", "Scottish", showInTeamsList = true, tableDividers = List(1, 4, 8, 9)),
     Competition("123", "/football/scottish-league-two", "Scottish League Two", "Scottish League Two", "Scottish", showInTeamsList = true, tableDividers = List(1, 4)),
+    Competition("750", "/football/euro-2016", "Euro 2016", "Euro", "Internationals"),
     Competition("751", "/football/euro-2016-qualifiers", "Euro 2016 qualifying", "Euro 2016 qual.", "Internationals"),
     Competition("501", "/football/champions-league-qualifying", "Champions League qualifying", "Champions League qual.", "European"),
     Competition("510", "/football/uefa-europa-league", "Europa League", "Europa League", "European", tableDividers = List(2)),
@@ -128,7 +129,6 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
     Competition("320", "/football/scottishcup", "Scottish Cup", "Scottish Cup", "Scottish"),
     Competition("321", "/football/cis-insurance-cup", "Scottish League Cup", "Scottish League Cup", "Scottish"),
     Competition("721", "/football/friendlies", "International friendlies", "Friendlies", "Internationals"),
-    Competition("750", "/football/euro-2016", "Euro 2016", "Euro", "Internationals"),
     Competition("870", "/football/women-s-world-cup-2015", "Women's World Cup 2015", "Women's World Cup", "Internationals", showInTeamsList = true, tableDividers = List(2))
 
   )

--- a/sport/app/football/feed/Competitions.scala
+++ b/sport/app/football/feed/Competitions.scala
@@ -128,6 +128,7 @@ trait Competitions extends LiveMatches with Logging with implicits.Collections w
     Competition("320", "/football/scottishcup", "Scottish Cup", "Scottish Cup", "Scottish"),
     Competition("321", "/football/cis-insurance-cup", "Scottish League Cup", "Scottish League Cup", "Scottish"),
     Competition("721", "/football/friendlies", "International friendlies", "Friendlies", "Internationals"),
+    Competition("750", "/football/euro-2016", "Euro 2016", "Euro", "Internationals"),
     Competition("870", "/football/women-s-world-cup-2015", "Women's World Cup 2015", "Women's World Cup", "Internationals", showInTeamsList = true, tableDividers = List(2))
 
   )


### PR DESCRIPTION
## What does this change?

Add Euro 2016 to the list of football competitions
## What is the value of this and can you measure success?

So you can see fixtures and results for the Euro 2016 games ⚽ ⚽ ⚽ 
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell 
@alexduf will do the same for MAPI

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
