### PR TITLE
Measure Google Analytics pageview confidence

### DIFF
--- a/admin/app/controllers/admin/AnalyticsConfidenceController.scala
+++ b/admin/app/controllers/admin/AnalyticsConfidenceController.scala
@@ -1,18 +1,20 @@
 package controllers.admin
 
-import play.api.mvc.Controller
 import common.{ExecutionContexts, Logging}
-import tools._
 import controllers.AuthLogging
+import play.api.mvc.Controller
+import tools._
 
 class AnalyticsConfidenceController extends Controller with Logging with AuthLogging with ExecutionContexts {
   def renderConfidence() = AuthActions.AuthActionTest.async { implicit request =>
     for {
       omniture <- CloudWatch.omnitureConfidence
       ophan <- CloudWatch.ophanConfidence
+      google <- CloudWatch.googleConfidence
     } yield {
       val omnitureAverage = omniture.dataset.flatMap(_.values.headOption).sum / omniture.dataset.length
       val ophanAverage = ophan.dataset.flatMap(_.values.headOption).sum / ophan.dataset.length
+      val googleAverage = google.dataset.flatMap(_.values.headOption).sum / google.dataset.length
 
       val omnitureGraph = new AwsLineChart("Omniture confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-2`, Colour.success)) {
         override lazy val dataset = omniture.dataset.map{ point =>
@@ -26,7 +28,13 @@ class AnalyticsConfidenceController extends Controller with Logging with AuthLog
         }
       }
 
-      Ok(views.html.lineCharts("PROD", Seq(omnitureGraph, ophanGraph)))
+      val googleGraph = new AwsLineChart("Google confidence", Seq("Time", "%", "avg."), ChartFormat(Colour.`tone-comment-1`, Colour.success)) {
+        override lazy val dataset = ophan.dataset.map{ point =>
+          point.copy(values =  point.values :+ googleAverage)
+        }
+      }
+
+      Ok(views.html.lineCharts("PROD", Seq(omnitureGraph, ophanGraph, googleGraph)))
     }
   }
 }

--- a/admin/app/services/CloudWatchStats.scala
+++ b/admin/app/services/CloudWatchStats.scala
@@ -42,5 +42,7 @@ object CloudWatchStats extends Logging with ExecutionContexts {
 
   def analyticsPageViews: Future[GetMetricStatisticsResult] = sanityData("kpis-analytics-page-views")
 
+  def googleAnalyticsPageViews: Future[GetMetricStatisticsResult] = sanityData("kpis-analytics-page-views-google")
+
   def pageViewsHavingAnAd: Future[GetMetricStatisticsResult] = sanityData("first-ad-rendered")
 }

--- a/admin/app/tools/CloudWatch.scala
+++ b/admin/app/tools/CloudWatch.scala
@@ -202,27 +202,22 @@ object CloudWatch extends Logging with ExecutionContexts {
     } yield new AwsLineChart(graphTitle, Seq("Time", "Hits", "Misses"), ChartFormat(Colour.success, Colour.error), hits, misses)
   }
 
-  def omnitureConfidence = for {
+  def confidenceGraph(metricName: String): Future[AwsLineChart] = for {
     percentConversion <- withErrorLogging(euWestClient.getMetricStatisticsFuture(new GetMetricStatisticsRequest()
       .withStartTime(new DateTime().minusWeeks(2).toDate)
       .withEndTime(new DateTime().toDate)
       .withPeriod(900)
       .withStatistics("Average")
       .withNamespace("Analytics")
-      .withMetricName("omniture-percent-conversion")
+      .withMetricName(metricName)
       .withDimensions(stage)))
-  } yield new AwsLineChart("omniture-percent-conversion", Seq("Time", "%"), ChartFormat.SingleLineBlue, percentConversion)
+  } yield new AwsLineChart(metricName, Seq("Time", "%"), ChartFormat.SingleLineBlue, percentConversion)
 
-  def ophanConfidence = for {
-    metric <- withErrorLogging(euWestClient.getMetricStatisticsFuture(new GetMetricStatisticsRequest()
-      .withStartTime(new DateTime().minusWeeks(2).toDate)
-      .withEndTime(new DateTime().toDate)
-      .withPeriod(900)
-      .withStatistics("Average")
-      .withNamespace("Analytics")
-      .withMetricName("ophan-percent-conversion")
-      .withDimensions(stage)))
-  } yield new AwsLineChart("ophan-percent-conversion", Seq("Time", "%"), ChartFormat.SingleLineBlue, metric)
+  def omnitureConfidence: Future[AwsLineChart] = confidenceGraph("omniture-percent-conversion")
+
+  def ophanConfidence: Future[AwsLineChart] = confidenceGraph("ophan-percent-conversion")
+
+  def googleConfidence: Future[AwsLineChart] = confidenceGraph("google-percent-conversion")
 
   def user50x = for {
     metric <- withErrorLogging(euWestClient.getMetricStatisticsFuture(new GetMetricStatisticsRequest()

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -1,6 +1,7 @@
 @(page: model.Page)
 @import views.support.GoogleAnalyticsAccount
 @import conf.switches.Switches.GoogleAnalyticsSwitch
+@import conf.Configuration
 
 @if(GoogleAnalyticsSwitch.isSwitchedOn) {
     <script id='google_analytics'>
@@ -42,7 +43,12 @@
         ga('set', 'dimension10', guardian.config.page.toneIds);
         ga('set', 'dimension11', guardian.config.page.seriesId);
 
-        ga('send', 'pageview');
+        ga('send', 'pageview', {
+            hitCallback: function() {
+                var image = new Image();
+                image.src = "@{Configuration.debug.beaconUrl}/count/pvg.gif";
+            }
+        });
     </script>
 
     @*

--- a/diagnostics/app/model/diagnostics/analytics/Metric.scala
+++ b/diagnostics/app/model/diagnostics/analytics/Metric.scala
@@ -12,6 +12,7 @@ object Metric extends Logging {
     // page views
     ("pv", CountMetric("kpis-page-views", "raw page views - simple <img> in body, no javascript involved")),
     ("pva", CountMetric("kpis-analytics-page-views", "page view fires after analytics")),
+    ("pvg", CountMetric("kpis-analytics-page-views-google", "page view fires after Google Analytics")),
     ("omniture-pageview-error", CountMetric("omniture-pageview-error", "omniture-pageview-error")),
 
     ("ads-blocked", CountMetric("ads-blocked", "ads-blocked")),


### PR DESCRIPTION
## What does this change?
- Adds a beacon to count successful GA pageview events, similar to the existing one for Omniture
- Adds a graph to the admin dashboard to display the GA pageview count confidence
## What is the value of this and can you measure success?

We can monitor the quality of our GA data collection
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

I'll add one after I test on CODE
## Request for comment

@dominickendrick 
