### PR TITLE
Fix typo error preventing correct init of mobile labs alert banner

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -420,7 +420,7 @@ define([
                 ['c-email', modules.initEmail],
                 ['c-user-features', userFeatures.refresh],
                 ['c-headlines-test-analytics', modules.headlinesTestAnalytics],
-                ['c-mobile-labs-banner', modules.mobileLabsAlertBanner()]
+                ['c-mobile-labs-banner', modules.mobileLabsAlertBanner]
             ]), function (fn) {
                 fn();
             });


### PR DESCRIPTION
## What does this change?

Fix this issue when [reaching this article](https://www.theguardian.com/technology/2016/jun/04/google-influence-hiring-government-officials)

<img width="942" alt="capture d ecran 2016-06-05 a 11 07 10" src="https://cloud.githubusercontent.com/assets/615085/15804820/b6b2f256-2b0d-11e6-8e63-e1b0c655aefa.png">

The typo has been inserted by [those changes](https://github.com/guardian/frontend/pull/13201)
