### PR TITLE
Call Id.init() before using Id in standard

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/identity-common.js
+++ b/static/src/javascripts/bootstraps/enhanced/identity-common.js
@@ -11,8 +11,7 @@ define([
     robust,
     Id
 ) {
-    function setCssClass(config) {
-        Id.init(config);
+    function setCssClass() {
         // Used to show elements that need signin. Use .sign-in-required
         if (Id.isUserLoggedIn()) {
             document.documentElement.className = document.documentElement.className

--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -249,6 +249,11 @@ define([
             }
         }
 
+        /**
+         * Initialise Identity module
+         */
+        identity.init();
+
         // show hiring message if we're in a very modern browser
         try { // this should never interfere with anything, so `try` it
             if ('repeat' in String.prototype && !config.page.isDev) {

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -169,7 +169,6 @@ define([
         if (userListSubsChecked) {
             return Promise.resolve(userListSubs);
         } else {
-            Id.init();
             return Id.getUserEmailSignUps()
                 .then(buildUserSubscriptions)
                 .catch(function (error) {

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -169,6 +169,7 @@ define([
         if (userListSubsChecked) {
             return Promise.resolve(userListSubs);
         } else {
+            Id.init();
             return Id.getUserEmailSignUps()
                 .then(buildUserSubscriptions)
                 .catch(function (error) {


### PR DESCRIPTION
## What does this change?

Makes sure `Id.init()` gets called in the e-mail subscribe module run-checks. Otherwise `Id.ApiRoot` and `Id.idUrl` will be `null`.

The below code from `static/src/javascripts/projects/common/modules/identity/api.js` outlines why that is:

```
    Id.idApiRoot = null;
    Id.idUrl = null;

    Id.init = function () {
        Id.idApiRoot = config.page.idApiUrl;
        Id.idUrl = config.page.idUrl;
        mediator.emit('module:identity:api:loaded');
    };
```

Currently on certain pages that try to check the e-mail subscription status of the user, the code in `getUserEmailSubscriptions()` in `static/src/javascripts/projects/common/modules/email/run-checks.js` fails because the `Id.ApiRoot` is `null` and the wrong Identity API URL gets constructed:

![image](https://cloud.githubusercontent.com/assets/164991/15774244/432d12ee-2973-11e6-9123-23ade07cef7d.png)
## What is the value of this and can you measure success?

Should make the e-mail subscribe module work on all pages and the console error about the failed request should go away.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
