### PR TITLE
Immersive article headline tweaks

### DIFF
--- a/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveGalleryMainMedia.scala.html
@@ -1,0 +1,37 @@
+@(page: ContentPage)(implicit request: RequestHeader)
+
+@import layout.ContentWidths.MainMedia
+@import model.ContentPage
+@import views.support.TrailCssClasses.toneClass
+@import views.support.ContributorLinks
+
+<div class="content content--immersive tonal tonal--@toneClass(page.item) immersive-main-media">
+
+    @page.item.elements.mainPicture.map(_.images).orElse(page.item.trail.trailPicture).map { picture =>
+        @fragments.image(
+            picture = picture,
+            classes = Seq("immersive-main-media__media"),
+            widths = MainMedia.immersive,
+            imageAltText = "",
+            isImmersiveMainMedia = true
+        )
+    }
+
+    <div class="immersive-main-media__headline-container--dark immersive-main-media__headline-container">
+        <div class="gs-container">
+            @fragments.meta.metaInline(page.item)
+
+            <h1 class="content__headline content__headline--immersive content__headline--gallery content__headline--immersive--with-main-media">
+                @fragments.inlineSvg("camera", "icon", List("inline-tone-fill", "inline-icon--media"))
+                @Html(page.item.trail.headline)
+            </h1>
+
+            @if(page.item.content.hasTonalHeaderByline) {
+                @page.item.trail.byline.map { text =>
+                    <span class="content__headline content__headline--byline">@ContributorLinks(text, page.item.tags.contributors)</span>
+                }
+            }
+
+        </div>
+    </div>
+</div>

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -1,57 +1,40 @@
 @(page: ContentPage)(implicit request: RequestHeader)
 
 @import layout.ContentWidths.MainMedia
-@import model.{Gallery,Article,ContentPage,GalleryPage}
+@import model.ContentPage
 @import views.support.TrailCssClasses.toneClass
-@import views.support.{ContributorLinks, RenderClasses}
+@import views.support.RenderClasses
 
 @defining((
-    page.item.tags.isGallery,
-    page.item.tags.isArticle,
     page.item.tags.isUSMinuteSeries,
-    page.item.tags.isArticle && page.item.elements.hasMainEmbed,
-    page.item.fields.main.nonEmpty || page.item.tags.isGallery
-)) { case (isGallery, isArticle, isMinuteSeries, hasEmbed, hasMainMedia) =>
+    page.item.elements.hasMainEmbed,
+    page.item.fields.main.nonEmpty
+)) { case (isMinuteSeries, hasEmbed, hasMainMedia) =>
 
     <div class="@RenderClasses(Map(
-            "new-gallery" -> isGallery,
-            "content--immersive-article" -> isArticle,
             "content--minute-article" -> isMinuteSeries,
             "content--immersive-article-without-main-media" -> !hasMainMedia,
             "immersive-main-media" -> hasMainMedia
         ),
-        "content", "content--immersive tonal", s"tonal--${toneClass(page.item)}")
+        "content", "content--immersive", "content--immersive-article", "tonal", s"tonal--${toneClass(page.item)}")
     ">
-        @if(!isGallery) {
-            <div class="gs-container immersive-main-media__logo">
-                <a href="@LinkTo{/}">
-                    <span class="u-h">The Guardian</span>
-                    @fragments.inlineSvg("guardian-logo-160", "logo", Seq("immersive-main-media__logo__svg"))
-                </a>
-                @page.item match {
-                    case article: Article => {
-                        @if(article.isUSMinute) {
-                            <a class="logo--us-election" href="@LinkTo{/us-news/us-elections-2016}">
-                                <span class="u-h">The US Election 2016</span>
-                                @fragments.inlineSvg("us-election-logo", "logo")
-                            </a>
-                        }
-                    }
-                    case _ => {}
-                }
-            </div>
-        }
+        <div class="gs-container immersive-main-media__logo">
+            <a href="@LinkTo{/}">
+                <span class="u-h">The Guardian</span>
+                @fragments.inlineSvg("guardian-logo-160", "logo", Seq("immersive-main-media__logo__svg"))
+            </a>
 
