### PR TITLE
Fix liveblog header padding

### DIFF
--- a/static/src/stylesheets/module/_badging.scss
+++ b/static/src/stylesheets/module/_badging.scss
@@ -58,53 +58,53 @@
 
 /* Liveblog Rules
    ========================================================================== */
-.content--liveblog {
-    .content__head--aus-election {
-        .content__header .gs-container {
-            background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog.jpg');
-        }
 
-        &.tonal__head--tone-dead {
-            .content__header .gs-container {
-                background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog_dead.jpg');
-            }
-        }
-    }
-
-    .content__head--us-election {
-        .content__header .gs-container {
-            background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615039/uselectionliveblogon.jpg');
-        }
-
-        &.tonal__head--tone-dead {
-            .content__header .gs-container {
-                background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615570/uselectionliveblogoff.jpg');
-            }
-        }
-    }
-
+.content__head--aus-election {
     .content__header .gs-container {
-        background-position: right bottom;
-        background-repeat: no-repeat;
-        background-size: gs-span(4);
+        background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog.jpg');
+    }
+
+    &.tonal__head--tone-dead {
+        .content__header .gs-container {
+            background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog_dead.jpg');
+        }
+    }
+}
+
+.content__head--us-election {
+    .content__header .gs-container {
+        background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615039/uselectionliveblogon.jpg');
+    }
+
+    &.tonal__head--tone-dead {
+        .content__header .gs-container {
+            background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615570/uselectionliveblogoff.jpg');
+        }
+    }
+}
+
+.content__head--aus-election .content__header .gs-container,
+.content__head--us-election .content__header .gs-container {
+    background-position: right bottom;
+    background-repeat: no-repeat;
+    background-size: gs-span(4);
+    padding-bottom: gs-height(2) + $gs-baseline * 2;
+
+    @include mq(tablet) {
+        padding-bottom: gs-height(3);
+        background-size: gs-span(5);
+    }
+
+    @include mq(desktop) {
+        padding-bottom: gs-height(4);
+    }
+
+    @include mq(leftCol) {
+        padding-bottom: gs-height(3);
+    }
+
+    @include mq(wide) {
         padding-bottom: gs-height(2) + $gs-baseline * 2;
-
-        @include mq(tablet) {
-            padding-bottom: gs-height(3);
-            background-size: gs-span(5);
-        }
-
-        @include mq(desktop) {
-            padding-bottom: gs-height(4);
-        }
-
-        @include mq(leftCol) {
-            padding-bottom: gs-height(3);
-        }
-
-        @include mq(wide) {
-            padding-bottom: gs-height(2) + $gs-baseline * 2;
-            background-size: gs-span(6);
-        }
+        background-size: gs-span(6);
     }
 }


### PR DESCRIPTION
## What does this change?

Fixes a padding issue with liveblog headers where styles for liveblog election headers were applying to all liveblog headers. This was introduced in #13282 
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

Regular liveblogs are fixed :
**before:**
<img width="1160" alt="screen shot 2016-06-21 at 14 39 40" src="https://cloud.githubusercontent.com/assets/1289259/16231659/175fdbd8-37bf-11e6-961d-668fc4eaf6a5.png">

**after:**
<img width="1147" alt="screen shot 2016-06-21 at 14 39 32" src="https://cloud.githubusercontent.com/assets/1289259/16231669/1ea9ea6e-37bf-11e6-93f8-81313c0d9f3b.png">

**before:**
<img width="1148" alt="screen shot 2016-06-21 at 15 04 03" src="https://cloud.githubusercontent.com/assets/1289259/16232284/d0ab1380-37c1-11e6-9a84-ea80a18f694c.png">

**after:**
<img width="1152" alt="screen shot 2016-06-21 at 15 03 57" src="https://cloud.githubusercontent.com/assets/1289259/16232296/dd34cc68-37c1-11e6-9e7d-d90bbf60a0b6.png">

Election Liveblog stay the same :

**before:**
<img width="1161" alt="screen shot 2016-06-21 at 14 39 16" src="https://cloud.githubusercontent.com/assets/1289259/16231908/447cc7e2-37c0-11e6-90a5-897d17458ddf.png">

**after:**
<img width="1161" alt="screen shot 2016-06-21 at 14 39 16" src="https://cloud.githubusercontent.com/assets/1289259/16232053/e96406d0-37c0-11e6-8c72-35fac2aaa96b.png">
## Request for comment

@NataliaLKB @sammorrisdesign 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
