### PR TITLE
Immersive articles should always have white headlines

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -110,6 +110,7 @@
 .content__headline--immersive-article {
     @include fs-headline(7, true);
     line-height: 1;
+    color: #ffffff;
 
     @include mq(desktop) {
         font-size: 4rem;


### PR DESCRIPTION
Originally I was under the impression that immersive articles were always long reads, and always feature tone. However, I was very mistaken! Apparently neither of those things are true.

Because of thinking, currently on the site if someone makes an immersive article that is news tone, the headline will appear grey, not white. This PR decouples that and makes sure the headlines are always white.
## Screenshots

What could happen:
![image](https://cloud.githubusercontent.com/assets/8774970/16081991/dacc7c64-3307-11e6-92ba-b1945fbbd8a7.png)

How it should be:
![image](https://cloud.githubusercontent.com/assets/8774970/16081968/c012e26e-3307-11e6-94cd-f1a131e2f138.png)
## Request for comment

@na7hangood
