### PR TITLE
Add try/catch around localstorage calls

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyAdfreeRenderCondition.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyAdfreeRenderCondition.scala.js
@@ -76,29 +76,30 @@
     function readLocalStorage(key) {
         if ("localStorage" in window) {
             var data;
-            var dataParsed;
-            data = localStorage.getItem(key);
-            if (data === null) {
-                return null;
-            }
 
             try {
-                dataParsed = JSON.parse(data);
+                data = localStorage.getItem(key);
+                if (data === null) {
+                    return null;
+                } else {
+                    return JSON.parse(data).value;
+                }
             } catch (e) {
-                this.remove(key);
                 return null;
             }
-
-            return dataParsed.value;
         }
     }
 
     function writeLocalStorage(key, data) {
         if ("localStorage" in window) {
-            var value = JSON.stringify({
-                value: data
-            });
-            return localStorage.setItem(key, value);
+            try {
+                var value = JSON.stringify({
+                    value: data
+                });
+                return localStorage.setItem(key, value);
+            } catch (e) {
+                return null;
+            }
         }
     }
 


### PR DESCRIPTION
## What does this change?

Adds try/catch around localstorage calls in the new user ad-free test
## What is the value of this and can you measure success?

Stops javascript crashing in Safari private browsing mode
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots
## Request for comment

@piuccio @jbreckmckye 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
