### PR TITLE
kill controls on expired videos

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -242,6 +242,7 @@ define([
                     });
                     player.bigPlayButton.dispose();
                     player.errorDisplay.open();
+                    player.controlBar.dispose();
                 });
             } else {
                 blockVideoAds = videoInfo.shouldHideAdverts;


### PR DESCRIPTION
## What does this change?

Kills the control bar so you can't play the video.
As before, we know this isn't the real way to expire videos. Roll on atoms.
## What is the value of this and can you measure success?

People can't play video
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

👾 
## Request for comment

@akash1810 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
