### PR TITLE
New header dummy test

### DIFF
--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -27,6 +27,17 @@ object ABHeadlinesTestVariant extends TestDefinition(
   }
 }
 
+object ABHeadlinesTestControl extends TestDefinition(
+  "headlines-ab-control",
+  "To test how much of a difference changing a headline makes (control group)",
+  owners = Seq(Owner.withGithub("dominickendrick")),
+  new LocalDate(2016, 8, 10) // Wednesday
+  ) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-hlt").contains("hlt-C")
+  }
+}
+
 object ABNewHeaderVariant extends TestDefinition(
   name = "ab-new-header-variant",
   description = "Feature switch (0% test) for the new header",
@@ -38,14 +49,25 @@ object ABNewHeaderVariant extends TestDefinition(
   }
 }
 
-object ABHeadlinesTestControl extends TestDefinition(
-  "headlines-ab-control",
-  "To test how much of a difference changing a headline makes (control group)",
-  owners = Seq(Owner.withGithub("dominickendrick")),
-  new LocalDate(2016, 8, 10) // Wednesday
-  ) {
+object ABNewHeaderDummyTestControl extends TestDefinition(
+  name = "ab-new-header-dummy-test-control",
+  description = "New header dummy test control",
+  owners = Seq(Owner.withGithub("nataliaLKB")),
+  sellByDate = new LocalDate(2016, 7, 26) // Tuesday
+) {
   def canRun(implicit request: RequestHeader): Boolean = {
-    request.headers.get("X-GU-hlt").contains("hlt-C")
+    request.headers.get("X-GU-ab-new-header-dummy").contains("new-header-control")
+  }
+}
+
+object ABNewHeaderDummyTestVariant extends TestDefinition(
+  name = "ab-new-header-dummy-test-variant",
+  description = "New header dummy test variant",
+  owners = Seq(Owner.withGithub("nataliaLKB")),
+  sellByDate = new LocalDate(2016, 7, 26) // Tuesday
+) {
+  def canRun(implicit request: RequestHeader): Boolean = {
+    request.headers.get("X-GU-ab-new-header-dummy").contains("new-header-variant")
   }
 }
 

--- a/common/app/mvt/MultiVariateTesting.scala
+++ b/common/app/mvt/MultiVariateTesting.scala
@@ -31,7 +31,7 @@ object ABNewHeaderVariant extends TestDefinition(
   name = "ab-new-header-variant",
   description = "Feature switch (0% test) for the new header",
   owners = Seq(Owner.withGithub("natalialkb")),
-  sellByDate = new LocalDate(2016, 7, 27) // Wednesday
+  sellByDate = new LocalDate(2016, 9, 8) // Thursday
 ) {
   def canRun(implicit request: RequestHeader): Boolean = {
     request.headers.get("X-GU-ab-new-header").contains("variant")


### PR DESCRIPTION
## What does this change?

This adds two serverside dummy tests. It is in preparation for the new header tests that I hope to get out soon. 

Corresponding [fastly PR](https://github.com/guardian/fastly-edge-cache/pull/659) which will set the amounts for the buckets.
## Purposes of the dummy tests:
- Check if the control and variant get equal sized buckets
- See if the data we get back is enough to start testing
- Help us estimate how many people should be in each bucket
## Does this affect other platforms - Amp, Apps, etc?

Nope!
## Request for comment

@stephanfowler 
