### PR TITLE
Vertical align sharing sharing comments icon

### DIFF
--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -956,7 +956,7 @@ $comment-recommend-button-size: 19px;
 }
 
 .comment-share-icon svg {
-    vertical-align: text-top;
+    vertical-align: middle;
 }
 
 .sharing-buttons {


### PR DESCRIPTION
## What does this change?

Noticed on my personal laptop that the icon was showing too high up, I'm unable to reproduce it on this machine, but this should solve the problem

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
