### PR TITLE
business -  use guardian sans-serif font

### DIFF
--- a/static/src/stylesheets/module/business/_stocks.scss
+++ b/static/src/stylesheets/module/business/_stocks.scss
@@ -105,7 +105,7 @@ $stocks-icon-height: 10px;
 
 .stocks__price {
     margin-right: .25em;
-    font-family: sans-serif;
+    font-family: $f-sans-serif-text;
     letter-spacing: .05em;
 }
 


### PR DESCRIPTION
## What does this change?

Use guardian `sans-serif` font to not break design instead of the custom one.
See #13553
