### PR TITLE
Add recently secured sections for LinkTo & condense tests

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -1,7 +1,7 @@
 package common
 
 import common.editions.{Au, Us, International}
-import common.Edition.{editionRegex}
+import common.Edition.editionRegex
 import conf.Configuration
 import conf.switches.Switches
 import implicits.Requests
@@ -31,7 +31,7 @@ trait LinkTo extends Logging {
   val httpsEnabledSections: Seq[String] =
     Seq("info", "email", "science", "crosswords", "technology", "business", "sport", "football",
       "culture", "film", "tv-and-radio", "music", "books", "artanddesign", "stage",
-      "membership")
+      "membership", "uk-news", "world", "cities", "environment", "money", "society")
 
   def apply(html: Html)(implicit request: RequestHeader): String = this(html.toString(), Edition(request))
   def apply(link: String)(implicit request: RequestHeader): String = this(link, Edition(request))

--- a/common/test/common/LinkToTest.scala
+++ b/common/test/common/LinkToTest.scala
@@ -69,11 +69,8 @@ class LinkToTest extends FlatSpec with Matchers with implicits.FakeRequests {
   it should "be https on https-enabled sections whether editionalised or not" in {
     for (ed <- editions) {
       for (secureSection <- LinkTo.httpsEnabledSections) {
-        if (ed.editionalisedSections.contains(secureSection)) {
-          TheGuardianLinkTo(s"http://www.theguardian.com/$secureSection", ed) should be (s"https://www.theguardian.com/${ed.id.toLowerCase}/$secureSection")
-        } else {
-          TheGuardianLinkTo(s"http://www.theguardian.com/$secureSection", ed) should be (s"https://www.theguardian.com/$secureSection")
-        }
+        val expectedPath = if(ed.editionalisedSections.contains(secureSection)) s"${ed.id.toLowerCase}/$secureSection" else secureSection
+        TheGuardianLinkTo(s"http://www.theguardian.com/$secureSection", ed) should be (s"https://www.theguardian.com/$expectedPath")
         TheGuardianLinkTo(s"/$secureSection/foo", ed) should be (s"https://www.theguardian.com/$secureSection/foo")
       }
     }
@@ -90,14 +87,9 @@ class LinkToTest extends FlatSpec with Matchers with implicits.FakeRequests {
   it should "correctly link editionalised sections" in {
     for (edition <- editions) {
       for (section <- edition.editionalisedSections) {
-        val testLink = TheGuardianLinkTo(s"/$section", edition)
-        if (section.isEmpty) {
-          // network front
-          testLink should endWith (s"www.theguardian.com/${edition.networkFrontId}")
-        } else {
-          // not network front
-          testLink should endWith (s"www.theguardian.com/${edition.networkFrontId}/$section")
-        }
+        val testLink = TheGuardianLinkTo(s"http://www.theguardian.com/$section", edition)
+        val expectedPath = if(section.isEmpty) edition.networkFrontId else s"${edition.networkFrontId}/$section"
+        testLink should endWith (s"www.theguardian.com/$expectedPath")
       }
     }
   }


### PR DESCRIPTION
## What does this change?

Makes `LinkTo`-generated links https for recently secured sections
## What is the value of this and can you measure success?

Reduces redirect hops
## Does this affect other platforms - Amp, Apps, etc?

No

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
