### PR TITLE
Commercial: fix false positive in lazy-loaded containers

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/lazy-load.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/lazy-load.js
@@ -33,8 +33,11 @@ define([
             var lazyLoad = dfpEnv.advertsToLoad
                 .filter(function (advert) {
                     var rect = advert.node.getBoundingClientRect();
+                    var isNotHidden = rect.top + rect.left + rect.right + rect.bottom !== 0;
+                    var isNotTooFarFromTop = (1 - depthOfScreen) * viewportHeight < rect.bottom;
+                    var isNotTooFarFromBottom = rect.top < viewportHeight * depthOfScreen;
                     // load the ad only if it's setting within an acceptable range
-                    return (1 - depthOfScreen) * viewportHeight < rect.bottom && rect.top < viewportHeight * depthOfScreen;
+                    return isNotHidden && isNotTooFarFromTop && isNotTooFarFromBottom;
                 });
 
             lazyLoad.forEach(function(advert) {


### PR DESCRIPTION
`Element.getBoundingClientRect()` will return a zero-filled structure when the element is inside another element which is not displayed. This structure will go through [the test that tells if the ad is within the viewport range](https://github.com/guardian/frontend/compare/rk-inline2?expand=1#diff-b2831f831e4bbc7ec76981ed134c91cbL37) and succeed, hence implying the ad should be displayed.

This happens for ads inside containers that are lazy-loaded, i.e. containers starting from the 10th on fronts. To fix this issue, we just add another guard to detect the zero-filled structure.

cc @guardian/commercial-dev 
