### PR TITLE
Facia shouldn't 503 when a collection is Not found

### DIFF
--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -214,8 +214,8 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
           if (request.isJson)
             Cached(60) {JsonCollection(html)}
           else
-            Cached(60)(WithoutRevalidationResult(NotFound))
-      }.getOrElse(ServiceUnavailable)
+            Cached(60)(WithoutRevalidationResult(NotFound("containers are only available as json")))
+      }.getOrElse(Cached(60)(WithoutRevalidationResult(NotFound(s"collection id $collectionId does not exist"))))
     }
   }
 

--- a/static/src/javascripts/projects/common/modules/onward/tonal.js
+++ b/static/src/javascripts/projects/common/modules/onward/tonal.js
@@ -29,16 +29,30 @@ define([
     Component.define(TonalComponent);
 
     TonalComponent.prototype.tones = {
-        features: '-alpha/features/feature-stories.json',
-        comment: '-alpha/contributors/feature-stories.json'
+        uk: {
+            features: 'uk-alpha/features/feature-stories',
+            comment: 'uk-alpha/contributors/feature-stories'
+        },
+        us: {
+            features: 'us-alpha/features/feature-stories',
+            comment: 'us-alpha/contributors/feature-stories'
+        },
+        au: {
+            features: 'au-alpha/features/feature-stories',
+            comment: 'au-alpha/contributors/feature-stories'
+        },
+        int: {
+            features: '22167321-f8cf-4f4a-b646-165e5b1e9a30',
+            comment: 'ee3386bb-9430-4a6d-8bca-b99d65790f3b'
+        }
     };
 
     TonalComponent.prototype.getEndpoint = function () {
-        return '/container/' + this.edition + this.tones[this.getTone()];
+        return '/container/' + this.tones[this.edition][this.getTone()] + '.json';
     };
 
     TonalComponent.prototype.isSupported = function () {
-        return this.getTone() in this.tones;
+        return this.getTone() in this.tones[this.edition];
     };
 
     TonalComponent.prototype.getTone = function () {


### PR DESCRIPTION
I want to add something to scale (and alert probably) on 5xx errors.
The reason I want to scale on 5xx errors is the panic shedding functionality reports 5xx errors when the server is overloaded rather than just going slow and falling over.  This reduces the average latency measured by the ELB, which means it stops us autoscaling.

At the moment if you get /container/int-alpha/features/feature-stories.json you get a 503 error.  This turns out it's because the collection is not found.  This is adding a lot of noise (120 a minute) to the 5xxs and it should probably be a 404 not found.

This PR changes it to be a 404.

I've also updated the frontend client side code to grab the right container id when it's the international edition, thanks to @piuccio for helping out there!
