### PR TITLE
Fix edition switch when https-enabled

### DIFF
--- a/common/app/controllers/PreferenceController.scala
+++ b/common/app/controllers/PreferenceController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import java.net.URI
 import common.LinkTo
 import conf.Configuration.site
 import model.NoCache
@@ -10,7 +11,7 @@ trait PreferenceController extends Results {
   // we do not want people redirecting to arbitrary domains
   def allowedUrl(url: String)(implicit request: RequestHeader) = site.host match {
     case "" => url.startsWith("/") && !url.startsWith("//")
-    case host => LinkTo(url) startsWith host
+    case host => URI.create(LinkTo(url)).getHost == URI.create(host).getHost
   }
 
   protected def getShortenedDomain(domain: String) = {


### PR DESCRIPTION
## What does this change?

We should only compare hosts when assessing valid redirect targets in edition switch.
## What is the value of this and can you measure success?

Fixes edition switching.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Request for comment

@alexduf @johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
