### PR TITLE
Add sharing comments functionality

### DIFF
--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -474,4 +474,15 @@ trait FeatureSwitches {
     exposeClientSide = true
   )
 
+  // Owner: Maria Livia Chiorean
+  val SharingComments = Switch(
+    SwitchGroup.Feature,
+    "sharing-comments",
+    "When ON, the user will be able to share comments",
+    owners = Seq(Owner.withGithub("marialivia16")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = true
+  )
+
 }

--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -121,6 +121,7 @@ object ShareLinks {
     create(platform, campaignHref, title, mediaPath)
   }
 
+  // TODO: Use campaign codes
   def createShareLinkForComment(platform: SharePlatform, href: String, text: String, quote: Option[String] = None): ShareLink = {
     create(platform, href, text, None, quote)
   }

--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -83,7 +83,7 @@ object ShareLinks {
 
   val defaultShares = List(Facebook, Twitter, PinterestBlock)
 
-  private[model] def create(platform: SharePlatform, href: String, title: String, mediaPath: Option[String]): ShareLink = {
+  private[model] def create(platform: SharePlatform, href: String, title: String, mediaPath: Option[String], quote: Option[String] = None): ShareLink = {
 
     val encodedHref = href.urlEncoded
     val fullMediaPath: Option[String] = mediaPath.map { originalPath =>
@@ -93,6 +93,7 @@ object ShareLinks {
     lazy val facebookParams = List(
       Some("app_id" -> facebookAppId),
       Some("href" -> encodedHref),
+      quote.map(q => "quote" -> q),
       mediaPath.map(path => "picture" -> path.urlEncoded)
     ).flatten.toMap
 
@@ -120,8 +121,12 @@ object ShareLinks {
     create(platform, campaignHref, title, mediaPath)
   }
 
-  def createShareLinks(platforms: Seq[SharePlatform], href: String, title: String, mediaPath: Option[String]): Seq[ShareLink] = {
-    platforms.map(create(_, href, title, mediaPath))
+  def createShareLinkForComment(platform: SharePlatform, href: String, text: String, quote: Option[String] = None): ShareLink = {
+    create(platform, href, text, None, quote)
+  }
+
+  def createShareLinks(platforms: Seq[SharePlatform], href: String, title: String, mediaPath: Option[String], quote: Option[String] = None): Seq[ShareLink] = {
+    platforms.map(create(_, href, title, mediaPath, quote))
   }
 }
 

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -64,7 +64,7 @@
 
         <div class="d-comment__content">
 
-            @if(!comment.isBlocked){ @* Change here should be double check for functionality relating to wether recs should show when recs are closed *@
+            @if(!comment.isBlocked){ @* Change here should be double check for functionality relating to whether recs should show when recs are closed *@
                 <div
                     class="d-comment__recommend js-recommend-comment"
                     data-comment-id="@comment.id"
@@ -113,6 +113,8 @@
                             data-comment-highlighted="@comment.isHighlighted" data-link-name="Pick comment">@if(comment.isHighlighted){Unpick}else{Pick}</button>
 
                     </div>
+
+                    @commentShare(comment)
 
                     <div class="report-comment-container js-report-comment-container d-comment__action d-comment__action--report">
                         <a href="@controllers.routes.CommentsController.reportAbuseForm(comment.id)" rel="nofollow" class="js-report-comment" data-comment-id="@comment.id" target="_blank" data-link-name="Open report abuse">Report</a>

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -106,15 +106,14 @@
                             Reply
                         </a>
 
+                        @commentShare(comment)
+
                         <span class="d-comment__action-separator d-staff-required">|</span>
 
                         <button class="u-button-reset d-comment__action d-comment__action--pick d-staff-required" role="button"
                             data-comment-id="@comment.id"
                             data-comment-highlighted="@comment.isHighlighted" data-link-name="Pick comment">@if(comment.isHighlighted){Unpick}else{Pick}</button>
-
                     </div>
-
-                    @commentShare(comment)
 
                     <div class="report-comment-container js-report-comment-container d-comment__action d-comment__action--report">
                         <a href="@controllers.routes.CommentsController.reportAbuseForm(comment.id)" rel="nofollow" class="js-report-comment" data-comment-id="@comment.id" target="_blank" data-link-name="Open report abuse">Report</a>

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -1,5 +1,6 @@
 @(comment: Comment, isClosedForRecommendation: Boolean = true, isResponse: Boolean = false)(implicit request: RequestHeader)
 @import conf.Configuration
+@import conf.switches.Switches.SharingComments
 
 @* Please don't use the isTopComment switch - we've kept it pretty clean without it, but just need a solution for IDs *@
 <li class="d-comment
@@ -106,7 +107,9 @@
                             Reply
                         </a>
 
-                        @commentShare(comment)
+                        @if(SharingComments.isSwitchedOn) {
+                            @commentShare(comment)
+                        }
 
                         <span class="d-comment__action-separator d-staff-required">|</span>
 

--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -1,34 +1,37 @@
 @(comment: Comment)
 @import org.jsoup.Jsoup
 @import org.jsoup.safety.Whitelist
+@import conf.switches.Switches.SharingComments
 
-<div class="sharing-component d-comment__action">
+@if(SharingComments.isSwitchedOn) {
+    <div class="sharing-component d-comment__action">
 
-    <div class="sharing-text">@fragments.inlineSvg("share", "icon") Share</div>
+        <div class="sharing-text">@fragments.inlineSvg("share", "icon") Share</div>
 
-    <div class="block-share block-share--gallery sharing-buttons" data-link-name="block share">
-    @defining(s"https://gu.com${comment.discussion.key}#comment-${comment.id}") { permalink =>
-        @defining(Jsoup.clean(comment.body, Whitelist.none())) { commentBody =>
-            <a class="social__action social-icon-wrapper"
-            href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"${comment.profile.displayName} commented: '$commentBody'")).href"
-            target="_blank"
-            data-link-name="social facebook">
-                <span class='inline-icon__fallback button share-modal__item share-modal__item--facebook'>Share on Facebook</span>
-                @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon social-icon social-icon--facebook"))
-                <span class="u-h">Facebook</span>
-            </a>
+        <div class="block-share block-share--gallery sharing-buttons" data-link-name="block share">
+        @defining(s"https://gu.com${comment.discussion.key}#comment-${comment.id}") { permalink =>
+            @defining(Jsoup.clean(comment.body, Whitelist.none())) { commentBody =>
+                <a class="social__action social-icon-wrapper"
+                href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"${comment.profile.displayName} commented: '$commentBody'")).href"
+                target="_blank"
+                data-link-name="social-comment facebook">
+                    <span class='inline-icon__fallback button share-modal__item share-modal__item--facebook'>Share on Facebook</span>
+                    @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon social-icon social-icon--facebook"))
+                    <span class="u-h">Facebook</span>
+                </a>
 
-            <a class="social__action social-icon-wrapper"
-            href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = comment.webUrl, text = s"'${commentBody.take(111)}...'").href"
-            target="_blank"
-            data-link-name="social twitter">
-                <span class='inline-icon__fallback button share-modal__item share-modal__item--twitter'>Share on Facebook</span>
-                @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon social-icon social-icon--twitter"))
-                <span class="u-h">Twitter</span>
-            </a>
+                <a class="social__action social-icon-wrapper"
+                href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = comment.webUrl, text = s"'${commentBody.take(111)}...'").href"
+                target="_blank"
+                data-link-name="social-comment twitter">
+                    <span class='inline-icon__fallback button share-modal__item share-modal__item--twitter'>Share on Facebook</span>
+                    @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon social-icon social-icon--twitter"))
+                    <span class="u-h">Twitter</span>
+                </a>
+            }
         }
-    }
+        </div>
     </div>
+}
 
-</div>
 

--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -1,0 +1,25 @@
+@(comment: Comment)
+@import org.jsoup.Jsoup
+@import org.jsoup.safety.Whitelist
+
+<div class="block-share block-share--gallery inactive-share-buttons" data-link-name="block share">
+    @defining(s"https://gu.com${comment.discussion.key}#comment-${comment.id}") { permalink =>
+        @defining(Jsoup.clean(comment.body, Whitelist.none())) { commentBody =>
+            <a class="rounded-icon block-share__item block-share__item--facebook js-blockshare-link"
+            href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"${comment.profile.displayName} commented: '$commentBody'")).href"
+            target="_blank"
+            data-link-name="social facebook">
+                @fragments.inlineSvg("share-facebook", "icon")
+                <span class="u-h">Facebook</span>
+            </a>
+
+            <a class="rounded-icon block-share__item block-share__item--twitter js-blockshare-link"
+            href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = comment.webUrl, text = s"'${commentBody.take(111)}...'").href"
+            target="_blank"
+            data-link-name="social twitter">
+                @fragments.inlineSvg("share-twitter", "icon")
+                <span class="u-h">Twitter</span>
+            </a>
+        }
+    }
+</div>

