### PR TITLE
Load the GA JS before Omniture

### DIFF
--- a/common/app/views/fragments/analytics/base.scala.html
+++ b/common/app/views/fragments/analytics/base.scala.html
@@ -9,9 +9,9 @@
                             Core Analytics
 ******************************************************************************@
 
-@fragments.analytics.omniture(page)
-
 @fragments.analytics.google(page)
+
+@fragments.analytics.omniture(page)
 
 @fragments.analytics.comscore(page)
 


### PR DESCRIPTION
## What does this change?

Load the GA snippet before the Omniture one
## What is the value of this and can you measure success?

Just to see if this improves the GA confidence (clutching at straws)
## Does this affect other platforms - Amp, Apps, etc?

No 
## Screenshots

n/a
## Request for comment

anyone

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
