### PR TITLE
add tone to video info endpoint

### DIFF
--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -1,11 +1,11 @@
 package controllers
 
-import com.gu.contentapi.client.model.v1.{ContentFields, ItemResponse, Content => ApiContent}
+import com.gu.contentapi.client.model.v1.{ItemResponse, Content => ApiContent}
 import common._
 import contentapi.ContentApiClient
 import conf.switches.Switches
 import model._
-import play.api.libs.json.{Format, JsObject, Json}
+import play.api.libs.json._
 import play.api.mvc._
 import views.support.RenderOtherStatus
 
@@ -22,7 +22,12 @@ object MediaController extends Controller with RendersItemResponse with Logging 
 
   def renderInfoJson(path: String) = Action.async { implicit request =>
     lookup(path) map {
-      case Left(model)  => MediaInfo(expired = false, shouldHideAdverts = model.media.content.shouldHideAdverts)
+      case Left(model)  =>
+        MediaInfo(
+          expired = false,
+          shouldHideAdverts = model.media.content.shouldHideAdverts,
+          VideoTone.fromTags(model.media.tags.tags)
+        )
       case Right(other) => MediaInfo(expired = true, shouldHideAdverts = true)
     } map { mediaInfo =>
       Cached(60)(JsonComponent(Json.toJson(mediaInfo).as[JsObject]))
@@ -63,7 +68,26 @@ object MediaController extends Controller with RendersItemResponse with Logging 
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
 }
 
-case class MediaInfo(expired: Boolean, shouldHideAdverts: Boolean)
+case class MediaInfo(expired: Boolean, shouldHideAdverts: Boolean, tone: Option[VideoTone] = None)
 object MediaInfo {
-  implicit val jsonFormats: Format[MediaInfo] = Json.format[MediaInfo]
+  implicit val jsonWrites: Writes[MediaInfo] = Json.writes[MediaInfo]
 }
+
+sealed trait VideoTone {
+  val tag: String
+  def name = tag.replace("tone/", "")
+}
+object VideoTone {
+  implicit val jsonWrites: Writes[VideoTone] = Writes(a => JsString(a.name))
+
+  def fromString(s: String) =
+    Seq(VideoExplainer, VideoBreaking, VideoDocumentary, VideoNewsFeature).find(_.tag == s)
+
+  def fromTags(tags: List[Tag]) =
+    tags.map(tag => fromString(tag.id)).find(tone => tone.nonEmpty).flatten
+}
+
+case object VideoBreaking    extends VideoTone { val tag = "tone/news" }
+case object VideoExplainer   extends VideoTone { val tag = "tone/explainers" }
+case object VideoDocumentary extends VideoTone { val tag = "tone/documentaries" }
+case object VideoNewsFeature extends VideoTone { val tag = "tone/features" }

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -68,17 +68,17 @@ object MediaController extends Controller with RendersItemResponse with Logging 
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
 }
 
-case class MediaInfo(expired: Boolean, shouldHideAdverts: Boolean, tone: Option[VideoTone] = None)
+case class MediaInfo(expired: Boolean, shouldHideAdverts: Boolean, tone: Option[VideoType] = None)
 object MediaInfo {
   implicit val jsonWrites: Writes[MediaInfo] = Json.writes[MediaInfo]
 }
 
-sealed trait VideoTone {
+sealed trait VideoType {
   val tag: String
   def name = tag.replace("tone/", "")
 }
-object VideoTone {
-  implicit val jsonWrites: Writes[VideoTone] = Writes(a => JsString(a.name))
+object VideoType {
+  implicit val jsonWrites: Writes[VideoType] = Writes(videoType => JsString(videoType.name))
 
   def fromString(s: String) =
     Seq(VideoExplainer, VideoBreaking, VideoDocumentary, VideoNewsFeature).find(_.tag == s)
@@ -87,7 +87,7 @@ object VideoTone {
     tags.map(tag => fromString(tag.id)).find(tone => tone.nonEmpty).flatten
 }
 
-case object VideoBreaking    extends VideoTone { val tag = "tone/news" }
-case object VideoExplainer   extends VideoTone { val tag = "tone/explainers" }
-case object VideoDocumentary extends VideoTone { val tag = "tone/documentaries" }
-case object VideoNewsFeature extends VideoTone { val tag = "tone/features" }
+case object VideoBreaking    extends VideoType { val tag = "tone/news" }
+case object VideoExplainer   extends VideoType { val tag = "tone/explainers" }
+case object VideoDocumentary extends VideoType { val tag = "tone/documentaries" }
+case object VideoNewsFeature extends VideoType { val tag = "tone/features" }


### PR DESCRIPTION
## What does this change?

Adding the tone to the video endpoint.
This should help us push info to Ophan allowing us to see what type of video is doing well.
## What is the value of this and can you measure success?

We can measure success 
## Does this affect other platforms - Amp, Apps, etc?

No (not for now)
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
