### PR TITLE
Remove Aus campaign email sign-up

### DIFF
--- a/static/src/javascripts/projects/common/modules/email/email-article.js
+++ b/static/src/javascripts/projects/common/modules/email/email-article.js
@@ -97,17 +97,6 @@ define([
                 modClass: 'end-article',
                 insertMethod: insertBottomOfArticle
             },
-            ausCampaignCatchup: {
-                listId: '3689',
-                listName: 'ausCampaignCatchup',
-                campaignCode: 'AU_campaign_signup_page',
-                headline: 'Sign up for the Campaign catchup',
-                description: 'Get the day\'s top election news and commentary coverage delivered to your inbox every afternoon',
-                successHeadline: 'Thank you for signing up',
-                successDescription: 'We will send you the latest Campaign catchup every weekday afternoon',
-                modClass: 'end-article',
-                insertMethod: insertBottomOfArticle
-            },
             usBriefing: {
                 listId: '1493',
                 listName: 'usBriefing',

--- a/static/src/javascripts/projects/common/modules/email/run-checks.js
+++ b/static/src/javascripts/projects/common/modules/email/run-checks.js
@@ -119,15 +119,6 @@ define([
             return (config.page.section === 'us-news' && allowedArticleStructure()) ||
                 config.page.series === 'Guardian US briefing';
         },
-        ausCampaignCatchup: function () {
-            return page.keywordExists([
-                'Australia news',
-                'Australian politics',
-                'Australian election 2016',
-                'Guardian Australia\'s Morning Mail',
-                'Australian election briefing'
-            ]);
-        },
         theGuardianToday: function () {
             return config.switches.emailInArticleGtoday &&
                 !pageHasBlanketBlacklist() &&


### PR DESCRIPTION
## What does this change?

Removes the Australia campaign catch-up email sign-up.
