### PR TITLE
Removing space in amp cors origin list

### DIFF
--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -23,7 +23,9 @@ ajax.cors.origin=http://www.theguardian.com,https://www.theguardian.com,https://
 
 amp.host=amp.theguardian.com
 amp.scheme=https://
-amp.cors.origin=https://www.theguardian.com,https://amp.theguardian.com, https://cdn.ampproject.org
+
+# no spaces
+amp.cors.origin=https://www.theguardian.com,https://amp.theguardian.com,https://cdn.ampproject.org
 
 # ID
 id.url=https://profile.theguardian.com


### PR DESCRIPTION
Some requests are failing for `amp-lists` due to a CORS error.

This is an AMP list:
![image](https://cloud.githubusercontent.com/assets/8774970/16268045/974d8ea6-3884-11e6-84e6-db3a742fb52b.png)

This is what the headers should look like if you are looking at the page on the Google cache:
![image](https://cloud.githubusercontent.com/assets/8774970/16268082/c1252676-3884-11e6-86c4-a5c2d755916a.png)

This is what they are currently looking like in some situations:
![image](https://cloud.githubusercontent.com/assets/8774970/16268117/f2b4b260-3884-11e6-9c76-3aef1648ec9d.png)

Sometimes this error shows up, and sometimes it doesn't. When I test CORS locally everything seems to work. I think potentially this space in the prod properties might be the cause of this problem. Other ideas welcome 😄 
## What is the value of this and can you measure success?

The Newsstand team at Google want to launch support for AMP. They are waiting for our pages to work perfectly before this.
## Does this affect other platforms - Amp, Apps, etc?

This should only affect AMP
