### PR TITLE
hosted content play button back to neutral-7

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -163,6 +163,7 @@ $omgbColor: #e41f13;
             top: 16px;
             left: 16px;
             border-width: 8px 8px 8px 18px;
+            border-color: transparent transparent transparent $neutral-7;
         }
 
         @include fs-textSans(4);


### PR DESCRIPTION
## What does this change?

[recently changed](https://github.com/guardian/frontend/pull/13502) the play button to be neutral-1 by default - this was a global change but should not have touched hosted content 😶
## What is the value of this and can you measure success?

branding
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

![screen shot 2016-07-06 at 13 20 06](https://cloud.githubusercontent.com/assets/836140/16617565/4598b006-437c-11e6-8467-4981b006f939.jpeg)
## Request for comment

@ScottPainterGNM @Calanthe 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
