### PR TITLE
Limit scope of CAPi styling for h2, h3 

### DIFF
--- a/static/src/stylesheets/module/content/_live-blog.scss
+++ b/static/src/stylesheets/module/content/_live-blog.scss
@@ -229,6 +229,10 @@ $block-padding-right: $gs-gutter;
 .blog .from-content-api {
 
     .block-title {
+        @include fs-header(2);
+        @include mq(tablet) {
+            @include fs-header(3, true);
+        }
         margin-top: ($gs-baseline/4)*-1;
         margin-bottom: $gs-baseline;
 

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -63,7 +63,7 @@
         position: relative;
         margin-bottom: .8em;
     }
-    h2 {
+    > h2 {
         @include fs-header(2);
 
         @include mq(tablet) {
@@ -71,7 +71,7 @@
             margin-bottom: 1px;
         }
     }
-    h3 {
+    > h3 {
         @include fs-bodyHeading(2);
         margin: 0;
 


### PR DESCRIPTION
This addresses #13286 , the greedy css rules based on `from-content-api`. There isn't much consensus about this, as we can see the majority of rules in `from-content-api` are child-based, but some are general descendant. This does fix issues with body-based ad-slots, so I think it's worth doing. I can't see any reason to target elements we don't want to style, I haven't managed to find a counter-example.
