### PR TITLE
Fabric: Fix wrong slot name in articles

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -23,11 +23,13 @@ define([
     /* bodyAds is a counter that keeps track of the number of inline MPUs
      * inserted dynamically. It is used to give each MPU its own ID. */
     var bodyAds;
+    var replaceTopSlot;
     var inlineMerchRules;
     var longArticleRules;
 
     function boot() {
         bodyAds = 0;
+        replaceTopSlot = detect.isBreakpoint({max : 'phablet'});
     }
 
     function getRules() {
@@ -96,7 +98,7 @@ define([
                 countAdded += 1;
                 var para = paras.shift();
                 var adDefinition = 'inline' + bodyAds;
-                insertAdAtPara(para, adDefinition, 'inline');
+                insertAdAtPara(para, replaceTopSlot && countAdded === 1 ? 'top-above-nav' : adDefinition, 'inline');
             }
             return countAdded;
         }


### PR DESCRIPTION
It was decided that the first inline slot should be named `top-above-nav` on smartphones, so that Fabric creatives can be delivered.

**This is quite urgent** as a running campaign is under-delivering.

cc @rich-nguyen 
