### PR TITLE
Hosted By videos - stop errors

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/hosted-video.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-video.js
@@ -43,30 +43,34 @@ define([
     }
 
     function init() {
-        var $videoEl = $('.vjs-hosted__video');
-
-        if (!$videoEl.length) {
-            return;
-        }
-
         require(['bootstraps/enhanced/media/main'], function () {
             require(['bootstraps/enhanced/media/video-player'], function(videojs){
-                var mediaId = $videoEl.attr('data-media-id');
+                var $videoEl = $('.vjs-hosted__video');
+
+                if (!$videoEl.length) {
+                    return;
+                }
 
                 player = videojs($videoEl.get(0), videojsOptions());
                 player.guMediaType = 'video';
                 videojs.plugin('fullscreener', fullscreener);
 
                 // unglitching the volume on first load
-                var vol = player.volume();
-                if (vol) {
-                    player.volume(0);
-                    player.volume(vol);
-                }
 
                 player.ready(function () {
+                    var vol;
+                    initLoadingSpinner(player);
+                    upgradeVideoPlayerAccessibility(player);
+
+                    vol = player.volume();
+                    if (vol) {
+                        player.volume(0);
+                        player.volume(vol);
+                    }
+
                     player.fullscreener();
 
+                    var mediaId = $videoEl.attr('data-media-id');
                     deferToAnalytics(function () {
                         events.initOmnitureTracking(player);
                         events.initOphanTracking(player, mediaId);
@@ -75,8 +79,6 @@ define([
                         events.bindContentEvents(player);
                     });
 
-                    initLoadingSpinner(player);
-                    upgradeVideoPlayerAccessibility(player);
                 });
             });
         });


### PR DESCRIPTION
## What does this change?

Change the order of the video player initialisation steps in hosted-video.js
## What is the value of this and can you measure success?

Should hopefully stop the hosted videos erroring when playing/pausing/scrubbing.
"A network error caused the media download to fail part-way."
## Request for comment

@ScottPainterGNM @kelvin-chappell 
