### PR TITLE
Remove redundant setup step and file

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-make install

--- a/setup.sh
+++ b/setup.sh
@@ -122,10 +122,6 @@ install_libpng() {
   fi
 }
 
-install_dependencies() {
-  $BASEDIR/install-dependencies.sh
-}
-
 compile() {
   make install compile
 }
@@ -150,7 +146,6 @@ main() {
   install_gcc
   install_grunt
   install_libpng
-  install_dependencies
   compile
   report
 }


### PR DESCRIPTION
There's no need for `install-dependencies.sh` since it only calls `make install`. I've also removed  the install dependencies step from the script, since `compile` calls `make install` as well.

@sndrs 
