### PR TITLE
Enable Clever Friend for all users and start tailoring test

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -19,7 +19,7 @@ define([
     'common/modules/experiments/tests/participation-low-fric-recipes',
     'common/modules/experiments/tests/participation-low-fric-fashion',
     'common/modules/experiments/tests/participation-low-fric-sport',
-    'common/modules/experiments/tests/clever-friend-brexit',
+    'common/modules/experiments/tests/clever-friend-brexit-tailor',
     'common/modules/experiments/tests/welcome-header',
     'common/modules/experiments/tests/participation-discussion-test',
     'common/modules/experiments/tests/new-user-adverts-disabled',

--- a/static/src/javascripts/projects/common/modules/experiments/tests/clever-friend-brexit-tailor.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/clever-friend-brexit-tailor.js
@@ -8,7 +8,7 @@ define([
     }
 
     return function () {
-        this.id = 'CleverFriendBrexit';
+        this.id = 'CleverFriendBrexitTailor';
         this.start = '2016-06-01';
         this.expiry = '2016-07-31';
         this.author = 'Roberto Tyley';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/clever-friend-brexit.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/clever-friend-brexit.js
@@ -1,31 +1,48 @@
 define([
 
 ], function() {
+    function noop() {}
+
+    function companionInteractives() {
+        return document.querySelectorAll('figure[data-canonical-url^="https://interactive.guim.co.uk/2016/05/brexit-companion/"]');
+    }
+
     return function () {
         this.id = 'CleverFriendBrexit';
-        this.start = '2016-05-09';
+        this.start = '2016-06-01';
         this.expiry = '2016-07-31';
-        this.author = 'Anne Byrne';
-        this.description = 'Only expose the clever friend embed to 10% of people, by removing it for 90%';
-        this.audience = 0.9;
+        this.author = 'Roberto Tyley';
+        this.description = 'Tailor explainers (beginner/advanced/intermediate) for half the audience';
+        this.audience = 1;
         this.audienceOffset = 0.0;
-        this.successMeasure = 'Not really an a/b test, just using the audience segmentation for a soft launch';
+        this.successMeasure = 'Level of interaction with the explainer';
         this.audienceCriteria = 'All users';
         this.dataLinkNames = '';
-        this.idealOutcome = '';
+        this.idealOutcome = 'Tailored explainers will show greater levels of user engagement and positive response (survey links)';
 
         this.canRun = function () {
-            return true;
+            var companions = companionInteractives();
+            for (var i = 0; i < companions.length; i++) {
+                var url = companions[i].getAttribute('data-canonical-url');
+                if (url.indexOf('tailored=true') >= 0) return true;
+            }
+            return false;
         };
 
         this.variants = [{
-            id: 'remove-embed',
+            id: 'remove-tailoring',
             test: function() {
-                var companions = document.querySelectorAll('figure[data-canonical-url^="https://interactive.guim.co.uk/2016/05/brexit-companion/"]');
+                var companions = companionInteractives();
                 for (var i = 0; i < companions.length; i++) {
-                    companions[i].parentNode.removeChild(companions[i]);
+                    var c = companions[i];
+                    var url = c.getAttribute('data-canonical-url');
+                    c.setAttribute('data-canonical-url', url.replace('tailored=true','tailored=false'));
                 }
             }
+        },
+        {
+            id: 'keep-tailoring',
+            test: noop
         }];
     };
 });


### PR DESCRIPTION
## What does this change?

Enable Clever Friend for all users (rather than restricting it to 10% of users) - and test tailoring for 50% of users. So the Explainer will start showing content depending on how many `politics/eu-referendum` articles the user has read.
## What is the value of this and can you measure success?

We're hoping to see better user engagement with the tailored content.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![image](https://cloud.githubusercontent.com/assets/52038/15714073/0042bc80-2811-11e6-88e4-381007cf4183.png)
## Request for comment

@joelochlann @SiAdcock 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
