### PR TITLE
Twitter share image resize

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -549,7 +549,7 @@ import collection.JavaConversions._
 
         // at the time of writing, Twitter does not like i.guim.co.uk
         // will see if I can get that fixed, but in the meantime this must be static.guim.co.uk
-        $("meta[name='twitter:image']").getAttributes("content").head should be("https://static-secure.guim.co.uk/sys-images/Guardian/Pix/GU_front_gifs/2013/9/15/1379275549160/Irans-President-Hassan-Ro-010.jpg")
+        $("meta[name='twitter:image']").getAttributes("content").head should be("https://static-secure.guim.co.uk/sys-images/Guardian/Pix/GU_front_gifs/2013/9/15/1379275549160/Irans-President-Hassan-Ro-010.jpg?w=1200&q=55&auto=format&usm=12&fit=max&s=2536d2d0e1a5d9daa8dc9f8466901e44")
       }
     }
 

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -546,7 +546,7 @@ import collection.JavaConversions._
         $("meta[name='twitter:site']").getAttributes("content").head should be("@guardian")
         $("meta[name='twitter:card']").getAttributes("content").head should be("summary_large_image")
         $("meta[name='twitter:app:url:googleplay']").getAttributes("content").head should startWith("guardian://www.theguardian.com/world")
-        $("meta[name='twitter:image']").getAttributes("content").head should contain("/2013/9/15/1379275549160/Irans-President-Hassan-Ro-010.jpg")
+        $("meta[name='twitter:image']").getAttributes("content").head should include("2013/9/15/1379275549160/Irans-President-Hassan-Ro-010.jpg")
       }
     }
 

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -546,10 +546,7 @@ import collection.JavaConversions._
         $("meta[name='twitter:site']").getAttributes("content").head should be("@guardian")
         $("meta[name='twitter:card']").getAttributes("content").head should be("summary_large_image")
         $("meta[name='twitter:app:url:googleplay']").getAttributes("content").head should startWith("guardian://www.theguardian.com/world")
-
-        // at the time of writing, Twitter does not like i.guim.co.uk
-        // will see if I can get that fixed, but in the meantime this must be static.guim.co.uk
-        $("meta[name='twitter:image']").getAttributes("content").head should be("https://static-secure.guim.co.uk/sys-images/Guardian/Pix/GU_front_gifs/2013/9/15/1379275549160/Irans-President-Hassan-Ro-010.jpg?w=1200&q=55&auto=format&usm=12&fit=max&s=2536d2d0e1a5d9daa8dc9f8466901e44")
+        $("meta[name='twitter:image']").getAttributes("content").head should contain("/2013/9/15/1379275549160/Irans-President-Hassan-Ro-010.jpg")
       }
     }
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -19,7 +19,7 @@ import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
 import org.scala_tools.time.Imports._
 import play.api.libs.json._
-import views.support.{ChaptersLinksCleaner, FacebookOpenGraphImage, ImgSrc, Item700, StripHtmlTagsAndUnescapeEntities}
+import views.support._
 
 import scala.collection.JavaConversions._
 import scala.language.postfixOps
