### PR TITLE
Hosted pages - changes in the twitter and email shared text 

### DIFF
--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -47,7 +47,7 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/willard-wigan_banner.jpg"),
-      twitterTxt = videoTitle + " feat @crownandqueue. Watch full film: ",
+      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue. Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )
@@ -77,7 +77,7 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/adrienne-treeby_banner.jpg"),
-      twitterTxt = videoTitle + " feat @crownandqueue. Watch full film: ",
+      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue. Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )
@@ -104,7 +104,7 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/pete-lawrence_banner.jpg"),
-      twitterTxt = videoTitle + " feat @crownandqueue. Watch full film: ",
+      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue. Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )
@@ -131,7 +131,7 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/susan-derges_banner.jpg"),
-      twitterTxt = videoTitle + " feat @crownandqueue. Watch full film: ",
+      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue. Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )
@@ -157,7 +157,7 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/quay-brothers_banner.jpg"),
-      twitterTxt = videoTitle + " feat @crownandqueue. Watch full film: ",
+      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue. Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -47,8 +47,8 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/willard-wigan_banner.jpg"),
-      twitterTxt = "Advertiser content hosted by the Guardian: Leffe presents " + videoTitle + " feat @crownandqueue. Watch full film: ",
-      emailTxt = "Advertiser content hosted by the Guardian: Leffe presents " + videoTitle,
+      twitterTxt = videoTitle + " feat @crownandqueue. Watch full film: ",
+      emailTxt = videoTitle,
       nextPage = None
     )
   }
@@ -77,8 +77,8 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/adrienne-treeby_banner.jpg"),
-      twitterTxt = "Advertiser content hosted by the Guardian: Leffe presents " + videoTitle + " feat @crownandqueue. Watch full film: ",
-      emailTxt = "Advertiser content hosted by the Guardian: Leffe presents " + videoTitle,
+      twitterTxt = videoTitle + " feat @crownandqueue. Watch full film: ",
+      emailTxt = videoTitle,
       nextPage = None
     )
   }
@@ -104,8 +104,8 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/pete-lawrence_banner.jpg"),
-      twitterTxt = "Advertiser content hosted by the Guardian: Leffe presents " + videoTitle + " feat @crownandqueue. Watch full film: ",
-      emailTxt = "Advertiser content hosted by the Guardian: Leffe presents " + videoTitle,
+      twitterTxt = videoTitle + " feat @crownandqueue. Watch full film: ",
+      emailTxt = videoTitle,
       nextPage = None
     )
   }
@@ -131,8 +131,8 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/susan-derges_banner.jpg"),
-      twitterTxt = "Advertiser content hosted by the Guardian: Leffe presents " + videoTitle + " feat @crownandqueue. Watch full film: ",
-      emailTxt = "Advertiser content hosted by the Guardian: Leffe presents " + videoTitle,
+      twitterTxt = videoTitle + " feat @crownandqueue. Watch full film: ",
+      emailTxt = videoTitle,
       nextPage = None
     )
   }
@@ -157,8 +157,8 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/quay-brothers_banner.jpg"),
-      twitterTxt = "Advertiser content hosted by the Guardian: Leffe presents " + videoTitle + " feat @crownandqueue. Watch full film: ",
-      emailTxt = "Advertiser content hosted by the Guardian: Leffe presents " + videoTitle,
+      twitterTxt = videoTitle + " feat @crownandqueue. Watch full film: ",
+      emailTxt = videoTitle,
       nextPage = None
     )
   }

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -42,8 +42,8 @@ object RenaultHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/ren_commercial_banner.jpg"),
-      twitterTxt = "Advertiser content hosted by the Guardian: " + videoTitle + " Watch full film: ",
-      emailTxt = "Advertiser content hosted by the Guardian: " + videoTitle,
+      twitterTxt = videoTitle + " Watch full film: ",
+      emailTxt = videoTitle,
       nextPage = None
     )
   }
@@ -67,8 +67,8 @@ object RenaultHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/ren_commercial_banner.jpg"),
-      twitterTxt = "Advertiser content hosted by the Guardian: " + videoTitle + " Watch full film: ",
-      emailTxt = "Advertiser content hosted by the Guardian: " + videoTitle,
+      twitterTxt = videoTitle + " Watch full film: ",
+      emailTxt = videoTitle,
       nextPage = None
     )
   }
@@ -92,8 +92,8 @@ object RenaultHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/ren_commercial_banner.jpg"),
-      twitterTxt = "Advertiser content hosted by the Guardian: " + videoTitle + " Watch full film: ",
-      emailTxt = "Advertiser content hosted by the Guardian: " + videoTitle,
+      twitterTxt = videoTitle + " Watch full film: ",
+      emailTxt = videoTitle,
       nextPage = None
     )
   }


### PR DESCRIPTION
## What does this change?

"Advertiser content hosted by the Guardian" removed from the Twitter and share via email text.

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
