### PR TITLE
Give crawlers more choice in metatags

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -69,7 +69,7 @@
                                             <meta itemprop="width" content="@mv.videos.width" />
                                         }
                                         <meta itemprop="requiresSubscription" content="false" />
-                                        <meta itemprop="image" content="@Html(video.content.openGraphImage)" />
+                                        <meta itemprop="image" content="@Html(video.content.signedArticleImage)" />
                                         @video.elements.thumbnail.map{ img => <meta itemprop="thumbnail" content="@SeoOptimisedContentImage.bestFor(img.images)" /> }
                                         @video.elements.mainVideo.map { videoElement =>
                                             @fragments.media.video(VideoPlayer(

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -31,6 +31,7 @@
                         ) { player =>
                             @fragments.media.video(player, true, amp = amp)
                             <meta itemprop="name" content="@player.title">
+                            <meta itemprop="image" content="@player.poster">
                             <meta itemprop="thumbnail" content="@player.poster">
                             <meta itemprop="thumbnailUrl" content="@player.poster">
                             <meta itemprop="uploadDate" content="@article.trail.webPublicationDate"> @*This should ideally be the video publication date (and not the article one) but at the moment this info is not exposed via the article capi endpoint*@

--- a/article/app/views/fragments/mainMedia.scala.html
+++ b/article/app/views/fragments/mainMedia.scala.html
@@ -31,6 +31,7 @@
                         ) { player =>
                             @fragments.media.video(player, true, amp = amp)
                             <meta itemprop="name" content="@player.title">
+                            <meta itemprop="thumbnail" content="@player.poster">
                             <meta itemprop="thumbnailUrl" content="@player.poster">
                             <meta itemprop="uploadDate" content="@article.trail.webPublicationDate"> @*This should ideally be the video publication date (and not the article one) but at the moment this info is not exposed via the article capi endpoint*@
 

--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -103,6 +103,10 @@ final case class Content(
   lazy val showCircularBylinePicAtSide: Boolean =
     cardStyle == Feature && tags.hasLargeContributorImage && tags.contributors.length == 1
 
+  lazy val signedArticleImage: String = {
+    ImgSrc(rawOpenGraphImage, EmailArticleImage)
+  }
+
   // read this before modifying: https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#images
   lazy val openGraphImage: String = {
     ImgSrc(rawOpenGraphImage, FacebookOpenGraphImage)


### PR DESCRIPTION
## What does this change?

Details of issue in #13333 

The change to mainMedia.scala.html adds the missing `itemprop="thumbnail"` and `itemprop="image"` that are not generated when the main media is video. I believe this is why Google is falling back to the Open Graph image.

This should fix the meta tags on pages like this:
https://www.theguardian.com/commentisfree/2016/jun/16/the-guardian-view-on-jo-cox-an-attack-on-humanity-idealism-and-democracy

(using signedArticleImage since the openGraphImage may have an overlay applied!)
## What is the value of this and can you measure success?

Google and AMP should preferentially use Schema.org tags (itemprop); some content types are missing certain meta-tags. Adding them should change how Google and AMP display our content, and remove the banner overlay from the image on links.
## Does this affect other platforms - Amp, Apps, etc?

AMP
Google search results
Any other web crawlers that use Schema to scrape our site
## Screenshots
##### Before:

<img width="1232" alt="missing meta-tags" src="https://cloud.githubusercontent.com/assets/8607683/16262628/52365daa-3868-11e6-9548-b5116a758f78.png">
##### With generated meta-tags:

<img width="1131" alt="new meta-tags generated" src="https://cloud.githubusercontent.com/assets/8607683/16261199/a2ab0bce-3862-11e6-989c-e0db4224b9c8.png">
## Request for comment
