### PR TITLE
[do-not-merge] fix video embed tracking

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -97,14 +97,10 @@
         <script>
             @Html(curlConfig().body)
 
-            @if(Configuration.assets.useHashedBundles) {
-                window.curl.paths['bootstraps/video-embed'] = '@Static("javascripts/bootstraps/video-embed.js")';
-                window.curl.paths['ophan/embed'] = '@{Configuration.javascript.config("ophanEmbedJsUrl")}';
-            } else {
-                window.curl.paths['bootstraps/video-embed'] = '@{Configuration.assets.path}javascripts/bootstraps/video-embed.js';
-                window.curl.paths['ophan/embed'] = '@{Configuration.javascript.config("ophanEmbedJsUrl")}';
-            }
+            window.curl.paths['ophan/embed'] = '@{Configuration.javascript.config("ophanEmbedJsUrl")}';
+
             @Html(common.Assets.js.curl)
+
             require(['bootstraps/video-embed'], function(bootstrap) {
                 bootstrap.init();
             });

--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -65,7 +65,6 @@ window.curlConfig = {
             'bootstraps/enhanced/media/video-player':   'bootstraps/enhanced/media/video-player-dev.js',
             videojs:                                    'components/video.js/video.js',
             'videojs-contrib-ads':                      'components/videojs-contrib-ads/videojs.ads.js',
-            videojsembeddev:                            'bootstraps/enhanced/media/videojsembed-dev.js',
             videojsembed:                               'components/videojs-embed/videojs.embed.js',
             'videojs-ima':                              'components/videojs-ima/videojs.ima.js',
             videojspersistvolume:                       'components/videojs-persistvolume/videojs.persistvolume.js',

--- a/static/src/javascripts/bootstraps/enhanced/media/videojsembed-dev.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/videojsembed-dev.js
@@ -1,5 +1,0 @@
-define([
-    'js!videojsembeddev'
-], function(videojsembed) {
-    return videojsembed;
-});

--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -3,8 +3,6 @@ define([
     'bean',
     'bonzo',
     'qwery',
-    'videojs',
-    'videojsembed',
     'common/utils/$',
     'common/utils/config',
     'common/utils/defer-to-analytics',
@@ -13,19 +11,17 @@ define([
     'common/modules/component',
     'common/modules/video/tech-order',
     'common/modules/video/events',
-    'common/modules/video/fullscreener',
     'common/views/svgs',
     'text!common/views/ui/loading.html',
     'text!common/views/media/titlebar.html',
     'lodash/functions/debounce',
     'common/modules/video/videojs-options',
-    'common/modules/video/events'
+    'bootstraps/enhanced/media/video-player',
+    'common/modules/video/fullscreener'
 ], function (
     bean,
     bonzo,
     qwery,
-    videojs,
-    videojsembed,
     $,
     config,
     deferToAnalytics,
@@ -34,12 +30,13 @@ define([
     Component,
     techOrder,
     events,
-    fullscreener,
     svgs,
     loadingTmpl,
     titlebarTmpl,
     debounce,
-    videojsOptions
+    videojsOptions,
+    videojs,
+    fullscreener
 ) {
 
     function initLoadingSpinner(player) {


### PR DESCRIPTION
## What does this change?

tracking of embeded video off-platform is currently broken because of a js error `Cannot read property 'pageViewId' of undefined` (e.g https://embed.theguardian.com/embed/video/world/video/2016/may/31/giant-alligator-crosses-florida-golf-course-video)

this fixes that by only importing [videoplayer](https://github.com/guardian/frontend/blob/master/static/src/javascripts/bootstraps/enhanced/media/video-player.js) which itself imports `videoembed` rather than importing `videojs` and `videoembed` separately.

related https://github.com/guardian/frontend/pull/13433
## What is the value of this and can you measure success?

tracking off-platform video embeds
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots
### before 😢

![screen shot 2016-07-07 at 13 09 34](https://cloud.githubusercontent.com/assets/836140/16652663/ec4eadfc-4443-11e6-8a83-70050accde84.jpeg)
### after 😄 🎉

![screen shot 2016-07-06 at 10 25 05](https://cloud.githubusercontent.com/assets/836140/16613441/0660b270-4364-11e6-9f45-43c7a204297d.jpeg)
## Request for comment

@jamesgorrie / anyone as James is on holiday this week

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
