### PR TITLE
Updates to Zootropolis video page

### DIFF
--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -3,7 +3,9 @@
 @import views.html.hosted.guardianHostedHeader
 @import java.net.URLEncoder
 
-@cssClass(owner: String) = {hosted-tone--@{owner.toLowerCase.replaceAll("\\s+", "-")}}
+@brandColorCss(page: HostedVideoPage) = {hosted-tone--@{page.campaign.cssClass.toLowerCase.replaceAll("\\s+", "-")}}
+@brandBackgroundCss(page: HostedVideoPage) = {hosted-tone-bg--@{page.campaign.cssClass.toLowerCase.replaceAll("\\s+", "-")}}
+@brandBtnCss(page: HostedVideoPage) = {hosted-tone-btn--@{page.campaign.cssClass.toLowerCase.replaceAll("\\s+", "-")}}
 
 @main(page, Some("commercial")) { } {
     @guardianHostedHeader("hosted-video-page", page.campaign.cssClass, page.campaign.logo.url)
@@ -28,7 +30,7 @@
                     <div class="hosted-fading js-hosted-fading">
                         <div class="hosted__video-overlay"></div>
                         <div class="hosted__meta">
-                            <h1 class="hosted__heading @cssClass(page.campaign.owner)">@{page.video.title}</h1>
+                            <h1 class="hosted__heading @brandColorCss(page)">@{page.video.title}</h1>
                         </div>
                         <div class="hostedbadge hostedbadge--shouldscale">
                                 <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
@@ -49,7 +51,7 @@
                         </div>
                         <div class="hosted-next-autoplay__video">
                             <div class="hosted-next-autoplay__header">
-                                <div class="hosted-next-autoplay__continue @cssClass(page.campaign.owner)">Continue watching</div>
+                                <div class="hosted-next-autoplay__continue @brandColorCss(page)">Continue watching</div>
                                 <h2 class="hosted-next-autoplay__subheader">@{nextPage.video.title}</h2>
                             </div>
                             <a href="@{nextPage.pageUrl}" class="hosted-next-autoplay__poster" data-link-name="Next Hosted Video Autoplay: @{nextPage.video.title}">
@@ -114,7 +116,7 @@
             </header>
             <div class="adverts__body">
                 <div class="hosted__meta">
-                    <h1 class="hosted__heading @cssClass(page.campaign.owner)">@{page.video.title}</h1>
+                    <h1 class="hosted__heading @brandColorCss(page)">@{page.video.title}</h1>
                 </div>
                 <div class="hosted__standfirst">
                     <p class="hosted__text">@{page.standfirst}</p>
@@ -129,7 +131,7 @@
             <div class="hosted__next-video">
                 <div class="hosted__next-video--header">
                     <h2 class="hosted__text hosted__next-video--up-next">More from</h2>
-                    <h2 class="hosted__next-video--client-name @cssClass(page.campaign.owner)">@{page.campaign.owner}</h2>
+                    <h2 class="hosted__next-video--client-name @brandColorCss(page)">@{page.campaign.owner}</h2>
                 </div>
                 <a href="@{nextPage.pageUrl}" class="hosted__next-video--tile" data-link-name="Next Hosted Video: @{nextPage.video.title}">
                     <img class="hosted__next-video-thumb" src="@{nextPage.video.posterUrl}" alt="Next Video: @{nextPage.video.title}">
@@ -141,19 +143,19 @@
         <section class="adverts hosted__container--full">
             <div class="hosted__banner" style="background-image: url(@{page.ctaBanner});">
                 <a href="@{page.cta.url}" rel="nofollow" class="hosted__cta-link" data-link-name="@{page.cta.trackingCode}" target="_blank">
-                    <div class="hostedbadge hostedbadge--shouldscale hostedbadge--pushdown hosted-tone-bg--@{page.campaign.owner.toLowerCase}">
+                    <div class="hostedbadge hostedbadge--shouldscale hostedbadge--pushdown @brandBackgroundCss(page)">
                         <img class="hostedbadge__logo" src="@{page.campaign.logo.url}" alt="logo @{page.campaign.owner}">
                     </div>
                     @if(page.cta.btnText.length == 0) {
                         <div class="hosted__cta-wrapper">
-                            <span class="hosted__cta-text hosted-tone--@{page.campaign.owner.toLowerCase}">@{page.cta.label}</span>
-                            @fragments.inlineSvg("external-link", "icon", List("i-right","advert__more","button","button--large","button--primary","hosted__cta","hosted-tone-btn--" + page.campaign.owner.toLowerCase))
+                            <span class="hosted__cta-text @brandColorCss(page)">@{page.cta.label}</span>
+                            @fragments.inlineSvg("external-link", "icon", List("i-right","advert__more","button","button--large","button--primary","hosted__cta", brandBtnCss(page).toString()))
                         </div>
                     } else {
                         <div class="hosted__cta-wrapper hosted__cta-btn-wrapper">
                             <span class="hosted__cta-label">@{page.cta.label}</span>
                             <br/>
-                            <span class="hosted__cta-btn-text">@{page.cta.btnText} @fragments.inlineSvg("external-link", "icon")</span>
+                            <span class="hosted__cta-btn-text @brandBtnCss(page)">@{page.cta.btnText} @fragments.inlineSvg("external-link", "icon")</span>
                         </div>
                     }
                 </a>

--- a/commercial/app/views/hosted/guardianHostedVideo.scala.html
+++ b/commercial/app/views/hosted/guardianHostedVideo.scala.html
@@ -52,13 +52,13 @@
                         <div class="hosted-next-autoplay__video">
                             <div class="hosted-next-autoplay__header">
                                 <div class="hosted-next-autoplay__continue @brandColorCss(page)">Continue watching</div>
-                                <h2 class="hosted-next-autoplay__subheader">@{nextPage.video.title}</h2>
+                                <h2 class="hosted-next-autoplay__subheader">@{nextPage.title}</h2>
                             </div>
-                            <a href="@{nextPage.pageUrl}" class="hosted-next-autoplay__poster" data-link-name="Next Hosted Video Autoplay: @{nextPage.video.title}">
-                                <img class="hosted-next-autoplay__poster-img" src="@{nextPage.video.posterUrl}">
+                            <a href="@{nextPage.pageUrl}" class="hosted-next-autoplay__poster" data-link-name="Next Hosted Video Autoplay: @{nextPage.title}">
+                                <img class="hosted-next-autoplay__poster-img" src="@{nextPage.imageUrl}">
                                 <div class="hosted-next-autoplay__poster-timer js-autoplay-timer" data-next-page="@{nextPage.pageUrl}">10s</div>
                             </a>
-                            <a href="@{nextPage.pageUrl}" class="hosted__next-video--mobile" data-link-name="Next Hosted Video @{nextPage.video.title}" target="_blank">
+                            <a href="@{nextPage.pageUrl}" class="hosted__next-video--mobile" data-link-name="Next Hosted Video @{nextPage.title}" target="_blank">
                                 Watch now
                             </a>
                         </div>
@@ -133,9 +133,9 @@
                     <h2 class="hosted__text hosted__next-video--up-next">More from</h2>
                     <h2 class="hosted__next-video--client-name @brandColorCss(page)">@{page.campaign.owner}</h2>
                 </div>
-                <a href="@{nextPage.pageUrl}" class="hosted__next-video--tile" data-link-name="Next Hosted Video: @{nextPage.video.title}">
-                    <img class="hosted__next-video-thumb" src="@{nextPage.video.posterUrl}" alt="Next Video: @{nextPage.video.title}">
-                    <p class="hosted__next-video-title">@{nextPage.video.title}</p>
+                <a href="@{nextPage.pageUrl}" class="hosted__next-video--tile" data-link-name="Next Hosted Video: @{nextPage.title}">
+                    <img class="hosted__next-video-thumb" src="@{nextPage.imageUrl}" alt="Next Video: @{nextPage.title}">
+                    <p class="hosted__next-video-title">@{nextPage.title}</p>
                 </a>
             </div>
             }

