### PR TITLE
Show adverts in AMP live blog

### DIFF
--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -2,45 +2,33 @@
 @import model.Article
 @import model.liveblog.{LiveBlogDate,BodyBlock}
 @import views.BodyCleaner
-@import views.support.AmpAd
-@import common.Edition
 
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader)
 
-@blocks.sliding(5, 5).map { blockGroup =>
-    @blockGroup.map { block =>
-        <div id="block-@block.id" class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
-            <p class="block-time published-time">
-                <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
-                @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
-                </a>
-            </p>
-            @block.title.map { title =>
-                <h2 class="block-title" itemprop="headline">@title</h2>
+@blocks.map { block =>
+    <div id="block-@block.id" class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
+        <p class="block-time published-time">
+            <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
+            @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
+            </a>
+        </p>
+        @block.title.map { title =>
+            <h2 class="block-title" itemprop="headline">@title</h2>
+        }
+        @block.contributors.map { contributorId =>
+            @article.tags.tags.find(_.id == s"profile/$contributorId").map{ contributorTag =>
+                @views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
             }
-            @block.contributors.map { contributorId =>
-                @article.tags.tags.find(_.id == s"profile/$contributorId").map{ contributorTag =>
-                    @views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
-                }
-            }
-            <div class="block-elements@if(block.contributors.isEmpty){ block-elements--no-byline}" itemprop="articleBody">
-            @BodyCleaner(article, block.bodyHtml, amp)
-            </div>
-            @block.republishedDate(timezone).map { case LiveBlogDate(republishedDate, _, ampm, gmt) =>
-            <p class="block-time updated-time">Updated
-                <time datetime="@republishedDate">at @ampm @gmt</time>
-            </p>
-            }
-            @views.html.fragments.share.blockLevelSharing(s"block-${block.id}", article.sharelinks.elementShares(s"block-${block.id}", None), article.metadata.contentType, amp)
+        }
+        <div class="block-elements@if(block.contributors.isEmpty){ block-elements--no-byline}" itemprop="articleBody">
+        @BodyCleaner(article, block.bodyHtml, amp)
         </div>
-    }
-
-    @if(blockGroup.length == 5) {
-        <div class="live-blog-amp-ad-container">
-            <amp-ad width="300" height="250" type="doubleclick"
-            json=@AmpAd.buildJsonString(article, request.path, Edition(request).id.toLowerCase())
-            data-slot=@AmpAd.buildDataSlot(article)>
-            </amp-ad>
-        </div>
-    }
+        @block.republishedDate(timezone).map { case LiveBlogDate(republishedDate, _, ampm, gmt) =>
+        <p class="block-time updated-time">Updated
+            <time datetime="@republishedDate">at @ampm @gmt</time>
+        </p>
+        }
+        @views.html.fragments.share.blockLevelSharing(s"block-${block.id}", article.sharelinks.elementShares(s"block-${block.id}", None), article.metadata.contentType, amp)
+    </div>
 }
+

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -1,12 +1,11 @@
-@import model.liveblog.BodyBlock
-@import model.Article
 @import org.joda.time.DateTimeZone
+@import model.Article
+@import model.liveblog.{LiveBlogDate,BodyBlock}
+@import views.BodyCleaner
 @import views.support.AmpAd
+@import common.Edition
 
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader)
-
-@import views.BodyCleaner
-@import model.liveblog.{LiveBlogDate}
 
 @blocks.sliding(5, 5).map { blockGroup =>
     @blockGroup.map { block =>
@@ -36,12 +35,12 @@
         </div>
     }
 
-    @* TODO: find edition*@
-    <div class="live-blog-amp-ad-container">
-        <amp-ad width="300" height="250" type="doubleclick"
-            json=@AmpAd.buildJsonString(article, request.path, "uk")
+    @if(blockGroup.length == 5) {
+        <div class="live-blog-amp-ad-container">
+            <amp-ad width="300" height="250" type="doubleclick"
+            json=@AmpAd.buildJsonString(article, request.path, Edition(request).id.toLowerCase())
             data-slot=@AmpAd.buildDataSlot(article)>
-        </amp-ad>
-    </div>
-
+            </amp-ad>
+        </div>
+    }
 }

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -1,7 +1,7 @@
 @import model.liveblog.BodyBlock
 @import model.Article
 @import org.joda.time.DateTimeZone
-@import play.api.libs.json.Json
+@import views.support.AmpAd
 
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader)
 
