### PR TITLE
Add null check in interactive Ophan event

### DIFF
--- a/static/src/javascripts/bootstraps/standard/main.js
+++ b/static/src/javascripts/bootstraps/standard/main.js
@@ -131,7 +131,12 @@ define([
                 });
 
                 require(['ophan/ng'], function(ophan) {
-                   ophan.trackComponentAttention(el.querySelector('a').href, el);
+                    var a = el.querySelector('a');
+                    var href = a && a.href;
+
+                    if (href) {
+                        ophan.trackComponentAttention(href, el);
+                    }
                 });
             });
         }


### PR DESCRIPTION
fixes this: ![screen shot 2016-06-23 at 16 25 14](https://cloud.githubusercontent.com/assets/1064734/16309020/2d41848c-395f-11e6-8554-c822feb35779.png)

as seen on http://www.theguardian.com/politics/ng-interactive/2016/jun/23/brexit-europe-eu-nationals-in-uk-photo-essay
