### PR TITLE
Remove Twitter overlay on paid content

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -8,7 +8,7 @@ import com.gu.facia.client.models.TrailMetaData
 import common._
 import common.dfp.DfpAgent
 import conf.Configuration
-import conf.switches.Switches.{FacebookShareUseTrailPicFirstSwitch, FacebookShareImageLogoOverlay}
+import conf.switches.Switches.{FacebookShareUseTrailPicFirstSwitch, FacebookShareImageLogoOverlay, TwitterShareImageLogoOverlay}
 import cricketPa.CricketTeams
 import layout.ContentWidths.GalleryMedia
 import model.content.{Atoms, Quiz}
@@ -114,6 +114,15 @@ final case class Content(
       ImgSrc(rawOpenGraphImage, Item700)
     } else {
       ImgSrc(rawOpenGraphImage, FacebookOpenGraphImage)
+    }
+  }
+
+  // URL of image to use in the twitter card. Image must be less than 1MB in size: https://dev.twitter.com/cards/overview
+  lazy val twitterCardImage: String = {
+    if (isAdvertisementFeature && TwitterShareImageLogoOverlay.isSwitchedOn) {
+      ImgSrc(rawOpenGraphImage, Item700)
+    } else {
+      ImgSrc(rawOpenGraphImage, TwitterImage)
     }
   }
 
@@ -248,7 +257,7 @@ final case class Content(
 
   val twitterProperties = Map(
     "twitter:app:url:googleplay" -> metadata.webUrl.replaceFirst("^[a-zA-Z]*://", "guardian://"), //replace current scheme with guardian mobile app scheme
-    "twitter:image" -> ImgSrc(rawOpenGraphImage, TwitterImage)
+    "twitter:image" -> twitterCardImage
   ) ++ contributorTwitterHandle.map(handle => "twitter:creator" -> s"@$handle").toList
 
   val quizzes: Seq[Quiz] = atoms.map(_.quizzes).getOrElse(Nil)


### PR DESCRIPTION
## What does this change?

Just like #13411, but for Twitter! 🎉 

The branded overlay will no longer appear on images for paid content when articles are tweeted.

Swapping to using one of the other image profiles for the `twitter:image` meta-tag on paid content.
## What is the value of this and can you measure success?

Success will be if we exclude the banner from 'paid for' content when it is tweeted (see image below).
## Does this affect other platforms - Amp, Apps, etc?

Twitter
Anywhere else that uses Twitter Card meta-data (none known at this date)
Information on Twitter Cards: https://dev.twitter.com/cards/overview
## Screenshots

Paid content currently has the overlay appearing:
<img width="518" alt="paid content" src="https://cloud.githubusercontent.com/assets/8607683/16458728/0d42ccb4-3e18-11e6-9e41-ddbed0404fff.png">
## Request for comment
