### PR TITLE
Fix ad size in comments slot

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/create-slot.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/create-slot.js
@@ -72,7 +72,7 @@ define([
         fobadge: badgeDefinition,
         comments: {
             sizeMappings: {
-                mobile: compile(adSizes.outOfPage, adSizes.badge)
+                mobile: compile(adSizes.outOfPage, adSizes.mpu)
             }
         },
         'top-above-nav': {


### PR DESCRIPTION
The slot should contain MPUs, not badges.

cc @guardian/commercial-dev 
