### PR TITLE
Track attention time of interactives

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -129,6 +129,10 @@ define([
                         });
                     });
                 });
+
+                require(['ophan/ng'], function(ophan) {
+                   ophan.trackComponentAttention(el.querySelector('a').href, el);
+                });
             });
         }
 


### PR DESCRIPTION
## What does this change?

I've [recently added functionality](https://github.com/guardian/ophan/pull/1515) to Ophan's tracker JS to report attention time for individual elements on the page.

Originally this was tracking anything with a `data-component` attribute but in [this PR](https://github.com/guardian/ophan/pull/1522) I changed things so you need to explicitly register an element to track its attention.

This code registers the `<figure></figure>` container of all interactives to track their attention time. 
## What is the value of this and can you measure success?

We've been using interactives to embed explainers into articles like [this one](https://www.theguardian.com/business/2016/jun/16/high-street-sales-rise-despite-brexit-fears) as a potential membership feature. We're tracking feedback clicks on the explainers but we want to put these figures in the context of how many people scrolled down and saw these explainers.
## Does this affect other platforms - Amp, Apps, etc?

Just web

@dominickendrick 
