### PR TITLE
Render iframe refactor

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
@@ -3,6 +3,7 @@ define([
     'bonzo',
     'Promise',
     'common/utils/fastdom-promise',
+    'common/utils/report-error',
 
     // These need to be bundled, so that they can be fetched asynchronously in production
     'common/modules/commercial/creatives/commercial-component',
@@ -28,7 +29,8 @@ define([
     bean,
     bonzo,
     Promise,
-    fastdom
+    fastdom,
+    reportError
 ) {
     /**
      * Not all adverts render themselves - some just provide data for templates that we implement in commercial.js.
@@ -80,7 +82,7 @@ define([
                 ).then(
                  renderCreative
             ).catch(function (err) {
-                console.log(err);
+                reportError(err)
             });
         } else {
             return Promise.resolve(true);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
@@ -82,7 +82,7 @@ define([
                 ).then(
                  renderCreative
             ).catch(function (err) {
-                reportError(err)
+                reportError("Failed to get creative JSON " + err);
             });
         } else {
             return Promise.resolve(true);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
@@ -77,11 +77,10 @@ define([
         var creativeConfig = fetchCreativeConfig();
 
         if (creativeConfig) {
-            return hideIframe().then(
-                 JSON.parse
-                ).then(
-                 renderCreative
-            ).catch(function (err) {
+            return hideIframe()
+                .then(JSON.parse)
+                .then(renderCreative)
+                .catch(function (err) {
                 reportError('Failed to get creative JSON ' + err);
             });
         } else {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
@@ -82,7 +82,7 @@ define([
                 ).then(
                  renderCreative
             ).catch(function (err) {
-                reportError("Failed to get creative JSON " + err);
+                reportError('Failed to get creative JSON ' + err);
             });
         } else {
             return Promise.resolve(true);

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
@@ -89,7 +89,6 @@ define([
         function fetchCreativeConfig() {
                 var breakoutScript = iFrame.contentDocument.body.querySelector('.breakout__script[type="application/json"]');
                 return breakoutScript ? breakoutScript.innerHTML : null;
-                // return breakoutScript ? JSON.parse(breakoutScript.innerHTML) : null;
         }
 
         function renderCreative(config) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
@@ -75,20 +75,21 @@ define([
         var creativeConfig = fetchCreativeConfig();
 
         if (creativeConfig) {
-            return hideIframe().then(function () {
-                return renderCreative(creativeConfig);
+            return hideIframe().then(
+                 JSON.parse
+                ).then(
+                 renderCreative
+            ).catch(function (err) {
+                console.log(err);
             });
         } else {
             return Promise.resolve(true);
         }
 
         function fetchCreativeConfig() {
-            try {
                 var breakoutScript = iFrame.contentDocument.body.querySelector('.breakout__script[type="application/json"]');
-                return breakoutScript ? JSON.parse(breakoutScript.innerHTML) : null;
-            } catch (_) {
-                return null;
-            }
+                return breakoutScript ? breakoutScript.innerHTML : null;
+                // return breakoutScript ? JSON.parse(breakoutScript.innerHTML) : null;
         }
 
         function renderCreative(config) {
@@ -102,6 +103,7 @@ define([
         function hideIframe() {
             return fastdom.write(function () {
                 iFrame.style.display = 'none';
+                return creativeConfig;
             });
         }
     }


### PR DESCRIPTION
## What does this change?

Refactor the creative config received from DFP so as to hide the iframe if nothing is received.

Should help when empty iframes are rendered with no creative JSON received causing issues with text indentation.
## Request for comment

@regiskuckaertz @guardian/commercial-dev 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
