### PR TITLE
[test] always showcase main media videos

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -462,6 +462,17 @@ define([
         }
     }
 
+    function showcaseMainMedia() {
+        $('.content__meta-container').addClass('content__meta-container--showcase');
+        $('.media-primary').addClass('media-primary--showcase');
+    }
+
+    function initTests() {
+        if(ab.isInVariant('VideoMainMediaAlwaysShowcase', 'variant')) {
+            showcaseMainMedia();
+        }
+    }
+
     function init() {
         // The `hasMultipleVideosInPage` flag is temporary until the # will be fixed
         var shouldPreroll = commercialFeatures.videoPreRolls &&
@@ -484,6 +495,7 @@ define([
         initFacia();
         initMoreInSection();
         initOnwardContainer();
+        initTests();
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-showcase-main-media.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-showcase-main-media.js
@@ -26,11 +26,11 @@ define([
 
         this.variants = [
             {
-                id: 'baseline1',
+                id: 'control',
                 test: function () {}
             },
             {
-                id: 'baseline2',
+                id: 'variant',
                 test: function () {}
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-showcase-main-media.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-showcase-main-media.js
@@ -7,13 +7,13 @@ define([
 ) {
     return function () {
         this.id = 'VideoMainMediaAlwaysShowcase';
-        this.start = '2016-06-07';
-        this.expiry = '2016-06-14';
+        this.start = '2016-06-15';
+        this.expiry = '2016-06-21';
         this.author = 'Akash Askoolum';
         this.description = 'Test if a big main media video leads to more plays';
         this.showForSensitive = true;
-        this.audience = 1;
-        this.audienceOffset = 0;
+        this.audience = 0.1;
+        this.audienceOffset = 0.9;
         this.successMeasure = '';
         this.audienceCriteria = '';
         this.dataLinkNames = '';


### PR DESCRIPTION
## What does this change?

Testing if large main media video leads to more plays.
## What is the value of this and can you measure success?

⬆️ video plays.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

![screen shot 2016-06-06 at 18 31 05](https://cloud.githubusercontent.com/assets/836140/15831304/db95d842-2c14-11e6-9493-bd7619e423c2.jpeg)
## Request for comment

@jamesgorrie @mr-mr 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
