### PR TITLE
Refreshing the ad-block message at bottom of page.

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -62,7 +62,7 @@ define([
             message = messages[config.page.edition];
 
         if (message) {
-            new Message('adblock-message', {
+            new Message('adblock-message-2016-06-15', {
                 pinOnHide: false,
                 siteMessageLinkName: 'adblock',
                 siteMessageCloseBtn: 'hide'


### PR DESCRIPTION
## What does this change?

This change updates the ad-block message which at the bottom of an article page for non-paying members who block ads.
## What is the value of this and can you measure success?

This change will redisplay the message banner to any users who have previously closed it.
## Does this affect other platforms - Amp, Apps, etc?

This only affects desktop-sized screens.
## Screenshots

<img width="1660" alt="picture 110" src="https://cloud.githubusercontent.com/assets/1515970/16082785/a7b74040-330a-11e6-899e-628241461d20.png">
## Request for comment

cc @tomverran @dominickendrick @nlindblad 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
