### PR TITLE
Log dapi request latency as its own field

### DIFF
--- a/common/app/common/Logging.scala
+++ b/common/app/common/Logging.scala
@@ -2,6 +2,9 @@ package common
 
 import play.api.Logger
 import org.apache.commons.lang.exception.ExceptionUtils
+import net.logstash.logback.marker.LogstashMarker
+import net.logstash.logback.marker.Markers._
+import scala.collection.JavaConverters._
 
 trait Logging {
 
@@ -9,5 +12,29 @@ trait Logging {
 
   protected def logException(e: Exception) = {
     log.error(ExceptionUtils.getStackTrace(e))
+  }
+
+  /*
+   * Passing custom fields into the logs
+   * Fields are passed as a map (fieldName -> fieldValue)
+   * Supported field value types: String, Int and Double
+   */
+  sealed trait CanBeLogField[T]
+  implicit object StringField extends CanBeLogField[String]
+  implicit object IntField extends CanBeLogField[Int]
+  implicit object DoubleField extends CanBeLogField[Double]
+
+  private def customFieldMarkers[T: CanBeLogField](fields: Map[String, T]) : LogstashMarker = {
+    appendEntries(fields.asJava)
+  }
+
+  def logInfoWithCustomFields[T: CanBeLogField](message: String, customFields: Map[String, T]): Unit = {
+    log.logger.info(customFieldMarkers(customFields), message)
+  }
+  def logWarningWithCustomFields[T: CanBeLogField](message: String, error: Throwable, customFields: Map[String, T]): Unit = {
+    log.logger.warn(customFieldMarkers(customFields), message, error)
+  }
+  def logErrorWithCustomFields[T: CanBeLogField](message: String, error: Throwable, customFields: Map[String, T]): Unit = {
+    log.logger.error(customFieldMarkers(customFields), message, error)
   }
 }

--- a/discussion/app/discussion/util/Http.scala
+++ b/discussion/app/discussion/util/Http.scala
@@ -13,7 +13,8 @@ trait Http extends Logging with ExecutionContexts {
       response =>
         response.status match {
           case 200 =>
-            log.info(s"DAPI responded successfully in ${stopWatch.elapsed} ms for url: ${url}")
+            val dapiLatency = stopWatch.elapsed
+            logInfoWithCustomFields(s"DAPI responded successfully in ${dapiLatency} ms for url: ${url}", Map("dapi.response.latency.millis" -> dapiLatency.toInt))
             Json.parse(response.body)
           case _ =>
             log.error(onError(response))


### PR DESCRIPTION
## What does this change?

Log dapi request latency as its own field...
## What is the value of this and can you measure success?

...so we can graph it in Kibana 😀 
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@johnduffell @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
