### PR TITLE
Remove sponsored badges from Immersive template

### DIFF
--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -104,10 +104,6 @@
                                     <span class="content__headline content__headline--byline">@ContributorLinks(text, page.item.tags.contributors)</span>
                                 }
                             }
-
-                            @if(galleryPage.showBadge && !page.item.commercial.isAdvertisementFeature) {
-                                @fragments.commercial.badge(page.item, page)
-                            }
                         }
                         case _ => {
                             @page.item match {


### PR DESCRIPTION
## What does this change?

Currently a badge is included in both the immersive template as well as the article/long-read/etc template beneath. This results in having two badges on the page, which looks bad and introduces further problems of DFP getting confused and throwing a hissy fit.
## What is the value of this and can you measure success?

Badges look better and ads are served to the page.
## Screenshots

**before**
![image](https://cloud.githubusercontent.com/assets/1821099/16115221/9774ae8a-33bd-11e6-87de-26ec136a88c5.png)

**after**
![image](https://cloud.githubusercontent.com/assets/1821099/16115257/cf2f6054-33bd-11e6-9bca-2d43239535e1.png)