--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -2,24 +2,33 @@
 @import org.jsoup.Jsoup
 @import org.jsoup.safety.Whitelist
 
-<div class="block-share block-share--gallery inactive-share-buttons" data-link-name="block share">
+<div class="sharing-component d-comment__action">
+
+    <div class="sharing-text">@fragments.inlineSvg("share", "icon") Share</div>
+
+    <div class="block-share block-share--gallery sharing-buttons" data-link-name="block share">
     @defining(s"https://gu.com${comment.discussion.key}#comment-${comment.id}") { permalink =>
         @defining(Jsoup.clean(comment.body, Whitelist.none())) { commentBody =>
-            <a class="rounded-icon block-share__item block-share__item--facebook js-blockshare-link"
+            <a class="social__action social-icon-wrapper"
             href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"${comment.profile.displayName} commented: '$commentBody'")).href"
             target="_blank"
             data-link-name="social facebook">
-                @fragments.inlineSvg("share-facebook", "icon")
+                <span class='inline-icon__fallback button share-modal__item share-modal__item--facebook'>Share on Facebook</span>
+                @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon social-icon social-icon--facebook"))
                 <span class="u-h">Facebook</span>
             </a>
 
-            <a class="rounded-icon block-share__item block-share__item--twitter js-blockshare-link"
+            <a class="social__action social-icon-wrapper"
             href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = comment.webUrl, text = s"'${commentBody.take(111)}...'").href"
             target="_blank"
             data-link-name="social twitter">
