### PR TITLE
Removes all breaks in gallery captions

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -500,6 +500,9 @@ object GalleryCaptionCleaner {
 
     // <strong> is removed in place of having a <h2> element
     firstStrong.foreach(_.remove())
+    // There is an inconsistent number of <br> tags in gallery captions.
+    // To create some consistency, re will remove them all.
+    galleryCaption.getElementsByTag("br").remove()
 
     captionTitle.addClass("gallery__caption__title")
     captionTitle.text(captionTitleText)


### PR DESCRIPTION
After a change I made yesterday in #13134 this started happening:

![image](https://cloud.githubusercontent.com/assets/8774970/15742756/c9cc9cea-28b8-11e6-8519-9833c33e26c4.png)
(notice the extra space between the caption title and the caption body)

This is because in composer you have a free text field for gallery captions. This has resulted in inconsistencies in the html we receive for them. Yesterday we started cleaning the html to make it a bit better. 

The best solution though would be to get a caption title and a caption body from composer though, rather than just a caption. I talked to them yesterday, but will follow up today!

With this PR, we only have one break between the title and the body like so:
![image](https://cloud.githubusercontent.com/assets/8774970/15742902/9e39153a-28b9-11e6-940d-2b46988bf417.png)
## Does this affect other platforms - Amp, Apps, etc?

Nope 😄 
## Request for comment

@gtrufitt 
