### PR TITLE
Ability to add multiple video playlists

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -403,7 +403,9 @@ define([
 
     function initFacia() {
         if (config.page.isFront) {
-            videoContainer();
+            $('.js-video-playlist').each(function(el) {
+                videoContainer.init(el);
+            });
         }
     }
 

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -33,7 +33,7 @@ define([
 
         INIT: function init(previousState) {
             fastdom.read(function() {
-            // Lazy load images on scroll for mobile
+                // Lazy load images on scroll for mobile
                 $('.js-video-playlist-image', previousState.container).each(function(el) {
                     var elementInview = ElementInview(el , $('.js-video-playlist-inner', previousState.container).get(0), {
                         // This loads 1 image in the future
@@ -54,6 +54,7 @@ define([
                     });
                 });
             });
+            return previousState;
         }
     };
 
@@ -117,7 +118,7 @@ define([
             length: container.getAttribute('data-number-of-videos'),
             videoWidth: 700,
             container: container
-        }
+        };
     }
 
     function setupDispatches(dispatch, container) {

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -4,120 +4,145 @@
 
 define([
     'bean',
-    'fastdom',
+    'common/utils/fastdom-promise',
     'common/utils/$',
     'common/utils/element-inview',
-    'bootstraps/enhanced/media/video-player'
+    'bootstraps/enhanced/media/video-player',
+    'lodash/objects/assign',
+    'common/utils/create-store'
 ], function (
     bean,
     fastdom,
     $,
     ElementInview,
-    videojs
+    videojs,
+    assign,
+    createStore
 ) {
 
-    var containerPos = 0,
-        videoWidth = 700,
-        translateWidth = 0,
-        $videoPlaylist = $('.js-video-playlist'),
-        numberOfVideos = $videoPlaylist.attr('data-number-of-videos'),
-        preloadImageCount = 2;
+    var reducers = {
+        NEXT: function next(previousState) {
+            var position = previousState.position >= previousState.length ? previousState.position : previousState.position + 1;
+            return assign({}, previousState, getPositionState(position, previousState.length));
+        },
 
-    function init() {
-        if ($videoPlaylist.length > 0) {
-            bindEvents();
-            initLazyLoadImages();
-        }
-    }
+        PREV: function prev(previousState) {
+            var position = previousState.position <= 0 ? 0 : previousState.position - 1;
+            return assign({}, previousState, getPositionState(position, previousState.length));
+        },
 
-    function bindEvents() {
-        bean.on(document, 'click', $('.js-video-playlist-next'), function () {
-            moveCarousel('next');
-        }.bind(this));
-        bean.on(document, 'click', $('.js-video-playlist-prev'), function () {
-            moveCarousel('prev');
-        }.bind(this));
-    }
-
-    function moveCarousel(direction) {
-        $videoPlaylist.removeClass('video-playlist--end video-playlist--start');
-        $('.video-playlist__item--active').removeClass('video-playlist__item--active');
-
-        if (direction === 'next') {
-            fetchImage(containerPos + preloadImageCount);
-            containerPos++;
-        } else {
-            containerPos--;
-        }
-
-        if (containerPos >= numberOfVideos) {
-            containerPos = numberOfVideos;
-            $videoPlaylist.addClass('video-playlist--end');
-        } else if (containerPos <= 0) {
-            containerPos = 0;
-            $videoPlaylist.addClass('video-playlist--start');
-        }
-
-        resetPlayers();
-
-        translateWidth = 0 - videoWidth * containerPos;
-
-        $('.js-video-playlist-item-' + containerPos).addClass('video-playlist__item--active');
-
-        $('.js-video-playlist-inner').attr('style',
-            '-webkit-transform: translate(' + translateWidth + 'px);' +
-            'transform: translate(' + translateWidth + 'px);'
-        );
-    }
-
-    function resetPlayers() {
-        $('.js-video-playlist .vjs').each(function() {
-            videojs($(this)[0]).pause();
-        });
-    }
-
-    // iniLazyLoadImages is used for when a user scrolls i.e. thin viewport
-    // and fetchImage is used for when the carousel controls are used i.e. fat viewport
-    function initLazyLoadImages() {
-        $('.js-video-playlist-image').each(function(el) {
-            // We wrap this in a read as ElementInview reads the DOM.
+        INIT: function init(previousState) {
             fastdom.read(function() {
-                var elementInview = ElementInview(el , $('.js-video-playlist-inner').get(0), {
-                    // This loads 1 image in the future
-                    left: 410
-                });
+            // Lazy load images on scroll for mobile
+                $('.js-video-playlist-image', previousState.container).each(function(el) {
+                    var elementInview = ElementInview(el , $('.js-video-playlist-inner', previousState.container).get(0), {
+                        // This loads 1 image in the future
+                        left: 410
+                    });
 
-                elementInview.on('firstview', function(el) {
-                    fastdom.write(function() {
-                        var dataSrc = el.getAttribute('data-src');
-                        var src = el.getAttribute('src');
+                    elementInview.on('firstview', function(el) {
+                        fastdom.write(function() {
+                            var dataSrc = el.getAttribute('data-src');
+                            var src = el.getAttribute('src');
 
-                        if (dataSrc && !src) {
-                            fastdom.write(function() {
-                                el.setAttribute('src', dataSrc);
-                            });
-                        }
+                            if (dataSrc && !src) {
+                                fastdom.write(function() {
+                                    el.setAttribute('src', dataSrc);
+                                });
+                            }
+                        });
                     });
                 });
             });
-        });
-    }
+        }
+    };
 
-    function fetchImage(i) {
-        $('.js-video-playlist-image--' + i).map(function(el) {
+    function fetchLazyImage(container, i) {
+        $('.js-video-playlist-image--' + i, container).each(function(el) {
             fastdom.read(function () {
                 var dataSrc = el.getAttribute('data-src');
                 var src = el.getAttribute('src');
-                if (dataSrc && !src) {
+                return dataSrc && !src ? dataSrc : null;
+            }).then(function(src) {
+                if (src) {
                     fastdom.write(function() {
-                        el.setAttribute('src', dataSrc);
+                        el.setAttribute('src', src);
                     });
                 }
             });
         });
     }
 
-    return function () {
-        init();
+    function update(state, container) {
+        var translateWidth = -state.videoWidth * state.position;
+
+        return fastdom.write(function() {
+            container.querySelector('.video-playlist__item--active').classList.remove('video-playlist__item--active');
+            container.querySelector('.js-video-playlist-item-' + state.position).classList.add('video-playlist__item--active');
+
+            container.classList.remove('video-playlist--end', 'video-playlist--start');
+            if (state.atEnd) {
+                container.classList.add('video-playlist--end');
+            } else if (state.atStart) {
+                container.classList.add('video-playlist--start');
+            }
+
+            // fetch the next image (for desktop)
+            fetchLazyImage(container, state.position + 1);
+
+            // pause all players (we should potentially think about this site wide)
+            $('.js-video-playlist .vjs').each(function(el) {
+                videojs($(el)[0]).pause();
+            });
+
+            container.querySelector('.js-video-playlist-item-' + state.position).classList.add('video-playlist__item--active');
+            container.querySelector('.js-video-playlist-inner').setAttribute('style',
+                '-webkit-transform: translate(' + translateWidth + 'px);' +
+                'transform: translate(' + translateWidth + 'px);'
+            );
+        });
+    }
+
+    function getPositionState(position, length) {
+        return {
+            position: position,
+            atStart: position === 0,
+            atEnd: position >= length
+        };
+    }
+
+    function getInitialState(container) {
+        return {
+            position: 0,
+            length: container.getAttribute('data-number-of-videos'),
+            videoWidth: 700,
+            container: container
+        }
+    }
+
+    function setupDispatches(dispatch, container) {
+        bean.on(container, 'click', '.js-video-playlist-next', function() {
+            dispatch({ type: 'NEXT' });
+        });
+
+        bean.on(container, 'click', '.js-video-playlist-prev', function() {
+            dispatch({ type: 'PREV' });
+        });
+    }
+
+    function reducer(previousState, action) {
+        return reducers[action.type] ? reducers[action.type](previousState) : previousState;
+    }
+
+    return {
+        init: function(container) {
+            var initialState = getInitialState(container);
+            var store = createStore(reducer, initialState);
+
+            setupDispatches(store.dispatch, container);
+            store.subscribe(function() {
+                update(store.getState(), container);
+            });
+        }
     };
 });

--- a/static/src/javascripts/projects/common/modules/video/video-container.js
+++ b/static/src/javascripts/projects/common/modules/video/video-container.js
@@ -1,7 +1,3 @@
-/**
-    Video Container
- */
-
 define([
     'bean',
     'common/utils/fastdom-promise',


### PR DESCRIPTION
## What does this change?

We were adding no context to the video playlists, so adding multiple borked with events etc.

Using the content store as it's a nice way to deal with state, and this quite stateful. Less mutation = more 💪 
## What is the value of this and can you measure success?

We can add more than one carousel (which we need to as we're planning on changing the video front).
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