--- a/common/app/common/commercial/hosted/HostedArticlePage.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage.scala
@@ -8,7 +8,7 @@ case class HostedArticlePage(
   campaign: HostedCampaign,
   pageUrl: String,
   pageName: String,
-  pageTitle: String,
+  title: String,
   standfirst: String,
   standfirstLink: String,
   facebookImageUrl: String,
@@ -21,7 +21,7 @@ case class HostedArticlePage(
 )
   extends HostedPage {
 
-  val title = pageTitle
+  val pageTitle = s"Advertiser content hosted by the Guardian: $title"
   val imageUrl = mainPicture
 
   override val metadata: MetaData = {

--- a/common/app/common/commercial/hosted/HostedArticlePage.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage.scala
@@ -21,6 +21,9 @@ case class HostedArticlePage(
 )
   extends HostedPage {
 
+  val title = pageTitle
+  val imageUrl = mainPicture
+
   override val metadata: MetaData = {
     val keywordId = s"${campaign.id}/${campaign.id}"
     val keywordName = campaign.id

--- a/common/app/common/commercial/hosted/HostedGalleryPage.scala
+++ b/common/app/common/commercial/hosted/HostedGalleryPage.scala
@@ -22,7 +22,7 @@ case class HostedGalleryPage(
 
   val pageTitle: String = s"Advertiser content hosted by the Guardian: $title - gallery"
   val twitterText = shareText.getOrElse(if(standfirst.length < 136) standfirst else title) + " #ad"
-  val imageUrl = images.head.url
+  val imageUrl = images.headOption.map(_.url).getOrElse("")
 
   def nextGalleries: List[HostedGalleryPage] = nextGalleryNames.flatMap(HostedPages.fromCampaignAndPageName(campaign.id, _) flatMap {
     case gallery: HostedGalleryPage => Some(gallery)

--- a/common/app/common/commercial/hosted/HostedGalleryPage.scala
+++ b/common/app/common/commercial/hosted/HostedGalleryPage.scala
@@ -22,6 +22,7 @@ case class HostedGalleryPage(
 
   val pageTitle: String = s"Advertiser content hosted by the Guardian: $title - gallery"
   val twitterText = shareText.getOrElse(if(standfirst.length < 136) standfirst else title) + " #ad"
+  val imageUrl = images.head.url
 
   def nextGalleries: List[HostedGalleryPage] = nextGalleryNames.flatMap(HostedPages.fromCampaignAndPageName(campaign.id, _) flatMap {
     case gallery: HostedGalleryPage => Some(gallery)

--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -6,6 +6,8 @@ trait HostedPage extends StandalonePage {
   def campaign: HostedCampaign
   def pageUrl: String
   def pageName: String
+  def title: String
+  def imageUrl: String
   def pageTitle: String
   def standfirst: String
 

--- a/common/app/common/commercial/hosted/HostedVideoPage.scala
+++ b/common/app/common/commercial/hosted/HostedVideoPage.scala
@@ -14,10 +14,12 @@ case class HostedVideoPage(
   ctaBanner: String,
   twitterTxt: String,
   emailTxt: String,
-  nextPage: Option[HostedVideoPage]
+  nextPage: Option[HostedPage]
 ) extends HostedPage {
 
   val pageTitle: String  = s"Advertiser content hosted by the Guardian: ${video.title} - video"
+  val title = video.title
+  val imageUrl = video.posterUrl
 
   override val metadata: MetaData = {
     val keywordId = s"${campaign.id}/${campaign.id}"

--- a/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/RenaultHostedPages.scala
@@ -1,6 +1,7 @@
 package common.commercial.hosted.hardcoded
 
 import common.commercial.hosted._
+import conf.Configuration.site.host
 import conf.Static
 
 object RenaultHostedPages {
@@ -28,7 +29,7 @@ object RenaultHostedPages {
     val videoTitle = "Designing the car of the future"
     HostedVideoPage(
       campaign,
-      pageUrl = "https://www.theguardian.com/commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser",
+      pageUrl = s"$host/commercial/advertiser-content/renault-car-of-the-future/design-competition-teaser",
       pageName = teaserPageName,
       standfirst = "Who better to dream up the cars of tomorrow than the people who'll be buying them? Students at Central St Martins are working with Renault to design the interior for cars that will drive themselves. Watch this short video to find out more about the project, and visit this page again soon to catch up on the students' progress",
       video = HostedVideo(
@@ -53,7 +54,7 @@ object RenaultHostedPages {
     val videoTitle = "Renault shortlists 'car of the future' designs"
     HostedVideoPage(
       campaign,
-      pageUrl = "https://www.theguardian.com/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode1",
+      pageUrl = s"$host/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode1",
       pageName = episode1PageName,
       standfirst = "Renault challenged Central St Martins students to dream up the car of the future. The winning design will be announced at Clerkenwell Design Week (and on this site). Watch this short video to find out who made the shortlist",
       video = HostedVideo(
@@ -78,7 +79,7 @@ object RenaultHostedPages {
     val videoTitle = "Is this the car of the future?"
     HostedVideoPage(
       campaign,
-      pageUrl = "https://www.theguardian.com/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode2",
+      pageUrl = s"$host/commercial/advertiser-content/renault-car-of-the-future/design-competition-episode2",
       pageName = episode2PageName,
       standfirst = "A group of Central St Martins students took part in a competition to dream up the car of the future. The winning design is radical and intriguing. Meet the team whose blue-sky thinking may have created a blueprint for tomorrow's autonomous cars",
       video = HostedVideo(

--- a/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/VisitBritainHostedPages.scala
@@ -1,6 +1,7 @@
 package common.commercial.hosted.hardcoded
 
 import common.commercial.hosted._
+import conf.Configuration.site.host
 import conf.switches.Switches
 
 object VisitBritainHostedPages {
@@ -194,7 +195,7 @@ object VisitBritainHostedPages {
   val activitiesGallery: HostedGalleryPage = HostedGalleryPage(
     campaign = campaign,
     images = activityImages,
-    pageUrl = "https://www.theguardian.com/advertiser-content/visit-britain/activities",
+    pageUrl = s"$host/advertiser-content/visit-britain/activities",
     pageName = activitiesPageName,
     title = "Don’t be a sloth this summer",
     ctaText = "Explore our collection of unique experiences from all over Great Britain & Northern Ireland",
@@ -208,7 +209,7 @@ object VisitBritainHostedPages {
   val cityGallery: HostedGalleryPage = HostedGalleryPage(
     campaign = campaign,
     images = cityImages,
-    pageUrl = "https://www.theguardian.com/advertiser-content/visit-britain/city",
+    pageUrl = s"$host/advertiser-content/visit-britain/city",
     pageName = cityPageName,
     title = "Take a city break from the norm",
     ctaText = "Explore our collection of unique experiences from all over Great Britain & Northern Ireland",
@@ -221,7 +222,7 @@ object VisitBritainHostedPages {
   private val coastGallery: HostedGalleryPage = HostedGalleryPage(
     campaign = campaign,
     images = coastImages,
-    pageUrl = "https://www.theguardian.com/advertiser-content/visit-britain/coast",
+    pageUrl = s"$host/advertiser-content/visit-britain/coast",
     pageName = coastPageName,
     title = "Find cool-on-sea this summer",
     ctaText = "Explore our collection of unique experiences from all over Great Britain & Northern Ireland",
@@ -234,7 +235,7 @@ object VisitBritainHostedPages {
   private val countrysideGallery: HostedGalleryPage = HostedGalleryPage(
     campaign = campaign,
     images = countrysideImages,
-    pageUrl = "https://www.theguardian.com/advertiser-content/visit-britain/countryside",
+    pageUrl = s"$host/advertiser-content/visit-britain/countryside",
     pageName = countrysidePageName,
     title = "Mend your relationship with Mother Nature",
     ctaText = "Explore our collection of unique experiences from all over Great Britain & Northern Ireland",

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -72,7 +72,7 @@ object ZootropolisHostedPages {
     campaign,
     pageUrl = s"$host/advertiser-content/${campaign.id}/$articlePageName",
     pageName = articlePageName,
-    pageTitle = "Advertiser content hosted by the Guardian: some title here",
+    title = "Meet the characters of Zootropolis",
     standfirst = "Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our",
     standfirstLink = "commercial content explainer.",
     facebookImageUrl = "TODO",

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -24,7 +24,7 @@ object ZootropolisHostedPages {
     btnText = "Out now on digital download"
   )
 
-  private val videoPage: HostedVideoPage = {
+  private val videoPageWithoutNextPage: HostedVideoPage = {
     val videoTitle = "Disney’s’ Zootropolis: Download & keep today!"
     HostedVideoPage(
       campaign,
@@ -83,6 +83,10 @@ object ZootropolisHostedPages {
     emailTxt = "TODO",
     customData
   )
+
+
+  private lazy val videoPage = if (Switches.hostedArticle.isSwitchedOn) videoPageWithoutNextPage
+    .copy(nextPage = Some(articlePage)) else videoPageWithoutNextPage
 
   def fromPageName(pageName: String): Option[HostedPage] = {
     pageName match {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -107,32 +107,6 @@
     }
 }
 
-.hostedbadge.hosted-tone-bg--zootropolis {
-    .hostedbadge__info {
-        color: #ffffff;
-    }
-}
-
-.hosted-article-page.zootropolis ~ .survey-overlay-simple {
-    .survey-text__header {
-        background-color: $zootropolisColor;
-    }
-}
-
-.hosted-article-page.zootropolis ~ .survey-overlay-simple {
-    .survey-text__header {
-        background-color: $zootropolisColor;
-        color: #ffffff;
-
-        .site-message__close-btn {
-            border-color: #ffffff;
-
-            .inline-cross {
-                fill: #ffffff;
-            }
-        }
-    }
-}
 
 .hosted-article-page.zootropolis {
     @mixin animal-stripe {

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -60,11 +60,11 @@ $leffeColor: #dec190;
 }
 
 .hosted-tone-btn--leffe {
-    &,
+    &.hosted-tone-btn--leffe,
     &:focus,
     &:hover {
-        background-color: $leffeColor;
-        border-color: $leffeColor;
+        background-color: #ffffff;
+        border-color: #ffffff;
     }
 }
 
@@ -77,11 +77,15 @@ $leffeColor: #dec190;
 }
 
 .hosted-tone-btn--zootropolis {
-    &,
+    &.hosted-tone-btn--zootropolis,
     &:focus,
     &:hover {
         background-color: $zootropolisColor;
         border-color: $zootropolisColor;
+        color: #ffffff;
+        svg {
+            fill: #ffffff;
+        }
     }
 }
 
@@ -1141,6 +1145,33 @@ $leffeColor: #dec190;
         .hosted-next-autoplay__video,
         .hosted-next-autoplay__next-in-series {
             border-top: 1px solid $renaultColor;
+        }
+    }
+}
+
+.hostedbadge.hosted-tone-bg--zootropolis {
+    .hostedbadge__info {
+        color: #ffffff;
+    }
+}
+
+.hosted-page.zootropolis ~ .survey-overlay-simple {
+    .survey-text__header {
+        background-color: $zootropolisColor;
+    }
+}
+
+.hosted-page.zootropolis ~ .survey-overlay-simple {
+    .survey-text__header {
+        background-color: $zootropolisColor;
+        color: #ffffff;
+
+        .site-message__close-btn {
+            border-color: #ffffff;
+
+            .inline-cross {
+                fill: #ffffff;
+            }
         }
     }
 }

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -5,7 +5,9 @@ $renaultColor: #ffc421;
 $renaultLight: #fff9e9;
 $omgbColor: #e41f13;
 $zootropolisColor: #2ec869;
+$zootropolisLight: #d5f4e1;
 $leffeColor: #dec190;
+$leffeLight: #f8f2e9;
 
 @import '_hosted-video.scss';
 @import '_hosted-gallery.scss';
@@ -919,6 +921,14 @@ $leffeColor: #dec190;
 .leffe {
     .hosted__next-video .hosted__next-video--tile {
         border-top-color: $leffeColor;
+        background: $leffeLight;
+    }
+}
+
+.zootropolis {
+    .hosted__next-video .hosted__next-video--tile {
+        border-top-color: $zootropolisColor;
+        background: $zootropolisLight;
     }
 }
 


### PR DESCRIPTION
## What does this change?
- use brand colour in appropriate places
- refactor the video template a little
- add link to zootropolis article page from video
- fix page URLs for VB and renault campaigns
## Screenshots
### Before:

![image](https://cloud.githubusercontent.com/assets/6290008/17103152/e21850b0-5274-11e6-9674-1e035c3def8b.png)
### After:

![image](https://cloud.githubusercontent.com/assets/6290008/17103130/bcf022ea-5274-11e6-9b54-3bd69cc7b5d8.png)

@guardian/labs-beta 
