### PR TITLE
enable Wimbledon ad for live blogs and wimbledon-2016 section

### DIFF
--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -35,7 +35,12 @@ object Commercial {
     }
 
     private def isWimbledonEnabled(metaData: MetaData, edition: Edition) = {
-      (metaData.id == "sport/tennis" || metaData.id == "sport/wimbledon") && edition == Uk
+      edition == Uk &&
+      ( metaData.id == "sport/tennis" ||
+        metaData.id == "sport/wimbledon" ||
+        metaData.id == "sport/wimbledon-2016" ||
+        (metaData.adUnitSuffix == "sport/liveblog" && metaData.id.contains("wimbledon-2016")) // so that liveblogs relating to wimbledon-2016 are captured
+      )
     }
 
     def adSizes(metaData: MetaData, edition: Edition): Map[String, Seq[String]] = {


### PR DESCRIPTION
## What does this change?

The Wimbledon top-slot ad - set to run from now until the end of the tournament - is intended to run on Wimbledon live blogs as well as the **wimbledon-2016** section. This changes makes it so.

It isn't nice to do pattern matching, but this is a fix to a temporary piece of functionality that is well tested and signed off.
## Request for comment

@regiskuckaertz @Calum-Campbell 
