### PR TITLE
Removes blockquotes from comment share body

### DIFF
--- a/discussion/app/views/fragments/commentShare.scala.html
+++ b/discussion/app/views/fragments/commentShare.scala.html
@@ -9,7 +9,7 @@
 
     <div class="sharing-buttons" data-link-name="comment social">
     @defining(s"${comment.webUrl}") { permalink =>
-        @defining(StringEscapeUtils.unescapeHtml(Jsoup.clean(comment.body, Whitelist.none()))) { commentBody =>
+        @defining(StringEscapeUtils.unescapeHtml(Jsoup.clean(comment.body.replaceAll("<blockquote>.*</blockquote>", ""), Whitelist.none()))) { commentBody =>
             <a href="@ShareLinks.createShareLinkForComment(platform = Facebook, href = permalink, text = "", quote = Some(s"""${comment.profile.displayName} commented: "$commentBody"""")).href"
             target="_blank"
             class="social__action social-icon-wrapper"


### PR DESCRIPTION
## What does this change?

Removes blockquotes from the body of the shared comment because there is no delimitation between the quote and the actual comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
