### PR TITLE
Commercial: remove obsolete ad sizes

### DIFF
--- a/applications/app/views/fragments/galleryBody.scala.html
+++ b/applications/app/views/fragments/galleryBody.scala.html
@@ -94,8 +94,8 @@
                             adSlot,
                             Seq("gallery-inline", "dark"),
                             Map(
-                                "mobile" -> (Seq("1,1", "300,50") ++ mpuSlotSize),
-                                "mobile-landscape" -> (Seq("1,1", "300,50", "320,50") ++ mpuSlotSize),
+                                "mobile" -> (Seq("1,1") ++ mpuSlotSize),
+                                "mobile-landscape" -> (Seq("1,1") ++ mpuSlotSize),
                                 "tablet" -> Seq("1,1", "300,250")
                             )
                         )

--- a/applications/app/views/fragments/paidAdvertisementGalleryBody.scala.html
+++ b/applications/app/views/fragments/paidAdvertisementGalleryBody.scala.html
@@ -79,8 +79,8 @@
                             adSlot,
                             Seq("gallery-inline", "dark"),
                             Map(
-                                "mobile" -> (Seq("1,1", "300,50") ++ mpuSlotSize),
-                                "mobile-landscape" -> (Seq("1,1", "300,50", "320,50") ++ mpuSlotSize),
+                                "mobile" -> (Seq("1,1") ++ mpuSlotSize),
+                                "mobile-landscape" -> (Seq("1,1") ++ mpuSlotSize),
                                 "tablet" -> Seq("1,1", "300,250")
                             )
                         )

--- a/static/src/javascripts/projects/common/modules/commercial/ad-sizes.js
+++ b/static/src/javascripts/projects/common/modules/commercial/ad-sizes.js
@@ -11,7 +11,6 @@ define(function () {
         fluid:                  AdSize(0, 0),
 
         // guardian proprietary ad sizes
-        stickyMpu:              AdSize(300, 251),
         badge:                  AdSize(140, 90),
         merchandisingHigh:      AdSize(88, 87),
         merchandising:          AdSize(88, 88),

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/create-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/create-slot.js
@@ -32,7 +32,6 @@ define([
                 mobile: compile(
                     adSizes.outOfPage,
                     adSizes.mpu,
-                    adSizes.stickyMpu,
                     adSizes.halfPage,
                     config.page.edition === 'US' ? adSizes.portrait : null
                 )

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
@@ -55,22 +55,12 @@ define([
     sizeCallbacks[adSizes.fluid] = addFluid250(['ad-slot--top-banner-ad']);
 
     /**
-     * Trigger sticky scrolling if the ad has the magic 'sticky' size
-     */
-    sizeCallbacks[adSizes.stickyMpu] = function (_, advert) {
-        stickyMpu(bonzo(advert.node));
-    };
-
-    /**
      * Trigger sticky scrolling for MPUs in the right-hand article column
      */
     sizeCallbacks[adSizes.mpu] = function (_, advert) {
         var $node = bonzo(advert.node);
         if ($node.hasClass('ad-slot--right')) {
-            var mobileAdSizes = advert.sizes.mobile;
-            if (mobileAdSizes && mobileAdSizes.some(function (size) { return size[0] === 300 && size[1] === 251; })) {
-                stickyMpu($node);
-            }
+            stickyMpu($node);
         } else {
             return addFluid(['ad-slot--facebook'])(_, advert);
         }

--- a/static/test/javascripts/spec/common/commercial/article-aside-adverts.spec.js
+++ b/static/test/javascripts/spec/common/commercial/article-aside-adverts.spec.js
@@ -77,7 +77,7 @@ define([
 
         it('should have the correct size mappings', function (done) {
             articleAsideAdverts.init().then(function () {
-                expect($('.ad-slot', $fixturesContainer).data('mobile')).toBe('1,1|300,250|300,251|300,600');
+                expect($('.ad-slot', $fixturesContainer).data('mobile')).toBe('1,1|300,250|300,600');
                 done();
             });
         });


### PR DESCRIPTION
We're getting rid of 300x251, an old ad size we used to make an MPU sticky, because the MPU in the right column always sticks.

Also a few remnants of 300x50 and 320x50 that are long dead.

cc @guardian/commercial-dev 
