### PR TITLE
Fix video dev deps

### DIFF
--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -5,6 +5,7 @@
 window.curlConfig = {
     baseUrl: '@{Configuration.assets.path}javascripts',
     apiName: 'require',
+    @* We need this as a dependecy for the ima and ads plugins *@
     @if(!Configuration.assets.useHashedBundles){ preloads: ['videojs-global'], }
     paths: {
         @if(Configuration.assets.useHashedBundles) {
@@ -63,7 +64,6 @@ window.curlConfig = {
             svgs:                           '../inline-svgs',
 
             // video
-            'bootstraps/enhanced/media/video-player':   'bootstraps/enhanced/media/video-player-dev.js',
             'videojs-global':                           'bootstraps/enhanced/media/videojs-global.js',
             'videojs-ima':                              'bootstraps/enhanced/media/videojs-ima.js',
             'videojs':                                  'components/video.js/video.js',

--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -5,6 +5,7 @@
 window.curlConfig = {
     baseUrl: '@{Configuration.assets.path}javascripts',
     apiName: 'require',
+    @if(!Configuration.assets.useHashedBundles){ preloads: ['videojs-global'], }
     paths: {
         @if(Configuration.assets.useHashedBundles) {
             'bootstraps/enhanced/main':          '@Static("javascripts/bootstraps/enhanced/main.js")',
@@ -63,13 +64,15 @@ window.curlConfig = {
 
             // video
             'bootstraps/enhanced/media/video-player':   'bootstraps/enhanced/media/video-player-dev.js',
-            videojs:                                    'components/video.js/video.js',
-            'videojs-contrib-ads':                      'components/videojs-contrib-ads/videojs.ads.js',
-            videojsembeddev:                            'bootstraps/enhanced/media/videojsembed-dev.js',
-            videojsembed:                               'components/videojs-embed/videojs.embed.js',
-            'videojs-ima':                              'components/videojs-ima/videojs.ima.js',
-            videojspersistvolume:                       'components/videojs-persistvolume/videojs.persistvolume.js',
-            videojsplaylist:                            'components/videojs-playlist-audio/videojs.playlist.js',
+            'videojs-global':                           'bootstraps/enhanced/media/videojs-global.js',
+            'videojs-ima':                              'bootstraps/enhanced/media/videojs-ima.js',
+            'videojs':                                  'components/video.js/video.js',
+            'videojs-ima-lib':                          'components/videojs-ima/videojs.ima.js',
+            'videojs-ads-lib':                          'components/videojs-contrib-ads/videojs.ads.js',
+
+            'videojs-embed':                            'components/videojs-embed/videojs.embed.js',
+            'videojs-persistvolume':                    'components/videojs-persistvolume/videojs.persistvolume.js',
+            'videojs-playlist':                         'components/videojs-playlist-audio/videojs.playlist.js',
 
             // These paths are for the pre-fetch-modules.js performance-optimisation module, used by boot.js.
             // The resolved paths are loaded through pre-fetch-modules XHR, not curl, so they don't inherit the standard baseUrl.

--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -64,14 +64,13 @@ window.curlConfig = {
             svgs:                           '../inline-svgs',
 
             // video
-            'videojs-ima':                              'bootstraps/enhanced/media/videojs-ima.js',
-            'videojs':                                  'components/video.js/video.js',
-            'videojs-ima-lib':                          'components/videojs-ima/videojs.ima.js',
-            'videojs-ads-lib':                          'components/videojs-contrib-ads/videojs.ads.js',
-
-            'videojs-embed':                            'components/videojs-embed/videojs.embed.js',
-            'videojs-persistvolume':                    'components/videojs-persistvolume/videojs.persistvolume.js',
-            'videojs-playlist':                         'components/videojs-playlist-audio/videojs.playlist.js',
+            'videojs-ima':                  'bootstraps/enhanced/media/videojs-ima.js',
+            'videojs':                      'components/video.js/video.js',
+            'videojs-ima-lib':              'components/videojs-ima/videojs.ima.js',
+            'videojs-ads-lib':              'components/videojs-contrib-ads/videojs.ads.js',
+            'videojs-embed':                'components/videojs-embed/videojs.embed.js',
+            'videojs-persistvolume':        'components/videojs-persistvolume/videojs.persistvolume.js',
+            'videojs-playlist':             'components/videojs-playlist-audio/videojs.playlist.js',
 
             // These paths are for the pre-fetch-modules.js performance-optimisation module, used by boot.js.
             // The resolved paths are loaded through pre-fetch-modules XHR, not curl, so they don't inherit the standard baseUrl.

--- a/common/app/templates/inlineJS/blocking/curlConfig.scala.js
+++ b/common/app/templates/inlineJS/blocking/curlConfig.scala.js
@@ -6,7 +6,7 @@ window.curlConfig = {
     baseUrl: '@{Configuration.assets.path}javascripts',
     apiName: 'require',
     @* We need this as a dependecy for the ima and ads plugins *@
-    @if(!Configuration.assets.useHashedBundles){ preloads: ['videojs-global'], }
+    @if(!Configuration.assets.useHashedBundles){ preloads: ['bootstraps/enhanced/media/videojs-global'], }
     paths: {
         @if(Configuration.assets.useHashedBundles) {
             'bootstraps/enhanced/main':          '@Static("javascripts/bootstraps/enhanced/main.js")',
@@ -64,7 +64,6 @@ window.curlConfig = {
             svgs:                           '../inline-svgs',
 
             // video
-            'videojs-global':                           'bootstraps/enhanced/media/videojs-global.js',
             'videojs-ima':                              'bootstraps/enhanced/media/videojs-ima.js',
             'videojs':                                  'components/video.js/video.js',
             'videojs-ima-lib':                          'components/videojs-ima/videojs.ima.js',

--- a/grunt-configs/requirejs.js
+++ b/grunt-configs/requirejs.js
@@ -22,12 +22,15 @@ module.exports = function (grunt, options) {
                 reqwest:              'components/reqwest/reqwest',
                 stripe:               'vendor/stripe/stripe.min',
                 svgs:                 '../../../common/conf/assets/inline-svgs',
-                videojs:              'components/video.js/video',
-                videojsads:           'components/videojs-contrib-ads/videojs.ads',
-                videojsembed:         'components/videojs-embed/videojs.embed',
-                videojsima:           'components/videojs-ima/videojs.ima',
-                videojspersistvolume: 'components/videojs-persistvolume/videojs.persistvolume',
-                videojsplaylist:      'components/videojs-playlist-audio/videojs.playlist',
+
+                // video
+                videojs:                 'components/video.js/video',
+                'videojs-embed':         'components/videojs-embed/videojs.embed',
+                'videojs-ima':           'components/videojs-ima/videojs.ima',
+                'videojs-ads-lib':       'components/videojs-contrib-ads/videojs.ads',
+                'videojs-persistvolume': 'components/videojs-persistvolume/videojs.persistvolume',
+                'videojs-playlist':      'components/videojs-playlist-audio/videojs.playlist',
+
                 // plugins
                 text:                 'components/requirejs-text/text',
                 inlineSvg:            'projects/common/utils/inlineSvg',
@@ -292,10 +295,10 @@ module.exports = function (grunt, options) {
                 generateSourceMaps: true,
                 preserveLicenseComments: false,
                 shim: {
-                    videojsima: {
-                        deps: ['videojsads']
+                    'videojs-ima': {
+                        deps: ['videojs-ads-lib']
                     },
-                    videojsads: {
+                    'videojs-ads-lib': {
                         deps: ['bootstraps/enhanced/media/videojs-global']
                     }
                 }

--- a/static/src/javascripts/bootstraps/enhanced/media/video-player-dev.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/video-player-dev.js
@@ -1,10 +1,9 @@
 define([
     'videojs',
-    'bootstraps/enhanced/media/videojsads',
-    'bootstraps/enhanced/media/videojsima',
-    'js!videojspersistvolume',
-    'js!videojsplaylist',
-    'js!videojsembed'
+    'videojs-ima',
+    'videojs-embed',
+    'videojs-persistvolume',
+    'videojs-playlist'
 ], function (video) {
     return video;
 });

--- a/static/src/javascripts/bootstraps/enhanced/media/video-player-dev.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/video-player-dev.js
@@ -1,9 +1,0 @@
-define([
-    'videojs',
-    'videojs-ima',
-    'videojs-embed',
-    'videojs-persistvolume',
-    'videojs-playlist'
-], function (video) {
-    return video;
-});

--- a/static/src/javascripts/bootstraps/enhanced/media/video-player.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/video-player.js
@@ -1,10 +1,9 @@
 define([
     'videojs',
-    'videojsads',
-    'videojsima',
+    'videojs-ima',
+    'videojs-embed',
     'videojs-persistvolume',
-    'videojs-playlist',
-    'videojs-embed'
+    'videojs-playlist'
 ], function (video) {
     return video;
 });

--- a/static/src/javascripts/bootstraps/enhanced/media/video-player.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/video-player.js
@@ -2,9 +2,9 @@ define([
     'videojs',
     'videojsads',
     'videojsima',
-    'videojspersistvolume',
-    'videojsplaylist',
-    'videojsembed'
+    'videojs-persistvolume',
+    'videojs-playlist',
+    'videojs-embed'
 ], function (video) {
     return video;
 });

--- a/static/src/javascripts/bootstraps/enhanced/media/videojs-ima.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/videojs-ima.js
@@ -1,0 +1,1 @@
+define(['js!videojs-ads-lib', 'js!videojs-ima-lib'], function () {});

--- a/static/src/javascripts/bootstraps/enhanced/media/videojs-ima.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/videojs-ima.js
@@ -1,1 +1,3 @@
+// This is only used when we're not using hashedBundles.
+// When using hashedBundles, we use requirejs's shim.
 define(['js!videojs-ads-lib', 'js!videojs-ima-lib'], function () {});

--- a/static/src/javascripts/bootstraps/enhanced/media/videojsads.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/videojsads.js
@@ -1,1 +1,0 @@
-define(['bootstraps/enhanced/media/videojs-global', 'js!videojs-contrib-ads!order'], function () {});

--- a/static/src/javascripts/bootstraps/enhanced/media/videojsembed-dev.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/videojsembed-dev.js
@@ -1,5 +1,0 @@
-define([
-    'js!videojsembeddev'
-], function(videojsembed) {
-    return videojsembed;
-});

--- a/static/src/javascripts/bootstraps/enhanced/media/videojsima.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/videojsima.js
@@ -1,1 +1,0 @@
-define(['bootstraps/enhanced/media/videojs-global', 'js!videojs-ima!order'], function () {});

--- a/static/src/javascripts/bootstraps/video-embed.js
+++ b/static/src/javascripts/bootstraps/video-embed.js
@@ -4,7 +4,7 @@ define([
     'bonzo',
     'qwery',
     'videojs',
-    'videojsembed',
+    'videojs-embed',
     'common/utils/$',
     'common/utils/config',
     'common/utils/defer-to-analytics',

--- a/static/src/javascripts/projects/common/modules/commercial/hosted-video.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-video.js
@@ -92,8 +92,9 @@ define([
                 require(['bootstraps/enhanced/media/video-player'], function (videojs) {
                     var $videoEl = $('.vjs-hosted__video');
 
-                    if (!$videoEl.length) {
-                        resolve();
+                    if ($videoEl.length === 0) {
+                        // halt execution
+                        return resolve();
                     }
 
                     player = videojs($videoEl.get(0), videojsOptions());

--- a/static/src/javascripts/projects/common/modules/video/onward-container.js
+++ b/static/src/javascripts/projects/common/modules/video/onward-container.js
@@ -36,7 +36,7 @@ define([
         var paginatedEndpoint = endpoint + (page ? '?page=' + page : '');
         component.manipulationType = manipulationType;
         component.endpoint = paginatedEndpoint;
-
+        console.log(el)
         el.innerHTML = ''; // we have no replace in component
 
         return component.fetch(el, 'html');

--- a/static/src/javascripts/projects/common/modules/video/onward-container.js
+++ b/static/src/javascripts/projects/common/modules/video/onward-container.js
@@ -36,7 +36,7 @@ define([
         var paginatedEndpoint = endpoint + (page ? '?page=' + page : '');
         component.manipulationType = manipulationType;
         component.endpoint = paginatedEndpoint;
-        console.log(el)
+
         el.innerHTML = ''; // we have no replace in component
 
         return component.fetch(el, 'html');


### PR DESCRIPTION
## What does this change?

Having a `video-player-dev` and `video-player` is strange.
This move the logic into our build systems (which is where some of it was too).

There was also some changing of the module names to match the module names given by the components, making it even simpler.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

👍 
## Request for comment

@akash1810 @gidsg 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
