### PR TITLE
Remove "hide" toggle on multi campaign containers 

### DIFF
--- a/common/app/layout/Front.scala
+++ b/common/app/layout/Front.scala
@@ -120,6 +120,7 @@ object ContainerCommercialOptions {
         isSponsored = dfpTag.paidForType == Sponsored,
         isPaidContainer = dfpTag.paidForType == AdvertisementFeature,
         isFoundationSupported = dfpTag.paidForType == FoundationFunded,
+        hasPaidForContent = false,
         sponsor,
         sponsorshipTag = Some(SponsorshipTag(dfpTag.tagType, capiTagId)),
         sponsorshipType = Some(dfpTag.paidForType.name),
@@ -157,6 +158,7 @@ object ContainerCommercialOptions {
           isSponsored = dfpTag.paidForType == Sponsored,
           isPaidContainer = dfpTag.paidForType == AdvertisementFeature,
           isFoundationSupported = dfpTag.paidForType == FoundationFunded,
+          hasPaidForContent = false,
           sponsor = dfpTag.lineItems.headOption flatMap (_.sponsor),
           sponsorshipTag,
           sponsorshipType = Some(dfpTag.paidForType.name),
@@ -170,10 +172,22 @@ object ContainerCommercialOptions {
     collection.items.headOption flatMap mkFromFirstItemInCollection getOrElse empty
   }
 
+  val multi = ContainerCommercialOptions(
+    isSponsored = false,
+    isPaidContainer = false,
+    isFoundationSupported = false,
+    hasPaidForContent = true,
+    sponsor = None,
+    sponsorshipTag = None,
+    sponsorshipType = None,
+    omitMPU = false
+  )
+
   val empty = ContainerCommercialOptions(
     isSponsored = false,
     isPaidContainer = false,
     isFoundationSupported = false,
+    hasPaidForContent = false,
     sponsor = None,
     sponsorshipTag = None,
     sponsorshipType = None,
@@ -187,12 +201,13 @@ case class ContainerCommercialOptions(
   isSponsored: Boolean,
   isPaidContainer: Boolean,
   isFoundationSupported: Boolean,
+  hasPaidForContent: Boolean,
   sponsor: Option[String],
   sponsorshipTag: Option[SponsorshipTag],
   sponsorshipType: Option[String],
   omitMPU: Boolean
 ) {
-  val isPaidFor = isSponsored || isPaidContainer || isFoundationSupported
+  val isPaidFor = isSponsored || isPaidContainer || isFoundationSupported || hasPaidForContent
 }
 
 object FaciaContainer {
@@ -255,7 +270,7 @@ object FaciaContainer {
     container match {
       case MostPopular => ContainerCommercialOptions.mostPopular(omitMPU)
       case Commercial(SingleCampaign(_)) => ContainerCommercialOptions.fromCollection(collectionEssentials)
-      case Commercial(MultiCampaign(_)) => ContainerCommercialOptions.empty
+      case Commercial(MultiCampaign(_)) => ContainerCommercialOptions.multi
       case _ => ContainerCommercialOptions.fromConfig(config.config)
     },
     config.config.description.map(DescriptionMetaHeader),

--- a/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
+++ b/common/app/views/fragments/containers/facia_cards/commercialContainer.scala.html
@@ -36,7 +36,7 @@
                                     }
                                 >
                                     <div class="rich-link tone-paidfor--item">
-                                        <div class="rich-link__container js-container__header">
+                                        <div class="rich-link__container">
                                             @for( InlineImage(images) <- cardWithSponsorData.card.displayElement) {
                                                 @itemImage(images)
                                             }


### PR DESCRIPTION
Paid containers should never have a "hide" toggle, yet multi campaigns erroneously do:

![picture 1](https://cloud.githubusercontent.com/assets/629976/17173589/96b228c8-53f3-11e6-9a9e-f548219c8e2f.jpg)

The root of this comes from two small errors:
1. [each card](https://github.com/guardian/frontend/compare/rk-multi-campaign-hide?expand=1#diff-cba913f7f475ab49435b6f99beffaabfL39) in the container has the `js-container__header` class, which is a hook used to insert the toggle
2. the container itself has the `js-container--toggle` [although it shouldn't](https://github.com/guardian/frontend/blob/master/common/app/views/support/GetClasses.scala#L117). This is because currently [multi campaigns are "empty" commercial containers](https://github.com/guardian/frontend/blob/master/common/app/layout/Front.scala#L258).

After fixing these two issues:

![picture 2](https://cloud.githubusercontent.com/assets/629976/17173683/36999074-53f4-11e6-9005-47b1c04c6f8b.jpg)

cc @kelvin-chappell @JonNorman 
