### PR TITLE
Remove commercial empty responses report switch

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -296,16 +296,6 @@ trait CommercialSwitches {
     exposeClientSide = false
   )
 
-  val reportEmptyDfpResponsesSwitch = Switch(
-    SwitchGroup.Commercial,
-    "report-empty-dfp-responses",
-    "If on, the client will report empty dfp ad responses.",
-    owners = Seq(Owner.withGithub("rich-nguyen")),
-    safeState = Off,
-    sellByDate = new LocalDate(2016,7,8),
-    exposeClientSide = true
-  )
-
   val SponsoredSwitch = Switch(
     group = CommercialLabs,
     "sponsored",

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/on-slot-render.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/on-slot-render.js
@@ -46,7 +46,7 @@ define([
         // This empty slot could be caused by a targeting problem,
         // let's report these and diagnose the problem in sentry.
         // Keep the sample rate low, otherwise we'll get rate-limited (report-error will also sample down)
-        if (config.switches.reportEmptyDfpResponses && Math.random() < 0.001) {
+        if (Math.random() < 0.001) {
             var adUnitPath = event.slot.getAdUnitPath();
             var adTargetingMap = event.slot.getTargetingMap();
             var adTargetingKValues = adTargetingMap ? adTargetingMap['k'] : [];

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/on-slot-render.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/on-slot-render.js
@@ -46,7 +46,7 @@ define([
         // This empty slot could be caused by a targeting problem,
         // let's report these and diagnose the problem in sentry.
         // Keep the sample rate low, otherwise we'll get rate-limited (report-error will also sample down)
-        if (Math.random() < 0.001) {
+        if (Math.random() < 0.0001) {
             var adUnitPath = event.slot.getAdUnitPath();
             var adTargetingMap = event.slot.getTargetingMap();
             var adTargetingKValues = adTargetingMap ? adTargetingMap['k'] : [];


### PR DESCRIPTION
This is useful, we'd like to keep it. Now further down-sampled to avoid any rate limiting.
