### PR TITLE
Fix short URL lookups for capi merchandising component

### DIFF
--- a/commercial/app/model/commercial/CapiAgent.scala
+++ b/commercial/app/model/commercial/CapiAgent.scala
@@ -22,10 +22,23 @@ object CapiAgent extends Logging {
     val urlsNotInCache = shortUrlIds filterNot cache.contains
 
     def addToCache(contents: Seq[ContentType]): Future[Map[String, Option[ContentType]]] = {
-      val initialValues = urlsNotInCache.map(_ -> None).toMap
-      shortUrlAgent alter (_ ++ initialValues)
-      val newContents = contents.map(content => content.content.shortUrlId -> Some(content)).toMap
-      shortUrlAgent alter (_ ++ newContents)
+
+      /*
+       * There's some ambiguity about short IDs in capi.
+       * To search by ID, the capi query takes the form: /search?ids=p/4z2fv
+       * But the internalShortId field for the result has a leading slash, eg. /p/4z2fv
+       * So for consistency strip leading slash so that it's in a lookupable form,
+       * ie suitable to be included in a capi ids query.
+       */
+      def mkCacheKey(shortUrlId: String): String = shortUrlId.stripPrefix("/")
+
+      shortUrlAgent alter { cache =>
+        val initialValuesForUrlsNotInCache = urlsNotInCache.map(_ -> None).toMap
+        cache ++ initialValuesForUrlsNotInCache
+        cache ++ contents.map { content =>
+          mkCacheKey(content.content.shortUrlId) -> Some(content)
+        }.toMap
+      }
     }
 
     val eventualNewCache = if (urlsNotInCache.isEmpty) {

--- a/commercial/test/model/commercial/CapiAgentTest.scala
+++ b/commercial/test/model/commercial/CapiAgentTest.scala
@@ -11,4 +11,12 @@ class CapiAgentTest extends FlatSpec with Matchers {
   it should "give ID of a valid short URL with campaign suffix" in {
     CapiAgent.idsFromShortUrls(Seq("p/4dy39/stw")) shouldBe Seq("p/4dy39")
   }
+
+  it should "give ID of a valid short URL with leading slash" in {
+    CapiAgent.idsFromShortUrls(Seq("/p/4dy39")) shouldBe Seq("p/4dy39")
+  }
+
+  it should "give ID of a valid short URL with leading slash and campaign suffix" in {
+    CapiAgent.idsFromShortUrls(Seq("/p/4dy39/stw")) shouldBe Seq("p/4dy39")
+  }
 }


### PR DESCRIPTION
I didn't quite fix it in #13631!

This should do it.

There's also a slight improvement to the agent update, to avoid potential dirty reads.

/cc @guardian/commercial-dev 
