### PR TITLE
Remove use of AkkaAsync object in Notification trait

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -16,11 +16,16 @@ import play.api.http.HttpErrorHandler
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
-import services.ConfigAgentLifecycle
+import services.{ConfigAgentLifecycle, EmailService}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
+}
+
+trait AdminServices {
+  def akkaAsync: AkkaAsync
+  lazy val emailService = wire[EmailService]
 }
 
 trait Controllers extends AdminControllers {
@@ -44,7 +49,7 @@ trait AdminLifecycleComponents {
   )
 }
 
-trait AppComponents extends FrontendComponents with AdminLifecycleComponents with Controllers {
+trait AppComponents extends FrontendComponents with AdminLifecycleComponents with Controllers with AdminServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/admin/app/controllers/AdminControllers.scala
+++ b/admin/app/controllers/AdminControllers.scala
@@ -1,11 +1,14 @@
 package controllers
 
 import com.softwaremill.macwire._
+import common.AkkaAsync
 import controllers.admin._
 import controllers.admin.commercial.{DfpDataController, SlotController, TakeoverWithEmptyMPUsController}
 import controllers.cache.{ImageDecacheController, PageDecacheController}
 
 trait AdminControllers {
+  def akkaAsync: AkkaAsync
+
   lazy val oAuthLoginController = wire[OAuthLoginController]
   lazy val uncachedWebAssets = wire[UncachedWebAssets]
   lazy val uncachedAssets = wire[UncachedAssets]

--- a/admin/app/controllers/FrontPressController.scala
+++ b/admin/app/controllers/FrontPressController.scala
@@ -1,33 +1,33 @@
 package controllers
 
-import common.{ExecutionContexts, Logging}
+import common.{AkkaAsync, ExecutionContexts, Logging}
 import controllers.admin.AuthActions
-import jobs.{LowFrequency, StandardFrequency, HighFrequency, RefreshFrontsJob}
+import jobs.{HighFrequency, LowFrequency, RefreshFrontsJob, StandardFrequency}
 import play.api.mvc.Controller
 
-class FrontPressController extends Controller with Logging with AuthLogging with ExecutionContexts {
+class FrontPressController(akkaAsync: AkkaAsync) extends Controller with Logging with AuthLogging with ExecutionContexts {
 
   def press() = AuthActions.AuthActionTest { implicit request =>
     Ok(views.html.press())
   }
 
   def queueAllFrontsForPress() = AuthActions.AuthActionTest { implicit request =>
-    RefreshFrontsJob.runAll() match {
+    RefreshFrontsJob.runAll(akkaAsync) match {
       case Some(l) => Ok(s"Pushed ${l.length} fronts to the SQS queue")
       case None => InternalServerError("Could not push to the SQS queue, is there an SNS topic set? (frontPressSns)")
     }
   }
 
   def queueHighFrequencyFrontsForPress() = AuthActions.AuthActionTest { implicit request =>
-    runJob(RefreshFrontsJob.runFrequency(HighFrequency), "high frequency")
+    runJob(RefreshFrontsJob.runFrequency(akkaAsync)(HighFrequency), "high frequency")
   }
 
   def queueStandardFrequencyFrontsForPress() = AuthActions.AuthActionTest { implicit request =>
-    runJob(RefreshFrontsJob.runFrequency(StandardFrequency), "standard frequency")
+    runJob(RefreshFrontsJob.runFrequency(akkaAsync)(StandardFrequency), "standard frequency")
   }
 
   def queueLowFrequencyFrontsForPress() = AuthActions.AuthActionTest { implicit request =>
-    runJob(RefreshFrontsJob.runFrequency(LowFrequency), "low frequency")
+    runJob(RefreshFrontsJob.runFrequency(akkaAsync)(LowFrequency), "low frequency")
   }
 
   private def runJob(didRun: Boolean, jobName: String) = {

--- a/admin/app/controllers/SwitchboardController.scala
+++ b/admin/app/controllers/SwitchboardController.scala
@@ -7,11 +7,11 @@ import controllers.AuthLogging
 import conf.Configuration
 import play.api.mvc._
 import scala.concurrent.Future
-import services.Notification
+import services.SwitchNotification
 import tools.Store
 import model.NoCache
 
-class SwitchboardController extends Controller with AuthLogging with Logging with ExecutionContexts {
+class SwitchboardController(akkaAsync: AkkaAsync) extends Controller with AuthLogging with Logging with ExecutionContexts {
 
   val SwitchPattern = """([a-z\d-]+)=(on|off)""".r
 
@@ -70,7 +70,7 @@ class SwitchboardController extends Controller with AuthLogging with Logging wit
     log.info("switches successfully updated")
 
     val changes = updates filterNot { current contains _ }
-    Notification.onSwitchChanges(requester, Configuration.environment.stage, changes)
+    SwitchNotification.onSwitchChanges(akkaAsync)(requester, Configuration.environment.stage, changes)
     changes foreach { change =>
       log.info(s"Switch change by ${requester}: ${change}")
     }

--- a/admin/app/controllers/SwitchboardPlistaController.scala
+++ b/admin/app/controllers/SwitchboardPlistaController.scala
@@ -6,11 +6,11 @@ import conf.switches.{SwitchState, Switches}
 import controllers.AuthLogging
 import conf.Configuration
 import play.api.mvc._
-import services.Notification
+import services.SwitchNotification
 import tools.Store
 import model.NoCache
 
-class SwitchboardPlistaController extends Controller with AuthLogging with Logging with ExecutionContexts {
+class SwitchboardPlistaController(akkaAsync: AkkaAsync) extends Controller with AuthLogging with Logging with ExecutionContexts {
 
   def renderSwitchboard() = AuthActions.AuthActionTest { implicit request =>
     log("loaded plista Switchboard", request)
@@ -41,7 +41,7 @@ class SwitchboardPlistaController extends Controller with AuthLogging with Loggi
       if (alterationMade) {
         val update = Switches.PlistaForOutbrainAU.name + "=" + newState
 
-        Notification.onSwitchChanges(requester, Configuration.environment.stage, List() :+ update)
+        SwitchNotification.onSwitchChanges(akkaAsync)(requester, Configuration.environment.stage, List() :+ update)
         log.info(s"Switch change by ${requester}: ${update}")
       }
 

--- a/admin/app/dfp/DfpAdUnitCacheJob.scala
+++ b/admin/app/dfp/DfpAdUnitCacheJob.scala
@@ -9,8 +9,8 @@ import scala.concurrent.Future
 
 class DfpAdUnitCacher(val rootAdUnit: Any, val filename: String) extends ExecutionContexts with Logging {
 
-  def run(): Future[Unit] = Future {
-    AkkaAsync {
+  def run(akkaAsync: AkkaAsync): Future[Unit] = Future {
+    akkaAsync {
       val adUnits = DfpApi.readActiveAdUnits(rootAdUnit.toString)
       if (adUnits.nonEmpty) {
         val rows = adUnits.map(adUnit => s"${adUnit.id},${adUnit.path.mkString(",")}")

--- a/admin/app/dfp/DfpDataCacheLifecycle.scala
+++ b/admin/app/dfp/DfpDataCacheLifecycle.scala
@@ -71,19 +71,19 @@ class DfpDataCacheLifecycle(
     new Job[Unit] {
       val name: String = "DFP-Ad-Units-Update"
       val interval: Int = 60
-      def run(): Future[Unit] = DfpAdUnitCacheJob.run()
+      def run(): Future[Unit] = DfpAdUnitCacheJob.run(akkaAsync)
     },
 
     new Job[Unit] {
       val name: String = "DFP-Mobile-Apps-Ad-Units-Update"
       val interval: Int = 60
-      def run(): Future[Unit] = DfpMobileAppAdUnitCacheJob.run()
+      def run(): Future[Unit] = DfpMobileAppAdUnitCacheJob.run(akkaAsync)
     },
 
     new Job[Unit] {
       val name: String = "DFP-Facebook-IA-Ad-Units-Update"
       val interval: Int = 60
-      def run(): Future[Unit] = DfpFacebookIaAdUnitCacheJob.run()
+      def run(): Future[Unit] = DfpFacebookIaAdUnitCacheJob.run(akkaAsync)
     },
 
     new Job[Seq[GuCreativeTemplate]] {

--- a/admin/app/jobs/AdsStatusEmailJob.scala
+++ b/admin/app/jobs/AdsStatusEmailJob.scala
@@ -8,7 +8,7 @@ import tools.Store
 
 import scala.concurrent.Future
 
-object AdsStatusEmailJob extends Logging with ExecutionContexts {
+case class AdsStatusEmailJob(emailService: EmailService) extends Logging with ExecutionContexts {
 
   private val subject = "NGW Ad Targeting Status"
 
@@ -21,7 +21,7 @@ object AdsStatusEmailJob extends Logging with ExecutionContexts {
       adOpsUs <- adOpsUsTeam
       adOpsAu <- adOpsAuTeam
     } yield {
-      EmailService.send(
+      emailService.send(
         from = adTech,
         to = Seq(adOps, adOpsUs, adOpsAu),
         cc = Seq(adTech),

--- a/admin/app/jobs/ExpiringAdFeaturesEmailJob.scala
+++ b/admin/app/jobs/ExpiringAdFeaturesEmailJob.scala
@@ -9,7 +9,7 @@ import services.EmailService
 
 import scala.concurrent.Future
 
-object ExpiringAdFeaturesEmailJob extends Logging with ExecutionContexts {
+case class ExpiringAdFeaturesEmailJob(emailService: EmailService) extends Logging with ExecutionContexts {
 
   def run(): Future[Unit] = {
 
@@ -35,7 +35,7 @@ object ExpiringAdFeaturesEmailJob extends Logging with ExecutionContexts {
         val htmlBody =
           views.html.commercial.email.expiringAdFeatures(expired, expiring).body.trim()
 
-        EmailService.send(
+        emailService.send(
           from = adTech,
           to = gLabs :+ adOps,
           cc = Seq(adTech),

--- a/admin/app/jobs/ExpiringSwitchesEmailJob.scala
+++ b/admin/app/jobs/ExpiringSwitchesEmailJob.scala
@@ -8,7 +8,7 @@ import services.EmailService
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-object ExpiringSwitchesEmailJob extends ExecutionContexts with Logging {
+case class ExpiringSwitchesEmailJob(emailService: EmailService) extends ExecutionContexts with Logging {
 
   def run(): Future[Unit] = {
     (for (webEngineers <- webEngineersEmail) yield {
@@ -16,7 +16,7 @@ object ExpiringSwitchesEmailJob extends ExecutionContexts with Logging {
 
       if (expiringSwitches.nonEmpty) {
         val htmlBody = views.html.email.expiringSwitches(expiringSwitches).body.trim()
-        val eventualResult = EmailService.send(
+        val eventualResult = emailService.send(
           from = webEngineers,
           to = Seq(webEngineers),
           subject = "Expiring Feature Switches",

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -56,17 +56,17 @@ class AdminLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, akk
     }
 
     jobs.scheduleEveryNMinutes("FrontPressJobHighFrequency", adminPressJobHighPushRateInMinutes) {
-      if(FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(HighFrequency)
+      if(FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(akkaAsync)(HighFrequency)
       Future.successful(())
     }
 
     jobs.scheduleEveryNMinutes("FrontPressJobStandardFrequency", adminPressJobStandardPushRateInMinutes) {
-      if(FrontPressJobSwitchStandardFrequency.isSwitchedOn) RefreshFrontsJob.runFrequency(StandardFrequency)
+      if(FrontPressJobSwitchStandardFrequency.isSwitchedOn) RefreshFrontsJob.runFrequency(akkaAsync)(StandardFrequency)
       Future.successful(())
     }
 
     jobs.scheduleEveryNMinutes("FrontPressJobLowFrequency", adminPressJobLowPushRateInMinutes) {
-      if(FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(LowFrequency)
+      if(FrontPressJobSwitch.isSwitchedOn) RefreshFrontsJob.runFrequency(akkaAsync)(LowFrequency)
       Future.successful(())
     }
 
@@ -97,7 +97,7 @@ class AdminLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, akk
     //every 7, 22, 37, 52 minutes past the hour, 28 seconds past the minute (e.g 13:07:28, 13:22:28)
     jobs.schedule("VideoEncodingsJob", "28 7/15 * * * ?") {
       log.info("Starting VideoEncodingsJob")
-      VideoEncodingsJob.run()
+      VideoEncodingsJob.run(akkaAsync)
     }
 
     jobs.scheduleEveryNMinutes("AssetMetricsCache", 60 * 6) {
@@ -132,7 +132,7 @@ class AdminLifecycle(appLifecycle: ApplicationLifecycle, jobs: JobScheduler, akk
 
     akkaAsync.after1s {
       RebuildIndexJob.run()
-      VideoEncodingsJob.run()
+      VideoEncodingsJob.run(akkaAsync)
       AssetMetricsCache.run()
     }
   }

--- a/admin/app/services/R2PagePressNotifier.scala
+++ b/admin/app/services/R2PagePressNotifier.scala
@@ -1,15 +1,15 @@
 package services
 
-import common.Logging
+import common.{AkkaAsync, Logging}
 import implicits.R2PressNotification.pressMessageFormatter
 import model.R2PressMessage
 import play.api.libs.json.Json
 
 object R2PagePressNotifier extends Logging {
 
-  def enqueue(message: R2PressMessage): String = {
+  def enqueue(akkaAsync: AkkaAsync)(message: R2PressMessage): String = {
     try {
-      R2PressNotification.sendWithoutSubject(Json.toJson[R2PressMessage](message).toString())
+      R2PressNotification.sendWithoutSubject(akkaAsync)(Json.toJson[R2PressMessage](message).toString())
       val msg = s"Queued for pressing: ${message.url} (from preserved source: ${message.fromPreservedSrc})"
       log.info(msg)
       msg

--- a/admin/app/services/R2PressedPageTakedownNotifier.scala
+++ b/admin/app/services/R2PressedPageTakedownNotifier.scala
@@ -1,12 +1,12 @@
 package services
 
-import common.Logging
+import common.{AkkaAsync, Logging}
 
 object R2PressedPageTakedownNotifier extends Logging {
 
-  def enqueue(path: String): String = {
+  def enqueue(akkaAsync: AkkaAsync)(path: String): String = {
     try {
-      R2PressedPageTakedownNotification.sendWithoutSubject(path)
+      R2PressedPageTakedownNotification.sendWithoutSubject(akkaAsync)(path)
       val msg = s"Queued for takedown: $path"
       log.info(msg)
       msg


### PR DESCRIPTION
## What does this change?

Removing use of AkkaAsync object
I am gonna try to make small(ish) and digestable PR, so it is not too boring to review. Anyway it makes sense to review commit by commit 😬 
## What is the value of this and can you measure success?

=> Play 2.5

The end goal is to get rid of the AkkaAsync object which rely on
Play.current. _Play.current_ being deprecated in Play 2.5
Instead using dependency injection to pass AkkaAsync instance to the
different functions where it is needed
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
