### PR TITLE
add facebook iframe fix for video embeds

### DIFF
--- a/common/app/views/support/cleaner/VideoEmbedCleaner.scala
+++ b/common/app/views/support/cleaner/VideoEmbedCleaner.scala
@@ -1,13 +1,16 @@
 package views.support.cleaner
 
-import java.net.URL
+import java.net.{URL, URLEncoder}
 
-import model.{Article, VideoAsset, VideoElement, ShareLinks}
+import model.{Article, ShareLinks, VideoAsset, VideoElement}
 import org.jsoup.nodes.{Document, Element}
 import views.support.{HtmlCleaner, Item640}
+
 import scala.collection.JavaConversions._
 
 case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
+  val facebookVideoEmbedUrl = "https://www.facebook.com/v2.3/plugins/video.php?href="
+  def facebookVideoEmbedUrlFor(url: String) = s"$facebookVideoEmbedUrl${URLEncoder.encode(url, "UTF-8")}"
 
   def addShareButtons(document: Document): Unit = {
     document.getElementsByClass("element-video").foreach(element => {
@@ -93,8 +96,18 @@ case class VideoEmbedCleaner(article: Article) extends HtmlCleaner {
 
   override def clean(document: Document): Document = {
     document.getElementsByClass("element-video").filter { element: Element =>
-      element.getElementsByClass("gu-video").length == 0
+      element.getElementsByClass("gu-video").isEmpty
     }.foreach { element: Element =>
+      val canonicalUrl = element.attr("data-canonical-url")
+
+      // As Facebook have declared that you have to use their video JS plugin, which in turn pulls in their whole JS API
+      // We've decided to use the canonical URL, and create the video element here rather that CAPI, as, if it changes
+      // again, we can change it here and it will also fix things retrospectively.
+      if (canonicalUrl.startsWith("https://www.facebook.com")) {
+        val facebookUrl = facebookVideoEmbedUrlFor(element.attr("data-canonical-url"))
+        element.child(0).attr("src", facebookUrl)
+      }
+
       element.child(0).wrap("<div class=\"embed-video-wrapper u-responsive-ratio u-responsive-ratio--hd\"></div>")
     }
 


### PR DESCRIPTION
## What does this change?

We now set the Facebook video iframe in dotcom as it seems that FB change the way they do it, and their solution is to use their JS plugin, which pulls in everything Facebook. 

You can see that at this endpoint [here](https://www.facebook.com/plugins/video/oembed.json/?url=https%3A%2F%2Fwww.facebook.com%2Ffacebook%2Fvideos%2F10153231379946729%2F).
## What is the value of this and can you measure success?

Facebook videos look nice again.
## Does this affect other platforms - Amp, Apps, etc?

Nope.
## Screenshots
### before

![facebook-video-embed-before](https://cloud.githubusercontent.com/assets/31692/15828886/11bcd648-2c09-11e6-8b9e-6a597d66a67c.png)
### after

![facebook-video-embed-after](https://cloud.githubusercontent.com/assets/31692/15828881/0bda0250-2c09-11e6-92bf-23de199b0a01.png)
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
