### PR TITLE
Decouple source of page branding and container branding 

### DIFF
--- a/common/app/common/commercial/ContainerModel.scala
+++ b/common/app/common/commercial/ContainerModel.scala
@@ -1,7 +1,7 @@
 package common.commercial
 
 import common.Edition
-import conf.switches.Switches
+import conf.switches.Switches.containerBrandingFromCapi
 import model.facia.PressedCollection
 import views.support.{Commercial, SponsorDataAttributes}
 
@@ -13,7 +13,7 @@ case class ContainerModel(
                            branding: Option[Branding]
                          ) {
   val isSingleSponsorContainer: Boolean = {
-    if (Switches.staticBadgesSwitch.isSwitchedOn) {
+    if (containerBrandingFromCapi.isSwitchedOn) {
       branding.isDefined
     } else brandingAttributes.isDefined
   }

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -271,7 +271,16 @@ trait CommercialSwitches {
     "static-badges",
     "If on, all badges are served server side",
     safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 22),
+    sellByDate = new LocalDate(2016, 7, 13),
+    exposeClientSide = true
+  )
+
+  val containerBrandingFromCapi = Switch(
+    SwitchGroup.Commercial,
+    "static-container-badges",
+    "Serve container branding from capi",
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 7, 13),
     exposeClientSide = true
   )
 

--- a/common/app/views/commercial/containers/paidContainer.scala.html
+++ b/common/app/views/commercial/containers/paidContainer.scala.html
@@ -3,7 +3,7 @@
   containerModel: common.commercial.ContainerModel)(implicit request: RequestHeader)
 
 @import common.{Edition, LinkTo}
-@import conf.switches.Switches.staticBadgesSwitch
+@import conf.switches.Switches.containerBrandingFromCapi
 @import views.html.commercial.containerWrapper
 @import views.html.commercial.containers._
 @import views.html.fragments.commercial.contentLogo
