### PR TITLE
pass tags through the templates to reliably determine Wimbledonness

### DIFF
--- a/common/app/views/fragments/commercial/topBanner.scala.html
+++ b/common/app/views/fragments/commercial/topBanner.scala.html
@@ -1,10 +1,11 @@
-@(metaData: model.MetaData, edition: common.Edition)
+@(metaData: model.MetaData, edition: common.Edition, maybeTags: Option[Tags])
 @import views.support.Commercial.topAboveNavSlot
+@import model.Tags
 
-<div class="@topAboveNavSlot.cssClasses(metaData, edition)">
+<div class="@topAboveNavSlot.cssClasses(metaData, edition, maybeTags)">
     @fragments.commercial.standardAd(
         "top-above-nav",
         topAboveNavSlot.slotCssClasses(metaData),
-        topAboveNavSlot.adSizes(metaData, edition)
+        topAboveNavSlot.adSizes(metaData, edition, maybeTags)
     )
 </div>

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -9,7 +9,14 @@
 @headerAndTopAds(showAdverts: Boolean, edition: Edition, adBelowNav: Boolean) = {
     @if(!(page.metadata.shouldHideHeaderAndTopAds && getContent(page).exists(_.tags.isArticle))) {
         @if(showAdverts) {
-            @fragments.commercial.topBanner(page.metadata, edition)
+            @defining(
+                page match {
+                    case c: model.ContentPage => Some(c.item.tags)
+                    case _ => None
+                }
+            ) { maybeTags =>
+                @fragments.commercial.topBanner(page.metadata, edition, maybeTags)
+            }
         }
 
         @fragments.header(page)

--- a/common/app/views/support/Commercial.scala
+++ b/common/app/views/support/Commercial.scala
@@ -39,7 +39,7 @@ object Commercial {
       ( metaData.id == "sport/tennis" ||
         metaData.id == "sport/wimbledon" ||
         metaData.id == "sport/wimbledon-2016" ||
-        (metaData.adUnitSuffix == "sport/liveblog" && maybeTags.map(_.keywordIds contains "sport/wimbledon-2016").getOrElse(false)) // so that liveblogs relating to wimbledon-2016 are captured
+        (metaData.adUnitSuffix == "sport/liveblog" && maybeTags.exists(_.keywordIds contains "sport/wimbledon-2016")) // so that liveblogs relating to wimbledon-2016 are captured
       )
     }
 

--- a/common/test/views/support/CommercialTest.scala
+++ b/common/test/views/support/CommercialTest.scala
@@ -15,7 +15,7 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
 
   def pageShouldRequestAdSizes(pageId: String)(sizes: Seq[String]): Unit = {
     val metaData = metaDataFromId(pageId)
-    topAboveNavSlot.adSizes(metaData, defaultEdition).get("desktop").value shouldBe sizes
+    topAboveNavSlot.adSizes(metaData, defaultEdition, None).get("desktop").value shouldBe sizes
   }
 
   "topAboveNavSlot ad sizes" should "be variable for all pages" in {
@@ -44,11 +44,11 @@ class CommercialTest extends FlatSpec with Matchers with OptionValues with Befor
   // }
 
   they should "be default for any other page" in {
-    topAboveNavSlot.cssClasses(metaDataFromId("uk/culture"), defaultEdition, Nil) should
+    topAboveNavSlot.cssClasses(metaDataFromId("uk/culture"), defaultEdition, None, Nil) should
       endWith("top-banner-ad-container--reveal")
     topAboveNavSlot.cssClasses(metaDataFromId(
       "business/2015/jul/07/eurozone-calls-on-athens-to-get-serious-over-greece-debt-crisis"),
-      defaultEdition, Nil)
+      defaultEdition, None, Nil)
       .should(endWith("top-banner-ad-container--reveal"))
   }
 }


### PR DESCRIPTION
This is a followup to #13415 - instead of inspecting the URL/ID which is fraught with annoying edge cases (and requires that the articles are published with the phrase "Wimbledon 2016"), we now pass in the keywords to the top banner template and inspect them for "sport/wimbledon-2016".
