### PR TITLE
Fix article body ads naming

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -23,14 +23,16 @@ define([
 ) {
 
     /* bodyAds is a counter that keeps track of the number of inline MPUs
-     * inserted dynamically. It is used to give each MPU its own ID. */
+     * inserted dynamically. */
     var bodyAds;
+    var inlineAd;
     var replaceTopSlot;
     var inlineMerchRules;
     var longArticleRules;
 
     function boot() {
         bodyAds = 0;
+        inlineAd = 0;
         replaceTopSlot = detect.isBreakpoint({max : 'phablet'});
     }
 
@@ -96,11 +98,16 @@ define([
         function insertInlineAds(paras) {
             var countAdded = 0;
             while(countAdded < count && paras.length) {
-                bodyAds += 1;
-                countAdded += 1;
                 var para = paras.shift();
-                var adDefinition = 'inline' + bodyAds;
-                insertAdAtPara(para, replaceTopSlot && countAdded === 1 ? 'top-above-nav' : adDefinition, 'inline');
+                var adDefinition;
+                if (replaceTopSlot && bodyAds === 0) {
+                    adDefinition = 'top-above-nav';
+                } else {
+                    inlineAd += 1;
+                    adDefinition = 'inline' + inlineAd;
+                }
+                insertAdAtPara(para, adDefinition, 'inline');
+                bodyAds += 1;
             }
             return countAdded;
         }

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -108,6 +108,7 @@ define([
                 }
                 insertAdAtPara(para, adDefinition, 'inline');
                 bodyAds += 1;
+                countAdded += 1;
             }
             return countAdded;
         }


### PR DESCRIPTION
Fixes an issue where two `top-above-nav` slots would be inserted into the body of articles on mobile, and other inline slots would start from 2 instead of 1.

![picture 1](https://cloud.githubusercontent.com/assets/629976/16995044/0db3719a-4ea2-11e6-9199-bdc7701c8282.jpg)

cc @guardian/commercial-dev 
