### PR TITLE
run krux on section fronts but not network fronts

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/third-party-tags/krux.js
+++ b/static/src/javascripts/projects/common/modules/commercial/third-party-tags/krux.js
@@ -20,7 +20,7 @@ define([
     }
 
     return {
-        shouldRun: !config.page.isFront && config.switches.krux,
+        shouldRun: !(config.page.contentType == 'Network Front') && config.switches.krux,
         url: kruxUrl,
         getSegments: getSegments
     };


### PR DESCRIPTION
## What does this change?

Previously we had not run the Krux script on any fronts. 

Now we will run it on all section fronts but **not** on Network Fronts.
## Request for comment

@regiskuckaertz  @guardian/commercial-dev 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
