### PR TITLE
Perform ophan config assignment in blocking js

### DIFF
--- a/common/app/templates/inlineJS/blocking/config.scala.js
+++ b/common/app/templates/inlineJS/blocking/config.scala.js
@@ -29,6 +29,15 @@ window.guardian = {
     config: @JavaScript(templates.js.javaScriptConfig(page).body)
 };
 
+window.guardian.config.ophan = {
+    // This is duplicated from
+    // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+    // Please do not change this without talking to the Ophan project first.
+    pageViewId: new Date().getTime().toString(36) + 'xxxxxxxxxxxx'.replace(/x/g, function () {
+        return Math.floor(Math.random() * 36).toString(36);
+    })
+};
+
 // http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx
 /*@@cc_on
 @@if (@@_jscript_version <= 9)

--- a/common/app/templates/inlineJS/nonBlocking/ophanConfig.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/ophanConfig.scala.js
@@ -17,18 +17,7 @@
         return value;
     }
 
-    window.guardian.config.ophan = {
-
-        // This is duplicated from
-        // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
-        // Please do not change this without talking to the Ophan project first.
-        pageViewId: new Date().getTime().toString(36) + 'xxxxxxxxxxxx'.replace(/x/g, function () {
-            return Math.floor(Math.random() * 36).toString(36);
-        }),
-
-        browserId: getCookieValue("bwid")
-
-    };
+    window.guardian.config.ophan.browserId = getCookieValue("bwid");
 
 })(window, document);
 


### PR DESCRIPTION
I've moved the assignment of the ophan config object, so that the `pageViewId` field is definitely available.

I think there's a wider question about the timing behaviour of our app, using the polyfill async approach. It's promised on dom ready, but it appears like inline scripts were not fully executed... 
