### PR TITLE
fix report-comment error message

### DIFF
--- a/discussion/app/views/fragments/reportComment.scala.html
+++ b/discussion/app/views/fragments/reportComment.scala.html
@@ -1,7 +1,7 @@
 <form class="d-report-comment-form js-report-comment-form u-h">
     <div class="d-discussion__error js-discussion__report-comment-error d-discussion__error--hidden">
         <i class="i i-alert"></i>
-        <span class="d-discussion__error-text">Sorry there was an error reporting this comment. Please try another browser or network connection</span>
+        <span class="d-discussion__error-text">Sorry there was an error. Please try again later</span>
     </div>
 
     <button

--- a/discussion/app/views/fragments/reportComment.scala.html
+++ b/discussion/app/views/fragments/reportComment.scala.html
@@ -1,7 +1,7 @@
 <form class="d-report-comment-form js-report-comment-form u-h">
     <div class="d-discussion__error js-discussion__report-comment-error d-discussion__error--hidden">
         <i class="i i-alert"></i>
-        <span class="d-discussion__error-text">Sorry there was an error. Please try again later</span>
+        <span class="d-discussion__error-text">Sorry there was an error. Please try again later. If the problem persists, please <a data-link-name="report comment eeeor : mailto : userhelp" href="mailto:userhelp@@theguardian.com">Userhelp</a></span>
     </div>
 
     <button


### PR DESCRIPTION
## What does this change?

Changes the content of the error message displayed here: https://github.com/guardian/frontend/pull/13706
## What is the value of this and can you measure success?

N/A
## Does this affect other platforms - Amp, Apps, etc?

N/A
## Screenshots

N/A
## Request for comment

@nicl @gidsg 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
