### PR TITLE
Hosted Gallery improve tracking

### DIFF
--- a/commercial/app/views/hosted/guardianHostedGallery.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGallery.scala.html
@@ -17,11 +17,7 @@
                             </div>
                         }.toString)
                         @for(i <- page.images.indices.tail) {
-                            @guardianHostedGalleryImage(page.images(i), if (i == page.images.length - 1) {
-                                guardianHostedGalleryOj(page.ctaText, page.ctaLink, page.ctaButtonText, page.nextGalleries).toString
-                            } else if (page.ctaIndex.contains(i)) {
-                                guardianHostedGalleryCta(page.ctaText, page.ctaLink, page.ctaButtonText).toString
-                            } else "")
+                            @guardianHostedGalleryImage(page.images(i))
                         }
                     </div>
                     <div class="hosted-gallery__scroll-container js-hosted-gallery-scroll-container">

--- a/commercial/app/views/hosted/guardianHostedGalleryCta.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGalleryCta.scala.html
@@ -4,7 +4,7 @@
             @{ctaText}
         </div>
         <a class="hosted-gallery__cta-link" href="@{ctaLink}" target="_blank" data-link-name="@{buttonText}">
-            @{buttonText} @fragments.inlineSvg("arrow-right", "icon")
+            @{buttonText} @fragments.inlineSvg("external-link", "icon")
         </a>
     </div>
 

--- a/commercial/app/views/hosted/guardianHostedGalleryImage.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGalleryImage.scala.html
@@ -4,7 +4,7 @@
 @import model.ImageAsset
 @import com.gu.contentapi.client.model.v1.Asset
 @import com.gu.contentapi.client.model.v1.AssetType
