### PR TITLE
use the right healthcheck object

### DIFF
--- a/diagnostics/app/Global.scala
+++ b/diagnostics/app/Global.scala
@@ -1,7 +1,8 @@
 import common.Logback.LogstashLifecycle
 import common._
-import conf.{HealthCheck, CachedHealthCheckLifeCycle}
+import conf.CachedHealthCheckLifeCycle
 import conf.switches.SwitchboardLifecycle
+import controllers.HealthCheck
 import model.ApplicationIdentity
 import play.api.inject.ApplicationLifecycle
 import play.api.GlobalSettings

--- a/diagnostics/app/conf/HealthCheck.scala
+++ b/diagnostics/app/conf/HealthCheck.scala
@@ -1,3 +1,0 @@
-package conf
-
-object HealthCheck extends AllGoodCachedHealthCheck(9006, "/robots.txt")


### PR DESCRIPTION
## What does this change?

Fixes a deployment error: there was two similar healtcheck, it needs to be consistent to work
## Request for comment

@johnduffell

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
