### PR TITLE
extending headline tests

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -19,7 +19,7 @@ import conf.switches.Switches.ServerSideTests
 object ABHeadlinesTestVariant extends TestDefinition(
   "headlines-ab-variant",
   "To test how much of a difference changing a headline makes (variant group)",
-  new LocalDate(2016, 6, 10)
+  new LocalDate(2016, 7, 1)
   ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-hlt").contains("hlt-V")
@@ -39,7 +39,7 @@ object ABNewHeaderVariant extends TestDefinition(
 object ABHeadlinesTestControl extends TestDefinition(
   "headlines-ab-control",
   "To test how much of a difference changing a headline makes (control group)",
-  new LocalDate(2016, 6, 10)
+  new LocalDate(2016, 7, 1)
   ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-hlt").contains("hlt-C")


### PR DESCRIPTION
## What does this change?

Extends headline AB tests. After talking to some of the other participants in this test, they have decided to put more effort in to getting items to test.
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
