### PR TITLE
Tbonnin real fix football test

### DIFF
--- a/sport/test/CompetitionAgentTest.scala
+++ b/sport/test/CompetitionAgentTest.scala
@@ -2,13 +2,22 @@ package test
 
 import feed.{CompetitionSupport, Competitions, CompetitionAgent}
 import model.Competition
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Span}
-import org.joda.time.LocalDate
+import org.joda.time.{LocalDate, DateTime, DateTimeUtils}
 
 
-@DoNotDiscover class CompetitionAgentTest extends FlatSpec with Matchers with implicits.Football with Eventually with ConfiguredTestSuite {
+@DoNotDiscover class CompetitionAgentTest extends FlatSpec with Matchers with implicits.Football with Eventually with ConfiguredTestSuite with BeforeAndAfterAll {
+
+  override def beforeAll() = {
+    // Tests in this suite are time dependent:
+    // => Force date to the day the test files have been generated (Note: time doesn't matter)
+    val fixedDate = new DateTime(2016, 6, 22, 15, 0).getMillis
+    DateTimeUtils.setCurrentMillisFixed(fixedDate)
+  }
+
+  override def afterAll() = DateTimeUtils.setCurrentMillisSystem()
 
   override implicit val patienceConfig = PatienceConfig(timeout = scaled(Span(3000, Millis)), interval = scaled(Span(100, Millis)))
 

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -15,7 +15,6 @@ import play.api.libs.ws.{WS, WSResponse}
 import conf.FootballClient
 import pa.{Http, Response => PaResponse}
 import play.api.Play.current
-import org.joda.time.LocalDate
 
 import scala.concurrent.Future
 
@@ -87,13 +86,8 @@ object FeedHttpRecorder extends HttpRecorder[WSResponse] {
 object TestHttp extends Http with ExecutionContexts {
 
   def GET(url: String): Future[PaResponse] = {
-
-    //Force date to the day the test files has been generated
-    val today = new LocalDate()
-    val urlWithTestDate = url.replace(today.toString("yyyyMMdd"), "20160622")
-
-    FootballHttpRecorder.load(urlWithTestDate) {
-      WS.url(urlWithTestDate)
+    FootballHttpRecorder.load(url) {
+      WS.url(url)
         .withRequestTimeout(10000)
         .get()
         .map { wsResponse =>

--- a/sport/test/testdata/44abf55dad758df1b52977360d96786552d5fdd7a954bd1b339098314ae89379
+++ b/sport/test/testdata/44abf55dad758df1b52977360d96786552d5fdd7a954bd1b339098314ae89379
@@ -1,1 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><results xsi:noNamespaceSchemaLocation="http://pasportapis6.cloudapp.net/API/Schemas/Football/Competition/results.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><errors><error>No data available</error></errors></results>


### PR DESCRIPTION
## What does this change?

Follow-up for https://github.com/guardian/frontend/pull/13396/commits/37a1beffd5c6871e5082c8401b169f3c753db707 which ends up not being a bullet proof and clean solution

Tests in CompetitionAgentTest suite are time dependent (ex: competition getResults fetches data starting 30 days ago).
In order to make the test repeatable, we freeze the date to the day the test files have been generated
## What is the value of this and can you measure success?

Green build every day 💚 
## Does this affect other platforms - Amp, Apps, etc?

No, only tests
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