-        @if(isArticle && hasEmbed) {
-            <div class="immersive-main-media__media">
-                <div class="immersive-main-media__media__loading">
-                    <div class="immersive-main-media__loading-animation is-updating"></div>
-                    <span class="u-h">Loading header</span>
-                </div>
-                @Html(page.item.fields.main)
-            </div>
-        } else {
-            @if(hasMainMedia) {
+            @if(isMinuteSeries) {
+                <a class="logo--us-election" href="@LinkTo{/us-news/us-elections-2016}">
+                    <span class="u-h">The US Election 2016</span>
+                    @fragments.inlineSvg("us-election-logo", "logo")
+                </a>
+            }
+
+        </div>
+
+        <div class="immersive-main-media__media">
+            @if(page.item.elements.hasMainPicture) {
                 @page.item.elements.mainPicture.map(_.images).orElse(page.item.trail.trailPicture).map { picture =>
                     @fragments.image(
                         picture = picture,
@@ -61,8 +44,17 @@
                         isImmersiveMainMedia = true
                     )
                 }
+            } else {
+                @if(hasMainMedia) {
+                    <div class="immersive-main-media__media__loading">
+                        <div class="immersive-main-media__loading-animation is-updating"></div>
+                        <span class="u-h">Loading header</span>
+                    </div>
+                    @Html(page.item.fields.main)
+                }
             }
-        }
+        </div>
+
 
         @if(isMinuteSeries) {
             <div class="content--minute-article--overlay"></div>
@@ -74,74 +66,48 @@
             ))
         ">
             <div class="gs-container">
-                @if(!isGallery && !isMinuteSeries) { <div class="content__main-column"> }
+                @if(!isMinuteSeries) { <div class="content__main-column"> }
 
                 @if(!isMinuteSeries) {
                     @fragments.meta.metaInline(page.item)
                 }
 
                 <h1 class="@RenderClasses(Map(
-                        "content__headline--gallery" -> isGallery,
-                        "content__headline--immersive-article" -> isArticle,
                         "content__headline--minute" -> isMinuteSeries,
-                        "content__headline--immersive--with-main-media" -> (hasMainMedia || isGallery)
-                    ), "content__headline", "content__headline--immersive")
+                        "content__headline--immersive--with-main-media" -> hasMainMedia
+                    ), "content__headline", "content__headline--immersive", "content__headline--immersive-article")
                 ">
