### PR TITLE
HSTS opt in/out

### DIFF
--- a/applications/app/controllers/OptInController.scala
+++ b/applications/app/controllers/OptInController.scala
@@ -30,6 +30,7 @@ class OptInController extends Controller {
   def handle(feature: String, choice: String) = Action { implicit request =>
     Cached(60)(WithoutRevalidationResult(feature match {
       case "https" => https.opt(choice)
+      case "hsts" => hsts.opt(choice)
       case "header" => header.opt(choice)
       case "gallery" => gallery.opt(choice)
       case _ => NotFound
@@ -37,6 +38,7 @@ class OptInController extends Controller {
   }
 
   val https = HttpsOptFeature("https_opt_in")
+  val hsts = OptInFeature("hsts_opt_in")
   val header = OptInFeature("new_header_opt_in")
   val gallery = OptInFeature("gallery_redesign_opt_in")
 }


### PR DESCRIPTION
## What does this change?

Adds a new opt in/out feature that allows us to begin tests with HSTS headers. The HSTS header would be set for anybody opting in, regardless of whether the base url is served over https. 

This is to allow https opt in/out to be unaffected by our HSTS tests, but it's likely that you would opt in to both https and HSTS to get meaningful results. 
## What is the value of this and can you measure success?

We can determine what issues remain prior to moving to 100% https.
## Does this affect other platforms - Amp, Apps, etc?

No. Web only.
## Request for comment

@desbo @mchv 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
