### PR TITLE
Commercial top slot height for Fabric

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
@@ -45,7 +45,7 @@ define([
     }
 
     var addFluid250 = addClassIfHasClass(['ad-slot--fluid250']);
-    var addFluid    = addClassIfHasClass(['ad-slot--fluid', 'ad-slot--h250']);
+    var addFluid    = addClassIfHasClass(['ad-slot--fluid']);
 
     var sizeCallbacks = {};
 


### PR DESCRIPTION
There already is a `min-height` rule on the top slot for fabric adverts, so no need to add this class.

Some creatives like Fabric lie about their height 250 because they add their own "Advertisement" label and therefore increase their inner height to 268.

cc @JonNorman @rich-nguyen 
