### PR TITLE
Headlines should show for Immersive Articles

### DIFF
--- a/article/app/views/fragments/headerImmersive.scala.html
+++ b/article/app/views/fragments/headerImmersive.scala.html
@@ -8,11 +8,4 @@
     here for SEO. *@
     <h1 class="is-hidden" itemprop="headline">@Html(article.trail.headline)</h1>
 
-    @if(article.fields.standfirst.isDefined && !article.isUSMinute) {
-        <div class="gs-container content__wrapper--standfirst mobile-only">
-            <div class="content__main-column">
-                @fragments.standfirst(article)
-            </div>
-        </div>
-    }
 </header>

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -135,4 +135,9 @@
             </div>
         </div>
     </div>
+    @if(isArticle && page.item.fields.standfirst.isDefined && !isMinuteSeries) {
+        <div class="content__wrapper--standfirst mobile-only">
+            @fragments.standfirst(page.item)
+        </div>
+    }
 }

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -63,76 +63,76 @@
             <div class="content--minute-article--overlay"></div>
         }
 
-        @if(!hasEmbed) {
-            <div class="immersive-main-media__headline-container @if(!isMinuteSeries){immersive-main-media__headline-container--dark}">
-                <div class="gs-container">
-                    @if(!isGallery && !isMinuteSeries) { <div class="content__main-column"> }
+        <div class="@RenderClasses(Map(
+            "immersive-main-media__headline-container--dark" -> !isMinuteSeries
+        ), "immersive-main-media__headline-container")
+        ">
+            <div class="gs-container">
+                @if(!isGallery && !isMinuteSeries) { <div class="content__main-column"> }
 
-                    @if(!isMinuteSeries) {
-                        @fragments.meta.metaInline(page.item)
-                    }
+                @if(!isMinuteSeries) {
+                    @fragments.meta.metaInline(page.item)
+                }
 
-                    <h1 class="@RenderClasses(Map(
+                <h1 class="@RenderClasses(Map(
                         "content__headline--gallery" -> isGallery,
                         "content__headline--immersive-article" -> isArticle,
                         "content__headline--minute" -> isMinuteSeries,
                         "content__headline--immersive--with-main-media" -> (page.item.fields.main.nonEmpty || isGallery)
-                    ),
-                        "content__headline", "content__headline--immersive")
-                    ">
-                        @page.item match {
-                            case _: Gallery => {
-                                @fragments.inlineSvg("camera", "icon", List("inline-tone-fill", "inline-icon--media"))
+                    ), "content__headline", "content__headline--immersive")
+                ">
+                    @page.item match {
+                        case _: Gallery => {
+                            @fragments.inlineSvg("camera", "icon", List("inline-tone-fill", "inline-icon--media"))
+                        }
+                        case article: Article => {
+                            @if(isMinuteSeries) {
+                                <a href="@LinkTo {/us-news/series/the-campaign-minute-2016}" class="logo--minute-article">
+                                    <span class="u-h">The Minute - </span>
+                                    @fragments.inlineSvg("minute-logo", "logo")
+                                </a>
                             }
+                        }
+                        case _ => {}
+                    }
+                    @Html(page.item.trail.headline)
+                </h1>
+
+                @page match {
+                    case galleryPage: GalleryPage => {
+                        @if(page.item.content.hasTonalHeaderByline) {
+                            @page.item.trail.byline.map { text =>
+                                <span class="content__headline content__headline--byline">@ContributorLinks(text, page.item.tags.contributors)</span>
+                            }
+                        }
+                    }
+                    case _ => {
+                        @page.item match {
                             case article: Article => {
                                 @if(isMinuteSeries) {
-                                    <a href="@LinkTo {/us-news/series/the-campaign-minute-2016}" class="logo--minute-article">
-                                        <span class="u-h">The Minute - </span>
-                                        @fragments.inlineSvg("minute-logo", "logo")
-                                    </a>
+
+                                    @if(!article.trail.shouldHidePublicationDate) {
+                                        @fragments.meta.dateline(article.trail.webPublicationDate, article.fields.lastModified, article.content.hasBeenModified, article.tags.isLiveBlog, article.fields.isLive, article.tags.isUSMinuteSeries)
+                                    }
+
+                                    @if(article.fields.standfirst.isDefined) {
+                                        @fragments.standfirst(article)
+                                    }
+                                }
+
+                                @if(!article.isUSMinute && article.fields.standfirst.isDefined) {
+                                    <div class="hide-on-mobile">
+                                        @fragments.standfirst(article)
+                                    </div>
                                 }
                             }
                             case _ => {}
                         }
-                        @Html(page.item.trail.headline)
-                    </h1>
-
-                    @page match {
-                        case galleryPage: GalleryPage => {
-                            @if(page.item.content.hasTonalHeaderByline) {
-                                @page.item.trail.byline.map { text =>
-                                    <span class="content__headline content__headline--byline">@ContributorLinks(text, page.item.tags.contributors)</span>
-                                }
-                            }
-                        }
-                        case _ => {
-                            @page.item match {
-                                case article: Article => {
-                                    @if(isMinuteSeries) {
-
-                                        @if(!article.trail.shouldHidePublicationDate) {
-                                            @fragments.meta.dateline(article.trail.webPublicationDate, article.fields.lastModified, article.content.hasBeenModified, article.tags.isLiveBlog, article.fields.isLive, article.tags.isUSMinuteSeries)
-                                        }
-
-                                        @if(article.fields.standfirst.isDefined) {
-                                            @fragments.standfirst(article)
-                                        }
-                                    }
-
-                                    @if(!article.isUSMinute && article.fields.standfirst.isDefined) {
-                                        <div class="hide-on-mobile">
-                                            @fragments.standfirst(article)
-                                        </div>
-                                    }
-                                }
-                                case _ => {}
-                            }
-                        }
                     }
+                }
 
-                    @if(!isGallery && !isMinuteSeries) { </div> }
-                </div>
+                @if(!isGallery && !isMinuteSeries) { </div> }
             </div>
-        }
+        </div>
     </div>
 }

