### PR TITLE
Do not add a messenger share button on amp

### DIFF
--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -167,14 +167,23 @@ final case class ShareLinks(
     ShareLinks.create(sharePlatform, href = href, title = metadata.webTitle, mediaPath = mediaPath)
   })
 
-  val pageShares: Seq[ShareLink] = pageShareOrder.map( sharePlatform => {
-    val contentTitle = sharePlatform match {
-      case Twitter if tags.isClimateChangeSeries => s"${metadata.webTitle} #keepitintheground"
-      case _ => metadata.webTitle
-    }
+  import play.api.mvc.RequestHeader
 
-    val href = createShortUrlWithCampaign(sharePlatform)
+  def pageShares(implicit request: RequestHeader): Seq[ShareLink] = {
+    
+    /* AMP does not support yet fb-messenger protocol */
+    val platforms = if (request.isAmp) pageShareOrder.filter(p => p != Messenger) else pageShareOrder
 
-    ShareLinks.create(sharePlatform, href = href, title = contentTitle, mediaPath = None)
-  })
+    platforms.map( sharePlatform => {
+      val contentTitle = sharePlatform match {
+        case Twitter if tags.isClimateChangeSeries => s"${metadata.webTitle} #keepitintheground"
+        case _ => metadata.webTitle
+      }
+
+      val href = createShortUrlWithCampaign(sharePlatform)
+
+      ShareLinks.create(sharePlatform, href = href, title = contentTitle, mediaPath = None)
+    })
+
+  }
 }


### PR DESCRIPTION
## What does this change?

Following the add of [messenger share button](https://github.com/guardian/frontend/pull/13089) AMP pages does not validate anymore 😞 
For instance [this page](https://amp.theguardian.com/football/blog/2016/may/31/milan-daniele-massaro-barcelona-golden-goal#development=1), show the following error:

```
https://amp.theguardian.com/football/blog/2016/may/31/milan-daniele-massaro-barcelona-golden-goal:1873:0 Invalid URL protocol 'fb-messenger:' for attribute 'href' in tag 'a'.   
```

This seems to be an `AMP` issue, as it should in theory allow `fb-messenger` protocol.
With the associated changes we do not display the button for `AMP` requests.

@johnduffell @NataliaLKB @stephanfowler 
