### PR TITLE
Give site messages an optional data-component

### DIFF
--- a/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/habit-forming-digest-promo.js
@@ -49,6 +49,7 @@ define([
 
             var message = new Message('habit-digest-message-07-16', {
                 pinOnHide: false,
+                siteMessageComponentName: 'habit digest snap',
                 siteMessageLinkName: 'habit digest message',
                 siteMessageCloseBtn: 'habit digest hide',
                 cssModifierClass: cssModifierClass

--- a/static/src/javascripts/projects/common/modules/ui/message.js
+++ b/static/src/javascripts/projects/common/modules/ui/message.js
@@ -32,6 +32,7 @@ define([
         this.permanent = opts.permanent || false;
         this.type = opts.type || 'banner';
         this.pinOnHide = opts.pinOnHide || false;
+        this.siteMessageComponentName = opts.siteMessageComponentName || '';
         this.siteMessageLinkName = opts.siteMessageLinkName || '';
         this.siteMessageCloseBtn = opts.siteMessageCloseBtn || '';
         this.prefs = 'messages';
@@ -69,6 +70,9 @@ define([
         this.updateMessageOnWidth();
         mediator.on('window:resize', debounce(this.updateMessageOnWidth, 200).bind(this));
 
+        if (this.siteMessageComponentName) {
+            siteMessage.attr('data-component', this.siteMessageComponentName);
+        }
         if (this.siteMessageLinkName) {
             siteMessage.attr('data-link-name', this.siteMessageLinkName);
         }


### PR DESCRIPTION
## What does this change?
- Adds an option to the Message prototype so that a `data-component` can be passed as an option
- The `data-component` encapsulates all the elements and `data-link-names` associated with a site message. Different site messages can have different strings for the `data-component`
- The habit-forming-digest message is now using the cool new data-component option
- Existing site messages are not affected; the `data-component` is an optional param
## What is the value of this and can you measure success?

The outer-most DIV of a site message can have a data-component! 🎉 

If you use `data-component` alongside `data-link-name` then queries for the data can be much simpler.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

<img width="577" alt="picture 137" src="https://cloud.githubusercontent.com/assets/8607683/17146901/29bcc098-5358-11e6-9230-ed58c1e98926.png">

Change to the query string parameters sent to Ophan:

<img width="444" alt="picture 138" src="https://cloud.githubusercontent.com/assets/8607683/17146939/5724cff8-5358-11e6-90fc-349af1fe2952.png">
## Request for comment

Thanks to @janua :clap:
