### PR TITLE
Hosted by page - Video controls fade out 1.5 seconds after hover

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -196,38 +196,53 @@ $renaultLight: #fff9e9;
         opacity: 0;
     }
 
-    &.vjs-paused {
-        .vjs-fullscreen-control,
-        .vjs-volume-menu-button,
-        .vjs-progress-control {
-            @include hosted-fade-out;
-        }
-
-        .vjs-big-play-button {
-            @include hosted-fade-in;
-        }
-
-        .vjs-control-bar {
-            background-color: unset;
-            transition: background-color 1s linear;
-        }
+    &.vjs-playing .vjs-time-control,
+    .vjs-fullscreen-control,
+    .vjs-volume-menu-button,
+    .vjs-progress-control {
+        @include hosted-fade-out;
+        transition-delay: 1500ms;
     }
 
-    &.vjs-playing {
+    .vjs-big-play-button {
+        @include hosted-fade-in;
+    }
+
+    .vjs-control-bar {
+        background-color: unset;
+        transition: background-color 1s linear;
+        transition-delay: 1500ms;
+    }
+
+    &.vjs-playing:hover {
+        .vjs-time-control,
         .vjs-fullscreen-control,
         .vjs-volume-menu-button,
         .vjs-progress-control {
             @include hosted-fade-in;
+            transition-delay: 0s;
         }
 
         .vjs-big-play-button {
             @include hosted-fade-out;
             display: block !important; //I know this is ugly but I need to overwrite display:none to show the animation
+            transition-delay: 0s;
         }
 
         .vjs-control-bar {
             background-color: rgba(25, 25, 25, .8);
-            transition: background-color 1s linear;
+            transition-delay: 0s;
+        }
+    }
+
+    &.vjs-paused,
+    &.vjs-paused:hover {
+        .vjs-time-control,
+        .vjs-fullscreen-control,
+        .vjs-volume-menu-button,
+        .vjs-progress-control,
+        .vjs-control-bar {
+            transition-delay: 0s;
         }
     }
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -189,13 +189,6 @@ $renaultLight: #fff9e9;
         border-radius: 30px;
     }
 
-    //those control buttons will fade in on video play
-    .vjs-fullscreen-control,
-    .vjs-volume-menu-button,
-    .vjs-progress-control {
-        opacity: 0;
-    }
-
     &.vjs-playing .vjs-time-control,
     .vjs-fullscreen-control,
     .vjs-volume-menu-button,
@@ -210,8 +203,7 @@ $renaultLight: #fff9e9;
 
     .vjs-control-bar {
         background-color: unset;
-        transition: background-color 1s linear;
-        transition-delay: 1500ms;
+        transition: background-color 1s linear 1500ms;
     }
 
     &.vjs-playing:hover {


### PR DESCRIPTION
## What does this change?

Um... Video controls fade out 1.5 seconds after hover (should it be :active?)

@Calanthe, you'll have to show me again how to record gifs!
## Request for comment

@Calanthe 
