### PR TITLE
Comments prevent loop

### DIFF
--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -114,7 +114,8 @@ $avatarPadding: $gs-gutter / 2;
     margin: 0;
 }
 
-.d-discussion__size-message {
+.d-discussion__size-message,
+.d-discussion__message {
     @include fs-textSans(2);
     margin-bottom: $gs-baseline * 2 / 3;
     border-top: 1px solid $neutral-4;
@@ -124,6 +125,10 @@ $avatarPadding: $gs-gutter / 2;
     & + .d-comment {
         border-top: 0;
     }
+}
+
+.d-discussion__message--error {
+    color: $status-negative;
 }
 
 .discussion__heading {


### PR DESCRIPTION
## What does this change?

There is a [discussion API bug](https://github.com/guardian/discussion-api/issues/395) that means we do not return the correct results when requesting some comments - which meant there was a loop that when checking for a particular comment, if it didn't exist, we would send the same request.

This prevents that loops, shows an error message to the user and pings Sentry.
