### PR TITLE
And finally, split up dfp-api.js

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -183,7 +183,7 @@ define([
             } else {
                 creativeIDs.push(event.creativeId);
                 renderAdvert(adSlotId, event)
-                .then(emitRenderEvents)
+                .then(emitRenderEvents);
             }
 
             function emitRenderEvents() {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -451,7 +451,7 @@ define([
     }
 
     /**
-     * PARSE RETURNED ADVERTS
+     * HANDLE RETURNED ADVERTS
      */
 
     function reportEmptyResponse(adSlotId, event) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -181,6 +181,7 @@ define([
                 reportEmptyResponse(adSlotId, event);
                 emitRenderEvents();
             } else {
+                creativeIDs.push(event.creativeId);
                 renderAdvert(adSlotId, event)
                 .then(emitRenderEvents)
             }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert-label.js
@@ -1,16 +1,20 @@
 define([
     'qwery',
+    'Promise',
     'common/utils/fastdom-promise'
 ], function (
     qwery,
+    Promise,
     fastdom
 ) {
     function renderAdvertLabel($adSlot) {
-        return fastdom.write(function () {
-            if (shouldRenderLabel($adSlot)) {
+        if (shouldRenderLabel($adSlot)) {
+            return fastdom.write(function () {
                 $adSlot.prepend('<div class="ad-slot__label" data-test-id="ad-slot-label">Advertisement</div>');
-            }
-        });
+            });
+        } else {
+            return Promise.resolve(null);
+        }
     }
 
     function shouldRenderLabel($adSlot) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert-label.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert-label.js
@@ -1,0 +1,23 @@
+define([
+    'qwery',
+    'common/utils/fastdom-promise'
+], function (
+    qwery,
+    fastdom
+) {
+    function renderAdvertLabel($adSlot) {
+        return fastdom.write(function () {
+            if (shouldRenderLabel($adSlot)) {
+                $adSlot.prepend('<div class="ad-slot__label" data-test-id="ad-slot-label">Advertisement</div>');
+            }
+        });
+    }
+
+    function shouldRenderLabel($adSlot) {
+        return !$adSlot.hasClass('ad-slot--frame') &&
+            !$adSlot.hasClass('gu-style') &&
+            ($adSlot.data('label') !== false && qwery('.ad-slot__label', $adSlot[0]).length === 0);
+    }
+
+    return renderAdvertLabel;
+});

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
@@ -1,0 +1,176 @@
+define([
+    'bonzo',
+    'qwery',
+    'raven',
+    'common/utils/$',
+    'common/utils/fastdom-promise',
+    'common/modules/commercial/ad-sizes',
+    'common/modules/commercial/ads/sticky-mpu',
+    'common/modules/commercial/dfp/apply-creative-template',
+    'common/modules/onward/geo-most-popular'
+], function (
+    bonzo,
+    qwery,
+    raven,
+    $,
+    fastdom,
+    adSizes,
+    stickyMpu,
+    applyCreativeTemplate,
+    geoMostPopular
+) {
+    /**
+     * ADVERT RENDERING
+     * ----------------
+     *
+     * Most adverts come back from DFP ready to display as-is. But sometimes we need more: embedded components that can share
+     * Guardian styles, for example, or behaviours like sticky-scrolling. This module helps 'finish' rendering any advert, and
+     * decorating them with these behaviours.
+     *
+     * This module is also responsible for adding advert labels.
+     */
+
+    var sizeCallbacks = {};
+
+    /**
+     * DFP fluid ads should use existing fluid-250 styles in the top banner position
+     */
+    sizeCallbacks[adSizes.fluid] = isFluid250('ad-slot--top-banner-ad');
+
+    /**
+     * Trigger sticky scrolling if the ad has the magic 'sticky' size
+     */
+    sizeCallbacks[adSizes.stickyMpu] = function (event, $adSlot) {
+        stickyMpu($adSlot);
+    };
+
+    /**
+     * Trigger sticky scrolling for MPUs in the right-hand article column
+     */
+    sizeCallbacks[adSizes.mpu] = function (event, $adSlot) {
+        if ($adSlot.hasClass('ad-slot--right')) {
+            var mobileAdSizes = $adSlot.attr('data-mobile');
+            if (mobileAdSizes && mobileAdSizes.indexOf(adSizes.stickyMpu) > -1) {
+                stickyMpu($adSlot);
+            }
+        }
+    };
+
+    /**
+     * Out of page adverts - creatives that aren't directly shown on the page - need to be hidden,
+     * and their containers closed up.
+     */
+    sizeCallbacks[adSizes.outOfPage] = function (event, $adSlot) {
+        if (!event.slot.getOutOfPage()) {
+            $adSlot.addClass('u-h');
+            var $parent = $adSlot.parent();
+            // if in a slice, add the 'no mpu' class
+            if ($parent.hasClass('js-fc-slice-mpu-candidate')) {
+                $parent.addClass('fc-slice__item--no-mpu');
+            }
+        }
+    };
+
+    /**
+     * Portrait adverts exclude the locally-most-popular widget
+     */
+    sizeCallbacks[adSizes.portrait] = function () {
+        // remove geo most popular
+        geoMostPopular.whenRendered.then(function (geoMostPopular) {
+            fastdom.write(function () {
+                bonzo(geoMostPopular.elem).remove();
+            });
+        });
+    };
+
+    /**
+     * Top banner ads with fluid250 size get special styling
+     */
+    sizeCallbacks[adSizes.fluid250] = isFluid250('ad-slot--top-banner-ad');
+
+    /**
+     * Mobile adverts with fabric sizes get 'fluid' full-width design
+     */
+    sizeCallbacks[adSizes.fabric] = isFluid('ad-slot--mobile');
+
+    /**
+     * Commercial components with merch sizing get fluid-250 styling
+     */
+    sizeCallbacks[adSizes.merchandising] = isFluid250('ad-slot--commercial-component');
+
+    function isFluid250(className) {
+        return function (_, $adSlot) {
+            if ($adSlot.hasClass(className)) {
+                fastdom.write(function () {
+                    $adSlot.addClass('ad-slot__fluid250');
+                });
+            }
+        };
+    }
+
+    function isFluid(className) {
+        return function (_, $adSlot) {
+            if ($adSlot.hasClass(className)) {
+                fastdom.write(function () {
+                    $adSlot.addClass('ad-slot--fluid');
+                });
+            }
+        };
+    }
+
+    /**
+     *
+     * @param adSlotId - DOM ID of the rendered slot
+     * @param slotRenderEvent - GPT slotRenderEndedEvent
+     * @returns {Promise} - resolves once all necessary rendering is queued up
+     */
+    function renderAdvert(adSlotId, slotRenderEvent) {
+        var size;
+        var $adSlot = $('#' + adSlotId);
+
+        // remove any placeholder ad content
+        var $placeholder = $('.ad-slot__content--placeholder', $adSlot);
+        var $adSlotContent = $('div', $adSlot);
+
+        if ($adSlotContent[0]) {
+            fastdom.write(function () {
+                $placeholder.remove();
+                $adSlotContent.addClass('ad-slot__content');
+            });
+        }
+
+        // Check if creative is a new gu style creative and place labels accordingly.
+        return applyCreativeTemplate($adSlot).then(function () {
+            addLabel($adSlot);
+
+            size = slotRenderEvent.size.join(',');
+            // is there a callback for this size?
+            if (sizeCallbacks[size]) {
+                sizeCallbacks[size](slotRenderEvent, $adSlot);
+            }
+
+            if ($adSlot.hasClass('ad-slot--container-inline') && $adSlot.hasClass('ad-slot--not-mobile')) {
+                fastdom.write(function () {
+                    $adSlot.parent().css('display', 'flex');
+                });
+            }
+        }).catch(raven.captureException);
+    }
+
+    function addLabel($adSlot) {
+        fastdom.write(function () {
+            if (shouldRenderLabel($adSlot)) {
+                $adSlot.prepend('<div class="ad-slot__label" data-test-id="ad-slot-label">Advertisement</div>');
+            }
+        });
+    }
+
+    function shouldRenderLabel($adSlot) {
+        return !$adSlot.hasClass('ad-slot--frame') &&
+            !$adSlot.hasClass('gu-style') &&
+            ($adSlot.data('label') !== false && qwery('.ad-slot__label', $adSlot[0]).length === 0);
+    }
+
+    return renderAdvert;
+
+});

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
@@ -139,7 +139,6 @@ define([
             });
         }
 
-        // Check if creative is a new gu style creative and place labels accordingly.
         return applyCreativeTemplate($adSlot).then(function () {
             renderAdvertLabel($adSlot);
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
@@ -27,7 +27,7 @@ define([
      *
      * Most adverts come back from DFP ready to display as-is. But sometimes we need more: embedded components that can share
      * Guardian styles, for example, or behaviours like sticky-scrolling. This module helps 'finish' rendering any advert, and
-     * decorating them with these behaviours.
+     * decorates them with these behaviours.
      *
      */
 

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
@@ -7,6 +7,7 @@ define([
     'common/modules/commercial/ad-sizes',
     'common/modules/commercial/ads/sticky-mpu',
     'common/modules/commercial/dfp/apply-creative-template',
+    'common/modules/commercial/dfp/render-advert-label',
     'common/modules/onward/geo-most-popular'
 ], function (
     bonzo,
@@ -17,6 +18,7 @@ define([
     adSizes,
     stickyMpu,
     applyCreativeTemplate,
+    renderAdvertLabel,
     geoMostPopular
 ) {
     /**
@@ -27,7 +29,6 @@ define([
      * Guardian styles, for example, or behaviours like sticky-scrolling. This module helps 'finish' rendering any advert, and
      * decorating them with these behaviours.
      *
-     * This module is also responsible for adding advert labels.
      */
 
     var sizeCallbacks = {};
@@ -140,7 +141,7 @@ define([
 
         // Check if creative is a new gu style creative and place labels accordingly.
         return applyCreativeTemplate($adSlot).then(function () {
-            addLabel($adSlot);
+            renderAdvertLabel($adSlot);
 
             size = slotRenderEvent.size.join(',');
             // is there a callback for this size?
@@ -154,20 +155,6 @@ define([
                 });
             }
         }).catch(raven.captureException);
-    }
-
-    function addLabel($adSlot) {
-        fastdom.write(function () {
-            if (shouldRenderLabel($adSlot)) {
-                $adSlot.prepend('<div class="ad-slot__label" data-test-id="ad-slot-label">Advertisement</div>');
-            }
-        });
-    }
-
-    function shouldRenderLabel($adSlot) {
-        return !$adSlot.hasClass('ad-slot--frame') &&
-            !$adSlot.hasClass('gu-style') &&
-            ($adSlot.data('label') !== false && qwery('.ad-slot__label', $adSlot[0]).length === 0);
     }
 
     return renderAdvert;

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
@@ -125,7 +125,6 @@ define([
      * @returns {Promise} - resolves once all necessary rendering is queued up
      */
     function renderAdvert(adSlotId, slotRenderEvent) {
-        var size;
         var $adSlot = $('#' + adSlotId);
 
         // remove any placeholder ad content
@@ -142,7 +141,7 @@ define([
         return applyCreativeTemplate($adSlot).then(function () {
             renderAdvertLabel($adSlot);
 
-            size = slotRenderEvent.size.join(',');
+            var size = slotRenderEvent.size.join(',');
             // is there a callback for this size?
             if (sizeCallbacks[size]) {
                 sizeCallbacks[size](slotRenderEvent, $adSlot);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
@@ -119,7 +119,6 @@ define([
     }
 
     /**
-     *
      * @param adSlotId - DOM ID of the rendered slot
      * @param slotRenderEvent - GPT slotRenderEndedEvent
      * @returns {Promise} - resolves once all necessary rendering is queued up

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/render-advert.js
@@ -127,22 +127,12 @@ define([
     function renderAdvert(adSlotId, slotRenderEvent) {
         var $adSlot = $('#' + adSlotId);
 
-        // remove any placeholder ad content
-        var $placeholder = $('.ad-slot__content--placeholder', $adSlot);
-        var $adSlotContent = $('div', $adSlot);
-
-        if ($adSlotContent[0]) {
-            fastdom.write(function () {
-                $placeholder.remove();
-                $adSlotContent.addClass('ad-slot__content');
-            });
-        }
+        removePlaceholders($adSlot);
 
         return applyCreativeTemplate($adSlot).then(function () {
             renderAdvertLabel($adSlot);
 
             var size = slotRenderEvent.size.join(',');
-            // is there a callback for this size?
             if (sizeCallbacks[size]) {
                 sizeCallbacks[size](slotRenderEvent, $adSlot);
             }
@@ -153,6 +143,18 @@ define([
                 });
             }
         }).catch(raven.captureException);
+    }
+
+    function removePlaceholders($adSlot) {
+        var $placeholder = $('.ad-slot__content--placeholder', $adSlot);
+        var $adSlotContent = $('div', $adSlot);
+
+        if ($adSlotContent[0]) {
+            fastdom.write(function () {
+                $placeholder.remove();
+                $adSlotContent.addClass('ad-slot__content');
+            });
+        }
     }
 
     return renderAdvert;

--- a/static/test/javascripts/spec/common/commercial/dfp/dfp-api.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/dfp-api.spec.js
@@ -1,7 +1,6 @@
 define([
     'bean',
     'bonzo',
-    'fastdom',
     'qwery',
     'Promise',
     'common/utils/$',
@@ -10,7 +9,6 @@ define([
 ], function (
     bean,
     bonzo,
-    fastdom,
     qwery,
     Promise,
     $,
@@ -27,8 +25,7 @@ define([
                     '<div id="dfp-ad-html-slot" class="js-ad-slot" data-name="html-slot" data-mobile="300,50"></div>\
                     <div id="dfp-ad-script-slot" class="js-ad-slot" data-name="script-slot" data-mobile="300,50|320,50" data-refresh="false"></div>\
                     <div id="dfp-ad-already-labelled" class="js-ad-slot ad-label--showing" data-name="already-labelled" data-mobile="300,50|320,50"  data-tablet="728,90"></div>\
-                    <div id="dfp-ad-dont-label" class="js-ad-slot" data-label="false" data-name="dont-label" data-mobile="300,50|320,50"  data-tablet="728,90" data-desktop="728,90|900,250|970,250"></div>\
-                    <div id="dfp-ad-gu-style" class="gu-style" data-name="gu-style" data-mobile="300,250" data-desktop="300,250"></div>'
+                    <div id="dfp-ad-dont-label" class="js-ad-slot" data-label="false" data-name="dont-label" data-mobile="300,50|320,50"  data-tablet="728,90" data-desktop="728,90|900,250|970,250"></div>'
                 ]
             },
             makeFakeEvent = function (id, isEmpty) {
@@ -300,61 +297,5 @@ define([
 
         });
 
-        describe('labelling', function () {
-            var slotId = 'dfp-ad-html-slot';
-
-            it('should be added', function (done) {
-                var $slot = $('#' + slotId);
-                dfp.init();
-
-                fastdom.defer(function () {
-                    window.googletag.cmd.forEach(function (func) { func(); });
-                    window.googletag.pubads().listener(makeFakeEvent(slotId));
-                    fastdom.defer(10, function () {
-                        expect($('.ad-slot__label', $slot[0]).text()).toBe('Advertisement');
-                        done();
-                    });
-                });
-            });
-
-            it('should not be added if data-label attribute is false', function () {
-                var $slot = $('#' + slotId).attr('data-label', false);
-                dfp.init();
-                window.googletag.cmd.forEach(function (func) { func(); });
-                window.googletag.pubads().listener(makeFakeEvent(slotId));
-                expect($('.ad-slot__label', $slot[0]).length).toBe(0);
-            });
-
-            it('should be added only once', function (done) {
-                var fakeEvent = makeFakeEvent(slotId),
-                    $slot = $('#' + slotId);
-                dfp.init();
-
-                fastdom.defer(function () {
-                    window.googletag.cmd.forEach(function (func) { func(); });
-                    window.googletag.pubads().listener(fakeEvent);
-                    window.googletag.pubads().listener(fakeEvent);
-
-                    fastdom.defer(10, function () {
-                        expect($('.ad-slot__label', $slot[0]).length).toBe(1);
-                        done();
-                    });
-                });
-            });
-
-            it('should not be added when ad is gu style type', function (done) {
-                var $slot = $('#dfp-ad-gu-style');
-                dfp.init();
-
-                fastdom.defer(function () {
-                    window.googletag.cmd.forEach(function (func) { func(); });
-                    window.googletag.pubads().listener(makeFakeEvent('dfp-ad-gu-style'));
-                    fastdom.defer(10, function () {
-                        expect($('.ad-slot__label', $slot[0]).length).toBe(0);
-                        done();
-                    });
-                });
-            });
-        });
     });
 });

--- a/static/test/javascripts/spec/common/commercial/dfp/render-advert-label.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/render-advert-label.spec.js
@@ -1,0 +1,85 @@
+define([
+    'bonzo',
+    'common/modules/commercial/dfp/render-advert-label'
+], function (
+    bonzo,
+    renderAdvertLabel
+) {
+    describe('Rendering advert labels', function () {
+
+        var adverts = {};
+        var labelSelector = '.ad-slot__label';
+
+        beforeEach(function () {
+            adverts.withLabel = bonzo(bonzo.create(
+                '<div class="js-ad-slot"></div>'
+            ));
+
+            adverts.labelDisabled = bonzo(bonzo.create(
+                '<div class="js-ad-slot" data-label="false"></div>'
+            ));
+
+            adverts.alreadyLabelled = bonzo(bonzo.create(
+                '<div class="js-ad-slot">' +
+                    '<div class="ad-slot__label">Advertisement</div>' +
+                '</div>'
+            ));
+
+            adverts.guStyle = bonzo(bonzo.create(
+                '<div class="js-ad-slot gu-style"></div>'
+            ));
+
+            adverts.frame = bonzo(bonzo.create(
+                '<div class="js-ad-slot ad-slot--frame"></div>'
+            ));
+        });
+
+        it('Can add a label', function (done) {
+            renderAdvertLabel(adverts.withLabel).then(function () {
+                var label = adverts.withLabel[0].querySelector(labelSelector);
+                expect(label).not.toBe(null);
+                done();
+            });
+        });
+
+        it('The label has a message', function (done) {
+            renderAdvertLabel(adverts.withLabel).then(function () {
+                var label = adverts.withLabel[0].querySelector(labelSelector);
+                expect(label.textContent).toBe('Advertisement');
+                done();
+            });
+        });
+
+        it('Won`t add a label if it has an attribute data-label=`false`', function (done) {
+            renderAdvertLabel(adverts.labelDisabled).then(function () {
+                var label = adverts.withLabel[0].querySelector(labelSelector);
+                expect(label).toBe(null);
+                done();
+            });
+        });
+
+        it('Won`t add a label if the adSlot already has one', function (done) {
+            renderAdvertLabel(adverts.alreadyLabelled).then(function () {
+                var label = adverts.withLabel[0].querySelector(labelSelector);
+                expect(label).toBe(null);
+                done();
+            });
+        });
+
+        it('Won`t add a label to guStyle ads', function (done) {
+            renderAdvertLabel(adverts.guStyle).then(function () {
+                var label = adverts.withLabel[0].querySelector(labelSelector);
+                expect(label).toBe(null);
+                done();
+            });
+        });
+
+        it('Won`t add a label to frame ads', function (done) {
+            renderAdvertLabel(adverts.frame).then(function () {
+                var label = adverts.withLabel[0].querySelector(labelSelector);
+                expect(label).toBe(null);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
It seems, sadly, that this could be my last pull request to this project. As such I'd like to at least use it to resolve one of the grievances I have with the ball of mud that is `dfp-api.js`.

This isn't a comprehensive refactor. In an ideal world, I'd probably have split the file into three modules: 
- an `advertisingService` that does nothing except dispatch requests and set up the targeting and dependencies that requires.
- a `renderAds` module that breathes behaviour, interactivity and styles into the creatives that come back;
- something responsible for setting up our lazy loaded ads (and dispatching whatever is already in view). Maybe I'd call it `requestAdverts` or something.

Mindful of economy of time, however, I've just done the second - pull out the `renderAds` stage from `dfp-api` into its own dedicated module. This would be the largest of the three modules, and seems to offer the greatest opportunity for tangential concerns like ad styling to 'leak into' `dfp-api`.

`dfp-api` is still something of an nebulous 'bag of holding', but my hope is that this change makes it a _little_ easier to navigate and a _little_ more focused in its concerns.

@guardian/commercial-dev @uplne 
