### PR TITLE
Remove switch for hosted tracking

### DIFF
--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -355,14 +355,4 @@ trait CommercialSwitches {
     sellByDate = new LocalDate(2016, 8, 17),
     exposeClientSide = false
   )
-
-  val hostedContentTracking = Switch(
-    group = CommercialLabs,
-    name = "hosted-content-tracking",
-    description = "Use special extra tracking parameters for hosted content",
-    owners = Owner.group(CommercialLabs),
-    safeState = Off,
-    sellByDate = new LocalDate(2016, 7, 29),
-    exposeClientSide = true
-  )
 }

--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -19,7 +19,7 @@ define([
          * It's safe for the next page load though.
          */
         function resetProp71Cookie() {
-            if (config.switches.hostedContentTracking && config.page.toneIds == 'tone/hosted-content') {
+            if (config.page.toneIds == 'tone/hosted') {
                 s.getPreviousValue(s.prop71, 's_prev_ch');
             }
         }
@@ -56,7 +56,7 @@ define([
                 'prop39'    // media id
             ];
 
-        if (config.switches.hostedContentTracking && config.page.toneIds == 'tone/hosted-content') {
+        if (config.page.toneIds == 'tone/hosted') {
             trackingVars.push('prop71');    // previous site section
         }
 
@@ -69,7 +69,7 @@ define([
         };
 
         this.sendEvent = function (event, eventName, ad) {
-             
+
             resetProp71Cookie();
 
             omniture.populateEventProperties(eventName || event);

--- a/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
+++ b/static/src/javascripts/projects/common/modules/analytics/omnitureMedia.js
@@ -19,7 +19,7 @@ define([
          * It's safe for the next page load though.
          */
         function resetProp71Cookie() {
-            if (config.page.toneIds == 'tone/hosted') {
+            if (config.isHosted) {
                 s.getPreviousValue(s.prop71, 's_prev_ch');
             }
         }
@@ -56,7 +56,7 @@ define([
                 'prop39'    // media id
             ];
 
-        if (config.page.toneIds == 'tone/hosted') {
+        if (config.isHosted) {
             trackingVars.push('prop71');    // previous site section
         }
 


### PR DESCRIPTION
Now redundant.
And ID of hosted tone changed last week so there's a bug fixed.

/cc @guardian/commercial-dev 
