### PR TITLE
Do not share articles using short urls

### DIFF
--- a/applications/test/ShareLinksTest.scala
+++ b/applications/test/ShareLinksTest.scala
@@ -23,13 +23,13 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
 
         pageShares.map(_.text) should be (List("Facebook", "Twitter", "Email", "LinkedIn", "Google plus", "WhatsApp", "Messenger"))
         pageShares.map(_.href) should be (List(
-          "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsfb&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsfb",
-          "https://twitter.com/intent/tweet?text=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fstw",
-          "mailto:?subject=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&body=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsbl",
-          "http://www.linkedin.com/shareArticle?mini=true&title=Cameron+statement+to+the+Commons+on+the+EU+referendum+-+Politics+live&url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j",
-          "https://plus.google.com/share?url=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsgp&amp;hl=en-GB&amp;wwc=1",
-          "whatsapp://send?text=%22Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live%22%20http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fswa",
-          "fb-messenger://share?link=http%3A%2F%2Fgu.com%2Fp%2F4gc8j%2Fsme&app_id=180444840287"))
+          "https://www.facebook.com/dialog/share?app_id=202314643182694&href=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_fb&redirect_uri=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_fb",
+          "https://twitter.com/intent/tweet?text=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_tw",
+          "mailto:?subject=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&body=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_link",
+          "http://www.linkedin.com/shareArticle?mini=true&title=Cameron+statement+to+the+Commons+on+the+EU+referendum+-+Politics+live&url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live",
+          "https://plus.google.com/share?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_gp&amp;hl=en-GB&amp;wwc=1",
+          "whatsapp://send?text=%22Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live%22%20https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_wa",
+          "fb-messenger://share?link=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_me&app_id=180444840287"))
       }
     }
   }
@@ -47,9 +47,9 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
 
         elementShares.map(_.text) should be(List("Facebook", "Twitter", "Pinterest"))
         elementShares.map(_.href) should be(List(
-          "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fsfb%232&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fsfb%232",
-          "https://twitter.com/intent/tweet?text=2014%20Wildlife%20photographer%20of%20the%20Year&url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%2Fstw%232",
-          "http://www.pinterest.com/pin/create/button/?description=2014+Wildlife+photographer+of+the+Year&url=http%3A%2F%2Fgu.com%2Fp%2F42jcb%232&media="
+          "https://www.facebook.com/dialog/share?app_id=202314643182694&href=https%3A%2F%2Fwww.theguardian.com%2Fenvironment%2Fgallery%2F2014%2Foct%2F22%2F2014-wildlife-photographer-of-the-year%3FCMP%3Dshare_btn_fb%26page%3Dwith%3A2%232&redirect_uri=https%3A%2F%2Fwww.theguardian.com%2Fenvironment%2Fgallery%2F2014%2Foct%2F22%2F2014-wildlife-photographer-of-the-year%3FCMP%3Dshare_btn_fb%26page%3Dwith%3A2%232",
+          "https://twitter.com/intent/tweet?text=2014%20Wildlife%20photographer%20of%20the%20Year&url=https%3A%2F%2Fwww.theguardian.com%2Fenvironment%2Fgallery%2F2014%2Foct%2F22%2F2014-wildlife-photographer-of-the-year%3FCMP%3Dshare_btn_tw%26page%3Dwith%3A2%232",
+          "http://www.pinterest.com/pin/create/button/?description=2014+Wildlife+photographer+of+the+Year&url=https%3A%2F%2Fwww.theguardian.com%2Fenvironment%2Fgallery%2F2014%2Foct%2F22%2F2014-wildlife-photographer-of-the-year%3Fpage%3Dwith%3A2%232&media="
         ))
       }
     }
