### PR TITLE
Rolex/Wimbledon ad only on desktops with a fixed height

### DIFF
--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -33,8 +33,8 @@ object Commercial {
       metaData.id == "uk/technology"
     }
 
-    private def isWimbledonEnabled(metaData: MetaData) = {
-      metaData.id == "sport/tennis" || metaData.id == "sport/wimbledon"
+    private def isWimbledonEnabled(metaData: MetaData, edition: Edition) = {
+      (metaData.id == "sport/tennis" || metaData.id == "sport/wimbledon") && edition.id == "UK"
     }
 
     def adSizes(metaData: MetaData, edition: Edition): Map[String, Seq[String]] = {
@@ -46,7 +46,7 @@ object Commercial {
         "mobile" -> (Seq("1,1", "88,70") ++ leaderboardAdvertsTop ++ fabricAdvertsTop ++ fluidAdvertsTop),
         "desktop" -> (Seq("1,1", "88,70") ++ leaderboardAdvertsTop ++ Seq("940,230", "900,250", "970,250") ++ fabricAdvertsTop ++ fluidAdvertsTop)
       )
-      if (WimbledonTopAd.isSwitchedOn && isWimbledonEnabled(metaData)) {
+      if (WimbledonTopAd.isSwitchedOn && isWimbledonEnabled(metaData, edition)) {
           topSlotAdSizes + wimbledonLeftCol
       } else {
           topSlotAdSizes
@@ -55,7 +55,7 @@ object Commercial {
 
     // The sizesOverride parameter is for testing only.
     def cssClasses(metaData: MetaData, edition: Edition, sizesOverride: Seq[AdSize] = Nil): String = {
-      var wimbledonClasses = if (WimbledonTopAd.isSwitchedOn && isWimbledonEnabled(metaData)) Seq("top-banner-ad-container--wimbledon") else Nil
+      var wimbledonClasses = if (WimbledonTopAd.isSwitchedOn && isWimbledonEnabled(metaData, edition)) Seq("top-banner-ad-container--wimbledon") else Nil
       val classes = Seq(
         "top-banner-ad-container",
         "top-banner-ad-container--desktop",

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -41,13 +41,16 @@ object Commercial {
       val fabricAdvertsTop = Seq("88,71")
       val fluidAdvertsTop = Seq("fluid")
       val leaderboardAdvertsTop = if (FixedTechTopSlot.isSwitchedOn && isUKTechFront(metaData)) None else Some("728,90")
-      val wimbledonAdvertTopTablet = if (WimbledonTopAd.isSwitchedOn) Some("720,320") else None
-      val wimbledonAdvertTopDesktop = if (WimbledonTopAd.isSwitchedOn) Some("970,375") else None
-      Map(
+      val wimbledonLeftCol = ("left-col" -> (Seq("1,1", "88,70") ++ leaderboardAdvertsTop ++ Seq("940,230", "900,250", "970,250") ++ fabricAdvertsTop ++ fluidAdvertsTop ++ Seq("970,375")))
+      val topSlotAdSizes = Map(
         "mobile" -> (Seq("1,1", "88,70") ++ leaderboardAdvertsTop ++ fabricAdvertsTop ++ fluidAdvertsTop),
-        "tablet" -> (Seq("1,1", "88,70") ++ wimbledonAdvertTopTablet ++ leaderboardAdvertsTop ++ fabricAdvertsTop ++ fluidAdvertsTop),
-        "desktop" -> (Seq("1,1", "88,70") ++ leaderboardAdvertsTop ++ Seq("940,230", "900,250", "970,250") ++ fabricAdvertsTop ++ fluidAdvertsTop ++ wimbledonAdvertTopDesktop)
+        "desktop" -> (Seq("1,1", "88,70") ++ leaderboardAdvertsTop ++ Seq("940,230", "900,250", "970,250") ++ fabricAdvertsTop ++ fluidAdvertsTop)
       )
+      if (WimbledonTopAd.isSwitchedOn && isWimbledonEnabled(metaData)) {
+          topSlotAdSizes + wimbledonLeftCol
+      } else {
+          topSlotAdSizes
+      }
     }
 
     // The sizesOverride parameter is for testing only.

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -33,6 +33,10 @@ object Commercial {
       metaData.id == "uk/technology"
     }
 
+    private def isWimbledonEnabled(metaData: MetaData) = {
+      metaData.id == "sport/tennis" || metaData.id == "sport/wimbledon"
+    }
+
     def adSizes(metaData: MetaData, edition: Edition): Map[String, Seq[String]] = {
       val fabricAdvertsTop = Seq("88,71")
       val fluidAdvertsTop = Seq("fluid")
@@ -48,13 +52,14 @@ object Commercial {
 
     // The sizesOverride parameter is for testing only.
     def cssClasses(metaData: MetaData, edition: Edition, sizesOverride: Seq[AdSize] = Nil): String = {
+      var wimbledonClasses = if (WimbledonTopAd.isSwitchedOn && isWimbledonEnabled(metaData)) Seq("top-banner-ad-container--wimbledon") else Nil
       val classes = Seq(
         "top-banner-ad-container",
         "top-banner-ad-container--desktop",
         "top-banner-ad-container--above-nav",
         "js-top-banner-above-nav",
         "top-banner-ad-container--reveal"
-      )
+      ) ++ wimbledonClasses
 
       classes mkString " "
     }

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -1,6 +1,7 @@
 package views.support
 
 import common.Edition
+import common.editions.Uk
 import common.commercial.{Branding, CardContent, ContainerModel, PaidContent}
 import common.dfp.AdSize.responsiveSize
 import common.dfp._
@@ -34,7 +35,7 @@ object Commercial {
     }
 
     private def isWimbledonEnabled(metaData: MetaData, edition: Edition) = {
-      (metaData.id == "sport/tennis" || metaData.id == "sport/wimbledon") && edition.id == "UK"
+      (metaData.id == "sport/tennis" || metaData.id == "sport/wimbledon") && edition == Uk
     }
 
     def adSizes(metaData: MetaData, edition: Edition): Map[String, Seq[String]] = {
@@ -55,7 +56,7 @@ object Commercial {
 
     // The sizesOverride parameter is for testing only.
     def cssClasses(metaData: MetaData, edition: Edition, sizesOverride: Seq[AdSize] = Nil): String = {
-      var wimbledonClasses = if (WimbledonTopAd.isSwitchedOn && isWimbledonEnabled(metaData, edition)) Seq("top-banner-ad-container--wimbledon") else Nil
+      val wimbledonClasses = if (WimbledonTopAd.isSwitchedOn && isWimbledonEnabled(metaData, edition)) Some("top-banner-ad-container--wimbledon") else None
       val classes = Seq(
         "top-banner-ad-container",
         "top-banner-ad-container--desktop",

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -130,6 +130,13 @@
         }
     }
 }
+.top-banner-ad-container--wimbledon {
+    @include mq(desktop) {
+        > .ad-slot--top-banner-ad {
+            height: 375px;
+        }
+    }
+}
 
 .ad-slot--top-banner-ad {
     text-align: center;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -131,7 +131,7 @@
     }
 }
 .top-banner-ad-container--wimbledon {
-    @include mq(desktop) {
+    @include mq(leftCol) {
         > .ad-slot--top-banner-ad {
             height: 375px;
         }


### PR DESCRIPTION
Pat asked that (1) the Rolex ad does not show up on tablets and (2) the top slot has a fixed height on desktops.

(1) can be achieved in targeting in DFP, but (2) can only be done via a media query. The only solution I found was to therefore delay the ad until the `leftCol` breakpoint has been crossed—i.e. screens smaller than 1140px wide won't see the ad, even on desktops.

I'm happy to improve if someone has a better idea.

cc @guardian/commercial-dev 
