### PR TITLE
Fix football link issue #13177

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -13,8 +13,7 @@ define([
     'common/modules/sport/football/match-list-live',
     'common/modules/sport/football/tag-page-stats',
     'common/modules/sport/score-board',
-    'common/modules/ui/rhc',
-    'lodash/functions/debounce'
+    'common/modules/ui/rhc'
 ], function (
     bean,
     bonzo,
@@ -30,8 +29,7 @@ define([
     MatchListLive,
     tagPageStats,
     ScoreBoard,
-    rhc,
-    debounce
+    rhc
 ) {
 
     function renderNav(match, callback) {

--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -275,37 +275,6 @@ define([
             window.location = this.value;
         });
 
-        // World Cup content
-        // config.switches.worldCupWallchartEmbed
-        // Remove this content below when you remove the switch as it's specific to World Cup 2014
-        if (config.page.isFootballWorldCup2014) {
-            $('a').attr('target', '_top');
-
-            (function () {
-                var t, h, i, resize;
-
-                // This stops the SecurityError from halting the execution any further.
-                try {
-                    i = $('.interactive iframe', window.parent.document).get(0);
-                } catch (e) {/**/}
-
-                resize = (function r() {
-                    if (!t) {
-                        // if this isn't timed out, it triggers another resize
-                        h = $('#js-context').offset().height + 50;
-
-                        if (i) { i.height = h; }
-                        t = setTimeout(function () {
-                            clearTimeout(t); t = null;
-                        }, 200);
-                    }
-                    return r;
-                })();
-                mediator.on('window:resize', debounce(resize, 200));
-                bean.on(document, 'click', '.dropdown__button', resize);
-            })();
-        }
-
         tagPageStats();
     }
 

--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -275,14 +275,6 @@ define([
             window.location = this.value;
         });
 
-        if (!config.page.isFootballWorldCup2014) {
-            bean.on(document.body, 'click', '.table tr[data-link-to]', function (e) {
-                if (!e.target.getAttribute('href')) {
-                    window.location = this.getAttribute('data-link-to');
-                }
-            });
-        }
-
         // World Cup content
         // config.switches.worldCupWallchartEmbed
         // Remove this content below when you remove the switch as it's specific to World Cup 2014


### PR DESCRIPTION
## What does this change?
- Remove the event setting `window.location = this.getAttribute('data-link-to');` as it is appending a click event to a table containing hyperlinks, this was causing issue #13177
- Removes an unused code block (as instructed by the comment); the switch `worldCupWallchartEmbed` appears to no longer exist
## What is the value of this and can you measure success?
- CMD+click on a football result will no longer open the match page in the current tab ⚽
- Removes some dead code 💀 (lines 286-316)
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

N/A
## Request for comment

@TBonnin 
