### PR TITLE
Fix: space between body adverts

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -4,6 +4,7 @@ define([
     'common/utils/config',
     'common/utils/detect',
     'common/modules/article/space-filler',
+    'common/modules/commercial/ad-sizes',
     'common/modules/commercial/dfp/add-slot',
     'common/modules/commercial/dfp/track-ad-render',
     'common/modules/commercial/dfp/create-slot',
@@ -15,6 +16,7 @@ define([
     config,
     detect,
     spaceFiller,
+    adSizes,
     addSlot,
     trackAdRender,
     createSlot,
@@ -49,7 +51,7 @@ define([
                 ' > :not(p):not(h2):not(.ad-slot)': {minAbove: 35, minBelow: 400}
             },
             filter: function(slot) {
-                if (!prevSlot || Math.abs(slot.top - prevSlot.top) >= this.selectors[' .ad-slot'].minBelow) {
+                if (!prevSlot || Math.abs(slot.top - prevSlot.top) - adSizes.mpu.height >= this.selectors[' .ad-slot'].minBelow) {
                     prevSlot = slot;
                     return true;
                 }

--- a/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
+++ b/static/src/javascripts/projects/common/modules/commercial/article-body-adverts.js
@@ -74,7 +74,7 @@ define([
         if (!longArticleRules) {
             longArticleRules = getRules();
             longArticleRules.selectors[' .ad-slot'].minAbove =
-            longArticleRules.selectors[' .ad-slot'].minBelow = 1300;
+            longArticleRules.selectors[' .ad-slot'].minBelow = detect.getViewport().height;
         }
         return longArticleRules;
     }


### PR DESCRIPTION
This is not enough:

![picture 1](https://cloud.githubusercontent.com/assets/629976/17141425/e89c7b58-5343-11e6-890b-b5a952dde0c6.jpg)

That's because the height of the creative is not factored in `filter` when deciding whether there is enough space between two candidates.

cc @guardian/commercial-dev 
