### PR TITLE
Standalone controller migration

### DIFF
--- a/admin-jobs/app/controllers/NewsAlertController.scala
+++ b/admin-jobs/app/controllers/NewsAlertController.scala
@@ -53,10 +53,12 @@ trait NewsAlertController extends Controller with AuthenticationSupport with Exe
   }
 }
 
-object NewsAlertController extends NewsAlertController {
+class NewsAlertControllerImpl extends NewsAlertController {
   lazy val breakingNewsUpdater = actorSystem.actorOf(BreakingNewsUpdater.props())
   lazy val apiKey = Configuration.NewsAlert.apiKey.getOrElse(
     throw new RuntimeException("News Alert API Key not set")
   )
 }
+
+object NewsAlertController extends NewsAlertControllerImpl
 

--- a/applications/app/controllers/AllIndexController.scala
+++ b/applications/app/controllers/AllIndexController.scala
@@ -16,7 +16,7 @@ import views.support.PreviousAndNext
 
 import scala.concurrent.Future
 
-object AllIndexController extends Controller with ExecutionContexts with ItemResponses with Dates with Logging {
+class AllIndexController extends Controller with ExecutionContexts with ItemResponses with Dates with Logging {
 
   // no need to set the zone here, it gets it from the date.
   private val dateFormatUTC = DateTimeFormat.forPattern("yyyy/MMM/dd").withZone(DateTimeZone.UTC)
@@ -133,3 +133,5 @@ object AllIndexController extends Controller with ExecutionContexts with ItemRes
 
   private def urlFormat(date: DateTime) = date.toString(dateFormatUTC).toLowerCase
 }
+
+object AllIndexController extends AllIndexController

--- a/applications/app/controllers/CrosswordsController.scala
+++ b/applications/app/controllers/CrosswordsController.scala
@@ -46,7 +46,7 @@ trait CrosswordController extends Controller with Logging with ExecutionContexts
   }
 }
 
-object CrosswordPageController extends CrosswordController {
+class CrosswordPageController extends CrosswordController {
 
   def noResults()(implicit request: RequestHeader) = InternalServerError("Content API query returned an error.")
 
@@ -88,6 +88,8 @@ object CrosswordPageController extends CrosswordController {
     }
   }
 }
+
+object CrosswordPageController extends CrosswordPageController
 
 object CrosswordSearchController extends CrosswordController {
   val searchForm = Form(

--- a/applications/app/controllers/GalleryController.scala
+++ b/applications/app/controllers/GalleryController.scala
@@ -11,7 +11,7 @@ import views.support.RenderOtherStatus
 
 import scala.concurrent.Future
 
-object GalleryController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class GalleryController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
 
   def renderJson(path: String) = render(path)
   def render(path: String) = Action.async { implicit request => renderItem(path) }
@@ -61,3 +61,5 @@ object GalleryController extends Controller with RendersItemResponse with Loggin
   private def isSupported(c: ApiContent) = c.isGallery
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
 }
+
+object GalleryController extends GalleryController

--- a/applications/app/controllers/ImageContentController.scala
+++ b/applications/app/controllers/ImageContentController.scala
@@ -15,7 +15,7 @@ case class ImageContentPage(image: ImageContent, related: RelatedContent) extend
   override lazy val item = image
 }
 
