### PR TITLE
Giraffe article inline styling update

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -79,7 +79,7 @@ trait ABTestSwitches {
     "ab-giraffe",
     "Test effectiveness of inline CTA for contributions.",
     owners = Seq(Owner.withGithub("markjamesbutler"), Owner.withGithub("AWare")),
-    safeState = Off,
+    safeState = On,
     sellByDate = new LocalDate(2016, 8, 1),
     exposeClientSide = true
   )

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -79,7 +79,7 @@ trait ABTestSwitches {
     "ab-giraffe",
     "Test effectiveness of inline CTA for contributions.",
     owners = Seq(Owner.withGithub("markjamesbutler"), Owner.withGithub("AWare")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2016, 8, 1),
     exposeClientSide = true
   )

--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -26,7 +26,7 @@ define([
         this.author = 'Alex Ware';
         this.description = 'Add a button allowing readers to contribute money.';
         this.showForSensitive = false;
-        this.audience = 0.08;
+        this.audience = 0;
         this.audienceOffset = 0;
         this.successMeasure = 'Determine the best message for driving contributions.';
         this.audienceCriteria = 'All users';
@@ -65,33 +65,6 @@ define([
                 id: 'everyone',
                 test: function () {
                     writer('If everyone were to chip in, the Guardian\'s future would be more secure', 'https://membership.theguardian.com/contribute?INTCMP=article-1-everyone', 'Please support the Guardian and independent journalism');
-                },
-                success: function (complete) {
-                    completer(complete);
-                }
-            },
-            {
-                id: 'coffee',
-                test: function () {
-                    writer('Do you want the news with your coffee? Or do you just want coffee? Quality journalism costs. Please contribute', 'https://membership.theguardian.com/contribute?INTCMP=article-1-coffee', 'Please support the Guardian and independent journalism');
-                },
-                success: function (complete) {
-                    completer(complete);
-                }
-            },
-            {
-                id: 'heritage',
-                test: function () {
-                    writer('From the Peterloo massacre to the Panama Papers, we\'ve been on your side for almost 200 years. Contribute to the Guardian\'s future today', 'https://membership.theguardian.com/contribute?INTCMP=article-1-heritage', 'Please support the Guardian and independent journalism');
-                },
-                success: function (complete) {
-                    completer(complete);
-                }
-            },
-            {
-                id: 'global',
-                test: function () {
-                    writer('By the time you\'ve had your morning tea, reporters in Rio, Beijing, Dakar and Paris, have already filed their stories. Covering the world\'s news isn\'t cheap. Please chip in a few pounds', 'https://membership.theguardian.com/contribute?INTCMP=article-1-global', 'Please support the Guardian and independent journalism');
                 },
                 success: function (complete) {
                     completer(complete);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -26,7 +26,7 @@ define([
         this.author = 'Alex Ware';
         this.description = 'Add a button allowing readers to contribute money.';
         this.showForSensitive = false;
-        this.audience = 0;
+        this.audience = 0.08;
         this.audienceOffset = 0;
         this.successMeasure = 'Determine the best message for driving contributions.';
         this.audienceCriteria = 'All users';
@@ -64,7 +64,7 @@ define([
             {
                 id: 'everyone',
                 test: function () {
-                    writer('If everyone were to chip in, the Guardian\'s future would be more secure.', 'https://membership.theguardian.com/contribute?INTCMP=article-1-everyone', 'Please support the Guardian and independent journalism');
+                    writer('If everyone were to chip in, the Guardian\'s future would be more secure', 'https://membership.theguardian.com/contribute?INTCMP=article-1-everyone', 'Please support the Guardian and independent journalism');
                 },
                 success: function (complete) {
                     completer(complete);

--- a/static/src/stylesheets/module/experiments/_giraffe.scss
+++ b/static/src/stylesheets/module/experiments/_giraffe.scss
@@ -3,16 +3,19 @@
     display: block;
     margin-bottom: 1em;
     border-top: 1px dotted $neutral-4;
+    @include f-header;
 }
 .giraffe--heading {
-    margin-bottom: $gs-baseline;
-    color: $news-default;
+    margin-bottom: 0px;
+    margin-top: 4px;
+    color: $news-support-2  ;
+    line-height: 28px;
 }
 .button--giraffe__icon {
     float: right;
 }
 .giraffe--copy {
-    @include fs-textSans(3);
+
     color: $neutral-2;
     margin-bottom: $gs-baseline;
 }

--- a/static/src/stylesheets/module/experiments/_giraffe.scss
+++ b/static/src/stylesheets/module/experiments/_giraffe.scss
@@ -1,9 +1,9 @@
 .giraffe {
+    @include f-header;
     width: 100%;
     display: block;
     margin-bottom: 1em;
     border-top: 1px dotted $neutral-4;
-    @include f-header;
 }
 .giraffe--heading {
     margin-bottom: 0px;
@@ -15,7 +15,6 @@
     float: right;
 }
 .giraffe--copy {
-
     color: $neutral-2;
     margin-bottom: $gs-baseline;
 }


### PR DESCRIPTION
## What does this change?

Amends the styling of the Giraffe article inline component to differentiate it from the article itself.
## What is the value of this and can you measure success?

As stated in #13476
## Does this affect other platforms - Amp, Apps, etc?

As stated in #13476
## Screenshots

![screen shot 2016-07-12 at 18 34 20](https://cloud.githubusercontent.com/assets/406099/16776992/b93dac18-485f-11e6-909a-65e6fa71e10a.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
