### PR TITLE
Fix: adverts rows don't wrap by default

### DIFF
--- a/static/src/stylesheets/module/commercial/_adverts-soulmates.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-soulmates.scss
@@ -3,6 +3,8 @@
         // In the soulmates component, we want to show rows of 3 profiles
         // on mobile. Except if this is a manual component.
         &:not(.adverts--manual) .adverts__row {
+            flex-wrap: wrap;
+
             > * {
                 flex-basis: calc(33.33% - #{$gs-gutter});
                 &:nth-child(even)::before {

--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -207,8 +207,6 @@
         }
 
         @include mq($until: tablet) {
-            flex-flow: row wrap;
-
             > * {
                 flex-basis: calc(50% - #{$gs-gutter});
             }

--- a/static/src/stylesheets/module/commercial/_adverts.scss
+++ b/static/src/stylesheets/module/commercial/_adverts.scss
@@ -280,6 +280,7 @@
     .adverts__row--wrap {
         position: relative;
         padding-top: 0;
+        flex-wrap: wrap;
 
         @include mq(mobileLandscape) {
             > *::before {


### PR DESCRIPTION
This caused a layout bug in some flavours of webkit:

![picture 1](https://cloud.githubusercontent.com/assets/629976/16878750/bae46dca-4aa5-11e6-9cd4-c03e876809f0.jpg)

cc @guardian/commercial-dev 
