### PR TITLE
Hide iframe when rendering breakout creative

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
@@ -2,6 +2,7 @@ define([
     'bean',
     'bonzo',
     'Promise',
+    'common/utils/fastdom-promise',
 
     // These need to be bundled, so that they can be fetched asynchronously in production
     'common/modules/commercial/creatives/commercial-component',
@@ -26,7 +27,8 @@ define([
 ], function (
     bean,
     bonzo,
-    Promise
+    Promise,
+    fastdom
 ) {
     /**
      * Not all adverts render themselves - some just provide data for templates that we implement in commercial.js.
@@ -73,7 +75,9 @@ define([
         var creativeConfig = fetchCreativeConfig();
 
         if (creativeConfig) {
-            return renderCreative(creativeConfig);
+            return hideIframe().then(function () {
+                return renderCreative(creativeConfig);
+            });
         } else {
             return Promise.resolve(true);
         }
@@ -92,6 +96,12 @@ define([
                 require(['common/modules/commercial/creatives/' + config.name], function (Creative) {
                     resolve(new Creative(bonzo(adSlot), config.params, config.opts).create());
                 });
+            });
+        }
+
+        function hideIframe() {
+            return fastdom.write(function () {
+                iFrame.style.display = 'none';
             });
         }
     }


### PR DESCRIPTION
Turns out GTP will automatically assign the iframe `width` and `height` attributes with the returned creative dimensions:

![picture 1](https://cloud.githubusercontent.com/assets/629976/16580978/0163895c-429f-11e6-853c-5f8ab4bc10f4.jpg)

Therefore we must hide it:

![picture 2](https://cloud.githubusercontent.com/assets/629976/16580982/08559656-429f-11e6-8bfd-41f7ff71b2ab.jpg)

@guardian/commercial-dev 
