### PR TITLE
Article is heroic if content is heroic

### DIFF
--- a/common/app/model/content.scala
+++ b/common/app/model/content.scala
@@ -477,7 +477,7 @@ final case class Article (
   val isLiveBlog: Boolean = content.tags.isLiveBlog && content.fields.blocks.nonEmpty
   val isUSMinute: Boolean = content.tags.isUSMinuteSeries
   val isImmersive: Boolean = content.isImmersive
-  val isHeroic: Boolean = content.tags.isLabourLiverpoolSeries
+  val isHeroic: Boolean = content.isHeroic
   val isSixtyDaysModified: Boolean = fields.lastModified.isAfter(DateTime.now().minusDays(60))
   lazy val hasVideoAtTop: Boolean = soupedBody.body().children().headOption
     .exists(e => e.hasClass("gu-video") && e.tagName() == "video")


### PR DESCRIPTION
## What does this change?

The ArticleController determines whether the Heroic Article view should be loaded by checking the `isHeroic` flag on the `Article` object. Currently the `isHeroic` flag is set if and only if the content is tagged as being part of the Labour & Liverpool series, without taking into consideration whether the Heroic Template Feature Switch is on.

This change will ensure that the `isHeroic` flag on the `Article` is set if the `isHeroic` flag is set on the `Content` object, which itself is set if the Heroic Template Feature Switch is on.
## Request for comment

@NataliaLKB 
