### PR TITLE
Refactor commercial metrics to retain granularity of feed reporting

### DIFF
--- a/commercial/app/commercial/CommercialLifecycleMetrics.scala
+++ b/commercial/app/commercial/CommercialLifecycleMetrics.scala
@@ -1,0 +1,48 @@
+package commercial
+
+import common.{AkkaAgent, Logging}
+
+sealed trait FeedAction {}
+
+object FeedAction {
+  case object Fetch extends FeedAction { override def toString = "fetch" }
+  case object Parse extends FeedAction { override def toString = "parse" }
+}
+
+private[commercial] case class CommercialFeedEvent(feedName: String, feedAction: FeedAction, success: Boolean) {
+
+  val result: String = if (success) "success" else "failure"
+  val actionAndResult: String = s"$feedAction-$result"
+  val actionNameAndResult: String = s"$feedAction-$feedName-$result"
+}
+
+private object CommercialLifecycleMetrics extends Logging {
+
+  val feedEvents = AkkaAgent[Seq[CommercialFeedEvent]](Seq.empty)
+
+  private[commercial] def logMetric(metric: CommercialFeedEvent) = feedEvents.send(_ :+ metric)
+
+  def updateMetrics(): Unit = {
+
+    def toAggregatedMap(metricName: String, events: Seq[CommercialFeedEvent]) = metricName -> events.size.toDouble
+
+    def pushAggregateMetrics() = {
+      val metricsByActionAndResult = feedEvents.get groupBy (_.actionAndResult) map Function.tupled(toAggregatedMap _)
+      log.info(s"Updating commercial feeds 'aggregate' metric: $metricsByActionAndResult")
+      CommercialMetrics.metrics.put(metricsByActionAndResult)
+    }
+
+    def pushIndividualFeedMetrics() = {
+      val failingFeedsByActionAndName = feedEvents.get filterNot (_.success) groupBy (_.actionNameAndResult) map Function.tupled(toAggregatedMap _)
+      log.info(s"Updating commercial feeds 'failing' metric: $failingFeedsByActionAndName")
+      CommercialMetrics.metrics.put(failingFeedsByActionAndName)
+    }
+
+    def resetMetrics(): Unit = feedEvents.send(Seq.empty)
+
+    pushAggregateMetrics()
+    pushIndividualFeedMetrics()
+    CommercialMetrics.metrics.upload()
+    resetMetrics()
+  }
+}

--- a/commercial/app/commercial/RefreshJob.scala
+++ b/commercial/app/commercial/RefreshJob.scala
@@ -54,3 +54,9 @@ object MoneyBestBuysRefresh extends RefreshJob {
 
   def refresh() = BestBuysAgent.refresh()
 }
+
+object CommercialMetricsUpdate extends RefreshJob {
+  val name: String = "Update Metrics"
+
+  def refresh() = CommercialLifecycleMetrics.updateMetrics()
+}


### PR DESCRIPTION
## What does this change?

This PR precedes a future PR that will report/chart commercial feed fetching/parsing failures. Currently there is logic to report this in aggregate (i.e. number number of failed fetches/parses). This has been refactored such that the feed-level information is kept and can then be used to build pretty charts (in a separate PR).
## What is the value of this and can you measure success?

Supports future work for having a pretty dashboard or alerts if we want to set them up
## Does this affect other platforms - Amp, Apps, etc?

No
