### PR TITLE
Track excluded adunits in dfp data extraction

### DIFF
--- a/admin/app/dfp/DataValidation.scala
+++ b/admin/app/dfp/DataValidation.scala
@@ -9,7 +9,7 @@ object DataValidation {
   def isGuLineItemValid(guLineItem: GuLineItem, dfpLineItem: LineItem): Boolean = {
 
     // Check that all the direct dfp ad units have been accounted for in the targeting.
-    val guAdUnits = guLineItem.targeting.adUnits
+    val guAdUnits = guLineItem.targeting.adUnitsIncluded
 
     val dfpAdUnitIds = Option(dfpLineItem.getTargeting.getInventoryTargeting)
       .map( inventoryTargeting =>

--- a/admin/app/dfp/DfpDataExtractor.scala
+++ b/admin/app/dfp/DfpDataExtractor.scala
@@ -23,7 +23,8 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
           name = lineItem.name,
           id = lineItem.id,
           tags = lineItem.highMerchandisingTargets,
-          adUnits = lineItem.targeting.adUnits,
+          adUnitsIncluded = lineItem.targeting.adUnitsIncluded,
+          adUnitsExcluded = lineItem.targeting.adUnitsExcluded,
           customTargetSet = lineItem.targeting.customTargetSets
         )
       }
@@ -38,7 +39,7 @@ case class DfpDataExtractor(lineItems: Seq[GuLineItem]) {
       PageSkinSponsorship(
         lineItemName = lineItem.name,
         lineItemId = lineItem.id,
-        adUnits = lineItem.targeting.adUnits map (_.path mkString "/"),
+        adUnits = lineItem.targeting.adUnitsIncluded map (_.path mkString "/"),
         editions = editionsTargeted(lineItem),
         countries = countriesTargeted(lineItem),
         isR2Only = lineItem.targeting.targetsR2Only,

--- a/admin/app/views/commercial/LineItemSupport.scala
+++ b/admin/app/views/commercial/LineItemSupport.scala
@@ -7,13 +7,13 @@ object LineItemSupport {
   def targetedAdUnits(lineItem: GuLineItem): Seq[String] = {
     def mkString(adUnit: GuAdUnit): String = adUnit.path.mkString("/")
     val lineItemAdUnits = for {
-      adUnit <- lineItem.targeting.adUnits
+      adUnit <- lineItem.targeting.adUnitsIncluded
     } yield mkString(adUnit)
     val creativeAdUnits = for {
       placeholder <- lineItem.creativePlaceholders
       targeting <- placeholder.targeting
     } yield {
-        for (adUnit <- targeting.adUnits) yield mkString(adUnit)
+        for (adUnit <- targeting.adUnitsIncluded) yield mkString(adUnit)
       }
     (lineItemAdUnits ++ creativeAdUnits.flatten).sorted.distinct
   }

--- a/admin/app/views/commercial/highMerchandisingTargetedTags.scala.html
+++ b/admin/app/views/commercial/highMerchandisingTargetedTags.scala.html
@@ -41,9 +41,14 @@
                         <td><a href="@DfpLink.lineItem(lineItem.id)">@{lineItem.id}</a></td>
                         <td>@{lineItem.tags.mkString(", ")}</td>
                         <td>
-                            @for(adUnit <- lineItem.adUnits) {
+                            @for(adUnit <- lineItem.adUnitsIncluded) {
                                 <div>
-                                    <a href="@DfpLink.adUnit(adUnit.id)">@{adUnit.fullPath}</a>
+                                    <a href="@DfpLink.adUnit(adUnit.id)">+ @{adUnit.fullPath}</a>
+                                </div>
+                            }
+                            @for(adUnit <- lineItem.adUnitsExcluded) {
+                                <div>
+                                    <a href="@DfpLink.adUnit(adUnit.id)">- @{adUnit.fullPath}</a>
                                 </div>
                             }
                             @if(lineItem.isRunOfNetwork) {

--- a/admin/app/views/commercial/paidForTags.scala.html
+++ b/admin/app/views/commercial/paidForTags.scala.html
@@ -24,11 +24,11 @@
     } else {
         <div>Sponsor: <strong>@{lineItem.sponsor}</strong></div>
     }
-    @if(lineItem.targeting.adUnits.nonEmpty) {
-        @if(lineItem.targeting.adUnits.size == 1) {
-            <div>Ad Unit: @{lineItem.targeting.adUnits.map(_.path.mkString("/"))}</div>
+    @if(lineItem.targeting.adUnitsIncluded.nonEmpty) {
+        @if(lineItem.targeting.adUnitsIncluded.size == 1) {
+            <div>Ad Unit: @{lineItem.targeting.adUnitsIncluded.map(_.path.mkString("/"))}</div>
         } else {
-            <div>Ad Units: @{lineItem.targeting.adUnits.map(_.path.mkString("/")).mkString(", ")}</div>
+            <div>Ad Units: @{lineItem.targeting.adUnitsIncluded.map(_.path.mkString("/")).mkString(", ")}</div>
         }
     }
     @if(lineItem.targeting.editions.nonEmpty) {

--- a/admin/test/dfp/DfpApiValidationTest.scala
+++ b/admin/test/dfp/DfpApiValidationTest.scala
@@ -26,7 +26,8 @@ class DfpApiValidationTest extends FlatSpec with Matchers {
       costType = "CPM",
       creativePlaceholders = Nil,
       targeting = GuTargeting(
-        adUnits = adUnits,
+        adUnitsIncluded = adUnits,
+        adUnitsExcluded = Nil,
         geoTargetsIncluded = Nil,
         geoTargetsExcluded = Nil,
         customTargetSets = Nil),

--- a/admin/test/dfp/DfpDataCacheJobTest.scala
+++ b/admin/test/dfp/DfpDataCacheJobTest.scala
@@ -16,7 +16,9 @@ class DfpDataCacheJobTest extends FlatSpec with Matchers {
       status = if (completed) "COMPLETED" else "READY",
       costType = "CPM",
       creativePlaceholders = Nil,
-      targeting = GuTargeting(adUnits = Nil,
+      targeting = GuTargeting(
+        adUnitsIncluded = Nil,
+        adUnitsExcluded = Nil,
         geoTargetsIncluded = Nil,
         geoTargetsExcluded = Nil,
         customTargetSets = Nil),

--- a/common/app/common/dfp/AdSlotAgent.scala
+++ b/common/app/common/dfp/AdSlotAgent.scala
@@ -24,7 +24,7 @@ trait AdSlotAgent {
   }
 
   private def targetsAdUnit(lineItem: GuLineItem, adUnitWithoutRoot: String) = {
-    val adUnits = for (adUnit <- lineItem.targeting.adUnits) yield {
+    val adUnits = for (adUnit <- lineItem.targeting.adUnitsIncluded) yield {
       adUnit.path.mkString("/").stripSuffix("/ng")
     }
     adUnits.contains(fullAdUnit(adUnitWithoutRoot))

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -152,7 +152,8 @@ object GuAdUnit {
   val ARCHIVED = "ARCHIVED"
 }
 
-case class GuTargeting(adUnits: Seq[GuAdUnit],
+case class GuTargeting(adUnitsIncluded: Seq[GuAdUnit],
+                       adUnitsExcluded: Seq[GuAdUnit],
                        geoTargetsIncluded: Seq[GeoTarget],
                        geoTargetsExcluded: Seq[GeoTarget],
                        customTargetSets: Seq[CustomTargetSet]) {
@@ -178,7 +179,7 @@ case class GuTargeting(adUnits: Seq[GuAdUnit],
   val targetsR2Only: Boolean = customTargetSets exists (_.targetsR2Only)
 
   def targetsSectionFrontDirectly(sectionId: String): Boolean = {
-    adUnits.exists { adUnit =>
+    adUnitsIncluded.exists { adUnit =>
       val path = adUnit.path
       path.length == 3 &&
         path(1) == sectionId &&
@@ -188,27 +189,8 @@ case class GuTargeting(adUnits: Seq[GuAdUnit],
 }
 
 object GuTargeting {
-
-  implicit val targetingWrites = new Writes[GuTargeting] {
-    def writes(targeting: GuTargeting): JsValue = {
-      Json.obj(
-        "adUnits" -> targeting.adUnits,
-        "geoTargetsIncluded" -> targeting.geoTargetsIncluded,
-        "geoTargetsExcluded" -> targeting.geoTargetsExcluded,
-        "customTargetSets" -> targeting.customTargetSets
-      )
-    }
-  }
-
-  implicit val targetingReads: Reads[GuTargeting] = (
-    (JsPath \ "adUnits").read[Seq[GuAdUnit]] and
-      (JsPath \ "geoTargetsIncluded").read[Seq[GeoTarget]] and
-      (JsPath \ "geoTargetsExcluded").read[Seq[GeoTarget]] and
-      (JsPath \ "customTargetSets").read[Seq[CustomTargetSet]]
-    )(GuTargeting.apply _)
-
+  implicit val targetingFormat = Json.format[GuTargeting]
 }
-
 
 case class GuLineItem(id: Long,
                       name: String,
@@ -279,7 +261,7 @@ case class GuLineItem(id: Long,
   }
 
   lazy val targetsNetworkOrSectionFrontDirectly: Boolean = {
-    targeting.adUnits.exists { adUnit =>
+    targeting.adUnitsIncluded.exists { adUnit =>
       val path = adUnit.path
       (path.length == 3 || path.length == 4) && path(2) == "front"
     }

--- a/common/app/common/dfp/DfpData.scala
+++ b/common/app/common/dfp/DfpData.scala
@@ -142,6 +142,8 @@ case class GuAdUnit(id: String, path: Seq[String], status: String) {
   val isActive = status == "ACTIVE"
   val isInactive = status == "INACTIVE"
   val isArchived = status == "ARCHIVED"
+
+  val isRunOfNetwork = path.isEmpty
 }
 
 object GuAdUnit {

--- a/common/app/common/dfp/PaidForTagAgent.scala
+++ b/common/app/common/dfp/PaidForTagAgent.scala
@@ -27,7 +27,7 @@ trait PaidForTagAgent {
     def sectionMatches(maybeSectionId: Option[String], dfpTag: PaidForTag): Boolean = {
       maybeSectionId.isEmpty || maybeSectionId.exists { sectionId =>
         val tagAdUnitPaths = dfpTag.lineItems flatMap { lineItem =>
-          lineItem.targeting.adUnits map (_.path)
+          lineItem.targeting.adUnitsIncluded map (_.path)
         }
         tagAdUnitPaths.isEmpty || tagAdUnitPaths.exists { path =>
           path.tail.isEmpty || sectionId.startsWith(path.tail.head)

--- a/common/app/common/dfp/TagSponsorship.scala
+++ b/common/app/common/dfp/TagSponsorship.scala
@@ -78,14 +78,15 @@ case class HighMerchandisingLineItem(
   name: String,
   id: Long,
   tags: Seq[String],
-  adUnits: Seq[GuAdUnit],
+  adUnitsIncluded: Seq[GuAdUnit],
+  adUnitsExcluded: Seq[GuAdUnit],
   customTargetSet: Seq[CustomTargetSet]
   ) {
 
   val customTargets = customTargetSet.flatMap(_.targets)
   val editions = customTargets.filter( _.name == "edition").flatMap(_.values).distinct
   val urls = customTargets.filter( _.name == "url").flatMap(_.values).distinct
-  val isRunOfNetwork = adUnits.isEmpty
+  val isRunOfNetwork = adUnitsIncluded.isEmpty || (adUnitsIncluded.exists(_.isRunOfNetwork) && adUnitsIncluded.size == 1)
   val hasUnknownTarget = isRunOfNetwork && editions.isEmpty && urls.isEmpty && tags.isEmpty
 
   // Returns true if the metadata parameters explicitly match the lineItem.
@@ -94,7 +95,7 @@ case class HighMerchandisingLineItem(
     val cleansedPageEdition = edition.id.toLowerCase
     val cleansedPageTagNames = pageTags map (_.name.replaceAll(" ","-").toLowerCase)
 
-    val matchesAdUnit = adUnits.isEmpty || adUnits.exists(_.path contains adUnitSuffix)
+    val matchesAdUnit = adUnitsIncluded.isEmpty || adUnitsIncluded.exists(_.path contains adUnitSuffix)
     val matchesTag = cleansedPageTagNames.isEmpty || cleansedPageTagNames.exists(tags.contains)
     val matchesEdition = editions.isEmpty || editions.contains(cleansedPageEdition)
     val matchesUrl = urls.isEmpty || urls.contains(pagePath)

--- a/common/test/common/dfp/GuLineItemTest.scala
+++ b/common/test/common/dfp/GuLineItemTest.scala
@@ -19,7 +19,8 @@ class GuLineItemTest extends FlatSpec with Matchers {
 
   private def targeting(adUnits: Seq[GuAdUnit]): GuTargeting = {
     GuTargeting(
-      adUnits,
+      adUnitsIncluded = adUnits,
+      adUnitsExcluded = Nil,
       geoTargetsIncluded = Seq(GeoTarget(1, None, "COUNTRY", "Australia")),
       geoTargetsExcluded = Nil,
       customTargetSets = Nil

--- a/common/test/common/dfp/HighMerchandisingLineItemTest.scala
+++ b/common/test/common/dfp/HighMerchandisingLineItemTest.scala
@@ -13,21 +13,24 @@ class HighMerchandisingLineItemTest extends FlatSpec with Matchers {
         name = "test",
         id = 77942847,
         tags = Seq.empty,
-        adUnits = Seq(GuAdUnit("59359047", Seq("theguardian.com","money"), GuAdUnit.ACTIVE)),
+        adUnitsIncluded = Seq(GuAdUnit("59359047", Seq("theguardian.com","money"), GuAdUnit.ACTIVE)),
+        adUnitsExcluded = Seq.empty,
         customTargetSet = Seq(CustomTargetSet("AND",Seq(CustomTarget("slot","IS",Seq("merchandising-high")),CustomTarget("edition","IS",Seq("uk")))))
       ),
         HighMerchandisingLineItem(
           name = "test2",
           id = 77943847,
           tags = Seq("cricket","England","test"),
-          adUnits = Seq(GuAdUnit("59359047", Seq("theguardian.com","sport"), GuAdUnit.ACTIVE)),
+          adUnitsIncluded = Seq(GuAdUnit("59359047", Seq("theguardian.com","sport"), GuAdUnit.ACTIVE)),
+          adUnitsExcluded = Seq.empty,
           customTargetSet = Seq(CustomTargetSet("AND",Seq(CustomTarget("slot","IS",Seq("merchandising-high")))))
         ),
         HighMerchandisingLineItem(
           name = "test3",
           id = 77943847,
           tags = Seq.empty,
-          adUnits = Seq.empty,
+          adUnitsIncluded = Seq.empty,
+          adUnitsExcluded = Seq.empty,
           customTargetSet = Seq(CustomTargetSet("AND",Seq(CustomTarget("slot","IS",Seq("merchandising-high")),CustomTarget("url","IS",Seq("/commentisfree/2015/jul/21/it-hurts-but-im-going-to-defend-ashley-madison-and-37-million-cheaters")))))
         )
       )

--- a/common/test/common/dfp/PaidForTagAgentTest.scala
+++ b/common/test/common/dfp/PaidForTagAgentTest.scala
@@ -47,7 +47,7 @@ class PaidForTagAgentTest extends FlatSpec with Matchers {
       state,
       "CPM",
       Nil,
-      GuTargeting(adUnits, Nil, Nil, customTargetSets),
+      GuTargeting(adUnits, Nil, Nil, Nil, customTargetSets),
       DateTime.now()
     )
   }

--- a/common/test/common/dfp/PaidForTagTest.scala
+++ b/common/test/common/dfp/PaidForTagTest.scala
@@ -37,7 +37,7 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |            }
       |          ],
       |          "targeting": {
-      |            "adUnits": [
+      |            "adUnitsIncluded": [
       |              {
       |                "id": "59351727",
       |                "path": [
@@ -46,6 +46,9 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |                ],
       |                "status": "ACTIVE"
       |              }
+      |            ],
+      |            "adUnitsExcluded": [
+      |
       |            ],
       |            "geoTargetsIncluded": [
       |              {
@@ -111,7 +114,10 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |            }
       |          ],
       |          "targeting": {
-      |            "adUnits": [
+      |            "adUnitsIncluded": [
+      |
+      |            ],
+      |            "adUnitsExcluded": [
       |
       |            ],
       |            "geoTargetsIncluded": [
@@ -173,7 +179,7 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |            }
       |          ],
       |          "targeting": {
-      |            "adUnits": [
+      |            "adUnitsIncluded": [
       |              {
       |                "id": "59342247",
       |                "path": [
@@ -181,6 +187,9 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |                ],
       |                "status": "ACTIVE"
       |              }
+      |            ],
+      |            "adUnitsExcluded": [
+      |
       |            ],
       |            "geoTargetsIncluded": [
       |
@@ -241,7 +250,7 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |            }
       |          ],
       |          "targeting": {
-      |            "adUnits": [
+      |            "adUnitsIncluded": [
       |              {
       |                "id": "59350887",
       |                "path": [
@@ -250,6 +259,9 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |                ],
       |                "status": "ACTIVE"
       |              }
+      |            ],
+      |            "adUnitsExcluded": [
+      |
       |            ],
       |            "geoTargetsIncluded": [
       |
@@ -310,7 +322,10 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |            }
       |          ],
       |          "targeting": {
-      |            "adUnits": [
+      |            "adUnitsIncluded": [
+      |
+      |            ],
+      |            "adUnitsExcluded": [
       |
       |            ],
       |            "geoTargetsIncluded": [
@@ -372,7 +387,7 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |            }
       |          ],
       |          "targeting": {
-      |            "adUnits": [
+      |            "adUnitsIncluded": [
       |              {
       |                "id": "59342247",
       |                "path": [
@@ -380,6 +395,9 @@ class PaidForTagTest extends FlatSpec with Matchers with OptionValues {
       |                ],
       |                "status": "ACTIVE"
       |              }
+      |            ],
+      |            "adUnitsExcluded": [
+      |
       |            ],
       |            "geoTargetsIncluded": [
       |


### PR DESCRIPTION
Currently, a line item's targeting only contains the adunits it includes. However, there are occasions when the line item excludes adunits too. If we track these, we get the full targeting picture:

![commercial_high_slot](https://cloud.githubusercontent.com/assets/4549425/15779399/ea4ea6da-2993-11e6-9c59-654406753a40.jpg)
