### PR TITLE
Add switch owner and improve format of the Expiring switches email

### DIFF
--- a/admin/app/views/email/expiringSwitches.scala.html
+++ b/admin/app/views/email/expiringSwitches.scala.html
@@ -1,25 +1,54 @@
-@(expiringImminently: Seq[conf.switches.Switch], expiringSoon: Seq[conf.switches.Switch])
+@import conf.switches.Switch
+@import _root_.jobs.ExpiringSwitches
 
-@showSwitch(switch: conf.switches.Switch) = {
-    <li>
-        <div>@{switch.name}</div>
-        <div>expires @{switch.sellByDate.get.toString("E dd MMM")} 23:59 UTC</div>
+@(switches: Seq[Switch])
+
+@showSwitch(switch: conf.switches.Switch, showExpirationDate: Boolean) = {
+    <li style="padding-bottom: 6px">
+        <div>
+            <strong>@{switch.name}</strong>
+            - @showOwners(switch.owners)
+            @if(showExpirationDate) { - <span style="color:grey;font-style: italic;">expires @{switch.sellByDate.get.toString("E dd MMM")} at 23:59 (London time)</span>}
+        </div>
         <div>@{switch.description}</div>
     </li>
 }
 
-@if(expiringImminently.nonEmpty) {
-    <div>
-        <p style="color:red">These switches are going to expire imminently!</p>
-        <ul>@for(switch <- expiringImminently) {@showSwitch(switch)}</ul>
-    </div>
+@emergencyColor(index: Int) = @{
+    index match {
+        case 0 => "red"
+        case 1 => "orangeRed"
+        case 2 => "orange"
+        case _ => "black"
+    }
 }
 
-@if(expiringSoon.nonEmpty) {
-    <div>
-        <p style="color:orange">These switches are going to expire soon:</p>
-        <ul>@for(switch <- expiringSoon) {@showSwitch(switch)}</ul>
-    </div>
+@showOwners(owners: Seq[conf.switches.Owner]) = {
+    Owners: @for(owner <- owners) { @showOwner(owner) }
+}
+@showOwner(owner: conf.switches.Owner) = {
+    @if(owner.github.isEmpty) {
+       @owner.name
+    } else {
+        <a href="https://github.com/@{owner.github.get}">@{owner.name.getOrElse(owner.github)}</a>
+    }
+
 }
 
-<p>See https://frontend.gutools.co.uk/dev/switchboard</p>
+<html>
+    <head></head>
+    <body>
+        @defining(ExpiringSwitches(switches).groupByPriority) { allGroups =>
+            @for(group <- allGroups) {
+                @if(group.switches.nonEmpty) {
+                    <div>
+                        <h1 style="font-size:1.3em;color:@emergencyColor(allGroups.indexOf(group))">@group.description.capitalize</h1>
+                        <ul>@for(switch <- group.switches) {@showSwitch(switch, (allGroups.last == group))}</ul>
+                    </div>
+                }
+            }
+        }
+
+    <p>See https://frontend.gutools.co.uk/dev/switchboard</p>
+    </body>
+</html>

--- a/admin/app/views/email/expiringSwitches.scala.html
+++ b/admin/app/views/email/expiringSwitches.scala.html
@@ -27,12 +27,15 @@
     Owners: @for(owner <- owners) { @showOwner(owner) }
 }
 @showOwner(owner: conf.switches.Owner) = {
-    @if(owner.github.isEmpty) {
-       @owner.name
+    @if(!owner.github.isEmpty) {
+       <a href="https://github.com/@{owner.github.get}">@{owner.name.getOrElse(owner.github)}</a>
     } else {
-        <a href="https://github.com/@{owner.github.get}">@{owner.name.getOrElse(owner.github)}</a>
+        @if(!owner.email.isEmpty) {
+            <a href="mailto:@{owner.email.get}">@{owner.name.getOrElse(owner.email)}</a>
+        } else {
+            @owner.name
+        }
     }
-
 }
 
 <html>

--- a/admin/app/views/radiator.scala.html
+++ b/admin/app/views/radiator.scala.html
@@ -37,7 +37,7 @@
         <ul id="sell-by-date">
             @switches.map{ switch =>
                 @Switch.expiry(switch).daysToExpiry.map { days =>
-                    <li class="Expiring expiry-days-@days @if(Switch.expiry(switch).hasExpired){expired}">" title="@switch.name - expires in @days days">
+                    <li class="Expiring expiry-days-@days @if(Switch.expiry(switch).hasExpired){expired}" title="@switch.name - expires in @days days">
                         @switch.name
                     </li>
                 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -129,6 +129,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-video-nav",
     "Have video in the nav",
+    owners = Seq(Owner.withGithub("jamesgorrie")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 15),
     exposeClientSide = true
@@ -138,6 +139,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-video-main-media-always-showcase",
     "Make video main media always showcase",
+    owners = Seq(Owner.withGithub("akash1810")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 14),
     exposeClientSide = true
@@ -147,6 +149,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-video-football-thrasher",
     "Swap video thrashers on football front",
+    owners = Seq(Owner.withGithub("jamesgorrie")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 14),
     exposeClientSide = true
@@ -156,6 +159,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-video-yellow-button",
     "Make big play button yellow",
+    owners = Seq(Owner.withGithub("akash1810")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 14),
     exposeClientSide = true

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -4,11 +4,11 @@ import org.joda.time.LocalDate
 
 trait ABTestSwitches {
 
-  // Owner: Dotcom Reach
   val ABFrontsOnArticles2 = Switch(
     SwitchGroup.ABTests,
     "ab-fronts-on-articles2",
     "Injects fronts on articles for the test",
+    owners = Seq(Owner.withName("dotcom reach")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 5),
     exposeClientSide = true
@@ -18,6 +18,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-live-blog-chrome-notifications-internal",
     "Live blog chrome notifications - Internal",
+    owners = Seq(Owner.withGithub("desbo")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 4),
     exposeClientSide = true
@@ -27,6 +28,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-live-blog-chrome-notifications-prod",
     "Live blog chrome notifications - prod",
+    owners = Seq(Owner.withGithub("NathanielBennett")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 4),
     exposeClientSide = true
@@ -36,6 +38,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-participation-low-fric-recipes",
     "AB test switch to insert low friction participation into recipes",
+    owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 15),
     exposeClientSide = true
@@ -45,6 +48,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-participation-low-fric-fashion",
     "AB test switch to insert low friction participation into fashion",
+    owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 15),
     exposeClientSide = true
@@ -54,6 +58,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-clever-friend-brexit",
     "Switch to trigger segmentation for clever friend exposure",
+    owners = Seq(Owner.withGithub("annebyrne")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 29),
     exposeClientSide = true
@@ -63,6 +68,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-welcome-header",
     "Welcome header for first time users test",
+    owners = Seq(Owner.withGithub("marialivia16")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 30),
     exposeClientSide = true
@@ -72,6 +78,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-participation-discussion-test",
     "We are going to hide comments on a random half of articles",
+    owners = Seq(Owner.withGithub("NathanielBennett")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 21),
     exposeClientSide = true
@@ -81,6 +88,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-facebook-share-params",
     "Switch to add a query parameter to the url sent to Facebook when a user clicks the share button",
+    owners = Seq(Owner.withGithub("katebee")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 30),
     exposeClientSide = true
@@ -90,6 +98,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-new-user-adverts-disabled",
     "Enable adfree experience for 3 days for new users",
+    owners = Seq(Owner.withGithub("davidfurey")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 1),
     exposeClientSide = true
@@ -99,6 +108,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-participation-low-fric-sport-v2",
     "AB test switch to insert low friction participation into sport",
+    owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 15),
     exposeClientSide = true
@@ -108,6 +118,7 @@ trait ABTestSwitches {
     SwitchGroup.ABTests,
     "ab-video-teaser",
     "Show video teaser",
+    owners = Seq(Owner.withGithub("akash1810")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 17),
     exposeClientSide = true

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -9,24 +9,27 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "dfp-caching",
     "Have Admin will poll DFP to precache adserving data.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
   )
 
   val HeaderBiddingUS = Switch(
-     SwitchGroup.Commercial,
-     "header-bidding-us",
-     "Auction adverts on the client before calling DFP (US edition only)",
-     safeState = Off,
-     sellByDate = never,
-     exposeClientSide = true
+    SwitchGroup.Commercial,
+    "header-bidding-us",
+    "Auction adverts on the client before calling DFP (US edition only)",
+    owners = Seq(Owner.withGithub("regiskuckaertz ")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
   )
 
   val CommercialSwitch = Switch(
     SwitchGroup.Commercial,
     "commercial",
     "If this switch is OFF, no calls will be made to the ad server. BEWARE!",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -36,6 +39,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "standard-adverts",
     "Display 'standard' adverts, e.g. top banner ads, inline ads, MPUs, etc.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -45,6 +49,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "commercial-components",
     "Display commercial components, e.g. jobs, soulmates.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -54,6 +59,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "video-adverts",
     "Show adverts on videos.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -63,6 +69,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "sponsored",
     "Show sponsored badges, logos, etc.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -72,6 +79,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "liveblog-adverts",
     "Show inline adverts on liveblogs",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -81,6 +89,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "audience-science",
     "If this switch is on, Audience Science segments will be used to target ads.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -90,6 +99,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "audience-science-gateway",
     "If this switch is on, Audience Science Gateway segments will be used to target ads.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -99,6 +109,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "imr-worldwide",
     "Enable the IMR Worldwide audience segment tracking.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -108,6 +119,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "krux",
     "Enable Krux Control Tag",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -117,6 +129,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "remarketing",
     "Enable Remarketing tracking",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -126,6 +139,7 @@ trait CommercialSwitches {
     SwitchGroup.CommercialFeeds,
     "gu-travel-feed-fetch",
     "If this switch is on, cached travel offers feed will be updated from external source.",
+    owners = Seq(Owner.withGithub("kelvin-chappell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -135,6 +149,7 @@ trait CommercialSwitches {
     SwitchGroup.CommercialFeeds,
     "gu-travel-feed-parse",
     "If this switch is on, commercial components will be fed by travel offers feed.",
+    owners = Seq(Owner.withGithub("kelvin-chappell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -144,6 +159,7 @@ trait CommercialSwitches {
     SwitchGroup.CommercialFeeds,
     "gu-jobs-feed-fetch",
     "If this switch is on, jobs feed will be periodically updated from external source.",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -153,6 +169,7 @@ trait CommercialSwitches {
     SwitchGroup.CommercialFeeds,
     "gu-jobs-feed-parse",
     "If this switch is on, commercial components will be fed by jobs feed.",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -162,6 +179,7 @@ trait CommercialSwitches {
     SwitchGroup.CommercialFeeds,
     "gu-events",
     "If this switch is on, commercial components will be fed by masterclass and live-events feeds.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -171,6 +189,7 @@ trait CommercialSwitches {
     SwitchGroup.CommercialFeeds,
     "gu-soulmates",
     "If this switch is on, commercial components will be fed by soulmates feed.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -180,6 +199,7 @@ trait CommercialSwitches {
     SwitchGroup.CommercialFeeds,
     "moneysupermarket",
     "If this switch is on, commercial components will be fed by Moneysupermarket feeds.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -189,6 +209,7 @@ trait CommercialSwitches {
     SwitchGroup.CommercialFeeds,
     "gu-bookshop",
     "If this switch is on, commercial components will be fed by the Guardian Bookshop feed.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -198,6 +219,7 @@ trait CommercialSwitches {
     SwitchGroup.CommercialFeeds,
     "book-lookup",
     "If this switch is on, book data will be looked up using a third-party service.",
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -207,6 +229,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "gu-members-area",
     "If this switch is on, content flagged with membershipAccess will be protected",
+    owners = Seq(Owner.withGithub("JonNorman")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -216,6 +239,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "lc-mortgages",
     "If this switch is on, commercial components will be fed by London & Country mortgage feed.",
+    owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -225,6 +249,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "adblock",
     "Switch for the Adblock Message.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -234,6 +259,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "krux-video-tracking",
     "If this switch is ON, there will be a Krux pixel fired to track particular videos",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -243,6 +269,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "british-council-beacon",
     "British Council's beacon",
+    owners = Seq(Owner.withGithub("kenlim")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 8, 1),
     exposeClientSide = false
@@ -252,6 +279,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "fluid-adverts",
     "Request fluid adverts from DFP",
+    owners = Seq(Owner.withGithub("regiskuckaertz")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 30),
     exposeClientSide = true
@@ -261,6 +289,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "fixed-tech-top-slot",
     "Height of the top banner is fixed at 250px in the Tech section",
+    owners = Seq(Owner.withGithub("regiskuckaertz")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 30),
     exposeClientSide = false
@@ -270,6 +299,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "static-badges",
     "If on, all badges are served server side",
+    owners = Seq(Owner.withGithub("kelvin-chappell")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 13),
     exposeClientSide = true
@@ -288,6 +318,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "optimise-high-merchandising",
     "If on, server will check tags for high-merchandising target before rendering high-merch slot.",
+    owners = Seq(Owner.withGithub("Calum Campbell")),
     safeState = Off,
     sellByDate = new LocalDate(2016,7,8),
     exposeClientSide = false
@@ -297,6 +328,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "report-empty-dfp-responses",
     "If on, the client will report empty dfp ad responses.",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
     sellByDate = new LocalDate(2016,7,8),
     exposeClientSide = true
@@ -306,6 +338,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "hosted-episode2-content",
     "If on, third page of hosted content is available",
+    owners = Seq(Owner.withGithub("lps88")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 12),
     exposeClientSide = false

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -249,7 +249,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "adblock",
     "Switch for the Adblock Message.",
-    owners = Seq(Owner.withGithub("johnduffell")),
+    owners = Seq(Owner.withName("commercial team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -259,7 +259,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "krux-video-tracking",
     "If this switch is ON, there will be a Krux pixel fired to track particular videos",
-    owners = Seq(Owner.withGithub("johnduffell")),
+    owners = Seq(Owner.withGithub("commercial team")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -309,6 +309,7 @@ trait CommercialSwitches {
     SwitchGroup.Commercial,
     "static-container-badges",
     "Serve container branding from capi",
+    owners = Seq(Owner.withGithub("kelvin-chappell")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 13),
     exposeClientSide = true

--- a/common/app/conf/switches/FaciaSwitches.scala
+++ b/common/app/conf/switches/FaciaSwitches.scala
@@ -10,6 +10,7 @@ trait FaciaSwitches {
     SwitchGroup.Facia,
     "facia-tool-draft-content",
     "If this switch is on facia tool will offer draft content to editors, and press draft fronts from draft content",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -19,6 +20,7 @@ trait FaciaSwitches {
     SwitchGroup.Facia,
     "front-press-job-switch",
     "If this switch is on then the jobs to push and pull from SQS will run",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -28,6 +30,7 @@ trait FaciaSwitches {
     SwitchGroup.Facia,
     "front-press-job-switch-standard-frequency",
     "If this switch is on then the jobs to push and pull from SQS will run",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -37,6 +40,7 @@ trait FaciaSwitches {
     SwitchGroup.Facia,
     "facia-press-on-demand",
     "If this is switched on, you can force facia to press on demand (Leave off)",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -46,6 +50,7 @@ trait FaciaSwitches {
     SwitchGroup.Facia,
     "facia-inline-embeds",
     "If this is switched on, facia will prefetch embeds and render them on the server",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -55,6 +60,7 @@ trait FaciaSwitches {
     SwitchGroup.Facia,
     "facia-press-status-notifications",
     "If this is switched off, facia press will not send status notification on kinesis",
+    owners = Seq(Owner.withGithub("piuccio")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -64,6 +70,7 @@ trait FaciaSwitches {
     SwitchGroup.Facia,
     "facia-press-cross-account-storage",
     "If this is switched on, facia press will access the bucket in cmsFronts account",
+    owners = Seq(Owner.withGithub("piuccio")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 21),
     exposeClientSide = false

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -425,6 +425,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "email-signup-lab-notes",
     "When ON, insert the lab-notes email sign-up into Science section articles",
+    owners = Seq(Owner.withGithub("NathanielBennett")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -435,6 +436,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "email-signup-eu-ref",
     "When ON, insert the EU ref email sign-up into articles with the EU ref tag",
+    owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -8,6 +8,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "immersive-main-media",
     "If this switch is on, main media embeds won't be iframed",
+    owners = Seq(Owner.withGithub("sammorrisdesign")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 8, 22),
     exposeClientSide = false
@@ -17,6 +18,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "fixtures-and-results-container",
     "Fixtures and results container on football tag pages",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -26,6 +28,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "chapter-headings",
     "If this switch is turned on, we will add a block of chapter headings to the top of article pages",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 11, 7),
     exposeClientSide = false
@@ -35,6 +38,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "facebook-share-image-logo-overlay",
     "If this switch is turned on, we will overlay the guardian logo along the bottom of images shared on facebook",
+    owners = Seq(Owner.withGithub("dominickendrick")),
     safeState = On,
     sellByDate = new LocalDate(2016, 11, 7),
     exposeClientSide = false
@@ -44,6 +48,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "outbrain",
     "Enable the Outbrain content recommendation widget on web and AMP.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -53,6 +58,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "plista-for-outbrain-au",
     "Enable the Plista content recommendation widget to replace that of Outbrain for AU edition (for web only).",
+    owners = Seq(Owner.withGithub("JonNorman")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 8, 9),
     exposeClientSide = true
@@ -62,6 +68,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "foresee",
     "Enable Foresee surveys for a sample of our audience",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -71,6 +78,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "geo-most-popular",
     "If this is switched on users then 'most popular' will be upgraded to geo targeted",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -80,6 +88,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "web-fonts",
     "If this is switched on then the custom Guardian web font will load.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -89,6 +98,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "font-kerning",
     "If this is switched on then fonts will be kerned/optimised for legibility.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -98,6 +108,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "google-search",
     "If this switch is turned on then Google search is added to the sections nav.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -107,6 +118,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "id-profile-navigation",
     "If this switch is on you will see the link in the topbar taking you through to the users profile or sign in..",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -117,6 +129,7 @@ trait FeatureSwitches {
     "facebook-autosignin",
     "If this switch is on then users who have previously authorized the guardian app in facebook and who have not " +
       "recently signed out are automatically signed in.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -127,6 +140,7 @@ trait FeatureSwitches {
     "facebook-shareimage",
     "Facebook shares try to use article trail picture image first when switched ON, or largest available " +
       "image when switched OFF.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -136,6 +150,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "id-formstack",
     "If this switch is on, formstack forms will be available",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -145,6 +160,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "id-avatar-upload",
     "If this switch is on, users can upload avatars on their profile page",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -154,6 +170,7 @@ trait FeatureSwitches {
     SwitchGroup.Identity,
     "id-cookie-refresh",
     "If switched on, users cookies will be refreshed.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -163,6 +180,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "enhance-tweets",
     "If this switch is turned on then embedded tweets will be enhanced using Twitter's widgets.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -172,6 +190,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "enhanced-media-player",
     "If this is switched on then videos are enhanced using our JavaScript player",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -181,6 +200,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "breaking-news",
     "If this is switched on then the breaking news feed is requested and articles are displayed",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -190,6 +210,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "weather",
     "If this is switched on then the weather component is displayed",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -199,6 +220,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "history-tags",
     "If this is switched on then personalised history tags are shown in the meganav",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -208,6 +230,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "id-block-spam-emails",
     "If switched on, any new registrations with emails from ae blacklisted domin will be blocked",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -217,6 +240,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "id-log-tor-registrations",
     "If switched on, any user registrations from a known tor exit node will be logged",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -226,6 +250,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "football-feed-recorder",
     "If switched on then football matchday feeds will be recorded every minute",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -235,6 +260,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "crossword-svg-thumbnails",
     "If switched on, crossword thumbnails will be accurate SVGs",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -244,6 +270,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "sudoku",
     "If switched on, sudokus will be available",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -253,6 +280,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "cricket-scores",
     "If switched on, cricket score and scorecard link will be displayed",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -262,6 +290,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "rugby-world-cup",
     "If this switch is on rugby world cup scores will be loaded in to rugby match reports and liveblogs",
+    owners = Seq(Owner.withName("health team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -271,6 +300,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "stocks-widget",
     "If switched on, a stocks widget will be displayed on the business front",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -280,6 +310,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "discussion-all-page-size",
     "If this is switched on then users will have the option to load all comments",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -289,6 +320,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "check-for-missing-video-encodings",
     "If this switch is switched on then the job will run which will check all video content for missing encodings",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -298,6 +330,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "email-inline-in-footer",
     "show the email sign-up in the footer",
+    owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -307,6 +340,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "use-atoms",
     "use atoms from content api to enhance content",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -316,6 +350,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "amp-switch",
     "If this switch is on, link to amp pages will be in the metadata for articles",
+    owners = Seq(Owner.withGithub("NataliaLKB")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -325,6 +360,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "r2-page-press-service",
     "When ON, the R2 page press service will monitor the queue and press pages to S3",
+    owners = Seq(Owner.withGithub("JustinPinner")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -334,6 +370,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "email-in-article",
     "When ON, the email sign-up form will show on articles matching the email lists utilising the email module",
+    owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -344,6 +381,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "article-header-badge",
     "When ON, articles specified in the badges file will have visual elements added",
+    owners = Seq(Owner.withGithub("superfrank")),
     safeState = On,
     sellByDate = new LocalDate(2017, 2, 28),
     exposeClientSide = false
@@ -354,6 +392,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "email-in-article-gtoday",
     "When ON, the email sign-up form will show the Guardian today email sign-up on articles",
+    owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -364,6 +403,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "email-in-article-outbrain",
     "When ON, we will check whether email sign-up will be shown and, if so, the outbrain non-compliant merchandising widget will be shown",
+    owners = Seq(Owner.withGithub("gtrufitt")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -374,6 +414,7 @@ trait FeatureSwitches {
     SwitchGroup.Feature,
     "1x1px-slot",
     "When ON, we will force the creation of the 1x1px adSlot for surveys and pageskins globally",
+    owners = Seq(Owner.withGithub("Calum Campbell")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 8, 25),
     exposeClientSide = true

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -10,6 +10,7 @@ trait MonitoringSwitches {
     SwitchGroup.Monitoring,
     "ophan",
     "Enables the new Ophan tracking javascript",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -19,6 +20,7 @@ trait MonitoringSwitches {
     SwitchGroup.Monitoring,
     "enable-sentry-reporting",
     "If this switch is on, then js errors will be reported to Sentry.",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
     never,
     exposeClientSide = true
@@ -28,6 +30,7 @@ trait MonitoringSwitches {
     SwitchGroup.Monitoring,
     "google-analytics",
     "If this switch is on, then Google Analytics is enabled",
+    owners = Seq(Owner.withGithub("Grant Klopper")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 8, 26),
     exposeClientSide = false
@@ -37,6 +40,7 @@ trait MonitoringSwitches {
     SwitchGroup.Monitoring,
     "scroll-depth",
     "Enables tracking and measurement of scroll depth",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     never,
     exposeClientSide = true
@@ -46,6 +50,7 @@ trait MonitoringSwitches {
     SwitchGroup.Monitoring,
     "css-logging",
     "If this is on, then a subset of clients will post css selector information for diagnostics.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     never,
     exposeClientSide = true
@@ -55,6 +60,7 @@ trait MonitoringSwitches {
     SwitchGroup.Monitoring,
     "csp-reporting",
     "Enables logging of CSP violations",
+    owners = Seq(Owner.withGithub("desbo")),
     safeState = Off,
     never,
     exposeClientSide = false
@@ -64,6 +70,7 @@ trait MonitoringSwitches {
     SwitchGroup.Monitoring,
     "third-party-embed-tracking",
     "Enables tracking on our off-site third party embedded content. Such as: videos on embed.theguardian.com.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     never,
     exposeClientSide = true
@@ -73,6 +80,7 @@ trait MonitoringSwitches {
     SwitchGroup.Monitoring,
     "logstash-logging",
     "Enables sending logs to Logstash",
+    owners = Seq(Owner.withGithub("tbonnin")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false

--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -30,7 +30,7 @@ trait MonitoringSwitches {
     SwitchGroup.Monitoring,
     "google-analytics",
     "If this switch is on, then Google Analytics is enabled",
-    owners = Seq(Owner.withGithub("Grant Klopper")),
+    owners = Seq(Owner.withGithub("gklopper")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 8, 26),
     exposeClientSide = false

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -9,6 +9,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "inline-standard-optimisation",
     "If this switch is on, the inline JS will be compressed using closure compiler's standard optimisation instead of whitespace only",
+    owners = Seq(Owner.withGithub("janua")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -19,6 +20,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "lazy-load-containers",
     "If this switch is on, containers past the 8th will be lazily loaded on mobile and tablet",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -28,6 +30,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "tag-page-size",
     "If this switch is on then we will request more items for larger tag pages",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -37,6 +40,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "long-cache-switch",
     "If this switch is on then content will get a longer cache time",
+    owners = Seq(Owner.withGithub("Grant Klopper")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -46,6 +50,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "circuit-breaker",
     "If this switch is switched on then the Content API circuit breaker will be operational",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false
@@ -55,6 +60,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "server-side-buckets",
     "When this switch expires, remove the remaining predefined server side testing buckets",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 6, 22),
     exposeClientSide = false
@@ -64,6 +70,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "auto-refresh",
     "Enables auto refresh in pages such as live blogs and live scores. Turn off to help handle exceptional load.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -73,6 +80,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "related-content",
     "If this switch is turned on then related content will show. Turn off to help handle exceptional load.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -82,6 +90,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "panic-monitoring",
     "If this switch is on, we monitor latency and requests to see if servers are overloaded",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 8),
     exposeClientSide = false
@@ -91,6 +100,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "panic-logging",
     "If this switch is on, we log latency when we are monitoring it with panic-monitoring",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 8),
     exposeClientSide = false
@@ -100,6 +110,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "panic-shedding",
     "If this switch is on, we try to keep response times below 1s by returning Service Unavailable errors if we're busy",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 7, 8),
     exposeClientSide = false
@@ -109,6 +120,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "rich-links",
     "If this switch is turned off then rich links will not be shown. Turn off to help handle exceptional load.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -118,6 +130,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "inline-critical-css",
     "If this switch is on critical CSS will be inlined into the head of the document.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -128,6 +141,7 @@ trait PerformanceSwitches {
     "async-css",
     "If this switch is on CSS will be loaded with media set to 'only x' and updated to 'all' when the stylesheet " +
       "has loaded using javascript. Disabling it will use standard link elements.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -137,6 +151,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "show-all-embeds",
     "If switched on then all embeds will be shown inside article bodies",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -146,6 +161,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "external-video-embeds",
     "If switched on then we will accept and display external video views",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -155,6 +171,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "discussion",
     "If this switch is on, comments are displayed on articles. Turn this off if the Discussion API is blowing up.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = true
@@ -164,6 +181,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "discussion-page-size",
     "If this is switched on then users will have the option to change their discussion page size",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -174,6 +192,7 @@ trait PerformanceSwitches {
     "open-cta",
     "If this switch is on, will see a CTA to comments on the right hand side. Turn this off if the Open API " +
       "is blowing up.",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -183,6 +202,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "image-server",
     "If this switch is on images will be served off i.guim.co.uk (dynamic image host).",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = On,
     sellByDate = never,
     exposeClientSide = false
@@ -192,6 +212,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "disable-sticky-ad-banner-on-mobile",
     "If this switch is on, the sticky ad banner will be disabled on mobile.",
+    owners = Seq(Owner.withName("health team")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -201,6 +222,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "save-for-later",
     "It this switch is turned on, user are able to save articles. Turn off if this causes overload on then identity api",
+    owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = true
@@ -210,6 +232,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "content-api-use-thrift",
     "If this switch is on then content api calls will be requested in thrift format, instead of json format.",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 8, 5),
     exposeClientSide = false
@@ -219,6 +242,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "use-link-preconnect",
     "If this switch is on then link preconnect hints will be on the page",
+    owners = Seq(Owner.withGithub("rich-nguyen")),
     safeState = Off,
     sellByDate = new LocalDate(2016, 8, 5),
     exposeClientSide = false

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -40,7 +40,7 @@ trait PerformanceSwitches {
     SwitchGroup.Performance,
     "long-cache-switch",
     "If this switch is on then content will get a longer cache time",
-    owners = Seq(Owner.withGithub("Grant Klopper")),
+    owners = Seq(Owner.withGithub("gklopper")),
     safeState = Off,
     sellByDate = never,
     exposeClientSide = false

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -56,16 +56,6 @@ trait PerformanceSwitches {
     exposeClientSide = false
   )
 
-  val ServerSideBucketsSwitch = Switch(
-    SwitchGroup.Performance,
-    "server-side-buckets",
-    "When this switch expires, remove the remaining predefined server side testing buckets",
-    owners = Seq(Owner.withGithub("johnduffell")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 22),
-    exposeClientSide = false
-  )
-
   val AutoRefreshSwitch = Switch(
     SwitchGroup.Performance,
     "auto-refresh",

--- a/common/app/conf/switches/ServerSideABTestSwitches.scala
+++ b/common/app/conf/switches/ServerSideABTestSwitches.scala
@@ -12,6 +12,7 @@ trait ServerSideABTestSwitches {
       SwitchGroup.ServerSideABTests,
       "server-side-tests",
       "Enables the server side testing system",
+      owners = Seq(Owner.withGithub("johnduffell")),
       safeState = Off,
       sellByDate = never,
       exposeClientSide = false

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -49,11 +49,12 @@ trait Initializable[T] extends ExecutionContexts with Logging {
   def onInitialized: Future[T] = initialized.future
 }
 
-case class Owner(name: Option[String], github: Option[String])
+case class Owner(name: Option[String], github: Option[String], email: Option[String])
 object Owner {
-  def apply(name: String, github: String) = new Owner(Some(name), Some(github))
-  def withGithub(githubAccount: String) = new Owner(None, Some(githubAccount))
-  def withName(name: String) = new Owner(Some(name), None)
+  def apply(name: String, github: String) = new Owner(Some(name), Some(github), None)
+  def withGithub(githubAccount: String) = new Owner(None, Some(githubAccount), None)
+  def withName(name: String) = new Owner(Some(name), None, None)
+  def withEmail(email: String) = new Owner(None, None, Some(email))
 }
 
 case class Switch(

--- a/common/app/conf/switches/Switches.scala
+++ b/common/app/conf/switches/Switches.scala
@@ -3,7 +3,7 @@ package conf.switches
 import java.util.concurrent.TimeoutException
 
 import common._
-import org.joda.time.{DateTime, Days, LocalDate}
+import org.joda.time.{DateTime, DateTimeZone, Days, LocalDate}
 import play.api.Play
 
 import scala.concurrent.duration._
@@ -49,10 +49,18 @@ trait Initializable[T] extends ExecutionContexts with Logging {
   def onInitialized: Future[T] = initialized.future
 }
 
+case class Owner(name: Option[String], github: Option[String])
+object Owner {
+  def apply(name: String, github: String) = new Owner(Some(name), Some(github))
+  def withGithub(githubAccount: String) = new Owner(None, Some(githubAccount))
+  def withName(name: String) = new Owner(Some(name), None)
+}
+
 case class Switch(
   group: SwitchGroup,
   name: String,
   description: String,
+  owners: Seq[Owner],
   safeState: SwitchState,
   sellByDate: Option[LocalDate],
   exposeClientSide: Boolean
@@ -98,6 +106,7 @@ object Switch {
     group: SwitchGroup,
     name: String,
     description: String,
+    owners: Seq[Owner],
     safeState: SwitchState,
     sellByDate: LocalDate,
     exposeClientSide: Boolean
@@ -105,6 +114,7 @@ object Switch {
     group,
     name,
     description,
+    owners,
     safeState,
     Some(sellByDate),
     exposeClientSide
@@ -118,7 +128,7 @@ object Switch {
 
   case class Expiry(daysToExpiry: Option[Int], expiresSoon: Boolean, hasExpired: Boolean)
 
-  def expiry(switch: Switch, today: LocalDate = new DateTime().toLocalDate) = {
+  def expiry(switch: Switch, today: LocalDate = new DateTime(DateTimeZone.forID("Europe/London")).toLocalDate) = { // We assume expiration datetime is set to London time
     val daysToExpiry = switch.sellByDate.map {
       Days.daysBetween(today, _).getDays
     }

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -1,6 +1,6 @@
 package mvt
 
-import conf.switches.{SwitchGroup, Switch}
+import conf.switches._
 import org.joda.time.LocalDate
 import play.api.mvc.RequestHeader
 import views.support.CamelCase
@@ -19,6 +19,7 @@ import conf.switches.Switches.ServerSideTests
 object ABHeadlinesTestVariant extends TestDefinition(
   "headlines-ab-variant",
   "To test how much of a difference changing a headline makes (variant group)",
+  owners = Seq(Owner.withGithub("dominickendrick")),
   new LocalDate(2016, 7, 1)
   ) {
   def canRun(implicit request: RequestHeader): Boolean = {
@@ -29,6 +30,7 @@ object ABHeadlinesTestVariant extends TestDefinition(
 object ABNewHeaderVariant extends TestDefinition(
   name = "ab-new-header-variant",
   description = "Feature switch (0% test) for the new header",
+  owners = Seq(Owner.withName("health team")),
   sellByDate = new LocalDate(2016, 6, 14)
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
@@ -39,6 +41,7 @@ object ABNewHeaderVariant extends TestDefinition(
 object ABHeadlinesTestControl extends TestDefinition(
   "headlines-ab-control",
   "To test how much of a difference changing a headline makes (control group)",
+  owners = Seq(Owner.withGithub("dominickendrick")),
   new LocalDate(2016, 7, 1)
   ) {
   def canRun(implicit request: RequestHeader): Boolean = {
@@ -68,12 +71,14 @@ object ActiveTests extends ServerSideABTests {
 abstract case class TestDefinition (
   name: String,
   description: String,
+  owners: Seq[Owner],
   sellByDate: LocalDate
 ) {
   val switch: Switch = Switch(
     SwitchGroup.ServerSideABTests,
     name,
     description,
+    owners,
     conf.switches.Off,
     sellByDate,
     exposeClientSide = true

--- a/common/test/common/MultiVariateTestingTest.scala
+++ b/common/test/common/MultiVariateTestingTest.scala
@@ -1,5 +1,6 @@
 package mvt
 
+import conf.switches.Owner
 import org.joda.time.LocalDate
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.mvc.RequestHeader
@@ -40,6 +41,7 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
     object test0 extends TestDefinition(
       "test0",
       "an experiment test",
+      Seq(Owner.withName("Fake owner")),
       new LocalDate(2100, 1, 1)
     ) {
       def canRun(implicit request: RequestHeader): Boolean = true
@@ -47,6 +49,7 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
     object test1 extends TestDefinition(
       "test1",
       "another experiment test",
+      Seq(Owner.withName("Fake owner")),
       new LocalDate(2100, 1, 1)
     ) {
       def canRun(implicit request: RequestHeader): Boolean = {
@@ -56,6 +59,7 @@ class MultiVariateTestingTest extends FlatSpec with Matchers {
     object test2 extends TestDefinition(
       "test2",
       "still another experiment test",
+      Seq(Owner.withName("Fake owner")),
       new LocalDate(2100, 1, 1)
     ) {
       def canRun(implicit request: RequestHeader): Boolean = {

--- a/common/test/conf/switches/SwitchesTest.scala
+++ b/common/test/conf/switches/SwitchesTest.scala
@@ -18,6 +18,7 @@ class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
     testSwitchGroup,
     "test-switch",
     "exciting switch",
+    owners = Seq(Owner.withGithub("FakeOwner")),
     safeState = Off,
     sellByDate = new LocalDate(2018, 2, 1),
     exposeClientSide = true
@@ -27,6 +28,7 @@ class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
     testSwitchGroup,
     "forever-switch",
     "exciting switch",
+    owners = Seq(Owner.withGithub("FakeOwner")),
     safeState = Off,
     sellByDate = None,
     exposeClientSide = true
@@ -63,6 +65,10 @@ class SwitchesTest extends FlatSpec with Matchers with AppendedClues {
   // If you are wondering why this test has failed then read, https://github.com/guardian/frontend/pull/2711
   they should "be deleted once expired" in {
     forAllSwitches(Switch.expiry(_).hasExpired shouldBe false)
+  }
+
+  they should "all have at least one owner" in {
+    forAllSwitches(_.owners.nonEmpty shouldBe true)
   }
 
   they should "have weekday expiry dates" in {


### PR DESCRIPTION
## What does this change?

Add the concept of switch owner as well as improving the formatting of the expiring switch email

I first thought about using email addresses as switch owners, however because this is a public repo we cannot expose emails directly. It would then require to keep a map of name -> email in the config. That might be an overkill.
I gave up on this idea then and only add the concept of owner, which can be identify by a name (ex: `health team`) and/or a github account)
I used `git blame` to assign already existing switches. I might have made some mistakes (:wink: @johnduffell)
Possible improvement: when a switch is about to expire, automatically open a github issue and assign it to the owner. :)

See the screenshot below for the change regarding formatting

Let me know if you think this could be useful. Thank you
## What is the value of this and can you measure success?

Easier to spot which switch is about to expire
Easier to spot who is responsible for a given switch that is about to expire
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![screen shot 2016-06-02 at 12 16 40](https://cloud.githubusercontent.com/assets/233326/15743577/751b98b2-28be-11e6-9c78-71ce134003f0.png)
## Request for comment

@johnduffell @regiskuckaertz @jamespamplin @JustinPinner @alexduf @rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
