### PR TITLE
Change tracking to track granted only when it's a new state

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts/bootstraps/enhanced/notifications.js
@@ -109,10 +109,11 @@ define([
         },
 
         subscribeHandler: function () {
-            var alreadyGranted = Notification.permission === 'granted';
+            var wasNotGranted = Notification.permission !== 'granted';
             modules.subscribe().then(modules.follow)
                 .then(function() {
-                    if (!alreadyGranted && Notification.permission === 'granted') {
+                    var isNowGranted = Notification.permission === 'granted';
+                    if (wasNotGranted && isNowGranted) {
                         omniture.trackLinkImmediate('browser-notifications-granted');
                     }
                 }) .catch( function () {

--- a/static/src/javascripts/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts/bootstraps/enhanced/notifications.js
@@ -107,9 +107,10 @@ define([
         },
 
         subscribeHandler: function () {
+            var alreadyGranted = Notification.permission === 'granted';
             modules.subscribe().then(modules.follow)
                 .then(function() {
-                    if (Notification.permission === 'granted') {
+                    if (!alreadyGranted && Notification.permission === 'granted') {
                         omniture.trackLinkImmediate('browser-notifications-granted');
                     }
                 }) .catch( function () {

--- a/static/src/javascripts/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts/bootstraps/enhanced/notifications.js
@@ -47,6 +47,8 @@ define([
         },
 
         getSub: function () {
+            //This function can change Notification.permission
+            //by asking the user if it is in 'default' state.
             return modules.getReg().then(function (reg) {return reg.pushManager.getSubscription();});
         },
 


### PR DESCRIPTION
This fixes the tracking so that it will only count `granted` state if it has not been granted before.

@samdesborough @NathanielBennett 
