### PR TITLE
Update live blog notifications expiry and start

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/live-blog-chrome-notifications-internal.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/live-blog-chrome-notifications-internal.js
@@ -11,7 +11,7 @@ define([
 
         this.id = 'LiveBlogChromeNotificationsInternal';
         this.start = '2016-03-03';
-        this.expiry = '2016-06-01';
+        this.expiry = '2016-08-31';
         this.author = 'Nathaniel Bennett';
         this.description = 'Allows users to to subscribe to live blogs on chrome - internal users only';
         this.audience = 0.0;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/live-blog-chrome-notifications-prod.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/live-blog-chrome-notifications-prod.js
@@ -10,8 +10,8 @@ define([
     return function () {
 
         this.id = 'LiveBlogChromeNotificationsProd';
-        this.start = '2016-08-04';
-        this.expiry = '2016-06-01';
+        this.start = '2016-06-08';
+        this.expiry = '2016-08-31';
         this.author = 'Nathaniel Bennett';
         this.description = 'Allows users to to subscribe to live blogs on chrome - separately to internal test so we can run the internal one on prod if need be';
         this.audience = 0.02;


### PR DESCRIPTION
This changes the expiry on `live-blog-chrome-notifications-internal` to August 31st 2016.

Also changes the expiry on `live-blog-chrome-notifications-prod` to August 31st 2016, but brings back the **start** to June the 8th 2016 so that it will _actually run_.

@samdesborough @NathanielBennett @crifmulholland 
