### PR TITLE
HealthCheck: introduce the notion of non expiring internal healthcheck

### DIFF
--- a/admin-jobs/app/controllers/HealthCheck.scala
+++ b/admin-jobs/app/controllers/HealthCheck.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
 class HealthCheck extends AllGoodCachedHealthCheck(
   9015,
-  "/news-alert/alerts"
+  ExpiringSingleHealthCheck("/news-alert/alerts")
 )

--- a/admin/app/controllers/HealthCheck.scala
+++ b/admin/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
-class HealthCheck extends AllGoodCachedHealthCheck(9001, "/login")
+class HealthCheck extends AllGoodCachedHealthCheck(9001, ExpiringSingleHealthCheck("/login"))

--- a/applications/app/controllers/HealthCheck.scala
+++ b/applications/app/controllers/HealthCheck.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 import contentapi.SectionsLookUp
 import play.api.mvc.{Action, AnyContent}
 
@@ -8,11 +8,11 @@ import scala.concurrent.Future
 
 class HealthCheck extends AllGoodCachedHealthCheck(
   9002,
-  "/books",
-  "/books/harrypotter",
-  "/travel/gallery/2012/nov/20/st-petersburg-pushkin-museum",
-  "/travel/gallery/2012/nov/20/st-petersburg-pushkin-museum?index=2",
-  "/world/video/2012/nov/20/australian-fake-bomber-sentenced-sydney-teenager-video"
+  ExpiringSingleHealthCheck("/books"),
+  ExpiringSingleHealthCheck("/books/harrypotter"),
+  ExpiringSingleHealthCheck("/travel/gallery/2012/nov/20/st-petersburg-pushkin-museum"),
+  ExpiringSingleHealthCheck("/travel/gallery/2012/nov/20/st-petersburg-pushkin-museum?index=2"),
+  ExpiringSingleHealthCheck("/world/video/2012/nov/20/australian-fake-bomber-sentenced-sydney-teenager-video")
 ) {
   override def healthCheck(): Action[AnyContent] = Action.async { request =>
     if (!SectionsLookUp.isLoaded()) {

--- a/archive/app/controllers/HealthCheck.scala
+++ b/archive/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
-class HealthCheck extends AllGoodCachedHealthCheck(9003, "/404/www.theguardian.com/Adzip/adzip-fb.html")
+class HealthCheck extends AllGoodCachedHealthCheck(9003, ExpiringSingleHealthCheck("/404/www.theguardian.com/Adzip/adzip-fb.html"))

--- a/article/app/controllers/HealthCheck.scala
+++ b/article/app/controllers/HealthCheck.scala
@@ -1,5 +1,8 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
-class HealthCheck extends AllGoodCachedHealthCheck(9004, "/world/2012/sep/11/barcelona-march-catalan-independence")
+class HealthCheck extends AllGoodCachedHealthCheck(
+  9004,
+  ExpiringSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
+)

--- a/commercial/app/controllers/HealthCheck.scala
+++ b/commercial/app/controllers/HealthCheck.scala
@@ -1,13 +1,13 @@
 package controllers
 
-import conf.AnyGoodCachedHealthCheck
+import conf.{AnyGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
 object HealthCheck extends AnyGoodCachedHealthCheck(
   9005,
-  "/commercial/soulmates/mixed.json",
-  "/commercial/masterclasses.json",
-  "/commercial/travel/offers.json",
-  "/commercial/jobs.json",
-  "/commercial/money/bestbuys.json",
-  "/commercial/books/books.json"
+  ExpiringSingleHealthCheck("/commercial/soulmates/mixed.json"),
+  ExpiringSingleHealthCheck("/commercial/masterclasses.json"),
+  ExpiringSingleHealthCheck("/commercial/travel/offers.json"),
+  ExpiringSingleHealthCheck("/commercial/jobs.json"),
+  ExpiringSingleHealthCheck("/commercial/money/bestbuys.json"),
+  ExpiringSingleHealthCheck("/commercial/books/books.json")
 )

--- a/common/test/conf/CachedHealthCheckTest.scala
+++ b/common/test/conf/CachedHealthCheckTest.scala
@@ -15,7 +15,7 @@ import scala.util.Random
 class CachedHealthCheckTest extends WordSpec with Matchers with SingleServerSuite with ScalaFutures with ExecutionContexts {
 
   //Helper method to construct mock Results
-  def mockResult(statusCode: Int, date: DateTime = DateTime.now, expiration: Duration = 10.seconds): HealthCheckResult = {
+  def mockResult(statusCode: Int, date: DateTime = DateTime.now, expiration: HealthCheckExpiration = HealthCheckExpires.Duration(10.seconds)): HealthCheckResult = {
     val path = s"/path/${Random.alphanumeric.take(12).mkString}"
     statusCode match {
       case 200 => new HealthCheckResult(path, HealthCheckResultTypes.Success(statusCode), date, expiration)
@@ -27,11 +27,11 @@ class CachedHealthCheckTest extends WordSpec with Matchers with SingleServerSuit
   def getHealthCheck(mockResults: List[HealthCheckResult], policy: HealthCheckPolicy)(testBlock: Future[Result] => Unit) = {
 
     // Create a CachedHealthCheck controller with mock results
-    val mockPaths: Seq[String] = mockResults.map(_.url)
+    val mockHealthChecks: Seq[SingleHealthCheck] = mockResults.map(result => ExpiringSingleHealthCheck(result.url))
     val mockTestPort: Int = 9100
-    val controller = new CachedHealthCheck(policy, mockTestPort, mockPaths:_*) {
+    val controller = new CachedHealthCheck(policy, mockTestPort, mockHealthChecks:_*) {
       override val cache = new HealthCheckCache {
-        override def fetchResults(testPort: Int, paths: String*): Future[Seq[HealthCheckResult]] = {
+        override def fetchResults(testPort: Int, paths: SingleHealthCheck*): Future[Seq[HealthCheckResult]] = {
           Future.successful(mockResults)
         }
       }
@@ -59,8 +59,8 @@ class CachedHealthCheckTest extends WordSpec with Matchers with SingleServerSuit
       "cached result is expired" should {
         "503" in {
           val expiration = 5.seconds
-          val date = DateTime.now.minus(expiration.toMillis + 1)
-          val mockResults = List(mockResult(200, date, expiration))
+          val resultDate = DateTime.now.minus(expiration.toMillis + 1)
+          val mockResults = List(mockResult(200, resultDate, HealthCheckExpires.Duration(expiration)))
           getHealthCheck(mockResults, HealthCheckPolicy.All) { response =>
             status(response) should be (503)
           }
@@ -82,6 +82,15 @@ class CachedHealthCheckTest extends WordSpec with Matchers with SingleServerSuit
           }
         }
       }
+      "results which are never expiring" should {
+        "200" in {
+          val resultDate = DateTime.now.minus(scala.util.Random.nextLong) // random date in the past
+          val mockResults = List(mockResult(200, resultDate, HealthCheckExpires.Never))
+          getHealthCheck(mockResults, HealthCheckPolicy.All) { response =>
+            status(response) should be (200)
+          }
+        }
+      }
     }
     "at least one request must be successful" when {
       "cache result is empty" should {
@@ -94,8 +103,8 @@ class CachedHealthCheckTest extends WordSpec with Matchers with SingleServerSuit
       "one cached result is successful but expired" should {
         "503" in {
           val expiration = 5.seconds
-          val date = DateTime.now.minus(expiration.toMillis + 1)
-          val mockResults = List(mockResult(200, date, expiration), mockResult(404))
+          val resultDate = DateTime.now.minus(expiration.toMillis + 1)
+          val mockResults = List(mockResult(200, resultDate, HealthCheckExpires.Duration(expiration)), mockResult(404))
           getHealthCheck(mockResults, HealthCheckPolicy.Any) { response =>
             status(response) should be(503)
           }

--- a/diagnostics/app/controllers/HealthCheck.scala
+++ b/diagnostics/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
-class HealthCheck extends AllGoodCachedHealthCheck(9006, "/robots.txt")
+class HealthCheck extends AllGoodCachedHealthCheck(9006, ExpiringSingleHealthCheck("/robots.txt"))

--- a/discussion/app/controllers/HealthCheck.scala
+++ b/discussion/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
-object HealthCheck extends AllGoodCachedHealthCheck(9007, "/discussion/p/37v3a")
+object HealthCheck extends AllGoodCachedHealthCheck(9007, ExpiringSingleHealthCheck("/discussion/p/37v3a"))

--- a/facia/app/controllers/HealthCheck.scala
+++ b/facia/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
-object HealthCheck extends AllGoodCachedHealthCheck(9008, "/uk/business")
+object HealthCheck extends AllGoodCachedHealthCheck(9008, ExpiringSingleHealthCheck("/uk/business"))

--- a/identity/app/controllers/HealthCheck.scala
+++ b/identity/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
-object HealthCheck extends AllGoodCachedHealthCheck(9010, "/signin")
+object HealthCheck extends AllGoodCachedHealthCheck(9010, ExpiringSingleHealthCheck("/signin"))

--- a/onward/app/controllers/HealthCheck.scala
+++ b/onward/app/controllers/HealthCheck.scala
@@ -1,9 +1,9 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
 object HealthCheck extends AllGoodCachedHealthCheck(
   9011,
-  "/top-stories.json",
-  "/most-read/society.json"
+  ExpiringSingleHealthCheck("/top-stories.json"),
+  ExpiringSingleHealthCheck("/most-read/society.json")
 )

--- a/preview/app/controllers/HealthCheck.scala
+++ b/preview/app/controllers/HealthCheck.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
 class HealthCheck extends AllGoodCachedHealthCheck(
  9017,
- "/world/2012/sep/11/barcelona-march-catalan-independence"
+ ExpiringSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
 )

--- a/rss/app/controllers/HealthCheck.scala
+++ b/rss/app/controllers/HealthCheck.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
 object HealthCheck extends AllGoodCachedHealthCheck(
   9014,
-  "/books/harrypotter/rss"
+  ExpiringSingleHealthCheck("/books/harrypotter/rss")
 )

--- a/sport/app/football/controllers/HealthCheck.scala
+++ b/sport/app/football/controllers/HealthCheck.scala
@@ -1,9 +1,9 @@
 package football.controllers
 
-import conf.AllGoodCachedHealthCheck
+import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
 
 object HealthCheck extends AllGoodCachedHealthCheck(
   9013,
-  "/football/live",
-  "/football/premierleague/results"
+  ExpiringSingleHealthCheck("/football/live"),
+  ExpiringSingleHealthCheck("/football/premierleague/results")
 )

--- a/training-preview/app/controllers/HealthCheck.scala
+++ b/training-preview/app/controllers/HealthCheck.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import common.ExecutionContexts
-import conf.{AllGoodCachedHealthCheck, CachedHealthCheckLifeCycle}
+import conf.{AllGoodCachedHealthCheck, CachedHealthCheckLifeCycle, ExpiringSingleHealthCheck}
 import dispatch.{FunctionHandler, Http}
 import scala.concurrent.Future
 import contentapi.{ContentApiClient, Response}
@@ -40,7 +40,7 @@ class TrainingHttp extends contentapi.Http with ExecutionContexts {
 
 class HealthCheck extends AllGoodCachedHealthCheck(
  9016,
- "/info/developer-blog/2016/apr/14/training-preview-healthcheck"
+ ExpiringSingleHealthCheck("/info/developer-blog/2016/apr/14/training-preview-healthcheck")
 ) {
   init()
 


### PR DESCRIPTION
## What does this change?

The goal is to be able to have healthcheck endpoints that would be
checked only once (ex: anything that involves upstream services)
Doing so would limit dependencies on upstream services while still
verifying that calling those upstream services is correclty configured at startup

This PR doesn't change the current behaviour of healthchecks since they are all still happening every 5s in the background. Introducing non-expiring healthcheck could be done in a following PR

@johnduffell I looked at having different refresh intervals depending on the healthcheck endpoint but this would introduce multiple refreshing jobs, a complexity I don't really want to add in the codebase
## What is the value of this and can you measure success?

Avoid marking a frontend instance as unhealthy when an upstream service is temporarily unresponsive or slow, which trigger ec2 instances unnecessary restarts and potentially cascading issues 
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
