### PR TITLE
Bigger images for image objects

### DIFF
--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -136,7 +136,7 @@ import collection.JavaConversions._
 
         And("I should see the image url")
         findFirst("[itemprop='associatedMedia image'] [itemprop=url]").getAttribute("content") should
-          endWith("/img/static/sys-images/Guardian/Pix/pictures/2012/8/6/1344274684805/Gunnerside-village-Swaled-009.jpg?w=300&q=55&auto=format&usm=12&fit=max&s=5c104f891f729f652c8f50caf5ee2dc6")
+          endWith("/img/static/sys-images/Guardian/Pix/pictures/2012/8/6/1344274684805/Gunnerside-village-Swaled-009.jpg?w=700&q=55&auto=format&usm=12&fit=max&s=a3609bca562f97c2c3b80fd2d625c132")
 
         And("I should see the image width")
         findFirst("[itemprop='associatedMedia image'] [itemprop=width]").getAttribute("content") should be("460")

--- a/common/app/views/fragments/imageFigure.scala.html
+++ b/common/app/views/fragments/imageFigure.scala.html
@@ -36,7 +36,7 @@
         @if(isMain) {
             <meta itemprop="representativeOfPage" content="true">
         }
-        <meta itemprop="url" content="@ImgSrc.getFallbackUrl(picture)">
+        <meta itemprop="url" content="@ImgSrc.findNearestSrc(picture, Item700)">
         <meta itemprop="width" content="@ImgSrc.getFallbackAsset(picture).fold(0)(_.width)">
         <meta itemprop="height" content="@ImgSrc.getFallbackAsset(picture).fold(0)(_.height)">
 


### PR DESCRIPTION
## What does this change?

Swaps the 300px wide image URL in the `itemprop=url` to a 700px wide one.
## What is the value of this and can you measure success?

Shares a larger image (>696px) with crawlers reading our Schema microdata/metadata (http://schema.org/)

> ImageObject, required
> 
> The representative image of the article. Only a marked-up image that directly belongs to the article should be specified.
> 
> Images should be at least 696 pixels wide

https://developers.google.com/search/docs/guides/mark-up-content
## Does this affect other platforms - Amp, Apps, etc?

Anything that uses Schema (http://schema.org/) structured data to parse or scrape our pages.
Google search, Bing, etc.

AMP will be unaffected, the AMP html is found on a separate page (`<link rel="amphtml"`) and the images for AMP are marked up using AMP tags: `<amp-img src="example.jpg"`
## Screenshots
#### BEFORE

<img width="1249" alt="picture 104" src="https://cloud.githubusercontent.com/assets/8607683/16661846/d1a1cb6e-446c-11e6-951e-58b7c77fae8c.png">
#### AFTER

<img width="1246" alt="picture 105" src="https://cloud.githubusercontent.com/assets/8607683/16661886/fe7e275e-446c-11e6-8585-42f364cc5479.png">
## Request for comment
