### PR TITLE
Standalone lifecycle migration

### DIFF
--- a/commercial/app/commercial/RefreshJob.scala
+++ b/commercial/app/commercial/RefreshJob.scala
@@ -1,6 +1,6 @@
 package commercial
 
-import common.{Jobs, Logging}
+import common.{JobScheduler, Logging}
 import model.commercial.jobs.Industries
 import model.commercial.events.MasterclassTagsAgent
 import model.commercial.money.BestBuysAgent
@@ -9,31 +9,32 @@ import model.commercial.travel.Countries
 trait RefreshJob extends Logging {
 
   def name: String
+  def jobs: JobScheduler
 
   protected def refresh(): Unit
 
   def start(schedule: String): Unit = {
-    Jobs.deschedule(s"${name}RefreshJob")
+    jobs.deschedule(s"${name}RefreshJob")
 
     log.info(s"$name refresh on schedule $schedule")
-    Jobs.schedule(s"${name}RefreshJob", schedule) {
+    jobs.schedule(s"${name}RefreshJob", schedule) {
       refresh()
     }
   }
 
   def stop(): Unit = {
-    Jobs.deschedule(s"${name}RefreshJob")
+    jobs.deschedule(s"${name}RefreshJob")
   }
 }
 
-object MasterclassTagsRefresh extends RefreshJob {
+class MasterclassTagsRefresh(val jobs: JobScheduler) extends RefreshJob {
 
   val name: String = "MasterClassTags"
 
   def refresh() = MasterclassTagsAgent.refresh()
 }
 
-object CountriesRefresh extends RefreshJob {
+class CountriesRefresh(val jobs: JobScheduler) extends RefreshJob {
 
   val name: String = "Countries"
 
@@ -41,21 +42,21 @@ object CountriesRefresh extends RefreshJob {
 
 }
 
-object IndustriesRefresh extends RefreshJob {
+class IndustriesRefresh(val jobs: JobScheduler) extends RefreshJob {
 
   val name: String = "Industries"
 
   def refresh() = Industries.refresh()
 }
 
-object MoneyBestBuysRefresh extends RefreshJob {
+class MoneyBestBuysRefresh(val jobs: JobScheduler) extends RefreshJob {
 
   val name: String = "Best Buys"
 
   def refresh() = BestBuysAgent.refresh()
 }
 
-object CommercialMetricsRefresh extends RefreshJob {
+class CommercialMetricsRefresh(val jobs: JobScheduler) extends RefreshJob {
   val name: String = "Update Metrics"
 
   def refresh() = CommercialLifecycleMetrics.update()

--- a/common/app/common/dfp/DfpAgentLifecycle.scala
+++ b/common/app/common/dfp/DfpAgentLifecycle.scala
@@ -29,7 +29,10 @@ class DfpAgentLifecycle(
   }
 }
 
-class FaciaDfpAgentLifecycle(appLifeCycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends DfpAgentLifecycle(appLifeCycle) {
+class FaciaDfpAgentLifecycle(
+  appLifeCycle: ApplicationLifecycle,
+  jobs: JobScheduler = Jobs,
+  akkaAsync: AkkaAsync = AkkaAsync)(implicit ec: ExecutionContext) extends DfpAgentLifecycle(appLifeCycle, jobs, akkaAsync) {
 
   override def refreshDfpAgent(): Unit = {
     DfpAgent.refresh()

--- a/sport/app/football/conf/context.scala
+++ b/sport/app/football/conf/context.scala
@@ -8,7 +8,10 @@ import play.api.inject.ApplicationLifecycle
 import play.api.libs.ws.WS
 import scala.concurrent.{ExecutionContext, Future}
 
-class FootballLifecycle(appLifeCycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends LifecycleComponent {
+class FootballLifecycle(
+  appLifeCycle: ApplicationLifecycle,
+  jobs: JobScheduler = Jobs,
+  akkaAsync: AkkaAsync = AkkaAsync)(implicit ec: ExecutionContext) extends LifecycleComponent {
 
   appLifeCycle.addStopHook { () => Future {
     descheduleJobs()
@@ -21,43 +24,43 @@ class FootballLifecycle(appLifeCycle: ApplicationLifecycle)(implicit ec: Executi
       val minutes = index * 5 / 60 % 5
       val cron = s"$seconds $minutes/5 * * * ?"
 
-      Jobs.schedule(s"CompetitionAgentRefreshJob_$id", cron) {
+      jobs.schedule(s"CompetitionAgentRefreshJob_$id", cron) {
         Competitions.refreshCompetitionAgent(id)
       }
     }
 
-    Jobs.schedule("MatchDayAgentRefreshJob", "0 0/5 * * * ?") {
+    jobs.schedule("MatchDayAgentRefreshJob", "0 0/5 * * * ?") {
       Competitions.refreshMatchDay()
     }
 
-    Jobs.schedule("CompetitionRefreshJob", "0 0/10 * * * ?") {
+    jobs.schedule("CompetitionRefreshJob", "0 0/10 * * * ?") {
       Competitions.refreshCompetitionData()
     }
 
-    Jobs.schedule("LiveBlogRefreshJob", "0 0/2 * * * ?") {
+    jobs.schedule("LiveBlogRefreshJob", "0 0/2 * * * ?") {
       LiveBlogAgent.refresh()
     }
 
-    Jobs.schedule("TeamMapRefreshJob", "0 0/10 * * * ?") {
+    jobs.schedule("TeamMapRefreshJob", "0 0/10 * * * ?") {
       TeamMap.refresh()
     }
   }
 
   private def descheduleJobs() {
-    Competitions.competitionIds map { id =>
-      Jobs.deschedule(s"CompetitionAgentRefreshJob_$id")
+    Competitions.competitionIds foreach { id =>
+      jobs.deschedule(s"CompetitionAgentRefreshJob_$id")
     }
-    Jobs.deschedule("MatchDayAgentRefreshJob")
-    Jobs.deschedule("CompetitionRefreshJob")
-    Jobs.deschedule("LiveBlogRefreshJob")
-    Jobs.deschedule("TeamMapRefreshJob")
+    jobs.deschedule("MatchDayAgentRefreshJob")
+    jobs.deschedule("CompetitionRefreshJob")
+    jobs.deschedule("LiveBlogRefreshJob")
+    jobs.deschedule("TeamMapRefreshJob")
   }
 
   override def start(): Unit = {
     descheduleJobs()
     scheduleJobs()
 
-    AkkaAsync {
+    akkaAsync.after1s {
       val competitionUpdate = Competitions.refreshCompetitionData()
       competitionUpdate.onSuccess { case _ => Competitions.competitionIds.foreach(Competitions.refreshCompetitionAgent) }
       Competitions.refreshMatchDay()

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -1,6 +1,6 @@
 package rugby.conf
 
-import common.{LifecycleComponent, AkkaAsync, Jobs}
+import common.{JobScheduler, LifecycleComponent, AkkaAsync, Jobs}
 import play.api.inject.ApplicationLifecycle
 import rugby.feed.{CapiFeed, OptaFeed}
 import rugby.jobs.RugbyStatsJob
@@ -9,45 +9,49 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
 
-class RugbyLifecycle(appLifeCycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends LifecycleComponent {
+class RugbyLifecycle(
+  appLifeCycle: ApplicationLifecycle,
+  jobs: JobScheduler = Jobs,
+  akkaAsync: AkkaAsync = AkkaAsync
+)(implicit ec: ExecutionContext) extends LifecycleComponent {
 
   protected val initializationTimeout: FiniteDuration = 10.seconds
 
   override def start(): Unit = {
-    Jobs.deschedule("FixturesAndResults")
-    Jobs.schedule("FixturesAndResults", "5 0/30 * * * ?") {
+    jobs.deschedule("FixturesAndResults")
+    jobs.schedule("FixturesAndResults", "5 0/30 * * * ?") {
       RugbyStatsJob.fixturesAndResults(OptaFeed.getFixturesAndResults)
     }
 
-    Jobs.deschedule("GroupTables")
-    Jobs.schedule("GroupTables", "10 0/30 * * * ?") {
+    jobs.deschedule("GroupTables")
+    jobs.schedule("GroupTables", "10 0/30 * * * ?") {
       RugbyStatsJob.groupTables(OptaFeed.getGroupTables)
     }
 
 
-    Jobs.deschedule("PastEventScores")
-    Jobs.schedule("PastEventScores", "20 0/30 * * * ?") {
+    jobs.deschedule("PastEventScores")
+    jobs.schedule("PastEventScores", "20 0/30 * * * ?") {
       RugbyStatsJob.fetchPastScoreEvents
     }
 
-    Jobs.deschedule("PastMatchesStat")
-    Jobs.schedule("PastMatchesStat", "30 0/30 * * * ?") {
+    jobs.deschedule("PastMatchesStat")
+    jobs.schedule("PastMatchesStat", "30 0/30 * * * ?") {
       RugbyStatsJob.fetchPastMatchesStat
     }
 
 
-    Jobs.deschedule("MatchNavArticles")
-    Jobs.schedule("MatchNavArticles", "35 0/30 * * * ?") {
+    jobs.deschedule("MatchNavArticles")
+    jobs.schedule("MatchNavArticles", "35 0/30 * * * ?") {
       RugbyStatsJob.sendMatchArticles(CapiFeed.getMatchArticles())
     }
 
-    AkkaAsync {
+    akkaAsync.after1s {
       RugbyStatsJob.fixturesAndResults(OptaFeed.getFixturesAndResults)
       RugbyStatsJob.groupTables(OptaFeed.getGroupTables)
     }
 
     //delay to allow previous jobs to complete
-    AkkaAsync.after(initializationTimeout) {
+    akkaAsync.after(initializationTimeout) {
       RugbyStatsJob.fetchPastScoreEvents
       RugbyStatsJob.fetchPastMatchesStat
       RugbyStatsJob.sendMatchArticles(CapiFeed.getMatchArticles())


### PR DESCRIPTION
## What does this change?

This is another very repetitive PR that modifies all the lifecycle objects used by standalones apps (preview and training-preview) in order to stop depending on Play.current.
It also provides default values for each one of them in order to be backward compatible for the time being

This is a necessary step to be able to migrate the standalone apps away from using globals, which is itself a necessary step towards play 2.5
## Request for comment

@TBonnin @johnduffell 
