### PR TITLE
Control the margins of the inline slot

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -418,6 +418,14 @@
         width: 0;
         height: 0;
     }
+
+    &.ad-slot--rendered > * {
+        margin: 5px $gs-gutter / 2 $gs-baseline / 2 0;
+        @include mq(mobileLandscape) {
+            margin-bottom: $gs-baseline;
+            margin-right: $gs-gutter;
+        }
+    }
 }
 .ad-slot--fobadge.ad-slot--im {
     min-width: gs-span(2) + $gs-gutter;

--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -363,13 +363,10 @@
 }
 
 .adverts--legacy-inline {
-    margin: 5px $gs-gutter / 2 $gs-baseline / 2 0;
     padding: 0;
     width: $gs-gutter * 6.5;
 
     @include mq(mobileLandscape) {
-        margin-bottom: $gs-baseline;
-        margin-right: $gs-gutter;
         width: gs-span(3);
     }
 


### PR DESCRIPTION
The inline event and book components still use the old code. I will migrate them but until then the margins need to be controlled by the slot itself:

![picture 4](https://cloud.githubusercontent.com/assets/629976/16615481/e71fc120-436e-11e6-93bc-fcccb8ec0203.jpg)

Now:

![picture 5](https://cloud.githubusercontent.com/assets/629976/16615489/eb9476c4-436e-11e6-9fd3-0916c2c775aa.jpg)