@@ -33,32 +33,13 @@
         }
         @views.html.fragments.share.blockLevelSharing(s"block-${block.id}", article.sharelinks.elementShares(s"block-${block.id}", None), article.metadata.contentType, amp)
     </div>
+
+    @* TODO: find edition *@
     <div class="live-blog-amp-ad-container">
-        @*
-          TODO:
-            edition
-            se(ries)
-            k(eywords)
-            co(ntributord)
-            bl(ogs)
-        *@
         <amp-ad width="300" height="250" type="doubleclick"
-        json="@Json.obj(
-            "targeting" -> Json.obj(
-                "url" -> request.path,
-                "edition" -> "uk",
-                "se" -> article.trail.tags.series.mkString(","),
-                "ct" -> article.metadata.contentType,
-                "p" -> "amp",
-                "keywordIds" -> article.trail.tags.keywords.map(_.id).mkString(","),
-                "k" -> article.trail.tags.keywords.mkString(","),
-                "co" -> article.trail.tags.contributors.mkString(","),
-                "bl" -> article.trail.tags.blogs.mkString(","),
-                "authorIds" -> article.trail.tags.contributors.map(_.id).mkString(","),
-                "section" -> article.metadata.sectionId
-            )
-        ).toString()"
-        data-slot="/59666047/theguardian.com/@article.metadata.sectionId/@article.metadata.contentType.toLowerCase/amp">
+            json=@AmpAd.buildJsonString(article, request.path, "uk")
+            data-slot=@AmpAd.buildDataSlot(article)>
         </amp-ad>
     </div>
+
 }

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -1,6 +1,7 @@
 @import model.liveblog.BodyBlock
 @import model.Article
 @import org.joda.time.DateTimeZone
+@import play.api.libs.json.Json
 
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader)
 
@@ -31,5 +32,33 @@
         </p>
         }
         @views.html.fragments.share.blockLevelSharing(s"block-${block.id}", article.sharelinks.elementShares(s"block-${block.id}", None), article.metadata.contentType, amp)
+    </div>
+    <div class="live-blog-amp-ad-container">
+        @*
+          TODO:
+            edition
+            se(ries)
+            k(eywords)
+            co(ntributord)
+            bl(ogs)
+        *@
+        <amp-ad width="300" height="250" type="doubleclick"
+        json="@Json.obj(
+            "targeting" -> Json.obj(
+                "url" -> request.path,
+                "edition" -> "uk",
+                "se" -> article.trail.tags.series.mkString(","),
+                "ct" -> article.metadata.contentType,
+                "p" -> "amp",
+                "keywordIds" -> article.trail.tags.keywords.map(_.id).mkString(","),
+                "k" -> article.trail.tags.keywords.mkString(","),
+                "co" -> article.trail.tags.contributors.mkString(","),
+                "bl" -> article.trail.tags.blogs.mkString(","),
+                "authorIds" -> article.trail.tags.contributors.map(_.id).mkString(","),
+                "section" -> article.metadata.sectionId
+            )
+        ).toString()"
+        data-slot="/59666047/theguardian.com/@article.metadata.sectionId/@article.metadata.contentType.toLowerCase/amp">
+        </amp-ad>
     </div>
 }

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -8,33 +8,35 @@
 @import views.BodyCleaner
 @import model.liveblog.{LiveBlogDate}
 
