### PR TITLE
Remove DFP timeout and speed up adverts init

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -472,7 +472,7 @@ define([
     }
 
     var waitForAdvert = memoize(function (id) {
-        return new Promise(function (resolve, reject) {
+        return new Promise(function (resolve) {
             checkAdvert();
             function checkAdvert() {
                 var advert = getAdvertById(id);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -473,15 +473,10 @@ define([
 
     var waitForAdvert = memoize(function (id) {
         return new Promise(function (resolve, reject) {
-            var failedAttempts = 50;
             checkAdvert();
             function checkAdvert() {
                 var advert = getAdvertById(id);
                 if (!advert) {
-                    failedAttempts -= 1;
-                    if (failedAttempts === 0) {
-                        reject(new Error('Ad ' + id + ' failed to load in time'));
-                    }
                     window.setTimeout(checkAdvert, 200);
                 } else {
                     resolve(advert);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -185,6 +185,7 @@ define([
     }
 
     function loadAdvertising() {
+        createAdverts();
         googletag.cmd.push(
             defineAdverts,
             setPublisherProvidedId,
@@ -199,9 +200,6 @@ define([
      * attributes on the element.
      */
     function defineAdverts() {
-        // Get all ad slots
-        adverts = qwery(adSlotSelector).map(createAdvert);
-
         // queue ads for load
         adverts.forEach(queueAdvert);
     }
@@ -498,6 +496,11 @@ define([
 
     function trackAdRender(id) {
         return waitForAdvert(id).then(function (_) { return _.whenRendered; });
+    }
+
+    function createAdverts() {
+        // Get all ad slots
+        adverts = qwery(adSlotSelector).map(createAdvert);
     }
 
     function getAdverts(isWithAllAds) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -495,11 +495,6 @@ define([
         });
     }
 
-    function initAdvert(advert) {
-        advert.sizes = getAdBreakpointSizes(advert);
-        advert.slot = defineSlot(advert.node, advert.sizes);
-    }
-
     function startLoadingAdvert(advert) {
         advert.isLoading = true;
     }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/dfp-api.js
@@ -509,7 +509,7 @@ define([
     }
 
     function createAdvert(adSlotNode) {
-        return Object.seal({
+        var advert = {
             id: adSlotNode.id,
             isHidden: false,
             isEmpty: false,
@@ -524,7 +524,18 @@ define([
             node: adSlotNode,
             sizes: null,
             slot: null
+        };
+        advert.whenLoaded = new Promise(function (resolve) {
+            advert.whenLoadedResolver = resolve;
+        }).then(function (isLoaded) {
+            advert.isLoaded = isLoaded;
         });
+        advert.whenRendered = new Promise(function (resolve) {
+            advert.whenRenderedResolver = resolve;
+        }).then(function (isRendered) {
+            advert.isRendered = isRendered;
+        });
+        return Object.seal(advert);
     }
 
     function emptyAdvert(advert) {
@@ -547,16 +558,6 @@ define([
     function initAdvert(advert) {
         advert.sizes = getAdBreakpointSizes(advert);
         advert.slot = defineSlot(advert.node, advert.sizes);
-        advert.whenLoaded = new Promise(function (resolve) {
-            advert.whenLoadedResolver = resolve;
-        }).then(function (isLoaded) {
-            advert.isLoaded = isLoaded;
-        });
-        advert.whenRendered = new Promise(function (resolve) {
-            advert.whenRenderedResolver = resolve;
-        }).then(function (isRendered) {
-            advert.isRendered = isRendered;
-        });
     }
 
     function startLoadingAdvert(advert) {


### PR DESCRIPTION
Multiple modules are waiting for an ad to have rendered before performing an action. This is done via `dfp.trackAdRender` which returns a promise that resolves when the corresponding creative has been rendered. Obviously, this presumes the promise exists in the first place, which, given the asynchronous nature of our code, cannot be assured.

To mitigate this, I introduced [a routine](https://github.com/guardian/frontend/compare/rk-remove-dfp-timeout?expand=1#diff-844a43280e1947d8dd7cc7a480fd0551L476) that _waits_ for an ad slot to have been registered. I optimistically introduced an 500s timeout (I know right? 😆 ) that I then upgraded to a whopping 10s. But this even wasn't enough, in one particular case: if the GPT library takes too much time to load, all our init code is delayed as much. Indeed, [everything is wrapped in a `googletag.cmd.push` call](https://github.com/guardian/frontend/compare/rk-remove-dfp-timeout?expand=1#diff-844a43280e1947d8dd7cc7a480fd0551L1880).

With that in mind, the PR introduces two fundamental changes:
- the decision to set timeout or not is now entirely up to the `dfp.trackAdRender` calling site: it feels arbitrary to unilaterally set a 10s timeout anyway.
- the initialisation of the adverts data structure is done "synchronously": we no longer wait for the GPT library before searching the DOM. This seems reasonable because there is nothing GPT-related during this process. _It is worth pointing out that this removes the reliance on GPT being loaded, but is still asynchronous in nature since we run everything in promises chains._

cc @ScottPainterGNM @rich-nguyen 
