### PR TITLE
Disable article component on fronts

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -34,7 +34,7 @@ define([
         this.idealOutcome = '';
         this.canRun = function () {
             var pageObj = window.guardian.config.page;
-            return !(pageObj.isSensitive || pageObj.isLiveBlog) && pageObj.edition === 'UK';
+            return !(pageObj.isSensitive || pageObj.isLiveBlog || pageObj.isFront) && pageObj.edition === 'UK';
         };
 
         var writer = function (linkText, linkHref, copy) {


### PR DESCRIPTION
## What does this change?

The article component was appearing on fronts accidentally.  This PR will ensure the test is not executed on fronts.
## What is the value of this and can you measure success?

None, this is simply a fix to remove the component from fronts.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

Offending include on front:

![image](https://cloud.githubusercontent.com/assets/406099/16947417/ca87aca2-4da6-11e6-8991-37f60c545f91.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
