### PR TITLE
Lifecycle batch 1

### DIFF
--- a/admin-jobs/app/Global.scala
+++ b/admin-jobs/app/Global.scala
@@ -1,24 +1,33 @@
 import common.Logback.Logstash
-import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
-import conf.AdminJobsHealthCheckLifeCycle
+import common.{LifecycleComponent, BackwardCompatibleLifecycleComponents, CloudWatchApplicationMetrics, ContentApiMetrics}
+import conf.InjectedCachedHealthCheckLifeCycle
 import conf.switches.SwitchboardLifecycle
 import contentapi.SectionsLookUpLifecycle
+import controllers.HealthCheck
 import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
+import play.api.inject.ApplicationLifecycle
+import play.api.GlobalSettings
 import services.ConfigAgentLifecycle
 
-object Global extends ConfigAgentLifecycle
+import scala.concurrent.ExecutionContext
+
+object Global extends GlobalSettings with BackwardCompatibleLifecycleComponents
+with ConfigAgentLifecycle
 with CloudWatchApplicationMetrics
 with SurgingContentAgentLifecycle
 with SectionsLookUpLifecycle
 with SwitchboardLifecycle
-with Logstash
-with AdminJobsHealthCheckLifeCycle {
+with Logstash {
   override lazy val applicationName = "frontend-admin-jobs"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ List(
     ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.HttpLatencyTimingMetric,
     ContentApiMetrics.ContentApiErrorMetric
+  )
+
+  override def lifecycleComponents(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext): List[LifecycleComponent] = List(
+    new InjectedCachedHealthCheckLifeCycle(HealthCheck)
   )
 }

--- a/admin-jobs/app/conf/HealthCheck.scala
+++ b/admin-jobs/app/conf/HealthCheck.scala
@@ -1,8 +1,0 @@
-package conf
-
-import controllers.HealthCheck
-
-
-trait AdminJobsHealthCheckLifeCycle extends CachedHealthCheckLifeCycle {
-  override val healthCheckController = HealthCheck
-}

--- a/admin/app/Global.scala
+++ b/admin/app/Global.scala
@@ -1,24 +1,31 @@
-import common.CloudWatchApplicationMetrics
+import common.{LifecycleComponent, BackwardCompatibleLifecycleComponents, CloudWatchApplicationMetrics}
 import common.Logback.Logstash
 import common.dfp.DfpAgentLifecycle
+import conf.InjectedCachedHealthCheckLifeCycle
 import conf.switches.SwitchboardLifecycle
-import controllers.AdminHealthCheckLifeCycle
+import controllers.HealthCheck
 import dfp.DfpDataCacheLifecycle
 import model.AdminLifecycle
 import ophan.SurgingContentAgentLifecycle
-import play.api.mvc.{RequestHeader, Results}
+import play.api.GlobalSettings
+import play.api.inject.ApplicationLifecycle
 import services.ConfigAgentLifecycle
 
-object Global extends AdminLifecycle
+import scala.concurrent.ExecutionContext
+
+object Global extends GlobalSettings with BackwardCompatibleLifecycleComponents
   with ConfigAgentLifecycle
   with SwitchboardLifecycle
   with CloudWatchApplicationMetrics
-  with Results
   with SurgingContentAgentLifecycle
   with DfpAgentLifecycle
-  with DfpDataCacheLifecycle
-  with Logstash
-  with AdminHealthCheckLifeCycle {
+  with Logstash {
 
   override lazy val applicationName = "frontend-admin"
+
+  def lifecycleComponents(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext): List[LifecycleComponent] = List(
+    new AdminLifecycle(appLifecycle),
+    new DfpDataCacheLifecycle(appLifecycle),
+    new InjectedCachedHealthCheckLifeCycle(HealthCheck)
+  )
 }

--- a/admin/app/controllers/HealthCheck.scala
+++ b/admin/app/controllers/HealthCheck.scala
@@ -1,9 +1,5 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, CachedHealthCheckLifeCycle}
+import conf.AllGoodCachedHealthCheck
 
 object HealthCheck extends AllGoodCachedHealthCheck(9001, "/login")
-
-trait AdminHealthCheckLifeCycle extends CachedHealthCheckLifeCycle {
-  override val healthCheckController = HealthCheck
-}

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -2,19 +2,25 @@ package model
 
 import java.util.TimeZone
 
-import common.{AkkaAsync, Jobs, Logging}
+import common.{LifecycleComponent, AkkaAsync, Jobs, Logging}
 import conf.Configuration
 import conf.Configuration.environment
 import conf.switches.Switches._
 import football.feed.MatchDayRecorder
 import jobs._
-import play.api.GlobalSettings
+import play.api.inject.ApplicationLifecycle
 import services.EmailService
 import tools.{AssetMetricsCache, CloudWatch, LoadBalancer}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
-trait AdminLifecycle extends GlobalSettings with Logging {
+class AdminLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
+
+  appLifecycle.addStopHook { () => Future {
+    descheduleJobs()
+    CloudWatch.shutdown()
+    EmailService.shutdown()
+  }}
 
   lazy val adminPressJobStandardPushRateInMinutes: Int = Configuration.faciatool.adminPressJobStandardPushRateInMinutes
   lazy val adminPressJobHighPushRateInMinutes: Int = Configuration.faciatool.adminPressJobHighPushRateInMinutes
@@ -119,8 +125,7 @@ trait AdminLifecycle extends GlobalSettings with Logging {
     Jobs.deschedule("AssetMetricsCache")
   }
 
-  override def onStart(app: play.api.Application): Unit = {
-    super.onStart(app)
+  override def start(): Unit = {
     descheduleJobs()
     scheduleJobs()
 
@@ -129,12 +134,5 @@ trait AdminLifecycle extends GlobalSettings with Logging {
       VideoEncodingsJob.run()
       AssetMetricsCache.run()
     }
-  }
-
-  override def onStop(app: play.api.Application): Unit = {
-    descheduleJobs()
-    CloudWatch.shutdown()
-    EmailService.shutdown()
-    super.onStop(app)
   }
 }

--- a/applications/app/Global.scala
+++ b/applications/app/Global.scala
@@ -1,24 +1,28 @@
 import common.Logback.Logstash
 import common.dfp.DfpAgentLifecycle
-import common.{CloudWatchApplicationMetrics, ContentApiMetrics, EmailSubsciptionMetrics}
+import common._
+import conf.InjectedCachedHealthCheckLifeCycle
 import conf.switches.SwitchboardLifecycle
-import conf.ApplicationsHealthCheckLifeCycle
 import contentapi.SectionsLookUpLifecycle
+import controllers.HealthCheck
 import jobs.SiteMapLifecycle
 import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
+import play.api.inject.ApplicationLifecycle
+import play.api.GlobalSettings
 import services.{ConfigAgentLifecycle, IndexListingsLifecycle}
 
-object Global extends ConfigAgentLifecycle
+import scala.concurrent.ExecutionContext
+
+object Global extends GlobalSettings with BackwardCompatibleLifecycleComponents
+  with ConfigAgentLifecycle
   with CloudWatchApplicationMetrics
   with DfpAgentLifecycle
   with SurgingContentAgentLifecycle
   with IndexListingsLifecycle
   with SectionsLookUpLifecycle
   with SwitchboardLifecycle
-  with SiteMapLifecycle
-  with Logstash
-  with ApplicationsHealthCheckLifeCycle {
+  with Logstash {
   override lazy val applicationName = "frontend-applications"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ++ List(
@@ -32,5 +36,10 @@ object Global extends ConfigAgentLifecycle
     EmailSubsciptionMetrics.APINetworkError,
     EmailSubsciptionMetrics.ListIDError,
     EmailSubsciptionMetrics.AllEmailSubmission
+  )
+
+  override def lifecycleComponents(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext): List[LifecycleComponent] = List(
+    new SiteMapLifecycle(),
+    new InjectedCachedHealthCheckLifeCycle(HealthCheck)
   )
 }

--- a/applications/app/conf/context.scala
+++ b/applications/app/conf/context.scala
@@ -1,7 +1,0 @@
-package conf
-
-import controllers.HealthCheck
-
-trait ApplicationsHealthCheckLifeCycle extends CachedHealthCheckLifeCycle {
-  override val healthCheckController = HealthCheck
-}

--- a/applications/app/jobs/SitemapLifecycle.scala
+++ b/applications/app/jobs/SitemapLifecycle.scala
@@ -1,14 +1,13 @@
 package jobs
 
 import common._
-import play.api.GlobalSettings
 import services.{VideoSiteMap, NewsSiteMap}
 
-trait SiteMapLifecycle extends GlobalSettings with ExecutionContexts {
+import scala.concurrent.ExecutionContext
 
-  override def onStart(app: play.api.Application) {
-    super.onStart(app)
+class SiteMapLifecycle(implicit ec: ExecutionContext) extends LifecycleComponent {
 
+  override def start(): Unit = {
     Jobs.deschedule("SiteMap")
     Jobs.schedule("SiteMap", "0 0/2 * * * ?") {
       SiteMapJob.update()

--- a/archive/app/Global.scala
+++ b/archive/app/Global.scala
@@ -1,13 +1,23 @@
-import common.CloudWatchApplicationMetrics
 import common.Logback.Logstash
+import common.{CloudWatchApplicationMetrics, LifecycleComponent, BackwardCompatibleLifecycleComponents}
 import conf.switches.SwitchboardLifecycle
-import conf.ArchiveHealthCheckLifeCycle
+import conf.InjectedCachedHealthCheckLifeCycle
+import controllers.HealthCheck
+import play.api.inject.ApplicationLifecycle
+import play.api.GlobalSettings
 import services.ArchiveMetrics
 
-object Global extends CloudWatchApplicationMetrics
-  with ArchiveMetrics
+import scala.concurrent.ExecutionContext
+
+object Global extends GlobalSettings with BackwardCompatibleLifecycleComponents
+  with CloudWatchApplicationMetrics
   with SwitchboardLifecycle
-  with Logstash
-  with ArchiveHealthCheckLifeCycle {
+  with Logstash {
+
   override lazy val applicationName = "frontend-archive"
+
+  override def lifecycleComponents(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext): List[LifecycleComponent] = List(
+    new ArchiveMetrics(appLifecycle),
+    new InjectedCachedHealthCheckLifeCycle(HealthCheck)
+  )
 }

--- a/archive/app/conf/context.scala
+++ b/archive/app/conf/context.scala
@@ -1,7 +1,0 @@
-package conf
-
-import controllers.HealthCheck
-
-trait ArchiveHealthCheckLifeCycle extends CachedHealthCheckLifeCycle {
-  override val healthCheckController = HealthCheck
-}

--- a/archive/app/services/ArchiveMetrics.scala
+++ b/archive/app/services/ArchiveMetrics.scala
@@ -1,32 +1,32 @@
 package services
 
-import common.Jobs
+import common.{LifecycleComponent, Jobs}
 import metrics.CountMetric
 import model.diagnostics.CloudWatch
-import play.api.{GlobalSettings, Application => PlayApp}
+import play.api.inject.ApplicationLifecycle
+
+import scala.concurrent.{ExecutionContext, Future}
 
 object GoogleBotMetric {
   val Googlebot404Count = CountMetric("googlebot-404s", "Googlebot 404s")
 }
 
-trait ArchiveMetrics extends GlobalSettings {
+class ArchiveMetrics(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends LifecycleComponent {
+
+  appLifecycle.addStopHook{ () => Future{
+    Jobs.deschedule("ArchiveSystemMetricsJob")
+  }}
 
   private def report() {
     CloudWatch.putMetrics("ArchiveMetrics", List(GoogleBotMetric.Googlebot404Count), List.empty)
   }
 
-  override def onStart(app: PlayApp) {
+  override def start():Unit = {
     Jobs.deschedule("ArchiveSystemMetricsJob")
-    super.onStart(app)
 
     Jobs.schedule("ArchiveSystemMetricsJob", "0 * * * * ?"){
       report()
     }
-  }
-
-  override def onStop(app: PlayApp) {
-    Jobs.deschedule("ArchiveSystemMetricsJob")
-    super.onStop(app)
   }
 
 }

--- a/archive/app/services/ArchiveMetrics.scala
+++ b/archive/app/services/ArchiveMetrics.scala
@@ -21,7 +21,7 @@ class ArchiveMetrics(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionC
     CloudWatch.putMetrics("ArchiveMetrics", List(GoogleBotMetric.Googlebot404Count), List.empty)
   }
 
-  override def start():Unit = {
+  override def start(): Unit = {
     Jobs.deschedule("ArchiveSystemMetricsJob")
 
     Jobs.schedule("ArchiveSystemMetricsJob", "0 * * * * ?"){

--- a/article/app/Global.scala
+++ b/article/app/Global.scala
@@ -1,25 +1,34 @@
 import common.Logback.Logstash
 import common.dfp.DfpAgentLifecycle
-import common.{CloudWatchApplicationMetrics, ContentApiMetrics}
+import common.{LifecycleComponent, BackwardCompatibleLifecycleComponents, CloudWatchApplicationMetrics, ContentApiMetrics}
 import conf.switches.SwitchboardLifecycle
-import conf.ArticleHealthCheckLifeCycle
+import conf.InjectedCachedHealthCheckLifeCycle
+import controllers.HealthCheck
 import metrics.FrontendMetric
 import ophan.SurgingContentAgentLifecycle
+import play.api.inject.ApplicationLifecycle
+import play.api.GlobalSettings
 import services.NewspaperBooksAndSectionsAutoRefresh
 
-object Global
-  extends NewspaperBooksAndSectionsAutoRefresh
+import scala.concurrent.ExecutionContext
+
+object Global extends GlobalSettings with BackwardCompatibleLifecycleComponents
   with DfpAgentLifecycle
   with CloudWatchApplicationMetrics
   with SurgingContentAgentLifecycle
   with SwitchboardLifecycle
-  with Logstash
-  with ArticleHealthCheckLifeCycle {
+  with Logstash {
+
   override lazy val applicationName = "frontend-article"
 
   override def applicationMetrics: List[FrontendMetric] = super.applicationMetrics ::: List(
     ContentApiMetrics.HttpLatencyTimingMetric,
     ContentApiMetrics.HttpTimeoutCountMetric,
     ContentApiMetrics.ContentApiErrorMetric
+  )
+
+  override def lifecycleComponents(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext): List[LifecycleComponent] = List(
+    NewspaperBooksAndSectionsAutoRefresh,
+    new InjectedCachedHealthCheckLifeCycle(HealthCheck)
   )
 }

--- a/article/app/conf/context.scala
+++ b/article/app/conf/context.scala
@@ -1,7 +1,0 @@
-package conf
-
-import controllers.HealthCheck
-
-trait ArticleHealthCheckLifeCycle extends CachedHealthCheckLifeCycle {
-  override val healthCheckController = HealthCheck
-}

--- a/article/app/controllers/PublicationController.scala
+++ b/article/app/controllers/PublicationController.scala
@@ -17,7 +17,6 @@ class PublicationController @Inject() (bookAgent: NewspaperBookTagAgent = Newspa
                               extends Controller
                               with ExecutionContexts
                               with ItemResponses
-                              with NewspaperBooksAndSectionsAutoRefresh
                               with Dates
                               with Logging {
 

--- a/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
+++ b/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
@@ -1,17 +1,15 @@
 package services
 
-import common.AutoRefresh
+import common.{LifecycleComponent, AutoRefresh}
 import model.{TagDefinition, TagIndexListings}
-import play.api.{Application, GlobalSettings}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Future, blocking}
 import scala.language.postfixOps
 
-trait NewspaperBooksAndSectionsAutoRefresh extends GlobalSettings {
-  override def onStart(app: Application): Unit = {
-    super.onStart(app)
+object NewspaperBooksAndSectionsAutoRefresh extends LifecycleComponent {
+  override def start(): Unit = {
     NewspaperBookTagAgent.start()
     NewspaperBookSectionTagAgent.start()
   }

--- a/commercial/app/Global.scala
+++ b/commercial/app/Global.scala
@@ -2,18 +2,26 @@ import commercial.CommercialLifecycle
 import common.Logback.Logstash
 import common._
 import conf.switches.SwitchboardLifecycle
-import conf.CommercialHealthCheckLifeCycle
+import conf.InjectedCachedHealthCheckLifeCycle
+import controllers.HealthCheck
 import metrics.MetricUploader
+import play.api.GlobalSettings
+import play.api.inject.ApplicationLifecycle
+
+import scala.concurrent.ExecutionContext
 
 package object CommercialMetrics {
-
   val metrics = MetricUploader("Commercial")
 }
 
-object Global extends CommercialLifecycle
+object Global extends GlobalSettings with BackwardCompatibleLifecycleComponents
   with SwitchboardLifecycle
   with CloudWatchApplicationMetrics
-  with Logstash
-  with CommercialHealthCheckLifeCycle {
+  with Logstash {
   override lazy val applicationName = "frontend-commercial"
+
+  override def lifecycleComponents(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext): List[LifecycleComponent] = List(
+    new CommercialLifecycle(appLifecycle),
+    new InjectedCachedHealthCheckLifeCycle(HealthCheck)
+  )
 }

--- a/commercial/app/conf/context.scala
+++ b/commercial/app/conf/context.scala
@@ -1,8 +1,0 @@
-package conf
-
-import controllers.HealthCheck
-
-
-trait CommercialHealthCheckLifeCycle extends CachedHealthCheckLifeCycle {
-  override val healthCheckController = HealthCheck
-}

--- a/common/app/common/LifecycleComponent.scala
+++ b/common/app/common/LifecycleComponent.scala
@@ -1,0 +1,19 @@
+package common
+
+import play.api.inject.ApplicationLifecycle
+import play.api.{GlobalSettings, Application}
+
+import scala.concurrent.ExecutionContext
+
+trait LifecycleComponent {
+  def start(): Unit
+}
+
+trait BackwardCompatibleLifecycleComponents extends GlobalSettings {
+  def lifecycleComponents(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext): List[LifecycleComponent]
+  override def onStart(app: Application): Unit = {
+    super.onStart(app)
+    val appLifecycle = app.injector.instanceOf[ApplicationLifecycle]
+    lifecycleComponents(appLifecycle)(app.actorSystem.dispatcher).foreach(_.start())
+  }
+}

--- a/common/app/conf/HealthCheck.scala
+++ b/common/app/conf/HealthCheck.scala
@@ -152,3 +152,7 @@ trait CachedHealthCheckLifeCycle extends GlobalSettings {
   }
 }
 
+// this is temporary and allows me to split a big PR
+class InjectedCachedHealthCheckLifeCycle(val healthCheckController: CachedHealthCheck) extends CachedHealthCheckLifeCycle with LifecycleComponent {
+  override def start(): Unit = super.onStart(Play.current)
+}

--- a/common/app/conf/switches/SwitchboardLifecycle.scala
+++ b/common/app/conf/switches/SwitchboardLifecycle.scala
@@ -4,7 +4,7 @@ import common._
 import conf.Configuration
 import play.api.{Application, GlobalSettings}
 
-trait SwitchboardLifecycle extends GlobalSettings with ExecutionContexts with Logging {
+trait SwitchboardLifecycle extends GlobalSettings with Logging {
 
   override def onStart(app: Application) {
     super.onStart(app)

--- a/common/app/model/ApplicationIdentity.scala
+++ b/common/app/model/ApplicationIdentity.scala
@@ -1,0 +1,5 @@
+package model
+
+case class ApplicationIdentity(
+  name: String
+)

--- a/diagnostics/app/conf/HealthCheck.scala
+++ b/diagnostics/app/conf/HealthCheck.scala
@@ -1,0 +1,3 @@
+package conf
+
+object HealthCheck extends AllGoodCachedHealthCheck(9006, "/robots.txt")

--- a/diagnostics/app/conf/context.scala
+++ b/diagnostics/app/conf/context.scala
@@ -1,8 +1,5 @@
 package conf
 
-import controllers.HealthCheck
-
-
 trait DiagnosticsHealthCheckLifeCycle extends CachedHealthCheckLifeCycle {
-  override val healthCheckController = HealthCheck
+  override val healthCheckController = controllers.HealthCheck
 }

--- a/standalone/app/StandaloneGlobal.scala
+++ b/standalone/app/StandaloneGlobal.scala
@@ -1,6 +1,6 @@
 import com.gu.googleauth.{FilterExemption, UserIdentity}
 import commercial.CommercialLifecycle
-import common.ExecutionContexts
+import common.{LifecycleComponent, BackwardCompatibleLifecycleComponents}
 import common.Logback.Logstash
 import common.dfp.FaciaDfpAgentLifecycle
 import conf._
@@ -8,15 +8,17 @@ import conf.switches.SwitchboardLifecycle
 import controllers.AuthCookie
 import feed.OnwardJourneyLifecycle
 import play.Play
+import play.api.GlobalSettings
+import play.api.inject.ApplicationLifecycle
 import play.api.mvc.Results._
 import play.api.mvc._
 import play.api.mvc.{Filters => PlayFilters}
 import rugby.conf.RugbyLifecycle
 import services.ConfigAgentLifecycle
 
-import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 
-class StandaloneGlobal extends CommercialLifecycle
+class StandaloneGlobal extends GlobalSettings with BackwardCompatibleLifecycleComponents
   with OnwardJourneyLifecycle
   with ConfigAgentLifecycle
   with FaciaDfpAgentLifecycle
@@ -24,4 +26,8 @@ class StandaloneGlobal extends CommercialLifecycle
   with FootballLifecycle
   with CricketLifecycle
   with RugbyLifecycle
-  with Logstash
+  with Logstash {
+  override def lifecycleComponents(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext): List[LifecycleComponent] = List(
+    new CommercialLifecycle(appLifecycle)(ec)
+  )
+}


### PR DESCRIPTION
## What does this change?

This PR starts to refactor our lifecycle-related events (onStart, onStop) into injectable objects. These injectable object are necessary to be able to migrate to play 2.5.
Given the sheer size of the full change (600+ lines) I started re-deviding it in 3 PR. This is the first batch, expect two more to come on that topic only.
Because of that, a temporary class `BackwardCompatibleLifecycleComponents` makes the link between the old world of `Global`s and the world of `ApplicationLoaders`.
## What is the value of this and can you measure success?

Smooth migration towards play2.5, human size PR
## Request for comment

@TBonnin @johnduffell 
