### PR TITLE
extend test for another month

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-test.js
@@ -48,7 +48,7 @@ define([
 
             this.id = 'ParticipationDiscussionTest';
             this.start = '2016-05-26';
-            this.expiry = '2016-07-24';
+            this.expiry = '2016-07-25';
             this.author = 'Nathaniel Bennett';
             this.description = 'Hide comments for a percentage of users to determine what effect it has on their dwell time and loyalty ';
             this.audience = 0.1;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-test.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/participation-discussion-test.js
@@ -48,7 +48,7 @@ define([
 
             this.id = 'ParticipationDiscussionTest';
             this.start = '2016-05-26';
-            this.expiry = '2016-06-24';
+            this.expiry = '2016-07-24';
             this.author = 'Nathaniel Bennett';
             this.description = 'Hide comments for a percentage of users to determine what effect it has on their dwell time and loyalty ';
             this.audience = 0.1;


### PR DESCRIPTION
## What does this change?

Extends the test introduced here https://github.com/guardian/frontend/pull/12990, for another month
## What is the value of this and can you measure success?

As before
## Does this affect other platforms - Amp, Apps, etc?

N/A
## Screenshots
## Request for comment

@gtrufitt @crifmulholland 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
