### PR TITLE
Show different message when you can't skip an ad.

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -302,13 +302,13 @@ define([
                                             adTagUrl: getAdUrl(),
                                             prerollTimeout: 1000
                                         });
-                                        player.ima.requestAds();
                                         player.on('adstart', function() {
                                             var adDuration = player.ima.getAdsManager().getCurrentAd().getDuration();
                                             if (adDuration > skipAdTime) {
                                                 player.adSkipCountdown(skipAdTime);
                                             }
                                         });
+                                        player.ima.requestAds();
 
                                         // Video analytics event.
                                         player.trigger(events.constructEventName('preroll:request', player));

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -296,17 +296,13 @@ define([
                                 raven.wrap(
                                     { tags: { feature: 'media' } },
                                     function () {
-                                        var skipAdTime = 15;
                                         player.ima({
                                             id: mediaId,
                                             adTagUrl: getAdUrl(),
                                             prerollTimeout: 1000
                                         });
                                         player.on('adstart', function() {
-                                            var adDuration = player.ima.getAdsManager().getCurrentAd().getDuration();
-                                            if (adDuration > skipAdTime) {
-                                                player.adSkipCountdown(skipAdTime);
-                                            }
+                                            player.adSkipCountdown(15);
                                         });
                                         player.ima.requestAds();
 

--- a/static/src/javascripts/projects/common/modules/video/events.js
+++ b/static/src/javascripts/projects/common/modules/video/events.js
@@ -233,10 +233,15 @@ define([
                     this.ima.getAdsManager().stop();
                 },
                 init: function () {
-                    var skipButton = template(adsSkipOverlayTmpl, { skipTimeout: skipTimeout });
+                    var adDuration = this.ima.getAdsManager().getCurrentAd().getDuration();
+
+                    var skipButton = template(adsSkipOverlayTmpl, {
+                        adDuration: adDuration,
+                        skipTimeout: skipTimeout
+                    });
 
                     $(this.el()).append(skipButton);
-                    intervalId = setInterval(events.update.bind(this), 250);
+                    intervalId = setInterval(events.update.bind(this), 500);
 
                 },
                 end: function () {

--- a/static/src/javascripts/projects/common/views/ui/video-ads-skip-overlay.html
+++ b/static/src/javascripts/projects/common/views/ui/video-ads-skip-overlay.html
@@ -1,3 +1,10 @@
 <div class="js-ads-skip vjs-ads-skip">
-    <span class="vjs-ads-skip__countdown">You may skip this advert in <span class="js-skip-remaining-time"><%=skipTimeout%></span> seconds</span>
+    <span class="vjs-ads-skip__countdown">
+        <% if (adDuration > skipTimeout) { %>
+        You may skip this advert in
+        <% } else { %>
+        Your video will start in
+        <% } %>
+        <span class="js-skip-remaining-time"><%=skipTimeout%></span> seconds
+    </span>
 </div>


### PR DESCRIPTION
## What does this change?

Apologies for the double whammy.
- Show prerolls on video pages again as we were just resolving the promise with `shouldHideAdverts: true`, whereas we should have been looking it up.
- Only add the skip timer when the ad is longer than the time to skip.
## What is the value of this and can you measure success?
- We get no more complaints saying how can I skip if the ad ends before I can skip.
- We serve preroll again.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
