### PR TITLE
Hosted Leffe page - mobile fixes

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -166,11 +166,18 @@ $leffeColor: #dec190;
     vertical-align: top;
 
     .vjs-big-play-button .vjs-control-text {
-        margin-left: 0;
+        @include fs-textSans(4);
+        margin-left: 16px;
         margin-top: 0;
         width: 136px;
         height: 48px;
         text-indent: -999px;
+        color: #ffffff;
+        border: 2px solid #ffffff;
+        border-radius: 30px;
+        @include mq(desktop) {
+            margin-left: 0;
+        }
 
         &:before {
             content: 'Watch now';
@@ -189,11 +196,6 @@ $leffeColor: #dec190;
             border-width: 8px 8px 8px 18px;
             border-color: transparent transparent transparent $neutral-7;
         }
-
-        @include fs-textSans(4);
-        color: #ffffff;
-        border: 2px solid #ffffff;
-        border-radius: 30px;
     }
 
     .vjs-control,
@@ -472,10 +474,13 @@ $leffeColor: #dec190;
 }
 
 .hosted__cta-wrapper {
+    padding-top: 140px;
     position: relative;
     z-index: 1;
     margin-left: 20px;
-    padding-top: 270px;
+    @include mq(desktop) {
+        padding-top: 270px;
+    }
 
     a {
         // hack stop the link underline
@@ -484,7 +489,10 @@ $leffeColor: #dec190;
 }
 
 .hosted__cta-btn-wrapper {
-    padding-top: 220px;
+    padding-top: 90px;
+    @include mq(desktop) {
+        padding-top: 220px;
+    }
 }
 
 .hosted__cta.button {


### PR DESCRIPTION
## What does this change?

A few mobile fixes on the Leffe hosted page:
- the `Watch now` button is now aligned correctly
- the CTA button is located correctly inside the banner
## Screenshots

Before:
![screen shot 2016-07-12 at 16 54 59](https://cloud.githubusercontent.com/assets/489567/16797860/427081be-48e1-11e6-8b60-167a6e43caea.png)

![screen shot 2016-07-12 at 16 54 17](https://cloud.githubusercontent.com/assets/489567/16797882/50aceaf6-48e1-11e6-8f8b-6d100d042ec6.png)

![screen shot 2016-07-12 at 16 54 10](https://cloud.githubusercontent.com/assets/489567/16797906/70aa319c-48e1-11e6-8308-bd8755e0d1f8.png)

After:
![screen shot 2016-07-12 at 16 57 22](https://cloud.githubusercontent.com/assets/489567/16797872/4998a58e-48e1-11e6-8ef7-b5aae34bbb9c.png)

![screen shot 2016-07-12 at 16 54 25](https://cloud.githubusercontent.com/assets/489567/16797896/5f975c36-48e1-11e6-83cc-895c5886b36d.png)

![screen shot 2016-07-12 at 16 53 19](https://cloud.githubusercontent.com/assets/489567/16797922/7d2a9380-48e1-11e6-92d6-1670d976e1f4.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
