### PR TITLE
Log all Guardian specific headers regardless of the case

### DIFF
--- a/common/app/filters/RequestLoggingFilter.scala
+++ b/common/app/filters/RequestLoggingFilter.scala
@@ -29,7 +29,7 @@ class RequestLoggingFilter extends Filter with Logging with ExecutionContexts {
         case (headerName, headerValues) => (headerName, headerValues.mkString(","))
       }
       val whitelistedHeaders = allHeadersFields.filterKeys(whitelistedHeaderNames.contains(_))
-      val guardianSpecificHeaders = allHeadersFields.filterKeys(_.startsWith("X-GU-"))
+      val guardianSpecificHeaders = allHeadersFields.filterKeys(_.toUpperCase.startsWith("X-GU-"))
       (whitelistedHeaders ++ guardianSpecificHeaders).toList.map(t => LogFieldString(s"req.header.${t._1}", t._2))
     }
     private lazy val customFields: List[LogField] = List(


### PR DESCRIPTION
## What does this change?

Log all Guardian specific headers regardless of the case
## What is the value of this and can you measure success?

Better logging and debugging 🎯 
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@johnduffell 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
