### PR TITLE
extend caption test

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -50,7 +50,7 @@ trait ABTestSwitches {
     "Testing if increasing prominence of video caption drives plays.",
     owners = Seq(Owner.withGithub("gidsg")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 7, 25),
+    sellByDate = new LocalDate(2016, 8, 3),
     exposeClientSide = true
   )
 

--- a/static/src/javascripts/projects/common/modules/experiments/tests/video-caption.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/video-caption.js
@@ -12,12 +12,12 @@ define([
     return function()
     {
         this.id = 'VideoCaption';
-        this.start = '2016-07-22';
-        this.expiry = '2016-07-25';
+        this.start = '2016-07-26';
+        this.expiry = '2016-08-03';
         this.author = 'Gideon Goldberg';
         this.description = 'Increase the prominence of the video caption on in-article videos.';
-        this.audience = 0.06;
-        this.audienceOffset = 0.1;
+        this.audience = 0.21;
+        this.audienceOffset = 0.2;
         this.successMeasure = 'Video starts.';
         this.audienceCriteria = 'Users viewing an article with a video embedded.';
         this.dataLinkNames = '';


### PR DESCRIPTION
## What does this change?

Extend the A/B Video caption test
## What is the value of this and can you measure success?

The previous run did not get the required volume of traffic (as video embed usage is quite variable) so extending the time and audience (test size agreed with @harrysalmon) to be able to assess value of test.

Note: I have checked this does not conflict with `HostedAutoplay` test as that test will not meet the `canRun` condition of this test.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

See https://github.com/guardian/frontend/pull/13640
## Request for comment

@akash1810 @jamesgorrie 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
