### PR TITLE
Enable ad-free test

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyAdfreeRenderCondition.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyAdfreeRenderCondition.scala.js
@@ -56,14 +56,14 @@
             && mvtCookieId <= largestTestId
             && !isIOS() && !isSafari()) {
             variants = [{
-                id: 'sampletest-variant',
+                id: 'variant',
                 test: function () {
-                    writeCookie(AD_FREE_COOKIE, 'sampletest-variant');
+                    writeCookie(AD_FREE_COOKIE, 'variant');
                 }
             }, {
-                id: 'sampletest-control',
+                id: 'control',
                 test: function () {
-                    writeCookie(AD_FREE_COOKIE, 'sampletest-control');
+                    writeCookie(AD_FREE_COOKIE, 'control');
                 }
             }];
             testVariantIndex = mvtCookieId % variants.length;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/new-user-adverts-disabled.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/new-user-adverts-disabled.js
@@ -30,14 +30,14 @@ define([
         };
 
         this.variants = [{
-            id: 'sampletest-variant',
+            id: 'variant',
             test: function () {
-                cookies.add('gu_adfree_test', 'sampletest-variant');
+                cookies.add('gu_adfree_test', 'variant');
             }
         }, {
-            id: 'sampletest-control',
+            id: 'control',
             test: function () {
-                cookies.add('gu_adfree_test', 'sampletest-control');
+                cookies.add('gu_adfree_test', 'control');
             }
         }];
 


### PR DESCRIPTION
## What does this change?

Enables a test disabling ads for the first 3 days a new user visits the site
## What is the value of this and can you measure success?

Hypothesis is that it will reduce churn
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots
## Request for comment

https://docs.google.com/document/d/1MsBeGxzllnvX1L1FDaKMhAKIC8ZsHqA3c_Ct_4GDqbQ/edit

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
