### PR TITLE
Facebook ads: Allow test mode to be enabled in the DFP creative

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/facebook.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/facebook.js
@@ -60,7 +60,7 @@ define([
                 );
             });
 
-            var markup = facebookTpl(assign({ externalLink: svgs('externalLink') }, adUnits[this.params.placement]));
+            var markup = facebookTpl(assign({ externalLink: svgs('externalLink'), testMode: this.params.testMode }, adUnits[this.params.placement]));
             var labelMarkup = labelTpl({ data: {
                 buttonTitle: 'Ad',
                 infoTitle: 'Advertising on the Guardian',

--- a/static/src/javascripts/projects/common/views/commercial/creatives/facebook.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/facebook.html
@@ -1,4 +1,4 @@
-<div class="fb-ad" data-placementid="<%=placementId%>" data-format="native" data-nativeadid="<%=adId%>" data-testmode="false"></div>
+<div class="fb-ad" data-placementid="<%=placementId%>" data-format="native" data-nativeadid="<%=adId%>" data-testmode="<%=testMode%>"></div>
 <aside class="creative creative--facebook" id="<%=adId%>">
     <a class="fbAdLink advert advert--facebook">
         <div class="fbAdMedia thirdPartyMediaClass advert__image-container"></div>


### PR DESCRIPTION
This is useful for debugging placements (i.e. ad slots in Facebook lingo)

cc @guardian/commercial-dev 
