### PR TITLE
DFP commercial line items should be validated against active adunits

### DIFF
--- a/admin/app/dfp/AdUnitAgent.scala
+++ b/admin/app/dfp/AdUnitAgent.scala
@@ -39,7 +39,7 @@ object AdUnitAgent extends DataAgent[String, GuAdUnit] {
 object AdUnitService {
 
   // Retrieves the ad unit object if the id matches and the ad unit is active.
-  def adUnit(adUnitId: String): Option[GuAdUnit] = {
+  def activeAdUnit(adUnitId: String): Option[GuAdUnit] = {
     AdUnitAgent.get.data.get(adUnitId).collect {
       case adUnit if adUnit.isActive => adUnit
     }

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -18,7 +18,7 @@ object DataMapper {
     def toGuAdUnits(inventoryTargeting: InventoryTargeting): Seq[GuAdUnit] = {
 
       //noinspection MapFlatten
-      val directAdUnits = toSeq(inventoryTargeting.getTargetedAdUnits).map(_.getAdUnitId).map(AdUnitService.adUnit).flatten
+      val directAdUnits = toSeq(inventoryTargeting.getTargetedAdUnits).map(_.getAdUnitId).map(AdUnitService.activeAdUnit).flatten
 
       //noinspection MapFlatten
       val adUnitsDerivedFromPlacements = {

--- a/admin/app/dfp/DataMapper.scala
+++ b/admin/app/dfp/DataMapper.scala
@@ -1,6 +1,5 @@
 package dfp
 
-import com.google.api.ads.dfp.axis.utils.v201508.StatementBuilder
 import com.google.api.ads.dfp.axis.v201508._
 import common.dfp._
 import dfp.ApiHelper.{isPageSkin, optJavaInt, toJodaTime, toSeq}
@@ -11,7 +10,7 @@ object DataMapper {
   def toGuAdUnit(dfpAdUnit: AdUnit): GuAdUnit = {
     val ancestors = toSeq(dfpAdUnit.getParentPath)
     val ancestorNames = if (ancestors.isEmpty) Nil else ancestors.map(_.getName).tail
-    GuAdUnit(dfpAdUnit.getId, ancestorNames :+ dfpAdUnit.getName)
+    GuAdUnit(dfpAdUnit.getId, ancestorNames :+ dfpAdUnit.getName, dfpAdUnit.getStatus.getValue)
   }
 
   private def toGuTargeting(session: SessionWrapper)(dfpTargeting: Targeting): GuTargeting = {

--- a/admin/app/dfp/DataValidation.scala
+++ b/admin/app/dfp/DataValidation.scala
@@ -17,11 +17,11 @@ object DataValidation {
       )).getOrElse(Nil)
 
     // The validation should not account for inactive or archived ad units.
-    val activeDfpAdUnits = dfpAdUnitIds.filterNot { adUnit =>
-      AdUnitService.isArchivedAdUnit(adUnit) || AdUnitService.isInactiveAdUnit(adUnit)
+    val activeDfpAdUnitIds = dfpAdUnitIds.filterNot { adUnitId =>
+      AdUnitService.isArchivedAdUnit(adUnitId) || AdUnitService.isInactiveAdUnit(adUnitId)
     }
 
-    activeDfpAdUnits.forall( adUnitId => {
+    activeDfpAdUnitIds.forall( adUnitId => {
       guAdUnits.exists(_.id == adUnitId)
     })
   }

--- a/admin/app/dfp/DataValidation.scala
+++ b/admin/app/dfp/DataValidation.scala
@@ -16,7 +16,12 @@ object DataValidation {
         toSeq(inventoryTargeting.getTargetedAdUnits).map(_.getAdUnitId()
       )).getOrElse(Nil)
 
-    dfpAdUnitIds.forall( adUnitId => {
+    // The validation should not account for inactive or archived ad units.
+    val activeDfpAdUnits = dfpAdUnitIds.filterNot { adUnit =>
+      AdUnitService.isArchivedAdUnit(adUnit) || AdUnitService.isInactiveAdUnit(adUnit)
+    }
+
+    activeDfpAdUnits.forall( adUnitId => {
       guAdUnits.exists(_.id == adUnitId)
     })
   }

--- a/admin/app/dfp/PlacementAgent.scala
+++ b/admin/app/dfp/PlacementAgent.scala
@@ -26,7 +26,7 @@ object PlacementService {
       session.placements(stmtBuilder) flatMap (_.getTargetedAdUnitIds.toSeq)
     }
     val adUnitIds = PlacementAgent.get.data getOrElse(placementId, fallback)
-    adUnitIds.flatMap(AdUnitService.adUnit)
+    adUnitIds.flatMap(AdUnitService.activeAdUnit)
   }
 
 }

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -11,7 +11,8 @@ class DfpApiValidationTest extends FlatSpec with Matchers {
     val adUnits = adUnitIds.map( adUnitId => {
       GuAdUnit(
         id = adUnitId,
-        path = Nil)
+        path = Nil,
+        status = GuAdUnit.ACTIVE)
     })
 
     GuLineItem(

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -146,6 +146,10 @@ case class GuAdUnit(id: String, path: Seq[String], status: String) {
 
 object GuAdUnit {
   implicit val adUnitFormat = Json.format[GuAdUnit]
+
+  val ACTIVE = "ACTIVE"
+  val INACTIVE = "INACTIVE"
+  val ARCHIVED = "ARCHIVED"
 }
 
 case class GuTargeting(adUnits: Seq[GuAdUnit],

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -136,29 +136,17 @@ object GeoTarget {
 
 }
 
-
-case class GuAdUnit(id: String, path: Seq[String]) {
+case class GuAdUnit(id: String, path: Seq[String], status: String) {
   val fullPath = path.mkString("/")
+
+  val isActive = status == "ACTIVE"
+  val isInactive = status == "INACTIVE"
+  val isArchived = status == "ARCHIVED"
 }
 
 object GuAdUnit {
-
-  implicit val adUnitWrites = new Writes[GuAdUnit] {
-    def writes(adUnit: GuAdUnit): JsValue = {
-      Json.obj(
-        "id" -> adUnit.id,
-        "path" -> adUnit.path
-      )
-    }
-  }
-
-  implicit val adUnitReads: Reads[GuAdUnit] = (
-    (JsPath \ "id").read[String] and
-      (JsPath \ "path").read[Seq[String]]
-    )(GuAdUnit.apply _)
-
+  implicit val adUnitFormat = Json.format[GuAdUnit]
 }
-
 
 case class GuTargeting(adUnits: Seq[GuAdUnit],
                        geoTargetsIncluded: Seq[GeoTarget],

--- a/common/test/common/dfp/GuLineItemTest.scala
+++ b/common/test/common/dfp/GuLineItemTest.scala
@@ -12,8 +12,8 @@ class GuLineItemTest extends FlatSpec with Matchers {
 
   private val defaultTargeting = targeting(
     Seq(
-      GuAdUnit("id", Seq("theguardian.com")),
-      GuAdUnit("id", Seq("theguardian.com", "business", "front"))
+      GuAdUnit("id", Seq("theguardian.com"), GuAdUnit.ACTIVE),
+      GuAdUnit("id", Seq("theguardian.com", "business", "front"), GuAdUnit.ACTIVE)
     )
   )
 
@@ -60,17 +60,17 @@ class GuLineItemTest extends FlatSpec with Matchers {
   }
 
   it should "be false for a section front targeted indirectly" in {
-    val target = targeting(Seq(GuAdUnit("id", Seq("theguardian.com"))))
+    val target = targeting(Seq(GuAdUnit("id", Seq("theguardian.com"), GuAdUnit.ACTIVE)))
     lineItem(targeting = target) should not be 'suitableForTopAboveNavSlot
   }
 
   it should "be false for an untargeted section front" in {
-    val target = targeting(Seq(GuAdUnit("id", Seq("theguardian.com", "politics"))))
+    val target = targeting(Seq(GuAdUnit("id", Seq("theguardian.com", "politics"), GuAdUnit.ACTIVE)))
     lineItem(targeting = target) should not be 'suitableForTopAboveNavSlot
   }
 
   it should "be false for a front whose section is targeted but front not targeted directly" in {
-    val target = targeting(Seq(GuAdUnit("id", Seq("theguardian.com", "business"))))
+    val target = targeting(Seq(GuAdUnit("id", Seq("theguardian.com", "business"), GuAdUnit.ACTIVE)))
     lineItem(targeting = target) should not be 'suitableForTopAboveNavSlot
   }
 

--- a/common/test/common/dfp/HighMerchandisingLineItemTest.scala
+++ b/common/test/common/dfp/HighMerchandisingLineItemTest.scala
@@ -13,14 +13,14 @@ class HighMerchandisingLineItemTest extends FlatSpec with Matchers {
         name = "test",
         id = 77942847,
         tags = Seq.empty,
-        adUnits = Seq(GuAdUnit("59359047", Seq("theguardian.com","money"))),
+        adUnits = Seq(GuAdUnit("59359047", Seq("theguardian.com","money"), GuAdUnit.ACTIVE)),
         customTargetSet = Seq(CustomTargetSet("AND",Seq(CustomTarget("slot","IS",Seq("merchandising-high")),CustomTarget("edition","IS",Seq("uk")))))
       ),
         HighMerchandisingLineItem(
           name = "test2",
           id = 77943847,
           tags = Seq("cricket","England","test"),
-          adUnits = Seq(GuAdUnit("59359047", Seq("theguardian.com","sport"))),
+          adUnits = Seq(GuAdUnit("59359047", Seq("theguardian.com","sport"), GuAdUnit.ACTIVE)),
           customTargetSet = Seq(CustomTargetSet("AND",Seq(CustomTarget("slot","IS",Seq("merchandising-high")))))
         ),
         HighMerchandisingLineItem(

--- a/common/test/common/dfp/PaidForTagAgentTest.scala
+++ b/common/test/common/dfp/PaidForTagAgentTest.scala
@@ -33,7 +33,7 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
                          sponsor: Option[String] = None,
                          expiryDate: Option[DateTime] = None,
                          adUnitPaths: Seq[String] = Nil) = {
-    val adUnits = adUnitPaths.map(path => GuAdUnit("0", path.split("/")))
+    val adUnits = adUnitPaths.map(path => GuAdUnit("0", path.split("/"), GuAdUnit.ACTIVE))
     val customTargetSets = editionId map { edition =>
       Seq(CustomTargetSet("AND", Seq(CustomTarget("edition", "IS", Seq(edition)))))
     } getOrElse Nil

--- a/common/test/common/dfp/PaidForTagTest.scala
+++ b/common/test/common/dfp/PaidForTagTest.scala
@@ -43,7 +43,8 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |                "path": [
       |                  "theguardian.com",
       |                  "small-business-network"
-      |                ]
+      |                ],
+      |                "status": "ACTIVE"
       |              }
       |            ],
       |            "geoTargetsIncluded": [
@@ -177,7 +178,8 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |                "id": "59342247",
       |                "path": [
       |                  "theguardian.com"
-      |                ]
+      |                ],
+      |                "status": "ACTIVE"
       |              }
       |            ],
       |            "geoTargetsIncluded": [
@@ -245,7 +247,8 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |                "path": [
       |                  "theguardian.com",
       |                  "sustainable-business"
-      |                ]
+      |                ],
+      |                "status": "ACTIVE"
       |              }
       |            ],
       |            "geoTargetsIncluded": [
@@ -374,7 +377,8 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |                "id": "59342247",
       |                "path": [
       |                  "theguardian.com"
-      |                ]
+      |                ],
+      |                "status": "ACTIVE"
       |              }
       |            ],
       |            "geoTargetsIncluded": [

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -2,7 +2,6 @@ package conf
 
 import common._
 import feed.Competitions
-import football.controllers.HealthCheck
 import model.{TeamMap, LiveBlogAgent}
 import pa.{PaClientErrorsException, Http, PaClient}
 import play.api.inject.ApplicationLifecycle


### PR DESCRIPTION
This fixes an issue where line items targeting inactive/archived ad units were being rejected from our system. 

The correct behaviour is to reject unknown adunits, instead of rejecting adunits which are not active.

Note to self: This will invalidate the format for: line items report, high merch report, and paid for tags report. In the long term, its better to do this invalidation than use an `Option` for something that will always be there.
