### PR TITLE
Default comment ordering to oldest first

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -316,6 +316,16 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  val DiscussionOrderByOldest = Switch(
+    SwitchGroup.Feature,
+    "discussion-order-by-oldest",
+    "If on, comments default sort ordering will be oldest first. If off, then the default is newest first",
+    owners = Seq(Owner.withGithub("nicl")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
   val MissingVideoEndcodingsJobSwitch = Switch(
     SwitchGroup.Feature,
     "check-for-missing-video-encodings",

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -70,7 +70,7 @@ Comments.prototype.defaultOptions = {
     discussionId: null,
     showRepliesCount: 3,
     commentId: null,
-    order: 'newest',
+    order: config.switches.discussionOrderByOldest ? 'oldest' : 'newest',
     threading: 'collapsed'
 };
 


### PR DESCRIPTION
## What does this change?

The default sort ordering for comments -> oldest first.
## What is the value of this and can you measure success?

The hope is that it will reduce abusive behaviour as the oldest comments are more likely to be moderated/decent. **We have no way to easily measure this as things stand.**
## Does this affect other platforms - Amp, Apps, etc?

No.
## Request for comment

@guardian/discussion @crifmulholland @alastairjardine let's discuss this with the Editoria/Mod people and decide whether to deploy.
