### PR TITLE
Hosted content selective loading

### DIFF
--- a/common/app/templates/inlineJS/nonBlocking/showUserName.scala.js
+++ b/common/app/templates/inlineJS/nonBlocking/showUserName.scala.js
@@ -4,9 +4,14 @@ try {
 
         if (isVeryModern && user) {
             window.requestAnimationFrame(() => {
-                document.getElementsByClassName('js-profile-info')[0].innerHTML = user.displayName;
-
+                var $profileInfoElem = document.getElementsByClassName('js-profile-info')[0];
                 var $profileNavElem = document.getElementsByClassName('js-profile-nav')[0];
+
+                if (!$profileInfoElem && !$profileNavElem) {
+                    return;
+                }
+
+                $profileInfoElem.innerHTML = user.displayName;
                 $profileNavElem.classList.add('is-signed-in');
 
                 var $signInLinkElem = $profileNavElem.getElementsByTagName('a')[0];

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -60,7 +60,6 @@ define([
         ['cm-load', dfpLoad],
         ['cm-thirdPartyTags', thirdPartyTags.init],
         ['cm-sponsorships', sponsorships.init],
-
         ['cm-paidforBand', paidforBand.init],
         ['cm-paidContainers', paidContainers.init],
         ['cm-ready', function () {

--- a/static/src/javascripts/bootstraps/commercial.js
+++ b/static/src/javascripts/bootstraps/commercial.js
@@ -60,9 +60,7 @@ define([
         ['cm-load', dfpLoad],
         ['cm-thirdPartyTags', thirdPartyTags.init],
         ['cm-sponsorships', sponsorships.init],
-        ['cm-hostedAbout', hostedAbout.init],
-        ['cm-hostedVideo', hostedVideo.init],
-        ['cm-hostedGallery', hostedGallery.init],
+
         ['cm-paidforBand', paidforBand.init],
         ['cm-paidContainers', paidContainers.init],
         ['cm-ready', function () {
@@ -71,6 +69,13 @@ define([
             return Promise.resolve();
         }]
     ];
+
+    if (config.isHosted) {
+        secondaryModules.unshift(
+            ['cm-hostedAbout', hostedAbout.init],
+            ['cm-hostedVideo', hostedVideo.init],
+            ['cm-hostedGallery', hostedGallery.init]);
+    }
 
     if (!(config.switches.staticBadges && config.switches.staticContainerBadges)) {
         primaryModules.push(['cm-badges', badges.init]);

--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -85,7 +85,7 @@ define([
             });
         }
 
-        if (config.isMedia || qwery('video, audio').length) {
+        if ((config.isMedia || qwery('video, audio').length) && !config.isHosted) {
             require(['bootstraps/enhanced/media/main'], function (media) {
                 bootstrapContext('media', media);
             });

--- a/static/src/javascripts/projects/common/modules/commercial/hosted-about.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-about.js
@@ -13,10 +13,6 @@ define([
 ) {
     function init() {
 
-        if (config.page.tones !== 'Hosted') {
-            return Promise.resolve();
-        }
-
         return new Promise(function(resolve) {
 
             var survey = new SurveySimple({

--- a/static/src/javascripts/projects/common/utils/config.js
+++ b/static/src/javascripts/projects/common/utils/config.js
@@ -50,7 +50,9 @@ define([
             return s ? s[0] : null;
         },
 
-        isMedia: ['Video', 'Audio'].indexOf(config.page.contentType) > -1
+        isMedia: ['Video', 'Audio'].indexOf(config.page.contentType) > -1,
+
+        isHosted: config.page.tones === 'Hosted'
 
     }, config);
 });


### PR DESCRIPTION
This addresses the following:
- we are currently loading the media js app on every page!
- there is an initialisation race condition between enhanced media, and hosted video media. This means that hosted video often fails to upgrade, and appears unskinned.
- hosted pages fail to run the `showUserName` inline script without throwing the error: `Cannot set property 'innerHTML' of undefined`
