### PR TITLE
revert changes to js di on video embed page

### DIFF
--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -3,6 +3,8 @@ define([
     'bean',
     'bonzo',
     'qwery',
+    'videojs',
+    'videojsembed',
     'common/utils/$',
     'common/utils/config',
     'common/utils/defer-to-analytics',
@@ -16,12 +18,13 @@ define([
     'text!common/views/ui/loading.html',
     'text!common/views/media/titlebar.html',
     'lodash/functions/debounce',
-    'common/modules/video/videojs-options',
-    'bootstraps/enhanced/media/video-player'
+    'common/modules/video/videojs-options'
 ], function (
     bean,
     bonzo,
     qwery,
+    videojs,
+    videojsembed,
     $,
     config,
     deferToAnalytics,
@@ -35,8 +38,7 @@ define([
     loadingTmpl,
     titlebarTmpl,
     debounce,
-    videojsOptions,
-    videojs
+    videojsOptions
 ) {
 
     function initLoadingSpinner(player) {


### PR DESCRIPTION
## What does this change?

backs out a change introduced in #13164 as the embed page is currently borking 😢 need to work out why https://github.com/guardian/frontend/pull/13168 is actually needed but until then, lets fix the embed page!
## What is the value of this and can you measure success?

embed page works again
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

n/a
## Request for comment

@jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