-                    @page.item match {
-                        case _: Gallery => {
-                            @fragments.inlineSvg("camera", "icon", List("inline-tone-fill", "inline-icon--media"))
-                        }
-                        case article: Article => {
-                            @if(isMinuteSeries) {
-                                <a href="@LinkTo {/us-news/series/the-campaign-minute-2016}" class="logo--minute-article">
-                                    <span class="u-h">The Minute - </span>
-                                    @fragments.inlineSvg("minute-logo", "logo")
-                                </a>
-                            }
-                        }
-                        case _ => {}
+                    @if(isMinuteSeries) {
+                        <a href="@LinkTo {/us-news/series/the-campaign-minute-2016}" class="logo--minute-article">
+                            <span class="u-h">The Minute - </span>
+                            @fragments.inlineSvg("minute-logo", "logo")
+                        </a>
                     }
                     @Html(page.item.trail.headline)
                 </h1>
 
-                @page match {
-                    case galleryPage: GalleryPage => {
-                        @if(page.item.content.hasTonalHeaderByline) {
-                            @page.item.trail.byline.map { text =>
-                                <span class="content__headline content__headline--byline">@ContributorLinks(text, page.item.tags.contributors)</span>
-                            }
-                        }
+                @if(isMinuteSeries) {
+
+                    @if(page.item.trail.shouldHidePublicationDate) {
+                        @fragments.meta.dateline(page.item.trail.webPublicationDate, page.item.fields.lastModified, page.item.content.hasBeenModified, page.item.tags.isLiveBlog, page.item.fields.isLive, isMinuteSeries)
                     }
-                    case _ => {
-                        @page.item match {
-                            case article: Article => {
-                                @if(isMinuteSeries) {
 
-                                    @if(!article.trail.shouldHidePublicationDate) {
-                                        @fragments.meta.dateline(article.trail.webPublicationDate, article.fields.lastModified, article.content.hasBeenModified, article.tags.isLiveBlog, article.fields.isLive, article.tags.isUSMinuteSeries)
-                                    }
-
-                                    @if(article.fields.standfirst.isDefined) {
-                                        @fragments.standfirst(article)
-                                    }
-                                }
-
-                                @if(!article.isUSMinute && article.fields.standfirst.isDefined) {
-                                    <div class="hide-on-mobile">
-                                        @fragments.standfirst(article)
-                                    </div>
-                                }
-                            }
-                            case _ => {}
-                        }
+                    @if(page.item.fields.standfirst.isDefined) {
+                        @fragments.standfirst(page.item)
                     }
                 }
 
-                @if(!isGallery && !isMinuteSeries) { </div> }
+                @if(!isMinuteSeries && page.item.fields.standfirst.isDefined) {
+                    <div class="hide-on-mobile">
+                        @fragments.standfirst(page.item)
+                    </div>
+                }
+
+                @if(!isMinuteSeries) { </div> }
             </div>
         </div>
     </div>
-    @if(isArticle && page.item.fields.standfirst.isDefined && !isMinuteSeries) {
+    @if(page.item.fields.standfirst.isDefined && !isMinuteSeries) {
         <div class="content__wrapper--standfirst mobile-only">
             @fragments.standfirst(page.item)
         </div>

--- a/common/app/views/fragments/immersiveMainMedia.scala.html
+++ b/common/app/views/fragments/immersiveMainMedia.scala.html
@@ -9,15 +9,18 @@
     page.item.tags.isGallery,
     page.item.tags.isArticle,
     page.item.tags.isUSMinuteSeries,
-    page.item.tags.isArticle && (page.item.elements.hasMainEmbed || page.item.elements.elements("main").isEmpty)
-)) { case (isGallery, isArticle, isMinuteSeries, hasEmbed) =>
+    page.item.tags.isArticle && page.item.elements.hasMainEmbed,
+    page.item.fields.main.nonEmpty || page.item.tags.isGallery
+)) { case (isGallery, isArticle, isMinuteSeries, hasEmbed, hasMainMedia) =>
 
     <div class="@RenderClasses(Map(
             "new-gallery" -> isGallery,
             "content--immersive-article" -> isArticle,
-            "content--minute-article" -> isMinuteSeries
+            "content--minute-article" -> isMinuteSeries,
+            "content--immersive-article-without-main-media" -> !hasMainMedia,
+            "immersive-main-media" -> hasMainMedia
         ),
-        "content", "content--immersive tonal", s"tonal--${toneClass(page.item)}", "immersive-main-media")
+        "content", "content--immersive tonal", s"tonal--${toneClass(page.item)}")
     ">
         @if(!isGallery) {
             <div class="gs-container immersive-main-media__logo">
@@ -48,14 +51,16 @@
                 @Html(page.item.fields.main)
             </div>
         } else {
-            @page.item.elements.mainPicture.map(_.images).orElse(page.item.trail.trailPicture).map { picture =>
-                @fragments.image(
-                    picture = picture,
-                    classes = Seq("immersive-main-media__media"),
-                    widths = MainMedia.immersive,
-                    imageAltText = "",
-                    isImmersiveMainMedia = true
-                )
+            @if(hasMainMedia) {
+                @page.item.elements.mainPicture.map(_.images).orElse(page.item.trail.trailPicture).map { picture =>
+                    @fragments.image(
+                        picture = picture,
+                        classes = Seq("immersive-main-media__media"),
+                        widths = MainMedia.immersive,
+                        imageAltText = "",
+                        isImmersiveMainMedia = true
+                    )
+                }
             }
         }
 
@@ -64,8 +69,9 @@
         }
 
         <div class="@RenderClasses(Map(
-            "immersive-main-media__headline-container--dark" -> !isMinuteSeries
-        ), "immersive-main-media__headline-container")
+                "immersive-main-media__headline-container--dark" -> (!isMinuteSeries && hasMainMedia),
+                "immersive-main-media__headline-container" -> hasMainMedia
+            ))
         ">
             <div class="gs-container">
                 @if(!isGallery && !isMinuteSeries) { <div class="content__main-column"> }
