### PR TITLE
Include the run-of-network adunit in the adunit agent

### DIFF
--- a/admin/app/controllers/admin/CommercialController.scala
+++ b/admin/app/controllers/admin/CommercialController.scala
@@ -36,7 +36,7 @@ object CommercialController extends Controller with Logging with AuthLogging wit
   }
 
   def renderSpecialAdUnits = AuthActions.AuthActionTest { implicit request =>
-    val specialAdUnits = DfpApi.readSpecialAdUnits(Configuration.commercial.dfpAdUnitRoot)
+    val specialAdUnits = DfpApi.readSpecialAdUnits(Configuration.commercial.dfpAdUnitGuRoot)
     Ok(views.html.commercial.specialAdUnits(environment.stage, specialAdUnits))
   }
 

--- a/admin/app/dfp/DfpAdUnitCacheJob.scala
+++ b/admin/app/dfp/DfpAdUnitCacheJob.scala
@@ -21,7 +21,7 @@ class DfpAdUnitCacher(val rootAdUnit: Any, val filename: String) extends Executi
   }
 }
 
-object DfpAdUnitCacheJob extends DfpAdUnitCacher(Configuration.commercial.dfpAdUnitRoot, Configuration.commercial.dfpActiveAdUnitListKey)
+object DfpAdUnitCacheJob extends DfpAdUnitCacher(Configuration.commercial.dfpAdUnitGuRoot, Configuration.commercial.dfpActiveAdUnitListKey)
 
 object DfpFacebookIaAdUnitCacheJob extends DfpAdUnitCacher(Configuration.commercial.dfpFacebookIaAdUnitRoot, Configuration.commercial.dfpFacebookIaAdUnitListKey)
 

--- a/admin/app/dfp/ServicesWrapper.scala
+++ b/admin/app/dfp/ServicesWrapper.scala
@@ -25,4 +25,6 @@ private[dfp] class ServicesWrapper(session: DfpSession) {
   lazy val creativeTemplateService = dfpServices.get(session, classOf[CreativeTemplateServiceInterface])
 
   lazy val creativeService = dfpServices.get(session, classOf[CreativeServiceInterface])
+
+  lazy val networkService = dfpServices.get(session, classOf[NetworkServiceInterface])
 }

--- a/admin/app/dfp/SessionWrapper.scala
+++ b/admin/app/dfp/SessionWrapper.scala
@@ -79,6 +79,10 @@ private[dfp] class SessionWrapper(dfpSession: DfpSession) {
     }
   }
 
