### PR TITLE
Refactor hosted page content

### DIFF
--- a/commercial/app/controllers/commercial/HostedContentController.scala
+++ b/commercial/app/controllers/commercial/HostedContentController.scala
@@ -1,103 +1,17 @@
 package controllers.commercial
 
-import common.commercial.{HostedPage, HostedVideo, HostedNextVideo}
-import conf.Static
-import conf.switches.Switches
+import common.commercial.HostedPage
 import model.Cached.RevalidatableResult
 import model.{Cached, NoCache}
-import play.api.mvc.{Action, AnyContent, Controller, Request}
+import play.api.mvc.{Action, Controller}
 import views.html.hosted.guardianHostedPage
 
 object HostedContentController extends Controller {
 
-  def renderHostedPage(pageName: String) = Action { implicit request: Request[AnyContent] =>
-    lazy val pageUrl = routes.HostedContentController.renderHostedPage(pageName).absoluteURL
-    val teaserPosterUrl: String = Static("images/commercial/renault-video-poster.jpg")
-    val episode1PosterUrl: String = Static("images/commercial/renault-video-poster-ep1.jpg")
-    val episode2PosterUrl: String = Static("images/commercial/renault-video-poster-ep2.jpg")
-
-    pageName match {
-
-      case "design-competition-teaser" =>
-        val page = HostedPage(
-          pageUrl,
-          pageName,
-          pageTitle = "Advertiser content hosted by the Guardian: Designing the car of the future - video",
-          standfirst = "Who better to dream up the cars of tomorrow than the people who'll be buying them? Students at Central St Martins are working with Renault to design the interior for cars that will drive themselves. Watch this short video to find out more about the project, and visit this page again soon to catch up on the students' progress",
-          logoUrl = Static("images/commercial/logo_renault.jpg"),
-          bannerUrl = Static("images/commercial/ren_commercial_banner.jpg"),
-          video = HostedVideo(
-            mediaId = "renault-car-of-the-future",
-            title = "Designing the car of the future",
-            duration = 86,
-            posterUrl = teaserPosterUrl,
-            srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160516GlabsTestSD"
-          ),
-          nextVideo = HostedNextVideo(
-            title = "Renault shortlists 'car of the future' designs",
-            link = "/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode1",
-            imageUrl = episode1PosterUrl
-          )
-        )
-        Cached(60)(RevalidatableResult.Ok(guardianHostedPage(page)))
-
-      case "design-competition-episode1" =>
-        val page = HostedPage(
-          pageUrl,
-          pageName,
-          pageTitle = "Renault shortlists 'car of the future' designs - video",
-          standfirst = "Renault challenged Central St Martins students to dream up the car of the future. The winning design will be announced at Clerkenwell Design Week (and on this site). Watch this short video to find out who made the shortlist",
-          logoUrl = Static("images/commercial/logo_renault.jpg"),
-          bannerUrl = Static("images/commercial/ren_commercial_banner.jpg"),
-          video = HostedVideo(
-            mediaId = "renault-car-of-the-future",
-            title = "Renault shortlists 'car of the future' designs",
-            duration = 160,
-            posterUrl = episode1PosterUrl,
-            srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160523GlabsRenaultTestHD"
-          ),
-          nextVideo = if(Switches.hostedEpisode2Content.isSwitchedOn) HostedNextVideo(
-            title = "Is this the car of the future?",
-            link = "/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode2",
-            imageUrl = episode2PosterUrl
-          ) else HostedNextVideo(
-            title = "Designing the car of the future",
-            link = "/commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser",
-            imageUrl = teaserPosterUrl
-          )
-        )
-        Cached(60)(RevalidatableResult.Ok(guardianHostedPage(page)))
-
-
-      case "design-competition-episode2" =>
-        if (Switches.hostedEpisode2Content.isSwitchedOn) {
-          val page = HostedPage(
-            pageUrl,
-            pageName,
-            pageTitle = "Is this the car of the future? - video",
-            standfirst = "A group of Central St Martins students took part in a competition to dream up the car of the future. The winning design is radical and intriguing. Meet the team whose blue-sky thinking may have created a blueprint for tomorrow's autonomous cars",
-            logoUrl = Static("images/commercial/logo_renault.jpg"),
-            bannerUrl = Static("images/commercial/ren_commercial_banner.jpg"),
-            video = HostedVideo(
-              mediaId = "renault-car-of-the-future",
-              title = "Is this the car of the future?",
-              duration = 160,
-              posterUrl = episode2PosterUrl,
-              srcUrl = "http://multimedia.guardianapis.com/interactivevideos/video.php?file=160603GlabsRenaultTest3"
-            ),
-            nextVideo = HostedNextVideo(
-              title = "Renault shortlists 'car of the future' designs",
-              link = "/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode1",
-              imageUrl = episode1PosterUrl
-            )
-          )
-          Cached(60)(RevalidatableResult.Ok(guardianHostedPage(page)))
-        } else {
-          NoCache(NotFound)
-        }
-
-      case _ =>
-        NoCache(NotFound)
+  def renderHostedPage(pageName: String) = Action { implicit request =>
+    HostedPage.fromPageName(pageName) match {
+      case Some(page) => Cached(60)(RevalidatableResult.Ok(guardianHostedPage(page)))
+      case None => NoCache(NotFound)
     }
   }
 }

--- a/commercial/app/views/hosted/guardianHostedPage.scala.html
+++ b/commercial/app/views/hosted/guardianHostedPage.scala.html
@@ -111,9 +111,9 @@
                     <h2 class="hosted__text hosted__next-video--up-next">More from</h2>
                     <h2 class="hosted__next-video--client-name hosted-tone--renault">Renault</h2>
                 </div>
-                <a href="@page.nextVideo.link" class="hosted__next-video--tile" data-link-name="Next Hosted Video: @page.nextVideo.title">
-                    <img class="hosted__next-video-thumb" src="@page.nextVideo.imageUrl">
-                    <p class="hosted__next-video-title">@page.nextVideo.title</p>
+                <a href="@page.nextPage.pageUrl" class="hosted__next-video--tile" data-link-name="Next Hosted Video: @page.nextPage.pageTitle">
+                    <img class="hosted__next-video-thumb" src="@page.nextPage.video.posterUrl">
+                    <p class="hosted__next-video-title">@page.nextPage.pageTitle</p>
                 </a>
             </div>
         </section>

--- a/common/app/common/commercial/HostedPage.scala
+++ b/common/app/common/commercial/HostedPage.scala
@@ -1,5 +1,7 @@
 package common.commercial
 
+import conf.Static
+import conf.switches.Switches
 import model.GuardianContentTypes.Hosted
 import model.{MetaData, StandalonePage}
 import play.api.libs.json.JsString
@@ -12,7 +14,7 @@ case class HostedPage(
                        logoUrl: String,
                        bannerUrl: String,
                        video: HostedVideo,
-                       nextVideo: HostedNextVideo
+                       nextPageName: String
                      ) extends StandalonePage {
 
   override val metadata: MetaData = {
@@ -44,6 +46,8 @@ case class HostedPage(
       )
     )
   }
+
+  lazy val nextPage = HostedPage.fromPageName(nextPageName) getOrElse HostedPage.defaultPage
 }
 
 case class HostedVideo(
@@ -54,9 +58,71 @@ case class HostedVideo(
                         srcUrl: String
                       )
 
+object HostedPage {
 
-case class HostedNextVideo(
-                        title: String,
-                        imageUrl: String,
-                        link: String
-                      )
+  private val teaserPageName = "design-competition-teaser"
+  private val episode1PageName = "design-competition-episode1"
+  private val episode2PageName = "design-competition-episode2"
+
+  private val teaser: HostedPage = HostedPage(
+    pageUrl = "https://www.theguardian.com/commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser",
+    pageName = teaserPageName,
+    pageTitle = "Advertiser content hosted by the Guardian: Designing the car of the future",
+    standfirst = "Who better to dream up the cars of tomorrow than the people who'll be buying them? Students at Central St Martins are working with Renault to design the interior for cars that will drive themselves. Watch this short video to find out more about the project, and visit this page again soon to catch up on the students' progress",
+    logoUrl = Static("images/commercial/logo_renault.jpg"),
+    bannerUrl = Static("images/commercial/ren_commercial_banner.jpg"),
+    video = HostedVideo(
+      mediaId = "renault-car-of-the-future",
+      title = "Designing the car of the future",
+      duration = 86,
+      posterUrl = Static("images/commercial/renault-video-poster.jpg"),
+      srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160516GlabsTestSD"
+    ),
+    nextPageName = episode1PageName
+  )
+
+  private val episode1: HostedPage = HostedPage(
+    pageUrl = "https://www.theguardian.com/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode1",
+    pageName = episode1PageName,
+    pageTitle = "Renault shortlists 'car of the future' designs",
+    standfirst = "Renault challenged Central St Martins students to dream up the car of the future. The winning design will be announced at Clerkenwell Design Week (and on this site). Watch this short video to find out who made the shortlist",
+    logoUrl = Static("images/commercial/logo_renault.jpg"),
+    bannerUrl = Static("images/commercial/ren_commercial_banner.jpg"),
+    video = HostedVideo(
+      mediaId = "renault-car-of-the-future",
+      title = "Renault shortlists 'car of the future' designs",
+      duration = 160,
+      posterUrl = Static("images/commercial/renault-video-poster-ep1.jpg"),
+      srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160523GlabsRenaultTestHD"
+    ),
+    nextPageName = if (Switches.hostedEpisode2Content.isSwitchedOn) episode2PageName else teaserPageName
+  )
+
+  private val episode2: HostedPage = HostedPage(
+    pageUrl = "https://www.theguardian.com/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode2",
+    pageName = episode2PageName,
+    pageTitle = "Is this the car of the future?",
+    standfirst = "A group of Central St Martins students took part in a competition to dream up the car of the future. The winning design is radical and intriguing. Meet the team whose blue-sky thinking may have created a blueprint for tomorrow's autonomous cars",
+    logoUrl = Static("images/commercial/logo_renault.jpg"),
+    bannerUrl = Static("images/commercial/ren_commercial_banner.jpg"),
+    video = HostedVideo(
+      mediaId = "renault-car-of-the-future",
+      title = "Is this the car of the future?",
+      duration = 158,
+      posterUrl = Static("images/commercial/renault-video-poster-ep2.jpg"),
+      srcUrl = "http://multimedia.guardianapis.com/interactivevideos/video.php?file=160603GlabsRenaultTest3"
+    ),
+    nextPageName = episode1PageName
+  )
+
+  lazy val defaultPage = teaser
+
+  def fromPageName(pageName: String): Option[HostedPage] = {
+    pageName match {
+      case `teaserPageName` => Some(teaser)
+      case `episode1PageName` => Some(episode1)
+      case `episode2PageName` if Switches.hostedEpisode2Content.isSwitchedOn => Some(episode2)
+      case _ => None
+    }
+  }
+}


### PR DESCRIPTION
This moves all the hosted content into `HostedPage` so that it's easier to work out.
It should have no effect on what's rendered.

/cc @Calanthe @lps88 
