### PR TITLE
Update the kinesis-logback appender

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,7 +66,7 @@ object Dependencies {
   val w3cSac = "org.w3c.css" % "sac" % "1.3"
   val libPhoneNumber = "com.googlecode.libphonenumber" % "libphonenumber" % "7.2.4"
   val logback = "net.logstash.logback" % "logstash-logback-encoder" % "4.6"
-  val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.2.0"
+  val kinesisLogbackAppender = "com.gu" % "kinesis-logback-appender" % "1.3.0"
 
   // Web jars
   val bootstrap = "org.webjars" % "bootstrap" % "3.3.5"


### PR DESCRIPTION
## What does this change?

Update the kinesis-logback appender
Kinesis-logback-appender 1.2.0 is incompatible with latest aws sdk and therefore logging has been  broken since [we updated to the latest aws sdk](https://github.com/guardian/frontend/pull/13588/files#diff-0ecdbc5a001d52fb34f5eafb7cd1aaa6L10) 

Kinesis ingest:
![screen shot 2016-07-15 at 14 32 12](https://cloud.githubusercontent.com/assets/233326/16875754/f0d15d24-4a98-11e6-82b7-0d475de4ad6f.png)
## What is the value of this and can you measure success?

Logging works again
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