@@ -78,7 +84,7 @@
                         "content__headline--gallery" -> isGallery,
                         "content__headline--immersive-article" -> isArticle,
                         "content__headline--minute" -> isMinuteSeries,
-                        "content__headline--immersive--with-main-media" -> (page.item.fields.main.nonEmpty || isGallery)
+                        "content__headline--immersive--with-main-media" -> (hasMainMedia || isGallery)
                     ), "content__headline", "content__headline--immersive")
                 ">
                     @page.item match {

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -54,7 +54,7 @@
 
         @page match {
             case page: model.ContentPage if (page.item.content.isImmersive && !page.item.content.tags.isInteractive) => {
-                <div class="immersive-header-container">
+                <div class="@if(page.item.fields.main.nonEmpty || page.item.content.isImmersiveGallery) { immersive-header-container }">
                     @headerAndTopAds(showAdverts, edition, adBelowNav)
 
                     @fragments.immersiveMainMedia(page)

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -53,8 +53,15 @@
         <a class="u-h skip" href="#maincontent" data-link-name="skip : main content">Skip to main content</a>
 
         @page match {
+            case page: model.ContentPage if (page.item.content.isImmersiveGallery && !page.item.content.tags.isInteractive) => {
+                <div class="immersive-header-container">
+                    @headerAndTopAds(showAdverts, edition, adBelowNav)
+
+                    @fragments.immersiveGalleryMainMedia(page)
+                </div>
+            }
             case page: model.ContentPage if (page.item.content.isImmersive && !page.item.content.tags.isInteractive) => {
-                <div class="@if(page.item.fields.main.nonEmpty || page.item.content.isImmersiveGallery) { immersive-header-container }">
+                <div class="@if(page.item.fields.main.nonEmpty) { immersive-header-container }">
                     @headerAndTopAds(showAdverts, edition, adBelowNav)
 
                     @fragments.immersiveMainMedia(page)

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -5,7 +5,12 @@
         flex-direction: column;
         min-height: 100vh;
     }
+}
 
+.content--immersive-article-without-main-media {
+    background-color: rgba(0, 0, 0, .5);
+    // Overriding padding coming from the content class
+    padding-bottom: 0;
 }
 
 .immersive-main-media {


### PR DESCRIPTION
This PR does two things.

https://github.com/guardian/frontend/commit/83793b0277a63e183cda3196647c76bc5e432d8a: The interactive team expect certain behaviour of interactive articles. The behaviour that I accidentally removed (but makes sense!) was if there is no main media than to move the headline to the top of the page.

[this article](https://www.theguardian.com/technology/2016/apr/12/the-dark-side-of-guardian-comments) Currently looks like this:
![image](https://cloud.githubusercontent.com/assets/8774970/16237439/65d743fe-37d4-11e6-9ea8-6a2585f8ce5c.png)

But they would expect it to look like this:
![image](https://cloud.githubusercontent.com/assets/8774970/16237430/5ed45952-37d4-11e6-9559-60c1202c301c.png)

Note that the interactive is still broken, but they will fix that!

https://github.com/guardian/frontend/commit/d0e4f5866b3c23ca7cc4fb5b8c001cc705daccd6: The second thing is I removed a few pattern matches and separated out the immersive media template into galleries and articles. There still may be more work to do to make it even better, but that can come in later PRs.
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@dominickendrick 🐼 