@@ -239,7 +239,7 @@ final case class Content(
 
   val twitterProperties = Map(
     "twitter:app:url:googleplay" -> metadata.webUrl.replaceFirst("^[a-zA-Z]*://", "guardian://"), //replace current scheme with guardian mobile app scheme
-    "twitter:image" -> rawOpenGraphImage
+    "twitter:image" -> ImgSrc(rawOpenGraphImage, TwitterImage)
   ) ++ contributorTwitterHandle.map(handle => "twitter:creator" -> s"@$handle").toList
 
   val quizzes: Seq[Quiz] = atoms.map(_.quizzes).getOrElse(Nil)

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -96,23 +96,7 @@ object Item640 extends Profile(width = Some(640))
 object Item700 extends Profile(width = Some(700))
 object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
 object Video700 extends VideoProfile(width = Some(700), height = Some(394)) // 16:9
-object TwitterImage extends Profile(width = Some(1200)) {
-  override val heightParam = "h=632"
-  val blendModeParam = "bm=normal"
-  val blendOffsetParam = "ba=bottom%2Cleft"
-  val blendImageParam = "blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n"
-  override val fitParam = "fit=crop"
-
-
-  override def resizeString = {
-    if(FacebookShareImageLogoOverlay.isSwitchedOn) {
-      val params = Seq(widthParam, heightParam, qualityparam, autoParam, sharpParam, fitParam, dprParam, blendModeParam, blendOffsetParam, blendImageParam).filter(_.nonEmpty).mkString("&")
-      s"?$params"
-    } else {
-      super.resizeString
-    }
-  }
-}
+object TwitterImage extends Profile(width = Some(1200))
 object FacebookOpenGraphImage extends Profile(width = Some(1200)) {
 
   override val heightParam = "h=632"

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -96,6 +96,7 @@ object Item640 extends Profile(width = Some(640))
 object Item700 extends Profile(width = Some(700))
 object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
 object Video700 extends VideoProfile(width = Some(700), height = Some(394)) // 16:9
+object TwitterImage extends Profile(width = Some(1200))
 object FacebookOpenGraphImage extends Profile(width = Some(1200)) {
 
   override val heightParam = "h=632"

--- a/common/app/views/support/Profile.scala
+++ b/common/app/views/support/Profile.scala
@@ -96,7 +96,23 @@ object Item640 extends Profile(width = Some(640))
 object Item700 extends Profile(width = Some(700))
 object Video640 extends VideoProfile(width = Some(640), height = Some(360)) // 16:9
 object Video700 extends VideoProfile(width = Some(700), height = Some(394)) // 16:9
-object TwitterImage extends Profile(width = Some(1200))
+object TwitterImage extends Profile(width = Some(1200)) {
+  override val heightParam = "h=632"
+  val blendModeParam = "bm=normal"
+  val blendOffsetParam = "ba=bottom%2Cleft"
+  val blendImageParam = "blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n"
+  override val fitParam = "fit=crop"
+
+
+  override def resizeString = {
+    if(FacebookShareImageLogoOverlay.isSwitchedOn) {
+      val params = Seq(widthParam, heightParam, qualityparam, autoParam, sharpParam, fitParam, dprParam, blendModeParam, blendOffsetParam, blendImageParam).filter(_.nonEmpty).mkString("&")
+      s"?$params"
+    } else {
+      super.resizeString
+    }
+  }
+}
 object FacebookOpenGraphImage extends Profile(width = Some(1200)) {
 
   override val heightParam = "h=632"


### PR DESCRIPTION
## What does this change?

The end result is a change to the content of the twitter:image meta-tag. 

There is currently no image profile for twitter images; this PR reduces the size of the image served to the Twitter scraper.
## What is the value of this and can you measure success?

Twitter uses Open Graph tags as fallbacks when Twitter Card meta-tags are missing or not usable. After creating custom images for Open Graph (#13210), it was discovered that Twitter sometimes uses the Open Graph image, despite a twitter:image meta-tag existing on our page.

The cause appears to be that we are serving a raw image to Twitter, however, images must be less than 1MB in size for Twitter Cards ([docs](https://dev.twitter.com/cards/overview)), and our raw images sometimes exceed this.

This PR should ensure that Twitter will always use the image from the twitter:image meta-tag, and will prevent the overlay from appearing on Twitter.
## Does this affect other platforms - Amp, Apps, etc?

Twitter
## Screenshots

**Twitter post that is using an Open Graph image:**

<img width="564" alt="Affected article with an overlay on Twitter" src="https://cloud.githubusercontent.com/assets/8607683/15863855/8b6b0db6-2ccc-11e6-946a-4ce5c3805a6d.png">

**Twitter post that is using a Twitter Card image:**

<img width="564" alt="Intended appearance of an article on Twitter" src="https://cloud.githubusercontent.com/assets/8607683/15864078/78d1ab5a-2ccd-11e6-9898-9ede17052539.png">
## Request for comment

@dominickendrick 
