### PR TITLE
Leffe cta fix

### DIFF
--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -140,26 +140,24 @@
         </section>
         <section class="adverts hosted__container--full">
             <div class="hosted__banner" style="background-image: url(@{page.ctaBanner});">
-                <div class="hostedbadge hostedbadge--shouldscale hostedbadge--pushdown hosted-tone-bg--@{page.campaign.owner.toLowerCase}">
-                    <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
-                </div>
-                @if(page.cta.btnText.length == 0) {
-                    <div class="hosted__cta-wrapper">
-                        <a href="@{page.cta.url}" rel="nofollow" class="hosted__cta-link" data-link-name="@{page.cta.trackingCode}" target="_blank">
+                <a href="@{page.cta.url}" rel="nofollow" class="hosted__cta-link" data-link-name="@{page.cta.trackingCode}" target="_blank">
+                    <div class="hostedbadge hostedbadge--shouldscale hostedbadge--pushdown hosted-tone-bg--@{page.campaign.owner.toLowerCase}">
+                        <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
+                    </div>
+                    @if(page.cta.btnText.length == 0) {
+                        <div class="hosted__cta-wrapper">
                             <span class="hosted__cta-text hosted-tone--@{page.campaign.owner.toLowerCase}">@{page.cta.label}</span>
                             @fragments.inlineSvg("arrow-right", "icon", List("i-right","advert__more","button","button--large","button--primary","hosted__cta","hosted-tone-btn--" + page.campaign.owner.toLowerCase))
-                        </a>
-                    </div>
-                } else {
-                    <div class="hosted__cta-wrapper">
-                        <div class="hosted__cta-btn-wrapper">
-                            <span class="hosted__cta-text hosted-tone--@{page.campaign.owner.toLowerCase}">@{page.cta.label}</span>
-                            <a href="@{page.cta.url}" class="hosted__cta-btn" data-link-name="@{page.cta.trackingCode}" target="_blank">
-                                @{page.cta.btnText}
-                            </a>
                         </div>
-                    </div>
-                }
+                    } else {
+                        <div class="hosted__cta-wrapper">
+                            <div class="hosted__cta-btn-wrapper">
+                                <span class="hosted__cta-label">@{page.cta.label}</span>
+                                <span class="hosted__cta-btn-text">@{page.cta.btnText} @fragments.inlineSvg("arrow-right", "icon")</span>
+                            </div>
+                        </div>
+                    }
+                </a>
             </div>
         </section>
     </div>

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -150,11 +150,9 @@
                             @fragments.inlineSvg("arrow-right", "icon", List("i-right","advert__more","button","button--large","button--primary","hosted__cta","hosted-tone-btn--" + page.campaign.owner.toLowerCase))
                         </div>
                     } else {
-                        <div class="hosted__cta-wrapper">
-                            <div class="hosted__cta-btn-wrapper">
-                                <span class="hosted__cta-label">@{page.cta.label}</span>
-                                <span class="hosted__cta-btn-text">@{page.cta.btnText} @fragments.inlineSvg("arrow-right", "icon")</span>
-                            </div>
+                        <div class="hosted__cta-wrapper hosted__cta-btn-wrapper">
+                            <span class="hosted__cta-label">@{page.cta.label}</span>
+                            <span class="hosted__cta-btn-text">@{page.cta.btnText} @fragments.inlineSvg("arrow-right", "icon")</span>
                         </div>
                     }
                 </a>

--- a/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/LeffeHostedPages.scala
@@ -25,7 +25,7 @@ object LeffeHostedPages {
     url = "https://www.facebook.com/Leffe.uk/",
     label = "Rediscover Time",
     trackingCode = "leffe-rediscover-time",
-    btnText = ""
+    btnText = "Visit Leffe on Facebook"
   )
 
   private val willardWiganPageWithoutNextPage: HostedVideoPage = {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -528,7 +528,8 @@ $leffeColor: #dec190;
     }
 }
 
-.hosted__cta-text {
+.hosted__cta-text,
+.hosted__cta-label {
     @include f-headlineSans;
 
     font-size: 25px;
@@ -536,6 +537,26 @@ $leffeColor: #dec190;
 
     @include mq(tablet) {
         font-size: 38px;
+    }
+}
+
+.hosted__cta-label {
+    color: #ffffff;
+}
+
+.hosted__cta-btn-text {
+    @include circular;
+    position: relative;
+    display: block;
+    padding: 4px 6px 4px 40px;
+    margin: 16px 0;
+    color: #000000;
+    width: 30%;
+    font-weight: bold;
+    background-color: #ffffff;
+
+    .inline-icon {
+        fill: #000000;
     }
 }
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -475,10 +475,7 @@ $leffeColor: #dec190;
     position: relative;
     z-index: 1;
     margin-left: 20px;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    height: 100%;
+    padding-top: 270px;
 
     a {
         // hack stop the link underline
@@ -487,7 +484,7 @@ $leffeColor: #dec190;
 }
 
 .hosted__cta-btn-wrapper {
-    padding-bottom: 5%;
+    padding-top: 220px;
 }
 
 .hosted__cta.button {
@@ -546,17 +543,20 @@ $leffeColor: #dec190;
 
 .hosted__cta-btn-text {
     @include circular;
+    @include f-headlineSans;
     position: relative;
     display: block;
-    padding: 4px 6px 4px 40px;
-    margin: 16px 0;
+    padding: 6px 6px 6px 14px;
     color: #000000;
-    width: 30%;
+    width: $gs-column-width * 3.2;
     font-weight: bold;
     background-color: #ffffff;
 
     .inline-icon {
         fill: #000000;
+        position: absolute;
+        top: 3px;
+        right: 10px;
     }
 }
 


### PR DESCRIPTION
## What does this change?

The whole CTA banner is clickable now. Also, if there is a button text specified (like in the Leffe campaign) it looks little different than the version without that button (like Renault).
## Screenshots

Renault CTA:
![screen shot 2016-07-11 at 12 20 07](https://cloud.githubusercontent.com/assets/489567/16728955/6f65ad42-4761-11e6-8110-a0e90799369a.png)

Leffe CTA:
![screen shot 2016-07-11 at 12 20 12](https://cloud.githubusercontent.com/assets/489567/16728961/77b76de6-4761-11e6-9faa-998cdd8a6dbd.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
