### PR TITLE
Phase out the ad-free test

### DIFF
--- a/common/app/templates/inlineJS/blocking/applyAdfreeRenderCondition.scala.js
+++ b/common/app/templates/inlineJS/blocking/applyAdfreeRenderCondition.scala.js
@@ -56,12 +56,12 @@
             && mvtCookieId <= largestTestId
             && !isIOS() && !isSafari()) {
             variants = [{
-                id: 'variant',
+                id: 'posttest-variant',
                 test: function () {
                     writeCookie(AD_FREE_COOKIE, 'variant');
                 }
             }, {
-                id: 'control',
+                id: 'posttest-control',
                 test: function () {
                     writeCookie(AD_FREE_COOKIE, 'control');
                 }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/new-user-adverts-disabled.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/new-user-adverts-disabled.js
@@ -30,12 +30,12 @@ define([
         };
 
         this.variants = [{
-            id: 'variant',
+            id: 'posttest-variant',
             test: function () {
                 cookies.add('gu_adfree_test', 'variant');
             }
         }, {
-            id: 'control',
+            id: 'posttest-control',
             test: function () {
                 cookies.add('gu_adfree_test', 'control');
             }


### PR DESCRIPTION
## What does this change?

Stops adding new users to the ad-free test variant group, but continues 
to serve ad-free to users already allocated.  These users will start seeing 
ads three days after their first visit, and then we can turn the test off
completely.
## What is the value of this and can you measure success?

Part of the ad-free test
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
