### PR TITLE
Add comscore analytics

### DIFF
--- a/common/app/conf/switches/MonitoringSwitches.scala
+++ b/common/app/conf/switches/MonitoringSwitches.scala
@@ -36,6 +36,16 @@ trait MonitoringSwitches {
     exposeClientSide = false
   )
 
+  val ComscoreSwitch = Switch(
+    SwitchGroup.Monitoring,
+    "comscore",
+    "If this switch is on, then Comscore reporting is enabled",
+    owners = Seq(Owner.withGithub("cb372")),
+    safeState = Off,
+    sellByDate = never,
+    exposeClientSide = false
+  )
+
   val ScrollDepthSwitch = Switch(
     SwitchGroup.Monitoring,
     "scroll-depth",

--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -13,6 +13,8 @@
 
 @fragments.analytics.google(page)
 
+@fragments.analytics.comscore(page)
+
 <script>
     @*
         Basic Omniture runs on both Core & 'Full experience'

--- a/common/app/views/fragments/analytics/comscore.scala.html
+++ b/common/app/views/fragments/analytics/comscore.scala.html
@@ -1,0 +1,21 @@
+@(page: model.Page)
+@import conf.switches.Switches.ComscoreSwitch
+
+@if(ComscoreSwitch.isSwitchedOn) {
+    <script id='comscore'>
+        var _comscore = _comscore || [];
+        _comscore.push({ c1: "2", c2: "6035250" });
+        (function() {
+            var s = document.createElement("script"), el = document.getElementsByTagName("script")[0];
+            s.async = true;
+            s.src = "https://sb.scorecardresearch.com/beacon.js";
+            el.parentNode.insertBefore(s, el);
+        })();
+    </script>
+    <noscript>
+        <img src="https://sb.scorecardresearch.com/p?c1=2&c2=6035250&cv=2.0&cj=1" />
+    </noscript>
+}
+
+
+

--- a/common/app/views/fragments/metaData.scala.html
+++ b/common/app/views/fragments/metaData.scala.html
@@ -7,7 +7,7 @@
 @import play.api.Play
 @import play.api.Play.current
 @import views.support.{SeoThumbnail, StripHtmlTags}
-@import conf.switches.Switches.{AmpSwitch, UseLinkPreconnect, GoogleAnalyticsSwitch, CommercialSwitch, SmartAppBanner}
+@import conf.switches.Switches.{AmpSwitch, UseLinkPreconnect, GoogleAnalyticsSwitch, ComscoreSwitch, CommercialSwitch, SmartAppBanner}
 
 @* Critical meta data that have an impact on rendering speed *@
 <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
@@ -29,6 +29,10 @@
         <link rel="dns-prefetch" href="//www.google-analytics.com" />
     }
 
+    @if(ComscoreSwitch.isSwitchedOn) {
+        <link rel="dns-prefetch" href="//sb.scorecardresearch.com" />
+    }
+
     @if(UseLinkPreconnect.isSwitchedOn) {
         <link rel="preconnect" crossorigin href="@Configuration.assets.path" />
         <link rel="preconnect" crossorigin href="@Configuration.images.path" />
@@ -40,6 +44,10 @@
 
         @if(GoogleAnalyticsSwitch.isSwitchedOn) {
             <link rel="preconnect" crossorigin href="//www.google-analytics.com" />
+        }
+
+        @if(ComscoreSwitch.isSwitchedOn) {
+            <link rel="preconnect" href="//sb.scorecardresearch.com" />
         }
 
         @if(CommercialSwitch.isSwitchedOn) {


### PR DESCRIPTION
## What does this change?

Adds a Comscore tag to the analytics section at bottom of the page. Hidden behind a switch for now.

Currently Comscore reporting is implemented by piggybacking on top of Omniture (the Omniture server sends a request to Comscore for every request it receives). With the move to Google Analytics, we need to start sending requests directly to Comscore.

We don't need to worry about double-counting during the migration period: Comscore have assured us that they will de-dupe at their end.
## What is the value of this and can you measure success?

Removes dependency on Omniture for Comscore reporting.
## Does this affect other platforms - Amp, Apps, etc?

No. We will need to do this on those platforms as well.
## Screenshots

n/a
## Request for comment

@gklopper @sndrs @rich-nguyen 
