### PR TITLE
Fixes lightbox bug

### DIFF
--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -89,7 +89,7 @@
         @lightboxIndex.map { index =>
         <a href="#img-@index" class="article__img-container js-gallerythumbs" data-link-name="Launch Article Lightbox" data-is-ajax>
             @imageHtml
-            @fragments.inlineSvg("expand-image", "icon", List("centered-icon rounded-icon article__fullscreen modern-visible"))
+            @fragments.inlineSvg("expand-image", "icon", List("centered-icon", "rounded-icon", "article__fullscreen", "modern-visible"))
         </a>
 
         @shareInfo.map { case (shareLinks, contentType) =>


### PR DESCRIPTION
Fixes: https://github.com/guardian/frontend/issues/13452.

It looks like this problem has been around for a while! Rather than a list of multiple strings, this is a list of one string. Fixing that fixes the lightbox problem 😄 .
## Does this affect other platforms - Amp, Apps, etc?

Nope:
## Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/8774970/16616172/686573de-4373-11e6-9f5a-36ef6cf5aa1a.png)

After:
![image](https://cloud.githubusercontent.com/assets/8774970/16616165/5e80c3e6-4373-11e6-8803-7bd6da8a5bdc.png)
