### PR TITLE
Change updateSubscription to handle cases of the subscription turning to

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/notifications.js
+++ b/static/src/javascripts/bootstraps/enhanced/notifications.js
@@ -177,14 +177,15 @@ define([
 
         updateSubscription: function (notificationsEndpoint) {
             return modules.getSub().then(function (sub) {
-                var endpoint = sub.endpoint,
-                    request = ajax({
+                var endpoint = sub && sub.endpoint;
+                if (endpoint) {
+                    return ajax({
                         url: notificationsEndpoint,
                         method: 'POST',
                         contentType: 'application/x-www-form-urlencoded',
                         data: {browserEndpoint: endpoint, notificationTopicId: config.page.pageId}
                     });
-                return request;
+                }
             });
         },
 


### PR DESCRIPTION
## What does this change?

This changes the call to `updateSubscription` to check if the `subscription` is `null`. This can happen when a user changes their notification preferences for a domain; and probably other reasons I am unaware of.

If a user is subscribed and changes their notification preferences for the domain, the status of the subscription (in the browser) and stay stuck in subscribed as this will try to get a `endpoint` of a `null` and fail the chain of calls in `JS` to fully unsubscribe.
## What is the value of this and can you measure success?

This makes notifications more reliable.
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@gtrufitt @NathanielBennett @crifmulholland 
