### PR TITLE
ensure hard disk is encrypted

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -56,8 +56,13 @@ create_frontend_properties() {
     if [[ ! -d "$path" ]]; then
       mkdir "$path"
     fi
-
-    aws s3 cp --profile frontend s3://aws-frontend-store/template-frontend.properties "$path/$filename"
+    
+    if [[ "$(fdesetup status)" != "FileVault is On." ]]; then
+      echo your hard disk is not encrypted!
+    else
+      aws s3 cp --profile frontend s3://aws-frontend-store/template-frontend.properties "$path/$filename"
+    fi
+ 
   fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -57,12 +57,16 @@ create_frontend_properties() {
       mkdir "$path"
     fi
     
-    if [[ "$(fdesetup status)" != "FileVault is On." ]]; then
-      echo your hard disk is not encrypted! follow these instructions: https://support.apple.com/en-gb/HT204837
-    else
-      aws s3 cp --profile frontend s3://aws-frontend-store/template-frontend.properties "$path/$filename"
+    if linux; then
+        EXTRA_STEPS+=("Sorry, can't check if your hard disk is encryped so won't download frontend.properties.  Please check (applies to both portable and Desktop machines) and download from s3://aws-frontend-store/template-frontend.properties")
+    elif mac; then
+      if [[ "$(fdesetup status)" != "FileVault is On." ]]; then
+        EXTRA_STEPS+=("won't download frontend.properties as your hard disk is not encrypted! Follow these instructions: https://support.apple.com/en-gb/HT204837")
+      else
+        aws s3 cp --profile frontend s3://aws-frontend-store/template-frontend.properties "$path/$filename"
+      fi
     fi
- 
+    
   fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -58,7 +58,7 @@ create_frontend_properties() {
     fi
     
     if [[ "$(fdesetup status)" != "FileVault is On." ]]; then
-      echo your hard disk is not encrypted!
+      echo your hard disk is not encrypted! follow these instructions: https://support.apple.com/en-gb/HT204837
     else
       aws s3 cp --profile frontend s3://aws-frontend-store/template-frontend.properties "$path/$filename"
     fi


### PR DESCRIPTION
Everyone's hard disk should be encrypted, this just adds a check to make sure it's so before downloading the properties file from S3.

Not sure how to do it on linux - someone who knows might update that side of the script?

@TBonnin 
@adamnfish @janua you are linux guys, what do you think?