-                @fragments.inlineSvg("share-twitter", "icon")
+                <span class='inline-icon__fallback button share-modal__item share-modal__item--twitter'>Share on Facebook</span>
+                @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon social-icon social-icon--twitter"))
                 <span class="u-h">Twitter</span>
             </a>
         }
     }
+    </div>
+
 </div>
+

--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -1,6 +1,7 @@
 @(comment: Comment)
 @import org.jsoup.Jsoup
 @import org.jsoup.safety.Whitelist
+@import org.apache.commons.lang.StringEscapeUtils
 
 <div class="sharing-component d-comment__action">
 
@@ -8,24 +9,29 @@
 
     <div class="sharing-buttons" data-link-name="comment social">
     @defining(s"https://gu.com${comment.discussion.key}#comment-${comment.id}") { permalink =>
-        @defining(Jsoup.clean(comment.body, Whitelist.none())) { commentBody =>
-            <a href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"${comment.profile.displayName} commented: '$commentBody'")).href"
+        @defining(StringEscapeUtils.unescapeHtml(Jsoup.clean(comment.body, Whitelist.none()))) { commentBody =>
+            <a href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"""${comment.profile.displayName} commented: "$commentBody"""")).href"
             target="_blank"
             class="social__action social-icon-wrapper"
             data-link-name="social-comment : facebook">
-                <span class="inline-icon__fallback button share-modal__item share-modal__item--facebook">Share on Facebook</span>
+                <span class="inline-icon__fallback button share-modal__item share-modal__item--facebook">
+                    Share on Facebook</span>
                 @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon social-icon social-icon--facebook comment-facebook-icon"))
                 <span class="u-h">Facebook</span>
             </a>
 
-            <a href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = comment.webUrl, text = s"'${commentBody.take(111)}...'").href"
-            target="_blank"
-            class="social__action social-icon-wrapper"
-            data-link-name="social-comment : twitter">
-                <span class="inline-icon__fallback button share-modal__item share-modal__item--twitter">Share on Facebook</span>
-                @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon social-icon social-icon--twitter comment-twitter-icon"))
-                <span class="u-h">Twitter</span>
-            </a>
+            @* Twitter allows 140 characters. We need 2 for the quotes and 24 for the URL. *@
+            @defining(if(commentBody.length <= 114) s""""$commentBody"""" else s""""${commentBody.take(111)}..."""") { commentText =>
+                <a href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = comment.webUrl, text = commentText).href"
+                target="_blank"
+                class="social__action social-icon-wrapper"
+                data-link-name="social-comment : twitter">
+                    <span class="inline-icon__fallback button share-modal__item share-modal__item--twitter">
+                        Share on Facebook</span>
+                    @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon social-icon social-icon--twitter comment-twitter-icon"))
+                    <span class="u-h">Twitter</span>
+                </a>
+            }
         }
     }
     </div>

