### PR TITLE
Notification tracking changes

### DIFF
--- a/common/app/views/fragments/liveNotificationsCallToActionPlaceHolder.scala.html
+++ b/common/app/views/fragments/liveNotificationsCallToActionPlaceHolder.scala.html
@@ -1,2 +1,0 @@
-@()(implicit request: RequestHeader)
-<aside id="notifications" class="notifications js-notifications" role="complementary"></aside>

--- a/static/src/javascripts/projects/common/views/ui/notifications-explainer.html
+++ b/static/src/javascripts/projects/common/views/ui/notifications-explainer.html
@@ -1,4 +1,4 @@
-<div class="js-live-notifications-explainer live-notifications-explainer">
+<div class="js-live-notifications-explainer live-notifications-explainer" data-link-name="notifications-explainer">
     <div class="live-notifications-explainer__content">
         <div class="live-notifications-explainer__header">
                 <h2 class="live-notifications-explainer__headline">Get alerts and stay up to date</h2>

--- a/static/src/javascripts/projects/common/views/ui/notifications-follow-link.html
+++ b/static/src/javascripts/projects/common/views/ui/notifications-follow-link.html
@@ -1,10 +1,10 @@
- <button class="button button--large button--tertiary js-notifications__button notifications__button notifications-follow-input--solo notifications__button--<%= isSubscribed ? 'subscribed' : 'unsubscribed' %>">
-    <%= icon %>
+ <button class="button button--large button--tertiary js-notifications__button notifications__button notifications-follow-input--solo notifications__button--<%= isSubscribed ? 'subscribed' : 'unsubscribed' %>" data-link-name="live-blog-notifications-turned-<%= isSubscribed ? 'off' : 'on' %>">
+     <%= icon %>
      <% if (isSubscribed) { %>
-     <span class="live-notifications__label live-notifications__label--subscribed" data-link-name="live-blog-notifications-turned-off">Alerts on for this story</span>
+     <span class="live-notifications__label live-notifications__label--subscribed">Alerts on for this story</span>
      <% } else { %>
-     <span class="live-notifications__label live-notifications__label--unsubscribed" data-link-name="live-blog-notifications-turned-on">Get alerts for this story</span>
+     <span class="live-notifications__label live-notifications__label--unsubscribed">Get alerts for this story</span>
      <% } %>
-</button>
+ </button>
 
 


### PR DESCRIPTION
## What does this change?

This adds a `data-link-name` to the notifications explainer in order to track who thinks it is a CTA.

This also moves the `data-link-name` in the signup button for notifications to the `button` parent; it is currently possible to sign up (and unsubscribe) to notifications but side step the tracking by clicking the button just outside the sign-up text in the DOM. This makes it harder to track who has clicked the button as they have to click exactly on the text to have it tracked.
## What is the value of this and can you measure success?

This is valuable to know which parts of the notification workflow are working and not working. This will also help with tracking users expectations of the explainer.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@NathanielBennett @gtrufitt @crifmulholland 