@@ -68,9 +68,9 @@ import org.scalatest.concurrent.{Futures, ScalaFutures}
 
         elementShares.map(_.text) should be (List("Facebook", "Twitter", "Google plus"))
         elementShares.map(_.href) should be (List(
-          "https://www.facebook.com/dialog/share?app_id=202314643182694&href=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3Fpage%3Dwith%3A2%26CMP%3Dshare_btn_fb%232&redirect_uri=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3Fpage%3Dwith%3A2%26CMP%3Dshare_btn_fb%232",
-          "https://twitter.com/intent/tweet?text=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3Fpage%3Dwith%3A2%26CMP%3Dshare_btn_tw%232",
-          "https://plus.google.com/share?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3Fpage%3Dwith%3A2%26CMP%3Dshare_btn_gp%232&amp;hl=en-GB&amp;wwc=1"
+          "https://www.facebook.com/dialog/share?app_id=202314643182694&href=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_fb%26page%3Dwith%3A2%232&redirect_uri=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_fb%26page%3Dwith%3A2%232",
+          "https://twitter.com/intent/tweet?text=Cameron%20statement%20to%20the%20Commons%20on%20the%20EU%20referendum%20-%20Politics%20live&url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_tw%26page%3Dwith%3A2%232",
+          "https://plus.google.com/share?url=https%3A%2F%2Fwww.theguardian.com%2Fpolitics%2Fblog%2Flive%2F2016%2Ffeb%2F03%2Feu-renegotiation-pmqs-cameron-corbyn-he-prepares-to-make-statement-to-mps-politics-live%3FCMP%3Dshare_btn_gp%26page%3Dwith%3A2%232&amp;hl=en-GB&amp;wwc=1"
         ))
       }
     }

