### PR TITLE
add facebook pixel

### DIFF
--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -2,6 +2,7 @@
 @import conf.Configuration
 @import conf.Static
 @import conf.switches.Switches.BritishCouncilBeacon
+@import views.support.FBPixel
 
 
 @******************************************************************************
@@ -41,6 +42,7 @@
 </noscript>
 
 <img src="@Configuration.debug.beaconUrl/count/pv.gif" alt="" style="display : none ;" rel="nofollow"/>
+<img src="https://www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1" height="1" width="1" style="display:none" rel="nofollow" alt="" />
 
 @if(BritishCouncilBeacon.isSwitchedOn && page.metadata.url.contains("british-council-partner-zone")) {
     <img alt="DCSIMG" id="DCSIMG" width="1" height="1"

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -35,9 +35,9 @@
             }) { omnitureCall =>
                 <amp-pixel src="@Html(omnitureCall)"></amp-pixel>
                 <amp-pixel src="//beacon.guim.co.uk/count/pva.gif"></amp-pixel>
-                <amp-pixel src="//www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1"></amp-pixel>
             }
         }
+        <amp-pixel src="//www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1"></amp-pixel>
         <amp-analytics config="https://ophan.theguardian.com/amp.json"></amp-analytics>
 
         <div class="main-body">

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -3,6 +3,7 @@
 @import common.{AnalyticsHost, CanonicalLink, LinkTo}
 @import conf.Configuration
 @import views.support.OmnitureAnalyticsData
+@import views.support.FBPixel
 
 <!doctype html>
 <html AMP>
@@ -34,6 +35,7 @@
             }) { omnitureCall =>
                 <amp-pixel src="@Html(omnitureCall)"></amp-pixel>
                 <amp-pixel src="//beacon.guim.co.uk/count/pva.gif"></amp-pixel>
+                <amp-pixel src="//www.facebook.com/tr?id=@FBPixel.account&ev=PageView&noscript=1"></amp-pixel>
             }
         }
         <amp-analytics config="https://ophan.theguardian.com/amp.json"></amp-analytics>

--- a/common/app/views/support/FBPixel.scala
+++ b/common/app/views/support/FBPixel.scala
@@ -1,0 +1,5 @@
+package views.support
+
+object FBPixel {
+  val account: String = "108317535975354"
+}


### PR DESCRIPTION
## What does this change?

adds a tracking pixel that reports to Facebook that you've read something on the guardian (if you're logged in to Facebook)
## What is the value of this and can you measure success?

it should mean our ad-spend on Facebook can be better targeted 
## Does this affect other platforms - Amp, Apps, etc?

AMP
## Request for comment

@stephanfowler 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

tell facebook that you've read the guardian
