### PR TITLE
fix video teaser canRun

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -145,7 +145,7 @@ trait ABTestSwitches {
     "ab-video-teaser",
     "Show video teaser",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 1),
+    sellByDate = new LocalDate(2016, 6, 3),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-teaser.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-teaser.js
@@ -1,14 +1,12 @@
 define([
-    'common/utils/$',
     'common/utils/config'
 ], function (
-    $,
     config
 ) {
     return function () {
         this.id = 'VideoTeaser';
-        this.start = '2016-05-23';
-        this.expiry = '2016-06-01';
+        this.start = '2016-06-02';
+        this.expiry = '2016-06-03';
         this.author = 'Akash Askoolum';
         this.description = 'Test if video teasing leads to more plays';
         this.showForSensitive = true;
@@ -21,7 +19,7 @@ define([
 
         this.canRun = function () {
             return config.page.isFront
-                && $('.gu-media-wrapper--video').length > 0
+                && document.getElementsByClassName('gu-media-wrapper--video').length > 0
                 && config.page.pageId !== 'video';
         };
 


### PR DESCRIPTION
## What does this change?

bye bye `$`

`canRun` was always returning false and so the baseline wasn't run... use `document.getElementByClassName` because it the alternative was returning `undefined`
## What is the value of this and can you measure success?

baselining a test
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

n/a
## Request for comment

@jamesgorrie @harrysalmon

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
