### PR TITLE
show empty end slate if there are no results

### DIFF
--- a/onward/app/controllers/VideoEndSlateController.scala
+++ b/onward/app/controllers/VideoEndSlateController.scala
@@ -86,6 +86,6 @@ object VideoEndSlateController extends Controller with Logging with Paging with 
 
   private def renderSeriesTrails(trails: Seq[Video])(implicit request: RequestHeader) = {
     val response = () => views.html.fragments.videoEndSlate(trails.take(4), "series", "More from this series")
-    renderFormat(response, response, 1)
+    renderFormat(response, response, 900)
   }
 }

--- a/onward/app/controllers/VideoEndSlateController.scala
+++ b/onward/app/controllers/VideoEndSlateController.scala
@@ -15,12 +15,12 @@ object VideoEndSlateController extends Controller with Logging with Paging with 
 
   def renderSection(sectionId: String) = Action.async { implicit request =>
     val response = lookupSection(Edition(request), sectionId) map { seriesItems =>
-      seriesItems map { trail => renderSectionTrails(trail) }
+      renderSectionTrails(seriesItems)
     }
-    response map { _ getOrElse NotFound }
+    response
   }
 
-  private def lookupSection(edition: Edition, sectionId: String)(implicit request: RequestHeader): Future[Option[Seq[Video]]] = {
+  private def lookupSection(edition: Edition, sectionId: String)(implicit request: RequestHeader): Future[Seq[Video]] = {
     val currentShortUrl = request.getQueryString("shortUrl").getOrElse("")
     log.info(s"Fetching video content in section: $sectionId" )
 
@@ -33,19 +33,16 @@ object VideoEndSlateController extends Controller with Logging with Paging with 
       .showFields("all")
     ).map {
         response =>
-          response.results.toList filter { content => !isCurrentStory(content) } map { result =>
+          response.results filter { content => !isCurrentStory(content) } map { result =>
             Content(result)
           } collect {
             case v: Video => v
-          } match {
-            case Nil => None
-            case results => Some(results)
           }
       }
 
       promiseOrResponse.recover{ case GuardianContentApiError(404, message, _) =>
          log.info(s"Got a 404 calling content api: $message" )
-         None
+         Nil
       }
   }
 
@@ -57,12 +54,13 @@ object VideoEndSlateController extends Controller with Logging with Paging with 
 
   def renderSeries(seriesId: String) = Action.async { implicit request =>
     val response = lookupSeries(Edition(request), seriesId) map { seriesItems =>
-      seriesItems map { trail => renderSeriesTrails(trail) }
+      renderSeriesTrails(seriesItems)
     }
-    response map { _ getOrElse NotFound }
+
+    response
   }
 
-  private def lookupSeries( edition: Edition, seriesId: String)(implicit request: RequestHeader): Future[Option[Seq[Video]]] = {
+  private def lookupSeries( edition: Edition, seriesId: String)(implicit request: RequestHeader): Future[Seq[Video]] = {
     val currentShortUrl = request.getQueryString("shortUrl").getOrElse("")
     log.info(s"Fetching content in series: ${seriesId} the ShortUrl ${currentShortUrl}" )
 
@@ -77,15 +75,12 @@ object VideoEndSlateController extends Controller with Logging with Paging with 
         Content(result)
       } collect {
         case v: Video => v
-      } match {
-        case Nil => None
-        case results => Some(results)
       }
     }
 
     promiseOrResponse.recover{ case GuardianContentApiError(404, message, _) =>
       log.info(s"Got a 404 calling content api: $message" )
-      None
+      Nil
     }
   }
 

--- a/onward/app/controllers/VideoEndSlateController.scala
+++ b/onward/app/controllers/VideoEndSlateController.scala
@@ -49,7 +49,7 @@ object VideoEndSlateController extends Controller with Logging with Paging with 
   private def renderSectionTrails(trails: Seq[Video])(implicit request: RequestHeader) = {
     val sectionName = trails.headOption.map(t => t.trail.sectionName).getOrElse("")
     val response = () => views.html.fragments.videoEndSlate(trails.take(4), "section", s"More ${sectionName} videos")
-    renderFormat(response, response, 1)
+    renderFormat(response, response, 900)
   }
 
   def renderSeries(seriesId: String) = Action.async { implicit request =>

--- a/onward/app/views/fragments/videoEndSlate.scala.html
+++ b/onward/app/views/fragments/videoEndSlate.scala.html
@@ -2,15 +2,17 @@
 
 @import views.support.Seq2zipWithRowInfo
 
+
 <div class="end-slate-container end-slate-container--video" data-component="video-end-slate-@componentId">
-
-    <div class="end-slate-container__header">
-        <h3 class="end-slate-container__heading">@heading</h3>
-    </div>
-    <ul class="u-cf u-unstyled end-slate end-slate--video l-row items--video" data-link-name="end slate">
-        @videos.zipWithRowInfo.map{ case (video, row) =>
-            @fragments.mediaItem(video, row.rowNum)
-        }
-    </ul>
-
+    @if(videos.nonEmpty) {
+        <div class="end-slate-container__header">
+            <h3 class="end-slate-container__heading">@heading</h3>
+        </div>
+        <ul class="u-cf u-unstyled end-slate end-slate--video l-row items--video" data-link-name="end slate">
+            @videos.zipWithRowInfo.map{ case (video, row) =>
+                @fragments.mediaItem(video, row.rowNum)
+            }
+        </ul>
+    }
 </div>
+


### PR DESCRIPTION
## What does this change?

@TBonnin noticed that we 404 if there is no results from CAPI on the endslate. This isn't a great response, we should probably just say, "Sorry, no videos". This does that.

It also stops the 404 not caching, and thus doing a CAPI call everytime.

If deemed a simple enough change, I'll push this out.
## What is the value of this and can you measure success?

CAPI loses some load.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
