### PR TITLE
Add back Ad sizes used in PrebidService

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/ad-sizes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-sizes.js
@@ -1,6 +1,8 @@
 define(function () {
     var adSizes = {
         // standard ad sizes
+        billboard:              AdSize(970, 250),
+        leaderboard:            AdSize(728, 90),
         mpu:                    AdSize(300, 250),
         halfPage:               AdSize(300, 600),
         portrait:               AdSize(300, 1050),
@@ -18,6 +20,8 @@ define(function () {
         fluid250:               AdSize(88, 70),
         outOfPage:              AdSize(1, 1)
     };
+    adSizes['970x250'] = adSizes.billboard;
+    adSizes['728x90'] = adSizes.leaderboard;
     adSizes['300x250'] = adSizes.mpu;
     adSizes['300x600'] = adSizes.halfPage;
     adSizes['300x1050'] = adSizes.portrait;


### PR DESCRIPTION
I got overzealous and removed ad sizes that were still in use in our PrebidService module

cc @rich-nguyen 
