### PR TITLE
Hosted by page - next video link, QA changes

### DIFF
--- a/commercial/app/controllers/commercial/HostedContentController.scala
+++ b/commercial/app/controllers/commercial/HostedContentController.scala
@@ -33,7 +33,6 @@ object HostedContentController extends Controller {
             srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160516GlabsTestSD&format=video/mp4&maxbitrate=2048"
           ),
           nextVideo = HostedNextVideo(
-            header = "Up next from",
             title = "Renault shortlists 'car of the future' designs",
             link = "/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode1",
             imageUrl = episode1PosterUrl
@@ -58,7 +57,6 @@ object HostedContentController extends Controller {
               srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160523GlabsRenaultTestHD&format=video/webm&maxbitrate=2048"
             ),
             nextVideo = HostedNextVideo(
-              header = "Also from",
               title = "Designing the car of the future",
               link = "/commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser",
               imageUrl = teaserPosterUrl

--- a/commercial/app/views/hosted/guardianHostedPage.scala.html
+++ b/commercial/app/views/hosted/guardianHostedPage.scala.html
@@ -117,10 +117,10 @@
             <div class="hosted__next-video">
                 @if(hostedPageLinksBetweenContent.isSwitchedOn) {
                 <div class="hosted__next-video--header">
-                    <h2 class="hosted__text hosted__next-video--up-next">@page.nextVideo.header</h2>
+                    <h2 class="hosted__text hosted__next-video--up-next">More from</h2>
                     <h2 class="hosted__next-video--client-name hosted-tone--renault">Renault</h2>
                 </div>
-                <a href="@page.nextVideo.link" class="hosted__next-video--tile" data-link-name="next-hosted-video">
+                <a href="@page.nextVideo.link" class="hosted__next-video--tile" data-link-name="Next Hosted Video: @page.nextVideo.title">
                     <img class="hosted__next-video-thumb" src="@page.nextVideo.imageUrl">
                     <p class="hosted__next-video-title">@page.nextVideo.title</p>
                 </a>

--- a/common/app/common/commercial/HostedPage.scala
+++ b/common/app/common/commercial/HostedPage.scala
@@ -56,7 +56,6 @@ case class HostedVideo(
 
 
 case class HostedNextVideo(
-                        header: String,
                         title: String,
                         imageUrl: String,
                         link: String

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -795,7 +795,7 @@ $renaultLight: #fff9e9;
 .hosted__next-video-thumb {
     height: 72px;
     width: 120px;
-    align-self: center;
+    align-self: flex-start;
 
     @include mq($until: phablet) {
         height: 54px;


### PR DESCRIPTION
## What does this change?
1. Change the wording above the links from 'Also from / Up next from' to 'More from Renault'.
2. The yellow line above the image should touch the image.
3. Change the tracking call to from  'next-hosted-video', to: 'next-hosted-video:media-title'.  
## Screenshots

Before
![image](https://cloud.githubusercontent.com/assets/6290008/15711731/3df9e576-2807-11e6-9ac3-accb0044edb2.png)
After
![image](https://cloud.githubusercontent.com/assets/6290008/15711774/70da1fc4-2807-11e6-8e66-c3a65b2f3c60.png)
## Request for comment

@Calanthe 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
