### PR TITLE
Discussion: add ping and do not expires original internal healthcheck

### DIFF
--- a/discussion/app/controllers/HealthCheck.scala
+++ b/discussion/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
-object HealthCheck extends AllGoodCachedHealthCheck(9007, ExpiringSingleHealthCheck("/discussion/p/37v3a"))
+object HealthCheck extends AllGoodCachedHealthCheck(9007, NeverExpiresSingleHealthCheck("/discussion/p/37v3a"))


### PR DESCRIPTION
## What does this change?

I am introducing a non expiring internal healthcheck into the discussion app. If this goes well I will extend it to all the apps relying on an upstream service. :)

The real user-facing endpoint which rely on an upstream service (DAPI) would only be checked until it becomes successful.
Then a 200 response from /_healthcheck will reveal that the app is running propely
## What is the value of this and can you measure success?

Make healthcheck less dependent on upstream services while still making sure upstream service are reachable at startup
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

No
## Request for comment

@alexduf @johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
