### PR TITLE
always ensure https urls for video pages

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -185,18 +185,19 @@ object BulletCleaner {
   def apply(body: String): String = body.replace("•", """<span class="bullet">•</span>""")
 }
 
-object VideoEncodingUrlCleaner {
-  def apply(url: String): String = url.filter(_ != '\n')
+trait HttpsUrl {
+  def ensureHttps(url: String): String = url.replace("http:", "https:")
 }
 
-object AmpSrcCleaner {
+object VideoEncodingUrlCleaner extends HttpsUrl {
+  def apply(url: String): String = ensureHttps(url.filter(_ != '\n'))
+}
+
+object AmpSrcCleaner extends HttpsUrl {
   def apply(videoSrc: String) = {
     // All media sources need to start with https for AMP.
-    // Temperary code until all media urls returned from CAPI are https
-    if (videoSrc.startsWith("http:")) {
-      val (first, last) = videoSrc.splitAt(4);
-      first + "s" + last
-    }
+    // Temporary code until all media urls returned from CAPI are https
+    ensureHttps(videoSrc)
   }
 }
 


### PR DESCRIPTION
## What does this change?

We're getting some video urls as http - lets just upgrade them on frontend rather than forcing capi to update itself. We do similar things on embeds already.
## What is the value of this and can you measure success?

https 🔒 
## Does this affect other platforms - Amp, Apps, etc?

Amp - only because of a code abstraction.
## Screenshots

n/a
## Request for comment

@jamesgorrie @fredex42

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
