### PR TITLE
Simplest ever fetch polyfill

### DIFF
--- a/static/src/javascripts/projects/common/utils/ajax-promise.js
+++ b/static/src/javascripts/projects/common/utils/ajax-promise.js
@@ -5,6 +5,7 @@ define([
     ajax,
     Promise
 ) {
+    // This should no longer be used. Prefer the new 'common/utils/fetch' or 'common/utils/fetch-json'
     return function wrappedAjax(params) {
         return new Promise(function (resolve, reject) {
             ajax(params)

--- a/static/src/javascripts/projects/common/utils/ajax.js
+++ b/static/src/javascripts/projects/common/utils/ajax.js
@@ -8,6 +8,7 @@ define([
     config
 ) {
     // This should no longer be used. Prefer the new 'ajax-promise' library instead, which is es6 compliant.
+    // Even better, use 'common/utils/fetch' or 'common/utils/fetch-json'
     var ajaxHost = config.page.ajaxUrl || '';
 
     function ajax(params) {

--- a/static/src/javascripts/projects/common/utils/fetch-json.js
+++ b/static/src/javascripts/projects/common/utils/fetch-json.js
@@ -1,0 +1,26 @@
+define([
+    'common/utils/config',
+    'common/utils/fetch'
+], function (
+    config,
+    fetch
+) {
+    function json (input, init) {
+        if (!input.match('^(https?:)?//')) {
+            input = (config.page.ajaxUrl || '') + input;
+            init = init || {};
+            init.mode = 'cors';
+        }
+
+        return fetch(input, init)
+        .then(function (resp) {
+            if (resp.ok) {
+                return resp.json();
+            } else {
+                throw new Error('Fetch error: ' + resp.statusText);
+            }
+        });
+    }
+
+    return json;
+});

--- a/static/src/javascripts/projects/common/utils/fetch.js
+++ b/static/src/javascripts/projects/common/utils/fetch.js
@@ -70,7 +70,7 @@ define([
 
         function text () {
             var result = bodyRead ? Promise.reject(new TypeError('Already read')) : Promise.resolve(body);
-            bodyRead = false;
+            bodyRead = true;
             return result;
         }
 

--- a/static/src/javascripts/projects/common/utils/fetch.js
+++ b/static/src/javascripts/projects/common/utils/fetch.js
@@ -1,0 +1,90 @@
+define([
+    'reqwest',
+    'Promise'
+], function (
+    reqwest,
+    Promise
+) {
+    /**
+     * Provide a minimal function equivalent to fetch. I don't dare calling it a
+     * polyfill but the signature is the same, albeit simplified.
+     *
+     * fetch (input, init): Promise
+     *
+     * Differences with the standard fetch are
+     *
+     * - fetch
+     * - - input can only be a string, Request is not supported
+     * - - does not support JSONP
+     * - - headers can't be specified
+     * - Request
+     * - - there's no way to send a body
+     * - Response
+     * - - blob is not supported
+     * - - formData is not supported
+     * - - headers are not populated
+     *
+     * If you're still wondering what it actually supports
+     * - CORS
+     * - credentials
+     * - response.text() and response.json()
+     * - response.ok .status .statusText
+     */
+    function fetch (input, init) {
+        return new Promise(function(resolve, reject) {
+            var req = buildRequest(input, init || {});
+            reqwest(req)
+            .then(function (resp) {
+                resolve(createResponse(resp));
+            })
+            .fail(function (resp) {
+                if (resp.status === 0) {
+                    // reqwest wasn't able to make the request
+                    reject(new Error('Fetch error: ' + resp.statusText));
+                } else {
+                    // an error response was received, in fetch this is not a rejection
+                    resolve(createResponse(resp));
+                }
+            });
+        });
+    }
+
+    function buildRequest (path, options) {
+        var isCors = options.mode === 'cors';
+        var withCredentials =
+            (isCors && options.credentials === 'include') ||
+            (!isCors && options.credentials === 'same-origin');
+
+        return {
+            url: path,
+            type: 'text',
+            method: options.method || 'GET',
+            crossOrigin: isCors,
+            withCredentials: withCredentials
+        };
+    }
+
+    function createResponse (response) {
+        var bodyRead = false;
+        var body = response.responseText;
+
+        function text () {
+            var result = bodyRead ? Promise.reject(new TypeError('Already read')) : Promise.resolve(body);
+            bodyRead = false;
+            return result;
+        }
+
+        return {
+            status: response.status,
+            ok: response.status >= 200 && response.status < 300,
+            statusText: response.statusText,
+            url: response.responseURL || '',
+            text: text,
+            json: function () {
+                return text().then(JSON.parse);
+            }
+        };
+    }
+
+    return fetch;
+});

--- a/static/src/javascripts/projects/facia/modules/onwards/weather.js
+++ b/static/src/javascripts/projects/facia/modules/onwards/weather.js
@@ -17,9 +17,9 @@ define([
     'qwery',
     'common/utils/report-error',
     'common/utils/$',
-    'common/utils/ajax-promise',
     'common/utils/config',
     'common/utils/detect',
+    'common/utils/fetch-json',
     'common/utils/mediator',
     'common/utils/template',
     'common/modules/analytics/omniture',
@@ -31,9 +31,9 @@ define([
     qwery,
     reportError,
     $,
-    ajaxPromise,
     config,
     detect,
+    fetchJson,
     mediator,
     template,
     omniture,
@@ -74,11 +74,8 @@ define([
         },
 
         getWeatherData: function (url) {
-            return ajaxPromise({
-                url: url,
-                type: 'json',
-                method: 'get',
-                crossOrigin: true
+            return fetchJson(url, {
+                mode: 'cors'
             });
         },
 

--- a/static/test/javascripts/spec/common/utils/fetch-json.spec.js
+++ b/static/test/javascripts/spec/common/utils/fetch-json.spec.js
@@ -1,0 +1,56 @@
+define([
+    'common/utils/fetch-json'
+], function (
+    json
+) {
+    describe('Fetch JSON util', function () {
+        beforeEach(function () {
+            this.xhr = sinon.useFakeXMLHttpRequest();
+            var requests = this.requests = [];
+            this.xhr.onCreate = function (xhr) {
+                requests.push(xhr);
+            };
+        });
+        afterEach(function () {
+            this.xhr.restore();
+        });
+
+        it('returns a promise which rejects on network errors', function (done) {
+            json('error-path')
+            .then(done.fail)
+            .catch(function (ex) {
+                expect(ex instanceof Error).toBe(true, 'rejects an error');
+                expect(ex.message).toMatch(/fetch error/i);
+            })
+            .then(done)
+            .catch(done.fail);
+
+            this.requests[0].respond(0, {}, 'invalid');
+        });
+
+        it('returns a promise which rejects invalid json responses', function (done) {
+            json('404-error-response')
+            .catch(function (ex) {
+                expect(ex instanceof Error).toBe(true, 'rejects an error');
+                expect(ex.message).toMatch(/json/i);
+            })
+            .then(done)
+            .catch(done.fail);
+
+            this.requests[0].respond(200, {}, 'Plain text');
+        });
+
+        it('resolves a correct response in json', function (done) {
+            json('correct-json')
+            .then(function (response) {
+                expect(response).toEqual({
+                    json: true
+                });
+            })
+            .then(done)
+            .catch(done.fail);
+
+            this.requests[0].respond(200, {}, '{"json":true}');
+        });
+    });
+});

--- a/static/test/javascripts/spec/common/utils/fetch.spec.js
+++ b/static/test/javascripts/spec/common/utils/fetch.spec.js
@@ -21,8 +21,8 @@ define([
             .catch(function (ex) {
                 expect(ex instanceof Error).toBe(true, 'rejects an error');
                 expect(ex.message).toMatch(/fetch error/i);
+                done();
             })
-            .then(done)
             .catch(done.fail);
 
             this.requests[0].respond(0, {}, 'invalid');
@@ -55,14 +55,34 @@ define([
 
                 return resp.json();
             })
+            .then(done.fail)
             .catch(function (ex) {
                 expect(ex instanceof Error).toBe(true, 'rejects an error');
                 expect(ex.message).toMatch(/json/i);
+                done();
             })
-            .then(done)
             .catch(done.fail);
 
             this.requests[0].respond(200, {}, 'Plain text');
+        });
+
+        it('rejects if trying to consume the body multiple times', function (done) {
+            fetch('multiple-body')
+            .then(function (resp) {
+                return Promise.all([
+                    resp.text(),
+                    resp.json()
+                ]);
+            })
+            .then(done.fail)
+            .catch(function (ex) {
+                expect(ex instanceof TypeError).toBe(true, 'rejects an error');
+                expect(ex.message).toBe('Already read');
+                done();
+            })
+            .catch(done.fail);
+
+            this.requests[0].respond(200, {}, '{}');
         });
 
         it('resolves a correct response in plain text', function (done) {

--- a/static/test/javascripts/spec/common/utils/fetch.spec.js
+++ b/static/test/javascripts/spec/common/utils/fetch.spec.js
@@ -1,0 +1,106 @@
+define([
+    'common/utils/fetch'
+], function (
+    fetch
+) {
+    describe('Fetch util', function () {
+        beforeEach(function () {
+            this.xhr = sinon.useFakeXMLHttpRequest();
+            var requests = this.requests = [];
+            this.xhr.onCreate = function (xhr) {
+                requests.push(xhr);
+            };
+        });
+        afterEach(function () {
+            this.xhr.restore();
+        });
+
+        it('returns a promise which rejects on network errors', function (done) {
+            fetch('error-path')
+            .then(done.fail)
+            .catch(function (ex) {
+                expect(ex instanceof Error).toBe(true, 'rejects an error');
+                expect(ex.message).toMatch(/fetch error/i);
+            })
+            .then(done)
+            .catch(done.fail);
+
+            this.requests[0].respond(0, {}, 'invalid');
+        });
+
+        it('returns a promise which resolves on error responses', function (done) {
+            fetch('404-error-response')
+            .then(function (resp) {
+                expect(resp.ok).toBe(false, 'resp.ok');
+                expect(resp.status).toBe(404, 'resp.status');
+                expect(resp.statusText).toBe('Not Found', 'resp.statusText');
+
+                return resp.text();
+            })
+            .then(function (responseText) {
+                expect(responseText).toBe('Error response');
+            })
+            .then(done)
+            .catch(done.fail);
+
+            this.requests[0].respond(404, {}, 'Error response');
+        });
+
+        it('rejects if response is not correct json', function (done) {
+            fetch('invalid-json')
+            .then(function (resp) {
+                expect(resp.ok).toBe(true, 'resp.ok');
+                expect(resp.status).toBe(200, 'resp.status');
+                expect(resp.statusText).toBe('OK', 'resp.statusText');
+
+                return resp.json();
+            })
+            .catch(function (ex) {
+                expect(ex instanceof Error).toBe(true, 'rejects an error');
+                expect(ex.message).toMatch(/json/i);
+            })
+            .then(done)
+            .catch(done.fail);
+
+            this.requests[0].respond(200, {}, 'Plain text');
+        });
+
+        it('resolves a correct response in plain text', function (done) {
+            fetch('correct-json')
+            .then(function (resp) {
+                expect(resp.ok).toBe(true, 'resp.ok');
+                expect(resp.status).toBe(200, 'resp.status');
+                expect(resp.statusText).toBe('OK', 'resp.statusText');
+
+                return resp.text();
+            })
+            .then(function (responseText) {
+                expect(responseText).toBe('{"json":true}');
+            })
+            .then(done)
+            .catch(done.fail);
+
+            this.requests[0].respond(200, {}, '{"json":true}');
+        });
+
+        it('resolves a correct response in json', function (done) {
+            fetch('correct-json')
+            .then(function (resp) {
+                expect(resp.ok).toBe(true, 'resp.ok');
+                expect(resp.status).toBe(200, 'resp.status');
+                expect(resp.statusText).toBe('OK', 'resp.statusText');
+
+                return resp.json();
+            })
+            .then(function (json) {
+                expect(json).toEqual({
+                    json: true
+                });
+            })
+            .then(done)
+            .catch(done.fail);
+
+            this.requests[0].respond(200, {}, '{"json":true}');
+        });
+    });
+});


### PR DESCRIPTION
## What does this change?

Introduce the simplest (most stupid) `fetch` polyfill. Internally it uses `reqwest` so there are no extra dependencies, but provides the same signature as the standard [fetch](https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch).

There's also a utility function to fetch JSON.

In the future, when we introduce a proper polyfill (maybe through @janua 's ESI) we can simply remove `common/utils/fetch` or change the require to `proper-polyfill/fetch`.
## What is the value of this and can you measure success?

First step in removing `reqwest`. Success means weather widget still works. If positive I'll convert some other modules to `fetch` (maybe).
## Does this affect other platforms - Amp, Apps, etc?

No 
## Request for comment

@sndrs @regiskuckaertz 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