--- a/article/test/ArticleFeatureTest.scala
+++ b/article/test/ArticleFeatureTest.scala
@@ -445,10 +445,10 @@ import collection.JavaConversions._
       goTo("/film/2012/nov/11/margin-call-cosmopolis-friends-with-kids-dvd-review") { browser =>
         import browser._
 
-        val mailShareUrl = "mailto:?subject=Mark%20Kermode's%20DVD%20round-up&body=http%3A%2F%2Fgu.com%2Fp%2F3bk2f%2Fsbl"
-        val fbShareUrl = "https://www.facebook.com/dialog/share?app_id=202314643182694&href=http%3A%2F%2Fgu.com%2Fp%2F3bk2f%2Fsfb&redirect_uri=http%3A%2F%2Fgu.com%2Fp%2F3bk2f%2Fsfb"
-        val twitterShareUrl = "https://twitter.com/intent/tweet?text=Mark%20Kermode's%20DVD%20round-up&url=http%3A%2F%2Fgu.com%2Fp%2F3bk2f%2Fstw"
-        val gplusShareUrl = "https://plus.google.com/share?url=http%3A%2F%2Fgu.com%2Fp%2F3bk2f%2Fsgp&amp;hl=en-GB&amp;wwc=1"
+        val mailShareUrl = "mailto:?subject=Mark%20Kermode's%20DVD%20round-up&body=https%3A%2F%2Fwww.theguardian.com%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review%3FCMP%3Dshare_btn_link"
+        val fbShareUrl = "https://www.facebook.com/dialog/share?app_id=202314643182694&href=https%3A%2F%2Fwww.theguardian.com%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review%3FCMP%3Dshare_btn_fb&redirect_uri=https%3A%2F%2Fwww.theguardian.com%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review%3FCMP%3Dshare_btn_fb"
+        val twitterShareUrl = "https://twitter.com/intent/tweet?text=Mark%20Kermode's%20DVD%20round-up&url=https%3A%2F%2Fwww.theguardian.com%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review%3FCMP%3Dshare_btn_tw"
+        val gplusShareUrl = "https://plus.google.com/share?url=https%3A%2F%2Fwww.theguardian.com%2Ffilm%2F2012%2Fnov%2F11%2Fmargin-call-cosmopolis-friends-with-kids-dvd-review%3FCMP%3Dshare_btn_gp&amp;hl=en-GB&amp;wwc=1"
 
         Then("I should see buttons for my favourite social network")
 

--- a/common/app/model/ShareLinks.scala
+++ b/common/app/model/ShareLinks.scala
@@ -144,36 +144,24 @@ final case class ShareLinks(
     List(Facebook, Twitter, PinterestBlock)
   }
 
-  private def createShortUrlWithCampaign(platform: SharePlatform): String = platform.campaign match {
-    case Some(campaign) => s"${fields.shortUrl}/$campaign"
-    case _ => fields.shortUrl
+  private def campaignParams(platform: SharePlatform): Map[String, String] = {
+    platform.campaign.flatMap(ShortCampaignCodes.getFullCampaign).map(campaign => Map("CMP" -> campaign)).getOrElse(Map.empty)
   }
 
   def elementShares(elementId: String, mediaPath: Option[String]): Seq[ShareLink] = elementShareOrder.map( sharePlatform => {
-
-    // Currently, only element shares on live blogs will use fully expanded urls. These urls take a CMP parameter.
-    // Everything else uses short urls with campaign codes.
-    val href = if (tags.isLiveBlog) {
-      val webUrlParams = List(
-        Some("page" -> s"with:$elementId"),
-        sharePlatform.campaign.flatMap(ShortCampaignCodes.getFullCampaign).map(campaign => "CMP" -> campaign)
-      ).flatten.toMap
-
-      metadata.webUrl.addFragment(elementId).appendQueryParams(webUrlParams)
-    } else {
-      createShortUrlWithCampaign(sharePlatform).addFragment(elementId)
-    }
-
+    val webUrlParams = campaignParams(sharePlatform)
+    val href = metadata.webUrl.addFragment(elementId).appendQueryParams(webUrlParams + ("page" -> s"with:$elementId"))
     ShareLinks.create(sharePlatform, href = href, title = metadata.webTitle, mediaPath = mediaPath)
   })
 
   val pageShares: Seq[ShareLink] = pageShareOrder.map( sharePlatform => {
+    val webUrlParams = campaignParams(sharePlatform)
+    val href = metadata.webUrl.appendQueryParams(webUrlParams)
+
     val contentTitle = sharePlatform match {
       case Twitter if tags.isClimateChangeSeries => s"${metadata.webTitle} #keepitintheground"
       case _ => metadata.webTitle
     }
-
-    val href = createShortUrlWithCampaign(sharePlatform)
 
     ShareLinks.create(sharePlatform, href = href, title = contentTitle, mediaPath = None)
   })


### PR DESCRIPTION
## What does this change?

The associated changes remove the usage of short urls when a user click on the social share buttons. Instead standard long urls are used.
## What is the value of this and can you measure success?

We have used short urls in the past because it was allowing us to embed urls more easily in twitter. However [twitter now shortened every urls (even the short ones)](https://support.twitter.com/articles/78124) which means short urls only add `3` redirections that increase the latency before accessing the article. The latency increase is more important with `https`.

See related changes:
- [Twitter and RSS integration changes](https://github.com/guardian/content-api-transformer/pull/8)
- [Android app changes](https://github.com/guardian/android-news-app/pull/3088)
- [iOs app changes](https://github.com/guardian/ios-live/pull/2477)
- [Editorial sharing url tool](https://github.com/guardian/gdn-short-code/pull/2)
## Does this affect other platforms - Amp, Apps, etc?

The code is used by `Amp`. 
## Audience tracking

Short campaign codes are translated to long campaign codes when frontend redirects a short url to a long url, so only long campaign codes are sent to ophan. The [ophan short url resolver](https://github.com/guardian/ophan/blob/master/shared-lib/src/main/scala/ophan/ShortUrlResolver.scala) simply follows redirect, so should continue to work fine. Therefore I think ophan should not be affected (may you confirm @obrienm @lindseydew ?)
## Communication to editorial

We have already communicate to editorial that we are removing the usage of short url, but I will write a specific email with a map between sort campaign codes and long campaign codes, so that  people editing manually the campaign code before are not lost   
