### PR TITLE
Internal healtchecks don't expire

### DIFF
--- a/admin-jobs/app/controllers/HealthCheck.scala
+++ b/admin-jobs/app/controllers/HealthCheck.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
 class HealthCheck extends AllGoodCachedHealthCheck(
   9015,
-  ExpiringSingleHealthCheck("/news-alert/alerts")
+  NeverExpiresSingleHealthCheck("/news-alert/alerts")
 )

--- a/admin/app/controllers/HealthCheck.scala
+++ b/admin/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
-class HealthCheck extends AllGoodCachedHealthCheck(9001, ExpiringSingleHealthCheck("/login"))
+class HealthCheck extends AllGoodCachedHealthCheck(9001, NeverExpiresSingleHealthCheck("/login"))

--- a/applications/app/controllers/HealthCheck.scala
+++ b/applications/app/controllers/HealthCheck.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import contentapi.SectionsLookUp
 import play.api.mvc.{Action, AnyContent}
 
@@ -8,11 +8,11 @@ import scala.concurrent.Future
 
 class HealthCheck extends AllGoodCachedHealthCheck(
   9002,
-  ExpiringSingleHealthCheck("/books"),
-  ExpiringSingleHealthCheck("/books/harrypotter"),
-  ExpiringSingleHealthCheck("/travel/gallery/2012/nov/20/st-petersburg-pushkin-museum"),
-  ExpiringSingleHealthCheck("/travel/gallery/2012/nov/20/st-petersburg-pushkin-museum?index=2"),
-  ExpiringSingleHealthCheck("/world/video/2012/nov/20/australian-fake-bomber-sentenced-sydney-teenager-video")
+  NeverExpiresSingleHealthCheck("/books"),
+  NeverExpiresSingleHealthCheck("/books/harrypotter"),
+  NeverExpiresSingleHealthCheck("/travel/gallery/2012/nov/20/st-petersburg-pushkin-museum"),
+  NeverExpiresSingleHealthCheck("/travel/gallery/2012/nov/20/st-petersburg-pushkin-museum?index=2"),
+  NeverExpiresSingleHealthCheck("/world/video/2012/nov/20/australian-fake-bomber-sentenced-sydney-teenager-video")
 ) {
   override def healthCheck(): Action[AnyContent] = Action.async { request =>
     if (!SectionsLookUp.isLoaded()) {

--- a/archive/app/controllers/HealthCheck.scala
+++ b/archive/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
-class HealthCheck extends AllGoodCachedHealthCheck(9003, ExpiringSingleHealthCheck("/404/www.theguardian.com/Adzip/adzip-fb.html"))
+class HealthCheck extends AllGoodCachedHealthCheck(9003, NeverExpiresSingleHealthCheck("/404/www.theguardian.com/Adzip/adzip-fb.html"))

--- a/article/app/controllers/HealthCheck.scala
+++ b/article/app/controllers/HealthCheck.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
 class HealthCheck extends AllGoodCachedHealthCheck(
   9004,
-  ExpiringSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
+  NeverExpiresSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
 )

--- a/commercial/app/controllers/HealthCheck.scala
+++ b/commercial/app/controllers/HealthCheck.scala
@@ -1,13 +1,13 @@
 package controllers
 
-import conf.{AnyGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AnyGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
 class HealthCheck extends AnyGoodCachedHealthCheck(
   9005,
-  ExpiringSingleHealthCheck("/commercial/soulmates/mixed.json"),
-  ExpiringSingleHealthCheck("/commercial/masterclasses.json"),
-  ExpiringSingleHealthCheck("/commercial/travel/offers.json"),
-  ExpiringSingleHealthCheck("/commercial/jobs.json"),
-  ExpiringSingleHealthCheck("/commercial/money/bestbuys.json"),
-  ExpiringSingleHealthCheck("/commercial/books/books.json")
+  NeverExpiresSingleHealthCheck("/commercial/soulmates/mixed.json"),
+  NeverExpiresSingleHealthCheck("/commercial/masterclasses.json"),
+  NeverExpiresSingleHealthCheck("/commercial/travel/offers.json"),
+  NeverExpiresSingleHealthCheck("/commercial/jobs.json"),
+  NeverExpiresSingleHealthCheck("/commercial/money/bestbuys.json"),
+  NeverExpiresSingleHealthCheck("/commercial/books/books.json")
 )

--- a/diagnostics/app/controllers/HealthCheck.scala
+++ b/diagnostics/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
-class HealthCheck extends AllGoodCachedHealthCheck(9006, ExpiringSingleHealthCheck("/robots.txt"))
+class HealthCheck extends AllGoodCachedHealthCheck(9006, NeverExpiresSingleHealthCheck("/robots.txt"))

--- a/facia/app/controllers/HealthCheck.scala
+++ b/facia/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
-class HealthCheck extends AllGoodCachedHealthCheck(9008, ExpiringSingleHealthCheck("/uk/business"))
+class HealthCheck extends AllGoodCachedHealthCheck(9008, NeverExpiresSingleHealthCheck("/uk/business"))

--- a/identity/app/controllers/HealthCheck.scala
+++ b/identity/app/controllers/HealthCheck.scala
@@ -1,5 +1,5 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
-class HealthCheck extends AllGoodCachedHealthCheck(9010, ExpiringSingleHealthCheck("/signin"))
+class HealthCheck extends AllGoodCachedHealthCheck(9010, NeverExpiresSingleHealthCheck("/signin"))

--- a/onward/app/controllers/HealthCheck.scala
+++ b/onward/app/controllers/HealthCheck.scala
@@ -1,9 +1,9 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
 class HealthCheck extends AllGoodCachedHealthCheck(
   9011,
-  ExpiringSingleHealthCheck("/top-stories.json"),
-  ExpiringSingleHealthCheck("/most-read/society.json")
+  NeverExpiresSingleHealthCheck("/top-stories.json"),
+  NeverExpiresSingleHealthCheck("/most-read/society.json")
 )

--- a/preview/app/controllers/HealthCheck.scala
+++ b/preview/app/controllers/HealthCheck.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
 class HealthCheck extends AllGoodCachedHealthCheck(
  9017,
- ExpiringSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
+ NeverExpiresSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
 )

--- a/rss/app/controllers/HealthCheck.scala
+++ b/rss/app/controllers/HealthCheck.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
 class HealthCheck extends AllGoodCachedHealthCheck(
   9014,
-  ExpiringSingleHealthCheck("/books/harrypotter/rss")
+  NeverExpiresSingleHealthCheck("/books/harrypotter/rss")
 )

--- a/sport/app/football/controllers/HealthCheck.scala
+++ b/sport/app/football/controllers/HealthCheck.scala
@@ -1,9 +1,9 @@
 package football.controllers
 
-import conf.{AllGoodCachedHealthCheck, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 
 class HealthCheck extends AllGoodCachedHealthCheck(
   9013,
-  ExpiringSingleHealthCheck("/football/live"),
-  ExpiringSingleHealthCheck("/football/premierleague/results")
+  NeverExpiresSingleHealthCheck("/football/live"),
+  NeverExpiresSingleHealthCheck("/football/premierleague/results")
 )

--- a/training-preview/app/controllers/HealthCheck.scala
+++ b/training-preview/app/controllers/HealthCheck.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import common.ExecutionContexts
-import conf.{AllGoodCachedHealthCheck, CachedHealthCheckLifeCycle, ExpiringSingleHealthCheck}
+import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import dispatch.{FunctionHandler, Http}
 import scala.concurrent.Future
 import contentapi.{ContentApiClient, Response}
@@ -40,7 +40,7 @@ class TrainingHttp extends contentapi.Http with ExecutionContexts {
 
 class HealthCheck extends AllGoodCachedHealthCheck(
  9016,
- ExpiringSingleHealthCheck("/info/developer-blog/2016/apr/14/training-preview-healthcheck")
+ NeverExpiresSingleHealthCheck("/info/developer-blog/2016/apr/14/training-preview-healthcheck")
 ) {
   init()
 


### PR DESCRIPTION
## What does this change?

This is a following this PR https://github.com/guardian/frontend/pull/13486 which has been live for 10 days without any issue.

Internal healthcheck are being executed only once to verify the service
can serve a real request but once it is successful the internal
healthcheck is not executed anymore. The goal is to minimize the impact
of any upstream services on the health of frontend services
## What is the value of this and can you measure success?

See above. Frontend health doesn't depend too much on the health of upstream services
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
