### PR TITLE
remove questions when quiz has a result

### DIFF
--- a/common/app/views/fragments/atoms/quiz.scala.html
+++ b/common/app/views/fragments/atoms/quiz.scala.html
@@ -15,11 +15,13 @@
     ("atom-quiz--instant-reveal", !quiz.revealAtEnd && quiz.quizType == "knowledge"),
     ("js-atom-quiz--instant-reveal", !quiz.revealAtEnd && quiz.quizType == "knowledge")
 ))">
-    @quiz.content.questions.zipWithIndex.map { case (question, index) =>
-        @renderQuestion(question,
-            playForm(s"answers[$index]"),
-            maybeResults.flatMap(_.getAnswerFor(question))
-        )
+    @if(maybeResults.isEmpty) {
+        @quiz.content.questions.zipWithIndex.map { case (question, index) =>
+            @renderQuestion(question,
+                playForm(s"answers[$index]"),
+                maybeResults.flatMap(_.getAnswerFor(question))
+            )
+        }
     }
     @renderFooter(maybeResults)
     @if(maybeResults.isEmpty) {


### PR DESCRIPTION
when people do personality quizzes, it shows a submit button and posts back, then showing the answers you put in with the result below.  This confuses people because they hit submit and expected to see their result not the questions they answered.

I was going to add an anchor to jump to, but you can't really do that with form actions (according to google) so I've just made it hide the questions when someone has a result.  There don't seem to be any personality quizzes done on the main site so far, so it's not going to break existing stuff as far as I can tell!

@rich-nguyen not quite what we discussed but probably ok. @sndrs just tagging you so you see this when you're around next
