### PR TITLE
change colour of play button from grey to yellow

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -119,11 +119,7 @@ $ima-controls-height: 70px;
             @include mq(mobileLandscape) {
                 @include video-play-button-size($vjs-large-button-size);
             }
-            background-color: rgba($media-mute, .6);
-            .gu-media-wrapper:hover &,
-            .gu-media__fallback:hover & {
-                background-color: $media-default;
-            }
+            background-color: $media-default;
         }
 
         &:after {
@@ -155,10 +151,6 @@ $ima-controls-height: 70px;
     .vjs-ad-loading & {
         display: none !important;
     }
-}
-
-.vjs-big-play-button--yellow .vjs-big-play-button .vjs-control-text:before {
-    background-color: $media-default;
 }
 
 .vjs-fullscreen-clickbox {


### PR DESCRIPTION
## What does this change?

We ran a [test](https://github.com/guardian/frontend/pull/13434/files) against this with the hypothesis that a yellow button helps to distinguish the element as a video rather than just another image and thus increases video starts.

We saw a 4.1% increase in video starts in the test, so making it a permanent change.
## What is the value of this and can you measure success?

video starts ⬆️ 
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

💛 

![screen shot 2016-07-04 at 16 21 44](https://cloud.githubusercontent.com/assets/836140/16565148/49d3feac-4203-11e6-8970-edbad234a4ae.jpeg)
## Request for comment

@jamesgorrie (or anyone as James is in Spain this week!)

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
