### PR TITLE
Don't add MPU under a thrasher

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/slice-adverts.js
@@ -56,7 +56,8 @@ define([
                     return true;
                 }
 
-                if (replaceTopSlot && index === 0) {
+                var isThrasher = bonzo(item.container).hasClass('fc-container--thrasher');
+                if (replaceTopSlot && index === 0 && !isThrasher) {
                     // it's mobile, so we needn't check for an adSlice
                     lastIndex = index;
                     return true;


### PR DESCRIPTION
On mobile, we must not add an MPU right under a thrasher.

Before:
![picture 2](https://cloud.githubusercontent.com/assets/629976/15680570/178a4430-274e-11e6-8ce2-9ff1c471b40e.jpg)

After:
![picture 1](https://cloud.githubusercontent.com/assets/629976/15680575/1b28f3c0-274e-11e6-98e6-3168ae3e6e3f.jpg)

cc @JonNorman @kenlim @rich-nguyen 
