### PR TITLE
Allow the app to serve files from /node_modules in dev

### DIFF
--- a/common/app/dev/DevAssetsController.scala
+++ b/common/app/dev/DevAssetsController.scala
@@ -20,6 +20,7 @@ object DevAssetsController extends Controller with ExecutionContexts {
     case path if new File(s"static/src/$path").exists() => s"static/src/$path"
     case path if new File(s"static/public/$path").exists() => s"static/public/$path"
     case path if new File(s"static/target/$path").exists() => s"static/target/$path"
+    case path if new File(s"node_modules/$path").exists() => s"node_modules/$path"
   }
 
   // All compiled assets will be loaded from the hash output folder.


### PR DESCRIPTION
## What does this change?

requests to `/assets` if `useHashedBundles` is false with also check in `/node_modules` 
## What is the value of this and can you measure success?

lays ground for removal of bower components
## Does this affect other platforms - Amp, Apps, etc?

just checking this is a good way to do it, not safety hole etc
## Request for comment

@johnduffell @rich-nguyen 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
