### PR TITLE
Addition of paying member status to feedback email

### DIFF
--- a/static/src/javascripts/projects/common/modules/onward/tech-feedback.js
+++ b/static/src/javascripts/projects/common/modules/onward/tech-feedback.js
@@ -65,6 +65,7 @@ define([
                     devicePixelRatio: window.devicePixelRatio,
                     ophanId: config.ophan.pageViewId,
                     gu_u: cookies.get('GU_U'),
+                    payingMember: cookies.get('gu_paying_member'),
                     abTests : summariseAbTests(ab.getParticipations())
                 };
                 var body = '\r\n\r\n\r\n\r\n------------------------------\r\nAdditional technical data about your request - please do not edit:\r\n\r\n'


### PR DESCRIPTION
## What does this change?

Adds the paying member status to the mailto footer of tech feedback and userhelp mails
## What is the value of this and can you measure success?

Provides us with more information on the user at initial point of contact, should help reduce back and forth with users and flag paying member status early.
## Does this affect other platforms - Amp, Apps, etc?

нет
## Screenshots
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
