### PR TITLE
Zootropolis article fixes

### DIFF
--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -67,7 +67,7 @@
                                 Zootropolis is a city like no other. But when optimistic Judy Hopps arrives, she discovers that being a bunny on a police force of big, tough animals isn’t so easy.
                             </p>
                             <p>
-                                <span class="drop-cap hosted-tone-bg--zootropolis">D</span> Determined to prove herself, she jumps at the opportunity to crack a case, even if it means partnering with a fast-talking fox, Nick Wilde. Walt Disney Animation Studios’ “Zootropolis,” is a comedy-adventure directed by Tangled’s Byron Howard.
+                                <span class="drop-cap hosted-tone-bg--zootropolis">D</span> etermined to prove herself, she jumps at the opportunity to crack a case, even if it means partnering with a fast-talking fox, Nick Wilde. Walt Disney Animation Studios’ “Zootropolis,” is a comedy-adventure directed by Tangled’s Byron Howard.
                             </p>
 
                             <!--Beginning of the Con Artist - fox !-->

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -72,15 +72,15 @@ object ZootropolisHostedPages {
     campaign,
     pageUrl = s"$host/advertiser-content/${campaign.id}/$articlePageName",
     pageName = articlePageName,
-    pageTitle = "Advertiser content hosted by the Guardian: some title here",
+    pageTitle = "Advertiser content hosted by the Guardian: Disney Zootropolis",
     standfirst = "Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our",
     standfirstLink = "commercial content explainer.",
-    facebookImageUrl = "TODO",
+    facebookImageUrl = Static("images/commercial/zootropolis.png"),
     cta,
     ctaBanner = Static("images/commercial/zootropolis-banner.png"),
     mainPicture = Static("images/commercial/zootropolis.png"),
-    twitterTxt = "TODO  #ad: ",
-    emailTxt = "TODO",
+    twitterTxt = "Disney Zootropolis asset pack on the Guardian #ad",
+    emailTxt = "Disney Zootropolis asset pack on the Guardian",
     customData
   )
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -3,6 +3,7 @@
         position: relative;
         height: 378px;
         margin-bottom: 10px;
+        overflow: hidden;
 
         &:after {
             content: '';
@@ -229,7 +230,7 @@
     .animal__info-about-header {
         @include fs-textSans(4);
         font-size: 30px;
-        line-height: 22px;
+        line-height: 28px;
         padding-bottom: 16px;
         font-weight: bold;
     }


### PR DESCRIPTION
## What does this change?

A few fixes based on feedback from the team:
- a proper social sharing text,
- the main image does not longer overflow the right column on desktop breakpoint,
- the first letter of the paragraph is removed because we have big cap,
- line height of headers on mobile are increased
## Screenshots

Before:
![screen shot 2016-07-25 at 14 20 13](https://cloud.githubusercontent.com/assets/489567/17102902/92e9a3b4-5273-11e6-97e4-96d710126e72.png)

![screen shot 2016-07-25 at 14 18 36](https://cloud.githubusercontent.com/assets/489567/17102913/9e8d5c4c-5273-11e6-96f4-e101255c5f4e.png)

![screen shot 2016-07-25 at 14 27 08](https://cloud.githubusercontent.com/assets/489567/17102983/e5b8720a-5273-11e6-81ad-26dd3f8c0739.png)
## Request for comment

After:
![screen shot 2016-07-25 at 14 20 20](https://cloud.githubusercontent.com/assets/489567/17102906/984d9a0e-5273-11e6-8bf6-c2f7e552ed0a.png)

![screen shot 2016-07-25 at 14 18 53](https://cloud.githubusercontent.com/assets/489567/17102920/a61d68a8-5273-11e6-877b-3da94d4d9744.png)

![screen shot 2016-07-25 at 14 16 14](https://cloud.githubusercontent.com/assets/489567/17102966/d3878030-5273-11e6-8e19-d37cde0c0351.png)

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