--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -1,37 +1,32 @@
 @(comment: Comment)
 @import org.jsoup.Jsoup
 @import org.jsoup.safety.Whitelist
-@import conf.switches.Switches.SharingComments
 
-@if(SharingComments.isSwitchedOn) {
-    <div class="sharing-component d-comment__action">
+<div class="sharing-component d-comment__action">
 
-        <div class="sharing-text">@fragments.inlineSvg("share", "icon") Share</div>
+    <div class="sharing-text">@fragments.inlineSvg("share", "icon", List("comment-share-icon")) Share</div>
 
-        <div class="block-share block-share--gallery sharing-buttons" data-link-name="block share">
-        @defining(s"https://gu.com${comment.discussion.key}#comment-${comment.id}") { permalink =>
-            @defining(Jsoup.clean(comment.body, Whitelist.none())) { commentBody =>
-                <a class="social__action social-icon-wrapper"
-                href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"${comment.profile.displayName} commented: '$commentBody'")).href"
-                target="_blank"
-                data-link-name="social-comment facebook">
-                    <span class='inline-icon__fallback button share-modal__item share-modal__item--facebook'>Share on Facebook</span>
-                    @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon social-icon social-icon--facebook"))
-                    <span class="u-h">Facebook</span>
-                </a>
+    <div class="sharing-buttons" data-link-name="comment social">
+    @defining(s"https://gu.com${comment.discussion.key}#comment-${comment.id}") { permalink =>
+        @defining(Jsoup.clean(comment.body, Whitelist.none())) { commentBody =>
+            <a href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"${comment.profile.displayName} commented: '$commentBody'")).href"
+            target="_blank"
+            class="social__action social-icon-wrapper"
+            data-link-name="social-comment : facebook">
+                <span class="inline-icon__fallback button share-modal__item share-modal__item--facebook">Share on Facebook</span>
+                @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon social-icon social-icon--facebook comment-facebook-icon"))
+                <span class="u-h">Facebook</span>
+            </a>
 
-                <a class="social__action social-icon-wrapper"
-                href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = comment.webUrl, text = s"'${commentBody.take(111)}...'").href"
-                target="_blank"
-                data-link-name="social-comment twitter">
-                    <span class='inline-icon__fallback button share-modal__item share-modal__item--twitter'>Share on Facebook</span>
-                    @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon social-icon social-icon--twitter"))
-                    <span class="u-h">Twitter</span>
-                </a>
-            }
+            <a href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = comment.webUrl, text = s"'${commentBody.take(111)}...'").href"
+            target="_blank"
+            class="social__action social-icon-wrapper"
+            data-link-name="social-comment : twitter">
+                <span class="inline-icon__fallback button share-modal__item share-modal__item--twitter">Share on Facebook</span>
+                @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon social-icon social-icon--twitter comment-twitter-icon"))
+                <span class="u-h">Twitter</span>
+            </a>
         }
-        </div>
+    }
     </div>
-}
-
-
+</div>

--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -8,13 +8,13 @@
     <div class="sharing-text">@fragments.inlineSvg("share", "icon", List("comment-share-icon")) Share</div>
 
     <div class="sharing-buttons" data-link-name="comment social">
