### PR TITLE
set contrib-ads timeuot slightly higher that ima timeout

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -299,7 +299,11 @@ define([
                                         player.ima({
                                             id: mediaId,
                                             adTagUrl: getAdUrl(),
-                                            prerollTimeout: 1000
+                                            prerollTimeout: 1000,
+                                            // We set this sightly higher so contrib-ads never timeouts before ima.
+                                            contribAdsSettings: {
+                                                timeout: 1200
+                                            }
                                         });
                                         player.on('adstart', function() {
                                             player.adSkipCountdown(15);


### PR DESCRIPTION
## What does this change?

We did this before but it corresponded with a dip in video traffic which was just a dip in traffic.
Stops the video playing before the ad.
## What is the value of this and can you measure success?

No more complaints
## Does this affect other platforms - Amp, Apps, etc?

No

@akash1810 
