### PR TITLE
Dev build lifecycle / Autorefresh

### DIFF
--- a/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
+++ b/article/app/services/NewspaperBooksAndSectionsAutoRefresh.scala
@@ -1,7 +1,9 @@
 package services
 
+import akka.actor.ActorSystem
 import common.{LifecycleComponent, AutoRefresh}
 import model.{TagDefinition, TagIndexListings}
+import play.libs.Akka
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -25,7 +27,7 @@ trait NewspaperTags {
   }
 }
 
-class NewspaperBookTagAgent extends AutoRefresh[TagIndexListings](0 seconds, 5 minutes) with NewspaperTags {
+class NewspaperBookTagAgent(actorSystem: => ActorSystem) extends AutoRefresh[TagIndexListings](0 seconds, 5 minutes, actorSystem) with NewspaperTags {
   override val source = "newspaper_books"
   override protected def refresh(): Future[TagIndexListings] = Future {
     blocking {
@@ -34,9 +36,9 @@ class NewspaperBookTagAgent extends AutoRefresh[TagIndexListings](0 seconds, 5 m
   }
 }
 
-object NewspaperBookTagAgent extends NewspaperBookTagAgent
+object NewspaperBookTagAgent extends NewspaperBookTagAgent(Akka.system())
 
-class NewspaperBookSectionTagAgent extends AutoRefresh[TagIndexListings](0 seconds, 5 minutes) with NewspaperTags {
+class NewspaperBookSectionTagAgent(actorSystem: => ActorSystem) extends AutoRefresh[TagIndexListings](0 seconds, 5 minutes, actorSystem) with NewspaperTags {
   override val source = "newspaper_book_sections"
   override protected def refresh(): Future[TagIndexListings] = Future {
     blocking {
@@ -45,4 +47,4 @@ class NewspaperBookSectionTagAgent extends AutoRefresh[TagIndexListings](0 secon
   }
 }
 
-object NewspaperBookSectionTagAgent extends NewspaperBookSectionTagAgent
+object NewspaperBookSectionTagAgent extends NewspaperBookSectionTagAgent(Akka.system())

--- a/common/app/contentapi/SectionsLookUpLifecycle.scala
+++ b/common/app/contentapi/SectionsLookUpLifecycle.scala
@@ -1,31 +1,35 @@
 package contentapi
 
-import common.{LifecycleComponent, AkkaAsync, Logging, Jobs}
+import common._
 import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{Future, ExecutionContext}
 
-class SectionsLookUpLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
+class SectionsLookUpLifecycle(
+  appLifecycle: ApplicationLifecycle,
+  jobs: JobScheduler = Jobs,
+  akkaAsync: AkkaAsync = AkkaAsync
+)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
 
   appLifecycle.addStopHook { () => Future {
     descheduleJobs()
   }}
 
   private def scheduleJobs() {
-    Jobs.schedule("SectionsLookUpJob", "0 * * * * ?") {
+    jobs.schedule("SectionsLookUpJob", "0 * * * * ?") {
       SectionsLookUp.refresh()
     }
   }
 
   private def descheduleJobs() {
-    Jobs.deschedule("SectionsLookUpJob")
+    jobs.deschedule("SectionsLookUpJob")
   }
 
   override def start(): Unit = {
     descheduleJobs()
     scheduleJobs()
 
-    AkkaAsync {
+    akkaAsync.after1s {
       SectionsLookUp.refresh()
     }
   }

--- a/diagnostics/app/common/DiagnosticsLifecycle.scala
+++ b/diagnostics/app/common/DiagnosticsLifecycle.scala
@@ -4,20 +4,20 @@ import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class DiagnosticsLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
+class DiagnosticsLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler = Jobs)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
 
   appLifecycle.addStopHook { () => Future {
     descheduleJobs()
   }}
 
   private def scheduleJobs() {
-    Jobs.schedule("DiagnosticsLoadJob", "0 * * * * ?") {
+    jobs.schedule("DiagnosticsLoadJob", "0 * * * * ?") {
       model.diagnostics.analytics.UploadJob.run()
     }
   }
 
   private def descheduleJobs() {
-    Jobs.deschedule("DiagnosticsLoadJob")
+    jobs.deschedule("DiagnosticsLoadJob")
   }
 
   override def start(): Unit = {


### PR DESCRIPTION
## What does this change?

These autorefresh need to be instantiated to create the app, and they were depending on a started app. This PR passes an already instantiated actor system so that the akka.system() doesn't throw an exception on startup.
It also injects more lifecycle objects for the same reason.

next PR is about removing Global on dev-build, this is a way to make the next PR less overwhelming.
## Request for comment

@TBonnin @johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
