### PR TITLE
Hosted Video - fix mime type

### DIFF
--- a/commercial/app/controllers/commercial/HostedContentController.scala
+++ b/commercial/app/controllers/commercial/HostedContentController.scala
@@ -31,7 +31,7 @@ object HostedContentController extends Controller {
             title = "Designing the car of the future",
             duration = 86,
             posterUrl = teaserPosterUrl,
-            srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160516GlabsTestSD&format=video/mp4&maxbitrate=2048"
+            srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160516GlabsTestSD"
           ),
           nextVideo = HostedNextVideo(
             title = "Renault shortlists 'car of the future' designs",
@@ -54,7 +54,7 @@ object HostedContentController extends Controller {
             title = "Renault shortlists 'car of the future' designs",
             duration = 160,
             posterUrl = episode1PosterUrl,
-            srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160523GlabsRenaultTestHD&format=video/webm&maxbitrate=2048"
+            srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160523GlabsRenaultTestHD"
           ),
           nextVideo = if(Switches.hostedEpisode2Content.isSwitchedOn) HostedNextVideo(
             title = "Is this the car of the future?",
@@ -83,7 +83,7 @@ object HostedContentController extends Controller {
               title = "Is this the car of the future?",
               duration = 160,
               posterUrl = episode2PosterUrl,
-              srcUrl = "http://multimedia.guardianapis.com/interactivevideos/video.php?file=160603GlabsRenaultTest3&format=video/webm&maxbitrate=2048"
+              srcUrl = "http://multimedia.guardianapis.com/interactivevideos/video.php?file=160603GlabsRenaultTest3"
             ),
             nextVideo = HostedNextVideo(
               title = "Renault shortlists 'car of the future' designs",

--- a/commercial/app/views/hosted/guardianHostedPage.scala.html
+++ b/commercial/app/views/hosted/guardianHostedPage.scala.html
@@ -29,10 +29,10 @@
                       data-block-video-ads="true"
                       poster="@page.video.posterUrl"
                       class="vjs-hosted__video hosted__video gu-media--video vjs vjs-tech-html5 vjs-paused vjs-controls-enabled vjs_video_1-dimensions vjs-user-active">
-                        <source type="video/mp4" src="@page.video.srcUrl">
-                        <source type="video/webm" src="@page.video.srcUrl">
-                        <source type="video/ogg" src="@page.video.srcUrl">
-                        <source type="video/m3u8" src="@page.video.srcUrl">
+                        <source type="video/mp4" src="@page.video.srcUrl&format=video/mp4&maxbitrate=2048">
+                        <source type="video/webm" src="@page.video.srcUrl&format=video/webm&maxbitrate=2048">
+                        <source type="video/ogg" src="@page.video.srcUrl&format=video/ogg&maxbitrate=2048">
+                        <source type="video/m3u8" src="@page.video.srcUrl&format=video/m3u8&maxbitrate=2048">
                     </video>
                     <div class="hosted-fading">
                         <div class="hosted__video-overlay"></div>


### PR DESCRIPTION
## What does this change?

We were using the same video url in all the <source> tags, they should each specify the correct mime type.

This was causing the video to not load properly in ios (it doesn't support webm type)
