### PR TITLE
Remove Euro 2016 from navbar and move Euro results table down

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -238,7 +238,6 @@ trait Navigation {
   val membership = SectionLink("membership", "membership", "Membership", "/membership")
 
   val footballNav = Seq(
-    SectionLink("football", "euro 2016", "Euro 2016", "/football/euro-2016"),
     SectionLink("football", "live scores", "Live scores", "/football/live"),
     SectionLink("football", "tables", "Tables", "/football/tables"),
     SectionLink("football", "competitions", "Competitions", "/football/competitions"),

--- a/sport/app/football/controllers/LeagueTableController.scala
+++ b/sport/app/football/controllers/LeagueTableController.scala
@@ -20,7 +20,6 @@ case class TablesPage(
 class LeagueTableController extends Controller with Logging with CompetitionTableFilters with ExecutionContexts {
 
     val tableOrder = Seq(
-        "Euro 2016",
         "Premier League",
         "La Liga",
         "Bundesliga",
@@ -33,6 +32,7 @@ class LeagueTableController extends Controller with Logging with CompetitionTabl
         "Scottish Championship",
         "Scottish League One",
         "Scottish League Two",
+        "Euro 2016",
         "Euro 2016 qualifying",
         "Champions League qualifying",
         "Europa League",


### PR DESCRIPTION
## What does this change?

Remove the Euro 2016 from the /football nav bar now 
Move down the Euro 2016 results table down
## What is the value of this and can you measure success?

The competition is finished. 
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @JustinPinner 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