--- a/common/app/views/fragments/standfirst.scala.html
+++ b/common/app/views/fragments/standfirst.scala.html
@@ -1,6 +1,6 @@
 @(item: model.ContentType)(implicit request: RequestHeader)
 
-<div class="content__standfirst @if(item.content.isImmersiveGallery) {content__standfirst--gallery}" data-link-name="standfirst" data-component="standfirst">
+<div class="content__standfirst @if(item.content.isImmersiveGallery) {content__standfirst--gallery} @if(item.content.isImmersive && item.tags.isArticle) {content__standfirst--immersive-article}" data-link-name="standfirst" data-component="standfirst">
     @item.fields.trailText.map{ t =>
 
         @defining({

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -121,20 +121,40 @@
     .content__main {
         padding-top: $gs-baseline / 2;
     }
+}
 
-    .content__standfirst {
-        .u-underline {
-            color: $neutral-6;
-            border-bottom: 1px solid rgba($neutral-6, .4);
+.content__standfirst--immersive-article {
+    position: relative;
+    padding-top: .33em;
+    padding-bottom: .5rem;
+    margin-bottom: 0;
+    color: #ffffff;
 
-            &:hover {
-                border-bottom-color: rgba($neutral-6, 1);
-            }
+    @include mq(desktop) {
+        padding-bottom: 1rem;
+
+        &:before {
+            content: '';
+            position: absolute;
+            top: 0;
+            height: 2px;
+            width: gs-span(2);
+            background-color: rgba(255, 255, 255, .2);
+        }
+    }
+
+    .u-underline {
+        color: $neutral-6;
+        border-bottom: 1px solid rgba($neutral-6, .4);
+
+        &:hover {
+            border-bottom-color: rgba($neutral-6, 1);
         }
     }
 }
 
 .content__wrapper--standfirst {
+    @include content-gutter();
     background-color: rgba(0, 0, 0, .5);
 }
 
@@ -161,27 +181,6 @@
     .content__headline--immersive--with-main-media {
         @include mq(desktop) {
             font-size: 3.25rem;
-        }
-    }
-
-    .content__standfirst {
-        position: relative;
-        padding-top: .33em;
-        padding-bottom: .5rem;
-        margin-bottom: 0;
-        color: #ffffff;
-
-        @include mq(desktop) {
-            padding-bottom: 1rem;
-
-            &:before {
-                content: '';
-                position: absolute;
-                top: 0;
-                height: 2px;
-                width: gs-span(2);
-                background-color: rgba(255, 255, 255, .2);
-            }
         }
     }
 


### PR DESCRIPTION
In #12775 I made the mistake of not showing an article's headline if there was an embed as a main media. 

I also put in a fix to show immersive article standfirsts how they should appear
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Screenshots
### Immersive Article with embed

**Before:**
![image](https://cloud.githubusercontent.com/assets/8774970/16202236/bcaea51e-370c-11e6-8c78-d2a3d62182f7.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/8774970/16202323/12ae9488-370d-11e6-8ff5-c343e27e0886.png)
## Request for comment

@sammorrisdesign @sndrs 
