### PR TITLE
Scope H2 style in immersive articles

### DIFF
--- a/static/src/stylesheets/module/content/_article-immersive.scss
+++ b/static/src/stylesheets/module/content/_article-immersive.scss
@@ -387,7 +387,7 @@
     }
 
     .section-title,
-    .from-content-api h2 {
+    .from-content-api > h2 {
         @include fs-headline(5);
         font-weight: 200;
 
@@ -665,4 +665,3 @@
         }
     }
 }
-


### PR DESCRIPTION
This one slipped through the crack:

![unnamed](https://cloud.githubusercontent.com/assets/629976/17175814/89e910c6-5401-11e6-8bc8-e3a3ff00e4a4.jpg)

@guardian/commercial-dev 
