### PR TITLE
iframe sentry error bug fix

### DIFF
--- a/static/src/javascripts/projects/common/modules/article/spacefinder.js
+++ b/static/src/javascripts/projects/common/modules/article/spacefinder.js
@@ -120,6 +120,7 @@ define([
 
                         var iframe = records[0].addedNodes[0];
                         if (isIframeLoaded(iframe)) {
+                            instance.disconnect();
                             resolve();
                         } else {
                             iframe.addEventListener('load', function () {
@@ -136,9 +137,13 @@ define([
         }
 
         function isIframeLoaded(iframe) {
-            return iframe.contentWindow &&
-                iframe.contentWindow.document &&
-                iframe.contentWindow.document.readyState === 'complete';
+           try {
+               return iframe.contentWindow &&
+                   iframe.contentWindow.document &&
+                   iframe.contentWindow.document.readyState === 'complete';
+           } catch(err) {
+               return true;
+           }
         }
     }, getFuncId);
 


### PR DESCRIPTION
## What does this change?

Include a try catch around the iframe isLoaded in the spacefinder. This is causing an error when there is an issue accessing the frame with javascript due to cross origin accessing. This fix allows for the error to fail silently and the promise to still resolve. 
## Request for comment

@regiskuckaertz @guardian/commercial-dev 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
