### PR TITLE
correct test name to match abtestswitch definition

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-showcase-main-media.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-showcase-main-media.js
@@ -6,7 +6,7 @@ define([
     config
 ) {
     return function () {
-        this.id = 'VideoShowcaseMainMedia';
+        this.id = 'VideoMainMediaAlwaysShowcase';
         this.start = '2016-06-07';
         this.expiry = '2016-06-14';
         this.author = 'Akash Askoolum';


### PR DESCRIPTION
## What does this change?

correct test name for https://github.com/guardian/frontend/pull/13229
## Request for comment

@jamesgorrie 
