### PR TITLE
Add a noscript for GA

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -52,8 +52,14 @@
     </script>
 
     @*
-    If at some point in the future this goes live, please somebody think of the "noscript" for Google Analytics
+    TODO For now we only include a confidence beacon in the noscript.
+    If this brings our confidence up, we should also request a pixel 
+    from a Fastly/frontend endpoint that can make a server-side call to GA to record the pageview.
     *@
+    <noscript id="googleNoScript">
+      <img id="googleConfidenceNoScriptImage" alt=""
+        src="@{Configuration.debug.beaconUrl}/count/pvg.gif" width="1" height="1" class="u-h" />
+    </noscript>
 }
 
 


### PR DESCRIPTION
## What does this change?

Adds a `<noscript>` tag below the GA snippet. For now it doesn't record the pageview with GA, it only contains a confidence beacon.
## What is the value of this and can you measure success?

To investigate whether the lack of a `noscript` is the cause of the low GA confidence (currently around 90%).
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

@dominickendrick 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
