### PR TITLE
Remove !important from AMP styles

### DIFF
--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -66,14 +66,14 @@
 }
 
 .u-h {
-    border: 0 !important;
-    clip: rect(0 0 0 0) !important;
-    height: 0.0625rem !important;
-    margin: -0.0625rem !important;
-    overflow: hidden !important;
-    padding: 0 !important;
-    position: absolute !important;
-    width: 0.0625rem !important;
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 0.0625rem;
+    margin: -0.0625rem;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 0.0625rem;
 }
 
 /* Social

--- a/common/app/views/fragments/amp/stylesheets/main.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/main.scala.html
@@ -264,6 +264,8 @@
     @fragments.amp.stylesheets.fonts()
     @fragments.amp.stylesheets.buttons()
     @fragments.amp.stylesheets.header()
-    @fragments.amp.stylesheets.liveBlog()
+    @if(metaData.contentType == "LiveBlog") {
+        @fragments.amp.stylesheets.liveBlog()
+    }
 
 </style>


### PR DESCRIPTION
## What does this change?
1. Prevent liveblog CSS from being included in non-liveblog articles
2. Remove `!important` from AMP liveblog stylesheet, as these break the AMP validator
## Request for comment

@NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
