### PR TITLE
fix video embed page

### DIFF
--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -3,8 +3,6 @@ define([
     'bean',
     'bonzo',
     'qwery',
-    'videojs',
-    'videojsembed',
     'common/utils/$',
     'common/utils/config',
     'common/utils/defer-to-analytics',
@@ -17,13 +15,13 @@ define([
     'common/views/svgs',
     'text!common/views/ui/loading.html',
     'text!common/views/media/titlebar.html',
-    'lodash/functions/debounce'
+    'lodash/functions/debounce',
+    'common/modules/video/videojs-options',
+    'bootstraps/enhanced/media/video-player'
 ], function (
     bean,
     bonzo,
     qwery,
-    videojs,
-    videojsembed,
     $,
     config,
     deferToAnalytics,
@@ -36,7 +34,9 @@ define([
     svgs,
     loadingTmpl,
     titlebarTmpl,
-    debounce
+    debounce,
+    videojsOptions,
+    videojs
 ) {
 
     function initLoadingSpinner(player) {
@@ -114,7 +114,7 @@ define([
 
             bonzo(el).addClass('vjs');
 
-            player = createVideoPlayer(el, {
+            player = createVideoPlayer(el, videojsOptions({
                 controls: true,
                 autoplay: !!window.location.hash && window.location.hash === '#autoplay',
                 preload: 'metadata', // preload='none' & autoplay breaks ad loading on chrome35
@@ -124,7 +124,7 @@ define([
                         location: 'https://embed.theguardian.com/embed/video/' + guardian.config.page.pageId
                     }
                 }
-            });
+            }));
 
             //Location of this is important
             events.handleInitialMediaError(player);


### PR DESCRIPTION
## What does this change?

Update video-embed to use `videojsOptions` which sets default options. Previously, we were hiding some elements using css, however using `videojsOptions` means they are not even added to the DOM (which should also increase performance).
## What is the value of this and can you measure success?

better rendering of content
## Does this affect other platforms - Amp, Apps, etc?

FIA
## Screenshots

from
![screen shot 2016-06-01 at 18 15 11](https://cloud.githubusercontent.com/assets/836140/15718640/5cb82ed8-2824-11e6-98f1-944f9b3a2a66.jpeg)

to
![screen shot 2016-06-01 at 18 15 17](https://cloud.githubusercontent.com/assets/836140/15718649/624c9bc2-2824-11e6-9cb9-8acda1d9a155.jpeg)
## Request for comment

@jamesgorrie @mchv 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
