### PR TITLE
add label for comment box

### DIFF
--- a/common/app/views/fragments/commentBox.scala.html
+++ b/common/app/views/fragments/commentBox.scala.html
@@ -39,7 +39,8 @@
         </div>
 
         <div class="d-comment-box__community-standards">Please keep comments respectful and abide by the <a href="/community-standards">community guidelines</a>.</div>
-        <textarea name="body" class="textarea d-comment-box__body" placeholder="Join the discussion…"></textarea>
+        <label for="d-comment-box" class="u-h">Enter comment</label>
+        <textarea name="body" class="textarea d-comment-box__body" placeholder="Join the discussion…" id="d-comment-box"></textarea>
         <button type="submit" data-link-name="post comment" class="u-button-reset button button--large button--primary submit-input--behaviour d-comment-box__submit">Post your comment</button>
         <span class="u-fauxlink d-comment-box__preview" role="button">Preview</span>
         <span class="u-fauxlink d-comment-box__hide-preview" role="button">Hide preview</span>


### PR DESCRIPTION
## What does this change?

Add accessibility label for post comment text area
## What is the value of this and can you measure success?

Help assistive technology users identify comment box
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

No visible change, label is off-screen
## Request for comment

CC @gtrufitt 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
