### PR TITLE
Hosted video fails fix

### DIFF
--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -17,10 +17,10 @@
                     data-block-video-ads="true"
                     poster="@page.video.posterUrl"
                     class="vjs-hosted__video hosted__video gu-media--video vjs vjs-tech-html5 vjs-paused vjs-controls-enabled vjs_video_1-dimensions vjs-user-active">
-                        <source type="video/mp4" src="@page.video.srcUrl&format=video/mp4&maxbitrate=2048">
-                        <source type="video/webm" src="@page.video.srcUrl&format=video/webm&maxbitrate=2048">
-                        <source type="video/ogg" src="@page.video.srcUrl&format=video/ogg&maxbitrate=2048">
-                        <source type="video/m3u8" src="@page.video.srcUrl&format=video/m3u8&maxbitrate=2048">
+                        <source type="video/mp4" src="@page.video.srcUrlMp4">
+                        <source type="video/webm" src="@page.video.srcUrlWebm">
+                        <source type="video/ogg" src="@page.video.srcUrlOgg">
+                        <source type="video/m3u8" src="@page.video.srcM3u8">
                     </video>
                     <div class="hosted-fading js-hosted-fading">
                         <div class="hosted__video-overlay"></div>

--- a/common/app/common/commercial/HostedPage.scala
+++ b/common/app/common/commercial/HostedPage.scala
@@ -110,7 +110,10 @@ case class HostedVideo(
                         title: String,
                         duration: Int,
                         posterUrl: String,
-                        srcUrl: String
+                        srcUrlMp4: String,
+                        srcUrlWebm: String,
+                        srcUrlOgg: String,
+                        srcM3u8: String
                       )
 
 case class HostedGalleryImage(

--- a/common/app/common/commercial/RenaultHostedPages.scala
+++ b/common/app/common/commercial/RenaultHostedPages.scala
@@ -23,7 +23,7 @@ object RenaultHostedPages {
       srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/05/17/160516GlabsTestSD_2M_H264.mp4",
       srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/05/17/160516GlabsTestSD_2M_vp8.webm",
       srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/05/17/160516GlabsTestSD-3_hi.ogv",
-      srcM3u8 = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160516GlabsTestSD&format=video/m3u8&maxbitrate=2048"
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/05/17/HLS/160516GlabsTestSD.m3u8"
     ),
     nextPageName = episode1PageName
   )
@@ -43,7 +43,7 @@ object RenaultHostedPages {
       srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/05/23/160523GlabsRenaultTestHD_2M_H264.mp4",
       srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/05/23/160523GlabsRenaultTestHD_2M_vp8.webm",
       srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/05/23/160523GlabsRenaultTestHD-3_hi.ogv",
-      srcM3u8 = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160523GlabsRenaultTestHD&format=video/m3u8&maxbitrate=2048"
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/05/23/HLS/160523GlabsRenaultTestHD.m3u8"
     ),
     nextPageName = episode2PageName
   )
@@ -63,7 +63,7 @@ object RenaultHostedPages {
       srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/03/160603GlabsRenaultTest3_2M_H264.mp4",
       srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/03/160603GlabsRenaultTest3_2M_vp8.webm",
       srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/03/160603GlabsRenaultTest3-3_hi.ogv",
-      srcM3u8 = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160603GlabsRenaultTest3&format=video/m3u8&maxbitrate=2048"
+      srcM3u8 = "https://cdn.theguardian.tv/interactive/2016/06/03/HLS/160603GlabsRenaultTest3.m3u8"
     ),
     nextPageName = episode1PageName
   )

--- a/common/app/common/commercial/RenaultHostedPages.scala
+++ b/common/app/common/commercial/RenaultHostedPages.scala
@@ -20,7 +20,10 @@ object RenaultHostedPages {
       title = "Designing the car of the future",
       duration = 86,
       posterUrl = Static("images/commercial/renault-video-poster.jpg"),
-      srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160516GlabsTestSD"
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/05/17/160516GlabsTestSD_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/05/17/160516GlabsTestSD_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/05/17/160516GlabsTestSD-3_hi.ogv",
+      srcM3u8 = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160516GlabsTestSD&format=video/m3u8&maxbitrate=2048"
     ),
     nextPageName = episode1PageName
   )
@@ -37,7 +40,10 @@ object RenaultHostedPages {
       title = "Renault shortlists 'car of the future' designs",
       duration = 160,
       posterUrl = Static("images/commercial/renault-video-poster-ep1.jpg"),
-      srcUrl = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160523GlabsRenaultTestHD"
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/05/23/160523GlabsRenaultTestHD_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/05/23/160523GlabsRenaultTestHD_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/05/23/160523GlabsRenaultTestHD-3_hi.ogv",
+      srcM3u8 = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160523GlabsRenaultTestHD&format=video/m3u8&maxbitrate=2048"
     ),
     nextPageName = episode2PageName
   )
@@ -54,7 +60,10 @@ object RenaultHostedPages {
       title = "Is this the car of the future?",
       duration = 158,
       posterUrl = Static("images/commercial/renault-video-poster-ep2.jpg"),
-      srcUrl = "http://multimedia.guardianapis.com/interactivevideos/video.php?file=160603GlabsRenaultTest3"
+      srcUrlMp4 = "https://cdn.theguardian.tv/interactive/2016/06/03/160603GlabsRenaultTest3_2M_H264.mp4",
+      srcUrlWebm = "https://cdn.theguardian.tv/interactive/2016/06/03/160603GlabsRenaultTest3_2M_vp8.webm",
+      srcUrlOgg = "https://cdn.theguardian.tv/interactive/mp4/1080/2016/06/03/160603GlabsRenaultTest3-3_hi.ogv",
+      srcM3u8 = "https://multimedia.guardianapis.com/interactivevideos/video.php?file=160603GlabsRenaultTest3&format=video/m3u8&maxbitrate=2048"
     ),
     nextPageName = episode1PageName
   )


### PR DESCRIPTION
## What does this change?

A fix for the hosted videos fails issues. The videos' URLs link directly to https://cdn.theguardian.tv now instead of http://multimedia.guardianapis.com which is much faster.
Also all links are https now.

I didn't change the `M3u8` link because it's only a playlist text file and it's downloaded not opened by the browser.
## What is the value of this and can you measure success?

No video errors on the hosted pages. Also videos load now much faster.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
