### PR TITLE
Catch errors reported by IE due to Iframe

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
@@ -88,8 +88,13 @@ define([
         }
 
         function fetchCreativeConfig() {
+            try {
                 var breakoutScript = iFrame.contentDocument.body.querySelector('.breakout__script[type="application/json"]');
                 return breakoutScript ? breakoutScript.innerHTML : null;
+            } catch (err) {
+                return null;
+            }
+
         }
 
         function renderCreative(config) {


### PR DESCRIPTION
## What does this change?

Catches the errors being thrown by IE and reported to Sentry. This is du to IE dealing with iFrames differently do other browsers. 

Should see a reduction in issue  :  https://app.getsentry.com/the-guardian/client-side-prod/issues/141001393/
## Request for comment

@regiskuckaertz @guardian/commercial-dev 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
