### PR TITLE
Add link to applications wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ http://developers.theguardian.com/join-the-team.html
 # Frontend
 [The Guardian](http://www.theguardian.com) website frontend.
 
-Frontend is a set of Play Framework 2 Scala applications.
+Frontend is [a set of Play Framework 2 Scala applications](https://github.com/guardian/frontend/wiki/Applications-architecture).
 
 Frontend is built in two parts, using Grunt for the client side asset build and
 SBT for the Play Framework backend.


### PR DESCRIPTION
## What does this change?

As an ongoing effort to provide better documentation for the frontend codebase, I have created a wiki page to describe what each Play app is responsible for: https://github.com/guardian/frontend/wiki/Applications-architecture

This PR is actually more about this wiki page than adding a link to it.
This is a work in progress obviously but I would really appreciate if as much people as possible could review the wiki page, add any missing information, fix any typo and correct my broken English. Thank you
## What is the value of this and can you measure success?

Make it easier for developers from other teams to grasp the complexity of the frontend codebase.
Hopefully this will reduce the number of times the question "What is this app doing?" is asked 😁 
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@sndrs @dominickendrick @stephanfowler @johnduffell @jfsoul @NataliaLKB @JustinPinner @paulbrown1982 @SiAdcock @sihil @philwills @alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
