### PR TITLE
Lydia hosted by video improvements

### DIFF
--- a/commercial/app/views/hosted/guardianHostedPage.scala.html
+++ b/commercial/app/views/hosted/guardianHostedPage.scala.html
@@ -100,6 +100,9 @@
                 </div>
             </header>
             <div class="adverts__body">
+                <div class="hosted__meta">
+                    <h1 class="hosted__heading hosted-tone--renault">@page.video.title</h1>
+                </div>
                 <div class="hosted__standfirst">
                     <p class="hosted__text">@page.standfirst</p>
                     <div class="hosted__terms">​This content was paid for and produced by Renault. For more information click

--- a/static/src/javascripts/projects/common/modules/commercial/hosted-video.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-video.js
@@ -8,6 +8,7 @@ define([
     'common/utils/defer-to-analytics',
     'common/modules/video/events',
     'common/modules/video/videojs-options',
+    'common/modules/video/fullscreener',
     'text!common/views/ui/loading.html'
 ], function (
     bean,
@@ -15,6 +16,7 @@ define([
     deferToAnalytics,
     events,
     videojsOptions,
+    fullscreener,
     loadingTmpl
 ) {
     var player;
@@ -53,6 +55,7 @@ define([
 
                 player = videojs($videoEl.get(0), videojsOptions());
                 player.guMediaType = 'video';
+                videojs.plugin('fullscreener', fullscreener);
 
                 // unglitching the volume on first load
                 var vol = player.volume();
@@ -62,6 +65,8 @@ define([
                 }
 
                 player.ready(function () {
+                    player.fullscreener();
+
                     deferToAnalytics(function () {
                         events.initOmnitureTracking(player);
                         events.initOphanTracking(player, mediaId);

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -157,18 +157,13 @@ $renaultLight: #fff9e9;
 
     .vjs-big-play-button .vjs-control-text {
         margin-left: -40px;
-        margin-top: -68px;
+        margin-top: -40px;
         width: 136px;
         height: 48px;
         text-indent: -999px;
 
-        @include mq($until: desktop) {
-            display: none; //Temporary disable on mobile and tablet, it will be removed when the tap events on video element will be fixed
-        }
-
-        @include mq(tablet) {
+        @include mq(mobileLandscape) {
             margin-left: -70px;
-            margin-top: -25px;
         }
 
         &:before {
@@ -240,17 +235,19 @@ $renaultLight: #fff9e9;
         bottom: 0;
         background-color: unset;
         font-size: 16px;
-        height: 50px;
+        padding-top: 2px;
+        height: 48px;
     }
 
     .vjs-fullscreen-control {
-        margin-top: 10px;
+        margin-top: 12px;
     }
 
     .vjs-volume-menu-button {
         @include mq(desktop) {
             margin-right: $gs-column-width * 1.5;
         }
+        height: auto;
     }
 
     .vjs-menu-button {
@@ -263,15 +260,7 @@ $renaultLight: #fff9e9;
 
     &.vjs {
         .vjs-play-control {
-            width: 37px;
-            height: 37px;
-            margin: 6px 0 6px 20px;
-            display: block;
-
-            @include mq(desktop) {
-                display: none; //We have a 'watch now' in the middle so don't need this one
-                margin-left: $gs-column-width * 1.5;
-            }
+            display: none; //We have a 'watch now' in the middle so don't need this one
         }
 
         .vjs-current-time {
@@ -296,20 +285,33 @@ $renaultLight: #fff9e9;
     position: absolute;
     left: 20px;
     width: 100%;
-    color: #ffffff;
+    bottom: 44px;
 
     @include mq($until: tablet) {
-        right: $gs-gutter;
-        width: auto;
-        bottom: 48px;
-    }
-
-    @include mq(tablet) {
-        bottom: 60px;
+        display: none;
     }
 
     @include mq(desktop) {
         left: $gs-column-width * 1.5;
+    }
+}
+
+.adverts__body .hosted__meta {
+    display: none;
+    position: relative;
+    width: auto;
+    padding: $gs-baseline $gs-gutter 0;
+    bottom: auto;
+    left: auto;
+    right: auto;
+
+    @include mq($until: tablet) {
+        display: block;
+    }
+
+    .hosted__heading {
+        font-size: 24px;
+        line-height: 22px;
     }
 }
 
@@ -331,6 +333,10 @@ $renaultLight: #fff9e9;
     .hosted__video-overlay {
         @include hosted-fade-in;
     }
+}
+
+.hosted__video .vjs-fullscreen-clickbox {
+    display: block;
 }
 
 .hosted-fading {


### PR DESCRIPTION
## What does this change?
- make sure the video will always play/pause on click (fullscreener plugin)
- use new style play button (white oval instead of yellow circle) on all sizes
- the video title now sites below the video on mobile size
- make sure the video controls are centred in the control bar
## Screenshots
- paused:

![image](https://cloud.githubusercontent.com/assets/6290008/15749079/0d5e1446-28d9-11e6-9cee-e46c972bdef4.png)
- playing:

![image](https://cloud.githubusercontent.com/assets/6290008/15749109/2c50ba84-28d9-11e6-86ef-d0b1e955fc94.png)
