### PR TITLE
Remove data-component attribute from links

### DIFF
--- a/common/app/views/support/HtmlCleaner.scala
+++ b/common/app/views/support/HtmlCleaner.scala
@@ -209,7 +209,6 @@ case class InBodyLinkCleaner(dataLinkName: String, amp: Boolean = false)(implici
       if (link.tagName == "a") {
         link.attr("href", LinkTo(link.attr("href"), edition))
         link.attr("data-link-name", dataLinkName)
-        link.attr("data-component", dataLinkName.replace(" ", "-"))
         link.addClass("u-underline")
       }
       if (amp && link.hasAttr("style")) {

--- a/discussion/app/views/fragments/commentSchema.scala.html
+++ b/discussion/app/views/fragments/commentSchema.scala.html
@@ -10,7 +10,7 @@
         <div class="comment__body u-text-hyphenate" itemprop="text">
             @defining(Edition(request)) { edition =>
                 @withJsoup(BulletCleaner(comment.body))(
-                    InBodyLinkCleaner("in body link")
+                    InBodyLinkCleaner("in comment link")
                 )
             }
         </div>


### PR DESCRIPTION
## What does this change?

Removes `data-component` attribute from in body and in comment links.

Changes `data-link-name` from comment links to be more honest.
## What is the value of this and can you measure success?

Less verbose HTML, less noise reported to Ophan.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

N/A
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

This is not used by Omniture and as far as Ophan is concerned doesn't make sense on these elements.
