### PR TITLE
Don't run Giraffe test on sensitive articles or live blog

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -66,7 +66,7 @@ trait ABTestSwitches {
 
   val giraffe = Switch(
     SwitchGroup.ABTests,
-    "ab-giraffe",
+    "ab-giraffe-article",
     "Test effectiveness of inline CTA for contributions.",
     owners = Seq(Owner.withGithub("markjamesbutler"), Owner.withGithub("AWare")),
     safeState = Off,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -33,7 +33,8 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = '';
         this.canRun = function () {
-             return window.guardian.config.page.edition == 'UK';
+             return !window.guardian.config.page.isSensitive &&
+                 !window.guardian.config.page.isLiveBlog && window.guardian.config.page.edition == 'UK';
         };
 
         var writer = function (linkText, linkHref, copy) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -33,8 +33,8 @@ define([
         this.dataLinkNames = '';
         this.idealOutcome = '';
         this.canRun = function () {
-             return !window.guardian.config.page.isSensitive &&
-                 !window.guardian.config.page.isLiveBlog && window.guardian.config.page.edition == 'UK';
+            var pageObj = window.guardian.config.page;
+            return !(pageObj.isSensitive || pageObj.isLiveBlog) && pageObj.edition === 'UK';
         };
 
         var writer = function (linkText, linkHref, copy) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -20,8 +20,8 @@ define([
 ) {
     return function () {
 
-        this.id = 'Giraffe';
-        this.start = '2016-07-03';
+        this.id = 'GiraffeArticle';
+        this.start = '2016-07-18';
         this.expiry = '2016-08-01';
         this.author = 'Alex Ware';
         this.description = 'Add a button allowing readers to contribute money.';


### PR DESCRIPTION
## What does this change?

Prevents the Giraffe ab test running on sensitive articles and live blogs.
## What is the value of this and can you measure success?

None, this is a functional change to ensure our test isn't shown on sensitive articles.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

None
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
