### PR TITLE
Add window.guardian object setup for adblocker detection

### DIFF
--- a/static/test/javascripts/setup.js
+++ b/static/test/javascripts/setup.js
@@ -35,7 +35,10 @@ window.guardian = {
         }
     },
     css: {},
-    adBlockers: {}
+    adBlockers: {
+        active: undefined,
+        onDetect: []
+    }
 };
 
 // Omniture variables expected on the page


### PR DESCRIPTION
Currently, Jasmine tests are cluttered with exceptions raised by `detect.js`:

![image](https://cloud.githubusercontent.com/assets/3148617/16081494/8ac3cea4-3305-11e6-82d6-adf234ed9380.png)

These exceptions don't fail any tests, but they do add noise and make real errors harder to find.

This happens because the code in question expects an array on the `guardian` object, normally created by a server-inserted script. This doesn't run in the test environment, so the array never exists, and calls to manipulate it through fatal errors.

As it turns out, though, there's a very straightforward solution: a simple `setup` script at the root of the `spec` folder can be wrangled to create the same config object we'd expect when running the code on an actual Guardian page.
