### PR TITLE
Use a sans-serif font for business stocks price

### DIFF
--- a/static/src/stylesheets/module/business/_stocks.scss
+++ b/static/src/stylesheets/module/business/_stocks.scss
@@ -106,6 +106,7 @@ $stocks-icon-height: 10px;
 .stocks__price {
     margin-right: .25em;
     font-family: sans-serif;
+    letter-spacing: .05em;
 }
 
 .stocks__closed,

--- a/static/src/stylesheets/module/business/_stocks.scss
+++ b/static/src/stylesheets/module/business/_stocks.scss
@@ -105,6 +105,7 @@ $stocks-icon-height: 10px;
 
 .stocks__price {
     margin-right: .25em;
+    font-family: sans-serif;
 }
 
 .stocks__closed,


### PR DESCRIPTION
### What does this change?

Currently business stocks price use guardian font where several numbers characters (`6`, `8` ⬆️  and `5` ⬇️ ) are not vertically aligned which render the reading difficult. I added a bit of space between letters to improve the reading.
#### before

<img width="232" alt="capture d ecran 2016-07-10 a 10 59 40" src="https://cloud.githubusercontent.com/assets/615085/16712919/1e83487c-468e-11e6-995b-9d1a35a9e326.png">
#### after

<img width="161" alt="capture d ecran 2016-07-10 a 11 24 34" src="https://cloud.githubusercontent.com/assets/615085/16712992/ea592abe-4690-11e6-9039-1f35f5f7e44c.png">
