### PR TITLE
Depluralise sports text in AMP header

### DIFF
--- a/common/app/views/fragments/amp/header.scala.html
+++ b/common/app/views/fragments/amp/header.scala.html
@@ -12,7 +12,7 @@
             <a href="@Configuration.site.host/commentisfree">opinion</a>
         </div>
         <div class="main-navigation_link">
-            <a href="@Configuration.site.host/sport">sports</a>
+            <a href="@Configuration.site.host/sport">sport</a>
         </div>
         <div class="main-navigation_link">
             <a href="@Configuration.site.host/culture">arts</a>


### PR DESCRIPTION
## What does this change?

As mentioned in #13689, I have updated the header in AMP articles to say "sport" rather than "sports"
## Screenshots

![picture 45](https://cloud.githubusercontent.com/assets/5931528/17103101/8803a930-5274-11e6-8ebd-15c6f234706b.png)

@stephanfowler @johnduffell @NataliaLKB @zeftilldeath 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
