### PR TITLE
tweak title margin and colors of deploys radiator

### DIFF
--- a/static/src/deploys-radiator/app/main.css
+++ b/static/src/deploys-radiator/app/main.css
@@ -26,15 +26,14 @@ body {
     margin: 0;
     padding: 0 10vw;
     font-family: 'Schoolbell';
-    animation: background linear 7200s;
-    animation-iteration-count: infinite;
+    background-color: #E5F9FF;
 }
 
 #root > h1 {
     font-size: 6vw;
-    margin-top: 7vw;
+    margin-top: 0;
     margin-bottom: 0;
-    padding-bottom: 2vw;
+    padding-bottom: 0;
     font-weight: bold;
     flex-basis: 100%
 }
@@ -114,7 +113,7 @@ h2 {
 .builds ul {
     list-style-type: none;
     text-align: center;
-    background-color: #ff0332;
+    background-color: blueviolet;
     color: white;
     padding: 1vw 0;
 }

--- a/static/src/deploys-radiator/app/render.js
+++ b/static/src/deploys-radiator/app/render.js
@@ -85,7 +85,7 @@ const renderGroupDeployListNode = (deploys) => {
     ]);
 };
 const renderPage = ([codeDeploys, prodDeploys], [latestCodeDeploy, oldestProdDeploy], commits) => {
-    const isInSync = oldestProdDeploy.build === latestCodeDeploy.build;
+    const isInSync = oldestProdDeploy.build === latestCodeDeploy.build && !hasDeployStarted(oldestProdDeploy) && !hasDeployStarted(latestCodeDeploy);
     return h(`${exp(commits.size == 0) ? '.unsynced' : ''}.row#root`, {}, [
         h('h1', [
             `${isInSync ? '🌷👌' : '🔥 ship it!'}`


### PR DESCRIPTION
## What does this change?

Remove margin/padding around the title so when the list of deploying apps is not cut off the screen when deploying
Also modify some colors
## What is the value of this and can you measure success?

You can see stuff on screen and colors are raising less questions
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![screen shot 2016-07-18 at 15 45 19](https://cloud.githubusercontent.com/assets/233326/16918768/e1ef27a6-4cfe-11e6-81c5-8ad36668133b.png)
## Request for comment

@sndrs 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
