### PR TITLE
Omniture - Remove old R2 storage

### DIFF
--- a/static/src/javascripts/projects/common/modules/analytics/analytics.js
+++ b/static/src/javascripts/projects/common/modules/analytics/analytics.js
@@ -41,8 +41,7 @@
             now     = new Date(),
             webPublicationDate = config.page.webPublicationDate;
 
-        var R2_STORAGE_KEY = 's_ni', // DO NOT CHANGE THIS, ITS IS SHARED WITH R2. BAD THINGS WILL HAPPEN!
-            NG_STORAGE_KEY = 'gu.analytics.referrerVars';
+        var NG_STORAGE_KEY = 'gu.analytics.referrerVars';
 
         var getChannel = function () {
             if (config.page.contentType === 'Network Front') {
@@ -200,7 +199,6 @@
 
             if (navInteraction) {
                 trackNavigationInteraction(navInteraction.value);
-                window.sessionStorage.removeItem(R2_STORAGE_KEY);
                 window.sessionStorage.removeItem(NG_STORAGE_KEY);
             }
 

--- a/static/src/javascripts/projects/common/modules/analytics/omniture.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omniture.js
@@ -37,8 +37,7 @@ define([
     map,
     robust
 ) {
-    var R2_STORAGE_KEY = 's_ni', // DO NOT CHANGE THIS, ITS IS SHARED WITH R2. BAD THINGS WILL HAPPEN!
-        NG_STORAGE_KEY = 'gu.analytics.referrerVars',
+    var NG_STORAGE_KEY = 'gu.analytics.referrerVars',
         standardProps = 'channel,prop1,prop2,prop3,prop4,prop8,prop9,prop10,prop13,prop25,prop31,prop37,prop38,prop47,' +
             'prop51,prop61,prop64,prop65,prop74,prop40,prop63,eVar7,eVar37,eVar38,eVar39,eVar50,eVar24,eVar60,eVar51,' +
             'eVar31,eVar18,eVar32,eVar40,list1,list2,list3,events';
@@ -80,7 +79,6 @@ define([
                 tag: spec.tag || 'untracked',
                 time: new Date().getTime()
             };
-            try { sessionStorage.setItem(R2_STORAGE_KEY, storeObj.tag); } catch (e) {/**/}
             storage.session.set(NG_STORAGE_KEY, storeObj);
         } else {
             // Do not perform a same-page track link when there isn't a tag.


### PR DESCRIPTION
## What does this change?

Remove code that store tag information for Omniture which I think is not needed to run anymore as we do not serve anything from `r2`.

cc @cb372 
