### PR TITLE
Hosted about popup mobile fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/hosted-about.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-about.js
@@ -13,7 +13,7 @@ define([
             header: 'Advertiser content',
             paragraph1: 'Advertiser content is used to describe advertisement features that are paid for, produced and controlled by the advertiser rather than the publisher​.',
             paragraph2: 'They​ are subject to regulation by the Advertising Standards Authority in the UK, the Federal Trade Commission in the US and the Advertising Standards Bureau in Australia.',
-            paragraph3: 'This content is produced by the advertiser and does not involve GNM staff.',
+            paragraph3: 'This content is produced by the advertiser and does not involve Guardian News and Media staff.',
             showCloseBtn: true
         });
 

--- a/static/src/stylesheets/module/commercial/surveys/_survey.scss
+++ b/static/src/stylesheets/module/commercial/surveys/_survey.scss
@@ -68,19 +68,18 @@
     }
 
     .survey-icon {
-        display: none;
         text-align: center;
         padding-top: 40px;
         background-color: #e3e3e3;
         line-height: 10px;
 
-        @include mq(tablet) {
-            display: block;
-        }
-
         svg {
-            width: 350px;
-            height: 226px;
+            width: 240px;
+            height: 154px;
+            @include mq(tablet) {
+                width: 350px;
+                height: 226px;
+            }
         }
     }
 


### PR DESCRIPTION
## What does this change?

Small fixes on the 'about hosted content' popup:
- The `GNM` replaced with the `Guardian News and Media`
- Smalle svg icon is shown on mobile
## Screenshots

Before:
![screen shot 2016-06-08 at 16 04 19](https://cloud.githubusercontent.com/assets/489567/15899279/267087ca-2d93-11e6-98f4-c4792985658c.png)

After:
![screen shot 2016-06-08 at 16 01 56](https://cloud.githubusercontent.com/assets/489567/15899291/2e88d822-2d93-11e6-833b-abda30e142ff.png)
