### PR TITLE
Disable giraffe component on advertising features

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -34,7 +34,7 @@ define([
         this.idealOutcome = '';
         this.canRun = function () {
             var pageObj = window.guardian.config.page;
-            return !(pageObj.isSensitive || pageObj.isLiveBlog || pageObj.isFront) && pageObj.edition === 'UK';
+            return !(pageObj.isSensitive || pageObj.isLiveBlog || pageObj.isFront || pageObj.isAdvertisementFeature) && pageObj.edition === 'UK';
         };
 
         var writer = function (linkText, linkHref, copy) {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/giraffe.js
@@ -20,7 +20,7 @@ define([
 ) {
     return function () {
 
-        this.id = 'GiraffeArticle';
+        this.id = 'GiraffeArticle20160719';
         this.start = '2016-07-18';
         this.expiry = '2016-08-01';
         this.author = 'Alex Ware';


### PR DESCRIPTION
## What does this change?

Removes the giraffe component on advertising features.
## What is the value of this and can you measure success?

None, just a fix.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

![image](https://cloud.githubusercontent.com/assets/406099/16951250/1aca0d26-4dbc-11e6-81b3-21c45e329581.png)
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
