### PR TITLE
No ads unless certain

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -206,8 +206,10 @@ define([
             if (!canonicalUrl) {
                 resolve(defaultVideoInfo);
             } else {
+                var ajaxInfoUrl = config.page.ajaxUrl + urlUtils.getPath(canonicalUrl);
+
                 ajax({
-                    url: canonicalUrl + '/info.json'
+                    url: ajaxInfoUrl + '/info.json'
                 }).then(function(videoInfo) {
                     resolve(videoInfo);
                 }, function() {

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -197,9 +197,10 @@ define([
 
         var videoInfo = new Promise(function(resolve) {
             // We only have the canonical URL in videos embedded in articles / main media.
+            // These are set to the safest defaults that will always play video.
             var defaultVideoInfo = {
                 expired: false,
-                shouldHideAdverts: false
+                shouldHideAdverts: true
             };
 
             if (!canonicalUrl) {


### PR DESCRIPTION
## What does this change?

Use the ajax URL for ajax requests, we missed this when we first did it. It's also creating havoc with https.
## What is the value of this and can you measure success?

Videos read this URL from the ajax URL.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
