### PR TITLE
Stop multiple URLs for hosted content

### DIFF
--- a/commercial/app/controllers/commercial/HostedContentController.scala
+++ b/commercial/app/controllers/commercial/HostedContentController.scala
@@ -1,7 +1,7 @@
 package controllers.commercial
 
-import common.commercial.hosted.hardcoded.HostedPages
-import common.commercial.hosted.{HostedGalleryPage, HostedVideoPage}
+import common.commercial.hosted.hardcoded.{HostedPages, LegacyHostedPages}
+import common.commercial.hosted.{HostedGalleryPage, HostedPage, HostedVideoPage}
 import model.Cached.RevalidatableResult
 import model.{Cached, NoCache}
 import play.api.mvc.{Action, Controller}
@@ -9,11 +9,21 @@ import views.html.hosted.{guardianHostedGallery, guardianHostedVideo}
 
 class HostedContentController extends Controller {
 
-  def renderHostedPage(campaignName: String, pageName: String) = Action { implicit request =>
-    HostedPages.fromPageName(campaignName, pageName) match {
+  private def renderPage(
+    campaignName: String,
+    pageName: String,
+    fromCampaignAndPageName: (String, String) => Option[HostedPage]
+  ) = Action { implicit request =>
+    fromCampaignAndPageName(campaignName, pageName) match {
       case Some(page: HostedVideoPage) => Cached(60)(RevalidatableResult.Ok(guardianHostedVideo(page)))
       case Some(page: HostedGalleryPage) => Cached(60)(RevalidatableResult.Ok(guardianHostedGallery(page)))
       case _ => NoCache(NotFound)
     }
   }
+
+  def renderLegacyHostedPage(campaignName: String, pageName: String) =
+    renderPage(campaignName, pageName, LegacyHostedPages.fromCampaignAndPageName)
+
+  def renderHostedPage(campaignName: String, pageName: String) =
+    renderPage(campaignName, pageName, HostedPages.fromCampaignAndPageName)
 }

--- a/commercial/conf/routes
+++ b/commercial/conf/routes
@@ -48,5 +48,5 @@ GET        /commercial/paid.json                                                
 GET        /commercial/paid                                                     controllers.commercial.PaidContentCardController.cardHtml
 
 # Hosted content
-GET        /commercial/advertiser-content/:campaignName/:pageName               controllers.commercial.HostedContentController.renderHostedPage(campaignName, pageName)
+GET        /commercial/advertiser-content/:campaignName/:pageName               controllers.commercial.HostedContentController.renderLegacyHostedPage(campaignName, pageName)
 GET        /advertiser-content/:campaignName/:pageName                          controllers.commercial.HostedContentController.renderHostedPage(campaignName, pageName)

--- a/common/app/common/commercial/hosted/hardcoded/HostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/HostedPages.scala
@@ -2,17 +2,27 @@ package common.commercial.hosted.hardcoded
 
 import common.commercial.hosted.HostedPage
 
-object HostedPages {
+object LegacyHostedPages {
 
   private val renaultCampaignName = "renault-car-of-the-future"
   private val galleryTestCampaignName = "hosted-gallery"
-  private val visitBritainCampaignName = "visit-britain"
-  private val leffeCampaignName = "leffe-rediscover-time"
 
-  def fromPageName(campaignName: String, pageName: String): Option[HostedPage] = {
+  def fromCampaignAndPageName(campaignName: String, pageName: String): Option[HostedPage] = {
     campaignName match {
       case `renaultCampaignName` => RenaultHostedPages.fromPageName(pageName)
       case `galleryTestCampaignName` => HostedGalleryTestPage.fromPageName(pageName)
+      case _ => None;
+    }
+  }
+}
+
+object HostedPages {
+
+  private val visitBritainCampaignName = "visit-britain"
+  private val leffeCampaignName = "leffe-rediscover-time"
+
+  def fromCampaignAndPageName(campaignName: String, pageName: String): Option[HostedPage] = {
+    campaignName match {
       case `visitBritainCampaignName` => VisitBritainHostedPages.fromPageName(pageName)
       case `leffeCampaignName` => LeffeHostedPages.fromPageName(pageName)
       case _ => None;

--- a/dev-build/conf/routes
+++ b/dev-build/conf/routes
@@ -301,7 +301,7 @@ GET            /commercial/paid.json                                            
 GET            /commercial/paid                                                                                                  controllers.commercial.PaidContentCardController.cardHtml
 GET            /commercial/multi.json                                                                                            controllers.commercial.Multi.renderMulti
 GET            /$path<commercial-containers>                                                                                     controllers.FaciaController.renderFront(path)
-GET            /commercial/advertiser-content/:campaignName/:pageName                                                            controllers.commercial.HostedContentController.renderHostedPage(campaignName, pageName)
+GET            /commercial/advertiser-content/:campaignName/:pageName                                                            controllers.commercial.HostedContentController.renderLegacyHostedPage(campaignName, pageName)
 GET            /advertiser-content/:campaignName/:pageName                                                                       controllers.commercial.HostedContentController.renderHostedPage(campaignName, pageName)
 
 # Commercial Admin


### PR DESCRIPTION
It's possible to serve hosted content on 
`/commercial/advertiser-content/...`
and 
`/advertiser-content...`

With this change, each hosted page is only available on a single path.
The content that's already been published is considered to be legacy in this fast-moving world.

/cc @Calanthe @lps88 
