### PR TITLE
Leffe CTA external icons fixes

### DIFF
--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -151,7 +151,7 @@
                         </div>
                     } else {
                         <div class="hosted__cta-wrapper hosted__cta-btn-wrapper">
-                            <span class="hosted__cta-label">@{page.cta.label}</span>
+                            <span class="hosted__cta-label">@{page.cta.label} @fragments.inlineSvg("external-link", "icon")</span>
                             <span class="hosted__cta-btn-text">@{page.cta.btnText} @fragments.inlineSvg("arrow-right", "icon")</span>
                         </div>
                     }

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -147,12 +147,12 @@
                     @if(page.cta.btnText.length == 0) {
                         <div class="hosted__cta-wrapper">
                             <span class="hosted__cta-text hosted-tone--@{page.campaign.owner.toLowerCase}">@{page.cta.label}</span>
-                            @fragments.inlineSvg("arrow-right", "icon", List("i-right","advert__more","button","button--large","button--primary","hosted__cta","hosted-tone-btn--" + page.campaign.owner.toLowerCase))
+                            @fragments.inlineSvg("external-link", "icon", List("i-right","advert__more","button","button--large","button--primary","hosted__cta","hosted-tone-btn--" + page.campaign.owner.toLowerCase))
                         </div>
                     } else {
                         <div class="hosted__cta-wrapper hosted__cta-btn-wrapper">
-                            <span class="hosted__cta-label">@{page.cta.label} @fragments.inlineSvg("external-link", "icon")</span>
-                            <span class="hosted__cta-btn-text">@{page.cta.btnText} @fragments.inlineSvg("arrow-right", "icon")</span>
+                            <span class="hosted__cta-label">@{page.cta.label}</span>
+                            <span class="hosted__cta-btn-text">@{page.cta.btnText} @fragments.inlineSvg("external-link", "icon")</span>
                         </div>
                     }
                 </a>

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -496,8 +496,6 @@ $leffeColor: #dec190;
 }
 
 .hosted__cta.button {
-    padding: 0;
-
     &,
     &:focus,
     &:hover {
@@ -505,26 +503,30 @@ $leffeColor: #dec190;
     }
 
     @include mq(mobile) {
+        padding: 4px;
         height: 26px;
+        width: 26px;
         margin: 6px;
         font-size: 14px;
         line-height: 26px;
 
         svg {
             fill: $neutral-1;
-            width: 24px;
-            height: 24px;
+            width: 16px;
+            height: 16px;
         }
     }
 
     @include mq(tablet) {
+        padding: 8px;
         height: 38px;
+        width: 38px;
         margin: 8px;
         line-height: 1;
 
         svg {
-            width: 37px;
-            height: 37px;
+            width: 20px;
+            height: 20px;
         }
     }
 
@@ -563,8 +565,13 @@ $leffeColor: #dec190;
     .inline-icon {
         fill: #000000;
         position: absolute;
-        top: 3px;
-        right: 10px;
+        top: 6px;
+        right: 16px;
+
+        svg {
+            width: 20px;
+            height: 20px;
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?

External links on the hosted video CTA banner should have proper icons indicating that the link is external.
## Screenshots

Leffe desktop:
![screen shot 2016-07-13 at 13 50 01](https://cloud.githubusercontent.com/assets/489567/16803895/d84985cc-4900-11e6-8217-c85d06afb00e.png)

Leffe mobile:
![screen shot 2016-07-13 at 13 49 38](https://cloud.githubusercontent.com/assets/489567/16803898/e2ac3f28-4900-11e6-87b2-2fe055241c26.png)

Renault desktop:
![screen shot 2016-07-13 at 13 49 56](https://cloud.githubusercontent.com/assets/489567/16803909/f7fee466-4900-11e6-8a87-1cebf57ef40f.png)

Renault mobile:
![screen shot 2016-07-13 at 13 49 43](https://cloud.githubusercontent.com/assets/489567/16803925/11d78064-4901-11e6-93db-a7da61ab8689.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
