### PR TITLE
Add missing thumbnailUrl for video elements

### DIFF
--- a/applications/app/views/fragments/mediaBody.scala.html
+++ b/applications/app/views/fragments/mediaBody.scala.html
@@ -70,7 +70,9 @@
                                         }
                                         <meta itemprop="requiresSubscription" content="false" />
                                         <meta itemprop="image" content="@Html(video.content.signedArticleImage)" />
-                                        @video.elements.thumbnail.map{ img => <meta itemprop="thumbnail" content="@SeoOptimisedContentImage.bestFor(img.images)" /> }
+                                        @video.elements.thumbnail.map{ img =>
+                                            <meta itemprop="thumbnail" content="@SeoOptimisedContentImage.bestFor(img.images)" />
+                                            <meta itemprop="thumbnailUrl" content="@SeoOptimisedContentImage.bestFor(img.images)" /> }
                                         @video.elements.mainVideo.map { videoElement =>
                                             @fragments.media.video(VideoPlayer(
                                                 videoElement,


### PR DESCRIPTION
## What does this change?

meta itemprop="thumbnailUrl" is missing from VideoObject.

Yes, having thumbnail and thumbnailUrl may seem redundant. There is an open issue on this with schemaorg: https://github.com/schemaorg/schemaorg/issues/239
## What is the value of this and can you measure success?

Source for articles with video as the main-media ([example](http://www.theguardian.com/politics/video/2016/jun/21/brendan-cox-jo-cox-was-killed-because-of-her-political-views-video)) contain no `thumbnailUrl` for the video.

Adding one removes an error reported by the structured data testing tool: https://search.google.com/structured-data/testing-tool#

The Google search result for this article is currently using the OpenGraph image, possibly as a fallback due to missing meta data?

<img width="259" alt="picture 102" src="https://cloud.githubusercontent.com/assets/8607683/16627674/31e29476-43a6-11e6-9015-85518b57ba0e.png">
## Does this affect other platforms - Amp, Apps, etc?

Anything that uses Schema (http://schema.org/) structured data to parse or scrape our pages.
Google search, Bing, etc.

Oddly, Google+ appears to be giving OpenGraph higher ranking when parsing pages (over Schema). Google Search currently favours Schema.
## Screenshots
#### BEFORE:

<img width="1057" alt="picture 101" src="https://cloud.githubusercontent.com/assets/8607683/16627463/52c1d0d6-43a5-11e6-987e-6f69eebbf992.png">
#### AFTER:

<img width="1137" alt="picture 100" src="https://cloud.githubusercontent.com/assets/8607683/16627380/edcd5c40-43a4-11e6-951a-9bbc14925003.png">
## Request for comment