-@blocks.map { block =>
-    <div id="block-@block.id" class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
-        <p class="block-time published-time">
-            <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
-            @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
-            </a>
-        </p>
-        @block.title.map { title =>
-            <h2 class="block-title" itemprop="headline">@title</h2>
-        }
-        @block.contributors.map { contributorId =>
-            @article.tags.tags.find(_.id == s"profile/$contributorId").map{ contributorTag =>
-                @views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
+@blocks.sliding(5, 5).map { blockGroup =>
+    @blockGroup.map { block =>
+        <div id="block-@block.id" class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
+            <p class="block-time published-time">
+                <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
+                @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
+                </a>
+            </p>
+            @block.title.map { title =>
+                <h2 class="block-title" itemprop="headline">@title</h2>
             }
-        }
-        <div class="block-elements@if(block.contributors.isEmpty){ block-elements--no-byline}" itemprop="articleBody">
-        @BodyCleaner(article, block.bodyHtml, amp)
+            @block.contributors.map { contributorId =>
+                @article.tags.tags.find(_.id == s"profile/$contributorId").map{ contributorTag =>
+                    @views.html.fragments.meta.bylineLiveBlockImage(contributorTag)
+                }
+            }
+            <div class="block-elements@if(block.contributors.isEmpty){ block-elements--no-byline}" itemprop="articleBody">
+            @BodyCleaner(article, block.bodyHtml, amp)
+            </div>
+            @block.republishedDate(timezone).map { case LiveBlogDate(republishedDate, _, ampm, gmt) =>
+            <p class="block-time updated-time">Updated
+                <time datetime="@republishedDate">at @ampm @gmt</time>
+            </p>
+            }
+            @views.html.fragments.share.blockLevelSharing(s"block-${block.id}", article.sharelinks.elementShares(s"block-${block.id}", None), article.metadata.contentType, amp)
         </div>
-        @block.republishedDate(timezone).map { case LiveBlogDate(republishedDate, _, ampm, gmt) =>
-        <p class="block-time updated-time">Updated
-            <time datetime="@republishedDate">at @ampm @gmt</time>
-        </p>
-        }
-        @views.html.fragments.share.blockLevelSharing(s"block-${block.id}", article.sharelinks.elementShares(s"block-${block.id}", None), article.metadata.contentType, amp)
-    </div>
+    }
 
-    @* TODO: find edition *@
+    @* TODO: find edition*@
     <div class="live-blog-amp-ad-container">
         <amp-ad width="300" height="250" type="doubleclick"
             json=@AmpAd.buildJsonString(article, request.path, "uk")

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -23,10 +23,11 @@
         }" data-test-id="live-blog-blocks"
         itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
             @if(amp) {
-                @model.currentPage.currentPage.blocks.sliding(5, 5).map { blockGroup =>
+                @model.currentPage.currentPage.blocks.sliding(5, 5).zipWithIndex.map { case (blockGroup, index) =>
                     @views.html.liveblog.liveBlogBlocks(blockGroup, article, timezone, amp)
 
-                    @if(blockGroup.length == 5) {
+                    @* Add advert every 5 blog posts, up to a maximum of 8 *@
+                    @if(blockGroup.length == 5 && index < 8) {
                         <div class="block amp-ad-container amp-ad-container--live-blog">
                             <amp-ad width="300" height="250" type="doubleclick"
                             json=@AmpAd.buildJsonString(article, request.path, Edition(request).id.toLowerCase())

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -14,7 +14,7 @@
         @if(blockGroup.length == 5 && index < 8) {
             <div class="block amp-ad-container amp-ad-container--live-blog">
                 <amp-ad width="300" height="250" type="doubleclick"
-                json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toJson().toString()
+                json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
                 data-slot=@AmpAdDataSlot(article).toString()>
                 </amp-ad>
             </div>

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -1,7 +1,26 @@
+@import model.Article
+
 @(model: LiveBlogPage, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.Edition
 @import views.support.AmpAd
+@import org.joda.time.DateTimeZone
+
+@liveBlogBlocksAMP(article: Article, timezone: DateTimeZone) = {
+    @model.currentPage.currentPage.blocks.sliding(5, 5).zipWithIndex.map { case (blockGroup, index) =>
+        @views.html.liveblog.liveBlogBlocks(blockGroup, article, timezone, amp)
+
+        @* Add advert every 5 blog posts, up to a maximum of 8 *@
+        @if(blockGroup.length == 5 && index < 8) {
+            <div class="block amp-ad-container amp-ad-container--live-blog">
+                <amp-ad width="300" height="250" type="doubleclick"
+                json=@AmpAd.adTargetingJson(article, request.path, Edition(request).id.toLowerCase()).toString()
+                data-slot=@AmpAd.buildDataSlot(article)>
+                </amp-ad>
+            </div>
+        }
+    }
+}
 
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
     <div class="js-article__container" data-component="body">
@@ -23,19 +42,7 @@
         }" data-test-id="live-blog-blocks"
         itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
             @if(amp) {
-                @model.currentPage.currentPage.blocks.sliding(5, 5).zipWithIndex.map { case (blockGroup, index) =>
-                    @views.html.liveblog.liveBlogBlocks(blockGroup, article, timezone, amp)
-
-                    @* Add advert every 5 blog posts, up to a maximum of 8 *@
-                    @if(blockGroup.length == 5 && index < 8) {
-                        <div class="block amp-ad-container amp-ad-container--live-blog">
-                            <amp-ad width="300" height="250" type="doubleclick"
-                            json=@AmpAd.adTargetingJson(article, request.path, Edition(request).id.toLowerCase()).toString()
-                            data-slot=@AmpAd.buildDataSlot(article)>
-                            </amp-ad>
-                        </div>
-                    }
-                }
+                @liveBlogBlocksAMP(article, timezone)
             } else {
                 @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone, amp)
             }

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -30,7 +30,7 @@
                     @if(blockGroup.length == 5 && index < 8) {
                         <div class="block amp-ad-container amp-ad-container--live-blog">
                             <amp-ad width="300" height="250" type="doubleclick"
-                            json=@AmpAd.buildJsonString(article, request.path, Edition(request).id.toLowerCase())
+                            json=@AmpAd.adTargetingJson(article, request.path, Edition(request).id.toLowerCase()).toString()
                             data-slot=@AmpAd.buildDataSlot(article)>
                             </amp-ad>
                         </div>

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -3,7 +3,7 @@
 @(model: LiveBlogPage, amp: Boolean = false)(implicit request: RequestHeader)
 
 @import common.Edition
-@import views.support.AmpAd
+@import views.support.{AmpAd, AmpAdDataSlot}
 @import org.joda.time.DateTimeZone
 
 @liveBlogBlocksAMP(article: Article, timezone: DateTimeZone) = {
@@ -14,8 +14,8 @@
         @if(blockGroup.length == 5 && index < 8) {
             <div class="block amp-ad-container amp-ad-container--live-blog">
                 <amp-ad width="300" height="250" type="doubleclick"
-                json=@AmpAd.adTargetingJson(article, request.path, Edition(request).id.toLowerCase()).toString()
-                data-slot=@AmpAd.buildDataSlot(article)>
+                json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toJson().toString()
+                data-slot=@AmpAdDataSlot(article).toString()>
                 </amp-ad>
             </div>
         }

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -1,6 +1,7 @@
 @(model: LiveBlogPage, amp: Boolean = false)(implicit request: RequestHeader)
 
-@import common.{Edition}
+@import common.Edition
+@import views.support.AmpAd
 
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
     <div class="js-article__container" data-component="body">
@@ -21,7 +22,22 @@
             _root_.liveblog.LatestBlock(article.blocks)
         }" data-test-id="live-blog-blocks"
         itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
-        @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone, amp)
+            @if(amp) {
+                @model.currentPage.currentPage.blocks.sliding(5, 5).map { blockGroup =>
+                    @views.html.liveblog.liveBlogBlocks(blockGroup, article, timezone, amp)
+
+                    @if(blockGroup.length == 5) {
+                        <div class="block amp-ad-container amp-ad-container--live-blog">
+                            <amp-ad width="300" height="250" type="doubleclick"
+                            json=@AmpAd.buildJsonString(article, request.path, Edition(request).id.toLowerCase())
+                            data-slot=@AmpAd.buildDataSlot(article)>
+                            </amp-ad>
+                        </div>
+                    }
+                }
+            } else {
+                @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone, amp)
+            }
         </div>
         @* Remove LiveFilter and the fragment once Toast comes out of AB test status *@
         @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -128,3 +128,14 @@
 .inline-share-gplus {
     fill: #e15440;
 }
+
+/* Ads
+========================================= */
+
+.amp-ad-container--live-blog {
+    float: none;
+    width: 100%;
+    margin-left: 0;
+    text-align: center;
+    padding-bottom: 1.5rem;
+}

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -2,7 +2,7 @@ package views.support
 
 import model.Tag
 import model.Article
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 
 object AmpAd {
   private def grabLastFragmentOfId(items: Seq[Tag]) = {
@@ -16,7 +16,7 @@ object AmpAd {
     }
   }
 
-  def buildJsonString(article: Article, uri: String, edition: String): String = {
+  def adTargetingJson(article: Article, uri: String, edition: String): JsObject = {
     Json.obj(
       "targeting" -> Json.obj(
         "url" -> uri,
@@ -31,7 +31,7 @@ object AmpAd {
         "authorIds" -> article.trail.tags.contributors.map(_.id).mkString(","),
         "section" -> article.metadata.sectionId
       )
-    ).toString()
+    )
   }
 
   def buildDataSlot(article: Article): String = {

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -4,7 +4,7 @@ import model.Tag
 import model.Article
 import play.api.libs.json.{JsObject, Json}
 
-object AmpAd {
+case class AmpAd(article: Article, uri: String, edition: String) {
   private def buildAdFlagsFromTags(items: Seq[Tag]) = {
     items.map { item =>
       if (item.id == "uk/uk") {
@@ -16,7 +16,7 @@ object AmpAd {
     }
   }
 
-  def adTargetingJson(article: Article, uri: String, edition: String): JsObject = {
+  def toJson(): JsObject = {
     Json.obj(
       "targeting" -> Json.obj(
         "url" -> uri,
@@ -33,8 +33,9 @@ object AmpAd {
       )
     )
   }
-
-  def buildDataSlot(article: Article): String = {
+}
+case class AmpAdDataSlot(article: Article) {
+  override def toString(): String = {
     val section = article.metadata.sectionId
     val contentType = article.metadata.contentType.toLowerCase
 

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -33,6 +33,10 @@ case class AmpAd(article: Article, uri: String, edition: String) {
       )
     )
   }
+
+  override def toString(): String = {
+    toJson().toString()
+  }
 }
 case class AmpAdDataSlot(article: Article) {
   override def toString(): String = {

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -5,7 +5,7 @@ import model.Article
 import play.api.libs.json.{JsObject, Json}
 
 object AmpAd {
-  private def grabLastFragmentOfId(items: Seq[Tag]) = {
+  private def buildAdFlagsFromTags(items: Seq[Tag]) = {
     items.map { item =>
       if (item.id == "uk/uk") {
         item.id
@@ -21,13 +21,13 @@ object AmpAd {
       "targeting" -> Json.obj(
         "url" -> uri,
         "edition" -> edition,
-        "se" -> grabLastFragmentOfId(article.trail.tags.series).mkString(","),
+        "se" -> buildAdFlagsFromTags(article.trail.tags.series).mkString(","),
         "ct" -> article.metadata.contentType,
         "p" -> "amp",
         "keywordIds" -> article.trail.tags.keywords.map(_.id).mkString(","),
-        "k" -> grabLastFragmentOfId(article.trail.tags.keywords).mkString(","),
-        "co" -> grabLastFragmentOfId(article.trail.tags.contributors).mkString(","),
-        "bl" -> grabLastFragmentOfId(article.trail.tags.blogs).mkString(","),
+        "k" -> buildAdFlagsFromTags(article.trail.tags.keywords).mkString(","),
+        "co" -> buildAdFlagsFromTags(article.trail.tags.contributors).mkString(","),
+        "bl" -> buildAdFlagsFromTags(article.trail.tags.blogs).mkString(","),
         "authorIds" -> article.trail.tags.contributors.map(_.id).mkString(","),
         "section" -> article.metadata.sectionId
       )

--- a/common/app/views/support/AmpAd.scala
+++ b/common/app/views/support/AmpAd.scala
@@ -1,0 +1,43 @@
+package views.support
+
+import model.Tag
+import model.Article
+import play.api.libs.json.Json
+
+object AmpAd {
+  private def grabLastFragmentOfId(items: Seq[Tag]) = {
+    items.map { item =>
+      if (item.id == "uk/uk") {
+        item.id
+      } else {
+        val keyword = item.id.split("/").last
+        keyword.replaceAll("""/[+s]+/g""", "-").toLowerCase()
+      }
+    }
+  }
+
+  def buildJsonString(article: Article, uri: String, edition: String): String = {
+    Json.obj(
+      "targeting" -> Json.obj(
+        "url" -> uri,
+        "edition" -> edition,
+        "se" -> grabLastFragmentOfId(article.trail.tags.series).mkString(","),
+        "ct" -> article.metadata.contentType,
+        "p" -> "amp",
+        "keywordIds" -> article.trail.tags.keywords.map(_.id).mkString(","),
+        "k" -> grabLastFragmentOfId(article.trail.tags.keywords).mkString(","),
+        "co" -> grabLastFragmentOfId(article.trail.tags.contributors).mkString(","),
+        "bl" -> grabLastFragmentOfId(article.trail.tags.blogs).mkString(","),
+        "authorIds" -> article.trail.tags.contributors.map(_.id).mkString(","),
+        "section" -> article.metadata.sectionId
+      )
+    ).toString()
+  }
+
+  def buildDataSlot(article: Article): String = {
+    val section = article.metadata.sectionId
+    val contentType = article.metadata.contentType.toLowerCase
+
+    s"/59666047/theguardian.com/$section/$contentType/amp"
+  }
+}

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -89,7 +89,7 @@ case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends
   def adAfter(element: Element) = {
     val ampAd = <div class="amp-ad-container">
           <amp-ad width="300" height="250" type="doubleclick"
-                  json={AmpAd(article, uri, edition.id.toLowerCase()).toJson().toString()}
+                  json={AmpAd(article, uri, edition.id.toLowerCase()).toString()}
                   data-slot={AmpAdDataSlot(article).toString()}>
           </amp-ad>
       </div>

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -1,11 +1,10 @@
 package views.support.cleaner
 
 import common.Edition
-import model.{Article, Tag}
+import model.Article
 import org.jsoup.nodes.{Document, Element}
-import play.api.libs.json.Json
-import views.support.HtmlCleaner
-import views.support.AmpAd
+import views.support.{AmpAd, AmpAdDataSlot, HtmlCleaner}
+
 import scala.collection.JavaConversions._
 
 object AmpAdCleaner {
@@ -18,7 +17,7 @@ object AmpAdCleaner {
     val ALLOWED = 0
     val DISALLOWED = 1
 
-    // create the contstraints for each paragraph how far before and after we can have it
+    // create the constraints for each paragraph how far before and after we can have it
     val constraints = children.map { element =>
 
       def para = element.tagName() != "p"
@@ -90,8 +89,8 @@ case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends
   def adAfter(element: Element) = {
     val ampAd = <div class="amp-ad-container">
           <amp-ad width="300" height="250" type="doubleclick"
-                  json={AmpAd.adTargetingJson(article, uri, edition.id.toLowerCase()).toString()}
-                  data-slot={AmpAd.buildDataSlot(article)}>
+                  json={AmpAd(article, uri, edition.id.toLowerCase()).toJson().toString()}
+                  data-slot={AmpAdDataSlot(article).toString()}>
           </amp-ad>
       </div>
 

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -5,7 +5,7 @@ import model.{Article, Tag}
 import org.jsoup.nodes.{Document, Element}
 import play.api.libs.json.Json
 import views.support.HtmlCleaner
-
+import views.support.AmpAd
 import scala.collection.JavaConversions._
 
 object AmpAdCleaner {
@@ -87,42 +87,11 @@ object AmpAdCleaner {
 
 case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends HtmlCleaner {
 
-  private def grabLastFragmentOfId(items: Seq[Tag]) = {
-    items.map { item =>
-      if (item.id == "uk/uk") {
-        item.id
-      } else {
-        val keyword = item.id.split("/").last
-        keyword.replaceAll("""/[+s]+/g""", "-").toLowerCase()
-      }
-    }
-  }
-
   def adAfter(element: Element) = {
-    val section = article.metadata.sectionId
-    val contentType = article.metadata.contentType.toLowerCase
-    val dataSlot = s"/59666047/theguardian.com/$section/$contentType/amp"
-
-    val json = Json.obj(
-      "targeting" -> Json.obj(
-        "url" -> uri,
-        "edition" -> edition.id.toLowerCase(),
-        "se" -> grabLastFragmentOfId(article.trail.tags.series).mkString(","),
-        "ct" -> article.metadata.contentType,
-        "p" -> "amp",
-        "keywordIds" -> article.trail.tags.keywords.map(_.id).mkString(","),
-        "k" -> grabLastFragmentOfId(article.trail.tags.keywords).mkString(","),
-        "co" -> grabLastFragmentOfId(article.trail.tags.contributors).mkString(","),
-        "bl" -> grabLastFragmentOfId(article.trail.tags.blogs).mkString(","),
-        "authorIds" -> article.trail.tags.contributors.map(_.id).mkString(","),
-        "section" -> article.metadata.sectionId
-      )
-    )
-
     val ampAd = <div class="amp-ad-container">
           <amp-ad width="300" height="250" type="doubleclick"
-                  json={json.toString()}
-                  data-slot={dataSlot}>
+                  json={AmpAd.buildJsonString(article, uri, edition.id.toLowerCase())}
+                  data-slot={AmpAd.buildDataSlot(article)}>
           </amp-ad>
       </div>
 

--- a/common/app/views/support/cleaner/AmpAdCleaner.scala
+++ b/common/app/views/support/cleaner/AmpAdCleaner.scala
@@ -90,7 +90,7 @@ case class AmpAdCleaner(edition: Edition, uri: String, article: Article) extends
   def adAfter(element: Element) = {
     val ampAd = <div class="amp-ad-container">
           <amp-ad width="300" height="250" type="doubleclick"
-                  json={AmpAd.buildJsonString(article, uri, edition.id.toLowerCase())}
+                  json={AmpAd.adTargetingJson(article, uri, edition.id.toLowerCase()).toString()}
                   data-slot={AmpAd.buildDataSlot(article)}>
           </amp-ad>
       </div>

--- a/common/test/views/support/AmpAdTest.scala
+++ b/common/test/views/support/AmpAdTest.scala
@@ -1,0 +1,157 @@
+package views.support
+
+import com.gu.contentapi.client.model.v1.{Section, Tag => ApiTag, TagType, Content => ApiContent}
+import org.scalatest.{FlatSpec, Matchers}
+import model.{Article, Content}
+import play.api.libs.json.JsString
+
+class AmpAdTest extends FlatSpec with Matchers {
+   "AmpAdDataSlot" should "return a string containing article's section ID" in {
+     val sectionId = "sectionId"
+     val result = AmpAdDataSlot(article(sectionId)).toString()
+
+     result should include(sectionId)
+   }
+
+  "AmpAdDataSlot" should "return a string containing article's contentType" in {
+    val contentType = "article"
+    val result = AmpAdDataSlot(article("")).toString()
+
+    result should include(contentType)
+  }
+
+  "AmpAd" should "return a JSON object containing passed URI" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val result = AmpAd(article(""), uri, edition).toJson()
+    val targetingUrl = (result \ "targeting" \ "url").as[JsString].value
+
+    targetingUrl should be(uri)
+  }
+
+  "AmpAd" should "return a JSON object containing passed edition" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val result = AmpAd(article(""), uri, edition).toJson()
+    val targetingEdition = (result \ "targeting" \ "edition").as[JsString].value
+
+    targetingEdition should be(edition)
+  }
+
+  "AmpAd" should "return a JSON object containing passed article's section ID" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val sectionId = "sectionId"
+    val result = AmpAd(article(sectionId), uri, edition).toJson()
+    val targetingSection = (result \ "targeting" \ "section").as[JsString].value
+
+    targetingSection should be(sectionId)
+  }
+
+  "AmpAd" should "return a JSON object containing passed article's content type" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val contentType = "Article"
+    val sectionId = "sectionId"
+    val result = AmpAd(article(sectionId), uri, edition).toJson()
+    val targetingContentType = (result \ "targeting" \ "ct").as[JsString].value
+
+    targetingContentType should be(contentType)
+  }
+
+  "AmpAd" should "return a JSON object containing passed article's series tag" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val sectionId = "sectionId"
+    val seriesTag = tag("series/foo", "Foo", TagType.Series)
+    val result = AmpAd(article(sectionId, seriesTag), uri, edition).toJson()
+    val targetingSeries = (result \ "targeting" \ "se").as[JsString].value
+
+    targetingSeries should be("foo")
+  }
+
+  "AmpAd" should "return a JSON object containing passed article's keyword IDs" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val sectionId = "sectionId"
+    val keywordTag1 = tag("keyword1", "Keyword1", TagType.Keyword)
+    val keywordTag2 = tag("keyword2", "Keyword2", TagType.Keyword)
+    val result = AmpAd(article(sectionId, keywordTag1, keywordTag2), uri, edition).toJson()
+    val targetingKeywordIds = (result \ "targeting" \ "keywordIds").as[JsString].value
+
+    targetingKeywordIds should be("keyword1,keyword2")
+  }
+
+  "AmpAd" should "return a JSON object containing passed article's keywords" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val sectionId = "sectionId"
+    val keywordTag1 = tag("keyword1", "Keyword1", TagType.Keyword)
+    val keywordTag2 = tag("keyword2", "Keyword2", TagType.Keyword)
+    val result = AmpAd(article(sectionId, keywordTag1, keywordTag2), uri, edition).toJson()
+    val targetingKeywords = (result \ "targeting" \ "k").as[JsString].value
+
+    targetingKeywords should be("keyword1,keyword2")
+  }
+
+  "AmpAd" should "return a JSON object containing passed article's contributors" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val sectionId = "sectionId"
+    val contributorTag1 = tag("contributor1", "Contributor1", TagType.Contributor)
+    val contributorTag2 = tag("contributor2", "Contributor2", TagType.Contributor)
+    val result = AmpAd(article(sectionId, contributorTag1, contributorTag2), uri, edition).toJson()
+    val targetingContributors = (result \ "targeting" \ "co").as[JsString].value
+
+    targetingContributors should be("contributor1,contributor2")
+  }
+
+  "AmpAd" should "return a JSON object containing passed article's author IDs" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val sectionId = "sectionId"
+    val contributorTag1 = tag("contributor1", "Contributor1", TagType.Contributor)
+    val contributorTag2 = tag("contributor2", "Contributor2", TagType.Contributor)
+    val result = AmpAd(article(sectionId, contributorTag1, contributorTag2), uri, edition).toJson()
+    val targetingAuthorIds = (result \ "targeting" \ "authorIds").as[JsString].value
+
+    targetingAuthorIds should be("contributor1,contributor2")
+  }
+
+  "AmpAd" should "return a JSON object containing passed article's blog tags" in {
+    val uri = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val edition = "uk"
+    val sectionId = "sectionId"
+    val blogTag = tag("blog", "Blog", TagType.Blog)
+    val result = AmpAd(article(sectionId, blogTag), uri, edition).toJson()
+    val targetingBlogs = (result \ "targeting" \ "bl").as[JsString].value
+
+    targetingBlogs should be("blog")
+  }
+
+  private def article(sectionId: String, tags: ApiTag*) = {
+    val contentApiItem = contentApi(sectionId, tags.toList)
+    val content = Content.make(contentApiItem)
+
+    Article.make(content)
+  }
+
+  private def contentApi(sectionId: String, tags: List[ApiTag]) = ApiContent(
+    id = "foo/2012/jan/07/bar",
+    webTitle = "Some article",
+    webUrl = "http://www.guardian.co.uk/foo/2012/jan/07/bar",
+    apiUrl = "http://content.guardianapis.com/foo/2012/jan/07/bar",
+    section = Option(section(sectionId)),
+    tags = tags
+  )
+
+  private def section(id: String) = {
+    val webTitle = "Some section"
+    val webUrl = "http://www.guardian.co.uk/foo/2012/jan/07/bar"
+    val apiUrl = "http://content.guardianapis.com/foo/2012/jan/07/bar"
+
+    Section(id, webTitle, webUrl, apiUrl)
+  }
+  private def tag(id: String, name: String, tagType: TagType = TagType.Keyword) = ApiTag(id, tagType, webTitle = name, webUrl = "does not matter",
+    apiUrl = "does not matter", sectionId = Some("does not matter"))
+}


### PR DESCRIPTION
## What does this change?

This change displays adverts in AMP live blog. The rules:
- ads appear every 5 blog posts
- no more than 8 ads to a page

In order to build the data for the `<amp-ad>` element, I have extracted the logic previously in `AmpAdCleaner` into a [helper object](https://github.com/guardian/frontend/blob/sa-amp-live-blog-ads/common/app/views/support/AmpAd.scala).
## Screenshots

![picture 49](https://cloud.githubusercontent.com/assets/5931528/17209553/71e6c14e-54b5-11e6-8a4e-09fa49a1e972.png)
## Request for comment

@NataliaLKB @johnduffell @TBonnin 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
