### PR TITLE
Update max MVT id in line with server-side test removal

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/mvt-cookie.js
+++ b/static/src/javascripts/projects/common/modules/analytics/mvt-cookie.js
@@ -7,9 +7,7 @@ define([
         VISITOR_ID_COOKIE = 's_vi',
         BROWSER_ID_COOKIE = 'bwid',
         // The full mvt ID interval is [1, 1000000]
-        // Server side mvt IDs occupy [9000000, 1000000)
-        // So the client-side mvt interval is [1, 899999]
-        MAX_CLIENT_MVT_ID = 899999;
+        MAX_CLIENT_MVT_ID = 1000000;
 
     function overwriteMvtCookie(testId) {
         // For test purposes only.


### PR DESCRIPTION
client-side MVT ids now occupy the full range (https://github.com/guardian/fastly-edge-cache/pull/630)
@TBonnin @gtrufitt 
