### PR TITLE
use correct omniture code on embed pages

### DIFF
--- a/applications/app/controllers/EmbedController.scala
+++ b/applications/app/controllers/EmbedController.scala
@@ -9,7 +9,6 @@ import play.api.mvc._
 import scala.concurrent.Future
 import contentapi.ContentApiClient
 
-case class EmbedPage(item: Video, title: String, isExpired: Boolean = false) extends ContentPage
 
 class EmbedController extends Controller with Logging with ExecutionContexts {
 

--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -1,4 +1,4 @@
-@(page: EmbedPage)(implicit request: RequestHeader)
+@(page: model.EmbedPage)(implicit request: RequestHeader)
 
 @import model.{Video, VideoPlayer}
 @import views.support.Video640

--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -128,6 +128,7 @@ class GuardianConfiguration extends Logging {
   object omniture {
     lazy val account = configuration.getStringProperty("guardian.page.omnitureAccount").getOrElse("guardiangu-network")
     lazy val ampAccount = configuration.getStringProperty("guardian.page.omnitureAmpAccount").getOrElse("guardiangudev-code")
+    lazy val thirdPartyAppsAccount = configuration.getStringProperty("guardian.page.thirdPartyAppsAccount").getOrElse("guardiangu-thirdpartyapps")
   }
 
   object googletag {

--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -443,6 +443,8 @@ case class GalleryPage(
   val showBadge = item.commercial.isSponsored(Some(Edition(request))) || item.commercial.isFoundationSupported || item.commercial.isAdvertisementFeature
 }
 
+case class EmbedPage(item: Video, title: String, isExpired: Boolean = false) extends ContentPage
+
 case class TagCombiner(
   id: String,
   leftTag: Tag,

--- a/common/app/views/fragments/analytics/omniture.scala.html
+++ b/common/app/views/fragments/analytics/omniture.scala.html
@@ -5,7 +5,7 @@
 @import conf.Configuration
 @import conf.Static
 
-@fragments.analytics.omnitureScript(Some(page.metadata))
+@fragments.analytics.omnitureScript(Some(page))
 
 <script id="gu-analytics">
         // analytics code

--- a/common/app/views/fragments/analytics/omnitureScript.scala.html
+++ b/common/app/views/fragments/analytics/omnitureScript.scala.html
@@ -1,4 +1,4 @@
-@(item: Option[model.MetaData])
+@(item: Option[model.Page])
 
 @import conf.Static
 @import views.support.OmnitureAnalyticsAccount

--- a/common/app/views/support/OmnitureAnalyticsData.scala
+++ b/common/app/views/support/OmnitureAnalyticsData.scala
@@ -3,20 +3,26 @@ package views.support
 import java.net.URLEncoder._
 
 import conf.Configuration
-import model.{ContentPage, MetaData, Page}
+import model.{ContentPage, MetaData, Page, EmbedPage}
 import play.api.libs.json.{JsString, JsValue, Json}
 import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 
+
 object OmnitureAnalyticsAccount {
-  def apply(page: MetaData): String = {
-    val sectionSpecficAccounts = Map(
-      ("guardian-masterclasses", "guardiangu-masterclasses"),
-      ("Guardian Masterclasses", "guardiangu-masterclasses"),
-      ("careers", "guardiangu-careers"),
-      ("Guardian Careers", "guardiangu-careers")
-    )
-    Seq(Some(Configuration.omniture.account), sectionSpecficAccounts.get(page.sectionId)).flatten.mkString(",")
+  def apply(page: Page): String = {
+    page match {
+      case _: EmbedPage => Configuration.omniture.thirdPartyAppsAccount
+      case _            => {
+        val sectionSpecficAccounts = Map(
+          ("guardian-masterclasses", "guardiangu-masterclasses"),
+          ("Guardian Masterclasses", "guardiangu-masterclasses"),
+          ("careers", "guardiangu-careers"),
+          ("Guardian Careers", "guardiangu-careers")
+        )
+        Seq(Some(Configuration.omniture.account), sectionSpecficAccounts.get(page.metadata.sectionId)).flatten.mkString(",")
+      }
+    }
   }
 }
 

--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -45,6 +45,7 @@ open.cta.apiRoot=http://opencontent.code.dev-guardianapis.com/discussion-api
 # if you create one make sure that is what you intend
 guardian.page.omnitureAmpAccount=guardiangudev-code
 guardian.page.omnitureAccount=guardiangudev-code
+guardian.page.thirdPartyAppsAccount=guardiangudev-code
 guardian.page.googleSearchId=007466294097402385199:m2ealvuxh1i
 guardian.page.fbAppId=202314643182694
 guardian.page.idApiJsClientToken=frontend-dev-js-client-token

--- a/common/conf/env/PROD.properties
+++ b/common/conf/env/PROD.properties
@@ -46,6 +46,7 @@ open.cta.apiRoot=http://opencontent.guardianapis.com/discussion-api
 #if you create one make sure that is what you intend
 guardian.page.omnitureAmpAccount=guardiangu-thirdpartyapps
 guardian.page.omnitureAccount=guardiangu-network
+guardian.page.thirdPartyAppsAccount=guardiangu-thirdpartyapps
 guardian.page.googleSearchId=007466294097402385199:m2ealvuxh1i
 guardian.page.fbAppId=180444840287
 guardian.page.host=http://www.theguardian.com

--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -3,8 +3,6 @@ define([
     'bean',
     'bonzo',
     'qwery',
-    'videojs',
-    'videojsembed',
     'common/utils/$',
     'common/utils/config',
     'common/utils/defer-to-analytics',
@@ -18,14 +16,12 @@ define([
     'text!common/views/ui/loading.html',
     'text!common/views/media/titlebar.html',
     'lodash/functions/debounce',
-    'common/modules/video/videojs-options',
-    'common/modules/video/events'
+    'bootstraps/enhanced/media/video-player',
+    'common/modules/video/videojs-options'
 ], function (
     bean,
     bonzo,
     qwery,
-    videojs,
-    videojsembed,
     $,
     config,
     deferToAnalytics,
@@ -39,6 +35,7 @@ define([
     loadingTmpl,
     titlebarTmpl,
     debounce,
+    videojs,
     videojsOptions
 ) {
 


### PR DESCRIPTION
## What does this change?

We're currently tracking embed pages to the `guardiangu-network` bucket when it should be the `guardiangu-thirdpartyapps` bucket.

This corrects that by pattern matching on `Page` and if `EmbedPage` use the correct code, else perform existing logic.
## What is the value of this and can you measure success?

Correct omniture tracking.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

n/a
## Request for comment

@jamesgorrie @mkopka 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