-@(image: HostedGalleryImage, content: String)
+@(image: HostedGalleryImage, content: String = "")
     <div class="js-hosted-gallery-image hosted-gallery__image hosted-tone--dark">
         <div class="hosted-gallery__image-sizer js-hosted-gallery-image-sizer">
             @fragments.image(

--- a/commercial/app/views/hosted/guardianHostedGalleryOj.scala.html
+++ b/commercial/app/views/hosted/guardianHostedGalleryOj.scala.html
@@ -6,7 +6,7 @@
                 @{ctaText}
             </div>
             <a class="hosted-gallery__cta-link" href="@{ctaLink}" target="_blank" data-link-name="@{buttonText}">
-                @{buttonText} @fragments.inlineSvg("arrow-right", "icon")
+                @{buttonText} @fragments.inlineSvg("external-link", "icon")
             </a>
         </div>
         @for(gallery <- nextGalleries){

--- a/common/app/common/commercial/hosted/HostedGalleryPage.scala
+++ b/common/app/common/commercial/hosted/HostedGalleryPage.scala
@@ -44,6 +44,7 @@ case class HostedGalleryPage(
         "keywords" -> JsString(keywordName),
         "toneIds" -> JsString(toneId),
         "tones" -> JsString(toneName),
+        "trackingPrefix" -> JsString(s"Hosted:GFE:gallery:$pageName"),
         "images" -> JsArray(images.map((image) => JsString(image.url))),
         "ctaIndex" -> JsNumber(ctaIndex.map(BigDecimal(_)).getOrElse(BigDecimal(images.length - 1)))
       ),

--- a/common/app/common/commercial/hosted/HostedGalleryPage.scala
+++ b/common/app/common/commercial/hosted/HostedGalleryPage.scala
@@ -44,7 +44,7 @@ case class HostedGalleryPage(
         "keywords" -> JsString(keywordName),
         "toneIds" -> JsString(toneId),
         "tones" -> JsString(toneName),
-        "trackingPrefix" -> JsString(s"Hosted:GFE:gallery:$pageName"),
+        "trackingPrefix" -> JsString(s"Hosted:GFE:gallery:$pageName:"),
         "images" -> JsArray(images.map((image) => JsString(image.url))),
         "ctaIndex" -> JsNumber(ctaIndex.map(BigDecimal(_)).getOrElse(BigDecimal(images.length - 1)))
       ),

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -198,7 +198,7 @@ object VisitBritainHostedPages {
     pageName = activitiesPageName,
     title = "Don’t be a sloth this summer",
     ctaText = "Explore our collection of unique experiences from all over Great Britain.",
-    ctaLink = "https://en.omgb.com/map/",
+    ctaLink = "http://en.omgb.com/map/",
     ctaButtonText = "Visit OMGB now",
     nextGalleryNames = List(cityPageName, coastPageName),
     standfirst = "Get your heart pumping with a daring dip in the Lake District or learn how to paddleboard along the Isle of Wight’s scenic coastline."
@@ -211,7 +211,7 @@ object VisitBritainHostedPages {
     pageName = cityPageName,
     title = "Take a city break from the norm",
     ctaText = "Explore our collection of unique experiences from all over Great Britain.",
-    ctaLink = "https://en.omgb.com/map/",
+    ctaLink = "http://en.omgb.com/map/",
     ctaButtonText = "Visit OMGB now",
     nextGalleryNames = List(coastPageName, countrysidePageName),
     standfirst = "Discover instagrammable events like the Bristol Balloon Fiesta; theatre under the stars and hotly-tipped comedy acts at Edinburgh Fringe."
@@ -224,7 +224,7 @@ object VisitBritainHostedPages {
     pageName = coastPageName,
     title = "Find cool-on-sea this summer",
     ctaText = "Explore our collection of unique experiences from all over Great Britain.",
-    ctaLink = "https://en.omgb.com/map/",
+    ctaLink = "http://en.omgb.com/map/",
     ctaButtonText = "Visit OMGB now",
     nextGalleryNames = List(countrysidePageName, activitiesPageName),
     standfirst = "Catch a show at an amphitheatre overlooking the Atlantic, go island hopping in sub-tropical climes and join the party at the Whitby Regatta."
@@ -237,7 +237,7 @@ object VisitBritainHostedPages {
     pageName = countrysidePageName,
     title = "Mend your relationship with Mother Nature",
     ctaText = "Explore our collection of unique experiences from all over Great Britain.",
-    ctaLink = "https://en.omgb.com/map/",
+    ctaLink = "http://en.omgb.com/map/",
     ctaButtonText = "Visit OMGB now",
     nextGalleryNames = List(activitiesPageName, cityPageName),
     standfirst = "Switch off and soak up the country air as you ramble through the heather-coated North York Moors or explore the dramatic scenery of Glen Coe."

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -194,7 +194,7 @@ object VisitBritainHostedPages {
   val activitiesGallery: HostedGalleryPage = HostedGalleryPage(
     campaign = campaign,
     images = activityImages,
-    pageUrl = "https://www.theguardian.com/commercial/advertiser-content/visit-britain/activities",
+    pageUrl = "https://www.theguardian.com/advertiser-content/visit-britain/activities",
     pageName = activitiesPageName,
     title = "Don’t be a sloth this summer",
     ctaText = "Explore our collection of unique experiences from all over Great Britain.",
@@ -207,7 +207,7 @@ object VisitBritainHostedPages {
   val cityGallery: HostedGalleryPage = HostedGalleryPage(
     campaign = campaign,
     images = cityImages,
-    pageUrl = "https://www.theguardian.com/commercial/advertiser-content/visit-britain/city",
+    pageUrl = "https://www.theguardian.com/advertiser-content/visit-britain/city",
     pageName = cityPageName,
     title = "Take a city break from the norm",
     ctaText = "Explore our collection of unique experiences from all over Great Britain.",
@@ -220,7 +220,7 @@ object VisitBritainHostedPages {
   private val coastGallery: HostedGalleryPage = HostedGalleryPage(
     campaign = campaign,
     images = coastImages,
-    pageUrl = "https://www.theguardian.com/commercial/advertiser-content/visit-britain/coast",
+    pageUrl = "https://www.theguardian.com/advertiser-content/visit-britain/coast",
     pageName = coastPageName,
     title = "Find cool-on-sea this summer",
     ctaText = "Explore our collection of unique experiences from all over Great Britain.",
@@ -233,7 +233,7 @@ object VisitBritainHostedPages {
   private val countrysideGallery: HostedGalleryPage = HostedGalleryPage(
     campaign = campaign,
     images = countrysideImages,
-    pageUrl = "https://www.theguardian.com/commercial/advertiser-content/visit-britain/countryside",
+    pageUrl = "https://www.theguardian.com/advertiser-content/visit-britain/countryside",
     pageName = countrysidePageName,
     title = "Mend your relationship with Mother Nature",
     ctaText = "Explore our collection of unique experiences from all over Great Britain.",

--- a/static/src/javascripts/projects/common/modules/commercial/hosted-gallery.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-gallery.js
@@ -64,11 +64,7 @@ define([
             // FSM CONFIG
             this.fsm = new FiniteStateMachine({
                 initial: 'image',
-                onChangeState: function (oldState, newState) {
-                    this.$galleryEl
-                        .removeClass('hosted-gallery--' + oldState)
-                        .addClass('hosted-gallery--' + newState);
-                },
+                onChangeState: function () {},
                 context: this,
                 states: this.states
             });
@@ -89,8 +85,14 @@ define([
     }
 
     HostedGallery.prototype.initScroll = function () {
-        bean.on(this.nextBtn, 'click', this.trigger.bind(this, 'next', {nav: 'Click'}));
-        bean.on(this.prevBtn, 'click', this.trigger.bind(this, 'prev', {nav: 'Click'}));
+        bean.on(this.nextBtn, 'click', function(){
+            this.scrollTo(this.index + 1);
+            this.trigger.bind(this, 'next', {nav: 'Click'});
+        }.bind(this));
+        bean.on(this.prevBtn, 'click', function(){
+            this.scrollTo(this.index - 1);
+            this.trigger.bind(this, 'prev', {nav: 'Click'});
+        }.bind(this));
 
         bean.on(this.$scrollEl[0], 'scroll', throttle(this.fadeContent.bind(this), 20));
     };
@@ -272,14 +274,10 @@ define([
     HostedGallery.prototype.scrollTo = function (index) {
         var scrollEl = this.$scrollEl;
         var length = this.$images.length;
-        var scrollTop = scrollEl[0].scrollTop;
         var scrollHeight = scrollEl[0].scrollHeight;
-        var progress = length * (scrollTop / scrollHeight);
-        if (Math.abs(progress - index + 1) > 0.99) {
-            fastdom.write(function () {
-                scrollEl.scrollTop((index - 1) * scrollHeight / length);
-            });
-        }
+        fastdom.write(function () {
+            scrollEl.scrollTop((index - 1) * scrollHeight / length);
+        });
     };
 
 
@@ -300,8 +298,6 @@ define([
                     this.translateContent(this.index, 0, 100);
                     bonzo(this.$galleryEl).toggleClass('show-oj', this.index === this.$images.length);
                     bonzo(this.$galleryEl).toggleClass('show-cta', this.index === config.page.ctaIndex + 1);
-                } else {
-                    this.scrollTo(this.index);
                 }
                 // event bindings
                 mediator.on('window:resize', this.resize);
@@ -400,10 +396,12 @@ define([
         };
         if (e.keyCode === 37 || e.keyCode === 38) { // up/left
             e.preventDefault();
+            this.scrollTo(this.index - 1);
             this.trigger('prev', {nav: 'KeyPress:' + keyNames[e.keyCode]});
             return false;
         } else if (e.keyCode === 39 || e.keyCode === 40) { // down/right
             e.preventDefault();
+            this.scrollTo(this.index + 1);
             this.trigger('next', {nav: 'KeyPress:' + keyNames[e.keyCode]});
             return false;
         } else if (e.keyCode === 73) { // 'i'

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
@@ -25,6 +25,7 @@
     visibility: hidden;
     bottom: 0;
     left: 0;
+    right: 0;
     transition: opacity 300ms ease, visibility 300ms ease;
 }
 
@@ -231,10 +232,8 @@
     }
 }
 
-.use-swipe .hosted-gallery__image .hosted-gallery__cta,
-.use-swipe .hosted-gallery__image .hosted-gallery__oj,
-.use-scroll.show-cta > .hosted-gallery__cta,
-.use-scroll.show-oj > .hosted-gallery__oj {
+.show-cta .hosted-gallery__cta,
+.show-oj .hosted-gallery__oj {
     opacity: 1;
     visibility: visible;
     .hosted-gallery__cta-link {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-gallery.scss
@@ -208,15 +208,13 @@
         text-decoration: none;
     }
 
-    .inline-arrow-right {
-        position: absolute;
-        bottom: 0;
-        right: 6px;
-        height: 40px;
+    .inline-external-link {
+        margin-left: 5px;
 
         svg {
-            height: 36px;
-            width: 36px;
+            height: 22px;
+            width: 20px;
+            vertical-align: top;
         }
     }
 
@@ -225,9 +223,9 @@
         margin: 8px 0 16px;
         width: 140px;
         font-size: 14px;
-        .inline-arrow-right {
-            height: 33px;
-            right: 3px;
+        .inline-external-link svg {
+            height: 16px;
+            width: 18px;
         }
     }
 }


### PR DESCRIPTION
## What does this change?
- Now able to track how the user navigates through the gallery, i.e. clicks or scrolls etc.
- Simplify the CTA/OJ, so there's only one version (of each) in the html
- allow key-press navigation in touch-screen mode
- change CTA button to external link icon instead of arrow

![image](https://cloud.githubusercontent.com/assets/6290008/16842034/d1ef88c4-49d3-11e6-85e2-9c787f6032eb.png)
## Request for comment

@Calanthe 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
