### PR TITLE
only send expired over if video is actually expired

### DIFF
--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -23,7 +23,7 @@ object MediaController extends Controller with RendersItemResponse with Logging 
   def renderInfoJson(path: String) = Action.async { implicit request =>
     lookup(path) map {
       case Left(model)  => MediaInfo(expired = false, shouldHideAdverts = model.media.content.shouldHideAdverts)
-      case Right(other) => MediaInfo(expired = true, shouldHideAdverts = true)
+      case Right(other) => MediaInfo(expired = other.header.status == 410, shouldHideAdverts = true)
     } map { mediaInfo =>
       Cached(60)(JsonComponent(Json.toJson(mediaInfo).as[JsObject]))
     }

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -5,6 +5,7 @@ import common._
 import contentapi.ContentApiClient
 import conf.switches.Switches
 import model._
+import play.api.http.Status._
 import play.api.libs.json.{Format, JsObject, Json}
 import play.api.mvc._
 import views.support.RenderOtherStatus
@@ -23,7 +24,7 @@ object MediaController extends Controller with RendersItemResponse with Logging 
   def renderInfoJson(path: String) = Action.async { implicit request =>
     lookup(path) map {
       case Left(model)  => MediaInfo(expired = false, shouldHideAdverts = model.media.content.shouldHideAdverts)
-      case Right(other) => MediaInfo(expired = other.header.status == 410, shouldHideAdverts = true)
+      case Right(other) => MediaInfo(expired = other.header.status == GONE, shouldHideAdverts = true)
     } map { mediaInfo =>
       Cached(60)(JsonComponent(Json.toJson(mediaInfo).as[JsObject]))
     }


### PR DESCRIPTION
## What does this change?

At the moment we say a video is expired if we get a bad response from CAPI.
We should only say it's expired if that is actually what it is.
## What is the value of this and can you measure success?

Videos will stop breaking.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

🐘 
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
