### PR TITLE
Add Lab notes email sign-up to the Science section

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -388,4 +388,14 @@ trait FeatureSwitches {
     sellByDate = new LocalDate(2016, 6, 8),
     exposeClientSide = true
   )
+
+  // Owner: Dotcom habitual / Gareth
+  val EmailSignupLabNotes = Switch(
+    SwitchGroup.Feature,
+    "email-signup-lab-notes",
+    "When ON, insert the lab-notes email sign-up into Science section articles",
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -75,6 +75,17 @@ define([
                 modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
+            labNotes: {
+                listId: '3701',
+                listName: 'labNotes',
+                campaignCode: 'lab_notes_article_signup',
+                headline: 'Sign up to Lab notes',
+                description: 'Get a weekly round-up of the biggest stories in science, insider knowledge from our network of bloggers, and a healthy dose of fun.',
+                successHeadline: 'Thank you for signing up for Lab notes',
+                successDescription: 'You\'ll receive an email every week.',
+                modClass: 'end-article',
+                insertMethod: insertBottomOfArticle
+            },
             ausCampaignCatchup: {
                 listId: '3689',
                 listName: 'ausCampaignCatchup',

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -111,6 +111,9 @@ define([
         theFiver: function () {
             return page.keywordExists(['Football']) && allowedArticleStructure();
         },
+        labNotes: function () {
+            return config.page.section === 'science';
+        },
         usBriefing: function () {
             return (config.page.section === 'us-news' && allowedArticleStructure()) ||
                 config.page.series === 'Guardian US briefing';

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -112,7 +112,7 @@ define([
             return page.keywordExists(['Football']) && allowedArticleStructure();
         },
         labNotes: function () {
-            return config.page.section === 'science';
+            return config.page.section === 'science' && config.switches.emailSignupLabNotes;
         },
         usBriefing: function () {
             return (config.page.section === 'us-news' && allowedArticleStructure()) ||


### PR DESCRIPTION
## What does this change?

Adds the Science lab notes email sign-up to the science  section
## Screenshots

![image](https://cloud.githubusercontent.com/assets/638051/15822505/038af7e6-2bee-11e6-86f3-7dbf6ecb4726.png)
## CC

@crifmulholland @NathanielBennett @samdesborough 
