### PR TITLE
Add email sign-up for EU Ref

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -398,4 +398,14 @@ trait FeatureSwitches {
     sellByDate = never,
     exposeClientSide = true
   )
+
+  // Owner: Dotcom habitual / Gareth
+  val emailSignupEuRef = Switch(
+    SwitchGroup.Feature,
+    "email-signup-eu-ref",
+    "When ON, insert the EU ref email sign-up into articles with the EU ref tag",
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
 }

--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -86,6 +86,17 @@ define([
                 modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
+            euRef: {
+                listId: '3698',
+                listName: 'euRef',
+                campaignCode: 'eu_ref_article_signup',
+                headline: 'EU referendum morning briefing',
+                description: 'Sign up for a round-up of the most recent EU referendum developments, the biggest talking points, and what to look out for each day.',
+                successHeadline: 'Thank you for signing up for the EU referendum morning briefing',
+                successDescription: 'You\'ll receive an email every morning.',
+                modClass: 'end-article',
+                insertMethod: insertBottomOfArticle
+            },
             ausCampaignCatchup: {
                 listId: '3689',
                 listName: 'ausCampaignCatchup',

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -92,7 +92,7 @@ define([
 
         if ($articleBody.length) {
             var allArticleEls = $('> *', $articleBody);
-            return every([].slice.call(allArticleEls, allArticleEls.length - 3), isParagraph);
+            return every([].slice.call(allArticleEls, allArticleEls.length - 2), isParagraph);
         } else {
             return false;
         }

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -112,6 +112,11 @@ define([
         labNotes: function () {
             return config.page.section === 'science' && config.switches.emailSignupLabNotes;
         },
+        euRef: function () {
+            return config.switches.emailSignupEuRef &&
+                    page.keywordExists(['EU referendum']) &&
+                    allowedArticleStructure();
+        },
         usBriefing: function () {
             return (config.page.section === 'us-news' && allowedArticleStructure()) ||
                 config.page.series === 'Guardian US briefing';

--- a/static/src/javascripts/projects/common/utils/page.js
+++ b/static/src/javascripts/projects/common/utils/page.js
@@ -3,15 +3,13 @@ define([
     'common/utils/config',
     'common/utils/detect',
     'lodash/objects/assign',
-    'lodash/collections/find',
-    'lodash/arrays/intersection'
+    'lodash/collections/find'
 ], function (
     $,
     config,
     detect,
     assign,
-    find,
-    intersection
+    find
 ) {
 
     function isit(isTrue, yes, no, arg) {
@@ -73,10 +71,15 @@ define([
         return isit(vis, yes, no, el);
     }
 
-    function keywordExists(keyword) {
+    function keywordExists(keywordArr) {
         var keywords = config.page.keywords ? config.page.keywords.split(',') : '';
+
         // Compare page keywords with passed in array
-        return !!intersection(keywords, keyword).length;
+        for (var i = 0; keywordArr.length > i; i++) {
+            if (keywords.indexOf(keywordArr[i]) > -1) return true;
+        }
+
+        return false;
     }
 
     return {


### PR DESCRIPTION
## What does this change?

Adds the email sign-up for EU referendum.

Note: We are discussing the scalability of this process...
## What is the value of this and can you measure success?

Drive sign-ups to the email.
## Screenshots

![screen shot 2016-06-07 at 14 44 04](https://cloud.githubusercontent.com/assets/638051/15860823/83326be4-2cc2-11e6-9836-4dbd1144d5d3.jpg)
## Request for comment

@crifmulholland @desbo @janua @guardian/participation 
