### PR TITLE
Whitelist headers log

### DIFF
--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -4,36 +4,50 @@ import common.{ExecutionContexts, Logging, StopWatch}
 import play.api.mvc.{Filter, RequestHeader, Result}
 import scala.concurrent.Future
 import scala.util.{Failure, Random, Success}
-import net.logstash.logback.marker.LogstashMarker
-import net.logstash.logback.marker.Markers._
 import play.api.Logger
-
-import scala.collection.JavaConverters._
 
 class RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
 
   case class RequestLogger(rh: RequestHeader)(implicit internalLogger: Logger, stopWatch: StopWatch) {
     private lazy val pseudoId = Random.nextInt(Integer.MAX_VALUE)
-    private lazy val customFields: Map[String, Any] = {
-      val headersFields = rh.headers.toMap.map {
-        case (headerName, headerValues) => (s"req.header.$headerName", headerValues.mkString(","))
+    private val headersFields: List[LogField] = {
+      val whitelistedHeaderNames = Set(
+        "Host",
+        "From",
+        "Origin",
+        "Referer",
+        "User-Agent",
+        "Cache-Control",
+        "If-None-Match",
+        "ETag",
+        "Fastly-Client",
+        "Fastly-Client-IP",
+        "Fastly-FF",
+        "Fastly-SSL"
+      )
+      val allHeadersFields = rh.headers.toMap.map {
+        case (headerName, headerValues) => (headerName, headerValues.mkString(","))
       }
-      Map(
-        "req.method" -> rh.method,
-        "req.url" -> rh.uri,
-        "req.id" -> pseudoId.toString,
-        "req.latency_millis" -> stopWatch.elapsed
-      ) ++ headersFields
+      val whitelistedHeaders = allHeadersFields.filterKeys(whitelistedHeaderNames.contains(_))
+      val guardianSpecificHeaders = allHeadersFields.filterKeys(_.startsWith("X-GU-"))
+      (whitelistedHeaders ++ guardianSpecificHeaders).toList.map(t => LogFieldString(s"req.header.${t._1}", t._2))
     }
+    private val customFields: List[LogField] = List(
+      "req.method" -> rh.method,
+      "req.url" -> rh.uri,
+      "req.id" -> pseudoId.toString,
+      "req.latency_millis" -> stopWatch.elapsed
+    )
+    private val allFields = customFields ++ headersFields
 
     def info(message: String): Unit = {
-      logInfoWithCustomFields(message, customFields)
+      logInfoWithCustomFields(message, allFields)
     }
     def warn(message: String, error: Throwable): Unit = {
-      logWarningWithCustomFields(message, error, customFields)
+      logWarningWithCustomFields(message, error, allFields)
     }
     def error(message: String, error: Throwable): Unit = {
-      logErrorWithCustomFields(message, error, customFields)
+      logErrorWithCustomFields(message, error, allFields)
     }
   }
 

--- a/discussion/app/discussion/util/Http.scala
+++ b/discussion/app/discussion/util/Http.scala
@@ -14,7 +14,8 @@ trait Http extends Logging with ExecutionContexts {
         response.status match {
           case 200 =>
             val dapiLatency = stopWatch.elapsed
-            logInfoWithCustomFields(s"DAPI responded successfully in ${dapiLatency} ms for url: ${url}", Map("dapi.response.latency.millis" -> dapiLatency.toInt))
+            val customFields: List[LogField] = List("dapi.response.latency.millis" -> dapiLatency.toInt)
+            logInfoWithCustomFields(s"DAPI responded successfully in ${dapiLatency} ms for url: ${url}", customFields)
             Json.parse(response.body)
           case _ =>
             log.error(onError(response))


### PR DESCRIPTION
## What does this change?

I bundled 2 changes in this patch maybe I should have made 2 PRs :/
1. Refactor Logging custom fields to allow sending fields with multiple types (Int, Long, Double, String). Before this patch you could only send fields of the same type.
2. Limit logging whitelisted headers and Guardian specific headers
## What is the value of this and can you measure success?

Logging all the headers leads to log a lot of crap🔪  that take a lot of space
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
