### PR TITLE
Add more Google Analytics trackers

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -17,43 +17,47 @@
         @***************************************************************************************
         * Code that is customised by us                                                        *
         ***************************************************************************************@
-        ga('create', '@GoogleAnalyticsAccount.account', 'auto');
+        @for(tracker <- Seq(GoogleAnalyticsAccount.editorialProd, GoogleAnalyticsAccount.editorialTest, GoogleAnalyticsAccount.headerBidding)) {
+            ga('create', '@tracker.trackingId', 'auto', '@tracker.trackerName');
+        }
 
-        ga('set', 'forceSSL', true);
+        @defining(GoogleAnalyticsAccount.editorialTracker.trackerName) { trackerName =>
+            ga('@{trackerName}.set', 'forceSSL', true);
 
-        ga('set', 'title', guardian.config.page.webTitle);
+            ga('@{trackerName}.set', 'title', guardian.config.page.webTitle);
 
-        @***************************************************************************************
-        * Custom dimensions common to all platforms across the whole Guardian estate           *
-        ***************************************************************************************@
-        ga('set', 'dimension1', guardian.config.ophan.pageViewId);
-        ga('set', 'dimension2', guardian.config.ophan.browserId);
-        ga('set', 'dimension3', 'theguardian.com'); @* Platform *@
+            @***************************************************************************************
+            * Custom dimensions common to all platforms across the whole Guardian estate           *
+            ***************************************************************************************@
+            ga('@{trackerName}.set', 'dimension1', guardian.config.ophan.pageViewId);
+            ga('@{trackerName}.set', 'dimension2', guardian.config.ophan.browserId);
+            ga('@{trackerName}.set', 'dimension3', 'theguardian.com'); @* Platform *@
 
-        @***************************************************************************************
-        * Custom dimensions for 'editorial' platforms (this site, the mobile apps, etc.)       *
-        * Some of these will be undefined for non-content pages, but that's fine.              *
-        ***************************************************************************************@
-        ga('set', 'dimension4', guardian.config.page.section);
-        ga('set', 'dimension5', guardian.config.page.contentType);
-        ga('set', 'dimension6', guardian.config.page.commissioningDesk);
-        ga('set', 'dimension7', guardian.config.page.contentId);
-        ga('set', 'dimension8', guardian.config.page.authorIds);
-        ga('set', 'dimension9', guardian.config.page.keywordIds);
-        ga('set', 'dimension10', guardian.config.page.toneIds);
-        ga('set', 'dimension11', guardian.config.page.seriesId);
+            @***************************************************************************************
+            * Custom dimensions for 'editorial' platforms (this site, the mobile apps, etc.)       *
+            * Some of these will be undefined for non-content pages, but that's fine.              *
+            ***************************************************************************************@
+            ga('@{trackerName}.set', 'dimension4', guardian.config.page.section);
+            ga('@{trackerName}.set', 'dimension5', guardian.config.page.contentType);
+            ga('@{trackerName}.set', 'dimension6', guardian.config.page.commissioningDesk);
+            ga('@{trackerName}.set', 'dimension7', guardian.config.page.contentId);
+            ga('@{trackerName}.set', 'dimension8', guardian.config.page.authorIds);
+            ga('@{trackerName}.set', 'dimension9', guardian.config.page.keywordIds);
+            ga('@{trackerName}.set', 'dimension10', guardian.config.page.toneIds);
+            ga('@{trackerName}.set', 'dimension11', guardian.config.page.seriesId);
 
-        ga('send', 'pageview', {
-            hitCallback: function() {
-                var image = new Image();
-                image.src = "@{Configuration.debug.beaconUrl}/count/pvg.gif";
-            }
-        });
+            ga('@{trackerName}.send', 'pageview', {
+                hitCallback: function() {
+                    var image = new Image();
+                    image.src = "@{Configuration.debug.beaconUrl}/count/pvg.gif";
+                }
+            });
+        }
     </script>
 
     @*
     TODO For now we only include a confidence beacon in the noscript.
-    If this brings our confidence up, we should also request a pixel 
+    If this brings our confidence up, we should also request a pixel
     from a Fastly/frontend endpoint that can make a server-side call to GA to record the pageview.
     *@
     <noscript id="googleNoScript">

--- a/common/app/views/support/GoogleAnalyticsAccount.scala
+++ b/common/app/views/support/GoogleAnalyticsAccount.scala
@@ -4,10 +4,21 @@ import conf.Configuration.environment
 
 object GoogleAnalyticsAccount {
 
-  private val prod = "UA-78705427-1"
-  private val test = "UA-33592456-1"
-  private val useMainAccount = environment.isProd && !environment.isPreview
+  case class Tracker(trackingId: String, trackerName: String)
 
-  val account: String = if (useMainAccount) prod else test
+  // The "All editorial" property in the main GA account ("GNM Universal")
+  val editorialProd = Tracker("UA-78705427-1", "allEditorialPropertyTracker")
+
+  // The "Guardian Test" property in the "Guardian Test" account.
+  // I recommend using this until you're sure your GA events are working as intended,
+  // to avoid polling the production GA property with incorrect data.
+  val editorialTest = Tracker("UA-33592456-1", "guardianTestPropertyTracker")
+
+  // Dedicated property just for header bidding events
+  val headerBidding = Tracker("UA-78705427-6", "headerBiddingPropertyTracker")
+
+  private val useProdTracker = environment.isProd && !environment.isPreview
+
+  val editorialTracker: Tracker = if (useProdTracker) editorialProd else editorialTest
 
 }


### PR DESCRIPTION
## What does this change?

Add a couple more GA trackers:
- One for the dedicated header bidding property used by #13542
- One for the test GA account, making it easy for people to send events to the test account until they're sure everything works as expected
## What is the value of this and can you measure success?

Unblocks #13542
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

@regiskuckaertz 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
