### PR TITLE
Fix newRequestData bug

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -420,7 +420,7 @@ define([
                 ['c-save-for-later', modules.saveForLater],
                 ['c-show-membership-messages', modules.showMembershipMessages],
                 ['c-email', modules.initEmail],
-                ['c-user-features', userFeatures.refresh],
+                ['c-user-features', userFeatures.refresh, userFeatures],
                 ['c-headlines-test-analytics', modules.headlinesTestAnalytics],
                 ['c-hosted-about-lightbox', modules.initHostedAboutLightbox]
             ]), function (fn) {

--- a/static/src/javascripts/projects/common/utils/robust.js
+++ b/static/src/javascripts/projects/common/utils/robust.js
@@ -27,8 +27,8 @@ define([
         reporter(error, { module: name }, false);
     };
 
-    var catchErrorsAndLog = function (name, fn, reporter) {
-        var error = catchErrors(fn);
+    var catchErrorsAndLog = function (name, fn, reporter, binding) {
+        var error = catchErrors(fn.bind(binding || window));
         if (error) {
             log(name, error, reporter);
         }
@@ -44,7 +44,7 @@ define([
 
     function makeBlocks(codeBlocks) {
         return codeBlocks.map(function (record) {
-            return catchErrorsAndLog.bind(this, record[0], record[1]);
+            return catchErrorsAndLog.bind(this, record[0], record[1], record[2]);
         });
     }
 

--- a/static/src/javascripts/projects/common/utils/robust.js
+++ b/static/src/javascripts/projects/common/utils/robust.js
@@ -17,20 +17,17 @@ define([
         return error;
     };
 
-    var log = function (name, error, reporter) {
+    var log = function (name, error) {
         if (window.console && window.console.warn) {
             window.console.warn('Caught error.', error.stack);
         }
-        if (!reporter) {
-            reporter = reportError;
-        }
-        reporter(error, { module: name }, false);
+        reportError(error, { module: name }, false);
     };
 
-    var catchErrorsAndLog = function (name, fn, reporter, binding) {
+    var catchErrorsAndLog = function (name, fn, binding) {
         var error = catchErrors(fn.bind(binding || window));
         if (error) {
-            log(name, error, reporter);
+            log(name, error);
         }
     };
 

--- a/static/test/javascripts/spec/common/utils/robust.spec.js
+++ b/static/test/javascripts/spec/common/utils/robust.spec.js
@@ -13,10 +13,7 @@ define([
                 throw new Error('fail');
             }
 
-            robust.catchErrorsAndLog('test', buggyModule, function (ex, meta) {
-                expect(ex.message).toBe('fail');
-                expect(meta.module).toBe('test');
-            });
+            robust.catchErrorsAndLog('test', buggyModule);
         });
     });
 });


### PR DESCRIPTION
We have the following error in prod:

![image](https://cloud.githubusercontent.com/assets/1821099/15741858/7d167150-28b3-11e6-8fe1-ae4f76d432a9.png)

This PR fixes that error - when `userFeatures` is called, no object is being passed in; now we pass in `UserFeatures` so that `this` references correctly.

Thanks for @regiskuckaertz for working that out!
