### PR TITLE
Increase onward endpoints caching from 1s to 900s

### DIFF
--- a/onward/app/controllers/MediaInSectionController.scala
+++ b/onward/app/controllers/MediaInSectionController.scala
@@ -89,7 +89,7 @@ class MediaInSectionController extends Controller with Logging with Paging with 
       ).withTimeStamps,
       FrontProperties.empty
     )(request)
-    renderFormat(response, response, 1)
+    renderFormat(response, response, 900)
   }
 }
 

--- a/onward/app/controllers/MostViewedSocialController.scala
+++ b/onward/app/controllers/MostViewedSocialController.scala
@@ -60,7 +60,7 @@ class MostViewedSocialController extends Controller with ExecutionContexts {
             properties
           )(request)
 
-          renderFormat(facebookResponse, facebookResponse, 1)
+          renderFormat(facebookResponse, facebookResponse, 900)
         }
 
       case _ =>

--- a/onward/app/controllers/SeriesController.scala
+++ b/onward/app/controllers/SeriesController.scala
@@ -108,7 +108,7 @@ class SeriesController extends Controller with Logging with Paging with Executio
       properties
     )(request)
 
-    renderFormat(response, response, 1)
+    renderFormat(response, response, 900)
   }
 }
 


### PR DESCRIPTION
## What does this change?

Some onward endpoints (most viewed on social,  series trails, media in section) were only cached 1s 
This patch increases the cache time to 900.
## What is the value of this and can you measure success?

More caching, Less load for the onward service
[Out of the 10 most requested urls for the onward services](http://kibana.gu-web.net/goto/f43653282dfccf59e4571535388e67a4), 9 are /series/.... urls (first one being weather api widget) 

I don't think there is any good reason to cache those endpoints for only 1s. Also all other onward endpoints seem to be cached for 900 ([example](https://github.com/guardian/frontend/blob/01176a76e5122b65eec87df4cc35212e50561167/onward/app/controllers/TopStoriesController.scala#L77))
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
