### PR TITLE
re-write all encoding urls to https

### DIFF
--- a/common/app/model/Encoding.scala
+++ b/common/app/model/Encoding.scala
@@ -1,8 +1,10 @@
 package model
 
+import views.support.HttpsUrl
+
 case class Encoding(format: String, url: String, rawFormat: String)
 
-object Encoding {
+object Encoding extends HttpsUrl {
 
   val typeMapping = Map(
     "mp4" -> "video/mp4"
@@ -10,7 +12,7 @@ object Encoding {
 
   def apply(url: String, rawFormat:String): Encoding = {
     val format = typeMapping.get(rawFormat).getOrElse(rawFormat)
-    Encoding(format, url, rawFormat)
+    Encoding(format, ensureHttps(url), rawFormat)
   }
 }
 


### PR DESCRIPTION
## What does this change?

This affects both video and audio as standalone pages and embeds.

We're getting `http` urls from Pluto/Composer/CAPI for video and audio - lets always upgrade them whilst waiting for those services to migrate content.

related - https://github.com/guardian/frontend/pull/13197
## What is the value of this and can you measure success?

🔒 
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

🔒 
## Request for comment

@mchv @jamesgorrie @fredex42

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
