### PR TITLE
Sticky top banner race conditions

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -411,7 +411,7 @@ object Article {
       javascriptConfigOverrides = javascriptConfig,
       opengraphPropertiesOverrides = opengraphProperties,
       twitterPropertiesOverrides = twitterProperties,
-      shouldHideHeaderAndTopAds = content.tags.isUSMinuteSeries || content.isImmersive
+      shouldHideHeaderAndTopAds = (content.tags.isUSMinuteSeries || content.isImmersive) && content.tags.isArticle
     )
   }
 

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -629,6 +629,8 @@ final case class Tags(
   lazy val isAusElection = tags.exists(t => t.id == "australia-news/australian-election-2016")
   lazy val isElection = isUSElection || isAusElection
 
+  lazy val hasSuperStickyBanner = PersonalInvestmentsCampaign.isRunning(keywordIds)
+
   lazy val keywordIds = keywords.map { _.id }
 
   lazy val commissioningDesk = tracking.map(_.id).collect { case Tags.CommissioningDesk(desk) => desk }.headOption
@@ -636,7 +638,7 @@ final case class Tags(
   def javascriptConfig: Map[String, JsValue] = Map(
     ("keywords", JsString(keywords.map { _.name }.mkString(","))),
     ("keywordIds", JsString(keywordIds.mkString(","))),
-    ("hasSuperStickyBanner", JsBoolean(PersonalInvestmentsCampaign.isRunning(keywordIds))),
+    ("hasSuperStickyBanner", JsBoolean(hasSuperStickyBanner)),
     ("nonKeywordTagIds", JsString(nonKeywordTags.map { _.id }.mkString(","))),
     ("richLink", JsString(richLink.getOrElse(""))),
     ("openModule", JsString(openModule.getOrElse(""))),

--- a/common/app/views/main.scala.html
+++ b/common/app/views/main.scala.html
@@ -7,7 +7,7 @@
 @import views.support.{Commercial, RenderClasses}
 
 @headerAndTopAds(showAdverts: Boolean, edition: Edition, adBelowNav: Boolean) = {
-    @if(!(page.metadata.shouldHideHeaderAndTopAds && getContent(page).exists(_.tags.isArticle))) {
+    @if(!page.metadata.shouldHideHeaderAndTopAds) {
         @if(showAdverts) {
             @defining(
                 page match {

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -1,6 +1,7 @@
 define([
     'Promise',
     'common/utils/config',
+    'common/utils/detect',
     'common/utils/mediator',
     'common/utils/robust',
     'common/utils/user-timing',
@@ -15,13 +16,14 @@ define([
     'common/modules/commercial/hosted-video',
     'common/modules/commercial/hosted-gallery',
     'common/modules/commercial/slice-adverts',
+    'common/modules/commercial/sticky-top-banner',
     'common/modules/commercial/third-party-tags',
     'common/modules/commercial/paidfor-band',
-    'common/modules/commercial/paid-containers',
-    'common/modules/commercial/sticky-top-banner'
+    'common/modules/commercial/paid-containers'
 ], function (
     Promise,
     config,
+    detect,
     mediator,
     robust,
     userTiming,
@@ -36,10 +38,10 @@ define([
     hostedVideo,
     hostedGallery,
     sliceAdverts,
+    stickyTopBanner,
     thirdPartyTags,
     paidforBand,
-    paidContainers,
-    stickyTopBanner
+    paidContainers
 ) {
     var modules = [
         ['cm-dfp', dfpInit],

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -134,23 +134,14 @@ define([
             },
 
             initialiseStickyAdBanner: function () {
-                if (!(config.switches.disableStickyAdBannerOnMobile && detect.getBreakpoint() === 'mobile')
-                    && !config.page.shouldHideAdverts
-                    && config.page.section !== 'childrens-books-site'
-                    && !config.tests.abNewHeaderVariant
-                    && (config.page.hasSuperStickyBanner
-                        || config.page.contentType !== 'Interactive'
-                        && config.page.contentType !== 'Crossword'
-                        && config.page.contentType !== 'Hosted'
-                        && !config.page.isImmersive
-                        && !config.page.isUsMinute
-                        && !config.page.isAdvertisementFeature
-                        )
+                if ((config.switches.disableStickyAdBannerOnMobile && detect.getBreakpoint() === 'mobile') ||
+                     config.page.disableStickyTopBanner ||
+                     config.tests.abNewHeaderVariant
                 ) {
+                    config.page.hasStickyAdBanner = false;
+                } else {
                     stickyAdBanner.initialise();
                     config.page.hasStickyAdBanner = true;
-                } else {
-                    config.page.hasStickyAdBanner = false;
                 }
             },
 

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -29,7 +29,6 @@ define([
     'common/modules/identity/autosignin',
     'common/modules/identity/cookierefresh',
     'common/modules/navigation/navigation',
-    'common/modules/commercial/sticky-top-banner',
     'common/modules/commercial/hosted-about',
     'common/modules/navigation/profile',
     'common/modules/navigation/search',
@@ -84,7 +83,6 @@ define([
     AutoSignin,
     CookieRefresh,
     navigation,
-    stickyAdBanner,
     hostedAbout,
     Profile,
     Search,
@@ -131,18 +129,6 @@ define([
 
             initialiseNavigation: function () {
                 navigation.init();
-            },
-
-            initialiseStickyAdBanner: function () {
-                if ((config.switches.disableStickyAdBannerOnMobile && detect.getBreakpoint() === 'mobile') ||
-                     config.page.disableStickyTopBanner ||
-                     config.tests.abNewHeaderVariant
-                ) {
-                    config.page.hasStickyAdBanner = false;
-                } else {
-                    stickyAdBanner.initialise();
-                    config.page.hasStickyAdBanner = true;
-                }
             },
 
             showTabs: function () {
@@ -385,7 +371,6 @@ define([
                 ['c-tabs', modules.showTabs],
                 ['c-top-nav', modules.initialiseTopNavItems],
                 ['c-init-nav', modules.initialiseNavigation],
-                ['c-sticky-ad-banner', modules.initialiseStickyAdBanner],
                 ['c-toggles', modules.showToggles],
                 ['c-dates', modules.showRelativeDates],
                 ['c-clickstream', modules.initClickstream],

--- a/static/src/javascripts/projects/common/modules/commercial/sticky-top-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/sticky-top-banner.js
@@ -211,7 +211,9 @@ define([
     };
 
     var initialise = function () {
-        if (detect.isBreakpoint({ min: 'desktop' })) {
+        // Although we check as much config as possible to decide whether to run sticky-top-banner,
+        // it is still entirely possible for the ad slot to be closed.
+        if (detect.isBreakpoint({ min: 'desktop' }) && $adBannerInner[0]) {
             getInitialState().then(function (initialState) {
                 var store = createStore(reducer, initialState);
 

--- a/static/src/javascripts/projects/common/modules/commercial/sticky-top-banner.js
+++ b/static/src/javascripts/projects/common/modules/commercial/sticky-top-banner.js
@@ -240,7 +240,7 @@ define([
     };
 
     return {
-        initialise: initialise,
+        init: initialise,
         // Needed for testing
         render: render
     };


### PR DESCRIPTION
There are some errors being thrown in Sentry which look like sticky top banner is operating on a dom tree without a `top-above-nav` slot. This is likely to be a race condition, where the commercial app is in the process of closing (ie removing) server-rendered slots. So we need to wait for commercial dom writes to finalise the slot structure on the page before running any sticky top banner code. I've moved the whole module into the commercial app.

Also, the logic to decide if we run with a sticky top banner, a top banner, or no top banner and header, was all a bit crazy. I've moved it to the server and tried to break it down, but it's still fundamentally complicated. 