-object ImageContentController extends Controller with RendersItemResponse with ImageQuery with Logging with ExecutionContexts {
+class ImageContentController extends Controller with RendersItemResponse with ImageQuery with Logging with ExecutionContexts {
 
   def renderJson(path: String) = render(path)
 
@@ -35,3 +35,5 @@ object ImageContentController extends Controller with RendersItemResponse with I
   private def isSupported(c: ApiContent) = c.isImageContent
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
 }
+
+object ImageContentController extends ImageContentController

--- a/applications/app/controllers/IndexController.scala
+++ b/applications/app/controllers/IndexController.scala
@@ -6,7 +6,7 @@ import model._
 import play.api.mvc.{Result, RequestHeader}
 import services.IndexPage
 
-object IndexController extends IndexControllerCommon {
+class IndexController extends IndexControllerCommon {
   protected def renderFaciaFront(model: IndexPage)(implicit request: RequestHeader): Result = {
     Cached(model.page) {
       if (request.isRss) {
@@ -21,3 +21,5 @@ object IndexController extends IndexControllerCommon {
     }
   }
 }
+
+object IndexController extends IndexController

--- a/applications/app/controllers/InteractiveController.scala
+++ b/applications/app/controllers/InteractiveController.scala
@@ -15,7 +15,7 @@ case class InteractivePage (interactive: Interactive, related: RelatedContent) e
   override lazy val item = interactive
 }
 
-object InteractiveController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class InteractiveController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
 
   def renderInteractiveJson(path: String): Action[AnyContent] = renderInteractive(path)
   def renderInteractive(path: String): Action[AnyContent] = Action.async { implicit request => renderItem(path) }
@@ -54,3 +54,5 @@ object InteractiveController extends Controller with RendersItemResponse with Lo
 
   override def canRender(i: ItemResponse): Boolean = i.content.exists(_.isInteractive)
 }
+
+object InteractiveController extends InteractiveController

--- a/applications/app/controllers/LatestIndexController.scala
+++ b/applications/app/controllers/LatestIndexController.scala
@@ -12,7 +12,7 @@ import services.{IndexPage, IndexPageItem}
 
 import scala.concurrent.Future
 
-object LatestIndexController extends Controller with ExecutionContexts with implicits.ItemResponses with Logging {
+class LatestIndexController extends Controller with ExecutionContexts with implicits.ItemResponses with Logging {
   def latest(path: String) = Action.async { implicit request =>
     loadLatest(path).map { _.map { index =>
       index.page match {
@@ -64,3 +64,5 @@ object LatestIndexController extends Controller with ExecutionContexts with impl
     }
   }
 }
+
+object LatestIndexController extends LatestIndexController

--- a/applications/app/controllers/MediaController.scala
+++ b/applications/app/controllers/MediaController.scala
@@ -16,7 +16,7 @@ case class MediaPage(media: ContentType, related: RelatedContent) extends Conten
   override lazy val item = media
 }
 
-object MediaController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class MediaController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
 
   def renderJson(path: String) = render(path)
   def render(path: String) = Action.async { implicit request => renderItem(path) }
@@ -63,6 +63,8 @@ object MediaController extends Controller with RendersItemResponse with Logging 
   private def isSupported(c: ApiContent) = c.isVideo || c.isAudio
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
 }
+
+object MediaController extends MediaController
 
 case class MediaInfo(expired: Boolean, shouldHideAdverts: Boolean)
 object MediaInfo {

--- a/applications/app/controllers/NewspaperController.scala
+++ b/applications/app/controllers/NewspaperController.scala
@@ -7,7 +7,7 @@ import model.{Cached, MetaData, SectionSummary, SimplePage}
 import play.api.mvc.{Action, Controller}
 import services.NewspaperQuery
 
-object NewspaperController extends Controller with Logging with ExecutionContexts {
+class NewspaperController extends Controller with Logging with ExecutionContexts {
 
   def latestGuardianNewspaper() = Action.async { implicit request =>
 
@@ -71,5 +71,7 @@ object NewspaperController extends Controller with Logging with ExecutionContext
     Cached(300)(WithoutRevalidationResult(MovedPermanently(s"/$path/$year/$month/$day")))
   }
 }
+
+object NewspaperController extends NewspaperController
 
 case class TodayNewspaper(page: SimplePage, bookSections: Seq[FaciaContainer])

--- a/applications/app/controllers/QuizController.scala
+++ b/applications/app/controllers/QuizController.scala
@@ -40,7 +40,7 @@ case class QuizAnswersPage(
   val shares: Seq[ShareLink] = if (results.isKnowledge) knowledgeShares else personalityShares
 }
 
-object QuizController extends Controller with ExecutionContexts with Logging {
+class QuizController extends Controller with ExecutionContexts with Logging {
 
   def submit(quizId: String, path: String) = Action.async { implicit request =>
     form.playForm.bindFromRequest.fold(
@@ -75,3 +75,5 @@ object QuizController extends Controller with ExecutionContexts with Logging {
   }
 
 }
+
+object QuizController extends QuizController

--- a/article/app/controllers/ArticleController.scala
+++ b/article/app/controllers/ArticleController.scala
@@ -28,7 +28,7 @@ case class ArticlePage(article: Article, related: RelatedContent) extends PageWi
 case class LiveBlogPage(article: Article, currentPage: LiveBlogCurrentPage, related: RelatedContent) extends PageWithStoryPackage
 case class MinutePage(article: Article, related: RelatedContent) extends PageWithStoryPackage
 
-object ArticleController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
+class ArticleController extends Controller with RendersItemResponse with Logging with ExecutionContexts {
 
   private def isSupported(c: ApiContent) = c.isArticle || c.isLiveBlog || c.isSudoku
   override def canRender(i: ItemResponse): Boolean = i.content.exists(isSupported)
@@ -226,6 +226,8 @@ object ArticleController extends Controller with RendersItemResponse with Loggin
   }
 
 }
+
+object ArticleController extends ArticleController
 
 object ParseBlockId extends RegexParsers {
   def apply(input: String): Option[String] = {

--- a/commercial/app/controllers/commercial/BookOffersController.scala
+++ b/commercial/app/controllers/commercial/BookOffersController.scala
@@ -9,7 +9,7 @@ import play.api.mvc._
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-object BookOffersController
+class BookOffersController
   extends Controller
   with ExecutionContexts
   with Logging
@@ -73,3 +73,5 @@ object BookOffersController
     }
   }
 }
+
+object BookOffersController extends BookOffersController

--- a/commercial/app/controllers/commercial/JobsController.scala
+++ b/commercial/app/controllers/commercial/JobsController.scala
@@ -4,7 +4,7 @@ import model.commercial.jobs.{JobSector, JobsAgent}
 import model.{Cached, NoCache}
 import play.api.mvc._
 
-object JobsController extends Controller with implicits.Requests {
+class JobsController extends Controller with implicits.Requests {
 
   implicit val codec = Codec.utf_8
 
@@ -33,3 +33,5 @@ object JobsController extends Controller with implicits.Requests {
     }
   }
 }
+
+object JobsController extends JobsController

--- a/commercial/app/controllers/commercial/MasterclassesController.scala
+++ b/commercial/app/controllers/commercial/MasterclassesController.scala
@@ -4,7 +4,7 @@ import model.commercial.events.{Masterclass, MasterclassAgent}
 import model.{Cached, NoCache}
 import play.api.mvc._
 
-object MasterclassesController extends Controller with implicits.Requests {
+class MasterclassesController extends Controller with implicits.Requests {
 
   implicit val codec = Codec.utf_8
 
@@ -24,3 +24,5 @@ object MasterclassesController extends Controller with implicits.Requests {
     }
   }
 }
+
+object MasterclassesController extends MasterclassesController

--- a/commercial/app/controllers/commercial/MoneyOffers.scala
+++ b/commercial/app/controllers/commercial/MoneyOffers.scala
@@ -7,7 +7,7 @@ import play.api.mvc._
 import play.twirl.api.Html
 import scala.concurrent.Future
 
-object MoneyOffers extends Controller with implicits.Requests {
+class MoneyOffers extends Controller with implicits.Requests {
 
   def renderBestBuys = Action.async { implicit request =>
     Future.successful {
@@ -61,6 +61,8 @@ object MoneyOffers extends Controller with implicits.Requests {
   }
 
 }
+
+object MoneyOffers extends MoneyOffers
 
 sealed trait BestBuysRelevance {
   def view(bestBuys: BestBuys)(implicit request: RequestHeader): Html

--- a/commercial/app/controllers/commercial/SoulmatesController.scala
+++ b/commercial/app/controllers/commercial/SoulmatesController.scala
@@ -6,7 +6,7 @@ import model.{Cached, NoCache}
 import play.api.mvc._
 import play.twirl.api.HtmlFormat
 
-object SoulmatesController extends Controller with implicits.Requests {
+class SoulmatesController extends Controller with implicits.Requests {
 
   private def result(groupName: String,
                      view: (Seq[Member], Option[String], Option[String]) => HtmlFormat.Appendable)
@@ -41,3 +41,5 @@ object SoulmatesController extends Controller with implicits.Requests {
     result(groupName, views.html.soulmates.soulmatesTest(_, _, _))
   }
 }
+
+object SoulmatesController extends SoulmatesController

--- a/commercial/app/controllers/commercial/TravelOffersController.scala
+++ b/commercial/app/controllers/commercial/TravelOffersController.scala
@@ -4,7 +4,7 @@ import model.commercial.travel.TravelOffersAgent
 import model.{Cached, NoCache}
 import play.api.mvc._
 
-object TravelOffersController extends Controller with implicits.Requests {
+class TravelOffersController extends Controller with implicits.Requests {
 
   def renderTravel = Action { implicit request =>
 
@@ -28,3 +28,4 @@ object TravelOffersController extends Controller with implicits.Requests {
     }
   }
 }
+object TravelOffersController extends TravelOffersController

--- a/common/app/controllers/EmailSignupController.scala
+++ b/common/app/controllers/EmailSignupController.scala
@@ -140,7 +140,7 @@ object EmailForm {
   }
 }
 
-object EmailSignupController extends Controller with ExecutionContexts with Logging {
+class EmailSignupController extends Controller with ExecutionContexts with Logging {
   val emailForm: Form[EmailForm] = Form(
     mapping(
       "email" -> nonEmptyText.verifying(emailAddress),
@@ -217,3 +217,5 @@ object EmailSignupController extends Controller with ExecutionContexts with Logg
     TinyResponse.noContent(Some("GET, POST, OPTIONS"))
   }
 }
+
+object EmailSignupController extends EmailSignupController

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -291,6 +291,8 @@ object Int {
   }
 }
 
-object FaciaController extends FaciaController {
+class FaciaControllerImpl extends FaciaController {
   val frontJsonFapi: FrontJsonFapi = FrontJsonFapiLive
 }
+
+object FaciaController extends FaciaControllerImpl

--- a/onward/app/controllers/CardController.scala
+++ b/onward/app/controllers/CardController.scala
@@ -9,7 +9,7 @@ import play.api.libs.ws.WS
 import play.api.libs.json.{ JsObject, Json }
 import scala.concurrent.Future
 
-object CardController extends Controller with Logging with ExecutionContexts {
+class CardController extends Controller with Logging with ExecutionContexts {
 
   import play.api.Play.current
 
@@ -85,3 +85,5 @@ object CardController extends Controller with Logging with ExecutionContexts {
     }
   }
 }
+
+object CardController extends CardController

--- a/onward/app/controllers/ChangeAlphaController.scala
+++ b/onward/app/controllers/ChangeAlphaController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import play.api.mvc._
 
-object ChangeAlphaController extends Controller with PreferenceController {
+class ChangeAlphaController extends Controller with PreferenceController {
 
   def render(optAction: String, redirectUrl: String) = Action { implicit request =>
     val abCookieName: String = "GU_FRONT_ALPHAS"
@@ -14,3 +14,5 @@ object ChangeAlphaController extends Controller with PreferenceController {
   }
 
 }
+
+object ChangeAlphaController extends ChangeAlphaController

--- a/onward/app/controllers/ChangeEditionController.scala
+++ b/onward/app/controllers/ChangeEditionController.scala
@@ -4,7 +4,7 @@ import common.Edition
 import model.NoCache
 import play.api.mvc._
 
-object ChangeEditionController extends Controller with PreferenceController {
+class ChangeEditionController extends Controller with PreferenceController {
   def render(editionId: String) = Action { implicit request =>
     NoCache(Edition.byId(editionId).map{ edition =>
       val home = edition.homePagePath
@@ -17,3 +17,5 @@ object ChangeEditionController extends Controller with PreferenceController {
     }.getOrElse(NotFound))
   }
 }
+
+object ChangeEditionController extends ChangeEditionController

--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -15,7 +15,7 @@ import slices.{Fixed, FixedContainers}
 
 import scala.concurrent.Future
 
-object MediaInSectionController extends Controller with Logging with Paging with ExecutionContexts with Requests {
+class MediaInSectionController extends Controller with Logging with Paging with ExecutionContexts with Requests {
   // These exist to work around the absence of default values in Play routing.
   def renderSectionMediaWithSeries(mediaType: String, sectionId: String, seriesId: String) =
     renderMedia(mediaType, sectionId, Some(seriesId))
@@ -92,3 +92,5 @@ object MediaInSectionController extends Controller with Logging with Paging with
     renderFormat(response, response, 1)
   }
 }
+
+object MediaInSectionController extends MediaInSectionController

--- a/onward/app/controllers/MostPopularController.scala
+++ b/onward/app/controllers/MostPopularController.scala
@@ -11,7 +11,7 @@ import views.support.FaciaToMicroFormat2Helpers._
 
 import scala.concurrent.Future
 
-object MostPopularController extends Controller with Logging with ExecutionContexts {
+class MostPopularController extends Controller with Logging with ExecutionContexts {
   val page = SimplePage(MetaData.make(
     "most-read",
     Some(SectionSummary.fromId("most-read")),
@@ -112,3 +112,5 @@ object MostPopularController extends Controller with Logging with ExecutionConte
     }
   }
 }
+
+object MostPopularController extends MostPopularController

--- a/onward/app/controllers/MostViewedAudioController.scala
+++ b/onward/app/controllers/MostViewedAudioController.scala
@@ -9,7 +9,7 @@ import play.api.mvc.{Action, Controller, RequestHeader}
 import services.CollectionConfigWithId
 import slices.{Fixed, FixedContainers}
 
-object MostViewedAudioController extends Controller with Logging with ExecutionContexts {
+class MostViewedAudioController extends Controller with Logging with ExecutionContexts {
   def renderMostViewed() = Action { implicit request =>
     getMostViewedAudio match {
       case Nil => Cached(60) { JsonNotFound() }
@@ -54,3 +54,5 @@ object MostViewedAudioController extends Controller with Logging with ExecutionC
     )
   }
 }
+
+object MostViewedAudioController extends MostViewedAudioController

--- a/onward/app/controllers/MostViewedVideoController.scala
+++ b/onward/app/controllers/MostViewedVideoController.scala
@@ -7,7 +7,7 @@ import play.api.mvc.{Action, Controller}
 import contentapi.ContentApiClient
 import contentapi.ContentApiClient.getResponse
 
-object MostViewedVideoController extends Controller with Logging with ExecutionContexts {
+class MostViewedVideoController extends Controller with Logging with ExecutionContexts {
 
   // Move this out of here if the test is successful
   def renderInSeries(series: String) = Action.async { implicit request =>
@@ -59,3 +59,5 @@ object MostViewedVideoController extends Controller with Logging with ExecutionC
     }
   }
 }
+
+object MostViewedVideoController extends MostViewedVideoController

--- a/onward/app/controllers/PopularInTag.scala
+++ b/onward/app/controllers/PopularInTag.scala
@@ -6,7 +6,7 @@ import model._
 import play.api.mvc.{ RequestHeader, Controller, Action }
 import services._
 
-object PopularInTag extends Controller with Related with Containers with Logging with ExecutionContexts {
+class PopularInTag extends Controller with Related with Containers with Logging with ExecutionContexts {
   def render(tag: String) = Action.async { implicit request =>
     val edition = Edition(request)
     val excludeTags = request.queryString.getOrElse("exclude-tag", Nil)
@@ -27,3 +27,5 @@ object PopularInTag extends Controller with Related with Containers with Logging
     )
   }
 }
+
+object PopularInTag extends PopularInTag

--- a/onward/app/controllers/RelatedController.scala
+++ b/onward/app/controllers/RelatedController.scala
@@ -11,7 +11,7 @@ import views.support.FaciaToMicroFormat2Helpers.isCuratedContent
 
 import scala.concurrent.duration._
 
-object RelatedController extends Controller with Related with Containers with Logging with ExecutionContexts {
+class RelatedController extends Controller with Related with Containers with Logging with ExecutionContexts {
 
   private val page = SimplePage(MetaData.make(
     "related-content",
@@ -61,3 +61,5 @@ object RelatedController extends Controller with Related with Containers with Lo
     )
   }
 }
+
+object RelatedController extends RelatedController

--- a/onward/app/controllers/RichLinkController.scala
+++ b/onward/app/controllers/RichLinkController.scala
@@ -10,7 +10,7 @@ import com.gu.contentapi.client.model.v1.ItemResponse
 import play.twirl.api.HtmlFormat
 import ContentApiClient.getResponse
 
-object RichLinkController extends Controller with Paging with Logging with ExecutionContexts with Requests   {
+class RichLinkController extends Controller with Paging with Logging with ExecutionContexts with Requests   {
 
   def renderHtml(path: String) = render(path)
 
@@ -45,3 +45,5 @@ object RichLinkController extends Controller with Paging with Logging with Execu
     }
   }
 }
+
+object RichLinkController extends RichLinkController

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -27,7 +27,7 @@ case class Series(id: String, tag: Tag, trails: RelatedContent) {
  }
 }
 
-object SeriesController extends Controller with Logging with Paging with ExecutionContexts with Requests {
+class SeriesController extends Controller with Logging with Paging with ExecutionContexts with Requests {
   def renderSeriesStories(seriesId: String) = Action.async { implicit request =>
     lookup(Edition(request), seriesId) map { series =>
       series.map(renderSeriesTrails).getOrElse(NotFound)
@@ -111,3 +111,5 @@ object SeriesController extends Controller with Logging with Paging with Executi
     renderFormat(response, response, 1)
   }
 }
+
+object SeriesController extends SeriesController

--- a/onward/app/controllers/TaggedContentController.scala
+++ b/onward/app/controllers/TaggedContentController.scala
@@ -11,7 +11,7 @@ import services._
 
 import scala.concurrent.Future
 
-object TaggedContentController extends Controller with Related with Logging with ExecutionContexts {
+class TaggedContentController extends Controller with Related with Logging with ExecutionContexts {
 
   def renderJson(tag: String) = Action.async { implicit request =>
     tagWhitelist.find(_ == tag).map { tag =>
@@ -56,3 +56,5 @@ object TaggedContentController extends Controller with Related with Logging with
     }
   }
 }
+
+object TaggedContentController extends TaggedContentController

--- a/onward/app/controllers/TopStoriesController.scala
+++ b/onward/app/controllers/TopStoriesController.scala
@@ -10,7 +10,7 @@ import play.api.mvc.{Action, Controller, RequestHeader}
 
 import scala.concurrent.Future
 
-object TopStoriesController extends Controller with Logging with Paging with ExecutionContexts {
+class TopStoriesController extends Controller with Logging with Paging with ExecutionContexts {
 
   def renderTopStoriesHtml = renderTopStories()
   def renderTopStories() = Action.async { implicit request =>
@@ -77,3 +77,5 @@ object TopStoriesController extends Controller with Logging with Paging with Exe
     renderFormat(response, response, 900)
   }
 }
+
+object TopStoriesController extends TopStoriesController

--- a/onward/app/weather/controllers/LocationsController.scala
+++ b/onward/app/weather/controllers/LocationsController.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 import scala.concurrent.Future
 import scalaz.std.option.optionInstance.tuple3
 
-object LocationsController extends Controller with ExecutionContexts with Logging {
+class LocationsController extends Controller with ExecutionContexts with Logging {
   def findCity(query: String) = Action.async { implicit request =>
     WeatherApi.searchForLocations(query) map { locations =>
       Cached(7.days)(JsonComponent.forJsValue(Json.toJson(CityResponse.fromLocationResponses(locations.toList))))
@@ -73,3 +73,5 @@ object LocationsController extends Controller with ExecutionContexts with Loggin
     }
   }
 }
+
+object LocationsController extends LocationsController

--- a/onward/app/weather/controllers/WeatherController.scala
+++ b/onward/app/weather/controllers/WeatherController.scala
@@ -8,7 +8,7 @@ import weather.WeatherApi
 import common.Seqs._
 import scala.concurrent.duration._
 
-object WeatherController extends Controller with ExecutionContexts {
+class WeatherController extends Controller with ExecutionContexts {
   val MaximumForecastDays = 10
 
   def forCity(cityId: String) = Action.async{ implicit request =>
@@ -25,3 +25,5 @@ object WeatherController extends Controller with ExecutionContexts {
     })
   }
 }
+
+object WeatherController extends WeatherController

--- a/sport/app/cricket/controllers/cricketMatchController.scala
+++ b/sport/app/cricket/controllers/cricketMatchController.scala
@@ -16,7 +16,7 @@ case class CricketMatchPage(theMatch: Match, matchId: String, team: CricketTeam)
     analyticsName = s"GFE:Cricket:automatic:match:${dateFormat.print(theMatch.gameDate)}:${theMatch.homeTeam.name} v ${theMatch.awayTeam.name}")
 }
 
-object CricketMatchController extends Controller with Logging with ExecutionContexts {
+class CricketMatchController extends Controller with Logging with ExecutionContexts {
 
   def renderMatchIdJson(date: String, teamId: String) = renderMatchId(date, teamId)
 
@@ -37,3 +37,5 @@ object CricketMatchController extends Controller with Logging with ExecutionCont
   }
 
 }
+
+object CricketMatchController extends CricketMatchController

--- a/sport/app/football/controllers/CompetitionListController.scala
+++ b/sport/app/football/controllers/CompetitionListController.scala
@@ -7,7 +7,7 @@ import conf._
 import play.api.mvc.{ Controller, Action }
 
 
-object CompetitionListController extends Controller with CompetitionListFilters with Logging with ExecutionContexts {
+class CompetitionListController extends Controller with CompetitionListFilters with Logging with ExecutionContexts {
 
   val page = new FootballPage("football/competitions", "football", "Leagues & competitions", "GFE:Football:automatic:Leagues & competitions")
 
@@ -27,3 +27,5 @@ object CompetitionListController extends Controller with CompetitionListFilters 
     renderFormat(htmlResponse, jsonResponse, page, Switches.all)
   }
 }
+
+object CompetitionListController extends CompetitionListController

--- a/sport/app/football/controllers/FixturesController.scala
+++ b/sport/app/football/controllers/FixturesController.scala
@@ -9,7 +9,7 @@ import pa.FootballTeam
 import play.api.mvc.{Action, AnyContent}
 
 
-object FixturesController extends MatchListController with CompetitionFixtureFilters {
+class FixturesController extends MatchListController with CompetitionFixtureFilters {
 
   private def fixtures(date: LocalDate) = new FixturesList(date, Competitions())
   private val page = new FootballPage("football/fixtures", "football", "All fixtures", "GFE:Football:automatic:fixtures")
@@ -79,3 +79,5 @@ object FixturesController extends MatchListController with CompetitionFixtureFil
     }.getOrElse(NotFound)
   }
 }
+
+object FixturesController extends FixturesController

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -17,7 +17,7 @@ case class TablesPage(
   lazy val singleCompetition = tables.size == 1
 }
 
-object LeagueTableController extends Controller with Logging with CompetitionTableFilters with ExecutionContexts {
+class LeagueTableController extends Controller with Logging with CompetitionTableFilters with ExecutionContexts {
 
     val tableOrder = Seq(
         "Euro 2016",
@@ -152,3 +152,5 @@ object LeagueTableController extends Controller with Logging with CompetitionTab
     }
   }
 }
+
+object LeagueTableController extends LeagueTableController

--- a/sport/app/football/controllers/MatchController.scala
+++ b/sport/app/football/controllers/MatchController.scala
@@ -46,7 +46,7 @@ case class MatchPage(theMatch: FootballMatch, lineUp: LineUp) extends Standalone
   )
 }
 
-object MatchController extends Controller with Football with Requests with Logging with ExecutionContexts {
+class MatchController extends Controller with Football with Requests with Logging with ExecutionContexts {
 
   private val dateFormat = DateTimeFormat.forPattern("yyyyMMMdd")
 
@@ -78,3 +78,5 @@ object MatchController extends Controller with Football with Requests with Loggi
     response.getOrElse(Future.successful(Cached(30)(WithoutRevalidationResult(Found("/football/results")))))
   }
 }
+
+object MatchController extends MatchController

--- a/sport/app/football/controllers/MatchDayController.scala
+++ b/sport/app/football/controllers/MatchDayController.scala
@@ -8,7 +8,7 @@ import football.model._
 import common.{Edition, JsonComponent}
 
 
-object MatchDayController extends MatchListController with CompetitionLiveFilters {
+class MatchDayController extends MatchListController with CompetitionLiveFilters {
 
   def liveMatchesJson() = liveMatches()
   def liveMatches(): Action[AnyContent] =
@@ -55,3 +55,5 @@ object MatchDayController extends MatchListController with CompetitionLiveFilter
     }
   }
 }
+
+object MatchDayController extends MatchDayController

--- a/sport/app/football/controllers/MoreOnMatchController.scala
+++ b/sport/app/football/controllers/MoreOnMatchController.scala
@@ -34,7 +34,7 @@ case class MatchNav(
   lazy val hasPreview = preview.isDefined
 }
 
-object MoreOnMatchController extends Controller with Football with Requests with Logging with ExecutionContexts with implicits.Dates {
+class MoreOnMatchController extends Controller with Football with Requests with Logging with ExecutionContexts with implicits.Dates {
   def interval(contentDate: LocalDate) = new Interval(contentDate.toDateTimeAtStartOfDay - 2.days, contentDate.toDateTimeAtStartOfDay + 3.days)
 
   private val dateFormat = DateTimeFormat.forPattern("yyyyMMdd").withZone(DateTimeZone.forID("Europe/London"))
@@ -225,3 +225,5 @@ object MoreOnMatchController extends Controller with Football with Requests with
     MatchNav(theMatch, matchReport, minByMin, preview, stats, currentPage)
   }
 }
+
+object MoreOnMatchController extends MoreOnMatchController

--- a/sport/app/football/controllers/ResultsController.scala
+++ b/sport/app/football/controllers/ResultsController.scala
@@ -9,7 +9,7 @@ import football.model._
 import pa.FootballTeam
 import model.Competition
 
-object ResultsController extends MatchListController with CompetitionResultFilters {
+class ResultsController extends MatchListController with CompetitionResultFilters {
 
   private def competitionOrTeam(tag: String): Option[Either[Competition, FootballTeam]] = {
     lookupCompetition(tag).map(Left(_))
@@ -80,3 +80,5 @@ object ResultsController extends MatchListController with CompetitionResultFilte
   def moreTagResultsFor(year: String, month: String, day: String, tag: String): Action[AnyContent] = renderMoreForDate(createDate(year, month, day), Some(tag))
   def moreTagResultsForJson(year: String, month: String, day: String, tag: String) = moreTagResultsFor(year, month, day, tag)
 }
+
+object ResultsController extends ResultsController

--- a/sport/app/football/controllers/WallchartController.scala
+++ b/sport/app/football/controllers/WallchartController.scala
@@ -8,7 +8,7 @@ import model.{Cached, Page}
 import football.model.CompetitionStage
 
 
-object WallchartController extends Controller with Logging with ExecutionContexts {
+class WallchartController extends Controller with Logging with ExecutionContexts {
   def renderWallchartEmbed(competitionTag: String) = renderWallchart(competitionTag, true)
   def renderWallchart(competitionTag: String, embed: Boolean = false) = Action { implicit request =>
     Competitions().withTag(competitionTag).map { competition =>
@@ -28,3 +28,5 @@ object WallchartController extends Controller with Logging with ExecutionContext
   }
 
 }
+
+object WallchartController extends WallchartController

--- a/sport/app/rugby/controllers/MatchesController.scala
+++ b/sport/app/rugby/controllers/MatchesController.scala
@@ -17,7 +17,7 @@ case class MatchPage(liveScore: Match) extends StandalonePage {
     analyticsName = s"GFE:Rugby:automatic:match:${liveScore.date.toString("dd MMM YYYY")}:${liveScore.homeTeam.name} v ${liveScore.awayTeam.name}")
 }
 
-object MatchesController extends Controller with Logging with ExecutionContexts {
+class MatchesController extends Controller with Logging with ExecutionContexts {
 
   def scoreJson(year: String, month: String, day: String, homeTeamId: String, awayTeamId: String) = score(year, month, day, homeTeamId, awayTeamId)
 
@@ -54,3 +54,5 @@ object MatchesController extends Controller with Logging with ExecutionContexts 
     }.getOrElse(NotFound)
   }
 }
+
+object MatchesController extends MatchesController


### PR DESCRIPTION
## What does this change?

This is a very repetitive PR that transforms all the controllers used by standalones apps (preview and training-preview) into classes.
It also creates a singleton for each one of them in order to be backward compatible for the time being

This is a necessary step to be able to migrate the standalone apps away from using globals, which is itself a necessary step towards play 2.5
## Request for comment

@TBonnin @johnduffell 
