### PR TITLE
Resolve deprecation warnings

### DIFF
--- a/project/Frontend.scala
+++ b/project/Frontend.scala
@@ -1,15 +1,12 @@
 package com.gu
 
-import sbt._
-import sbt.Keys._
-import play.Play.autoImport._
-import PlayKeys._
-import play._
-import play.sbt._
+import com.gu.Dependencies._
+import com.typesafe.sbt.web.Import._
+import play.sbt.Play.autoImport._
 import play.sbt.routes.RoutesKeys
 import play.twirl.sbt.Import._
-import com.typesafe.sbt.web.Import._
-import Dependencies._
+import sbt.Keys._
+import sbt._
 
 object Frontend extends Build with Prototypes {
 

--- a/project/Prototypes.scala
+++ b/project/Prototypes.scala
@@ -1,16 +1,16 @@
 package com.gu
 
-import com.gu.versioninfo.VersionInfo
-import com.typesafe.sbt.packager.universal.UniversalPlugin
-import sbt._
-import sbt.Keys._
-import com.typesafe.sbt.web.SbtWeb.autoImport._
-import com.typesafe.sbt.SbtNativePackager._
-import com.typesafe.sbt.packager.Keys._
+import com.gu.Dependencies._
 import com.gu.riffraff.artifact.RiffRaffArtifact
 import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
+import com.gu.versioninfo.VersionInfo
+import com.typesafe.sbt.SbtNativePackager._
+import com.typesafe.sbt.packager.Keys._
+import com.typesafe.sbt.packager.universal.UniversalPlugin
+import play.sbt.PlayScala
 import play.twirl.sbt.Import._
-import Dependencies._
+import sbt.Keys._
+import sbt._
 
 trait Prototypes {
   val version = "1-SNAPSHOT"
@@ -149,12 +149,12 @@ trait Prototypes {
     }
   )
 
-  def root() = Project("root", base = file(".")).enablePlugins(play.PlayScala)
+  def root() = Project("root", base = file(".")).enablePlugins(PlayScala)
     .settings(frontendCompilationSettings)
     .settings(frontendRootSettings)
 
   def application(applicationName: String) = {
-    Project(applicationName, file(applicationName)).enablePlugins(play.PlayScala, RiffRaffArtifact, UniversalPlugin)
+    Project(applicationName, file(applicationName)).enablePlugins(PlayScala, RiffRaffArtifact, UniversalPlugin)
     .settings(frontendDependencyManagementSettings)
     .settings(frontendCompilationSettings)
     .settings(frontendClientSideSettings)
@@ -166,7 +166,7 @@ trait Prototypes {
   }
 
   def library(applicationName: String) = {
-    Project(applicationName, file(applicationName)).enablePlugins(play.PlayScala)
+    Project(applicationName, file(applicationName)).enablePlugins(PlayScala)
     .settings(frontendDependencyManagementSettings)
     .settings(frontendCompilationSettings)
     .settings(frontendClientSideSettings)


### PR DESCRIPTION
Small hygiene improvement.  Doesn't actually change anything.

Resolves these:

```
[warn] Frontend.scala:28: value Play in package play is deprecated: Use play.sbt.Play instead
[warn]       filters,
[warn]       ^
[warn] Frontend.scala:41: value Play in package play is deprecated: Use play.sbt.Play instead
[warn]       ws,
[warn]       ^
[warn] Frontend.scala:129: value Play in package play is deprecated: Use play.sbt.Play instead
[warn]       filters,
[warn]       ^
[warn] Prototypes.scala:152: value PlayScala in package play is deprecated: Use play.sbt.Play instead
[warn]   def root() = Project("root", base = file(".")).enablePlugins(play.PlayScala)
[warn]                                                                     ^
[warn] Prototypes.scala:157: value PlayScala in package play is deprecated: Use play.sbt.Play instead
[warn]     Project(applicationName, file(applicationName)).enablePlugins(play.PlayScala, RiffRaffArtifact, UniversalPlugin)
[warn]                                                                        ^
[warn] Prototypes.scala:169: value PlayScala in package play is deprecated: Use play.sbt.Play instead
[warn]     Project(applicationName, file(applicationName)).enablePlugins(play.PlayScala)
[warn]                                                                        ^
[warn] 6 warnings found
```
