### PR TITLE
Send fine-grain logging to Log Stash for commercial feeds

### DIFF
--- a/commercial/app/commercial/CommercialLifecycle.scala
+++ b/commercial/app/commercial/CommercialLifecycle.scala
@@ -45,6 +45,7 @@ class CommercialLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: Execu
                           maybeSize: Option[Int] = None) = {
 
     val prefix = "commercial-feed"
+    
     val defaultFields: List[LogField] = List(
       prefix -> feed,
       s"$prefix-action" -> action,

--- a/commercial/app/commercial/CommercialLifecycle.scala
+++ b/commercial/app/commercial/CommercialLifecycle.scala
@@ -6,20 +6,30 @@ import model.commercial.jobs.Industries
 import model.commercial.events.MasterclassTagsAgent
 import model.commercial.money.BestBuysAgent
 import model.commercial.travel.Countries
+
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Random
 import scala.util.control.NonFatal
 
-private [commercial] object CommercialLifecycleMetrics {
+private [commercial] object CommercialLifecycleMetrics extends Logging {
 
-  val metricMap = Map(
+  val metricAgents = Map(
     "fetch-failure" -> AkkaAgent(0.0),
     "fetch-success" -> AkkaAgent(0.0),
     "parse-failure" -> AkkaAgent(0.0),
     "parse-success" -> AkkaAgent(0.0)
   )
+
+  private[commercial] def update(): Unit = {
+
+    val metricsAsMap = metricAgents map { case (key, agent) => key -> agent.get }
+
+    log.info(s"uploading commercial feed metrics: $metricsAsMap")
+    CommercialMetrics.metrics.put(metricsAsMap)
+    CommercialMetrics.metrics.upload()
+    metricAgents.values.foreach(_ send 0)
+  }
 }
 
 class CommercialLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
@@ -28,35 +38,45 @@ class CommercialLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: Execu
     stop()
   }}
 
+  private def toLogFields(feed: String,
+                          action: String,
+                          success: Boolean,
+                          maybeDuration: Option[Long] = None,
+                          maybeSize: Option[Int] = None) = {
+
+    val prefix = "commercial-feed"
+    val defaultFields: List[LogField] = List(
+      prefix -> feed,
+      s"$prefix-action" -> action,
+      s"$prefix-result" -> (if (success) "success" else "failure")
+    )
+
+    val optionalFields: List[Option[LogField]] = List(
+      maybeDuration map (LogFieldLong(s"$prefix-duration", _)),
+      maybeSize map (LogFieldLong(s"$prefix-size", _))
+    )
+
+    defaultFields ::: optionalFields.flatten
+  }
+
   private val refreshJobs: List[RefreshJob] = List(
-    MasterClassTagsRefresh,
+    MasterclassTagsRefresh,
     CountriesRefresh,
     IndustriesRefresh,
-    MoneyBestBuysRefresh
+    MoneyBestBuysRefresh,
+    CommercialMetricsRefresh
   )
 
   private def recordEvent(eventName:String, outcome:String): Unit = {
     val keyName = s"$eventName-$outcome"
-    CommercialLifecycleMetrics.metricMap
+    CommercialLifecycleMetrics.metricAgents
       .get(keyName)
-      .foreach(agent => agent.send(_ +1.0))
-  }
-
-  private def updateMetrics(): Unit = {
-    CommercialLifecycleMetrics.metricMap.foreach{
-      case (metricName, agent) => {
-        agent send {currentCount =>
-          log.info(s"uploading $metricName with count of : $currentCount")
-          CommercialMetrics.metrics.put(Map(metricName -> currentCount))
-          0
-        }
-      }
-    }
+      .foreach(agent => agent.send(_ + 1.0))
   }
 
   override def start(): Unit = {
 
-    def randomStartSchedule(minsLater: Int = 0) = s"0 ${Random.nextInt(15) + minsLater}/15 * * * ?"
+    def delayedStartSchedule(delayedStart: Int = 0, refreshStep: Int = 15) = s"0 $delayedStart/$refreshStep * * * ?"
 
     def fetchFeed(fetcher: FeedFetcher): Future[Unit] = {
 
@@ -70,13 +90,16 @@ class CommercialLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: Execu
           log.warn(s"$msgPrefix failed: ${e.getMessage}")
         case NonFatal(e) =>
           recordEvent("fetch","failure")
-          log.error(s"$msgPrefix failed: ${e.getMessage}", e)
+          logErrorWithCustomFields(s"$msgPrefix failed: ${e.getMessage}",
+                                   e,
+                                   toLogFields(feedName, "fetch", false))
       }
       eventualResponse onSuccess {
         case response =>
           S3FeedStore.put(feedName, response.feed)
           recordEvent("fetch","success")
-          log.info(s"$msgPrefix succeeded in ${response.duration}")
+          logInfoWithCustomFields(s"$msgPrefix succeeded in ${response.duration}",
+                                  toLogFields(feedName, "fetch", false, Some(response.duration.toSeconds)))
       }
       eventualResponse.map(_ => ())
     }
@@ -93,23 +116,28 @@ class CommercialLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: Execu
           log.warn(s"$msgPrefix failed: ${e.getMessage}")
         case NonFatal(e) =>
           recordEvent("parse","failure")
-          log.error(s"$msgPrefix failed: ${e.getMessage}", e)
+          logErrorWithCustomFields(s"$msgPrefix failed: ${e.getMessage}",
+                                   e,
+                                   toLogFields(feedName, "parse", false))
       }
       parsedFeed onSuccess {
         case feed =>
           recordEvent("parse","success")
-          log.info(s"$msgPrefix succeeded: parsed ${feed.contents.size} $feedName in ${feed.parseDuration}")
+          logInfoWithCustomFields(s"$msgPrefix succeeded: parsed ${feed.contents.size} $feedName in ${feed.parseDuration}",
+                                  toLogFields(feedName, "parse", true, Some(feed.parseDuration.toSeconds), Some(feed.contents.size)))
       }
       parsedFeed.map(_ => ())
     }
 
     def mkJobName(feedName: String, task: String): String = s"${feedName.replaceAll("/", "-")}-$task-job"
 
