### PR TITLE
Make share icons for comments bigger

### DIFF
--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -3,9 +3,9 @@
 @import org.jsoup.safety.Whitelist
 @import org.apache.commons.lang.StringEscapeUtils
 
-<div class="sharing-component d-comment__action">
+<div class="d-comment__action d-comment__action--share">
 
-    <div class="sharing-text">@fragments.inlineSvg("share", "icon", List("comment-share-icon")) Share</div>
+    <div class="sharing-text">@fragments.inlineSvg("share", "icon", List("comment-share-icon")) <span>Share</span></div>
 
     <div class="sharing-buttons" data-link-name="comment social">
     @defining(s"${comment.discussion.webUrl}") { permalink =>

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -871,7 +871,7 @@ $comment-recommend-button-size: 19px;
 
 .d-comment__action--reply {
     cursor: pointer;
-    margin-right: 5px;
+    margin-right: $gs-gutter / 4;
 
     &:hover {
         text-decoration: underline;
@@ -921,7 +921,7 @@ $comment-recommend-button-size: 19px;
 
 .d-comment__action--share {
     vertical-align: middle;
-    margin-left: 5px;
+    margin-left: $gs-gutter / 4;
 
     &:hover {
         .sharing-text span:nth-child(2) {
@@ -948,7 +948,7 @@ $comment-recommend-button-size: 19px;
 .sharing-text {
     cursor: pointer;
     display: inline-block;
-    margin-right: 5px;
+    margin-right: $gs-gutter / 4;
 }
 
 .comment-share-icon {

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -840,14 +840,13 @@ $comment-recommend-button-size: 19px;
 .d-comment__actions {
     position: absolute;
     bottom: $gs-baseline;
-    opacity: .7;
     .discussion--closed & {
         .d-comment__action--reply,
         .d-comment__action-separator,
         .d-comment__action-pick {
             display: none;
         }
-        .sharing-component {
+        .d-comment__action--share {
             margin: 0;
         }
     }
@@ -855,6 +854,10 @@ $comment-recommend-button-size: 19px;
 
 .d-comment__actions:hover {
     opacity: 1;
+}
+
+.d-comment__actions--left {
+    bottom: .5rem;
 }
 
 .d-comment__action {
@@ -868,6 +871,7 @@ $comment-recommend-button-size: 19px;
 
 .d-comment__action--reply {
     cursor: pointer;
+    margin-right: 5px;
 
     &:hover {
         text-decoration: underline;
@@ -915,30 +919,28 @@ $comment-recommend-button-size: 19px;
     }
 }
 
-.sharing-component {
-    height: 1.2rem;
+.d-comment__action--share {
     vertical-align: middle;
     margin-left: 5px;
 
     &:hover {
-        .sharing-buttons {
-            opacity: 1;
+        .sharing-text span:nth-child(2) {
+            text-decoration: underline;
         }
 
         .comment-facebook-icon,
         .comment-twitter-icon {
-            height: 1.2rem;
-            min-width: 1.2rem;
-            margin: 0;
+            transform: scale(1);
             cursor: pointer;
+            vertical-align: middle;
         }
 
         .comment-facebook-icon {
-            transition: all .3s ease-in-out;
+            transition: all .2s ease-in-out;
         }
 
         .comment-twitter-icon {
-            transition: all .3s .15s ease-in-out;
+            transition: all .2s .1s ease-in-out;
         }
     }
 }
@@ -946,7 +948,6 @@ $comment-recommend-button-size: 19px;
 .sharing-text {
     cursor: pointer;
     display: inline-block;
-    float: left;
     margin-right: 5px;
 }
 
@@ -965,17 +966,15 @@ $comment-recommend-button-size: 19px;
 
 .comment-facebook-icon,
 .comment-twitter-icon {
-    height: 0;
-    min-width: 0;
-    margin: .6rem;
+    transform: scale(0);
 }
 
 .comment-facebook-icon {
-    transition: all .3s .15s ease-in-out;
+    transition: all .2s .1s ease-in-out;
 }
 
 .comment-twitter-icon {
-    transition: all .3s ease-in-out;
+    transition: all .2s ease-in-out;
 }
 
 /* Report


### PR DESCRIPTION
## What does this change?
- Increases share icons' size to make them easily tappable on mobile.
- Removes opacity.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

![bigger icons](https://cloud.githubusercontent.com/assets/5732563/16946238/65a1b75c-4da0-11e6-8e45-eea86e64dec4.gif)
## Request for comment

@zeftilldeath 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
