### PR TITLE
Making election backgrounds only apply on liveblogs

### DIFF
--- a/static/src/stylesheets/module/_badging.scss
+++ b/static/src/stylesheets/module/_badging.scss
@@ -59,52 +59,54 @@
 /* Liveblog Rules
    ========================================================================== */
 
-.content__head--aus-election {
-    .content__header .gs-container {
-        background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog.jpg');
-    }
-
-    &.tonal__head--tone-dead {
+.content--liveblog {
+    .content__head--aus-election {
         .content__header .gs-container {
-            background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog_dead.jpg');
+            background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog.jpg');
+        }
+
+        &.tonal__head--tone-dead {
+            .content__header .gs-container {
+                background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog_dead.jpg');
+            }
         }
     }
-}
 
-.content__head--us-election {
-    .content__header .gs-container {
-        background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615039/uselectionliveblogon.jpg');
-    }
-
-    &.tonal__head--tone-dead {
+    .content__head--us-election {
         .content__header .gs-container {
-            background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615570/uselectionliveblogoff.jpg');
+            background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615039/uselectionliveblogon.jpg');
+        }
+
+        &.tonal__head--tone-dead {
+            .content__header .gs-container {
+                background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615570/uselectionliveblogoff.jpg');
+            }
         }
     }
-}
 
-.content__head--aus-election .content__header .gs-container,
-.content__head--us-election .content__header .gs-container {
-    background-position: right bottom;
-    background-repeat: no-repeat;
-    background-size: gs-span(4);
-    padding-bottom: gs-height(2) + $gs-baseline * 2;
-
-    @include mq(tablet) {
-        padding-bottom: gs-height(3);
-        background-size: gs-span(5);
-    }
-
-    @include mq(desktop) {
-        padding-bottom: gs-height(4);
-    }
-
-    @include mq(leftCol) {
-        padding-bottom: gs-height(3);
-    }
-
-    @include mq(wide) {
+    .content__head--aus-election .content__header .gs-container,
+    .content__head--us-election .content__header .gs-container {
+        background-position: right bottom;
+        background-repeat: no-repeat;
+        background-size: gs-span(4);
         padding-bottom: gs-height(2) + $gs-baseline * 2;
-        background-size: gs-span(6);
+
+        @include mq(tablet) {
+            padding-bottom: gs-height(3);
+            background-size: gs-span(5);
+        }
+
+        @include mq(desktop) {
+            padding-bottom: gs-height(4);
+        }
+
+        @include mq(leftCol) {
+            padding-bottom: gs-height(3);
+        }
+
+        @include mq(wide) {
+            padding-bottom: gs-height(2) + $gs-baseline * 2;
+            background-size: gs-span(6);
+        }
     }
 }


### PR DESCRIPTION
## What does this change?

This fixes a header background image regression caused in #13364
## Screenshots

**before:**

<img width="1151" alt="screen shot 2016-06-21 at 16 44 15" src="https://cloud.githubusercontent.com/assets/1289259/16236162/40aeb7ce-37cf-11e6-909a-2fd60a9100ac.png">

**after:**

<img width="1156" alt="screen shot 2016-06-21 at 16 45 14" src="https://cloud.githubusercontent.com/assets/1289259/16236187/5dbf6fc0-37cf-11e6-94b6-8696c5371f1e.png">
## Request for comment

@sammorrisdesign @NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
