### PR TITLE
Habit Digest snap banner

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -83,4 +83,14 @@ trait ABTestSwitches {
     sellByDate = new LocalDate(2016, 7, 25),
     exposeClientSide = true
   )
+
+  val ABHabitFormingDigestPromo = Switch(
+    SwitchGroup.ABTests,
+    "ab-habit-forming-digest-promo",
+    "Show infrequent users a banner offering a curated digest",
+    owners = Seq(Owner.withGithub("katebee")),
+    safeState = On,
+    sellByDate = new LocalDate(2016, 8, 1),
+    exposeClientSide = true
+  )
 }

--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -89,7 +89,7 @@ trait ABTestSwitches {
     "ab-habit-forming-digest-promo",
     "Show infrequent users a banner offering a curated digest",
     owners = Seq(Owner.withGithub("katebee")),
-    safeState = On,
+    safeState = Off,
     sellByDate = new LocalDate(2016, 8, 1),
     exposeClientSide = true
   )

--- a/static/src/javascripts/projects/common/modules/experiments/ab.js
+++ b/static/src/javascripts/projects/common/modules/experiments/ab.js
@@ -13,7 +13,8 @@ define([
     'common/modules/experiments/tests/join-discussion-after-poll',
     'common/modules/experiments/tests/hosted-autoplay',
     'common/modules/experiments/tests/giraffe',
-    'common/modules/experiments/tests/video-caption'
+    'common/modules/experiments/tests/video-caption',
+    'common/modules/experiments/tests/habit-forming-digest-promo'
 ], function (
     reportError,
     config,
@@ -29,7 +30,8 @@ define([
     JoinDiscussionAfterPoll,
     HostedAutoplay,
     Giraffe,
-    VideoCaption
+    VideoCaption,
+    HabitFormingDigestPromo
 ) {
 
     var TESTS = [
@@ -39,6 +41,7 @@ define([
         new JoinDiscussionAfterPoll(),
         new HostedAutoplay(),
         new Giraffe(),
+        new HabitFormingDigestPromo(),
         new VideoCaption()
     ];
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -35,8 +35,7 @@ define([
         this.idealOutcome = 'Visitors click on the CTA and demonstrate demand for the feature';
 
         this.canRun = function () {
-            return !(config.page.isAdvertisementFeature) &&
-            config.page.contentType === 'Article'
+            return !config.page.isAdvertisementFeature && config.page.contentType === 'Article';
         };
 
         var defaultData = {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -36,20 +36,12 @@ define([
 
         this.canRun = function () {
             return !(config.page.isAdvertisementFeature) &&
-            config.page.contentType === 'Article' &&
-            hasSeenMembership();
+            config.page.contentType === 'Article'
         };
 
         var defaultData = {
             arrowRight: svgs('arrowRight')
         };
-
-        // check that the membership banner has been seen and dismissed
-        function hasSeenMembership() {
-            var messageStates = storage.local.get('gu.prefs.messages');
-            return messageStates &&
-            messageStates.indexOf('membership-message-uk-2016-06-24') > -1;
-        }
 
         function renderDigestSnap(messageText, linkText, linkHref, variantName) {
             var data = defaults(

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -33,7 +33,7 @@ define([
         this.idealOutcome = 'Visitors click on the CTA and demonstrate demand for the feature';
 
         this.canRun = function () {
-            return !(config.page.isAdvertisementFeature) && config.page.contentType === 'Article';
+            return !(config.page.isAdvertisementFeature) && config.page.contentType === 'Article' && isInfrequentVisitor();
         };
 
         var defaultData = {
@@ -45,8 +45,7 @@ define([
             this.config = config;
 
             this.templates = {
-                'adblock-sticky-message': digestPromo,
-                'adblock-sticky-message-coin': adblockStickyMessageCoin
+                'adblock-sticky-message': digestPromo
             };
         };
 
@@ -55,25 +54,14 @@ define([
         };
 
         // check if the user is one of the target audience
-        function isInfrequentVisitor(cookieName) {
-            var habitCookie = cookies.get(cookieName);
-            if (!(habitCookie) && storage.local.isStorageAvailable()) {
+        function isInfrequentVisitor() {
+            if (storage.local.isStorageAvailable()) {
                 var alreadyVisited = storage.local.get('gu.alreadyVisited');
-                // check alreadyVisited and visit frequency?
-                return true;
+                if (alreadyVisited > 3) {
+                    return true;
+                }
             }
             return false;
-        }
-
-        // makes the thing
-        function renderDigestSnap2(messageText, linkText) {
-            return fastdomPromise.write(function () {
-                var article = document.getElementsByClassName('content__article-body')[0];
-                var insertionPoint = article.getElementsByTagName('p')[1];
-                var habitDigest = document.createElement('div');
-                habitDigest.innerHTML = digestPromo;
-                article.insertBefore(habitDigest, insertionPoint);
-            });
         }
 
         function renderDigestSnap(messageText, linkText, linkHref) {
@@ -93,25 +81,25 @@ define([
             {
                 id: 'digest',
                 test: function () {
-                    var messageText = "Get a package of stories tailored to you";
-                    var linkText = "Get started";
-                    var linkHref = "http://www.google.com";
+                    var messageText = 'Get a package of stories tailored to you';
+                    var linkText = 'Get started';
+                    var linkHref = 'http://www.google.com';
                     renderDigestSnap(messageText, linkText, linkHref);
                 }
             }, {
                 id: 'weekend',
                 test: function () {
-                    var messageText = "Get the best stuff you didn't have time to read during the week delivered to you every Saturday";
-                    var linkText = "Sign up";
-                    var linkHref = "http://www.google.com";
+                    var messageText = 'Get the best stuff you didn\'t have time to read during the week delivered to you every Saturday';
+                    var linkText = 'Sign up';
+                    var linkHref = 'http://www.google.com';
                     renderDigestSnap(messageText, linkText, linkHref);
                 }
             }, {
                 id: 'headlines',
                 test: function () {
-                    var messageText = "Get the top headlines delivered to you every morning";
-                    var linkText = "Sign up";
-                    var linkHref = "http://www.google.com";
+                    var messageText = 'Get the top headlines delivered to you every morning';
+                    var linkText = 'Sign up';
+                    var linkHref = 'http://www.google.com';
                     renderDigestSnap(messageText, linkText, linkHref);
                 }
             }

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -27,7 +27,7 @@ define([
         this.description = 'Show infrequent users a banner offering a curated digest';
         this.audience = 0;
         this.audienceOffset = 0;
-        this.successMeasure = 'Find if their is demand for various Guardian digest offerings';
+        this.successMeasure = 'Find if there is demand for various Guardian digest offerings';
         this.audienceCriteria = 'Infrequent visitors, excluding first time visits';
         this.dataLinkNames = 'habit forming digest promo';
         this.idealOutcome = 'Visitors click on the CTA and demonstrate demand for the feature';

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -1,0 +1,120 @@
+define([
+    'common/utils/config',
+    'common/utils/storage',
+    'common/utils/template',
+    'common/utils/fastdom-promise',
+    'common/modules/ui/message',
+    'common/views/svgs',
+    'lodash/objects/defaults',
+    'Promise',
+    'text!common/views/experiments/digest-promo.html'
+], function (
+    config,
+    storage,
+    template,
+    fastdomPromise,
+    Message,
+    svgs,
+    defaults,
+    Promise,
+    digestPromo
+) {
+    return function () {
+        this.id = 'HabitFormingDigestPromo';
+        this.start = '2016-07-13';
+        this.expiry = '2016-08-13';
+        this.author = 'Kate Whalen';
+        this.description = 'Show infrequent users a banner offering a curated digest';
+        this.audience = 1;
+        this.audienceOffset = 0;
+        this.successMeasure = 'Find if their is demand for various Guardian digest offerings';
+        this.audienceCriteria = 'Infrequent visitors, excluding first time visits';
+        this.dataLinkNames = 'habit forming digest promo';
+        this.idealOutcome = 'Visitors click on the CTA and demonstrate demand for the feature';
+
+        this.canRun = function () {
+            return !(config.page.isAdvertisementFeature) && config.page.contentType === 'Article';
+        };
+
+        var defaultData = {
+            arrowWhiteRight: svgs('arrowWhiteRight')
+        };
+
+        var DigestBanner = function (template, config) {
+            this.template = template;
+            this.config = config;
+
+            this.templates = {
+                'adblock-sticky-message': digestPromo,
+                'adblock-sticky-message-coin': adblockStickyMessageCoin
+            };
+        };
+
+        DigestBanner.prototype.renderTemplate = function () {
+            return template(this.templates[this.template], this.config);
+        };
+
+        // check if the user is one of the target audience
+        function isInfrequentVisitor(cookieName) {
+            var habitCookie = cookies.get(cookieName);
+            if (!(habitCookie) && storage.local.isStorageAvailable()) {
+                var alreadyVisited = storage.local.get('gu.alreadyVisited');
+                // check alreadyVisited and visit frequency?
+                return true;
+            }
+            return false;
+        }
+
+        // makes the thing
+        function renderDigestSnap2(messageText, linkText) {
+            return fastdomPromise.write(function () {
+                var article = document.getElementsByClassName('content__article-body')[0];
+                var insertionPoint = article.getElementsByTagName('p')[1];
+                var habitDigest = document.createElement('div');
+                habitDigest.innerHTML = digestPromo;
+                article.insertBefore(habitDigest, insertionPoint);
+            });
+        }
+
+        function renderDigestSnap(messageText, linkText, linkHref) {
+            var data = defaults({linkText: linkText}, {messageText: messageText}, {linkHref: linkHref}, defaultData);
+
+            var cssModifierClass = 'membership-message';
+
+            return new Message('habit-digest-message-07-16', {
+                pinOnHide: false,
+                siteMessageLinkName: 'habit digest message',
+                siteMessageCloseBtn: 'hide',
+                cssModifierClass: cssModifierClass
+            }).show(template(digestPromo, data));
+        }
+
+        this.variants = [
+            {
+                id: 'digest',
+                test: function () {
+                    var messageText = "Get a package of stories tailored to you";
+                    var linkText = "Get started";
+                    var linkHref = "http://www.google.com";
+                    renderDigestSnap(messageText, linkText, linkHref);
+                }
+            }, {
+                id: 'weekend',
+                test: function () {
+                    var messageText = "Get the best stuff you didn't have time to read during the week delivered to you every Saturday";
+                    var linkText = "Sign up";
+                    var linkHref = "http://www.google.com";
+                    renderDigestSnap(messageText, linkText, linkHref);
+                }
+            }, {
+                id: 'headlines',
+                test: function () {
+                    var messageText = "Get the top headlines delivered to you every morning";
+                    var linkText = "Sign up";
+                    var linkHref = "http://www.google.com";
+                    renderDigestSnap(messageText, linkText, linkHref);
+                }
+            }
+        ];
+    };
+});

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -6,7 +6,6 @@ define([
     'common/modules/ui/message',
     'common/modules/commercial/user-features',
     'common/views/svgs',
-    'lodash/objects/defaults',
     'lodash/arrays/uniq',
     'text!common/views/experiments/habit-digest-promo.html'
 ], function (
@@ -17,7 +16,6 @@ define([
     Message,
     userFeatures,
     svgs,
-    defaults,
     uniq,
     digestPromo
 ) {
@@ -38,17 +36,14 @@ define([
             return !config.page.isAdvertisementFeature && config.page.contentType === 'Article';
         };
 
-        var defaultData = {
-            arrowRight: svgs('arrowRight')
-        };
-
         function renderDigestSnap(messageText, linkText, linkHref, variantName) {
-            var data = defaults(
-                {linkText: linkText},
-                {messageText: messageText},
-                {linkHref: linkHref},
-                {variantName: variantName},
-                defaultData);
+            var templateData = {
+                linkText: linkText,
+                messageText: messageText,
+                linkHref: linkHref,
+                variantName: variantName,
+                arrowRight: svgs('arrowRight')
+            };
 
             var cssModifierClass = 'habit-digest';
 
@@ -59,7 +54,7 @@ define([
                 cssModifierClass: cssModifierClass
             });
 
-            if (message.show(template(digestPromo, data))) {
+            if (message.show(template(digestPromo, templateData))) {
                 // Only mark the message as closed if it was actually shown
                 // (i.e. there was no clash with another message)
                 message.remember();

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -51,13 +51,6 @@ define([
             messageStates.indexOf('membership-message-uk-2016-06-24') > -1;
         }
 
-        // alternative behaviour to other site messages: we only want to display this banner once to each user
-        function remember() {
-            var messageStates = storage.local.get('gu.prefs.messages') || [];
-            messageStates.push('habit-digest-message-07-16');
-            storage.local.set('gu.prefs.messages', uniq(messageStates));
-        }
-
         function renderDigestSnap(messageText, linkText, linkHref, variantName) {
             var data = defaults(
                 {linkText: linkText},
@@ -68,12 +61,14 @@ define([
 
             var cssModifierClass = 'habit-digest';
 
-            return new Message('habit-digest-message-07-16', {
+            var message = new Message('habit-digest-message-07-16', {
                 pinOnHide: false,
                 siteMessageLinkName: 'habit digest message',
                 siteMessageCloseBtn: 'habit digest hide',
                 cssModifierClass: cssModifierClass
-            }).show(template(digestPromo, data));
+            });
+            message.show(template(digestPromo, data));
+            message.remember();
         }
 
         this.variants = [
@@ -84,7 +79,6 @@ define([
                     var linkText = 'Sign up';
                     var linkHref = '/survey/mydigest';
                     renderDigestSnap(messageText, linkText, linkHref, 'digest');
-                    remember();
                 }
             }, {
                 id: 'weekend',
@@ -93,7 +87,6 @@ define([
                     var linkText = 'Sign up';
                     var linkHref = '/survey/weekendreading';
                     renderDigestSnap(messageText, linkText, linkHref, 'weekend');
-                    remember();
                 }
             }, {
                 id: 'headlines',
@@ -102,7 +95,6 @@ define([
                     var linkText = 'Sign up';
                     var linkHref = '/info/2015/dec/08/daily-email-uk';
                     renderDigestSnap(messageText, linkText, linkHref, 'headlines');
-                    remember();
                 }
             }
         ];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -59,8 +59,12 @@ define([
                 siteMessageCloseBtn: 'habit digest hide',
                 cssModifierClass: cssModifierClass
             });
-            message.show(template(digestPromo, data));
-            message.remember();
+
+            if (message.show(template(digestPromo, data))) {
+                // Only mark the message as closed if it was actually shown
+                // (i.e. there was no clash with another message)
+                message.remember();
+            }
         }
 
         this.variants = [

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -26,11 +26,11 @@ define([
         this.start = '2016-07-13';
         this.expiry = '2016-08-13';
         this.author = 'Kate Whalen';
-        this.description = 'Show infrequent users a banner offering a curated digest';
+        this.description = 'For just one pageview, show users a banner offering a curated digest';
         this.audience = 0;
         this.audienceOffset = 0;
         this.successMeasure = 'Find if there is demand for various Guardian digest offerings';
-        this.audienceCriteria = 'Infrequent visitors, excluding first time visits';
+        this.audienceCriteria = 'Everyone';
         this.dataLinkNames = 'habit forming digest promo';
         this.idealOutcome = 'Visitors click on the CTA and demonstrate demand for the feature';
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -37,7 +37,7 @@ define([
         };
 
         var defaultData = {
-            arrowWhiteRight: svgs('arrowWhiteRight')
+            arrowRight: svgs('arrowRight')
         };
 
         var DigestBanner = function (template, config) {
@@ -67,7 +67,7 @@ define([
         function renderDigestSnap(messageText, linkText, linkHref) {
             var data = defaults({linkText: linkText}, {messageText: messageText}, {linkHref: linkHref}, defaultData);
 
-            var cssModifierClass = 'membership-message';
+            var cssModifierClass = 'habit-digest';
 
             return new Message('habit-digest-message-07-16', {
                 pinOnHide: false,

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -37,24 +37,12 @@ define([
         this.canRun = function () {
             return !(config.page.isAdvertisementFeature) &&
             config.page.contentType === 'Article' &&
-            isInfrequentVisitor() &&
             hasSeenMembership();
         };
 
         var defaultData = {
             arrowRight: svgs('arrowRight')
         };
-
-        // check if the user is one of the target audience
-        function isInfrequentVisitor() {
-            if (storage.local.isStorageAvailable()) {
-                var alreadyVisited = storage.local.get('gu.alreadyVisited') || 0;
-                if (alreadyVisited > 3 && !userFeatures.isPayingMember()) {
-                    return true;
-                }
-            }
-            return false;
-        }
 
         // check that the membership banner has been seen and dismissed
         function hasSeenMembership() {

--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -7,6 +7,7 @@ define([
     'common/modules/commercial/user-features',
     'common/views/svgs',
     'lodash/objects/defaults',
+    'lodash/arrays/uniq',
     'text!common/views/experiments/habit-digest-promo.html'
 ], function (
     config,
@@ -17,6 +18,7 @@ define([
     userFeatures,
     svgs,
     defaults,
+    uniq,
     digestPromo
 ) {
     return function () {
@@ -35,7 +37,8 @@ define([
         this.canRun = function () {
             return !(config.page.isAdvertisementFeature) &&
             config.page.contentType === 'Article' &&
-            isInfrequentVisitor();
+            isInfrequentVisitor() &&
+            hasSeenMembership();
         };
 
         var defaultData = {
@@ -51,6 +54,20 @@ define([
                 }
             }
             return false;
+        }
+
+        // check that the membership banner has been seen and dismissed
+        function hasSeenMembership() {
+            var messageStates = storage.local.get('gu.prefs.messages');
+            return messageStates &&
+            messageStates.indexOf('membership-message-uk-2016-06-24') > -1;
+        }
+
+        // alternative behaviour to other site messages: we only want to display this banner once to each user
+        function remember() {
+            var messageStates = storage.local.get('gu.prefs.messages') || [];
+            messageStates.push('habit-digest-message-07-16');
+            storage.local.set('gu.prefs.messages', uniq(messageStates));
         }
 
         function renderDigestSnap(messageText, linkText, linkHref, variantName) {
@@ -79,6 +96,7 @@ define([
                     var linkText = 'Sign up';
                     var linkHref = '/survey/mydigest';
                     renderDigestSnap(messageText, linkText, linkHref, 'digest');
+                    remember();
                 }
             }, {
                 id: 'weekend',
@@ -87,6 +105,7 @@ define([
                     var linkText = 'Sign up';
                     var linkHref = '/survey/weekendreading';
                     renderDigestSnap(messageText, linkText, linkHref, 'weekend');
+                    remember();
                 }
             }, {
                 id: 'headlines',
@@ -95,6 +114,7 @@ define([
                     var linkText = 'Sign up';
                     var linkHref = '/info/2015/dec/08/daily-email-uk';
                     renderDigestSnap(messageText, linkText, linkHref, 'headlines');
+                    remember();
                 }
             }
         ];

--- a/static/src/javascripts/projects/common/views/experiments/digest-promo.html
+++ b/static/src/javascripts/projects/common/views/experiments/digest-promo.html
@@ -1,7 +1,8 @@
 
 <div class="site-message__digest">
-    <p class="digest-text__copy"><span class="digest-text__question">Pressed for time? </span>
-    <span class="digest-text__message"><%=messageText%></span></p>
+    <span class="digest-text__copy">
+        <span class="digest-text__question">Pressed for time? </span><%=messageText%>
+    </span>
     <ul class="site-message__actions u-unstyled">
         <li class="site-message__actions__item">
             <%=arrowRight%>

--- a/static/src/javascripts/projects/common/views/experiments/digest-promo.html
+++ b/static/src/javascripts/projects/common/views/experiments/digest-promo.html
@@ -1,13 +1,11 @@
 
-<div class="site-message__message site-message__message--membership" style="display:flex;align-items:center;">
-    <p style="margin:0;"><span class="digest-text__question" style="font-weight:bold">Pressed for time? </span>
+<div class="site-message__digest">
+    <p class="digest-text__copy"><span class="digest-text__question">Pressed for time? </span>
     <span class="digest-text__message"><%=messageText%></span></p>
-    <div style="display:inline">
-        <ul class="site-message__actions u-unstyled">
-            <li class="site-message__actions__item">
-                <%=arrowWhiteRight%>
-                <a href="<%=linkHref%>" target="_blank" data-link-name="<%=linkText%>"><%=linkText%></a>
-            </li>
-        </ul>
-    </div>
+    <ul class="site-message__actions u-unstyled">
+        <li class="site-message__actions__item">
+            <%=arrowRight%>
+            <a href="<%=linkHref%>" target="_blank" data-link-name="<%=linkText%>"><%=linkText%></a>
+        </li>
+    </ul>
 </div>

--- a/static/src/javascripts/projects/common/views/experiments/digest-promo.html
+++ b/static/src/javascripts/projects/common/views/experiments/digest-promo.html
@@ -1,0 +1,13 @@
+
+<div class="site-message__message site-message__message--membership" style="display:flex;align-items:center;">
+    <p style="margin:0;"><span class="digest-text__question" style="font-weight:bold">Pressed for time? </span>
+    <span class="digest-text__message"><%=messageText%></span></p>
+    <div style="display:inline">
+        <ul class="site-message__actions u-unstyled">
+            <li class="site-message__actions__item">
+                <%=arrowWhiteRight%>
+                <a href="<%=linkHref%>" target="_blank" data-link-name="<%=linkText%>"><%=linkText%></a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/static/src/javascripts/projects/common/views/experiments/habit-digest-promo.html
+++ b/static/src/javascripts/projects/common/views/experiments/habit-digest-promo.html
@@ -6,7 +6,7 @@
     <ul class="site-message__actions u-unstyled">
         <li class="site-message__actions__item">
             <%=arrowRight%>
-            <a href="<%=linkHref%>" target="_blank" data-link-name="<%=linkText%>"><%=linkText%></a>
+            <a href="<%=linkHref%>" target="_blank" data-link-name="habit digest <%=variantName%>"><%=linkText%></a>
         </li>
     </ul>
 </div>

--- a/static/src/stylesheets/content.scss
+++ b/static/src/stylesheets/content.scss
@@ -104,6 +104,7 @@
 
 @import 'module/experiments/_affix';
 @import 'module/experiments/_giraffe';
+@import 'module/experiments/_habit-digest';
 
 /* ==========================================================================
    Icons

--- a/static/src/stylesheets/module/experiments/_habit-digest.scss
+++ b/static/src/stylesheets/module/experiments/_habit-digest.scss
@@ -11,7 +11,6 @@
 
     .inline-icon {
         fill: $guardian-brand;
-
     }
 
     .u-vertical-align-middle-icon__svg {
@@ -38,6 +37,7 @@
     .site-message__actions__item {
         color: $guardian-brand;
         border-color: $guardian-brand;
+        cursor: pointer;
 
         a {
             color: $guardian-brand;
@@ -53,10 +53,16 @@
     }
 
     .site-message__close-btn {
-        border-color: #dfdfdf
+        border-color: rgba(189, 189, 189, .5);
+
+        &:hover,
+        &:focus,
+        &:active {
+            border-color: rgba(189, 189, 189, 1);
+        }
     }
 
     .inline-close--small {
-        fill: #dfdfdf
+        fill: $neutral-3;
     }
 }

--- a/static/src/stylesheets/module/experiments/_habit-digest.scss
+++ b/static/src/stylesheets/module/experiments/_habit-digest.scss
@@ -11,6 +11,11 @@
 
     .inline-icon {
         fill: $guardian-brand;
+
+    }
+
+    .u-vertical-align-middle-icon__svg {
+        vertical-align: inherit;
     }
 
     .site-message__digest {

--- a/static/src/stylesheets/module/experiments/_habit-digest.scss
+++ b/static/src/stylesheets/module/experiments/_habit-digest.scss
@@ -1,0 +1,55 @@
+
+.site-message--habit-digest {
+    background-color: #ffffff;
+    border-top: 1px solid $guardian-brand;
+    color: $guardian-brand;
+
+    .site-message__media {
+        display: table-cell;
+        padding: 10px 10px 0 0;
+    }
+
+    .inline-icon {
+        fill: $guardian-brand;
+    }
+
+    .digest-text__copy {
+        margin: 0 10px 0 0;
+        font-size: 0.9rem;
+    }
+
+    .digest-text__question {
+        font-weight: bold;
+        font-size: 1rem;
+    }
+
+    .site-message__actions {
+        margin: 8px 0px;
+    }
+
+    .site-message__actions__item {
+        color: $guardian-brand;
+        border-color: $guardian-brand;
+
+        a {
+            color: $guardian-brand;
+        }
+
+        .inline-icon {
+            fill: $guardian-brand;
+        }
+    }
+
+    .site-message__close {
+        width: 32px;
+        padding-top: 10px;
+    }
+
+    .site-message__close-btn {
+        border-color: #bdbdbd;
+    }
+
+    .inline-close--small {
+        fill: #bdbdbd;
+    }
+}

--- a/static/src/stylesheets/module/experiments/_habit-digest.scss
+++ b/static/src/stylesheets/module/experiments/_habit-digest.scss
@@ -6,25 +6,28 @@
 
     .site-message__media {
         display: table-cell;
-        padding: 10px 10px 0 0;
+        padding: $gs-baseline/2 $gs-gutter/2 0 0;
     }
 
     .inline-icon {
         fill: $guardian-brand;
     }
 
+    .site-message__digest {
+        margin-right: $gs-gutter/2;
+    }
+
     .digest-text__copy {
-        margin: 0 10px 0 0;
-        font-size: 0.9rem;
+        display: table-cell;
+        vertical-align: middle;
     }
 
     .digest-text__question {
         font-weight: bold;
-        font-size: 1rem;
     }
 
     .site-message__actions {
-        margin: 8px 0px;
+        margin: $gs-baseline/2 0;
     }
 
     .site-message__actions__item {
@@ -41,15 +44,14 @@
     }
 
     .site-message__close {
-        width: 32px;
-        padding-top: 10px;
+        padding-top: $gs-baseline/2;
     }
 
     .site-message__close-btn {
-        border-color: #bdbdbd;
+        border-color: #dfdfdf
     }
 
     .inline-close--small {
-        fill: #bdbdbd;
+        fill: #dfdfdf
     }
 }


### PR DESCRIPTION
## What does this change?

Adds an **inactive** test (currently off and at zero audience) for the Habit Digest promo. This test will show users a banner offering a curated digest.

The banner co-opts the Membership Message banner to display one of three variant messages to the visitor (see screenshots). It has a lower priority than the Breaking News banner, and will not appear again once a visitor has dismissed it.
- Users will only see one snap variant
- Users will only see the snap once
- Breaking news gets priority

The sign-up button is a false door / 404 test that will open a info page.
## What is the value of this and can you measure success?
- Discover if there is demand for various Guardian digest offerings
- See which version of the copy generates greatest engagement

Ideally, visitors will click on the CTA and demonstrate demand for the feature.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

<img width="651" alt="picture 126" src="https://cloud.githubusercontent.com/assets/8607683/16959157/8bb46274-4ddb-11e6-8cd3-d75b6a02da95.png">
## For a subsequent PR:
- ~~Check the links in the [banner variants](https://github.com/guardian/frontend/blob/2920e52b7a8c1cbb1a6204f9964211f6a846103c/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js#L96): are they correct and do the landing pages exist?~~ **done**
- Run the test (turn AB switch on and set audience percentage)
## Request for comment

@joelochlann 
