### PR TITLE
Admin fix: Add the actor system to the injector

### DIFF
--- a/admin/app/AdminAppLoader.scala
+++ b/admin/app/AdminAppLoader.scala
@@ -33,8 +33,9 @@ trait AppComponents extends BuiltInComponents with NingWSComponents {
   lazy val appIdentity = ApplicationIdentity("frontend-admin")
   lazy val appMetrics = ApplicationMetrics()
   implicit lazy val executionContext: ExecutionContext = actorSystem.dispatcher
-  // this is a workaround to make wsapi available to the injector
-  override lazy val injector: Injector = new SimpleInjector(NewInstanceInjector) + router + crypto + httpConfiguration + wsApi
+  // this is a workaround to make wsapi and the actorsystem available to the injector.
+  // I'm forced to do that as we still use Ws.url and Akka.system(app) *everywhere*, and both directly get the reference from the injector
+  override lazy val injector: Injector = new SimpleInjector(NewInstanceInjector) + router + crypto + httpConfiguration + wsApi + actorSystem
 }
 
 trait Controllers {


### PR DESCRIPTION
## What does this change?

It fixes the admin module.

We use WS.url and Akka.system everywhere and both these call are using the internal injector of the application. I can't reasonably fix the use of WS.url and Akka.system everywhere so I decided to add it to the injector.
Thanks @mchv for your brain :)
## Request for comment

@TBonnin @johnduffell @piuccio 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
