### PR TITLE
Work around intermittent hosted video button bug

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/hosted-video.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-video.js
@@ -3,7 +3,6 @@
  */
 
 define([
-    'Promise',
     'bean',
     'fastdom',
     'common/utils/$',
@@ -19,7 +18,6 @@ define([
     'lodash/collections/contains',
     'text!common/views/ui/loading.html'
 ], function (
-    Promise,
     bean,
     fastdom,
     $,
@@ -87,105 +85,101 @@ define([
     }
 
     function init() {
-        return new Promise(function (resolve) {
-            require(['bootstraps/enhanced/media/main'], function () {
-                require(['bootstraps/enhanced/media/video-player'], function (videojs) {
-                    var $videoEl = $('.vjs-hosted__video');
+        require(['bootstraps/enhanced/media/main'], function () {
+            require(['bootstraps/enhanced/media/video-player'], function(videojs){
+                var $videoEl = $('.vjs-hosted__video');
 
-                    if (!$videoEl.length) {
-                        return;
+                if (!$videoEl.length) {
+                    return;
+                }
+
+                player = videojs($videoEl.get(0), videojsOptions());
+                player.guMediaType = 'video';
+                videojs.plugin('fullscreener', fullscreener);
+
+                player.ready(function () {
+                    var vol;
+                    var duration = parseInt(this.duration(), 10);
+                    var $hostedNext = $('.js-hosted-next-autoplay');
+                    initLoadingSpinner(player);
+                    upgradeVideoPlayerAccessibility(player);
+
+                    // unglitching the volume on first load
+                    vol = player.volume();
+                    if (vol) {
+                        player.volume(0);
+                        player.volume(vol);
                     }
 
-                    player = videojs($videoEl.get(0), videojsOptions());
-                    player.guMediaType = 'video';
-                    videojs.plugin('fullscreener', fullscreener);
+                    player.fullscreener();
 
-                    player.ready(function () {
-                        var vol;
-                        var duration = parseInt(this.duration(), 10);
-                        var $hostedNext = $('.js-hosted-next-autoplay');
-                        initLoadingSpinner(player);
-                        upgradeVideoPlayerAccessibility(player);
+                    var mediaId = $videoEl.attr('data-media-id');
+                    deferToAnalytics(function () {
+                        events.initOmnitureTracking(player);
+                        events.initOphanTracking(player, mediaId);
 
-                        // unglitching the volume on first load
-                        vol = player.volume();
-                        if (vol) {
-                            player.volume(0);
-                            player.volume(vol);
-                        }
+                        events.bindGlobalEvents(player);
+                        events.bindContentEvents(player);
+                    });
 
-                        player.fullscreener();
-
-                        var mediaId = $videoEl.attr('data-media-id');
-                        deferToAnalytics(function () {
-                            events.initOmnitureTracking(player);
-                            events.initOphanTracking(player, mediaId);
-
-                            events.bindGlobalEvents(player);
-                            events.bindContentEvents(player);
-                        });
-
-                        player.on('error', function () {
-                            var err = player.error();
-                            if (err && 'message' in err && 'code' in err) {
-                                reportError(new Error(err.message), {
-                                    feature: 'hosted-player',
-                                    vjsCode: err.code
-                                }, false);
-                            }
-                        });
-
-                        if ($hostedNext.length && ab.getParticipations().HostedAutoplay
-                            && (ab.getParticipations().HostedAutoplay.variant === 'variant1' || ab.getParticipations().HostedAutoplay.variant === 'variant2')) {
-                            if (ab.getParticipations().HostedAutoplay.variant === 'variant2') {
-                                fastdom.write(function () {
-                                    $hostedNext.addClass('hosted-next-autoplay--variant2');
-                                });
-                            }
-                            fastdom.write(function () {
-                                $('.js-hosted-fading').addClass('hosted-autoplay-ab');
-                            });
-
-                            //on desktop show the next video link 10 second before the end of the currently watching video
-                            if (contains(['desktop', 'leftCol', 'wide'], detect.getBreakpoint())) {
-                                player.on('timeupdate', function () {
-                                    var currentTime = parseInt(this.currentTime(), 10);
-                                    var time = 10; //seconds before the end when to show the timer
-
-                                    if (duration - currentTime <= time) {
-                                        player.off('timeupdate');
-
-                                        var $timer = $('.js-autoplay-timer');
-                                        var nextVideoPage;
-
-                                        if ($timer.length) {
-                                            nextVideoPage = $timer.data('next-page');
-                                            nextVideoInterval = nextVideoTimer(time, $timer, nextVideoPage);
-                                            fastdom.write(function () {
-                                                $hostedNext.addClass('js-autoplay-start');
-                                            });
-                                            bean.on(document, 'click', $('.js-autoplay-cancel'), function () {
-                                                cancelAutoplay($hostedNext);
-                                            });
-                                        }
-                                    }
-                                });
-                            } else {
-                                player.one('ended', function () {
-                                    fastdom.write(function () {
-                                        $hostedNext.addClass('js-autoplay-start');
-                                    });
-                                    bean.on(document, 'click', $('.js-autoplay-cancel'), function () {
-                                        cancelAutoplayMobile($hostedNext);
-                                    });
-                                });
-                            }
+                    player.on('error', function () {
+                        var err = player.error();
+                        if (err && 'message' in err && 'code' in err) {
+                            reportError(new Error(err.message), {
+                                feature: 'hosted-player',
+                                vjsCode: err.code
+                            }, false);
                         }
                     });
+
+                    if ($hostedNext.length && ab.getParticipations().HostedAutoplay
+                        && (ab.getParticipations().HostedAutoplay.variant === 'variant1' || ab.getParticipations().HostedAutoplay.variant === 'variant2')) {
+                        if (ab.getParticipations().HostedAutoplay.variant === 'variant2') {
+                            fastdom.write(function () {
+                                $hostedNext.addClass('hosted-next-autoplay--variant2');
+                            });
+                        }
+                        fastdom.write(function () {
+                            $('.js-hosted-fading').addClass('hosted-autoplay-ab');
+                        });
+
+                        //on desktop show the next video link 10 second before the end of the currently watching video
+                        if (contains(['desktop', 'leftCol', 'wide'], detect.getBreakpoint())) {
+                            player.on('timeupdate', function() {
+                                var currentTime = parseInt(this.currentTime(), 10);
+                                var time = 10; //seconds before the end when to show the timer
+
+                                if (duration - currentTime <= time) {
+                                    player.off('timeupdate');
+
+                                    var $timer = $('.js-autoplay-timer');
+                                    var nextVideoPage;
+
+                                    if ($timer.length) {
+                                        nextVideoPage = $timer.data('next-page');
+                                        nextVideoInterval = nextVideoTimer(time, $timer, nextVideoPage);
+                                        fastdom.write(function () {
+                                            $hostedNext.addClass('js-autoplay-start');
+                                        });
+                                        bean.on(document, 'click', $('.js-autoplay-cancel'), function() {
+                                            cancelAutoplay($hostedNext);
+                                        });
+                                    }
+                                }
+                            });
+                        } else {
+                            player.one('ended', function() {
+                                fastdom.write(function () {
+                                    $hostedNext.addClass('js-autoplay-start');
+                                });
+                                bean.on(document, 'click', $('.js-autoplay-cancel'), function() {
+                                    cancelAutoplayMobile($hostedNext);
+                                });
+                            });
+                        }
+                    }
                 });
             });
-
-            resolve();
         });
     }
 


### PR DESCRIPTION
This reverts the part of https://github.com/guardian/frontend/pull/13590 that applies to hosted video.
It seems to be causing an intermittent bug here.
