### PR TITLE
Refactor 3rd party scripts

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -97,9 +97,7 @@ define([
             var service = services.shift();
             var script = document.createElement('script');
             script.src = service.url;
-            if (service.onLoad) {
-                script.onload = service.onLoad;
-            }
+            script.onload = service.onLoad;
             frag.appendChild(script);
         }
         ref.parentNode.insertBefore(frag, ref);

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -69,13 +69,6 @@ define([
             return false;
         }
 
-        switch (config.page.edition.toLowerCase()) {
-            case 'uk':
-                audienceSciencePql.load();
-                audienceScienceGateway.load();
-                break;
-        }
-
         // Outbrain/Plista needs to be loaded before first ad as it is checking for presence of high relevance component on page
         loadExternalContentWidget();
 
@@ -84,10 +77,14 @@ define([
     }
 
     function loadOther() {
+        if (config.page.edition === 'UK') {
+            audienceSciencePql.load();
+            audienceScienceGateway.load();
+        }
         imrWorldwide.load();
         remarketing.load();
 
-        if(!config.page.isFront){
+        if (!config.page.isFront){
             krux.load();
         }
     }

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -77,15 +77,32 @@ define([
     }
 
     function loadOther() {
-        var scripts = [
+        var services = [
             config.page.edition === 'UK' ? audienceSciencePql : null,
             config.page.edition === 'UK' ? audienceScienceGateway : null,
             imrWorldwide,
             remarketing,
             krux
-        ];
+        ].filter(function (_) { return _ && _.shouldRun; });
 
-        scripts.filter(function (_) { return _ && _.shouldRun; }).forEach(function (script) { script.load(); });
+        if (services.length) {
+            insertScripts(services);
+        }
+    }
+
+    function insertScripts(services) {
+        var ref = document.scripts[0];
+        var frag = document.createDocumentFragment();
+        while (services.length) {
+            var service = services.shift();
+            var script = document.createElement('script');
+            script.src = service.url;
+            if (service.onLoad) {
+                script.onload = service.onLoad;
+            }
+            frag.appendChild(script);
+        }
+        ref.parentNode.insertBefore(frag, ref);
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -77,16 +77,15 @@ define([
     }
 
     function loadOther() {
-        if (config.page.edition === 'UK') {
-            audienceSciencePql.load();
-            audienceScienceGateway.load();
-        }
-        imrWorldwide.load();
-        remarketing.load();
+        var scripts = [
+            config.page.edition === 'UK' ? audienceSciencePql : null,
+            config.page.edition === 'UK' ? audienceScienceGateway : null,
+            imrWorldwide,
+            remarketing,
+            krux
+        ];
 
-        if (!config.page.isFront){
-            krux.load();
-        }
+        scripts.filter(function (_) { return _ && _.shouldRun; }).forEach(function (script) { script.load(); });
     }
 
     return {

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags.js
@@ -78,12 +78,12 @@ define([
 
     function loadOther() {
         var services = [
-            config.page.edition === 'UK' ? audienceSciencePql : null,
-            config.page.edition === 'UK' ? audienceScienceGateway : null,
+            audienceSciencePql,
+            audienceScienceGateway,
             imrWorldwide,
             remarketing,
             krux
-        ].filter(function (_) { return _ && _.shouldRun; });
+        ].filter(function (_) { return _.shouldRun; });
 
         if (services.length) {
             insertScripts(services);

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
@@ -3,14 +3,9 @@ define([
 ], function (config) {
     var audienceScienceGatewayUrl = '//js.revsci.net/gateway/gw.js?csid=F09828&auto=t&bpid=theguardian';
 
-    function load() {
-        return require(['js!' + audienceScienceGatewayUrl]);
-    }
-
     return {
         shouldRun: config.switches.audienceScienceGateway,
-        url: audienceScienceGatewayUrl,
-        load: load
+        url: audienceScienceGatewayUrl
     };
 
 });

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
@@ -1,13 +1,15 @@
 define([
     'common/utils/config'
 ], function (config) {
+    var audienceScienceGatewayUrl = '//js.revsci.net/gateway/gw.js?csid=F09828&auto=t&bpid=theguardian';
 
     function load() {
-        return require(['js!' + '//js.revsci.net/gateway/gw.js?csid=F09828&auto=t&bpid=theguardian']);
+        return require(['js!' + audienceScienceGatewayUrl]);
     }
 
     return {
         shouldRun: config.switches.audienceScienceGateway,
+        url: audienceScienceGatewayUrl,
         load: load
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
@@ -3,12 +3,11 @@ define([
 ], function (config) {
 
     function load() {
-        if (config.switches.audienceScienceGateway) {
-            return require(['js!' + '//js.revsci.net/gateway/gw.js?csid=F09828&auto=t&bpid=theguardian']);
-        }
+        return require(['js!' + '//js.revsci.net/gateway/gw.js?csid=F09828&auto=t&bpid=theguardian']);
     }
 
     return {
+        shouldRun: config.switches.audienceScienceGateway,
         load: load
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-gateway.js
@@ -4,7 +4,7 @@ define([
     var audienceScienceGatewayUrl = '//js.revsci.net/gateway/gw.js?csid=F09828&auto=t&bpid=theguardian';
 
     return {
-        shouldRun: config.switches.audienceScienceGateway,
+        shouldRun: config.page.edition === 'UK' && config.switches.audienceScienceGateway,
         url: audienceScienceGatewayUrl
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
@@ -61,7 +61,7 @@ define([
     }
 
     return {
-        shouldRun: config.switches.audienceScienceGateway,
+        shouldRun: config.page.edition === 'UK' && config.switches.audienceScienceGateway,
         url: audienceSciencePqlUrl,
         reset: function () {
             section = sectionPlacements[config.page.section] ? config.page.section : 'default';

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
@@ -26,23 +26,21 @@ define([
             section = sectionPlacements[config.page.section] ? config.page.section : 'default';
         },
         load = once(function () {
-            if (config.switches.audienceScienceGateway) {
-                var placements = sectionPlacements[section],
-                    query = urlUtils.constructQuery({
-                        placementIdList: placements.join(','),
-                        cb: new Date().getTime()
-                    }),
-                    url = [gatewayUrl, '?', query].join('');
+            var placements = sectionPlacements[section],
+                query = urlUtils.constructQuery({
+                    placementIdList: placements.join(','),
+                    cb: new Date().getTime()
+                }),
+                url = [gatewayUrl, '?', query].join('');
 
-                return require(['js!' + url], function () {
-                    var asiPlacements = window.asiPlacements;
-                    var segments = storage.local.get(storageKey) || {};
-                    // override the global value with our previously stored one
-                    window.asiPlacements = segments[section];
-                    segments[section] = asiPlacements;
-                    storage.local.set(storageKey, segments);
-                });
-            }
+            return require(['js!' + url], function () {
+                var asiPlacements = window.asiPlacements;
+                var segments = storage.local.get(storageKey) || {};
+                // override the global value with our previously stored one
+                window.asiPlacements = segments[section];
+                segments[section] = asiPlacements;
+                storage.local.set(storageKey, segments);
+            });
         }),
 
         getSegments = function () {
@@ -64,6 +62,7 @@ define([
     init();
 
     return {
+        shouldRun: config.switches.audienceScienceGateway,
         load: load,
         init: init,
         getSegments: getSegments

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
@@ -10,61 +10,60 @@ define([
     'common/utils/chain'
 ], function (config, storage, urlUtils, once, pairs, zipObject, map, filter, chain) {
 
-    var gatewayUrl = '//pq-direct.revsci.net/pql',
-        storageKey = 'gu.ads.audsci-gateway',
-        sectionPlacements = {
-            sport:        ['FKSWod', '2xivTZ', 'MTLELH'],
-            football:     ['6FaXJO', 'ORE2W-', 'MTLELH'],
-            lifeandstyle: ['TQV1_5', 'J0tykU', 'kLC9nW', 'MTLELH'],
-            technology:   ['9a9VRE', 'TL3gqK', 'MTLELH'],
-            fashion:      ['TQV1_5', 'J0tykU', 'kLC9nW', 'MTLELH'],
-            news:         ['eMdl6Y', 'mMYVrM', 'MTLELH'],
-            'default':    ['FLh9mM', 'c7Zrhu', 'Y1C40a', 'LtKGsC', 'MTLELH']
-        },
-        section,
-        init = function () {
-            section = sectionPlacements[config.page.section] ? config.page.section : 'default';
-        },
-        load = once(function () {
-            var placements = sectionPlacements[section],
-                query = urlUtils.constructQuery({
-                    placementIdList: placements.join(','),
-                    cb: new Date().getTime()
-                }),
-                url = [gatewayUrl, '?', query].join('');
+    var gatewayUrl = '//pq-direct.revsci.net/pql';
+    var storageKey = 'gu.ads.audsci-gateway';
+    var sectionPlacements = {
+        sport:        ['FKSWod', '2xivTZ', 'MTLELH'],
+        football:     ['6FaXJO', 'ORE2W-', 'MTLELH'],
+        lifeandstyle: ['TQV1_5', 'J0tykU', 'kLC9nW', 'MTLELH'],
+        technology:   ['9a9VRE', 'TL3gqK', 'MTLELH'],
+        fashion:      ['TQV1_5', 'J0tykU', 'kLC9nW', 'MTLELH'],
+        news:         ['eMdl6Y', 'mMYVrM', 'MTLELH'],
+        'default':    ['FLh9mM', 'c7Zrhu', 'Y1C40a', 'LtKGsC', 'MTLELH']
+    };
+    var section = sectionPlacements[config.page.section] ? config.page.section : 'default';
+    var audienceSciencePqlUrl = getUrl();
 
-            return require(['js!' + url], function () {
-                var asiPlacements = window.asiPlacements;
-                var segments = storage.local.get(storageKey) || {};
-                // override the global value with our previously stored one
-                window.asiPlacements = segments[section];
-                segments[section] = asiPlacements;
-                storage.local.set(storageKey, segments);
-            });
-        }),
+    function getUrl() {
+        var placements = sectionPlacements[section];
+        var query = urlUtils.constructQuery({
+            placementIdList: placements.join(','),
+            cb: new Date().getTime()
+        });
+        return [gatewayUrl, '?', query].join('');
+    }
 
-        getSegments = function () {
-            var segments = {},
-                storedSegments = storage.local.get(storageKey);
-            if (config.switches.audienceScienceGateway && storedSegments) {
-                segments = chain(pairs(storedSegments[section])).and(filter, function (placement) {
-                        //keyword `default` written in dot notation throws an exception IE8
-                        return placement[1]['default']; //eslint-disable-line
-                    }).and(map, function (placement) {
-                        return ['pq_' + placement[0], 'T'];
-                    }).and(zipObject).valueOf();
-                // set up the global asiPlacements var in case dfp returns before asg
-                window.asiPlacements = storedSegments[section];
-            }
-            return segments;
-        };
+    function load() {
+        return require(['js!' + audienceSciencePqlUrl], function () {
+            var asiPlacements = window.asiPlacements;
+            var segments = storage.local.get(storageKey) || {};
+            // override the global value with our previously stored one
+            window.asiPlacements = segments[section];
+            segments[section] = asiPlacements;
+            storage.local.set(storageKey, segments);
+        });
+    }
 
-    init();
+    function getSegments() {
+        var segments = {},
+            storedSegments = storage.local.get(storageKey);
+        if (config.switches.audienceScienceGateway && storedSegments) {
+            segments = chain(pairs(storedSegments[section])).and(filter, function (placement) {
+                    //keyword `default` written in dot notation throws an exception IE8
+                    return placement[1]['default']; //eslint-disable-line
+                }).and(map, function (placement) {
+                    return ['pq_' + placement[0], 'T'];
+                }).and(zipObject).valueOf();
+            // set up the global asiPlacements var in case dfp returns before asg
+            window.asiPlacements = storedSegments[section];
+        }
+        return segments;
+    }
 
     return {
         shouldRun: config.switches.audienceScienceGateway,
+        url: audienceSciencePqlUrl,
         load: load,
-        init: init,
         getSegments: getSegments
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
@@ -27,10 +27,6 @@ define([
         return gatewayUrl + '?' + query;
     }
 
-    function load() {
-        return require(['js!' + audienceSciencePqlUrl], onLoad);
-    }
-
     function onLoad() {
         var asiPlacements = window.asiPlacements;
         var segments = storage.local.get(storageKey) || {};
@@ -63,7 +59,9 @@ define([
     return {
         shouldRun: config.switches.audienceScienceGateway,
         url: audienceSciencePqlUrl,
-        load: load,
+        reset: function () {
+            section = sectionPlacements[config.page.section] ? config.page.section : 'default';
+        },
         onLoad: onLoad,
         getSegments: getSegments
     };

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
@@ -39,7 +39,11 @@ define([
     function getSegments() {
         var segments = {};
         var storedSegments = storage.local.get(storageKey);
-        if (config.switches.audienceScienceGateway && storedSegments) {
+        if (
+            config.switches.audienceScienceGateway &&
+            storedSegments &&
+            storedSegments[section]
+        ) {
             segments = Object.keys(storedSegments[section])
                 .filter(function (placement) {
                     //keyword `default` written in dot notation throws an exception IE8

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/audience-science-pql.js
@@ -34,14 +34,16 @@ define([
     }
 
     function load() {
-        return require(['js!' + audienceSciencePqlUrl], function () {
-            var asiPlacements = window.asiPlacements;
-            var segments = storage.local.get(storageKey) || {};
-            // override the global value with our previously stored one
-            window.asiPlacements = segments[section];
-            segments[section] = asiPlacements;
-            storage.local.set(storageKey, segments);
-        });
+        return require(['js!' + audienceSciencePqlUrl], onLoad);
+    }
+
+    function onLoad() {
+        var asiPlacements = window.asiPlacements;
+        var segments = storage.local.get(storageKey) || {};
+        // override the global value with our previously stored one
+        window.asiPlacements = segments[section];
+        segments[section] = asiPlacements;
+        storage.local.set(storageKey, segments);
     }
 
     function getSegments() {
@@ -64,6 +66,7 @@ define([
         shouldRun: config.switches.audienceScienceGateway,
         url: audienceSciencePqlUrl,
         load: load,
+        onLoad: onLoad,
         getSegments: getSegments
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/imr-worldwide.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/imr-worldwide.js
@@ -3,9 +3,10 @@ define([
 ], function (
     config
 ) {
+    var imrWorldwideUrl = '//secure-au.imrworldwide.com/v60.js';
 
     function load() {
-        return require(['js!' + '//secure-au.imrworldwide.com/v60.js'], function () {
+        return require(['js!' + imrWorldwideUrl], function () {
             var pvar = { cid: 'au-guardian', content: '0', server: 'secure-au' };
             // nol_t is a global function set by the imrworldwide library
             /*eslint-disable no-undef*/
@@ -16,6 +17,7 @@ define([
 
     return {
         shouldRun: config.switches.imrWorldwide,
+        url: imrWorldwideUrl,
         load: load
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/imr-worldwide.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/imr-worldwide.js
@@ -5,10 +5,6 @@ define([
 ) {
     var imrWorldwideUrl = '//secure-au.imrworldwide.com/v60.js';
 
-    function load() {
-        return require(['js!' + imrWorldwideUrl], onLoad);
-    }
-
     function onLoad() {
         var pvar = { cid: 'au-guardian', content: '0', server: 'secure-au' };
         // nol_t is a global function set by the imrworldwide library
@@ -20,8 +16,7 @@ define([
     return {
         shouldRun: config.switches.imrWorldwide,
         url: imrWorldwideUrl,
-        onLoad: onLoad,
-        load: load
+        onLoad: onLoad
     };
 
 });

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/imr-worldwide.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/imr-worldwide.js
@@ -5,18 +5,17 @@ define([
 ) {
 
     function load() {
-        if (config.switches.imrWorldwide) {
-            return require(['js!' + '//secure-au.imrworldwide.com/v60.js'], function () {
-                var pvar = { cid: 'au-guardian', content: '0', server: 'secure-au' };
-                // nol_t is a global function set by the imrworldwide library
-                /*eslint-disable no-undef*/
-                var trac = nol_t(pvar);
-                trac.record().post();
-            });
-        }
+        return require(['js!' + '//secure-au.imrworldwide.com/v60.js'], function () {
+            var pvar = { cid: 'au-guardian', content: '0', server: 'secure-au' };
+            // nol_t is a global function set by the imrworldwide library
+            /*eslint-disable no-undef*/
+            var trac = nol_t(pvar);
+            trac.record().post();
+        });
     }
 
     return {
+        shouldRun: config.switches.imrWorldwide,
         load: load
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/imr-worldwide.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/imr-worldwide.js
@@ -6,18 +6,21 @@ define([
     var imrWorldwideUrl = '//secure-au.imrworldwide.com/v60.js';
 
     function load() {
-        return require(['js!' + imrWorldwideUrl], function () {
-            var pvar = { cid: 'au-guardian', content: '0', server: 'secure-au' };
-            // nol_t is a global function set by the imrworldwide library
-            /*eslint-disable no-undef*/
-            var trac = nol_t(pvar);
-            trac.record().post();
-        });
+        return require(['js!' + imrWorldwideUrl], onLoad);
+    }
+
+    function onLoad() {
+        var pvar = { cid: 'au-guardian', content: '0', server: 'secure-au' };
+        // nol_t is a global function set by the imrworldwide library
+        /*eslint-disable no-undef*/
+        var trac = nol_t(pvar);
+        trac.record().post();
     }
 
     return {
         shouldRun: config.switches.imrWorldwide,
         url: imrWorldwideUrl,
+        onLoad: onLoad,
         load: load
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/krux.js
@@ -7,8 +7,10 @@ define([
     cookies,
     storage
 ) {
+    var kruxUrl = '//cdn.krxd.net/controltag?confid=JVZiE3vn';
+
     function load() {
-        return require(['js!' + '//cdn.krxd.net/controltag?confid=JVZiE3vn']);
+        return require(['js!' + kruxUrl]);
     }
 
     function retrieve(n) {
@@ -23,6 +25,7 @@ define([
 
     return {
         shouldRun: config.switches.krux,
+        url: kruxUrl,
         load: load,
         getSegments: getSegments
     };

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/krux.js
@@ -20,7 +20,7 @@ define([
     }
 
     return {
-        shouldRun: config.switches.krux,
+        shouldRun: !config.page.isFront && config.switches.krux,
         url: kruxUrl,
         getSegments: getSegments
     };

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/krux.js
@@ -8,9 +8,7 @@ define([
     storage
 ) {
     function load() {
-        if (config.switches.krux) {
-            return require(['js!' + '//cdn.krxd.net/controltag?confid=JVZiE3vn']);
-        }
+        return require(['js!' + '//cdn.krxd.net/controltag?confid=JVZiE3vn']);
     }
 
     function retrieve(n) {
@@ -24,6 +22,7 @@ define([
     }
 
     return {
+        shouldRun: config.switches.krux,
         load: load,
         getSegments: getSegments
     };

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/krux.js
@@ -9,10 +9,6 @@ define([
 ) {
     var kruxUrl = '//cdn.krxd.net/controltag?confid=JVZiE3vn';
 
-    function load() {
-        return require(['js!' + kruxUrl]);
-    }
-
     function retrieve(n) {
         var k = 'kx' + n;
 
@@ -26,7 +22,6 @@ define([
     return {
         shouldRun: config.switches.krux,
         url: kruxUrl,
-        load: load,
         getSegments: getSegments
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/remarketing.js
@@ -18,6 +18,7 @@ define([
 
     return {
         shouldRun: config.switches.remarketing,
+        url: remarketingUrl,
         load: load
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/remarketing.js
@@ -6,10 +6,6 @@ define([
 
     var remarketingUrl = '//www.googleadservices.com/pagead/conversion_async.js';
 
-    function load() {
-        return require(['js!' + remarketingUrl], onLoad);
-    }
-
     function onLoad() {
         window.google_trackConversion({
             google_conversion_id: 971225648,
@@ -21,7 +17,6 @@ define([
     return {
         shouldRun: config.switches.remarketing,
         url: remarketingUrl,
-        load: load,
         onLoad: onLoad
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/remarketing.js
@@ -7,20 +7,17 @@ define([
     var remarketingUrl = '//www.googleadservices.com/pagead/conversion_async.js';
 
     function load() {
-
-        if (config.switches.remarketing) {
-            return require(['js!' + remarketingUrl], function () {
-                window.google_trackConversion({
-                    google_conversion_id: 971225648,
-                    google_custom_params: window.google_tag_params,
-                    google_remarketing_only: true
-                });
+        return require(['js!' + remarketingUrl], function () {
+            window.google_trackConversion({
+                google_conversion_id: 971225648,
+                google_custom_params: window.google_tag_params,
+                google_remarketing_only: true
             });
-        }
-
+        });
     }
 
     return {
+        shouldRun: config.switches.remarketing,
         load: load
     };
 

--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/remarketing.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/remarketing.js
@@ -7,19 +7,22 @@ define([
     var remarketingUrl = '//www.googleadservices.com/pagead/conversion_async.js';
 
     function load() {
-        return require(['js!' + remarketingUrl], function () {
-            window.google_trackConversion({
-                google_conversion_id: 971225648,
-                google_custom_params: window.google_tag_params,
-                google_remarketing_only: true
-            });
+        return require(['js!' + remarketingUrl], onLoad);
+    }
+
+    function onLoad() {
+        window.google_trackConversion({
+            google_conversion_id: 971225648,
+            google_custom_params: window.google_tag_params,
+            google_remarketing_only: true
         });
     }
 
     return {
         shouldRun: config.switches.remarketing,
         url: remarketingUrl,
-        load: load
+        load: load,
+        onLoad: onLoad
     };
 
 });

--- a/static/test/javascripts/spec/common/commercial/third-party-tags/audience-science-gateway.spec.js
+++ b/static/test/javascripts/spec/common/commercial/third-party-tags/audience-science-gateway.spec.js
@@ -31,7 +31,7 @@ define([
         });
 
         it('should be able to get segments', function () {
-            audienceScienceGateway.init();
+            audienceScienceGateway.reset();
             var stored = {},
                 storedValue = {
                     Y1C40a: {
@@ -68,14 +68,14 @@ define([
         });
 
         it('should return empty object if no segments', function () {
-            audienceScienceGateway.init();
+            audienceScienceGateway.reset();
             storage.local.set('gu.ads.audsci-gateway', {});
             expect(audienceScienceGateway.getSegments()).toEqual({});
         });
 
         it('should return empty object if switch is off', function () {
             config.page.section = undefined;
-            audienceScienceGateway.init();
+            audienceScienceGateway.reset();
             expect(audienceScienceGateway.getSegments()).toEqual({});
         });
 

--- a/static/test/javascripts/spec/common/commercial/third-party-tags/krux.spec.js
+++ b/static/test/javascripts/spec/common/commercial/third-party-tags/krux.spec.js
@@ -32,14 +32,11 @@ define([
         it('should not load if switch is off', function () {
             config.switches.krux = false;
 
-            expect(krux.load()).toBeFalsy();
+            expect(krux.shouldRun).toBeFalsy();
         });
 
         it('should send correct "netid" param', function () {
-            krux.load();
-            var url = requireStub.args[0][0][0];
-
-            expect(url).toBe('js!//cdn.krxd.net/controltag?confid=JVZiE3vn');
+            expect(krux.url).toBe('//cdn.krxd.net/controltag?confid=JVZiE3vn');
         });
 
     });


### PR DESCRIPTION
Every 3rd party module is basically doing the same thing many times, so I figured we could do that same thing only once instead.

cc @guardian/commercial-dev 