+    val jobRefreshStep = 15
+
     for (fetcher <- FeedFetcher.all) {
       val feedName = fetcher.feedMetaData.name
       val jobName = mkJobName(feedName, "fetch")
       Jobs.deschedule(jobName)
-      Jobs.scheduleEveryNMinutes(jobName, 15) {
+      Jobs.scheduleEveryNMinutes(jobName, jobRefreshStep) {
         fetchFeed(fetcher)
       }
     }
@@ -118,26 +146,15 @@ class CommercialLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: Execu
       val feedName = parser.feedMetaData.name
       val jobName = mkJobName(feedName, "parse")
       Jobs.deschedule(jobName)
-      Jobs.scheduleEveryNMinutes(jobName, 15) {
+      Jobs.scheduleEveryNMinutes(jobName, jobRefreshStep) {
         parseFeed(parser)
       }
     }
 
-    val jobName = "update-metrics"
-    Jobs.deschedule(jobName)
-    Jobs.scheduleEveryNMinutes(jobName, 15){
-      updateMetrics
-      Future.successful(())
-    }
-
-    Jobs.deschedule("cloudwatchUpload")
-    Jobs.scheduleEveryNMinutes("cloudwatchUpload", 15) {
-      CommercialMetrics.metrics.upload()
-      Future.successful(())
-    }
+    val refreshJobDelay = jobRefreshStep / refreshJobs.size
 
     refreshJobs.zipWithIndex foreach {
-      case (job, i) => job.start(randomStartSchedule(minsLater = i))
+      case (job, i) => job.start(delayedStartSchedule(delayedStart = i * refreshJobDelay, refreshStep = jobRefreshStep))
     }
 
     AkkaAsync {
@@ -155,6 +172,8 @@ class CommercialLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: Execu
       }
 
       BestBuysAgent.refresh()
+
+      CommercialLifecycleMetrics.update()
 
       for (fetcher <- FeedFetcher.all) {
         fetchFeed(fetcher)
@@ -176,7 +195,5 @@ class CommercialLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: Execu
     for (parser <- FeedParser.all) {
       Jobs.deschedule(s"${parser.feedMetaData.name}ParseJob")
     }
-
-    Jobs.deschedule("cloudwatchUpload")
   }
 }

--- a/commercial/app/commercial/RefreshJob.scala
+++ b/commercial/app/commercial/RefreshJob.scala
@@ -26,7 +26,7 @@ trait RefreshJob extends Logging {
   }
 }
 
-object MasterClassTagsRefresh extends RefreshJob {
+object MasterclassTagsRefresh extends RefreshJob {
 
   val name: String = "MasterClassTags"
 
@@ -54,3 +54,11 @@ object MoneyBestBuysRefresh extends RefreshJob {
 
   def refresh() = BestBuysAgent.refresh()
 }
+
+object CommercialMetricsRefresh extends RefreshJob {
+  val name: String = "Update Metrics"
+
+  def refresh() = CommercialLifecycleMetrics.update()
+}
+
+


### PR DESCRIPTION
## What does this change?

Whenever each commercial feed is parsed/fetched, it is logged with a number of key fields such that this can be visualised in Kibana.

We don't currently want to set an alarm on each action performed on each feed as this would be ~20 alarms, all of which would be fairly low priority.
