### PR TITLE
remove darkened sides on video front for carousel

### DIFF
--- a/common/app/views/fragments/containers/facia_cards/container.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/container.scala.html
@@ -64,7 +64,7 @@
 
         case _ => {
         <section id="@componentName"
-                 class="@GetClasses.forContainerDefinition(containerDefinition)"
+                 class="@GetClasses.forContainerDefinition(containerDefinition) @GetClasses.forFrontId(frontId)"
                  data-link-name="container-@{containerDefinition.index + 1} | @componentName"
                  data-id="@containerDefinition.dataId"
                  @renderBrandingDataAttributes()

--- a/common/app/views/support/GetClasses.scala
+++ b/common/app/views/support/GetClasses.scala
@@ -121,4 +121,8 @@ object GetClasses {
       case (kls, true) => kls
     }) ++ extraClasses: _*)
   }
+
+  def forFrontId(frontId: Option[String]) = RenderClasses(Seq(
+    "fc-container--video-no-fill-sides" -> frontId.contains("video")
+  ) collect { case (kls, true) => kls }: _*)
 }

--- a/static/src/stylesheets/module/facia/_container--video.scss
+++ b/static/src/stylesheets/module/facia/_container--video.scss
@@ -95,6 +95,10 @@ $video-width-desktop: 700px;
     }
 }
 
+.fc-container--video-no-fill-sides {
+    background-color: transparent;
+}
+
 .video-title {
     color: $media-default;
     display: block;


### PR DESCRIPTION
## What does this change?

We're going to be putting more than one carousel on the video front so it starts getting a bit dark.
This is just first pass, we'll play with it as we go on.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
### dark before

![dark-side](https://cloud.githubusercontent.com/assets/31692/15860357/9d806e62-2cc0-11e6-8e65-11243bee35ac.png)
### light now

![light-sight](https://cloud.githubusercontent.com/assets/31692/15860356/9c59dd66-2cc0-11e6-9830-cfc1578600cd.png)
## Request for comment

@akash1810 @blongden73 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
