### PR TITLE
Remove aus election badging on liveblogs

### DIFF
--- a/static/src/stylesheets/module/_badging.scss
+++ b/static/src/stylesheets/module/_badging.scss
@@ -54,18 +54,6 @@
    ========================================================================== */
 
 .content--liveblog {
-    .content__head--aus-election {
-        .content__header .gs-container {
-            background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog.jpg');
-        }
-
-        &.tonal__head--tone-dead {
-            .content__header .gs-container {
-                background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog_dead.jpg');
-            }
-        }
-    }
-
     .content__head--us-election {
         .content__header .gs-container {
             background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615039/uselectionliveblogon.jpg');

--- a/static/src/stylesheets/module/_badging.scss
+++ b/static/src/stylesheets/module/_badging.scss
@@ -54,18 +54,6 @@
    ========================================================================== */
 
 .content--liveblog {
-    .content__head--aus-election {
-        .content__header .gs-container {
-            background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog.jpg');
-        }
-
-        &.tonal__head--tone-dead {
-            .content__header .gs-container {
-                background-image: url('https://uploads.guim.co.uk/2016/05/11/Election_liveblog_dead.jpg');
-            }
-        }
-    }
-
     .content__head--us-election {
         .content__header .gs-container {
             background-image: url('https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2016/2/1/1454339615039/uselectionliveblogon.jpg');
@@ -78,7 +66,6 @@
         }
     }
 
-    .content__head--aus-election .content__header .gs-container,
     .content__head--us-election .content__header .gs-container {
         background-position: right bottom;
         background-repeat: no-repeat;


### PR DESCRIPTION
## What does this change?

Removes the badging hack that inserted the image of Katherine Murphy on AUS election liveblogs 
## What is the value of this and can you measure success?

editorial request
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

before:

![screen shot 2016-07-06 at 16 45 56](https://cloud.githubusercontent.com/assets/867233/16624399/5a86226a-4399-11e6-84c6-4e891a800617.png)

after:

![screen shot 2016-07-06 at 16 45 40](https://cloud.githubusercontent.com/assets/867233/16624658/825eb522-4399-11e6-9b45-2805a3a0417b.png)
## Request for comment

@sammorrisdesign @blongden73 or anyone in design who has the time to look

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
