### PR TITLE
remember to put cross origin request in video info

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -209,7 +209,9 @@ define([
                 var ajaxInfoUrl = config.page.ajaxUrl + urlUtils.getPath(canonicalUrl);
 
                 ajax({
-                    url: ajaxInfoUrl + '/info.json'
+                    url: ajaxInfoUrl + '/info.json',
+                    type: 'json',
+                    crossOrigin: true
                 }).then(function(videoInfo) {
                     resolve(videoInfo);
                 }, function() {


### PR DESCRIPTION
## What does this change?

I forgot to specify that it's a crossOrigin request, which it isn't on dev.
## What is the value of this and can you measure success?

It works.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
