### PR TITLE
In homepage weather widget search, show 10 results

### DIFF
--- a/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/search-tool.js
@@ -148,7 +148,7 @@ define([
                     type: 'json',
                     crossOrigin: true
                 }).then(function (positions) {
-                    this.renderList(positions, 5);
+                    this.renderList(positions, 10);
                     oldQuery = newQuery;
                 }.bind(this));
             },

--- a/static/src/stylesheets/module/_search-tool.scss
+++ b/static/src/stylesheets/module/_search-tool.scss
@@ -44,7 +44,7 @@
     box-sizing: border-box;
     color: $neutral-1;
     padding-top: $gs-baseline / 3;
-    padding-bottom: $gs-baseline;
+    padding-bottom: $gs-baseline / 3;
     width: 100%;
     display: block;
 

--- a/static/test/javascripts/spec/facia/search-tool.spec.js
+++ b/static/test/javascripts/spec/facia/search-tool.spec.js
@@ -207,7 +207,7 @@ define([
             spyOn(sut, 'renderList');
 
             sut.fetchData().then(function () {
-                expect(sut.renderList).toHaveBeenCalledWith([{'localizedName': 'London'}], 5);
+                expect(sut.renderList).toHaveBeenCalledWith([{'localizedName': 'London'}], 10);
                 done();
             });
 


### PR DESCRIPTION
## What does this change?

Weather widget: Accuweather API returns 10 results when searching for a city, however we only display the first 5 items at the moment. 
=> if the city you are looking for is not in the first 5 items it is not displayed :(
## What is the value of this and can you measure success?

No more user complaining they cannot find their city
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@sndrs 
Still looking for a way to test this locally :/

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
