### PR TITLE
hosted video pages - twitter txt fix

### DIFF
--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -1,6 +1,7 @@
 @import common.commercial.hosted.HostedVideoPage
 @(page: HostedVideoPage)(implicit request: RequestHeader)
 @import views.html.hosted.guardianHostedHeader
+@import java.net.URLEncoder
 
 @cssClass(owner: String) = {hosted-tone--@{owner.toLowerCase.replaceAll("\\s+", "-")}}
 
@@ -81,7 +82,7 @@
                         <li class="social__item social__item--twitter" data-link-name="twitter">
                             <a class="social__action social-icon-wrapper"
                             data-link-name="twitter-social-share-1"
-                            href="https://twitter.com/intent/tweet?text=@{page.twitterTxt}&url=@{page.pageUrl}"
+                            href="https://twitter.com/intent/tweet?text=@{URLEncoder.encode(page.twitterTxt, "utf-8")}&url=@{page.pageUrl}"
                             target="_blank"
                             title="twitter">
                                 <span class='inline-icon__fallback button share-modal__item share-modal__item--twitter'>Share on Twitter</span>

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -47,7 +47,7 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/willard-wigan_banner.jpg"),
-      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue. Watch full film: ",
+      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue #ad. Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )
@@ -77,7 +77,7 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/adrienne-treeby_banner.jpg"),
-      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue. Watch full film: ",
+      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue #ad. Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )
@@ -104,7 +104,7 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/pete-lawrence_banner.jpg"),
-      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue. Watch full film: ",
+      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue #ad. Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )
@@ -131,7 +131,7 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/susan-derges_banner.jpg"),
-      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue. Watch full film: ",
+      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue #ad. Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )
@@ -157,7 +157,7 @@ object LeffeHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/quay-brothers_banner.jpg"),
-      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue. Watch full film: ",
+      twitterTxt = "Leffe presents " + videoTitle + ", feat @crownandqueue #ad. Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -42,7 +42,7 @@ object RenaultHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/ren_commercial_banner.jpg"),
-      twitterTxt = videoTitle + " Watch full film: ",
+      twitterTxt = videoTitle + " #ad Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )
@@ -67,7 +67,7 @@ object RenaultHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/ren_commercial_banner.jpg"),
-      twitterTxt = videoTitle + " Watch full film: ",
+      twitterTxt = videoTitle + " #ad Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )
@@ -92,7 +92,7 @@ object RenaultHostedPages {
       ),
       cta,
       ctaBanner = Static("images/commercial/ren_commercial_banner.jpg"),
-      twitterTxt = videoTitle + " Watch full film: ",
+      twitterTxt = videoTitle + " #ad Watch full film: ",
       emailTxt = videoTitle,
       nextPage = None
     )


### PR DESCRIPTION
## What does this change?

The twitter message on hosted video pages includes `#ad` now and its properly encoded.
