### PR TITLE
make yellow play button accessible

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -134,7 +134,7 @@ $ima-controls-height: 70px;
             top: 1.85em;
             border-style: solid;
             border-width: 1em 0 1em 2.4em;
-            border-color: transparent transparent transparent #333333;
+            border-color: transparent transparent transparent $neutral-1;
             -moz-transform: scale(.99999); // fix for diagonal border aliasing in firefox
 
             @include mq(tablet) { // 0 border radius on mobile because stock android has a render bug with it here

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -120,6 +120,11 @@ $ima-controls-height: 70px;
                 @include video-play-button-size($vjs-large-button-size);
             }
             background-color: $media-default;
+
+            .gu-media-wrapper:hover &,
+            .gu-media__fallback:hover & {
+                background-color: darken($media-default, 15%);
+            }
         }
 
         &:after {
@@ -129,16 +134,11 @@ $ima-controls-height: 70px;
             top: 1.85em;
             border-style: solid;
             border-width: 1em 0 1em 2.4em;
-            border-color: transparent transparent transparent $neutral-7;
+            border-color: transparent transparent transparent #333333;
             -moz-transform: scale(.99999); // fix for diagonal border aliasing in firefox
 
             @include mq(tablet) { // 0 border radius on mobile because stock android has a render bug with it here
                 border-radius: .2em;
-            }
-
-            .gu-media-wrapper:hover &,
-            .gu-media__fallback:hover & {
-                border-left-color: #333333;
             }
         }
     }


### PR DESCRIPTION
## What does this change?

the current yellow and white fails accessibility tests, so making the button yellow and grey, with a darkened hover state (per social buttons)

original change https://github.com/guardian/frontend/pull/13471
## What is the value of this and can you measure success?

n/a
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

![yellow](https://cloud.githubusercontent.com/assets/836140/16615007/c2fda4ea-436b-11e6-8b40-d6c7f6abc1c6.gif)
## Request for comment

@sammorrisdesign @zeftilldeath 
