### PR TITLE
Fixing bug in new header menu

### DIFF
--- a/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
+++ b/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js
@@ -13,8 +13,7 @@ define([
 
     function animateMenuOpen() {
         return fastdomPromise.write(function () {
-            mainMenuEl.addClass('shown');
-            mainMenuEl.addClass('off-screen');
+            mainMenuEl.addClass('off-screen shown');
 
             burgerMenu.addClass('new-header__burger-icon--open');
             burgerLink.attr('href', '#');
@@ -37,30 +36,32 @@ define([
 
     function animateMenuClose() {
         return fastdomPromise.write(function () {
-            mainMenuEl.addClass('off-screen');
+            if (mainMenuEl.hasClass('shown')) {
+                mainMenuEl.addClass('off-screen');
 
-            burgerMenu.removeClass('new-header__burger-icon--open');
-            burgerLink.attr('href', mainMenuId);
+                burgerMenu.removeClass('new-header__burger-icon--open');
+                burgerLink.attr('href', mainMenuId);
 
-            // TODO: Support browsers that don't have transitions
-            // We still want to hide this
-            if (mainMenuEl.length > 0) {
+                // TODO: Support browsers that don't have transitions
+                // We still want to hide this
+                if (mainMenuEl.length > 0) {
 
-                mainMenuEl[0].addEventListener('transitionend', function handler() {
+                    mainMenuEl[0].addEventListener('transitionend', function handler() {
 
-                    mainMenuEl[0].removeEventListener('transitionend', handler);
+                        mainMenuEl[0].removeEventListener('transitionend', handler);
 
-                    return fastdomPromise.write(function () {
-                        mainMenuEl.removeClass('off-screen');
-                        mainMenuEl.removeClass('shown');
-                    }).then(function() {
                         return fastdomPromise.write(function () {
-                            $('.new-header__nav__menu-button').focus();
-                            // Users should be able to scroll again
-                            html.css('overflow', '');
+                            mainMenuEl.removeClass('off-screen');
+                            mainMenuEl.removeClass('shown');
+                        }).then(function () {
+                            return fastdomPromise.write(function () {
+                                $('.new-header__nav__menu-button').focus();
+                                // Users should be able to scroll again
+                                html.css('overflow', '');
+                            });
                         });
                     });
-                });
+                }
             }
         });
     }


### PR DESCRIPTION
## What does this change?

This fixing a problem that sometimes arises in the new header menu.

The bug seems to happen when the function `animateMenuClose` runs when the page loads. Even though there is no transition yet, [this event listener](https://github.com/guardian/frontend/blob/52756757d4c9b942c1cb6ad357081d787ded0760/static/src/javascripts/projects/common/modules/navigation/newHeaderNavigation.js#L49) is set. When you then open the menu the class `shown` gets added to the menu container. Then, the transition ends which triggers the callback and removes the class `shown`. This bug looks like this:
![navbug](https://cloud.githubusercontent.com/assets/8774970/16988719/47857396-4e89-11e6-80f8-c8c257283fca.gif)

Now everything is fine!
![navworking](https://cloud.githubusercontent.com/assets/8774970/16988726/4c07fa42-4e89-11e6-935f-7bd3bf3f13b4.gif)
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@SiAdcock @zeftilldeath 

❄️ 🐱 🐀 ⚡ 🐴 🐣 🐝 🔥 🐟 🐙 🐍 🐉 🍃 🌸 🌺 🍄 🌱 💧  
