### PR TITLE
Remove extra logging added to debug discussion

### DIFF
--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -250,14 +250,4 @@ trait PerformanceSwitches {
     sellByDate = new LocalDate(2016, 8, 5),
     exposeClientSide = false
   )
-
-  // Owner: tbonnin
-  val LogAllDiscussionIncomingRequests = Switch(
-    SwitchGroup.Performance,
-    "log-all-discussion-incoming-requests",
-    "If this switch is on then log all incoming discussion requests",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 2),
-    exposeClientSide = false
-  )
 }

--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -1,13 +1,9 @@
 package filters
 
-import java.util.UUID
-
 import common.{ExecutionContexts, Logging, StopWatch}
 import play.api.mvc.{Filter, RequestHeader, Result}
-
 import scala.concurrent.Future
 import scala.util.{Failure, Random, Success}
-import conf.switches.Switches
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers._
 import play.api.Logger
@@ -45,57 +41,6 @@ class RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
     implicit val stopWatch = new StopWatch
     val result = next(rh)
     val requestLogger = RequestLogger(rh)
-    result onComplete {
-      case Success(response) =>
-        response.header.headers.get("X-Accel-Redirect") match {
-          case Some(internalRedirect) =>
-            requestLogger.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and redirected to $internalRedirect")
-          case None =>
-            requestLogger.info(s"${rh.method} ${rh.uri} took ${stopWatch.elapsed} ms and returned ${response.header.status}")
-        }
-
-      case Failure(error) =>
-        requestLogger.warn(s"${rh.method} ${rh.uri} failed after ${stopWatch.elapsed} ms", error)
-    }
-    result
-  }
-}
-
-class DiscussionRequestLoggingFilter extends Filter with Logging with ExecutionContexts {
-
-  case class RequestLogger(rh: RequestHeader)(implicit internalLogger: Logger, stopWatch: StopWatch) {
-    private lazy val pseudoId = Random.nextInt(Integer.MAX_VALUE)
-    private def customFieldsMarkers(): LogstashMarker = {
-      val fields = Map(
-        "req.method" -> rh.method,
-        "req.url" -> rh.uri,
-        "req.uuid" -> pseudoId.toString,
-        "req.latency_ms" -> stopWatch.elapsed.toString
-      )
-      appendEntries(fields.asJava)
-    }
-
-    def info(message: String): Unit = {
-      internalLogger.logger.info(customFieldsMarkers, message)
-    }
-    def warn(message: String, error: Throwable): Unit = {
-      internalLogger.logger.warn(customFieldsMarkers, message, error)
-    }
-    def error(message: String, error: Throwable): Unit = {
-      internalLogger.logger.error(customFieldsMarkers, message, error)
-    }
-  }
-
-  override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
-
-    implicit val stopWatch = new StopWatch
-    val requestLogger = RequestLogger(rh)
-
-    if(Switches.LogAllDiscussionIncomingRequests.isSwitchedOn) {
-      requestLogger.info(s"Start handling ${rh.method} ${rh.uri}")
-    }
-
-    val result = next(rh)
     result onComplete {
       case Success(response) =>
         response.header.headers.get("X-Accel-Redirect") match {

--- a/discussion/app/Global.scala
+++ b/discussion/app/Global.scala
@@ -2,7 +2,7 @@ import common.CloudWatchApplicationMetrics
 import common.Logback.Logstash
 import conf._
 import conf.switches.SwitchboardLifecycle
-import filters.DiscussionRequestLoggingFilter
+import filters.RequestLoggingFilter
 import play.api.http.HttpFilters
 import play.api.mvc.EssentialFilter
 
@@ -21,7 +21,7 @@ class DiscussionFilters extends HttpFilters {
     new JsonVaryHeadersFilter,
     new Gzipper,
     new BackendHeaderFilter,
-    new DiscussionRequestLoggingFilter,
+    new RequestLoggingFilter,
     new SurrogateKeyFilter,
     new AmpFilter
   )


### PR DESCRIPTION
## What does this change?

Remove extra logging added to debug discussion
## What is the value of this and can you measure success?

This extra logging has not been very useful since the issue we saw with discussion 10 days ago (very little incoming reqs for 10s before a surge) hasn't happened again since this logging has been introduced 😢 
Still removing this code since it introduced a lot of additional logging and some ugly duplication of code 🔪 
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
