### PR TITLE
Use megalog to show extra steps in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -132,8 +132,7 @@ compile() {
 
 report() {
   if [[ ${#EXTRA_STEPS[@]} -gt 0 ]]; then
-    echo -e
-    echo "Remaining tasks: "
+    node ./tools/messages.js install-steps
     for i in "${!EXTRA_STEPS[@]}"; do
       echo "  $((i+1)). ${EXTRA_STEPS[$i]}"
     done

--- a/tools/messages.js
+++ b/tools/messages.js
@@ -64,5 +64,12 @@ switch (process.argv[2]) {
             heading: 'Pasteup files have changed'
         }, 'info');
         break;
+
+
+    case 'install-steps':
+      notify('Please run the following to complete your installation:', {
+        heading: 'Additional steps'
+      }, 'info');
+      break;
 }
 


### PR DESCRIPTION
## What does this change?

You get a more noticeable prompt if there are extra steps after running `setup.sh`.
## Screenshots

<img width="1241" alt="screen shot 2016-07-06 at 16 41 55" src="https://cloud.githubusercontent.com/assets/1064734/16624168/931fcf0a-4398-11e6-8c80-0cc2a27415eb.png">
## Request for comment

@sndrs 
