### PR TITLE
Fix headline colour for dark containers on immersive articles

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -112,10 +112,16 @@
     font-weight: 200;
 }
 
+.content--immersive-article-without-main-media,
+.immersive-main-media__headline-container--dark {
+    .content__headline--immersive-article {
+        color: #ffffff;
+    }
+}
+
 .content__headline--immersive-article {
     @include fs-headline(7, true);
     line-height: 1;
-    color: #ffffff;
 
     @include mq(desktop) {
         font-size: 4rem;

--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -112,7 +112,6 @@
     font-weight: 200;
 }
 
-.content--immersive-article-without-main-media,
 .immersive-main-media__headline-container--dark {
     .content__headline--immersive-article {
         color: #ffffff;


### PR DESCRIPTION
## What does this change?

Immersive articles with dark headline containers now will not have their headline colour overridden by the the tone of the article.
## Request for comment

@NataliaLKB @dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
