### PR TITLE
bump the healthcheck interval to 5 minutes to fix CdnHealthCheckTest

### DIFF
--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -111,4 +111,4 @@ notifications.subscriptions_table=frontend-notifications-DEV
 deploys-notify.api.key=this-is-the-dev-api-key
 
 #HealthCheck refresh interval (0 = no update on regular schedule)
-healthcheck.updateIntervalInSecs=0
+healthcheck.updateIntervalInSecs=300


### PR DESCRIPTION
## What does this change?

This fixes the default value of the configuration so that the tests run locally

@TBonnin 
