### PR TITLE
Add advertiser logo in Facebook ads

### DIFF
--- a/static/src/javascripts/projects/common/views/commercial/creatives/facebook.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/facebook.html
@@ -1,11 +1,11 @@
 <div class="fb-ad" data-placementid="<%=placementId%>" data-format="native" data-nativeadid="<%=adId%>" data-testmode="<%=testMode%>"></div>
 <aside class="creative creative--facebook" id="<%=adId%>">
     <a class="fbAdLink advert advert--facebook">
-        <div class="fbAdMedia thirdPartyMediaClass advert__image-container"></div>
-        <h2 class="fbAdTitle thirdPartyTitleClass advert__title"></h2>
-        <div class="fbAdBody thirdPartyBodyClass advert__meta"></div>
+        <div class="fbAdMedia advert__image-container"></div>
+        <h2 class="fbAdTitle advert__title"></h2>
+        <div class="fbAdBody advert__meta"></div>
         <div class="advert__more button button--tertiary button--medium">
-            <span class="fbAdCallToAction thirdPartyCallToActionClass"></span>
+            <span class="fbAdCallToAction"></span>
             <%=externalLink%>
         </div>
     </a>

--- a/static/src/javascripts/projects/common/views/commercial/creatives/facebook.html
+++ b/static/src/javascripts/projects/common/views/commercial/creatives/facebook.html
@@ -4,6 +4,7 @@
         <div class="fbAdMedia advert__image-container"></div>
         <h2 class="fbAdTitle advert__title"></h2>
         <div class="fbAdBody advert__meta"></div>
+        <div class="fbAdIcon advert__brand"></div>
         <div class="advert__more button button--tertiary button--medium">
             <span class="fbAdCallToAction"></span>
             <%=externalLink%>

--- a/static/src/stylesheets/module/commercial/_adverts-facebook.scss
+++ b/static/src/stylesheets/module/commercial/_adverts-facebook.scss
@@ -48,4 +48,12 @@
     .inline-icon {
         fill: $neutral-1;
     }
+
+    .advert__brand {
+        position: absolute;
+        bottom: $gs-baseline;
+        right: $gs-gutter / 2;
+        width: $gs-baseline * 4;
+        height: $gs-baseline * 4;
+    }
 }


### PR DESCRIPTION
Adds the logo to the bottom right corner:
![picture 1](https://cloud.githubusercontent.com/assets/629976/17145306/95a77656-5351-11e6-9f75-63b1fd1cbe55.jpg)

cc @guardian/commercial-dev 
