### PR TITLE
Introducing Guardian Revealer

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
@@ -1,0 +1,31 @@
+define([
+    'common/utils/fastdom-promise',
+    'common/utils/template',
+    'common/modules/commercial/creatives/add-tracking-pixel',
+    'text!common/views/commercial/creatives/revealer.html'
+], function(fastdom, template, addTrackingPixel, revealerStr) {
+    var hasBackgroundFixedSupport = !detect.isAndroid();
+    var revealerTpl;
+
+    function Revealer($adSlot, params) {
+        revealerTpl || (revealerTpl = template(revealerStr));
+
+        return Object.freeze({
+            create: create
+        });
+
+        function create() {
+            var markup = revealerTpl(params);
+
+            return fastdom.write(function () {
+                $adSlot[0].insertAdjacentHTML('beforeend', markup);
+                $adSlot.addClass('ad-slot--revealer');
+                if (params.trackingPixel) {
+                    addTrackingPixel($adSlot, params.trackingPixel + params.cacheBuster);
+                }
+            });
+        }
+    }
+
+    return Revealer;
+});

--- a/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/revealer.js
@@ -4,7 +4,6 @@ define([
     'common/modules/commercial/creatives/add-tracking-pixel',
     'text!common/views/commercial/creatives/revealer.html'
 ], function(fastdom, template, addTrackingPixel, revealerStr) {
-    var hasBackgroundFixedSupport = !detect.isAndroid();
     var revealerTpl;
 
     function Revealer($adSlot, params) {

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/apply-creative-template.js
@@ -10,6 +10,7 @@ define([
     'common/modules/commercial/creatives/gu-style-comcontent',
     'common/modules/commercial/creatives/frame',
     'common/modules/commercial/creatives/facebook',
+    'common/modules/commercial/creatives/revealer',
     'common/modules/commercial/creatives/expandable',
     'common/modules/commercial/creatives/expandable-v2',
     'common/modules/commercial/creatives/expandable-v3',

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/render-advert.js
@@ -62,7 +62,7 @@ define([
         if ($node.hasClass('ad-slot--right')) {
             stickyMpu($node);
         } else {
-            return addFluid(['ad-slot--facebook'])(_, advert);
+            return addFluid(['ad-slot--facebook', 'ad-slot--revealer'])(_, advert);
         }
     };
 

--- a/static/src/javascripts/projects/common/views/commercial/creatives/revealer.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/revealer.html
@@ -1,0 +1,6 @@
+<aside class="creative creative--revealer">
+    <a class="creative__cta" href="%%CLICK_URL_ESC%%<%=link%>" target="_blank">
+        <img class="creative__background" src="<%=backgroundImage%>" alt>
+        <img class="creative__button creative__button--<%=buttonVPos%> creative__button--<%=buttonHPos%>" src="<%=button%>" alt>
+    </a>
+</div>

--- a/static/src/stylesheets/module/commercial/_commercial.scss
+++ b/static/src/stylesheets/module/commercial/_commercial.scss
@@ -23,6 +23,7 @@
 /* Creative styles */
 @import '_creatives';
 @import 'creatives/_fabric-video';
+@import 'creatives/_revealer';
 
 /* GU styled commercial content */
 @import 'gustyle/_gu-comcontent';

--- a/static/src/stylesheets/module/commercial/_creatives.scss
+++ b/static/src/stylesheets/module/commercial/_creatives.scss
@@ -4,6 +4,10 @@
     height: 1px;
 }
 
+.creative__cta {
+    display: block;
+}
+
 .creative--scrollable-mpu {
     .creative--scrollable-mpu-inner {
         margin: 0 auto;

--- a/static/src/stylesheets/module/commercial/creatives/_revealer.scss
+++ b/static/src/stylesheets/module/commercial/creatives/_revealer.scss
@@ -1,0 +1,39 @@
+.creative--revealer {
+    height: 250px;
+    position: relative;
+
+    .creative__cta {
+        background-attachment: fixed;
+        background-size: cover;
+        height: 250px;
+    }
+
+    .creative__background {
+        position: fixed;
+        height: 100%;
+        top: 0;
+        left: $gs-gutter / 2;
+        right: $gs-gutter / 2;
+
+        @include mq(mobileLandscape) {
+            left: $gs-gutter;
+            right: $gs-gutter;
+        }
+    }
+
+    .creative__button {
+        position: absolute;
+    }
+
+    .creative__button--left    { left: 0; }
+    .creative__button--center  { left: 50%; transform: translate(-50%,0); }
+    .creative__button--right   { right: 0; }
+
+    .creative__button--top     { top: 0; }
+    .creative__button--middle  { top: 50%; transform: translate(0,-50%); }
+    .creative__button--bottom  { bottom: 0; }
+
+    .creative__button--center.creative__button--middle {
+        transform: translate(-50%,-50%);
+    }
+}

--- a/static/src/stylesheets/module/commercial/creatives/_revealer.scss
+++ b/static/src/stylesheets/module/commercial/creatives/_revealer.scss
@@ -26,14 +26,14 @@
     }
 
     .creative__button--left    { left: 0; }
-    .creative__button--center  { left: 50%; transform: translate(-50%,0); }
+    .creative__button--center  { left: 50%; transform: translate(-50%, 0); }
     .creative__button--right   { right: 0; }
 
     .creative__button--top     { top: 0; }
-    .creative__button--middle  { top: 50%; transform: translate(0,-50%); }
+    .creative__button--middle  { top: 50%; transform: translate(0, -50%); }
     .creative__button--bottom  { bottom: 0; }
 
     .creative__button--center.creative__button--middle {
-        transform: translate(-50%,-50%);
+        transform: translate(-50%, -50%);
     }
 }


### PR DESCRIPTION
A new template for fixed background images on mobile:

![revealer](https://cloud.githubusercontent.com/assets/629976/17053304/44dd06ba-4ff9-11e6-9fa1-7043e52ed467.gif)

This template is temporary. We will start moving all our templates to DFP fluid ads in this quarter.

cc @guardian/commercial-dev 