-    @defining(s"https://gu.com${comment.discussion.key}#comment-${comment.id}") { permalink =>
+    @defining(s"${comment.discussion.webUrl}") { permalink =>
         @defining(StringEscapeUtils.unescapeHtml(Jsoup.clean(comment.body, Whitelist.none()))) { commentBody =>
             <a href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"""${comment.profile.displayName} commented: "$commentBody"""")).href"
             target="_blank"
             class="social__action social-icon-wrapper"
             data-link-name="social-comment : facebook">
-                <span class="inline-icon__fallback button share-modal__item share-modal__item--facebook">
+                <span class="inline-icon__fallback button">
                     Share on Facebook</span>
                 @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon social-icon social-icon--facebook comment-facebook-icon"))
                 <span class="u-h">Facebook</span>
@@ -26,7 +26,7 @@
                 target="_blank"
                 class="social__action social-icon-wrapper"
                 data-link-name="social-comment : twitter">
-                    <span class="inline-icon__fallback button share-modal__item share-modal__item--twitter">
+                    <span class="inline-icon__fallback button">
                         Share on Facebook</span>
                     @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon social-icon social-icon--twitter comment-twitter-icon"))
                     <span class="u-h">Twitter</span>

--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -16,7 +16,7 @@
             data-link-name="social-comment : facebook">
                 <span class="inline-icon__fallback button">
                     Share on Facebook</span>
-                @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon social-icon social-icon--facebook comment-facebook-icon"))
+                @fragments.inlineSvg("share-facebook", "icon", List("rounded-icon", "social-icon", "social-icon--facebook", "comment-facebook-icon"))
                 <span class="u-h">Facebook</span>
             </a>
 
@@ -28,7 +28,7 @@
                 data-link-name="social-comment : twitter">
                     <span class="inline-icon__fallback button">
                         Share on Facebook</span>
-                    @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon social-icon social-icon--twitter comment-twitter-icon"))
+                    @fragments.inlineSvg("share-twitter", "icon", List("rounded-icon", "social-icon", "social-icon--twitter", "comment-twitter-icon"))
                     <span class="u-h">Twitter</span>
                 </a>
             }

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -842,7 +842,9 @@ $comment-recommend-button-size: 19px;
     bottom: $gs-baseline;
     opacity: .7;
     .discussion--closed & {
-        .d-comment__action--reply, .d-comment__action-separator, .d-comment__action-pick {
+        .d-comment__action--reply,
+        .d-comment__action-separator,
+        .d-comment__action-pick {
             display: none;
         }
         .sharing-component {
@@ -929,8 +931,8 @@ $comment-recommend-button-size: 19px;
         display: inline-block;
 
         .inline-icon {
-            height: 0rem;
-            min-width: 0rem;
+            height: 0;
+            min-width: 0;
             transition: all .3s ease-in-out;
         }
     }
@@ -951,19 +953,21 @@ $comment-recommend-button-size: 19px;
     a:first-child {
         margin-left: 5px;
     }
-}
 
-.sharing-component:hover {
-    .sharing-buttons {
-        opacity: 1;
+    &:hover {
+        .sharing-buttons {
+            opacity: 1;
 
-        .inline-icon {
-            height: 1.2rem;
-            min-width: 1.2rem;
-            cursor: pointer;
+            .inline-icon {
+                height: 1.2rem;
+                min-width: 1.2rem;
+                cursor: pointer;
+            }
         }
     }
 }
+
+
 
 /* Report
    ======================================================= */

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -518,6 +518,12 @@ $avatarPadding: $gs-gutter / 2;
     }
 }
 
+.d-comment__inner:hover {
+    .inactive-share-buttons {
+        display: block;
+    }
+}
+
 .d-comment__reply-to-author,
 .d-comment-box__reply-to-author {
     @include fs-textSans(4);
@@ -901,6 +907,10 @@ $comment-recommend-button-size: 19px;
     .d-comment__action-separator {
         display: inline-block;
     }
+}
+
+.inactive-share-buttons {
+    display: none;
 }
 
 /* Report

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -930,6 +930,7 @@ $comment-recommend-button-size: 19px;
         .comment-twitter-icon {
             height: 1.2rem;
             min-width: 1.2rem;
+            margin: 0;
             cursor: pointer;
         }
     }
@@ -952,7 +953,6 @@ $comment-recommend-button-size: 19px;
 .sharing-buttons {
     opacity: 0;
     cursor: pointer;
-    transition: opacity 0s ease-in-out;
     display: inline-block;
 }
 
@@ -960,7 +960,8 @@ $comment-recommend-button-size: 19px;
 .comment-twitter-icon {
     height: 0;
     min-width: 0;
-    transition: all .3s ease-in-out;
+    margin: .6rem;
+    transition: all .5s ease-in-out;
 }
 
 /* Report

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -936,7 +936,7 @@ $comment-recommend-button-size: 19px;
 }
 
 .sharing-text {
-    cursor: default;
+    cursor: pointer;
     display: inline-block;
     float: left;
 }

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -518,12 +518,6 @@ $avatarPadding: $gs-gutter / 2;
     }
 }
 
-.d-comment__inner:hover {
-    .inactive-share-buttons {
-        display: block;
-    }
-}
-
 .d-comment__reply-to-author,
 .d-comment-box__reply-to-author {
     @include fs-textSans(4);
@@ -846,13 +840,27 @@ $comment-recommend-button-size: 19px;
 .d-comment__actions {
     position: absolute;
     bottom: $gs-baseline;
+    opacity: 0.7;
     .discussion--closed & {
-        display: none;
+        .d-comment__action--reply, .d-comment__action-separator, .d-comment__action-pick {
+            display: none;
+        }
+        .sharing-component {
+            margin: 0 !important;
+
+            .sharing-text .inline-icon {
+                padding-left: 0 !important;
+            }
+        }
     }
 }
 
+.d-comment__actions:hover {
+    opacity: 1;
+}
+
 .d-comment__action {
-    @include fs-textSans(1);
+    @include fs-textSans(3);
     display: inline-block;
     color: $news-default;
     font-weight: bold;
@@ -909,8 +917,52 @@ $comment-recommend-button-size: 19px;
     }
 }
 
-.inactive-share-buttons {
-    display: none;
+.sharing-component {
+    height: 1.2rem;
+    vertical-align: middle;
+    margin-left: 5px;
+
+    .sharing-buttons {
+        opacity: 0;
+        cursor: pointer;
+        transition: opacity .0s ease-in-out;
+        display: inline-block;
+
+        .inline-icon {
+            height: 0rem;
+            min-width: 0rem;
+            transition: all .3s ease-in-out;
+        }
+    }
+
+    .sharing-text, .inline-icon {
+        cursor: default;
+        display: inline-block;
+        float: left;
+    }
+
+    .sharing-text {
+        .inline-icon {
+            padding: 1px 5px;
+            fill: #005689;
+        }
+    }
+
+    a:first-child {
+        margin-left: 5px;
+    }
+}
+
+.sharing-component:hover {
+    .sharing-buttons {
+        opacity: 1;
+
+        .inline-icon {
+            height: 1.2rem;
+            min-width: 1.2rem;
+            cursor: pointer;
+        }
+    }
 }
 
 /* Report

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -840,7 +840,7 @@ $comment-recommend-button-size: 19px;
 .d-comment__actions {
     position: absolute;
     bottom: $gs-baseline;
-    opacity: 0.7;
+    opacity: .7;
     .discussion--closed & {
         .d-comment__action--reply, .d-comment__action-separator, .d-comment__action-pick {
             display: none;
@@ -925,7 +925,7 @@ $comment-recommend-button-size: 19px;
     .sharing-buttons {
         opacity: 0;
         cursor: pointer;
-        transition: opacity .0s ease-in-out;
+        transition: opacity 0s ease-in-out;
         display: inline-block;
 
         .inline-icon {

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -848,11 +848,7 @@ $comment-recommend-button-size: 19px;
             display: none;
         }
         .sharing-component {
-            margin: 0 !important;
-
-            .sharing-text .inline-icon {
-                padding-left: 0 !important;
-            }
+            margin: 0;
         }
     }
 }
@@ -924,50 +920,48 @@ $comment-recommend-button-size: 19px;
     vertical-align: middle;
     margin-left: 5px;
 
-    .sharing-buttons {
-        opacity: 0;
-        cursor: pointer;
-        transition: opacity 0s ease-in-out;
-        display: inline-block;
-
-        .inline-icon {
-            height: 0;
-            min-width: 0;
-            transition: all .3s ease-in-out;
-        }
-    }
-
-    .sharing-text, .inline-icon {
-        cursor: default;
-        display: inline-block;
-        float: left;
-    }
-
-    .sharing-text {
-        .inline-icon {
-            padding: 1px 5px;
-            fill: #005689;
-        }
-    }
-
-    a:first-child {
-        margin-left: 5px;
-    }
-
     &:hover {
         .sharing-buttons {
             opacity: 1;
+            margin-left: 5px;
+        }
 
-            .inline-icon {
-                height: 1.2rem;
-                min-width: 1.2rem;
-                cursor: pointer;
-            }
+        .comment-facebook-icon,
+        .comment-twitter-icon {
+            height: 1.2rem;
+            min-width: 1.2rem;
+            cursor: pointer;
         }
     }
 }
 
+.sharing-text {
+    cursor: default;
+    display: inline-block;
+    float: left;
+}
 
+.comment-share-icon {
+    fill: $guardian-brand;
+}
+
+.comment-share-icon svg {
+    vertical-align: text-top;
+}
+
+.sharing-buttons {
+    opacity: 0;
+    cursor: pointer;
+    transition: opacity 0s ease-in-out;
+    display: inline-block;
+}
+
+.comment-facebook-icon,
+.comment-twitter-icon {
+    height: 0;
+    min-width: 0;
+    transition: all .3s ease-in-out;
+}
 
 /* Report
    ======================================================= */

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -932,6 +932,14 @@ $comment-recommend-button-size: 19px;
             margin: 0;
             cursor: pointer;
         }
+
+        .comment-facebook-icon {
+            transition: all .3s ease-in-out;
+        }
+
+        .comment-twitter-icon {
+            transition: all .3s .15s ease-in-out;
+        }
     }
 }
 
