### PR TITLE
Fix double badges in containers

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/badges.js
+++ b/static/src/javascripts/projects/common/modules/commercial/badges.js
@@ -69,6 +69,9 @@ define([
             return false;
         }
 
+        // Sponsored fronts must come first, because they add a badge to the
+        // first container. But if the first container turns out to be sponsored
+        // too, a second badge will be added ... i.e. if the both run in parallel.
         return Promise.all(qwery('.js-sponsored-front').map(processFront))
             .then(function () {
                 return Promise.all(qwery('.js-sponsored-container').map(processContainer)

--- a/static/src/javascripts/projects/common/modules/commercial/badges.js
+++ b/static/src/javascripts/projects/common/modules/commercial/badges.js
@@ -69,10 +69,11 @@ define([
             return false;
         }
 
-        return Promise.all(qwery('.js-sponsored-front').map(processFront)
-            .concat(qwery('.js-sponsored-container').map(processContainer))
-            .concat(qwery('.js-sponsored-card').map(processCard))
-        );
+        return Promise.all(qwery('.js-sponsored-front').map(processFront))
+            .then(function () {
+                return Promise.all(qwery('.js-sponsored-container').map(processContainer)
+                    .concat(qwery('.js-sponsored-card').map(processCard)));
+            });
     }
 
     function addPreBadge(adSlot, header, sponsor) {

--- a/static/src/javascripts/projects/common/modules/commercial/badges.js
+++ b/static/src/javascripts/projects/common/modules/commercial/badges.js
@@ -71,7 +71,7 @@ define([
 
         // Sponsored fronts must come first, because they add a badge to the
         // first container. But if the first container turns out to be sponsored
-        // too, a second badge will be added ... i.e. if the both run in parallel.
+        // too, a second badge will be added ... i.e. if they both run in parallel.
         return Promise.all(qwery('.js-sponsored-front').map(processFront))
             .then(function () {
                 return Promise.all(qwery('.js-sponsored-container').map(processContainer)


### PR DESCRIPTION
Sponsored fronts will add a badge to the first container, but if this container appears to be sponsored too, another badge will be added.

This change makes sure the front case is handled before the containers one, to avoid the double badge.

Before:
![picture 8](https://cloud.githubusercontent.com/assets/629976/16655666/5abb9b7e-4453-11e6-940c-3e4bdb8cfc4c.jpg)

After:
![picture 7](https://cloud.githubusercontent.com/assets/629976/16655671/5e018afa-4453-11e6-8dbb-f025959f8a79.jpg)

cc @JonNorman @rich-nguyen 
