### PR TITLE
Increase ad load timeout to 10s

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -475,16 +475,16 @@ define([
 
     var waitForAdvert = memoize(function (id) {
         return new Promise(function (resolve, reject) {
-            var failedAttempts = 5;
+            var failedAttempts = 50;
             checkAdvert();
             function checkAdvert() {
                 var advert = getAdvertById(id);
                 if (!advert) {
                     failedAttempts -= 1;
                     if (failedAttempts === 0) {
-                        reject(new Error('Ad ' + id + ' failed to load'));
+                        reject(new Error('Ad ' + id + ' failed to load in time'));
                     }
-                    window.setTimeout(checkAdvert, 100);
+                    window.setTimeout(checkAdvert, 200);
                 } else {
                     resolve(advert);
                 }


### PR DESCRIPTION
I introduced a new API to wait until an ad has rendered/loaded last friday, with a timeout of 500s... I thought that was more than enough but lo and behold: no it wasn't.

Pushing it to 10s 😭 

@ScottPainterGNM 
