### PR TITLE
add video caption a/b test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -80,7 +80,7 @@ trait ABTestSwitches {
     "Testing if increasing prominence of video caption drives plays.",
     owners = Seq(Owner.withGithub("gidsg")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 7, 25),
+    sellByDate = new LocalDate(2016, 9, 1),
     exposeClientSide = true
   )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -80,7 +80,7 @@ trait ABTestSwitches {
     "Testing if increasing prominence of video caption drives plays.",
     owners = Seq(Owner.withGithub("gidsg")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 9, 1),
+    sellByDate = new LocalDate(2016, 7, 25),
     exposeClientSide = true
   )
 }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -27,7 +27,9 @@ define([
     // This must be the full path because we use curl config to change it based
     // on env
     'bootstraps/enhanced/media/video-player',
-    'text!common/views/ui/loading.html'
+    'text!common/views/ui/loading.html',
+    'text!common/views/media/titlebar.html',
+    'common/utils/template'
 ], function (
     bean,
     bonzo,
@@ -55,7 +57,9 @@ define([
     moreInSeriesContainer,
     videojsOptions,
     videojs,
-    loadingTmpl
+    loadingTmpl,
+    titlebarTmpl,
+    template
 ) {
     function getAdUrl() {
         var queryParams = {
@@ -114,6 +118,22 @@ define([
         });
 
         return player;
+    }
+    
+    function removeCaptionLink(){
+        bonzo($('.caption--main a')).remove();
+    }
+
+    function addTitleBar() {
+        var videoTitleElement = document.querySelector('[data-link-name="Video caption link"]');
+
+        var data = {
+            webTitle: videoTitleElement.textContent,
+            pageId: config.page.pageId,
+            icon: null
+        };
+        $('.vjs-control-bar').after(template(titlebarTmpl, data));
+        removeCaptionLink();
     }
 
     function initPlayButtons(root) {
@@ -312,6 +332,10 @@ define([
                 });
 
                 playerSetupComplete.then(function () {
+                    if(ab.isInVariant('VideoCaption','caption-overlay')) {
+                        addTitleBar();
+                    }
+
                     if (autoplay) {
                         player.play();
                     }

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -132,7 +132,7 @@ define([
             pageId: config.page.pageId,
             icon: null
         };
-        $('.vjs-control-bar').after(template(titlebarTmpl, data));
+        $('[data-component="main video"] .vjs-control-bar').after(template(titlebarTmpl, data));
         removeCaptionLink();
     }
 

--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -125,11 +125,11 @@ define([
     }
 
     function addTitleBar() {
-        var videoTitleElement = document.querySelector('[data-link-name="Video caption link"]');
+        var videoTitleElement = document.querySelector('.caption--main a');
 
         var data = {
             webTitle: videoTitleElement.textContent,
-            pageId: config.page.pageId,
+            pageId: videoTitleElement.getAttribute('href'),
             icon: null
         };
         $('[data-component="main video"] .vjs-control-bar').after(template(titlebarTmpl, data));

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-caption.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-caption.js
@@ -12,12 +12,12 @@ define([
     return function()
     {
         this.id = 'VideoCaption';
-        this.start = '2016-07-18';
-        this.expiry = '2016-09-01';
+        this.start = '2016-07-22';
+        this.expiry = '2016-07-25';
         this.author = 'Gideon Goldberg';
         this.description = 'Increase the prominence of the video caption on in-article videos.';
-        this.audience = 0;
-        this.audienceOffset = 0;
+        this.audience = 0.06;
+        this.audienceOffset = 0.1;
         this.successMeasure = 'Video starts.';
         this.audienceCriteria = 'Users viewing an article with a video embedded.';
         this.dataLinkNames = '';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-caption.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-caption.js
@@ -1,36 +1,46 @@
-define(['qwery',
-        'common/utils/config'
-], function(
+define([
+    'common/utils/config',
+    'qwery',
+    'bonzo',
+    'common/utils/$'
+], function (
+    config,
     qwery,
-    config
-
-) {
-    return function() {
+    bonzo,
+    $
+    ){
+    return function()
+    {
         this.id = 'VideoCaption';
         this.start = '2016-07-18';
-        this.expiry = '2016-07-25';
+        this.expiry = '2016-09-01';
         this.author = 'Gideon Goldberg';
-        this.showForSensitive = true;
-        this.description = 'Test if increasing the prominence of the video caption on in-article videos leads to more plays.';
-        this.audience = 1;
+        this.description = 'Increase the prominence of the video caption on in-article videos.';
+        this.audience = 0;
         this.audienceOffset = 0;
-        this.successMeasure = 'Video starts';
-        this.audienceCriteria = '';
-        this.dataLinkNames = '';
-        this.idealOutcome = '';
+        this.successMeasure = 'Video starts.';
+        this.audienceCriteria = 'Users viewing an article with a video embedded.';
+        this.dataLinkNames = 'video caption play';
+        this.idealOutcome = 'Video starts are increased';
         this.canRun = function() {
             return config.page.contentType === 'Article' &&  qwery('[data-component="main video"]').length > 0;
         };
 
         this.variants = [
             {
-                id: 'baseline1',
+                id: 'control',
                 test: function () {
                 }
             },
             {
-                id: 'baseline2',
+                id: 'caption-overlay',
                 test: function () {
+                }
+            },
+            {
+                id: 'caption-larger-text',
+                test: function () {
+                    bonzo($('.caption--main a')).addClass('caption--large');
                 }
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-caption.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-caption.js
@@ -20,7 +20,7 @@ define([
         this.audienceOffset = 0;
         this.successMeasure = 'Video starts.';
         this.audienceCriteria = 'Users viewing an article with a video embedded.';
-        this.dataLinkNames = 'video caption play';
+        this.dataLinkNames = '';
         this.idealOutcome = 'Video starts are increased';
         this.canRun = function() {
             return config.page.contentType === 'Article' &&  qwery('[data-component="main video"]').length > 0;

--- a/static/src/stylesheets/module/content/_media-player.scss
+++ b/static/src/stylesheets/module/content/_media-player.scss
@@ -702,7 +702,7 @@ $ima-controls-height: 70px;
 
 .vjs-title-bar {
     @include fs-textSans(3);
-    position: fixed;
+    position: absolute;
     width: 100%;
     height: $gs-baseline*4;
     box-sizing: border-box;

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -165,7 +165,7 @@
    ========================================================================== */
 
 .caption {
-    @include fs-textSans(2);
+    @include fs-textSans(1);
     color: $neutral-2;
 }
 

--- a/static/src/stylesheets/module/external/_from-content-api.scss
+++ b/static/src/stylesheets/module/external/_from-content-api.scss
@@ -165,8 +165,12 @@
    ========================================================================== */
 
 .caption {
-    @include fs-textSans(1);
+    @include fs-textSans(2);
     color: $neutral-2;
+}
+
+.caption--large {
+    font-size: 18px;
 }
 
 .caption--img {


### PR DESCRIPTION
## What does this change?

Adds an A/B test with changes to the video caption
## What is the value of this and can you measure success?

Test if increasing the prominence of the video caption drives plays

(Do not merge yet, until we can set correct audience offset and time to run with @harrysalmon)
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

control:
<img width="634" alt="screen shot 2016-07-19 at 10 00 01" src="https://cloud.githubusercontent.com/assets/1764158/16944262/a0cf8d3a-4d97-11e6-93c4-3184d76c3d8e.png">
caption-overlay
<img width="645" alt="screen shot 2016-07-18 at 17 08 22" src="https://cloud.githubusercontent.com/assets/1764158/16944279/b0ccb67c-4d97-11e6-88b7-8da312ce58a3.png">
caption-larger-text
<img width="641" alt="screen shot 2016-07-18 at 17 07 58" src="https://cloud.githubusercontent.com/assets/1764158/16944335/ef8c4bd4-4d97-11e6-83c1-654e53210d37.png">
## Request for comment

CC @akash1810 @jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
