### PR TITLE
bump to play 2.4.8

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ resolvers ++= Seq(
   Resolver.url("bintray-sbt-plugin-releases", url("https://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 )
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.8")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")
 


### PR DESCRIPTION
## What does this change?

This should fix the CSRF problem encountered yesterday with https://github.com/guardian/frontend/pull/13490
## Request for comment

@TBonnin @johnduffell 
