### PR TITLE
[test] make big play button yellow on fronts

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -120,7 +120,7 @@ trait ABTestSwitches {
     "Make big play button yellow",
     owners = Seq(Owner.withGithub("akash1810")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 21), // Tuesday
+    sellByDate = new LocalDate(2016, 6, 27), // Tuesday
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -133,4 +133,13 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 6, 21),
     exposeClientSide = true
   )
+
+  val ABVideoYellowButton = Switch(
+    SwitchGroup.ABTests,
+    "ab-video-yellow-button",
+    "Make big play button yellow",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 6, 14),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -133,13 +133,4 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 6, 21),
     exposeClientSide = true
   )
-
-  val ABVideoYellowButton = Switch(
-    SwitchGroup.ABTests,
-    "ab-video-yellow-button",
-    "Make big play button yellow",
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 14),
-    exposeClientSide = true
-  )
 }

--- a/common/app/views/fragments/items/facia_cards/contentCard.scala.html
+++ b/common/app/views/fragments/items/facia_cards/contentCard.scala.html
@@ -60,13 +60,13 @@
                     // play ads or if the video is expired, but as fronts change really often, this is a non-problem.
                     if (item.isMediaLink) item.id else None
                 )) { player =>
-                    <div class="fc-item__media-wrapper u-faux-block-link__promote media__container--hidden js-video-player">
+                    <div class="fc-item__media-wrapper fc-item__video u-faux-block-link__promote media__container--hidden js-video-player">
                         <div class="fc-item__video-container">
                             @video(player, false, item.cardTypes.showVideoEndSlate, showPoster = false)
                         </div>
                     </div>
                 @fallback.map { fallbackImage =>
-                    <div class="fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
+                    <div class="fc-item__video fc-item__video-fallback media__placeholder--active js-video-placeholder gu-media__fallback">
                         <div data-link-name="video-play-button-overlay" class="@RenderClasses("fc-item__video-play", "media__placeholder--hidden", "vjs-big-play-button", "js-video-play-button")"><span class="vjs-control-text"></span></div>
                         @itemImage(
                             fallbackImage.imageMedia,

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -421,12 +421,12 @@ define([
     }
 
     function initYellowPlayButton() {
-        $('.fc-item__video-fallback', document.body).each(function (el) {
-            bonzo(el).addClass('vjs-big-play-button--yellow');
-        });
-
         var selector = '.fc-item__video';
         var hoverStateClassName = 'u-faux-block-link--hover';
+
+        $(selector).each(function (el) {
+            bonzo(el).parent().addClass('vjs-big-play-button--yellow');
+        });
 
         var showIntentToPlay = function (e) {
             fastdom.write(function () {

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -420,9 +420,35 @@ define([
         $('.media-primary').addClass('media-primary--showcase');
     }
 
+    function initYellowPlayButton() {
+        $('.fc-item__video-fallback', document.body).each(function (el) {
+            bonzo(el).addClass('vjs-big-play-button--yellow');
+        });
+
+        var selector = '.fc-item__video';
+        var hoverStateClassName = 'u-faux-block-link--hover';
+
+        var showIntentToPlay = function (e) {
+            fastdom.write(function () {
+                $(e.currentTarget).parent().addClass(hoverStateClassName);
+            });
+        };
+
+        var removeIntentToPlay = function (e) {
+            $(e.currentTarget).parent().removeClass(hoverStateClassName);
+        };
+
+        bean.on(document.body, 'mouseenter', selector, showIntentToPlay);
+        bean.on(document.body, 'mouseleave', selector, removeIntentToPlay);
+    }
+    
     function initTests() {
         if(ab.isInVariant('VideoMainMediaAlwaysShowcase', 'variant')) {
             showcaseMainMedia();
+        }
+
+        if(ab.isInVariant('VideoYellowButton', 'variant')) {
+            initYellowPlayButton();
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-yellow-button.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-yellow-button.js
@@ -24,11 +24,11 @@ define([
 
         this.variants = [
             {
-                id: 'baseline1',
+                id: 'control',
                 test: function () {}
             },
             {
-                id: 'baseline2',
+                id: 'variant',
                 test: function () {}
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-yellow-button.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-yellow-button.js
@@ -5,13 +5,13 @@ define([
 ) {
     return function () {
         this.id = 'VideoYellowButton';
-        this.start = '2016-06-07';
-        this.expiry = '2016-06-14';
+        this.start = '2016-06-22';
+        this.expiry = '2016-06-27';
         this.author = 'Akash Askoolum';
         this.description = 'Test if a yellow play button increases starts';
         this.showForSensitive = true;
-        this.audience = 1;
-        this.audienceOffset = 0;
+        this.audience = 0.05;
+        this.audienceOffset = 0.1;
         this.successMeasure = '';
         this.audienceCriteria = '';
         this.dataLinkNames = '';

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -157,6 +157,10 @@ $ima-controls-height: 70px;
     }
 }
 
+.vjs-big-play-button--yellow .vjs-control-text:before {
+    background-color: $media-default;
+}
+
 .vjs-fullscreen-clickbox {
     box-sizing: border-box;
     width: 100%;

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -157,7 +157,7 @@ $ima-controls-height: 70px;
     }
 }
 
-.vjs-big-play-button--yellow .vjs-control-text:before {
+.vjs-big-play-button--yellow .vjs-big-play-button .vjs-control-text:before {
     background-color: $media-default;
 }
 


### PR DESCRIPTION
## What does this change?

a similar test had positive results on main media so testing the effect on fronts

using similar principle as https://github.com/guardian/frontend/blob/master/static/src/javascripts/projects/common/modules/ui/faux-block-link.js to achieve a hover state on the whole card as the play button is going from yellow to yellow rather than grey to yellow, therefore hover state needs to be more obvious
## What is the value of this and can you measure success?

increase in video starts on fronts
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

![yellow](https://cloud.githubusercontent.com/assets/836140/15825827/26a21ad4-2bfd-11e6-8652-cff7c03d6766.gif)
## Request for comment

@jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
