### PR TITLE
Discussion - add specific error message

### DIFF
--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -72,7 +72,7 @@ CommentBox.prototype.errorMessages = {
     COMMENT_TOO_LONG: 'Your comment must be fewer than 5000 characters long.',
     USER_BANNED: 'Commenting has been disabled for this account (<a href="/community-faqs#321a">why?</a>).',
     DISCUSSION_CLOSED: 'Sorry your comment can not be published as the discussion is now closed for comments.',
-    PARENT_COMMENT_MODERATED: 'Sorry the comment can not be published as the comment you reply to as been moderated since',
+    PARENT_COMMENT_MODERATED: 'Sorry the comment can not be published as the comment you replied to as been moderated since.',
     COMMENT_RATE_LIMIT_EXCEEDED: 'You can only post one comment every minute. Please try again in a moment.',
     INVALID_PROTOCOL: 'Sorry your comment can not be published as it was not sent over a secure channel. Please report us this issue using the technical issue link in the page footer.',
     AUTH_COOKIE_INVALID: 'Sorry, your comment was not published as you are no longer signed in. Please sign in and try again.',

--- a/static/src/javascripts/projects/common/modules/discussion/comment-box.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comment-box.js
@@ -72,6 +72,7 @@ CommentBox.prototype.errorMessages = {
     COMMENT_TOO_LONG: 'Your comment must be fewer than 5000 characters long.',
     USER_BANNED: 'Commenting has been disabled for this account (<a href="/community-faqs#321a">why?</a>).',
     DISCUSSION_CLOSED: 'Sorry your comment can not be published as the discussion is now closed for comments.',
+    PARENT_COMMENT_MODERATED: 'Sorry the comment can not be published as the comment you reply to as been moderated since',
     COMMENT_RATE_LIMIT_EXCEEDED: 'You can only post one comment every minute. Please try again in a moment.',
     INVALID_PROTOCOL: 'Sorry your comment can not be published as it was not sent over a secure channel. Please report us this issue using the technical issue link in the page footer.',
     AUTH_COOKIE_INVALID: 'Sorry, your comment was not published as you are no longer signed in. Please sign in and try again.',


### PR DESCRIPTION
## What does this change?

Between the time a user start replying to a comment and the comment is posted the parent comment may has been moderated or deleted. In that case the current user experience display a generic error message:

![ce33e9ae-398f-47d7-9154-ce5004fa2be7](https://cloud.githubusercontent.com/assets/615085/13494686/b3bfed34-e13d-11e5-94ee-89eb9185fa6c.png)

See discussion API code:

[Comment deleted](https://github.com/guardian/discussion-api/blob/master/discussion-api/src/main/scala/com.gu.discussion.api/api/DiscussionApi.scala#L111-L113)

``` scala
val parentCommentOption = replyToCommentId map { parentId ⇒
      repositories.writeableComment(parentId) getOrElse NotFoundException(ApiErrorMessages.commentNotFound)
    }
```

[Comment moderated](https://github.com/guardian/discussion-api/blob/master/discussion-api/src/main/scala/com.gu.discussion.api/api/DiscussionApi.scala#L137-L139)

``` scala
if (Switchboard.noReplyModComments.enabled && (parent.status != "visible")) {
          InvalidApiRequest(ApiErrorMessages.commentParentModerated)
        }
```
