### PR TITLE
Fix top mobile slot height and z-index issues

### DIFF
--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -71,14 +71,13 @@
 
 .sticky-top-banner-ad {
     overflow: hidden;
-    z-index: 1022;
+    z-index: $zindex-popover;
     width: 100%;
     position: relative;
 }
 
 .ad-slot--top-banner-ad {
     text-align: center;
-    z-index: $zindex-popover;
 
     @include mq(wide) {
         width: gs-span(16) - ($left-column-wide + $gs-gutter);

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -112,7 +112,7 @@
 }
 
 .ad-slot--top-banner-ad-mobile {
-    min-height: 250px;
+    min-height: 100px;
     padding: $gs-baseline 0;
 
     @include mq(tablet) {
@@ -615,14 +615,20 @@
  */
 .ad-slot--fluid {
     width: auto;
+    padding-left: 0;
+    padding-right: 0;
+    padding-bottom: 0;
 }
 
 .ad-slot--fabric-v1,
 .ad-slot--fluid250 {
-    min-height: 250px;
     width: auto;
     margin-left: 0;
     padding: 0;
+
+    @include mq(desktop) {
+        min-height: 250px;
+    }
 
     .ad-slot__label {
         display: none;

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -160,7 +160,7 @@
             }
             @each $breakpoint, $container-width in $breakpoints {
                 @include mq($breakpoint) {
-                 width: $container-width;
+                    width: $container-width;
                 }
             }
         }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -649,15 +649,15 @@
     padding-bottom: 0;
 }
 
+.ad-slot--fabric-v1 {
+    min-height: 250px;
+}
+
 .ad-slot--fabric-v1,
 .ad-slot--fluid250 {
     width: auto;
     margin-left: 0;
     padding: 0;
-
-    @include mq(desktop) {
-        min-height: 250px;
-    }
 
     .ad-slot__label {
         display: none;
@@ -665,6 +665,10 @@
 }
 
 .ad-slot--fluid250 {
+    @include mq(desktop) {
+        min-height: 250px;
+    }
+
     &.ad-slot--top-banner-ad-mobile {
         padding-bottom: $gs-baseline*1.5;
     }

--- a/static/src/stylesheets/module/_adslot.scss
+++ b/static/src/stylesheets/module/_adslot.scss
@@ -137,6 +137,35 @@
         height: 250px;
     }
 
+    &.ad-slot--fluid {
+        > .ad-slot__label {
+            box-sizing: content-box;
+            // Copying stuff from _mixins.scss because I don't want to
+            // use @extend and no, I am not modifying the markup
+            margin-left: $gs-gutter / 2;
+            margin-right: $gs-gutter / 2;
+
+            @include mq(mobileLandscape) {
+                margin-left: $gs-gutter;
+                margin-right: $gs-gutter;
+            }
+            @include mq(containerWidestMobile) {
+                margin-left: auto;
+                margin-right: auto;
+                width: $mobile-max-container-width;
+            }
+            @include mq(tablet) {
+                padding-left: $gs-gutter;
+                padding-right: $gs-gutter;
+            }
+            @each $breakpoint, $container-width in $breakpoints {
+                @include mq($breakpoint) {
+                 width: $container-width;
+                }
+            }
+        }
+    }
+
     .ad-slot__label {
         margin-top: (-1) * $gs-row-height / 2;
     }


### PR DESCRIPTION
So, the fluid250 creative, despite its name, is only 100px high on mobile. I [changed the `min-height` to accommodate for that oddity](https://github.com/guardian/frontend/compare/rk-fluid250-mobile?expand=1#diff-080ab32aa8365abdced6a7d722b4d6a5R115).

![picture 3](https://cloud.githubusercontent.com/assets/629976/16944124/15fc74fc-4d97-11e6-9064-6908c08ab46d.jpg)

The z-index issue is also fixed:
![picture 4](https://cloud.githubusercontent.com/assets/629976/16944129/1d562b76-4d97-11e6-93f5-0d2e78756b25.jpg)

And as a side bonus there was a missing rule that did not reset the top slot correctly for fluid ads:
![picture 6](https://cloud.githubusercontent.com/assets/629976/16944172/3f4944de-4d97-11e6-9974-9d9dfd3e1e7d.jpg)

This is also fixed:
![picture 5](https://cloud.githubusercontent.com/assets/629976/16944180/4394ab6e-4d97-11e6-87a9-e56d98151f77.jpg)

cc @guardian/commercial-dev 