@@ -960,7 +968,14 @@ $comment-recommend-button-size: 19px;
     height: 0;
     min-width: 0;
     margin: .6rem;
-    transition: all .4s ease-in-out;
+}
+
+.comment-facebook-icon {
+    transition: all .3s .15s ease-in-out;
+}
+
+.comment-twitter-icon {
+    transition: all .3s ease-in-out;
 }
 
 /* Report

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -923,7 +923,6 @@ $comment-recommend-button-size: 19px;
     &:hover {
         .sharing-buttons {
             opacity: 1;
-            margin-left: 5px;
         }
 
         .comment-facebook-icon,
@@ -940,6 +939,7 @@ $comment-recommend-button-size: 19px;
     cursor: pointer;
     display: inline-block;
     float: left;
+    margin-right: 5px;
 }
 
 .comment-share-icon {
@@ -951,7 +951,6 @@ $comment-recommend-button-size: 19px;
 }
 
 .sharing-buttons {
-    opacity: 0;
     cursor: pointer;
     display: inline-block;
 }
@@ -961,7 +960,7 @@ $comment-recommend-button-size: 19px;
     height: 0;
     min-width: 0;
     margin: .6rem;
-    transition: all .5s ease-in-out;
+    transition: all .4s ease-in-out;
 }
 
 /* Report


### PR DESCRIPTION
## What does this change?

Adds the sharing functionality for comments.
TODO before merging:
- [x] Tweak animation
- [x] Add fb permalink's domain to App Domains field in app settings
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

Gif of showing buttons animation:
![comment](https://cloud.githubusercontent.com/assets/5732563/16153032/73d5332a-349c-11e6-8fb9-1d4d5a887744.gif)

Comment shared on Facebook:
<img src="https://cloud.githubusercontent.com/assets/5732563/16153089/c3f05a6a-349c-11e6-981c-7ca28ba9156d.jpg" data-canonical-src="https://cloud.githubusercontent.com/assets/5732563/16153089/c3f05a6a-349c-11e6-981c-7ca28ba9156d.jpg" width="400" />

Comment shared on Twitter:
<img src="https://cloud.githubusercontent.com/assets/5732563/16153072/abb1cb3c-349c-11e6-8bf3-2cede054c45a.jpg" data-canonical-src="https://cloud.githubusercontent.com/assets/5732563/16153072/abb1cb3c-349c-11e6-8bf3-2cede054c45a.jpg" width="400" />
## Request for comment

@guardian/participation - I created this PR so we can discuss about it, there are still changes that need to be done if we decide to put this in production.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
