### PR TITLE
Allow forcing of A/B complete events in dev mode

### DIFF
--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -144,8 +144,8 @@ Add #ab-<TestName>=<VariantName> to the end of your URL (in dev or prod) to forc
 e.g. www.theguardian.com/news#ab-MyGreatTest=GreenButton
 
 #### Firing complete events in dev mode
-In prod, the completion events are fired based on the MVT ID cookie. This doesn't exist in dev, so if you need to test a complete event, follow the #ab- pattern above.
-Whichever test you set in the hash will have its completion function called.
+In prod, the completion events are fired based on the MVT ID cookie. This doesn't exist in dev, so if you need to test a complete event, force yourself into the test using the #ab-<TestName>=<VariantName> pattern described above.
+This way, the `success` function of the test and variant you specify will be run, so you can test your completion behaviour.
 
 ### Detecting a user's bucket
 You can use this code to check anywhere in your JS whether you're in a test bucket.

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -139,6 +139,14 @@ define([
     })
 ```
 
+### Forcing yourself into a test
+Add #ab-<TestName>=<VariantName> to the end of your URL (in dev or prod) to force yourself into a test.
+e.g. www.theguardian.com/news#ab-MyGreatTest=GreenButton
+
+#### Firing complete events in dev mode
+In prod, the completion events are fired based on the MVT ID cookie. This doesn't exist in dev, so if you need to test a complete event, follow the #ab- pattern above.
+Whichever test you set in the hash will have its completion function called.
+
 ### Detecting a user's bucket
 You can use this code to check anywhere in your JS whether you're in a test bucket.
 ```

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -321,6 +321,16 @@ define([
             });
         },
 
+        forceRegisterCompleteEvent: function(testId, variantId) {
+            var test = getTest(testId);
+            var variant = test && test.variants.filter(function (v) {
+                return v.id.toLowerCase() === variantId.toLowerCase();
+            })[0];
+            var onTestComplete = variant && variant.success || noop;
+
+            onTestComplete(recordTestComplete(test, variantId));
+        },
+
         segmentUser: function () {
             var tokens,
                 forceUserIntoTest = /^#ab/.test(window.location.hash);
@@ -332,6 +342,7 @@ define([
                     test = abParam[0];
                     variant = abParam[1];
                     ab.forceSegment(test, variant);
+                    ab.forceRegisterCompleteEvent(test, variant);
                 });
             } else {
                 ab.segment();


### PR DESCRIPTION
## What does this change?

It's now possible to trigger the complete event listeners for an A/B test with the same anchor method you use to force yourself into a test, also adds a bit to the docs about this.
## What is the value of this and can you measure success?

Easier debugging of tests
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@dominickendrick @gtrufitt @markjamesbutler 
