### PR TITLE
Extend join discussion after poll test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -50,7 +50,7 @@ trait ABTestSwitches {
     "Does 'join discussion' message after poll participation increase comments",
     owners = Seq(Owner.withGithub("GHaberis")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 7, 13),
+    sellByDate = new LocalDate(2016, 7, 27),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/join-discussion-after-poll.js
+++ b/static/src/javascripts/projects/common/modules/experiments/join-discussion-after-poll.js
@@ -54,7 +54,7 @@ define([
         var messageElem = document.createElement('div');
 
         messageElem.classList.add('join-discussion-after-poll');
-        messageElem.innerHTML = '<p>Thanks for taking part! Why not <a data-link-name="Join discussion" href="#comments">join the discussion</a>?</p>';
+        messageElem.innerHTML = '<p>Thanks for taking part! Why not <a data-link-name="poll: cta: join discussion" href="#comments">join the discussion</a>?</p>';
 
         if (nextSibling) {
             nextSibling.parentNode.insertBefore(messageElem, nextSibling);

--- a/static/src/javascripts/projects/common/modules/experiments/join-discussion-after-poll.js
+++ b/static/src/javascripts/projects/common/modules/experiments/join-discussion-after-poll.js
@@ -54,7 +54,7 @@ define([
         var messageElem = document.createElement('div');
 
         messageElem.classList.add('join-discussion-after-poll');
-        messageElem.innerHTML = '<p>Thanks for taking part! Why not <a href="#comments">join the discussion</a>?</p>';
+        messageElem.innerHTML = '<p>Thanks for taking part! Why not <a data-link-name="Join discussion" href="#comments">join the discussion</a>?</p>';
 
         if (nextSibling) {
             nextSibling.parentNode.insertBefore(messageElem, nextSibling);

--- a/static/src/javascripts/projects/common/modules/experiments/tests/join-discussion-after-poll.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/join-discussion-after-poll.js
@@ -31,7 +31,7 @@ define([
     return function () {
         this.id = 'JoinDiscussionAfterPoll';
         this.start = '2016-06-15';
-        this.expiry = '2016-07-13';
+        this.expiry = '2016-07-27';
         this.author = 'George Haberis - Participation';
         this.description = 'Participation - Does "join discussion" message after poll participation increase comments';
         this.audience = 0.1;


### PR DESCRIPTION
## What does this change?

Extend join discussion after poll test by 2 weeks and add data-link-name attribute to the link to comments which should aid when querying data.
