### PR TITLE
Hosted Page fixes

### DIFF
--- a/common/app/conf/switches/ABTestSwitches.scala
+++ b/common/app/conf/switches/ABTestSwitches.scala
@@ -20,7 +20,7 @@ trait ABTestSwitches {
     "An autoplay overlay with the next video on a hosted page",
     owners = Seq(Owner.withGithub("Calanthe")),
     safeState = Off,
-    sellByDate = new LocalDate(2016, 7, 29),
+    sellByDate = new LocalDate(2016, 8, 12),
     exposeClientSide = true
   )
 

--- a/common/app/conf/switches/CommercialSwitches.scala
+++ b/common/app/conf/switches/CommercialSwitches.scala
@@ -349,7 +349,7 @@ trait CommercialSwitches {
   val hostedArticle = Switch(
     group = CommercialLabs,
     name = "hosted-article",
-    description = "Show hosted article or 404.",
+    description = "Show Zootropolis hosted article or 404.",
     owners = Owner.group(CommercialLabs),
     safeState = Off,
     sellByDate = new LocalDate(2016, 8, 17),

--- a/static/src/javascripts/projects/common/modules/commercial/hosted-gallery.js
+++ b/static/src/javascripts/projects/common/modules/commercial/hosted-gallery.js
@@ -37,7 +37,8 @@ define([
 
     function HostedGallery() {
         // CONFIG
-        this.useSwipe = detect.hasTouchScreen();
+        var breakpoint = detect.getBreakpoint();
+        this.useSwipe = detect.hasTouchScreen() && (breakpoint === 'mobile' || breakpoint === 'tablet');
         this.swipeThreshold = 0.05;
         this.index = this.index || 1;
         this.imageRatios = [];

--- a/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
@@ -12,7 +12,7 @@ define([
     return function () {
         this.id = 'HostedAutoplay';
         this.start = '2016-15-07';
-        this.expiry = '2016-29-07';
+        this.expiry = '2016-12-08';
         this.author = 'Zofia Korcz';
         this.description = 'An autoplay overlay with the next video on a hosted page.';
         this.audience = 0.75;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
@@ -11,8 +11,8 @@ define([
 ) {
     return function () {
         this.id = 'HostedAutoplay';
-        this.start = '2016-15-07';
-        this.expiry = '2016-12-08';
+        this.start = '2016-07-15';
+        this.expiry = '2016-08-12';
         this.author = 'Zofia Korcz';
         this.description = 'An autoplay overlay with the next video on a hosted page.';
         this.audience = 0.75;

--- a/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
+++ b/static/src/javascripts/projects/common/modules/experiments/tests/hosted-autoplay.js
@@ -22,8 +22,10 @@ define([
         this.dataLinkNames = 'Next video autoplay: Cancel autoplay of the next video, Discover Zoe from Renault, Next Hosted Video Autoplay, Immediately play the next video, Next Hosted Video';
         this.idealOutcome = 'People will either more often click on the next hosted video or wait until end of the current video to be redirected into the next video page url.';
 
+        var testCampaigns = ['leffe-rediscover-time', 'renault-car-of-the-future'];
+
         this.canRun = function () {
-            return config.page.contentType === 'Video' && config.page.tones === 'Hosted';
+            return config.page.contentType === 'Video' && config.page.tones === 'Hosted' && testCampaigns.indexOf(config.page.section) > -1;
         };
 
         this.variants = [


### PR DESCRIPTION
## What does this change?
- Gallery: only use swipe mode on mobile/tablet (not on desktop touchscreens)
- Disable next video autoplay AB test for Zootropolis campaign (only 1 video)
- extend AB test switch

@Calanthe 
