### PR TITLE
Add us-news, commentisfree and australia-news as secure LinkTo targets

### DIFF
--- a/common/app/common/LinkTo.scala
+++ b/common/app/common/LinkTo.scala
@@ -31,7 +31,8 @@ trait LinkTo extends Logging {
   val httpsEnabledSections: Seq[String] =
     Seq("info", "email", "science", "crosswords", "technology", "business", "sport", "football",
       "culture", "film", "tv-and-radio", "music", "books", "artanddesign", "stage",
-      "membership", "uk-news", "world", "cities", "environment", "money", "society")
+      "membership", "uk-news", "world", "cities", "environment", "money", "society",
+      "us-news", "commentisfree", "australia-news")
 
   def apply(html: Html)(implicit request: RequestHeader): String = this(html.toString(), Edition(request))
   def apply(link: String)(implicit request: RequestHeader): String = this(link, Edition(request))


### PR DESCRIPTION
## What does this change?

Makes LinkTo-generated links use https for us-news, commentisfree and australia-news. Existing tests pick up these new values so no new ones have been added.
## What is the value of this and can you measure success?

Prevents an unnecessary redirect from http to https when following links in those sections.
## Does this affect other platforms - Amp, Apps, etc?

No.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
