### PR TITLE
always show video over sublinks

### DIFF
--- a/static/src/stylesheets/module/facia/_items.scss
+++ b/static/src/stylesheets/module/facia/_items.scss
@@ -145,8 +145,7 @@
         }
 
         &[class*='fc-item--has-sublinks'] {
-            .fc-item__standfirst,
-            .fc-item__video {
+            .fc-item__standfirst {
                 display: none;
             }
         }


### PR DESCRIPTION
## What does this change?

Currently, if a card is showing video and has two or more sublinks, the video is hidden (for reasons unknown).
This is different for images - cards with an image and two sublinks shows all elements.

This change brings video and images inline - videos are always shown regardless of the number of sublinks.

(originally raised by CP)
## What is the value of this and can you measure success?

⬆️ videos on fronts and consequently ⬆️ plays on fronts
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

Before (image with two sublinks on left, video with two sublinks on right)
<img width="475" alt="screen shot 2016-07-21 at 23 38 43" src="https://cloud.githubusercontent.com/assets/836140/17041400/ba56bc44-4f9d-11e6-9ae3-65f49b7d6aa2.png">

After (image with two sublinks on left, video with two sublinks on right)
<img width="480" alt="screen shot 2016-07-21 at 23 50 13" src="https://cloud.githubusercontent.com/assets/836140/17041432/ea772206-4f9d-11e6-9ca7-e13d5cfd9c71.png">

NB - as you can see the before screenshot looks strange. Currently CP are advising to untick `show video` in the fronts tool as this causes the main media's poster image to be displayed, e.g.

<img width="478" alt="screen shot 2016-07-21 at 23 57 05" src="https://cloud.githubusercontent.com/assets/836140/17041587/e303f098-4f9e-11e6-94cb-8c8c14315ac1.png">
## Request for comment

@jamesgorrie @gidsg 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
