### PR TITLE
Updated bottom adblock banner to show for mobile too. Continue to exc…

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/adblock-messages.js
@@ -31,23 +31,19 @@ define([
         return config.switches.adblock;
     }
 
-    function noAdblockMsg() {
-        return adblockInUseSync() && notMobile() && (
-                !visitedMoreThanOnce() ||
-                !isAdblockSwitchOn() ||
-                (isAdblockSwitchOn() && visitedMoreThanOnce() && isPayingMember()));
-    }
-
     function showAdblockMsg() {
         return isAdblockSwitchOn() &&
-                adblockInUseSync() &&
-                !isPayingMember() &&
-                visitedMoreThanOnce() &&
-                notMobile();
+            adblockInUseSync() &&
+            !isPayingMember() &&
+            visitedMoreThanOnce();
+    }
+
+    function showAdblockBanner() {
+        return showAdblockMsg() && notMobile();
     }
 
     return {
-        noAdblockMsg: noAdblockMsg,
-        showAdblockMsg: showAdblockMsg
+        showAdblockMsg: showAdblockMsg,
+        showAdblockBanner: showAdblockBanner
     };
 });

--- a/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
+++ b/static/src/javascripts/projects/common/modules/commercial/donot-use-adblock.js
@@ -95,6 +95,8 @@ define([
         // Show messages only if adblock is used by non paying member
         if (adblockMsg.showAdblockMsg()) {
             showAdblockMessage();
+        }
+        if (adblockMsg.showAdblockBanner()) {
             showAdblockBanner();
         }
     }

--- a/static/test/javascripts/spec/common/commercial/adblock-messages.spec.js
+++ b/static/test/javascripts/spec/common/commercial/adblock-messages.spec.js
@@ -38,7 +38,7 @@ define([
             mockUserHasAdblock = true;
             mockBreakpoint = 'desktop';
 
-            expect(adblockMessage.noAdblockMsg()).toBe(true);
+            expect(adblockMessage.showAdblockMsg()).toBe(false);
         });
 
         it('should not show adblock messages when the adblock switch is off', function () {
@@ -47,7 +47,7 @@ define([
             mockUserHasAdblock = true;
             mockBreakpoint = 'desktop';
 
-            expect(adblockMessage.noAdblockMsg()).toBe(true);
+            expect(adblockMessage.showAdblockMsg()).toBe(false);
         });
 
         it('should not show adblock messages for non adblock users', function () {
@@ -68,7 +68,7 @@ define([
                 return true;
             };
 
-            expect(adblockMessage.noAdblockMsg()).toBe(true);
+            expect(adblockMessage.showAdblockMsg()).toBe(false);
         });
 
         it('should show adblock messages for non paying members', function () {
@@ -81,6 +81,30 @@ define([
             };
 
             expect(adblockMessage.showAdblockMsg()).toBe(true);
+        });
+
+        it('should show adblock messages for mobile', function () {
+            storage.local.set('gu.alreadyVisited', 10);
+            config.switches.adblock = true;
+            mockUserHasAdblock = true;
+            mockBreakpoint = 'mobile';
+            userFeatures.isPayingMember = function () {
+                return false;
+            };
+
+            expect(adblockMessage.showAdblockMsg()).toBe(true);
+        });
+
+        it('should not show adblock banner for mobile', function () {
+            storage.local.set('gu.alreadyVisited', 10);
+            config.switches.adblock = true;
+            mockUserHasAdblock = true;
+            mockBreakpoint = 'mobile';
+            userFeatures.isPayingMember = function () {
+                return false;
+            };
+
+            expect(adblockMessage.showAdblockBanner()).toBe(false);
         });
     });
 });


### PR DESCRIPTION
## What does this change?

This changes the Membership Adblock banner on the footer of the front to show it for mobile customers in addition to desktop currently.
- Updated bottom adblock banner to show for mobile too. 
- Continue to exclude the top banner for mobile.
## What is the value of this and can you measure success?

A previous change to refresh it for people who had closed it, brought in lots of new Supporters.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

<img width="332" alt="picture 117" src="https://cloud.githubusercontent.com/assets/1515970/16232796/d2d3ba2a-37c3-11e6-8f1a-f144a97782cf.png">
<img width="422" alt="picture 124" src="https://cloud.githubusercontent.com/assets/1515970/16232850/fdb91fd2-37c3-11e6-9b82-5227135a5b7c.png">
<img width="723" alt="picture 126" src="https://cloud.githubusercontent.com/assets/1515970/16232856/03bbce02-37c4-11e6-8eea-bf32ea3992df.png">
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->

cc @joelochlann @patstirling 
