### PR TITLE
DFP: ring-fence access to iframe document

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/apply-creative-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/apply-creative-template.js
@@ -84,8 +84,12 @@ define([
         }
 
         function fetchCreativeConfig() {
-            var breakoutScript = iFrame.contentDocument.body.querySelector('.breakout__script[type="application/json"]');
-            return breakoutScript ? JSON.parse(breakoutScript.innerHTML) : null;
+            try {
+                var breakoutScript = iFrame.contentDocument.body.querySelector('.breakout__script[type="application/json"]');
+                return breakoutScript ? JSON.parse(breakoutScript.innerHTML) : null;
+            } catch (_) {
+                return null;
+            }
         }
 
         function renderCreative(config) {


### PR DESCRIPTION
Same-origin security policy prevent cross-frame access and may break the whole ad rendering process.

cc @jbreckmckye @rich-nguyen @JonNorman 
