### PR TITLE
add euro 2016 link

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -238,6 +238,7 @@ trait Navigation {
   val membership = SectionLink("membership", "membership", "Membership", "/membership")
 
   val footballNav = Seq(
+    SectionLink("football", "euro 2016", "Euro 2016", "/football/euro-2016"),
     SectionLink("football", "live scores", "Live scores", "/football/live"),
     SectionLink("football", "tables", "Tables", "/football/tables"),
     SectionLink("football", "competitions", "Competitions", "/football/competitions"),


### PR DESCRIPTION
## What does this change?

adds euro 2016 to the football nav
## Screenshots

<img width="166" alt="screen shot 2016-06-09 at 15 42 14" src="https://cloud.githubusercontent.com/assets/867233/15933742/c4db6b62-2e58-11e6-86f8-649aaffee197.png">
## Request for comment

yes please 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
