### PR TITLE
Add link to Elasticsearch Head to admin dashboard

### DIFF
--- a/admin/app/views/admin.scala.html
+++ b/admin/app/views/admin.scala.html
@@ -42,6 +42,7 @@
                         <li><a href="@controllers.cache.routes.ImageDecacheController.renderImageDecacheForm()">Clear images</a></li>
                         <li><a href="@controllers.cache.routes.PageDecacheController.renderPageDecacheForm()">Clear page (content)</a></li>
                         <li><a href="@controllers.admin.routes.CssReportController.entry()">CSS Selector Usage</a></li>
+                        <li><a href="@Configuration.Elk.elasticsearchHeadUrl">Elasticsearch Head</a></li>
                     </ul>
                 </div>
             </div>
@@ -53,7 +54,7 @@
                 <div class="panel-heading">Ops metrics (is the site healthy?).</div>
                 <div class="panel-body">
                     <ul>
-                        <li><a href="@Configuration.Kibana.url">Kibana (Server side logs)</a></li>
+                        <li><a href="@Configuration.Elk.kibanaUrl">Kibana (Server side logs)</a></li>
                         <li><a href="@controllers.admin.routes.MetricsController.renderLoadBalancers()">Load Balancers</a></li>
                         <li><a href="@controllers.admin.routes.FastlyController.renderFastly()">Fastly</a></li>
                         <li>

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -541,8 +541,9 @@ class GuardianConfiguration(val application: String, val webappConfDirectory: St
     lazy val streamRegion = configuration.getStringProperty("logstash.stream.region")
   }
 
-  object Kibana {
-    lazy val url = configuration.getStringProperty("kibana.url")
+  object Elk {
+    lazy val kibanaUrl = configuration.getStringProperty("elk.kibana.url")
+    lazy val elasticsearchHeadUrl = configuration.getStringProperty("elk.elasticsearchHead.url")
   }
 }
 


### PR DESCRIPTION
## What does this change?

Add link to Elasticsearch Head to admin dashboard
Elasticsearch Head is the plugin that allows the management of the Elastic cluster: http://kibana.gu-web.net/__es/_plugin/head/#

Related: https://github.com/guardian/platform/pull/1012
## What is the value of this and can you measure success?

So I am not the only one to know the url 😜 
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![screen shot 2016-06-16 at 17 42 54](https://cloud.githubusercontent.com/assets/233326/16125100/ef314bfc-33e9-11e6-9c02-1fe5f3c1cca6.png)
## Request for comment

@JustinPinner 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
