### PR TITLE
Commercial: Fix trimming of scheme and host to get short id from short urls

### DIFF
--- a/commercial/app/model/commercial/Lookup.scala
+++ b/commercial/app/model/commercial/Lookup.scala
@@ -28,7 +28,7 @@ object Lookup extends ExecutionContexts with Logging {
 
   def contentByShortUrls(shortUrls: Seq[String]): Future[Seq[ContentType]] = {
     if (shortUrls.nonEmpty) {
-      val shortIds = shortUrls map (_.stripPrefix("http://").stripPrefix("gu.com").stripPrefix("/")) mkString ","
+      val shortIds = shortUrls map (_.replaceFirst("^[a-zA-Z]+://gu.com/","")) mkString ","
       getResponse(ContentApiClient.search(defaultEdition).ids(shortIds)) map {
         _.results map (Content(_))
       }

--- a/commercial/test/model/commercial/LookupTest.scala
+++ b/commercial/test/model/commercial/LookupTest.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
   }
 
   "contentByShortUrls" should "find content for genuine URLs" in {
-    val contents = contentsOf("http://gu.com/p/3qeqm", "http://gu.com/p/4v86p", "http://gu.com/p/4vf6t")
+    val contents = contentsOf("http://gu.com/p/3qeqm", "http://gu.com/p/4v86p", "https://gu.com/p/4vf6t")
     contents.map(_.metadata.webTitle) should be(Seq(
       "Wikipedia: meet the man who has edited 3m articles",
       "A book for the beach: In the Woods by Tana French",
@@ -29,7 +29,7 @@ import scala.concurrent.duration._
   }
 
   "contentByShortUrls" should "not find content for fake URLs" in {
-    contentsOf("http://gu.com/p/3qeqmjlkk", "http://gu.com/p/4gfshstv86p") should be(Nil)
+    contentsOf("http://gu.com/p/3qeqmjlkk", "https://gu.com/p/4gfshstv86p") should be(Nil)
   }
 
   "contentByShortUrls" should "not find content for badly-formed URLs" in {


### PR DESCRIPTION
## What does this change?

Commercial: Fix an issue where capi content would not be retrieved if short urls are on https   
## What is the value of this and can you measure success?

@mchv can push https://github.com/guardian/content-api/pull/1627 without breaking anything 😁 
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@mchv @kelvin-chappell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
