### PR TITLE
Fixing the new-header in safari

### DIFF
--- a/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
+++ b/static/src/stylesheets/layout/_ab-new-header-test-variant.scss
@@ -80,7 +80,6 @@
         padding-right: ($gs-gutter / 2);
         // Position after pseudo element which forces line break
         order: 1;
-        flex: 1;
         justify-content: space-between;
     }
 }


### PR DESCRIPTION
## What does this change?

Currently the new header on the smallest breakpoint doesn't look right on Safari. This just deletes the line of code that is causing the problem.
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Screenshots

**before:**
![image](https://cloud.githubusercontent.com/assets/8774970/16920863/3fe66fc4-4d07-11e6-843a-4487fad78b1a.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/8774970/16921052/ed6c3688-4d07-11e6-9bc6-105def74525a.png)
