### PR TITLE
Don't have an immersive main media on interactives

### DIFF
--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -53,7 +53,7 @@
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
         @page match {
-            case page: model.ContentPage if page.item.content.isImmersive => {
+            case page: model.ContentPage if (page.item.content.isImmersive && !page.item.content.tags.isInteractive) => {
                 <div class="immersive-header-container">
                     @headerAndTopAds(showAdverts, edition, adBelowNav)
 


### PR DESCRIPTION
This pull request fixes a bug where an immersive interactive looks like this:
![image](https://cloud.githubusercontent.com/assets/8774970/16076190/05cbe58a-32ea-11e6-95c6-5317bcbd51c4.png)

It is supposed to look like this:
![image](https://cloud.githubusercontent.com/assets/8774970/16076200/0db2dcf4-32ea-11e6-8e2f-029e44dabd64.png)