@@ -80,7 +80,7 @@
 }
 
 @logoSlot = {
-    @if(staticBadgesSwitch.isSwitchedOn) {
+    @if(containerBrandingFromCapi.isSwitchedOn) {
         @for(branding <- containerModel.branding) {
             @contentLogo(branding)
         }

--- a/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/standardContainer.scala.html
@@ -1,6 +1,6 @@
 @import common.commercial.ContainerModel
 @import common.{Edition, Localisation}
-@import conf.switches.Switches.staticBadgesSwitch
+@import conf.switches.Switches.containerBrandingFromCapi
 @import views.html.fragments.commercial.contentLogo
 @import views.html.fragments.containers.facia_cards.{containerHeader, showMore, showMoreButton, slice}
 @import views.support.RenderClasses
@@ -10,7 +10,7 @@
 
 @containerHeader(containerDefinition, frontProperties)
 
-@if(staticBadgesSwitch.isSwitchedOn) {
+@if(containerBrandingFromCapi.isSwitchedOn) {
     @if(containerDefinition.index == 0) {
         @for(frontBranding <- frontProperties.branding(Edition(request))) {
             @contentLogo(frontBranding)

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -4,7 +4,7 @@ import common.Edition
 import common.commercial.{Branding, CardContent, ContainerModel, PaidContent}
 import common.dfp.AdSize.responsiveSize
 import common.dfp._
-import conf.switches.Switches._
+import conf.switches.Switches.{FixedTechTopSlot, FluidAdverts, containerBrandingFromCapi}
 import layout.{ColumnAndCards, ContentCard, FaciaContainer}
 import model.pressed.{CollectionConfig, PressedContent}
 import model.{ContentType, MetaData, Page, Tag}
@@ -91,11 +91,11 @@ object Commercial {
         def isPaidBranding(branding: Option[Branding]): Boolean =
           branding.exists(_.sponsorshipType == PaidContent)
 
-        def isPaid(card: CardContent): Boolean = if (staticBadgesSwitch.isSwitchedOn) {
+        def isPaid(card: CardContent): Boolean = if (containerBrandingFromCapi.isSwitchedOn) {
           isPaidBranding(card.branding)
         } else false
 
-        val isPaidContainer = if (staticBadgesSwitch.isSwitchedOn) {
+        val isPaidContainer = if (containerBrandingFromCapi.isSwitchedOn) {
           isPaidBranding(containerModel.branding)
         } else {
           isPaidBrandingAttributes(containerModel.brandingAttributes)
@@ -110,8 +110,10 @@ object Commercial {
         isPaidContainer || isAllPaidContent
       }
 
-      !isPaidFront &&
-        (container.commercialOptions.isPaidContainer || optContainerModel.exists(isPaid))
+      !isPaidFront && (
+        (containerBrandingFromCapi.isSwitchedOff && container.commercialOptions.isPaidContainer)
+          || optContainerModel.exists(isPaid)
+        )
     }
 
     def mkSponsorDataAttributes(config: CollectionConfig): Option[SponsorDataAttributes] = {

--- a/common/app/views/support/commercial/TrackingCodeBuilder.scala
+++ b/common/app/views/support/commercial/TrackingCodeBuilder.scala
@@ -2,7 +2,7 @@ package views.support.commercial
 
 import common.Edition
 import common.commercial.{CardContent, ContainerModel}
-import conf.switches.Switches.staticBadgesSwitch
+import conf.switches.Switches.containerBrandingFromCapi
 import play.api.mvc.RequestHeader
 
 object TrackingCodeBuilder extends implicits.Requests {
@@ -12,7 +12,7 @@ object TrackingCodeBuilder extends implicits.Requests {
                                 container: ContainerModel,
                                 card: CardContent)(implicit request: RequestHeader): String = {
     val sponsor = {
-      if (staticBadgesSwitch.isSwitchedOn) {
+      if (containerBrandingFromCapi.isSwitchedOn) {
         container.branding.map(_.sponsorName) orElse card.branding.map(_.sponsorName) getOrElse ""
       } else {
         container.brandingAttributes.flatMap(_.sponsor) getOrElse ""

--- a/common/test/views/support/commercial/TrackingCodeBuilderTest.scala
+++ b/common/test/views/support/commercial/TrackingCodeBuilderTest.scala
@@ -1,7 +1,7 @@
 package views.support.commercial
 
 import common.commercial._
-import conf.switches.Switches.staticBadgesSwitch
+import conf.switches.Switches.containerBrandingFromCapi
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import play.api.test.FakeRequest
 import views.support.SponsorDataAttributes
@@ -9,7 +9,7 @@ import views.support.SponsorDataAttributes
 class TrackingCodeBuilderTest extends FlatSpec with Matchers with BeforeAndAfterEach {
 
   override protected def beforeEach(): Unit = {
-    staticBadgesSwitch.switchOff()
+    containerBrandingFromCapi.switchOff()
   }
 
   private def mkBrandingAttributes(sponsorName: String) = SponsorDataAttributes(
@@ -81,7 +81,7 @@ class TrackingCodeBuilderTest extends FlatSpec with Matchers with BeforeAndAfter
   }
 
   it should "populate tracking code when card has individual branding" in {
-    staticBadgesSwitch.switchOn()
+    containerBrandingFromCapi.switchOn()
     val code = TrackingCodeBuilder.mkInteractionTrackingCode(
       frontId = "front-id",
       containerIndex = 5,

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -39,7 +39,7 @@ define([
         ['cm-frontCommercialComponents', frontCommercialComponents.init]
     ];
 
-    if (!config.switches.staticBadges) {
+    if (!(config.switches.staticBadges && config.switches.staticContainerBadges)) {
         modules.push(['cm-badges', badges.init]);
     }
 


### PR DESCRIPTION
So that they can be changed independently.

This is because there are changes in the fronts tool to be communicated before container branding goes live, and it would be wise to decouple this from changes in the tag manager.
