### PR TITLE
Tweak membership message copy. Make it show on articles for mobile web.

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -130,7 +130,6 @@ define([
         this.async = {
             membershipMessages : detect.adblockInUse.then(function (adblockUsed) {
                 return !adblockUsed &&
-                    detect.getBreakpoint() !== 'mobile' &&
                     isArticle &&
                     !userFeatures.isPayingMember();
             })

--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -40,10 +40,7 @@ define([
             code:          'membership-message-uk-2016-06-24',
             minVisited:    10,
             data: {
-                messageText: [
-                    'Support Guardian journalism and our coverage of critical, under-reported stories from around the world.',
-                    'Become a Supporter for just £49 per year.'
-                ].join(' '),
+                messageText: 'The Guardian’s voice is needed now more than ever. Support our journalism for just £49 per year.',
                 linkText: 'Find out more'
             }
         },
@@ -52,7 +49,7 @@ define([
             code:          'membership-message-us-2016-06-24',
             minVisited:    10,
             data: {
-                messageText: 'Support open, independent journalism. Become a Supporter for just $4.99 per month',
+                messageText: 'Support open, independent journalism. Become a Supporter for just $4.99 per month.',
                 linkText: 'Find out more'
             }
         },
@@ -61,10 +58,7 @@ define([
             code:          'membership-message-int-2016-06-24',
             minVisited:    10,
             data: {
-                messageText: [
-                    'Support Guardian journalism and our coverage of critical, under-reported stories from around the world.',
-                    'Become a Supporter for just $49/€49 per year.'
-                ].join(' '),
+                messageText: 'The Guardian’s voice is needed now more than ever. Support our journalism for just $49/€49 per year.',
                 linkText: 'Find out more'
             }
         }

--- a/static/src/javascripts/projects/common/views/membership-message.html
+++ b/static/src/javascripts/projects/common/views/membership-message.html
@@ -1,9 +1,6 @@
-<p class="site-message__message" id="site-message__message">
-    <%=messageText%>
-</p>
-<ul class="site-message__actions u-unstyled">
-    <li class="site-message__actions__item">
-        <%=arrowWhiteRight%>
-        <a href="<%=linkHref%>" target="_blank" data-link-name="read more"><%=linkText%></a>
-    </li>
-</ul>
+<div id="site-message__message">
+    <div class="site-message__message site-message__message--membership">
+        <%=messageText%>
+    </div>
+    <a class="u-faux-block-link__overlay" target="_blank" href="<%=linkHref%>" data-link-name="Read more"></a>
+</div>

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -4,7 +4,7 @@
     display: block;
     color: #ffffff;
 
-    @include mq(desktop) {
+    @include mq(tablet) {
         @include fs-headline(2, true);
     }
 }
@@ -21,21 +21,13 @@
 }
 
 .site-message__inner {
+    display: table;
     padding: 0 $gs-gutter/2;
+    width: 100%;
 
     @include mq(tablet) {
-        display: table;
-        width: 100%;
         padding: 0;
-        min-height: gs-height(2) - $gs-baseline;
-    }
-
-    @include mq(desktop) {
-        min-height: gs-height(2) - $gs-baseline*2;
-    }
-
-    @include mq(wide) {
-        min-height: gs-height(1) + $gs-baseline;
+        min-height: gs-height(1) + $gs-baseline/2;
     }
 }
 
@@ -56,18 +48,21 @@
 }
 
 .site-message__copy {
-    padding-top: $gs-baseline;
-    padding-bottom: $gs-baseline;
+    padding-top: $gs-baseline/2;
+    padding-bottom: $gs-baseline/2;
+    position: relative;
+    display: table-cell;
+    vertical-align: middle;
 
     @include mq(tablet) {
+        padding-top: 0;
+        padding-bottom: 0;
         padding-left: $gs-gutter/2;
         padding-right: $gs-gutter/2;
     }
 
     @include mq(desktop) {
         padding: 0;
-        display: table-cell;
-        vertical-align: middle;
     }
 }
 
@@ -111,6 +106,10 @@
     @include mq(wide) {
         max-width: none;
     }
+}
+
+.site-message__message--membership {
+    max-width: none;
 }
 
 .site-message__message--tall {
@@ -199,10 +198,10 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 .site-message__close {
     display: table-cell;
     vertical-align: middle;
-    padding-right: $gs-gutter/2;
+    padding-right: $gs-gutter;
 
-    @include mq(desktop) {
-        padding-right: $gs-gutter;
+    @include mq(tablet) {
+        padding-right: $gs-gutter/2;
     }
 }
 
@@ -216,17 +215,12 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
     background: transparent;
     border: 1px solid rgba(#ffffff, .3);
     color: #ffffff;
+    float: right;
 
     &:hover,
     &:focus,
     &:active {
         border-color: #ffffff;
-    }
-
-    @include mq($until: tablet) {
-        position: absolute;
-        right: $gs-gutter;
-        top: $gs-baseline;
     }
 }
 
@@ -287,7 +281,7 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
         width: $gs-gutter;
         height: $gs-gutter;
         background-color: $neutral-1;
-        box-shadow: 0px 1px 0px $neutral-3;
+        box-shadow: 0 1px 0 $neutral-3;
 
         &:before {
             @include font(arial, bold, 14px);

--- a/static/src/stylesheets/module/_release-message.scss
+++ b/static/src/stylesheets/module/_release-message.scss
@@ -197,7 +197,9 @@ $btn-height: gs-height(1) - $gs-baseline/2; //30px
 
 .site-message__close {
     display: table-cell;
-    vertical-align: middle;
+    vertical-align: top;
+    padding-bottom: $gs-gutter/4;
+    padding-top: $gs-gutter/4;
     padding-right: $gs-gutter;
 
     @include mq(tablet) {

--- a/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
+++ b/static/test/javascripts/spec/common/commercial/commercial-features.spec.js
@@ -343,11 +343,11 @@ define(['helpers/injector', 'Promise'], function (Injector, Promise) {
                 });
             });
 
-            it('Does not display messages on mobile', function (done) {
+            it('Does display messages on mobile', function (done) {
                 detect.getBreakpoint = function () { return 'mobile'; };
                 features = new CommercialFeatures;
                 features.async.membershipMessages.then(function (flag) {
-                    expect(flag).toBe(false);
+                    expect(flag).toBe(true);
                     done();
                 });
             });


### PR DESCRIPTION
## What does this change?

This change displays the Membership Engaged Reader banner on mobile web screens in addition to the existing desktop + tablet. Also some copy has changed to ensure it is shorter and covers less of the page.
## What is the value of this and can you measure success?

We expect an uplift in supporters. We measure memberships which convert via the MEMBERSHIP_SUPPORTER_BANNER_\* campaign code.
## Does this affect other platforms - Amp, Apps, etc?

Only web.
## Screenshots

<img width="365" alt="picture 131" src="https://cloud.githubusercontent.com/assets/1515970/16415762/bd831116-3d36-11e6-8f53-85d5f97a3030.png">

<img width="615" alt="picture 132" src="https://cloud.githubusercontent.com/assets/1515970/16415765/c60116d0-3d36-11e6-9746-d4339beb90e4.png">
## Request for comment

cc @dominickendrick @joelochlann

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
