### PR TITLE
reverts a js change made in 13556, fixing the embed page

### DIFF
--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -3,6 +3,8 @@ define([
     'bean',
     'bonzo',
     'qwery',
+    'videojs',
+    'videojsembed',
     'common/utils/$',
     'common/utils/config',
     'common/utils/defer-to-analytics',
@@ -16,12 +18,13 @@ define([
     'text!common/views/ui/loading.html',
     'text!common/views/media/titlebar.html',
     'lodash/functions/debounce',
-    'bootstraps/enhanced/media/video-player',
     'common/modules/video/videojs-options'
 ], function (
     bean,
     bonzo,
     qwery,
+    videojs,
+    videojsembed,
     $,
     config,
     deferToAnalytics,
@@ -35,7 +38,6 @@ define([
     loadingTmpl,
     titlebarTmpl,
     debounce,
-    videojs,
     videojsOptions
 ) {
 


### PR DESCRIPTION
## What does this change?

I had tested this in DEV using bundled assets and it worked :/

Reverting the change as, annoyingly, its failing in PROD.
