### PR TITLE
init media tests in correct place

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -403,7 +403,10 @@ define([
     function initWithRaven(withPreroll) {
         raven.wrap(
             { tags: { feature: 'media' } },
-            function () { initPlayer(withPreroll); }
+            function () {
+                initPlayer(withPreroll);
+                initTests();
+            }
         )();
     }
 
@@ -465,7 +468,6 @@ define([
         initFacia();
         initMoreInSection();
         initOnwardContainer();
-        initTests();
     }
 
     return {


### PR DESCRIPTION
## What does this change?

there was no guarantee that the video was enhanced previously; moving initTests to initWithRaven does guarantee the player has finished initializing
## What is the value of this and can you measure success?

videojs elements are on the DOM before a test that manipulates them is run
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

💻
## Request for comment

@jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
