### PR TITLE
Add empty r2.press queues url properties in dev

### DIFF
--- a/common/conf/env/DEV.properties
+++ b/common/conf/env/DEV.properties
@@ -111,3 +111,7 @@ deploys-notify.api.key=this-is-the-dev-api-key
 
 #HealthCheck refresh interval (0 = no update on regular schedule)
 healthcheck.updateIntervalInSecs=300
+
+# r2 Press (empty in dev)
+admin.r2.page.press.sqs.queue.url=
+admin.r2.page.press.takedown.sqs.queue.url=


### PR DESCRIPTION
## What does this change?

Add mising properties for r2.press queues in dev (empty)
## What is the value of this and can you measure success?

Dev-build doesn't throw error
## Does this affect other platforms - Amp, Apps, etc?
## Screenshots
## Request for comment

@NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
