### PR TITLE
fixes play button triangle alignment in FF

### DIFF
--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -135,7 +135,6 @@ $ima-controls-height: 70px;
             border-style: solid;
             border-width: 1em 0 1em 2.4em;
             border-color: transparent transparent transparent $neutral-1;
-            -moz-transform: scale(.99999); // fix for diagonal border aliasing in firefox
 
             @include mq(tablet) { // 0 border radius on mobile because stock android has a render bug with it here
                 border-radius: .2em;


### PR DESCRIPTION
## What does this change?

Fixes the play button triangle in FF.

As the `-moz-transform` rule was declared last, it was winning and `transform: translate(-40%, -50%);` was ignored by the browser.

Tested on FF 47.0

Related to https://github.com/guardian/frontend/pull/13522
## What is the value of this and can you measure success?

a more centred, aligned button and general zen
## Does this affect other platforms - Amp, Apps, etc?

no
## Screenshots

before
![screen shot 2016-07-08 at 13 22 56](https://cloud.githubusercontent.com/assets/836140/16687681/0bd234ea-4512-11e6-8133-a1e904500859.jpeg)

after
![screen shot 2016-07-08 at 13 45 43](https://cloud.githubusercontent.com/assets/836140/16687697/180da870-4512-11e6-9ba7-e4ce0172b349.jpeg)
## Request for comment

@zeftilldeath @duarte 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
