### PR TITLE
add data-link to the quiz questions

### DIFF
--- a/common/app/views/fragments/atoms/quiz.scala.html
+++ b/common/app/views/fragments/atoms/quiz.scala.html
@@ -42,15 +42,16 @@
             ("atom-quiz__answers", true),
             ("atom-quiz__answers--images", hasImages(question))
         ))">
-            @question.answers.map( answer => {
-                val hasImage = answer.imageMedia.isDefined
-                renderAnswer(question, answer, field, hasImage, maybeUserAnswer, showResults)
-            })
+            @question.answers.zipWithIndex.map { case(answer, index) =>
+                @defining(answer.imageMedia.isDefined) { hasImage =>
+                    @renderAnswer(question, answer, index + 1, field, hasImage, maybeUserAnswer, showResults)
+                }
+            }
         </div>
     </fieldset>
 }
 
-@renderAnswer(question: Question, answer: Answer, field: play.api.data.Field, hasImage: Boolean, maybeUserAnswer: Option[Answer], showResults: Boolean) = {
+@renderAnswer(question: Question, answer: Answer, index: Int, field: play.api.data.Field, hasImage: Boolean, maybeUserAnswer: Option[Answer], showResults: Boolean) = {
     <div class="@RenderClasses(Map(
         ("atom-quiz__answer", true),
         ("atom-quiz__answer--image", hasImage),
@@ -61,6 +62,7 @@
             id="answer-@{answer.id}"
             value="@{answer.id}"
             class="atom-quiz__answer__input"
+            data-link-name="quiz-answer-number-@index"
             @{if (maybeUserAnswer.exists(_.equals(answer))) "checked=checked" }
             @{if (showResults) "disabled=disabled"}
             required


### PR DESCRIPTION
## What does this change?

We wanna track quiz usage. This adds data-link-names in quiz answers ( on a per question basis ) so that those clicks end up in omniture in lieu of the datalake work being completed
## What is the value of this and can you measure success?

Quiz answer clicks are recorded in omnture, that enables us to begin the value of quizzes
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

N/A
## Request for comment

@nicl @gidsg 
@crifmulholland this would have taken 5 minutes if play didn't suck

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
