### PR TITLE
Change the GA test property

### DIFF
--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -5,7 +5,7 @@ import conf.Configuration.environment
 object GoogleAnalyticsAccount {
 
   private val prod = "UA-78705427-1"
-  private val test = "UA-75852724-1"
+  private val test = "UA-33592456-1"
   private val useMainAccount = environment.isProd && !environment.isPreview
 
   val account: String = if (useMainAccount) prod else test


### PR DESCRIPTION
I'm not sure what it was pointing at before. Probably an account that Grant set up and only he had access to. Updated it to use the "official" GA test account, which is set up with the same custom dimensions, etc. as the production account.
