### PR TITLE
Fix Plista switch logic

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -48,7 +48,7 @@ define([
             $(documentAnchorClass).append(externalTpl({widgetType: widgetType}));
         }
 
-        var isMobileOrTablet = ['mobile', 'tablet'].indexOf(detect.getBreakpoint(false).name) >= 0;
+        var isMobileOrTablet = ['mobile', 'tablet'].indexOf(detect.getBreakpoint(false)) >= 0;
         var shouldIgnoreSwitch =  isMobileOrTablet || config.page.section === 'world' || config.page.edition.toLowerCase() !== 'au';
         var shouldServePlista = config.switches.plistaForOutbrainAu && !shouldIgnoreSwitch;
 


### PR DESCRIPTION
Don't need to call `.name` on the return of `getBreakpoint` is it already returned in the method.

@regiskuckaertz 
