### PR TITLE
tweak panic shedding sensitivity and better logging

### DIFF
--- a/common/app/conf/Filters.scala
+++ b/common/app/conf/Filters.scala
@@ -76,11 +76,11 @@ object Filters {
   // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
   // which effectively means "JsonVaryHeaders goes around Gzipper"
   def common: List[EssentialFilter] = List(
+    new RequestLoggingFilter,
     new PanicSheddingFilter,
     new JsonVaryHeadersFilter,
     new Gzipper,
     new BackendHeaderFilter,
-    new RequestLoggingFilter,
     new SurrogateKeyFilter,
     new AmpFilter
   )

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -81,8 +81,8 @@ trait PerformanceSwitches {
     "panic-monitoring",
     "If this switch is on, we monitor latency and requests to see if servers are overloaded",
     owners = Seq(Owner.withGithub("johnduffell")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 7, 8),
+    safeState = On,
+    sellByDate = new LocalDate(2016, 7, 27),
     exposeClientSide = false
   )
 
@@ -92,7 +92,7 @@ trait PerformanceSwitches {
     "If this switch is on, we log latency when we are monitoring it with panic-monitoring",
     owners = Seq(Owner.withGithub("johnduffell")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 7, 8),
+    sellByDate = new LocalDate(2016, 7, 27),
     exposeClientSide = false
   )
 
@@ -101,8 +101,8 @@ trait PerformanceSwitches {
     "panic-shedding",
     "If this switch is on, we try to keep response times below 1s by returning Service Unavailable errors if we're busy",
     owners = Seq(Owner.withGithub("johnduffell")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 7, 8),
+    safeState = On,
+    sellByDate = new LocalDate(2016, 7, 27),
     exposeClientSide = false
   )
 

--- a/common/app/conf/switches/PerformanceSwitches.scala
+++ b/common/app/conf/switches/PerformanceSwitches.scala
@@ -101,7 +101,7 @@ trait PerformanceSwitches {
     "panic-shedding",
     "If this switch is on, we try to keep response times below 1s by returning Service Unavailable errors if we're busy",
     owners = Seq(Owner.withGithub("johnduffell")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2016, 7, 27),
     exposeClientSide = false
   )

--- a/common/test/conf/PanicSheddingFilterTest.scala
+++ b/common/test/conf/PanicSheddingFilterTest.scala
@@ -7,8 +7,15 @@ class LatencyMonitorTest extends FlatSpec with Matchers with AppendedClues {
   import LatencyMonitor._
 
   "LatencyMonitor" should "have no latency after no request" in {
-    initialLatency should be(AverageLatency(0))
     initialLatency.latency should be(0)
+  }
+
+  "LatencyMonitor" should "weight the latency of initial requests up on startup" in {
+    // if we only had one request but it was slow, we should respect that to give us time to warm up
+    val TEST_LATENCY = 12345L
+    val result = updateLatency(TEST_LATENCY)(initialLatency)
+
+    result.latency should be (TEST_LATENCY)
   }
 
   "LatencyMonitor" should "approach the actual latency over time" in {

--- a/discussion/app/Global.scala
+++ b/discussion/app/Global.scala
@@ -25,11 +25,11 @@ class DiscussionFilters extends HttpFilters {
   // NOTE - order is important here, Gzipper AFTER CorsVaryHeaders
   // which effectively means "JsonVaryHeaders goes around Gzipper"
   lazy val filters: List[EssentialFilter] = List(
+    new RequestLoggingFilter,
     new PanicSheddingFilter,
     new JsonVaryHeadersFilter,
     new Gzipper,
     new BackendHeaderFilter,
-    new RequestLoggingFilter,
     new SurrogateKeyFilter,
     new AmpFilter
   )


### PR DESCRIPTION
This increases the response time of latency shedding so it will start taking account of the latency of the requests starting with the very first one.  In the previous implementation it would start off from cold allowing all requests, and would take about 150 requests to get to 75% sensitivity.
I have also tweaked the sensitivity to a spike in latency, it will only take 13 requests to get 75% sensitive to the change.  That means if latency was zero for all requests, and suddenly became 1 second, after 13 requests at 1 second latency it would consider the latency to be 750ms.

Another tweak is to make it always allow healthchecks through.  This means that as long as the healthcheck is ok on the job (i.e. within the 4 second timeout) then the healthcheck will respond OK.  This gives a small chance that the latency monitor could get "stuck" rejecting all requests, but the healthcheck would be passing, but as it is machines are getting marked unhealthy just because they are overloaded.  If we get autoscaling right (should scale on high latency metric) then it should scale up anyway in that situation.

@TBonnin @alexduf @jamespamplin any comments?  I'll monitor to make sure it's not firing off too often.
