### PR TITLE
listen to event before being able to play on video

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/main.js
@@ -87,8 +87,8 @@ define([
 
         if (config.isMedia || qwery('video, audio').length) {
             require(['bootstraps/enhanced/media/main', 'bootstraps/enhanced/media/analytics'], function (media, mediaAnalytics) {
-                bootstrapContext('media', media);
                 bootstrapContext('media : analytics', mediaAnalytics);
+                bootstrapContext('media', media);
             });
         }
 


### PR DESCRIPTION
## What does this change?

We need to attach the event listeners before setting videojs off as that could play the video before we're listening.
## What is the value of this and can you measure success?
## Does this affect other platforms - Amp, Apps, etc?
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
