### PR TITLE
Fix libpng check in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -115,10 +115,12 @@ install_gcc() {
 }
 
 install_libpng() {
-  if linux; then
-    sudo apt-get install -y libpng-dev
-  elif mac; then
-    brew install libpng
+  if ! installed libpng-config; then
+    if linux; then
+      sudo apt-get install -y libpng-dev
+    elif mac; then
+      brew install libpng
+    fi
   fi
 }
 


### PR DESCRIPTION
Another fix to stop the script crashing. If you try to `brew install` something that already exists, the script will terminate.