+  def getRootAdUnitId: String = {
+    services.networkService.getCurrentNetwork.getEffectiveRootAdUnitId
+  }
+
   object lineItemCreativeAssociations {
 
     private val licaService = services.licaService

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -277,7 +277,7 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
       if (environment.isProd) "http://m.code.dev-theguardian.com"
       else configuration.getStringProperty("guardian.page.host") getOrElse ""
 
-    lazy val dfpAdUnitRoot = configuration.getMandatoryStringProperty("guardian.page.dfpAdUnitRoot")
+    lazy val dfpAdUnitGuRoot = configuration.getMandatoryStringProperty("guardian.page.dfpAdUnitRoot")
     lazy val dfpFacebookIaAdUnitRoot = configuration.getMandatoryStringProperty("guardian.page.dfp.facebookIaAdUnitRoot")
     lazy val dfpMobileAppsAdUnitRoot = configuration.getMandatoryStringProperty("guardian.page.dfp.mobileAppsAdUnitRoot")
     lazy val dfpAccountId = configuration.getMandatoryStringProperty("guardian.page.dfpAccountId")

--- a/common/app/common/dfp/AdSlotAgent.scala
+++ b/common/app/common/dfp/AdSlotAgent.scala
@@ -5,7 +5,7 @@ import java.net.URI
 import common.Edition
 import common.dfp.AdSize.{leaderboardSize, responsiveSize}
 import common.editions.{Au, Uk, Us}
-import conf.Configuration.commercial.dfpAdUnitRoot
+import conf.Configuration.commercial.dfpAdUnitGuRoot
 
 trait AdSlotAgent {
 
@@ -15,7 +15,7 @@ trait AdSlotAgent {
 
   protected def takeoversWithEmptyMPUs: Seq[TakeoverWithEmptyMPUs]
 
-  private def fullAdUnit(adUnitWithoutRoot: String) = s"$dfpAdUnitRoot/$adUnitWithoutRoot"
+  private def fullAdUnit(adUnitWithoutRoot: String) = s"$dfpAdUnitGuRoot/$adUnitWithoutRoot"
 
   private def isCurrent(lineItem: GuLineItem) = {
     lineItem.startTime.isBeforeNow && (

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -60,7 +60,6 @@ object CustomTarget {
 
 }
 
-
 case class CustomTargetSet(op: String, targets: Seq[CustomTarget]) {
 
   def filterTags(tagCriteria: CustomTarget => Boolean)(bySlotType: CustomTarget => Boolean) = {

--- a/common/app/common/dfp/PageskinAdAgent.scala
+++ b/common/app/common/dfp/PageskinAdAgent.scala
@@ -12,7 +12,7 @@ trait PageskinAdAgent {
   private def findSponsorships(adUnitWithoutRoot: String, edition: Edition): Seq[PageSkinSponsorship] = {
 
     if (PageSkin.isValidAdUnit(adUnitWithoutRoot)) {
-      val adUnitWithRoot = s"$dfpAdUnitRoot/$adUnitWithoutRoot"
+      val adUnitWithRoot = s"$dfpAdUnitGuRoot/$adUnitWithoutRoot"
 
       def targetsAdUnitAndMatchesTheEdition(sponsorship: PageSkinSponsorship) = {
         val adUnits = sponsorship.adUnits map (_.stripSuffix("/ng"))

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -297,7 +297,7 @@ final case class MetaData (
     ("pageId", JsString(id)),
     ("section", JsString(section)),
     ("webTitle", JsString(webTitle)),
-    ("adUnit", JsString(s"/${Configuration.commercial.dfpAccountId}/${Configuration.commercial.dfpAdUnitRoot}/$adUnitSuffix/ng")),
+    ("adUnit", JsString(s"/${Configuration.commercial.dfpAccountId}/${Configuration.commercial.dfpAdUnitGuRoot}/$adUnitSuffix/ng")),
     ("buildNumber", JsString(buildNumber)),
     ("revisionNumber", JsString(revision)),
     ("analyticsName", JsString(analyticsName)),

--- a/common/test/common/dfp/PageskinAdAgentTest.scala
+++ b/common/test/common/dfp/PageskinAdAgentTest.scala
@@ -2,7 +2,7 @@ package common.dfp
 
 import common.Edition.defaultEdition
 import common.editions.{Au, Uk, Us}
-import conf.Configuration.commercial.dfpAdUnitRoot
+import conf.Configuration.commercial.dfpAdUnitGuRoot
 import org.scalatest.{FlatSpec, Matchers}
 
 class PageskinAdAgentTest extends FlatSpec with Matchers {
@@ -10,7 +10,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
   val examplePageSponsorships = Seq(
     PageSkinSponsorship("lineItemName",
       1234L,
-      Seq(s"$dfpAdUnitRoot/business/front"),
+      Seq(s"$dfpAdUnitGuRoot/business/front"),
       Seq(Uk),
       Seq("United Kingdom"),
       isR2Only = false,
@@ -18,7 +18,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       None),
     PageSkinSponsorship("lineItemName2",
       12345L,
-      Seq(s"$dfpAdUnitRoot/music/front"),
+      Seq(s"$dfpAdUnitGuRoot/music/front"),
       Nil,
       Nil,
       isR2Only = false,
@@ -26,7 +26,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       None),
     PageSkinSponsorship("lineItemName3",
       123456L,
-      Seq(s"$dfpAdUnitRoot/sport"),
+      Seq(s"$dfpAdUnitGuRoot/sport"),
       Nil,
       Nil,
       isR2Only = false,
@@ -34,7 +34,7 @@ class PageskinAdAgentTest extends FlatSpec with Matchers {
       None),
     PageSkinSponsorship("lineItemName4",
       1234567L,
-      Seq(s"$dfpAdUnitRoot/testSport/front"),
+      Seq(s"$dfpAdUnitGuRoot/testSport/front"),
       Seq(Uk),
       Seq("United Kingdom"),
       isR2Only = false,


### PR DESCRIPTION
This updates the adunit agent on the admin server so that it can resolve the id of the ad unit which corresponds to the run-of-network. This is sometimes used to target the whole inventory.
