### PR TITLE
Use permalink for sharing comments links

### DIFF
--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -8,7 +8,7 @@
     <div class="sharing-text">@fragments.inlineSvg("share", "icon", List("comment-share-icon")) Share</div>
 
     <div class="sharing-buttons" data-link-name="comment social">
-    @defining(s"${comment.discussion.webUrl}") { permalink =>
+    @defining(s"${comment.webUrl}") { permalink =>
         @defining(StringEscapeUtils.unescapeHtml(Jsoup.clean(comment.body, Whitelist.none()))) { commentBody =>
             <a href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"""${comment.profile.displayName} commented: "$commentBody"""")).href"
             target="_blank"
@@ -22,7 +22,7 @@
 
             @* Twitter allows 140 characters. We need 2 for the quotes and 24 for the URL. *@
             @defining(if(commentBody.length <= 114) s""""$commentBody"""" else s""""${commentBody.take(111)}..."""") { commentText =>
-                <a href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = comment.webUrl, text = commentText).href"
+                <a href="@ShareLinks.createShareLinkForComment(platform = Twitter, href = permalink, text = commentText).href"
                 target="_blank"
                 class="social__action social-icon-wrapper"
                 data-link-name="social-comment : twitter">


### PR DESCRIPTION
## What does this change?

Uses the permalink instead of the direct link for both FB and Twitter sharing links.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Request for comment

@mchv @nicl 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
