### PR TITLE
Track content type and tone of hosted content

### DIFF
--- a/common/app/common/commercial/hosted/HostedGalleryPage.scala
+++ b/common/app/common/commercial/hosted/HostedGalleryPage.scala
@@ -27,8 +27,6 @@ case class HostedGalleryPage(
   })
 
   override val metadata: MetaData = {
-    val toneId = "tone/hosted-content"
-    val toneName = "Hosted content"
     val sectionId = "hosted-gallery"
     val keywordId = s"$sectionId/$sectionId"
     val keywordName = sectionId
@@ -36,8 +34,8 @@ case class HostedGalleryPage(
       id = s"commercial/advertiser-content/$sectionId/$pageName",
       webTitle = pageTitle,
       section = Some(SectionSummary.fromId(sectionId)),
-      contentType = Hosted,
-      analyticsName = s"GFE:$sectionId:$Hosted:$pageName",
+      contentType = Gallery,
+      analyticsName = s"GFE:$sectionId:$Gallery:$pageName",
       description = Some(pageTitle),
       javascriptConfigOverrides = Map(
         "keywordIds" -> JsString(keywordId),

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -8,6 +8,9 @@ trait HostedPage extends StandalonePage {
   def pageName: String
   def pageTitle: String
   def standfirst: String
+
+  final val toneId = "tone/hosted"
+  final val toneName = "Hosted"
 }
 
 case class HostedCampaign(

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -20,16 +20,14 @@ case class HostedVideoPage(
   val pageTitle: String  = s"Advertiser content hosted by the Guardian: ${video.title} - video"
 
   override val metadata: MetaData = {
-    val toneId = "tone/hosted-content"
-    val toneName = "Hosted content"
     val keywordId = s"${campaign.id}/${campaign.id}"
     val keywordName = campaign.id
     MetaData.make(
       id = s"commercial/advertiser-content/${campaign.id}/$pageName",
       webTitle = pageTitle,
       section = Some(SectionSummary.fromId(campaign.id)),
-      contentType = Hosted,
-      analyticsName = s"GFE:${campaign.id}:$Hosted:$pageName",
+      contentType = Video,
+      analyticsName = s"GFE:${campaign.id}:$Video:$pageName",
       description = Some(standfirst),
       javascriptConfigOverrides = Map(
         "keywordIds" -> JsString(keywordId),

--- a/common/app/model/GuardianContentTypes.scala
+++ b/common/app/model/GuardianContentTypes.scala
@@ -29,5 +29,4 @@ object GuardianContentTypes {
   val LiveBlog = "LiveBlog"
   val TagIndex = "Index"
   val Crossword = "Crossword"
-  val Hosted = "Hosted"
 }


### PR DESCRIPTION
This change gives hosted content an identifying tone and reuses existing content types.
These are hardcoded in frontend at the moment, but their values for tracking should remain the same when we move to the scalable solution.

Eg. 
hosted video:
c9:Video
c10:Hosted

hosted gallery:
c9:Gallery
c10:Hosted

/cc @Calanthe @lps88 
