### PR TITLE
the test was meant to run for a week rather than 5 days

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -80,7 +80,7 @@ trait ABTestSwitches {
     "Make big play button yellow",
     owners = Seq(Owner.withGithub("akash1810")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 6, 27), // Tuesday
+    sellByDate = new LocalDate(2016, 6, 29),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-yellow-button.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-yellow-button.js
@@ -6,7 +6,7 @@ define([
     return function () {
         this.id = 'VideoYellowButton';
         this.start = '2016-06-22';
-        this.expiry = '2016-06-27';
+        this.expiry = '2016-06-29';
         this.author = 'Akash Askoolum';
         this.description = 'Test if a yellow play button increases starts';
         this.showForSensitive = true;


### PR DESCRIPTION
## What does this change?

we've lost a few hours of data - we may have to run the test again 😢 
## What is the value of this and can you measure success?

correct test duration
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

n/a
## Request for comment

@jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
