### PR TITLE
Quiz omniture record clicks

### DIFF
--- a/static/src/javascripts/projects/common/modules/atoms/quiz.js
+++ b/static/src/javascripts/projects/common/modules/atoms/quiz.js
@@ -2,12 +2,14 @@ define([
     'bean',
     'common/utils/$',
     'common/utils/fastdom-promise',
-    'lodash/collections/toArray'
+    'lodash/collections/toArray',
+    'common/modules/analytics/omniture'
 ], function (
     bean,
     $,
     fastdom,
-    toArray
+    toArray,
+    omniture
 ) {
     return {
         // find a bucket message to show once you finish a quiz
@@ -17,14 +19,17 @@ define([
             if (HTMLFormElement.prototype.checkValidity) {
                 // quizzes can be set to only show answers at the end, in which case we do a round trip.
                 // we'll run this code only if it's an instant-reveal quiz
-                var $quizzes = $('.js-atom-quiz--instant-reveal');
+                var $quizzes = $('.js-atom-quiz--instant-reveal'),
+                    $numberOfQuestions = $('.js-atom__quiz_question').length;
 
                 if ($quizzes.length > 0) {
                     bean.on(document, 'click', toArray($quizzes), function (e) {
-                        var quiz = e.currentTarget;
+                        var quiz = e.currentTarget,
+                            total = total = $(':checked + .atom-quiz__answer__item', quiz).length;
+
+                        omniture.trackLinkImmediate('quiz-question-answered-'+total);
                         if (quiz.checkValidity()) { // the form (quiz) is complete
-                            var $bucket__message = null,
-                                total = $(':checked + .atom-quiz__answer__item--is-correct', quiz).length;
+                            var $bucket__message = null;
                             do {
                                 // try and find a .bucket__message for your total
                                 $bucket__message = $('.js-atom-quiz__bucket-message--' + total, quiz);

--- a/static/src/javascripts/projects/common/modules/atoms/quiz.js
+++ b/static/src/javascripts/projects/common/modules/atoms/quiz.js
@@ -19,13 +19,12 @@ define([
             if (HTMLFormElement.prototype.checkValidity) {
                 // quizzes can be set to only show answers at the end, in which case we do a round trip.
                 // we'll run this code only if it's an instant-reveal quiz
-                var $quizzes = $('.js-atom-quiz--instant-reveal'),
-                    $numberOfQuestions = $('.js-atom__quiz_question').length;
+                var $quizzes = $('.js-atom-quiz--instant-reveal');
 
                 if ($quizzes.length > 0) {
                     bean.on(document, 'click', toArray($quizzes), function (e) {
                         var quiz = e.currentTarget,
-                            total = total = $(':checked + .atom-quiz__answer__item', quiz).length;
+                            total =  $(':checked + .atom-quiz__answer__item', quiz).length;
 
                         omniture.trackLinkImmediate('quiz-question-answered-'+total);
                         if (quiz.checkValidity()) { // the form (quiz) is complete


### PR DESCRIPTION
## What does this change?

Turns out that because the quiz questions aren't buttons or anchors, the clickstream doesn't  automatically record participation in omniture. We want this for the next for weeks ( or whatever it is )
## What is the value of this and can you measure success?

We see quiz clicks in omniture
## Does this affect other platforms - Amp, Apps, etc?

N/A
## Screenshots
## Request for comment

@gtrufitt @crifmulholland 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
