### PR TITLE
Revert "Use a sans-serif font for business stocks price"

### DIFF
--- a/static/src/stylesheets/module/business/_stocks.scss
+++ b/static/src/stylesheets/module/business/_stocks.scss
@@ -105,8 +105,6 @@ $stocks-icon-height: 10px;
 
 .stocks__price {
     margin-right: .25em;
-    font-family: sans-serif;
-    letter-spacing: .05em;
 }
 
 .stocks__closed,


### PR DESCRIPTION
Reverts guardian/frontend#13553

This is not consistent with guardian style, so reverting.   
