### PR TITLE
show video controls on videos with modifier set

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -1105,3 +1105,22 @@ $ima-controls-height: 70px;
 .vjs-modal-dialog-description {
     display: none;
 }
+
+// We have to use vjs classes here, and not BEM modifiers as videojs
+// changes the classes names via JS, and last time we messed with that,
+// we had major refactoring issues.
+.gu-media--show-controls-at-start.vjs-paused {
+    .vjs-control-bar {
+        bottom: 0;
+    }
+
+    .vjs-big-play-button .vjs-control-text {
+        &:before {
+            background-color: $media-default;
+        }
+
+        &:after {
+            border-left-color: #333333;
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?

I noticed we had the class `.gu-media--show-controls-at-start` a while back, [ran a test on putting it back](https://github.com/guardian/frontend/pull/13003) which proved to increase plays significantly, so we're adding it back.
## What is the value of this and can you measure success?

People notice, thus watch more video.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![screencapture](https://cloud.githubusercontent.com/assets/31692/15747019/bf183206-28d0-11e6-8a8d-fc845773f53d.png)
## Request for comment

@akash1810 @blongden73 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
