### PR TITLE
For krux in AMP: checking if local storage exists before using it

### DIFF
--- a/facia/public/amp_remote.html
+++ b/facia/public/amp_remote.html
@@ -73,8 +73,23 @@
             return config;
         }
 
+        function isLocalStorageReallyAvailable () {
+            var testKey = 'local-storage-module-test';
+            var data = 'test';
+
+            try {
+                // to fully test, need to set item
+                // http://stackoverflow.com/questions/9077101/iphone-localstorage-quota-exceeded-err-issue#answer-12976988
+                localStorage.setItem(testKey, data);
+                localStorage.removeItem(testKey);
+                return true;
+            } catch (e) {
+                return false;
+            }
+        }
+
         function attachKruxSegments(config) {
-            if (localStorage && localStorage.getItem('kxsegs') !== null) {
+            if (localStorage && isLocalStorageReallyAvailable() && localStorage.getItem('kxsegs') !== null) {
                 var kxSegList = localStorage.getItem('kxsegs').split(',');
 
                 if (kxSegList.length > 0) {

--- a/facia/public/amp_remote.html
+++ b/facia/public/amp_remote.html
@@ -74,7 +74,7 @@
         }
 
         function attachKruxSegments(config) {
-            if (localStorage.getItem('kxsegs') !== null) {
+            if (localStorage && localStorage.getItem('kxsegs') !== null) {
                 var kxSegList = localStorage.getItem('kxsegs').split(',');
 
                 if (kxSegList.length > 0) {


### PR DESCRIPTION
AMP pages will soon be available within Newsstand. In the test our ads aren't loading. The only information I know for sure:
- Ads load in Guardian AMP pages for newsstand for IOS
- On android other third party embeds, like twitter, seem to work
- Some of the calls to Krux and DFP are working, just not the final ones

While talking to @maxspencer and @ChrisOwen101 I learnt that even though it is a webview, localstorage is not supported, and might not be handled by this app. Therefore I am adding a check to the amp remote file.
## Does this affect other platforms - Amp, Apps, etc?

Only affects AMP
## Request for comment

@rich-nguyen 
