### PR TITLE
map on container elements to ensure existance

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -397,8 +397,11 @@ define([
         }
 
         var mediaType = getMediaType();
-        var el = $(mediaType === 'video' ? '.js-video-components-container' : '.js-media-popular')[0];
-        onwardContainer.init(el, mediaType);
+        var els = $(mediaType === 'video' ? '.js-video-components-container' : '.js-media-popular');
+
+        els.each(function(el) {
+            onwardContainer.init(el, mediaType);
+        });
     }
 
     function initWithRaven(withPreroll) {


### PR DESCRIPTION
## What does this change?

Running a foreach on the collection ensures that we definitely send an element over to the container.

At the moment we send undefined errors.
## What is the value of this and can you measure success?

No more error
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

🍭 
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
