### PR TITLE
Remove FB overlay on paid content

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -8,7 +8,7 @@ import com.gu.facia.client.models.TrailMetaData
 import common._
 import common.dfp.DfpAgent
 import conf.Configuration
-import conf.switches.Switches.FacebookShareUseTrailPicFirstSwitch
+import conf.switches.Switches.{FacebookShareUseTrailPicFirstSwitch, FacebookShareImageLogoOverlay}
 import cricketPa.CricketTeams
 import layout.ContentWidths.GalleryMedia
 import model.content.{Atoms, Quiz}
@@ -81,6 +81,7 @@ final case class Content(
   lazy val discussionId = Some(shortUrlId)
   lazy val isImmersiveGallery = metadata.contentType.toLowerCase == "gallery" && !trail.commercial.isAdvertisementFeature
   lazy val isImmersive = fields.displayHint.contains("immersive") || isImmersiveGallery || tags.isUSMinuteSeries
+  lazy val isAdvertisementFeature: Boolean = tags.tags.exists{ tag => tag.id == "tone/advertisement-features" }
 
   lazy val hasSingleContributor: Boolean = {
     (tags.contributors.headOption, trail.byline) match {
@@ -105,7 +106,11 @@ final case class Content(
 
   // read this before modifying: https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
   lazy val openGraphImage: String = {
-    ImgSrc(rawOpenGraphImage, FacebookOpenGraphImage)
+    if (isAdvertisementFeature && FacebookShareImageLogoOverlay.isSwitchedOn) {
+      ImgSrc(rawOpenGraphImage, Item700)
+    } else {
+      ImgSrc(rawOpenGraphImage, FacebookOpenGraphImage)
+    }
   }
 
   lazy val syndicationType = {


### PR DESCRIPTION
## What does this change?

The branded overlay on Open Graph will no longer appear on images when paid content is shared to other sites. 

Swapping to using one of the other image profiles for the `og:image` paid content
## What is the value of this and can you measure success?

Success will be if we exclude the banner from 'paid for' content posts.
## Does this affect other platforms - Amp, Apps, etc?

All platforms scraping our Open Graph images (Facebook, WhatsApp, etc.)
## Screenshots
##### BEFORE:

<img width="1244" alt="Before" src="https://cloud.githubusercontent.com/assets/8607683/16342653/3e2d27a2-3a2b-11e6-81f6-67f50249a9f6.png">
##### AFTER:

<img width="1248" alt="After" src="https://cloud.githubusercontent.com/assets/8607683/16342209/d76b0536-3a28-11e6-85f6-2ded4e1ac163.png">
## Request for comment

@stephanfowler @dominickendrick 
