### PR TITLE
Measure each time notifications are granted or denied

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts/bootstraps/enhanced/notifications.js
@@ -16,7 +16,8 @@ define([
     'text!common/views/ui/notifications-permission-denied-message.html',
     'lodash/collections/some',
     'lodash/arrays/uniq',
-    'lodash/arrays/without'
+    'lodash/arrays/without',
+    'common/modules/analytics/omniture'
 ], function (
     bonzo,
     qwery,
@@ -35,7 +36,8 @@ define([
     permissionsTemplate,
     some,
     uniq,
-    without
+    without,
+    omniture
 ) {
     var explainerDismissed = 'gu.notificationsExplainerDismissed',
         modules = {
@@ -106,9 +108,14 @@ define([
 
         subscribeHandler: function () {
             modules.subscribe().then(modules.follow)
-                .catch( function () {
+                .then(function() {
+                    if (Notification.permission === 'granted') {
+                        omniture.trackLinkImmediate('browser-notifications-granted');
+                    }
+                }) .catch( function () {
                     if (Notification.permission === 'denied') {
                         modules.notificationsDeniedMessage();
+                        omniture.trackLinkImmediate('browser-notifications-denied');
                     }
                 });
         },


### PR DESCRIPTION
## What does this change?

This adds tracking to the liveblog notification signup flow; we now track if the user `grants` or `denies` permission to the browser notifications.
## What is the value of this and can you measure success?

A big blocker in this flow is the browser step of asking the user permission to show notifications from our domain; it will be extremely useful to know if the drop-off happens here and if it is causing any issues.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@gtrufitt @NathanielBennett @crifmulholland 
