### PR TITLE
Ensuring the colour is maintained for the adblock banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -65,7 +65,8 @@ define([
             new Message('adblock-message-2016-06-15', {
                 pinOnHide: false,
                 siteMessageLinkName: 'adblock',
-                siteMessageCloseBtn: 'hide'
+                siteMessageCloseBtn: 'hide',
+                cssModifierClass: 'adblock-message'
             }).show(template(messageTemplate, {
                 linkHref: adblockLink + '?INTCMP=' + message.campaign,
                 messageText: message.messageText,


### PR DESCRIPTION
This is a fix to the colour of the refreshed banner, for recently merged: https://github.com/guardian/frontend/pull/13305 build 2450

cc @joelochlann 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
