### PR TITLE
Reorder images used in commercial containers

### DIFF
--- a/common/app/common/commercial/CardContent.scala
+++ b/common/app/common/commercial/CardContent.scala
@@ -28,7 +28,7 @@ object CardContent {
       lazy val videoImageMedia = maybeContent flatMap (_.elements.mainVideo.map(_.images))
       lazy val imageOverride = properties.image flatMap ImageOverride.createImageMedia
       lazy val defaultTrailPicture = maybeContent flatMap (_.trail.trailPicture)
-      videoImageMedia.orElse(imageOverride).orElse(defaultTrailPicture)
+      imageOverride.orElse(videoImageMedia).orElse(defaultTrailPicture)
     }
 
     val fallbackImageUrl = image flatMap ImgSrc.getFallbackUrl


### PR DESCRIPTION
## What does this change?

Currently, commercial containers do not honour an image override on a video card within the container. By reordering the priority, we now do.
## What is the value of this and can you measure success?

Editorial will send me flowers and chocolates
## Request for comment

@rich-nguyen 
