### PR TITLE
Add custom dimensions to the Google Analytics pageview event

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -170,6 +170,7 @@ final case class Content(
   val legallySensitive: Boolean = fields.legallySensitive.getOrElse(false)
 
   def javascriptConfig: Map[String, JsValue] = Map(
+    ("contentId", JsString(metadata.id)),
     ("publication", JsString(publication)),
     ("hasShowcaseMainElement", JsBoolean(elements.hasShowcaseMainElement)),
     ("hasStoryPackage", JsBoolean(hasStoryPackage)),

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -608,7 +608,7 @@ final case class Tags(
   lazy val isImageContent: Boolean = tags.exists { tag => List("type/cartoon", "type/picture", "type/graphic").contains(tag.id) }
   lazy val isInteractive: Boolean = tags.exists { _.id == Tags.Interactive }
 
-  lazy val hasLargeContributorImage: Boolean = tagsOfType("Contributor").filter(_.properties.contributorLargeImagePath.nonEmpty).nonEmpty
+  lazy val hasLargeContributorImage: Boolean = tagsOfType("Contributor").exists(_.properties.contributorLargeImagePath.nonEmpty)
 
   lazy val isCricketLiveBlog = isLiveBlog &&
     tags.map(_.id).exists(tagId => CricketTeams.teamTagIds.contains(tagId)) &&
@@ -626,6 +626,8 @@ final case class Tags(
 
   lazy val keywordIds = keywords.map { _.id }
 
+  lazy val commissioningDesk = tracking.map(_.id).collect { case Tags.CommissioningDesk(desk) => desk }.headOption
+
   def javascriptConfig: Map[String, JsValue] = Map(
     ("keywords", JsString(keywords.map { _.name }.mkString(","))),
     ("keywordIds", JsString(keywordIds.mkString(","))),
@@ -638,7 +640,8 @@ final case class Tags(
     ("tones", JsString(tones.map(_.name).mkString(","))),
     ("toneIds", JsString(tones.map(_.id).mkString(","))),
     ("blogs", JsString(blogs.map { _.name }.mkString(","))),
-    ("blogIds", JsString(blogs.map(_.id).mkString(",")))
+    ("blogIds", JsString(blogs.map(_.id).mkString(","))),
+    ("commissioningDesk", JsString(commissioningDesk.getOrElse("")))
   )
 }
 
@@ -689,6 +692,8 @@ object Tags {
   val reviewMappings = Seq(
     "tone/reviews"
   )
+
+  val CommissioningDesk = """tracking/commissioningdesk/(.*)""".r
 
   def make(apiContent: contentapi.Content) = {
     Tags(apiContent.tags.toList map { Tag.make(_) })

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -16,6 +16,8 @@ import org.scala_tools.time.Imports._
 import play.api.libs.json.{JsBoolean, JsString, JsValue}
 import play.api.mvc.RequestHeader
 
+import scala.util.Random
+
 object Commercial {
 
   private def make(metadata: MetaData, tags: Tags, maybeApiContent: Option[contentapi.Content]): model.Commercial = {
@@ -360,6 +362,23 @@ object Page {
   def getContent(page: Page): Option[ContentType] = {
     getContentPage(page).map(_.item)
   }
+}
+
+object Ophan {
+
+  private val randomChars = Stream.continually(Integer.toString(Math.floor(Random.nextDouble() * 36).toInt, 36))
+
+  /*
+   * This logic is duplicated from
+   * https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+   * Please do not change this without talking to the Ophan project first.
+   */
+  def generatePageViewId: String = {
+    val timestamp = java.lang.Long.toString(new java.util.Date().getTime(), 36)
+    val randomness = randomChars.take(12).mkString
+    s"$timestamp$randomness"
+  }
+
 }
 
 // A Page is something that has metadata, and anything with Metadata can be rendered.

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -1,7 +1,7 @@
 @(item: model.Page)(implicit request: RequestHeader)
 @import common.{Edition, StringEncodings}
 @import conf.Static
-@import play.api.libs.json.Json
+@import play.api.libs.json.{Json, JsString, JsNull}
 @import views.support.{CamelCase, JavaScriptPage}
 
 @defining(Edition(request)) { edition =>
@@ -27,6 +27,17 @@
         },
         "commercial": {
             "showingAdfree" : null
+        },
+        "ophan": {
+            @*
+             * This is duplicated from
+             * https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+             * Please do not change this without talking to the Ophan project first.
+             *@
+            "pageViewId": new Date().getTime().toString(36) + 'xxxxxxxxxxxx'.replace(/x/g, function () {
+                return Math.floor(Math.random() * 36).toString(36);
+            }),
+            "browserId": @JavaScript(StringEncodings.jsonToJS(Json.stringify(request.cookies.get("bwid").map(cookie => JsString(cookie.value)).getOrElse(JsNull))))
         }
     }
 }

--- a/common/app/templates/javaScriptConfig.scala.js
+++ b/common/app/templates/javaScriptConfig.scala.js
@@ -29,14 +29,7 @@
             "showingAdfree" : null
         },
         "ophan": {
-            @*
-             * This is duplicated from
-             * https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
-             * Please do not change this without talking to the Ophan project first.
-             *@
-            "pageViewId": new Date().getTime().toString(36) + 'xxxxxxxxxxxx'.replace(/x/g, function () {
-                return Math.floor(Math.random() * 36).toString(36);
-            }),
+            "pageViewId": @JavaScript(StringEncodings.jsonToJS(Json.stringify(JsString(model.Ophan.generatePageViewId)))),
             "browserId": @JavaScript(StringEncodings.jsonToJS(Json.stringify(request.cookies.get("bwid").map(cookie => JsString(cookie.value)).getOrElse(JsNull))))
         }
     }

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -5,6 +5,7 @@
 
 @if(GoogleAnalyticsSwitch.isSwitchedOn) {
     <script id='google_analytics'>
+
         @***************************************************************************************
         * Standard copy 'n paste Google Analytics code                                         *
         ***************************************************************************************@
@@ -22,10 +23,29 @@
 
         ga('set', 'forceSSL', true);
 
-        ga('send', {
-            hitType: 'pageview',
-            title: '@Html(page.metadata.webTitle.javascriptEscaped)'
-        });
+        ga('set', 'title', guardian.config.page.webTitle);
+
+        @***************************************************************************************
+        * Custom dimensions common to all platforms across the whole Guardian estate           *
+        ***************************************************************************************@
+        ga('set', 'dimension1', guardian.config.ophan.pageViewId);
+        ga('set', 'dimension2', guardian.config.ophan.browserId);
+        ga('set', 'dimension3', 'theguardian.com'); @* Platform *@
+
+        @***************************************************************************************
+        * Custom dimensions for 'editorial' platforms (this site, the mobile apps, etc.)       *
+        * Some of these will be undefined for non-content pages, but that's fine.              *
+        ***************************************************************************************@
+        ga('set', 'dimension4', guardian.config.page.section);
+        ga('set', 'dimension5', guardian.config.page.contentType);
+        ga('set', 'dimension6', guardian.config.page.commissioningDesk);
+        ga('set', 'dimension7', guardian.config.page.contentId);
+        ga('set', 'dimension8', guardian.config.page.author);
+        ga('set', 'dimension9', guardian.config.page.keywordIds);
+        ga('set', 'dimension10', guardian.config.page.toneIds);
+        ga('set', 'dimension11', guardian.config.page.seriesId);
+
+        ga('send', 'pageview');
     </script>
 
     @*

--- a/static/src/javascripts/projects/common/utils/config.js
+++ b/static/src/javascripts/projects/common/utils/config.js
@@ -15,13 +15,6 @@ define([
         config.page.adUnit = ['/', config.page.dfpAccountId, '/', adUnitOverride].join('');
     }
 
-    // This is duplicated from
-    // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
-    // Please do not change this without talking to the Ophan project first.
-    config.ophan = {pageViewId: new Date().getTime().toString(36) + 'xxxxxxxxxxxx'.replace(/x/g, function () {
-        return Math.floor(Math.random() * 36).toString(36);
-    })};
-
     return assign({
         hasTone: function (name) {
             return (this.page.tones || '').indexOf(name) > -1;

--- a/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
+++ b/static/test/javascripts/spec/common/commercial/build-page-targeting.spec.js
@@ -58,7 +58,9 @@ define([
                         audienceScienceGateway: true
                     };
 
-                    config.ophan.pageViewId = 'presetOphanPageViewId';
+                    config.ophan = {
+                        pageViewId: 'presetOphanPageViewId'
+                    };
 
                     cookies.get = function () {
                         return 'ng101';

--- a/static/test/javascripts/spec/common/commercial/dfp/dfp-api.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/dfp-api.spec.js
@@ -84,6 +84,9 @@ define([
                 config.images = {
                     commercial: {}
                 };
+                config.ophan = {
+                    pageViewId: 'dummyOphanPageViewId'
+                };
 
                 fixtures.render(fixturesConfig);
                 $style = $.create('<style type="text/css"></style>')


### PR DESCRIPTION
## What does this change?

Adds the following custom dimensions to the GA pageview event. 
1. Ophan pageview ID
2. Ophan browser ID
3. Platform (hardcoded to "theguardian.com")
4. Section ID
5. Content type
6. Commissioning desk
7. Content ID
8. Author name(s)
9. Keyword tag IDs
10. Tone tag IDs
11. Series tag ID

Of course, some of these are only relevant to content pages. On other pages the relevant JS variable will be `undefined` and so the custom dimension will not be set.

If this works as expected, I'll make a separate PR to remove the 1% sampling and switch to the new 'proper' GA account.
## What is the value of this and can you measure success?

More useful reporting in GA.
## Does this affect other platforms - Amp, Apps, etc?

No. GA integration for AMP will need to be done separately. Apps will also implement separately, using the same custom dimensions as the site.
## Screenshots

![screen shot 2016-06-21 at 10 46 45](https://cloud.githubusercontent.com/assets/106760/16225608/63231b0e-379f-11e6-9f49-6c1ef53a7623.png)

Not sure what to do about the keyword tag IDs list being too long to fit into a parameter. Will need some thought, but this is good enough for now.
## Request for comment

@gklopper 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
