### PR TITLE
Hosted thrasher gradient removal

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted-thrasher.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-thrasher.scss
@@ -210,7 +210,6 @@
         right: 0;
         bottom: 0;
         position: absolute;
-        background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, .4));
         border-top: 1px solid transparent;
     }
 


### PR DESCRIPTION
This PR removes the gradient on the hosted thrasher images, because the colours in the image will be adjusted manually.
## Screenshots

Before:
![screen shot 2016-06-14 at 18 03 20](https://cloud.githubusercontent.com/assets/489567/16051996/0750be3e-325a-11e6-89f1-1f6babac3110.png)

After:
![screen shot 2016-06-14 at 18 03 57](https://cloud.githubusercontent.com/assets/489567/16052015/1cdcb2b2-325a-11e6-8b86-1f57c0bddd1b.png)
