### PR TITLE
Removing call to WS.url (Continue #3)

### DIFF
--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -9,6 +9,7 @@ import controllers.{AdminControllers, HealthCheck}
 import _root_.dfp.DfpDataCacheLifecycle
 import http.AdminHttpErrorHandler
 import dev.DevAssetsController
+import football.feed.MatchDayRecorder
 import jobs.{FastlyCloudwatchLoadJob, R2PagePressJob, VideoEncodingsJob}
 import model.{AdminLifecycle, ApplicationIdentity}
 import ophan.SurgingContentAgentLifecycle
@@ -33,6 +34,7 @@ trait AdminServices {
   lazy val fastlyCloudwatchLoadJob = wire[FastlyCloudwatchLoadJob]
   lazy val r2PagePressJob = wire[R2PagePressJob]
   lazy val videoEncodingsJob = wire[VideoEncodingsJob]
+  lazy val matchDayRecorder = wire[MatchDayRecorder]
 }
 
 trait Controllers extends AdminControllers {
@@ -41,7 +43,7 @@ trait Controllers extends AdminControllers {
 }
 
 trait AdminLifecycleComponents {
-  self: AppComponents with Controllers =>
+  self: AppComponents with Controllers with AdminServices =>
 
   override lazy val lifecycleComponents: List[LifecycleComponent] = List(
     wire[LogstashLifecycle],

--- a/admin/app/football/controllers/FrontsController.scala
+++ b/admin/app/football/controllers/FrontsController.scala
@@ -21,7 +21,7 @@ import pa.LiveMatch
 import play.api.libs.json.JsResultException
 
 
-class FrontsController(wsClient: WSClient) extends Controller with ExecutionContexts with GetPaClient with Logging {
+class FrontsController(override val wsClient: WSClient) extends Controller with ExecutionContexts with GetPaClient with Logging {
   val SNAP_TYPE = "json.html"
   val SNAP_CSS = "football"
 

--- a/admin/app/football/controllers/PaBrowserController.scala
+++ b/admin/app/football/controllers/PaBrowserController.scala
@@ -1,19 +1,16 @@
 package controllers.admin
 
 import model.Cached.RevalidatableResult
-import play.api._
 import play.api.mvc._
-import play.api.Play.current
-import football.services.{GetPaClient, Client}
-import common.{Logging, ExecutionContexts}
-import org.joda.time.LocalDate
+import football.services.GetPaClient
+import common.ExecutionContexts
 import java.net.URLDecoder
-import scala.concurrent.Future
 import scala.language.postfixOps
-import model.{NoCache, Cached}
+import model.{Cached, NoCache}
+import play.api.libs.ws.WSClient
 
 
-class PaBrowserController extends Controller with ExecutionContexts with GetPaClient {
+class PaBrowserController(override val wsClient: WSClient) extends Controller with ExecutionContexts with GetPaClient {
 
   def browserSubstitution() =AuthActions.AuthActionTest { implicit request =>
     val submission = request.body.asFormUrlEncoded.getOrElse { throw new Exception("Could not read POST submission") }

--- a/admin/app/football/controllers/PlayerController.scala
+++ b/admin/app/football/controllers/PlayerController.scala
@@ -13,9 +13,9 @@ import model.{Cors, NoCache, Cached}
 import play.api.libs.json.{JsString, JsArray, JsObject}
 import org.joda.time.format.DateTimeFormat
 import play.twirl.api.HtmlFormat
+import play.api.libs.ws.WSClient
 
-
-class PlayerController extends Controller with ExecutionContexts with GetPaClient with Requests {
+class PlayerController(override val wsClient: WSClient) extends Controller with ExecutionContexts with GetPaClient with Requests {
 
   def playerIndex = AuthActions.AuthActionTest.async { implicit request =>
     for {

--- a/admin/app/football/controllers/TablesController.scala
+++ b/admin/app/football/controllers/TablesController.scala
@@ -8,11 +8,11 @@ import model.{Cors, Cached, NoCache}
 import org.joda.time.LocalDate
 import pa._
 import play.api.mvc._
-
+import play.api.libs.ws.WSClient
 import scala.concurrent.Future
 
 
-class TablesController extends Controller with ExecutionContexts with GetPaClient {
+class TablesController(override val wsClient: WSClient) extends Controller with ExecutionContexts with GetPaClient {
 
   def tablesIndex = AuthActions.AuthActionTest.async { implicit request =>
     for {

--- a/admin/app/football/feed/MatchDayRecorder.scala
+++ b/admin/app/football/feed/MatchDayRecorder.scala
@@ -4,14 +4,13 @@ import common.{Edition, ExecutionContexts, Logging}
 import conf.switches.Switches
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
-import play.api.libs.ws.WS
+import play.api.libs.ws.WSClient
 import services.S3
 import conf.AdminConfiguration.pa
 
 import scala.concurrent.ExecutionContext
-import play.api.Play.current
 
-object MatchDayRecorder extends ExecutionContexts with Logging {
+case class MatchDayRecorder(wsClient: WSClient) extends ExecutionContexts with Logging {
 
   private val feedDateFormat = DateTimeFormat.forPattern("yyyyMMdd").withZone(Edition.defaultEdition.timezone)
   private val fileDateFormat = DateTimeFormat.forPattern("yyyy/MM/dd/HH-mm-ss").withZone(Edition.defaultEdition.timezone)
@@ -23,7 +22,7 @@ object MatchDayRecorder extends ExecutionContexts with Logging {
     val now = DateTime.now
     val feedUrl = s"${pa.footballHost}/competitions/matchDay/${pa.footballApiKey}/${now.toString(feedDateFormat)}"
     val fileName = s"football-feeds/match-day/${now.toString(fileDateFormat)}.xml"
-    val result = WS.url(feedUrl).get()
+    val result = wsClient.url(feedUrl).get()
 
     result.onFailure {
       case t: Throwable => log.info(s"match day recorder failed $feedUrl", t)

--- a/admin/app/model/AdminLifecycle.scala
+++ b/admin/app/model/AdminLifecycle.scala
@@ -21,7 +21,8 @@ class AdminLifecycle(appLifecycle: ApplicationLifecycle,
                      emailService: EmailService,
                      fastlyCloudwatchLoadJob: FastlyCloudwatchLoadJob,
                      r2PagePressJob: R2PagePressJob,
-                     videoEncodingsJob: VideoEncodingsJob)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
+                     videoEncodingsJob: VideoEncodingsJob,
+                     matchDayRecorder: MatchDayRecorder)(implicit ec: ExecutionContext) extends LifecycleComponent with Logging {
 
   appLifecycle.addStopHook { () => Future {
     descheduleJobs()
@@ -82,7 +83,7 @@ class AdminLifecycle(appLifecycle: ApplicationLifecycle,
 
     // every minute, 22 seconds past the minute (e.g 13:01:22, 13:02:22)
     jobs.schedule("MatchDayRecorderJob", "22 * * * * ?") {
-      MatchDayRecorder.record()
+      matchDayRecorder.record()
     }
 
     if (environment.isProd) {

--- a/admin/test/football/PlayerControllerTest.scala
+++ b/admin/test/football/PlayerControllerTest.scala
@@ -1,15 +1,15 @@
 package football
 
 import common.ExecutionContexts
-import org.scalatest.{DoNotDiscover, ShouldMatchers, FreeSpec}
-import play.api.libs.json.{JsString, JsObject}
-import play.api.mvc.{AnyContentAsFormUrlEncoded}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, ShouldMatchers}
+import play.api.libs.json.{JsObject, JsString}
+import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test._
 import play.api.test.Helpers._
 import football.services.GetPaClient
-import test.ConfiguredTestSuite
+import test.{ConfiguredTestSuite, WithTestWsClient}
 
-@DoNotDiscover class PlayerControllerTest extends FreeSpec with ShouldMatchers with GetPaClient with ExecutionContexts with ConfiguredTestSuite {
+@DoNotDiscover class PlayerControllerTest extends FreeSpec with ShouldMatchers with GetPaClient with ExecutionContexts with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
 
   "test redirects player card form submission to correct player page" in {
     val Some(result) = route(FakeRequest(POST, "/admin/football/player/card", FakeHeaders(), AnyContentAsFormUrlEncoded(Map("player" -> List("123456"), "team" -> List("1"), "competition" -> List("100"), "playerCardType" -> List("attack")))))

--- a/admin/test/football/SiteControllerTest.scala
+++ b/admin/test/football/SiteControllerTest.scala
@@ -1,13 +1,20 @@
 package football
 
 import common.ExecutionContexts
-import org.scalatest.{DoNotDiscover, ShouldMatchers, FreeSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, ShouldMatchers}
 import play.api.test._
 import play.api.test.Helpers._
 import football.services.GetPaClient
-import test.ConfiguredTestSuite
+import test.{ConfiguredTestSuite, WithTestWsClient}
 
-@DoNotDiscover class SiteControllerTest extends FreeSpec with GetPaClient with ExecutionContexts with ShouldMatchers with ConfiguredTestSuite {
+@DoNotDiscover class SiteControllerTest
+  extends FreeSpec
+  with GetPaClient
+  with ExecutionContexts
+  with ShouldMatchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   "test index page loads" in {
     val Some(result) = route(FakeRequest(GET, "/admin/football"))

--- a/admin/test/football/TablesControllerTest.scala
+++ b/admin/test/football/TablesControllerTest.scala
@@ -3,17 +3,26 @@ package football
 import common.ExecutionContexts
 import controllers.admin.TablesController
 import football.model.PA
-import org.scalatest.{DoNotDiscover, ShouldMatchers, FreeSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec, ShouldMatchers}
 import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test._
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
-import test.ConfiguredTestSuite
+import test.{ConfiguredTestSuite, WithTestWsClient}
+
 import scala.annotation.tailrec
 import football.services.GetPaClient
+
 import scala.language.postfixOps
 
-@DoNotDiscover class TablesControllerTest extends FreeSpec with GetPaClient with ExecutionContexts with ShouldMatchers with ConfiguredTestSuite {
+@DoNotDiscover class TablesControllerTest
+  extends FreeSpec
+    with GetPaClient
+    with ExecutionContexts
+    with ShouldMatchers
+    with ConfiguredTestSuite
+    with BeforeAndAfterAll
+    with WithTestWsClient {
 
   "test tables index page loads with leagues" in {
     val Some(result) = route(FakeRequest(GET, "/admin/football/tables"))
@@ -69,7 +78,7 @@ import scala.language.postfixOps
   }
 
   "the internal surroundingItems function should work OK" in {
-    val tablesController = new TablesController()
+    val tablesController = new TablesController(wsClient)
     tablesController.surroundingItems[Int](1, List(1, 2, 3, 4, 5, 6), 4 ==) should equal(List(3, 4, 5))
     tablesController.surroundingItems[Int](2, List(1, 2, 3, 4, 5, 6), 4 ==) should equal(List(2, 3, 4, 5, 6))
     tablesController.surroundingItems[Int](3, List(1, 2, 3, 4, 5, 6), 4 ==) should equal(List(1, 2, 3, 4, 5, 6))

--- a/common/test/package.scala
+++ b/common/test/package.scala
@@ -129,7 +129,7 @@ trait WithTestWsClient {
   self: WithTestWsClient with BeforeAndAfterAll =>
 
   private val lazyWsClient = Lazy(NingWSClient(NingWSClientConfig(maxRequestRetry = 0)))
-  protected lazy val wsClient: WSClient = lazyWsClient
+  lazy val wsClient: WSClient = lazyWsClient
 
   override def afterAll() = if(lazyWsClient.isDefined) lazyWsClient.close
 }

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -54,7 +54,7 @@ trait Controllers
   lazy val surveyPageController = wire[SurveyPageController]
 }
 
-trait AppComponents extends FrontendComponents with Controllers with AdminServices {
+trait AppComponents extends FrontendComponents with Controllers with AdminServices with SportServices {
 
   override def router: Router = wire[Routes]
   override def appIdentity: ApplicationIdentity = ApplicationIdentity("dev-build")

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -22,15 +22,19 @@ import play.api.libs.ws.WSClient
 import rugby.conf.RugbyLifecycle
 import router.Routes
 import rugby.controllers.RugbyControllers
+import rugby.feed.OptaFeed
+import rugby.jobs.RugbyStatsJob
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
 }
 
-trait CricketServices {
+trait SportServices {
   def wsClient: WSClient
   lazy val cricketPaFeed = wire[PaFeed]
   lazy val cricketStatsJob = wire[CricketStatsJob]
+  lazy val rugbyFeed = wire[OptaFeed]
+  lazy val rugbyStatsJob = wire[RugbyStatsJob]
 }
 
 trait Controllers extends FootballControllers with CricketControllers with RugbyControllers {
@@ -38,8 +42,8 @@ trait Controllers extends FootballControllers with CricketControllers with Rugby
   lazy val devAssetsController = wire[DevAssetsController]
 }
 
-trait AppLifecycleComponents extends CricketServices {
-  self: FrontendComponents with Controllers =>
+trait AppLifecycleComponents {
+  self: FrontendComponents with Controllers with SportServices =>
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],
@@ -53,7 +57,7 @@ trait AppLifecycleComponents extends CricketServices {
   )
 }
 
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers {
+trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with SportServices{
 
   lazy val router: Router = wire[Routes]
 

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -7,8 +7,10 @@ import conf.switches.SwitchboardLifecycle
 import conf.{FootballLifecycle, CommonFilters, CachedHealthCheckLifeCycle}
 import cricket.conf.CricketLifecycle
 import cricket.controllers.CricketControllers
+import cricketPa.PaFeed
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import football.controllers.{FootballControllers, HealthCheck}
+import jobs.CricketStatsJob
 import model.ApplicationIdentity
 import ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
@@ -16,6 +18,7 @@ import play.api.http.{HttpErrorHandler, HttpRequestHandler}
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
+import play.api.libs.ws.WSClient
 import rugby.conf.RugbyLifecycle
 import router.Routes
 import rugby.controllers.RugbyControllers
@@ -24,12 +27,18 @@ class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
 }
 
+trait CricketServices {
+  def wsClient: WSClient
+  lazy val cricketPaFeed = wire[PaFeed]
+  lazy val cricketStatsJob = wire[CricketStatsJob]
+}
+
 trait Controllers extends FootballControllers with CricketControllers with RugbyControllers {
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
 }
 
-trait AppLifecycleComponents {
+trait AppLifecycleComponents extends CricketServices {
   self: FrontendComponents with Controllers =>
 
   override lazy val lifecycleComponents = List(

--- a/sport/app/cricket/conf/context.scala
+++ b/sport/app/cricket/conf/context.scala
@@ -10,7 +10,8 @@ import scala.concurrent.{Future, ExecutionContext}
 class CricketLifecycle(
   appLifeCycle: ApplicationLifecycle,
   jobs: JobScheduler,
-  akkaAsync: AkkaAsync
+  akkaAsync: AkkaAsync,
+  cricketStatsJob: CricketStatsJob
 )(implicit ec: ExecutionContext) extends LifecycleComponent {
 
   appLifeCycle.addStopHook { () => Future {
@@ -19,7 +20,7 @@ class CricketLifecycle(
 
   private def scheduleJobs() {
     jobs.schedule("CricketAgentRefreshJob", "0 * * * * ?") {
-      CricketStatsJob.run()
+      cricketStatsJob.run()
     }
   }
 
@@ -32,7 +33,7 @@ class CricketLifecycle(
     scheduleJobs()
 
     akkaAsync.after1s {
-      CricketStatsJob.run()
+      cricketStatsJob.run()
     }
   }
 }

--- a/sport/app/cricket/controllers/CricketControllers.scala
+++ b/sport/app/cricket/controllers/CricketControllers.scala
@@ -1,7 +1,9 @@
 package cricket.controllers
 
 import com.softwaremill.macwire._
+import jobs.CricketStatsJob
 
 trait CricketControllers {
+  def cricketStatsJob: CricketStatsJob
   lazy val cricketMatchController = wire[CricketMatchController]
 }

--- a/sport/app/rugby/conf/RugbyLifecycle.scala
+++ b/sport/app/rugby/conf/RugbyLifecycle.scala
@@ -1,11 +1,10 @@
 package rugby.conf
 
 import app.LifecycleComponent
-import common.{JobScheduler, AkkaAsync}
+import common.{AkkaAsync, JobScheduler}
 import play.api.inject.ApplicationLifecycle
-import rugby.feed.{CapiFeed, OptaFeed}
+import rugby.feed.CapiFeed
 import rugby.jobs.RugbyStatsJob
-
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
@@ -13,7 +12,8 @@ import scala.concurrent.duration._
 class RugbyLifecycle(
   appLifeCycle: ApplicationLifecycle,
   jobs: JobScheduler,
-  akkaAsync: AkkaAsync
+  akkaAsync: AkkaAsync,
+  rugbyStatsJob: RugbyStatsJob
 )(implicit ec: ExecutionContext) extends LifecycleComponent {
 
   protected val initializationTimeout: FiniteDuration = 10.seconds
@@ -21,41 +21,44 @@ class RugbyLifecycle(
   override def start(): Unit = {
     jobs.deschedule("FixturesAndResults")
     jobs.schedule("FixturesAndResults", "5 0/30 * * * ?") {
-      RugbyStatsJob.fixturesAndResults(OptaFeed.getFixturesAndResults)
+      rugbyStatsJob.fetchFixturesAndResults()
     }
 
     jobs.deschedule("GroupTables")
     jobs.schedule("GroupTables", "10 0/30 * * * ?") {
-      RugbyStatsJob.groupTables(OptaFeed.getGroupTables)
+      rugbyStatsJob.fetchGroupTables()
     }
 
 
     jobs.deschedule("PastEventScores")
     jobs.schedule("PastEventScores", "20 0/30 * * * ?") {
-      RugbyStatsJob.fetchPastScoreEvents
+      rugbyStatsJob.fetchPastScoreEvents
     }
 
     jobs.deschedule("PastMatchesStat")
     jobs.schedule("PastMatchesStat", "30 0/30 * * * ?") {
-      RugbyStatsJob.fetchPastMatchesStat
+      rugbyStatsJob.fetchPastMatchesStat
     }
 
 
     jobs.deschedule("MatchNavArticles")
     jobs.schedule("MatchNavArticles", "35 0/30 * * * ?") {
-      RugbyStatsJob.sendMatchArticles(CapiFeed.getMatchArticles())
+      val refreshedNavContent = CapiFeed.getMatchArticles(rugbyStatsJob.getAllResults())
+      rugbyStatsJob.sendMatchArticles(refreshedNavContent)
     }
 
     akkaAsync.after1s {
-      RugbyStatsJob.fixturesAndResults(OptaFeed.getFixturesAndResults)
-      RugbyStatsJob.groupTables(OptaFeed.getGroupTables)
+      rugbyStatsJob.fetchFixturesAndResults()
+      rugbyStatsJob.fetchGroupTables()
     }
 
     //delay to allow previous jobs to complete
     akkaAsync.after(initializationTimeout) {
-      RugbyStatsJob.fetchPastScoreEvents
-      RugbyStatsJob.fetchPastMatchesStat
-      RugbyStatsJob.sendMatchArticles(CapiFeed.getMatchArticles())
+      rugbyStatsJob.fetchPastScoreEvents
+      rugbyStatsJob.fetchPastMatchesStat
+
+      val refreshedNavContent = CapiFeed.getMatchArticles(rugbyStatsJob.getAllResults())
+      rugbyStatsJob.sendMatchArticles(refreshedNavContent)
     }
   }
 }

--- a/sport/app/rugby/controllers/RugbyControllers.scala
+++ b/sport/app/rugby/controllers/RugbyControllers.scala
@@ -1,7 +1,9 @@
 package rugby.controllers
 
 import com.softwaremill.macwire._
+import rugby.jobs.RugbyStatsJob
 
 trait RugbyControllers {
+  def rugbyStatsJob: RugbyStatsJob
   lazy val matchesController = wire[MatchesController]
 }

--- a/sport/app/rugby/feed/CapiFeed.scala
+++ b/sport/app/rugby/feed/CapiFeed.scala
@@ -16,16 +16,12 @@ case class MatchNavigation(
 
 object CapiFeed extends ExecutionContexts with Logging {
 
-  def getMatchArticles() : Future[Map[String, MatchNavigation]] = {
+  def getMatchArticles(matches: Seq[Match]) : Future[Map[String, MatchNavigation]] = {
     Future.sequence(
-      RugbyStatsJob.getAllResults().map { rugbyMatch =>
+      matches.map { rugbyMatch =>
         loadNavigation(rugbyMatch).map( _.map( (rugbyMatch.key, _) ) )
       }
     ).map(_.flatten.toMap)
-  }
-
-  def findMatchArticle(rugbyMatch: Match) : Option[MatchNavigation] = {
-    RugbyStatsJob.getMatchNavContent(rugbyMatch)
   }
 
   private def loadNavigation(rugbyMatch: Match): Future[Option[MatchNavigation]] = {

--- a/sport/app/rugby/feed/OptaFeed.scala
+++ b/sport/app/rugby/feed/OptaFeed.scala
@@ -1,14 +1,9 @@
 package rugby.feed
 
 import common.{ExecutionContexts, Logging}
-import play.api.Play.current
-import play.api.libs.ws.{WSRequest, WS}
-import rugby.jobs.RugbyStatsJob
+import play.api.libs.ws.WSClient
 import rugby.model._
-import conf.Configuration
-
 import scala.concurrent.Future
-import scala.xml.XML
 
 sealed trait OptaEvent {
   def competition: String
@@ -24,7 +19,7 @@ case object WorldCup2015 extends OptaEvent {
 
 case class RugbyOptaFeedException(message: String) extends RuntimeException(message)
 
-object OptaFeed extends ExecutionContexts with Logging {
+case class OptaFeed(wsClient: WSClient) extends ExecutionContexts with Logging {
 
   private def events = List(WorldCup2015)
 
@@ -42,7 +37,7 @@ object OptaFeed extends ExecutionContexts with Logging {
 
       val queryParams = List(competition,  season, apiKey, apiUser, feedType) ++ gameParameter
 
-      WS.url(s"$endpoint$path")
+      wsClient.url(s"$endpoint$path")
         .withHeaders(xmlContentType)
         .withQueryString(queryParams: _*)
         .get

--- a/sport/app/rugby/feed/OptaFeed.scala
+++ b/sport/app/rugby/feed/OptaFeed.scala
@@ -19,7 +19,7 @@ case object WorldCup2015 extends OptaEvent {
 
 case class RugbyOptaFeedException(message: String) extends RuntimeException(message)
 
-case class OptaFeed(wsClient: WSClient) extends ExecutionContexts with Logging {
+class OptaFeed(wsClient: WSClient) extends ExecutionContexts with Logging {
 
   private def events = List(WorldCup2015)
 

--- a/sport/app/rugby/jobs/RugbyStatsJob.scala
+++ b/sport/app/rugby/jobs/RugbyStatsJob.scala
@@ -9,7 +9,7 @@ import scala.util.Failure
 import scala.util.Success
 
 
-case class RugbyStatsJob(optaFeed: OptaFeed) extends ExecutionContexts with Logging {
+class RugbyStatsJob(optaFeed: OptaFeed) extends ExecutionContexts with Logging {
   protected val fixturesAndResultsMatches = AkkaAgent[Map[String, Match]](Map.empty)
   protected val matchNavContent = AkkaAgent[Map[String, MatchNavigation]](Map.empty)
   protected val pastScoreEvents = AkkaAgent[Map[String, Seq[ScoreEvent]]](Map.empty)

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -41,7 +41,7 @@ class SportTestSuite extends Suites (
   override lazy val port: Int = new HealthCheck().testPort
 
   // Inject stub api.
-  FootballClient.http = TestHttp(wsClient)
+  FootballClient.http = new TestHttp(wsClient)
   loadTestData()
 }
 
@@ -82,7 +82,7 @@ object FeedHttpRecorder extends HttpRecorder[WSResponse] {
 }
 
 // Stubs data for Football stats integration tests
-case class TestHttp(wsClient: WSClient) extends Http with ExecutionContexts {
+class TestHttp(wsClient: WSClient) extends Http with ExecutionContexts {
 
   def GET(url: String): Future[PaResponse] = {
     FootballHttpRecorder.load(url) {

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -8,13 +8,12 @@ import java.nio.ByteBuffer
 import java.util
 
 import football.controllers.HealthCheck
-import org.scalatest.Suites
+import org.scalatest.{BeforeAndAfterAll, Suites}
 import play.api.libs.ws.ning.NingWSResponse
 import recorder.HttpRecorder
-import play.api.libs.ws.{WS, WSResponse}
+import play.api.libs.ws.{WSClient, WSResponse}
 import conf.FootballClient
 import pa.{Http, Response => PaResponse}
-import play.api.Play.current
 
 import scala.concurrent.Future
 
@@ -37,12 +36,12 @@ class SportTestSuite extends Suites (
   new MatchFeatureTest,
   new ResultsFeatureTest,
   new rugby.model.MatchParserTest
-) with SingleServerSuite with FootballTestData {
+) with SingleServerSuite with FootballTestData with BeforeAndAfterAll with WithTestWsClient {
 
   override lazy val port: Int = new HealthCheck().testPort
 
   // Inject stub api.
-  FootballClient.http = TestHttp
+  FootballClient.http = TestHttp(wsClient)
   loadTestData()
 }
 
@@ -83,11 +82,11 @@ object FeedHttpRecorder extends HttpRecorder[WSResponse] {
 }
 
 // Stubs data for Football stats integration tests
-object TestHttp extends Http with ExecutionContexts {
+case class TestHttp(wsClient: WSClient) extends Http with ExecutionContexts {
 
   def GET(url: String): Future[PaResponse] = {
     FootballHttpRecorder.load(url) {
-      WS.url(url)
+      wsClient.url(url)
         .withRequestTimeout(10000)
         .get()
         .map { wsResponse =>

--- a/standalone/app/StandaloneLifecycleComponents.scala
+++ b/standalone/app/StandaloneLifecycleComponents.scala
@@ -10,7 +10,7 @@ import feed.OnwardJourneyLifecycle
 import rugby.conf.RugbyLifecycle
 import services.ConfigAgentLifecycle
 
-trait StandaloneLifecycleComponents {
+trait StandaloneLifecycleComponents extends CricketServices {
   self: FrontendComponents =>
   def standaloneLifecycleComponents: List[LifecycleComponent] = List(
     wire[LogstashLifecycle],

--- a/standalone/app/StandaloneLifecycleComponents.scala
+++ b/standalone/app/StandaloneLifecycleComponents.scala
@@ -10,7 +10,7 @@ import feed.OnwardJourneyLifecycle
 import rugby.conf.RugbyLifecycle
 import services.ConfigAgentLifecycle
 
-trait StandaloneLifecycleComponents extends CricketServices {
+trait StandaloneLifecycleComponents extends SportServices {
   self: FrontendComponents =>
   def standaloneLifecycleComponents: List[LifecycleComponent] = List(
     wire[LogstashLifecycle],


### PR DESCRIPTION
## What does this change?

Removing call to WS.url in sport app:
- Football PaFeed
- Cricket PaFeed
- Rugby Feed
## What is the value of this and can you measure success?

=> Play 2.5
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
