### PR TITLE
remove pinterest if not a gallery or an image content

### DIFF
--- a/applications/test/ShareLinksTest.scala
+++ b/applications/test/ShareLinksTest.scala
@@ -21,12 +21,11 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
         implicit val request = TestRequest()
         val pageShares = model.Content(apiContent).sharelinks.pageShares
 
-        pageShares.map(_.text) should be (List("Facebook", "Twitter", "Email", "Pinterest", "LinkedIn", "Google plus", "WhatsApp", "Messenger"))
+        pageShares.map(_.text) should be (List("Facebook", "Twitter", "Email", "LinkedIn", "Google plus", "WhatsApp", "Messenger"))
         pageShares.map(_.href) should be (List(
           "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsfb&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsfb",
           "https://twitter.com/intent/tweet?text=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fstw",
           "mailto:?subject=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&body=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsbl",
-          "http://www.pinterest.com/pin/find/?url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j",
           "http://www.linkedin.com/shareArticle?mini=true&title=Cameron+statement+to+the+Commons+on+the+EU+referendum+-+Politics+live&url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j",
           "https://plus.google.com/share?url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsgp&amp;hl=en-GB&amp;wwc=1",
           "whatsapp://send?text=%22Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live%22%20http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fswa",

--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -132,10 +132,10 @@ final case class ShareLinks(
   metadata: MetaData
 ) {
 
-  private val pageShareOrder: List[SharePlatform] = if (tags.isGallery) {
+  private val pageShareOrder: List[SharePlatform] = if (tags.isGallery || tags.isImageContent) {
     List(Facebook, Twitter, Email, PinterestPage, GooglePlus, WhatsApp, Messenger)
   } else {
-    List(Facebook, Twitter, Email, PinterestPage, LinkedIn, GooglePlus, WhatsApp, Messenger)
+    List(Facebook, Twitter, Email, LinkedIn, GooglePlus, WhatsApp, Messenger)
   }
 
   private val elementShareOrder: List[SharePlatform] = if (tags.isLiveBlog) {


### PR DESCRIPTION
## What does this change?

Following the add of [messenger share](https://github.com/guardian/frontend/pull/13089) we remove pinterest sharing button if the page is not a gallery and not an image content.
