### PR TITLE
Further restrict when Plista should be served

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -48,7 +48,11 @@ define([
             $(documentAnchorClass).append(externalTpl({widgetType: widgetType}));
         }
 
-        if (config.switches.plistaForOutbrainAu && config.page.edition.toLowerCase() === 'au') {
+        var isMobileOrTablet = ['mobile', 'tablet'].indexOf(detect.getBreakpoint(false).name) >= 0;
+        var shouldIgnoreSwitch =  isMobileOrTablet || config.page.section === 'world' || config.page.edition.toLowerCase() !== 'au';
+        var shouldServePlista = config.switches.plistaForOutbrainAu && !shouldIgnoreSwitch;
+
+        if (shouldServePlista) {
             fastdom.write(function () {
                 renderWidgetContainer('plista');
             }).then(plista.init);


### PR DESCRIPTION
## What does this change?

We have a switch that determines whether we serve Outbrain or Plista at the bottom of pages. Up until now, if the switch is enabled and we are on the AU edition, then Plista will be served, otherwise Outbrain.

At the request of the guys in AU, we are changing the policy slightly to the following:
- mobile/tablet: all sections have outbrain 100% if the time
- desktop: world news has outbrain 100% of the time
- everything else controlled by the switch (including requirement to be on the AU edition)

I _think_ I'm right in thinking that we no longer support IE8, and thus I'm fine to use `Array.prototype.indexOf`...
