### PR TITLE
Removing call to WS.url (continue #5)

### DIFF
--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -54,7 +54,7 @@ trait Controllers
   lazy val surveyPageController = wire[SurveyPageController]
 }
 
-trait AppComponents extends FrontendComponents with Controllers with AdminServices with SportServices with CommercialServices {
+trait AppComponents extends FrontendComponents with Controllers with AdminServices with SportServices with CommercialServices with DiscussionServices {
 
   override def router: Router = wire[Routes]
   override def appIdentity: ApplicationIdentity = ApplicationIdentity("dev-build")

--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -7,12 +7,14 @@ import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
 import conf.{CommonFilters, CachedHealthCheckLifeCycle}
 import controllers.{DiscussionControllers, HealthCheck}
+import discussion.DiscussionApi
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.http.HttpErrorHandler
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
+import play.api.libs.ws.WSClient
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
@@ -22,6 +24,12 @@ class AppLoader extends FrontendApplicationLoader {
 trait Controllers extends DiscussionControllers {
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
+}
+
+trait DiscussionServices {
+  def wsClient: WSClient
+
+  lazy val discussionApi = wire[DiscussionApi]
 }
 
 trait AppLifecycleComponents {
@@ -35,7 +43,7 @@ trait AppLifecycleComponents {
   )
 }
 
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers {
+trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with DiscussionServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/discussion/app/controllers/CommentCountController.scala
+++ b/discussion/app/controllers/CommentCountController.scala
@@ -2,10 +2,11 @@ package controllers
 
 import model.Cached
 import common.JsonComponent
+import discussion.DiscussionApiLike
 import play.api.libs.json.{JsArray, JsObject}
 import play.api.mvc.Action
 
-class CommentCountController extends DiscussionController {
+case class CommentCountController(val discussionApi: DiscussionApiLike) extends DiscussionController {
 
   def commentCountJson(shortUrls: String) = commentCount(shortUrls)
 
@@ -23,5 +24,3 @@ class CommentCountController extends DiscussionController {
   }
 
 }
-
-object CommentCountController extends CommentCountController

--- a/discussion/app/controllers/CommentCountController.scala
+++ b/discussion/app/controllers/CommentCountController.scala
@@ -6,7 +6,7 @@ import discussion.DiscussionApiLike
 import play.api.libs.json.{JsArray, JsObject}
 import play.api.mvc.Action
 
-case class CommentCountController(val discussionApi: DiscussionApiLike) extends DiscussionController {
+class CommentCountController(val discussionApi: DiscussionApiLike) extends DiscussionController {
 
   def commentCountJson(shortUrls: String) = commentCount(shortUrls)
 

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -5,18 +5,17 @@ import discussion.model.{BlankComment, DiscussionAbuseReport, DiscussionKey}
 import discussion.{DiscussionParams, ThreadedCommentPage, UnthreadedCommentPage}
 import model.Cached.RevalidatableResult
 import model.{Cached, MetaData, NoCache, SectionSummary, SimplePage, TinyResponse}
-import play.api.Play.current
 import play.api.data.Forms._
 import play.api.data._
 import play.api.data.validation._
-import play.api.libs.ws.{WS, WSResponse}
+import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.{Action, Cookie, RequestHeader, Result}
 import play.filters.csrf.{CSRFConfig, CSRFAddToken, CSRFCheck}
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-class CommentsController(csrfConfig: CSRFConfig) extends DiscussionController with ExecutionContexts {
+class CommentsController(csrfConfig: CSRFConfig, wsClient: WSClient) extends DiscussionController with ExecutionContexts {
 
   val userForm = Form(
     Forms.mapping(
@@ -108,7 +107,7 @@ class CommentsController(csrfConfig: CSRFConfig) extends DiscussionController wi
     val url = s"${conf.Configuration.discussion.apiRoot}/comment/${abuseReport.commentId}/reportAbuse"
     val headers = Seq("D2-X-UID" -> conf.Configuration.discussion.d2Uid, "GU-Client" -> conf.Configuration.discussion.apiClientHeader)
     if (cookie.isDefined) { headers :+  ("Cookie"->s"SC_GU_U=${cookie.get}") }
-    WS.url(url).withHeaders(headers: _*).withRequestTimeout(2000).post(abuseReportToMap(abuseReport))
+    wsClient.url(url).withHeaders(headers: _*).withRequestTimeout(2000).post(abuseReportToMap(abuseReport))
 
   }
 

--- a/discussion/app/controllers/CommentsController.scala
+++ b/discussion/app/controllers/CommentsController.scala
@@ -2,20 +2,19 @@ package controllers
 
 import common.{ExecutionContexts, JsonComponent}
 import discussion.model.{BlankComment, DiscussionAbuseReport, DiscussionKey}
-import discussion.{DiscussionParams, ThreadedCommentPage, UnthreadedCommentPage}
+import discussion.{DiscussionApiLike, DiscussionParams, ThreadedCommentPage, UnthreadedCommentPage}
 import model.Cached.RevalidatableResult
 import model.{Cached, MetaData, NoCache, SectionSummary, SimplePage, TinyResponse}
 import play.api.data.Forms._
 import play.api.data._
 import play.api.data.validation._
-import play.api.libs.ws.{WSClient, WSResponse}
-import play.api.mvc.{Action, Cookie, RequestHeader, Result}
-import play.filters.csrf.{CSRFConfig, CSRFAddToken, CSRFCheck}
+import play.api.mvc.{Action, RequestHeader, Result}
+import play.filters.csrf.{CSRFAddToken, CSRFCheck, CSRFConfig}
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
-class CommentsController(csrfConfig: CSRFConfig, wsClient: WSClient) extends DiscussionController with ExecutionContexts {
+class CommentsController(csrfConfig: CSRFConfig, val discussionApi: DiscussionApiLike) extends DiscussionController with ExecutionContexts {
 
   val userForm = Form(
     Forms.mapping(
@@ -95,22 +94,6 @@ class CommentsController(csrfConfig: CSRFConfig, wsClient: WSClient) extends Dis
     }
   }
 
-  def abuseReportToMap(abuseReport: DiscussionAbuseReport): Map[String, Seq[String]] = {
-  Map("categoryId" -> Seq(abuseReport.categoryId.toString),
-          "commentId" -> Seq(abuseReport.commentId.toString),
-          "reason" -> abuseReport.reason.toSeq,
-          "email" -> abuseReport.email.toSeq)
-  }
-
-
-  def postAbuseReportToDiscussionApi(abuseReport: DiscussionAbuseReport, cookie: Option[Cookie]): Future[WSResponse] = {
-    val url = s"${conf.Configuration.discussion.apiRoot}/comment/${abuseReport.commentId}/reportAbuse"
-    val headers = Seq("D2-X-UID" -> conf.Configuration.discussion.d2Uid, "GU-Client" -> conf.Configuration.discussion.apiClientHeader)
-    if (cookie.isDefined) { headers :+  ("Cookie"->s"SC_GU_U=${cookie.get}") }
-    wsClient.url(url).withHeaders(headers: _*).withRequestTimeout(2000).post(abuseReportToMap(abuseReport))
-
-  }
-
   object ReportAbuseFormValidation {
     val validCategory = (_: Int) match {
       case 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 => Valid
@@ -128,7 +111,7 @@ class CommentsController(csrfConfig: CSRFConfig, wsClient: WSClient) extends Dis
       userForm.bindFromRequest.fold(
         formWithErrors => Future.successful(BadRequest(views.html.discussionComments.reportComment(commentId, reportAbusePage, formWithErrors))),
         userData => {
-          postAbuseReportToDiscussionApi(userData, scGuU).map {
+          discussionApi.postAbuseReport(userData, scGuU).map {
             case success if success.status == 200 => NoCache(Redirect(routes.CommentsController.reportAbuseThankYou(commentId)))
             case error => InternalServerError(views.html.discussionComments.reportComment(commentId, reportAbusePage, userForm.fill(userData), errorMessage = Some(ReportAbuseFormValidation.genericErrorMessage)))
           }.recover({

--- a/discussion/app/controllers/CtaController.scala
+++ b/discussion/app/controllers/CtaController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import discussion.util.Http
 import play.api.libs.json.JsValue
-import play.api.libs.ws.WSResponse
+import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.{Controller, Action}
 import model.Cached
 import common.{ExecutionContexts, JsonComponent}
@@ -11,7 +11,7 @@ import conf.Configuration
 import scala.concurrent.Future
 import conf.switches.Switches
 
-class CtaController extends Controller with ExecutionContexts with Http with implicits.Requests {
+class CtaController(val wsClient: WSClient) extends Controller with ExecutionContexts with Http with implicits.Requests {
   private lazy val ctaApiRoot: String = Configuration.open.ctaApiRoot
 
   private def getTopComments(key: DiscussionKey): Future[List[Comment]] = {
@@ -40,5 +40,3 @@ class CtaController extends Controller with ExecutionContexts with Http with imp
     }
   }
 }
-
-object CtaController extends CtaController

--- a/discussion/app/controllers/DiscussionController.scala
+++ b/discussion/app/controllers/DiscussionController.scala
@@ -1,30 +1,14 @@
 package controllers
 
-import conf.Configuration
 import play.api.mvc.Controller
 import common.{ExecutionContexts, Logging}
-import discussion.DiscussionApi
-
-object delegate {
-  // var allows us to inject test api
-  var api = new DiscussionApi {
-
-    override protected val apiRoot =
-      if (Configuration.environment.isProd)
-        Configuration.discussion.apiRoot
-      else
-        Configuration.discussion.apiRoot.replaceFirst("https://", "http://") // CODE SSL cert is defective and expensive to fix
-
-    override protected val clientHeaderValue: String = Configuration.discussion.apiClientHeader
-  }
-
-}
+import discussion.DiscussionApiLike
 
 trait DiscussionController
   extends Controller
   with Logging
   with ExecutionContexts
-  with implicits.Requests{
+  with implicits.Requests {
 
-  protected lazy val discussionApi = delegate.api
+  val discussionApi: DiscussionApiLike
 }

--- a/discussion/app/controllers/DiscussionControllers.scala
+++ b/discussion/app/controllers/DiscussionControllers.scala
@@ -1,11 +1,13 @@
 package controllers
 
 import com.softwaremill.macwire._
+import discussion.DiscussionApi
 import play.api.libs.ws.WSClient
 import play.filters.csrf.CSRFComponents
 
 trait DiscussionControllers extends CSRFComponents {
   def wsClient: WSClient
+  def discussionApi: DiscussionApi
   lazy val commentCountController = wire[CommentCountController]
   lazy val commentsController = wire[CommentsController]
   lazy val ctaController = wire[CtaController]

--- a/discussion/app/controllers/DiscussionControllers.scala
+++ b/discussion/app/controllers/DiscussionControllers.scala
@@ -1,9 +1,11 @@
 package controllers
 
 import com.softwaremill.macwire._
+import play.api.libs.ws.WSClient
 import play.filters.csrf.CSRFComponents
 
 trait DiscussionControllers extends CSRFComponents {
+  def wsClient: WSClient
   lazy val commentCountController = wire[CommentCountController]
   lazy val commentsController = wire[CommentsController]
   lazy val ctaController = wire[CtaController]

--- a/discussion/app/controllers/ProfileActivityController.scala
+++ b/discussion/app/controllers/ProfileActivityController.scala
@@ -6,7 +6,7 @@ import discussion.model.Profile
 import model.{Cached, MetaData, SectionSummary, SimplePage}
 import play.api.mvc.Action
 
-case class ProfileActivityController(val discussionApi: DiscussionApiLike) extends DiscussionController {
+class ProfileActivityController(val discussionApi: DiscussionApiLike) extends DiscussionController {
   def profilePage(profile: Profile, pageType: String) = SimplePage(
     metadata = MetaData.make(
       id = s"discussion/profile/${profile.userId}/$pageType",

--- a/discussion/app/controllers/ProfileActivityController.scala
+++ b/discussion/app/controllers/ProfileActivityController.scala
@@ -1,11 +1,12 @@
 package controllers
 
 import common.JsonComponent
+import discussion.DiscussionApiLike
 import discussion.model.Profile
 import model.{Cached, MetaData, SectionSummary, SimplePage}
 import play.api.mvc.Action
 
-class ProfileActivityController extends DiscussionController {
+case class ProfileActivityController(val discussionApi: DiscussionApiLike) extends DiscussionController {
   def profilePage(profile: Profile, pageType: String) = SimplePage(
     metadata = MetaData.make(
       id = s"discussion/profile/${profile.userId}/$pageType",
@@ -63,5 +64,3 @@ class ProfileActivityController extends DiscussionController {
     }
   }
 }
-
-object ProfileActivityController extends ProfileActivityController

--- a/discussion/app/controllers/WitnessActivityController.scala
+++ b/discussion/app/controllers/WitnessActivityController.scala
@@ -1,11 +1,12 @@
 package controllers
 
-import play.api.mvc.{Controller, AnyContent, Action}
+import play.api.mvc.{Action, AnyContent, Controller}
 import model.Cached
 import common.{ExecutionContexts, JsonComponent}
 import discussion.model._
 import discussion.api.WitnessApi
 import conf.Configuration
+import play.api.libs.ws.WSClient
 
 trait WitnessActivityController extends WitnessApi with Controller with ExecutionContexts with implicits.Requests {
 
@@ -17,8 +18,6 @@ trait WitnessActivityController extends WitnessApi with Controller with Executio
   }
 }
 
-class WitnessActivityControllerImpl extends WitnessActivityController {
+class WitnessActivityControllerImpl(val wsClient: WSClient) extends WitnessActivityController {
   protected val witnessApiRoot: String = Configuration.witness.witnessApiRoot
 }
-
-object WitnessActivityController extends WitnessActivityControllerImpl

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -202,7 +202,7 @@ trait DiscussionApiLike extends Http with ExecutionContexts with Logging {
   }
 }
 
-case class DiscussionApi(val wsClient: WSClient) extends DiscussionApiLike {
+class DiscussionApi(val wsClient: WSClient) extends DiscussionApiLike {
   override protected val apiRoot =
     if (Configuration.environment.isProd)
       Configuration.discussion.apiRoot

--- a/discussion/app/discussion/DiscussionApi.scala
+++ b/discussion/app/discussion/DiscussionApi.scala
@@ -3,16 +3,18 @@ package discussion
 import java.net.URLEncoder
 
 import common.{ExecutionContexts, Logging}
+
 import scala.concurrent.Future
 import discussion.model._
-import play.api.mvc.{RequestHeader, Headers}
+import play.api.mvc.{Cookie, Headers, RequestHeader}
 import discussion.util.Http
-import play.api.libs.ws.WSResponse
+import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.libs.json.{JsNull, JsNumber, JsObject}
 import discussion.model.CommentCount
 import com.netaporter.uri.dsl._
+import conf.Configuration
 
-trait DiscussionApi extends Http with ExecutionContexts with Logging {
+trait DiscussionApiLike extends Http with ExecutionContexts with Logging {
 
   protected def GET(url: String, headers: (String, String)*): Future[WSResponse]
 
@@ -183,7 +185,33 @@ trait DiscussionApi extends Http with ExecutionContexts with Logging {
   }
 
   private def guClientHeader = ("GU-Client", clientHeaderValue)
+
+  def abuseReportToMap(abuseReport: DiscussionAbuseReport): Map[String, Seq[String]] = {
+    Map("categoryId" -> Seq(abuseReport.categoryId.toString),
+      "commentId" -> Seq(abuseReport.commentId.toString),
+      "reason" -> abuseReport.reason.toSeq,
+      "email" -> abuseReport.email.toSeq)
+  }
+
+  def postAbuseReport(abuseReport: DiscussionAbuseReport, cookie: Option[Cookie]): Future[WSResponse] = {
+    val url = s"${apiRoot}/comment/${abuseReport.commentId}/reportAbuse"
+    val headers = Seq("D2-X-UID" -> conf.Configuration.discussion.d2Uid, guClientHeader)
+    if (cookie.isDefined) { headers :+  ("Cookie"->s"SC_GU_U=${cookie.get}") }
+    wsClient.url(url).withHeaders(headers: _*).withRequestTimeout(2000).post(abuseReportToMap(abuseReport))
+
+  }
 }
+
+case class DiscussionApi(val wsClient: WSClient) extends DiscussionApiLike {
+  override protected val apiRoot =
+    if (Configuration.environment.isProd)
+      Configuration.discussion.apiRoot
+    else
+      Configuration.discussion.apiRoot.replaceFirst("https://", "http://") // CODE SSL cert is defective and expensive to fix
+
+  override protected val clientHeaderValue: String = Configuration.discussion.apiClientHeader
+}
+
 
 object AuthHeaders {
   val guIdToken = "GU-IdentityToken"

--- a/discussion/app/discussion/util/Http.scala
+++ b/discussion/app/discussion/util/Http.scala
@@ -1,11 +1,14 @@
 package discussion.util
 
-import play.api.libs.ws.{WS, WSResponse}
+import play.api.libs.ws.{WS, WSClient, WSResponse}
 import play.api.libs.json.{JsValue, Json}
 import common.{ExecutionContexts, Logging, StopWatch}
+
 import scala.concurrent.Future
 
 trait Http extends Logging with ExecutionContexts {
+
+  val wsClient: WSClient
 
   protected def getJsonOrError(url: String, onError: (WSResponse) => String, headers: (String, String)*): Future[JsValue] = {
     val stopWatch = new StopWatch
@@ -25,8 +28,7 @@ trait Http extends Logging with ExecutionContexts {
   }
 
   protected def GET(url: String, headers: (String, String)*): Future[WSResponse] = {
-    import play.api.Play.current
-    WS.url(url).withHeaders(headers: _*).withRequestTimeout(2000).get()
+    wsClient.url(url).withHeaders(headers: _*).withRequestTimeout(2000).get()
   }
 
 }

--- a/discussion/test/CommentCountControllerTest.scala
+++ b/discussion/test/CommentCountControllerTest.scala
@@ -2,13 +2,13 @@ package test
 
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
-import play.api.test.FakeRequest
 import controllers.CommentCountController
+import discussion.DiscussionApiLike
 
 @DoNotDiscover class CommentCountControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
   "Discussion" should "return 200" in {
-    val result = CommentCountController.commentCount("p/37v3a")(TestRequest())
+    val result = CommentCountController(new DiscussionApiStub(wsClient)).commentCount("p/37v3a")(TestRequest())
     status(result) should be(200)
   }
 }

--- a/discussion/test/CommentCountControllerTest.scala
+++ b/discussion/test/CommentCountControllerTest.scala
@@ -1,11 +1,10 @@
 package test
 
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
 import controllers.CommentCountController
-import discussion.DiscussionApiLike
 
-@DoNotDiscover class CommentCountControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class CommentCountControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
 
   "Discussion" should "return 200" in {
     val result = CommentCountController(new DiscussionApiStub(wsClient)).commentCount("p/37v3a")(TestRequest())

--- a/discussion/test/CommentCountControllerTest.scala
+++ b/discussion/test/CommentCountControllerTest.scala
@@ -7,7 +7,7 @@ import controllers.CommentCountController
 @DoNotDiscover class CommentCountControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
 
   "Discussion" should "return 200" in {
-    val result = CommentCountController(new DiscussionApiStub(wsClient)).commentCount("p/37v3a")(TestRequest())
+    val result = new CommentCountController(new DiscussionApiStub(wsClient)).commentCount("p/37v3a")(TestRequest())
     status(result) should be(200)
   }
 }

--- a/discussion/test/CommentPageControllerTest.scala
+++ b/discussion/test/CommentPageControllerTest.scala
@@ -10,7 +10,7 @@ import play.filters.csrf.CSRFConfig
 @DoNotDiscover class CommentPageControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
   "Discussion" should "return 200" in {
-    val commentsController = new CommentsController(CSRFConfig.fromConfiguration(app.configuration), wsClient)
+    val commentsController = new CommentsController(CSRFConfig.fromConfiguration(app.configuration), new DiscussionApiStub(wsClient))
     val result = commentsController.comments(DiscussionKey("p/37v3a"))(TestRequest())
     status(result) should be(200)
   }

--- a/discussion/test/CommentPageControllerTest.scala
+++ b/discussion/test/CommentPageControllerTest.scala
@@ -1,13 +1,12 @@
 package test
 
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
-import play.api.test.FakeRequest
 import controllers.CommentsController
 import discussion.model.DiscussionKey
 import play.filters.csrf.CSRFConfig
 
-@DoNotDiscover class CommentPageControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class CommentPageControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
 
   "Discussion" should "return 200" in {
     val commentsController = new CommentsController(CSRFConfig.fromConfiguration(app.configuration), new DiscussionApiStub(wsClient))

--- a/discussion/test/CommentPageControllerTest.scala
+++ b/discussion/test/CommentPageControllerTest.scala
@@ -10,7 +10,7 @@ import play.filters.csrf.CSRFConfig
 @DoNotDiscover class CommentPageControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
   "Discussion" should "return 200" in {
-    val commentsController = new CommentsController(CSRFConfig.fromConfiguration(app.configuration))
+    val commentsController = new CommentsController(CSRFConfig.fromConfiguration(app.configuration), wsClient)
     val result = commentsController.comments(DiscussionKey("p/37v3a"))(TestRequest())
     status(result) should be(200)
   }

--- a/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
+++ b/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
@@ -16,7 +16,7 @@ import play.api.libs.ws.WS
 
     override def GET(url: String, headers: (String, String)*) = {
       headersReceived = Map(headers:_*)
-      WS.url(testUrl).withRequestTimeout(1).get()
+      wsClient.url(testUrl).withRequestTimeout(1).get()
     }
 
     var headersReceived: Map[String,String] = Map.empty

--- a/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
+++ b/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
@@ -1,17 +1,17 @@
 package controllers
 
 import conf.Configuration
-import discussion.{DiscussionApi, DiscussionApiLike}
+import discussion.DiscussionApiLike
 import discussion.model.Comment
 import org.scalatest._
-import test.ConfiguredTestSuite
+import test.{ConfiguredTestSuite, WithTestWsClient}
 
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 import scala.concurrent.duration._
 import play.api.libs.ws.{WS, WSClient}
 
-@DoNotDiscover class DiscussionApiPluginIntegrationTest extends FlatSpecLike with Matchers with BeforeAndAfterAll with ConfiguredTestSuite {
+@DoNotDiscover class DiscussionApiPluginIntegrationTest extends FlatSpecLike with Matchers with BeforeAndAfterAll with ConfiguredTestSuite with WithTestWsClient {
 
   case class TestPlugin(val wsClient: WSClient) extends DiscussionApiLike {
 

--- a/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
+++ b/discussion/test/controllers/DiscussionApiPluginIntegrationTest.scala
@@ -13,7 +13,7 @@ import play.api.libs.ws.{WS, WSClient}
 
 @DoNotDiscover class DiscussionApiPluginIntegrationTest extends FlatSpecLike with Matchers with BeforeAndAfterAll with ConfiguredTestSuite with WithTestWsClient {
 
-  case class TestPlugin(val wsClient: WSClient) extends DiscussionApiLike {
+  class TestPlugin(val wsClient: WSClient) extends DiscussionApiLike {
 
     override def GET(url: String, headers: (String, String)*) = {
       headersReceived = Map(headers:_*)
@@ -27,7 +27,7 @@ import play.api.libs.ws.{WS, WSClient}
     override protected val clientHeaderValue: String = Configuration.discussion.apiClientHeader
   }
 
-  val testPlugin = TestPlugin(wsClient)
+  val testPlugin = new TestPlugin(wsClient)
 
   "DiscussionApiPlugin getJsonOrError " should "send GU-Client headers in GET request" in {
 

--- a/discussion/test/controllers/ProfileActivityControllerTest.scala
+++ b/discussion/test/controllers/ProfileActivityControllerTest.scala
@@ -10,7 +10,7 @@ import test.{ConfiguredTestSuite, DiscussionApiStub, WithTestWsClient}
   val userId = "10000001"
 
   "CommenterActivity" should "return profile discussions component" in {
-    val action = ProfileActivityController(new DiscussionApiStub(wsClient)).profileDiscussions(userId)
+    val action = new ProfileActivityController(new DiscussionApiStub(wsClient)).profileDiscussions(userId)
     val fakeRequest = FakeRequest(GET, "/discussion/profile/"+ userId +"/discussions.json").withHeaders("host" -> "localhost:9000")
     val result = action(fakeRequest)
 

--- a/discussion/test/controllers/ProfileActivityControllerTest.scala
+++ b/discussion/test/controllers/ProfileActivityControllerTest.scala
@@ -1,11 +1,11 @@
 package controllers
 
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
 import play.api.test.FakeRequest
-import test.{ConfiguredTestSuite, DiscussionApiStub}
+import test.{ConfiguredTestSuite, DiscussionApiStub, WithTestWsClient}
 
-@DoNotDiscover class ProfileActivityControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class ProfileActivityControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
 
   val userId = "10000001"
 

--- a/discussion/test/controllers/ProfileActivityControllerTest.scala
+++ b/discussion/test/controllers/ProfileActivityControllerTest.scala
@@ -3,14 +3,14 @@ package controllers
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
 import play.api.test.FakeRequest
-import test.ConfiguredTestSuite
+import test.{ConfiguredTestSuite, DiscussionApiStub}
 
 @DoNotDiscover class ProfileActivityControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
   val userId = "10000001"
 
   "CommenterActivity" should "return profile discussions component" in {
-    val action = ProfileActivityController.profileDiscussions(userId)
+    val action = ProfileActivityController(new DiscussionApiStub(wsClient)).profileDiscussions(userId)
     val fakeRequest = FakeRequest(GET, "/discussion/profile/"+ userId +"/discussions.json").withHeaders("host" -> "localhost:9000")
     val result = action(fakeRequest)
 

--- a/discussion/test/discussion/DiscussionApiTest.scala
+++ b/discussion/test/discussion/DiscussionApiTest.scala
@@ -2,26 +2,27 @@ package discussion
 
 import discussion.model.DiscussionKey
 import org.scalatest.{DoNotDiscover, FreeSpec}
-import play.api.libs.ws.WSResponse
+import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Headers
 import test.ConfiguredTestSuite
 import views.support.URLEncode
+
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
 @DoNotDiscover class DiscussionApiTest extends FreeSpec with ConfiguredTestSuite {
 
-  def urlValidator(expectedUrl: String) : DiscussionApi = {
-    new DiscussionApi {
-      override protected def GET(url: String, headers: (String, String)*): Future[WSResponse] = {
-        assert(expectedUrl === url)
-        Future {null} // Don't care what is returned for this test
-      }
-      protected val clientHeaderValue: String = ""
-      protected val apiRoot: String = ""
+  case class UrlValidatorDiscussionAPI(expectedUrl: String, val wsClient: WSClient = wsClient) extends DiscussionApiLike {
+    override protected def GET(url: String, headers: (String, String)*): Future[WSResponse] = {
+      assert(expectedUrl === url)
+      Future {null} // Don't care what is returned for this test
     }
+    protected val clientHeaderValue: String = ""
+    protected val apiRoot: String = ""
   }
+
+  def urlValidator(expectedUrl: String) : DiscussionApiLike = UrlValidatorDiscussionAPI(expectedUrl)
 
   def waitFor(f: Future[_], timeout: Duration = 2 seconds) = Await.ready(f, timeout)
 

--- a/discussion/test/discussion/DiscussionApiTest.scala
+++ b/discussion/test/discussion/DiscussionApiTest.scala
@@ -1,17 +1,16 @@
 package discussion
 
 import discussion.model.DiscussionKey
-import org.scalatest.{DoNotDiscover, FreeSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FreeSpec}
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.mvc.Headers
-import test.ConfiguredTestSuite
-import views.support.URLEncode
+import test.{ConfiguredTestSuite, WithTestWsClient}
 
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-@DoNotDiscover class DiscussionApiTest extends FreeSpec with ConfiguredTestSuite {
+@DoNotDiscover class DiscussionApiTest extends FreeSpec with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
 
   case class UrlValidatorDiscussionAPI(expectedUrl: String, val wsClient: WSClient = wsClient) extends DiscussionApiLike {
     override protected def GET(url: String, headers: (String, String)*): Future[WSResponse] = {

--- a/discussion/test/discussion/DiscussionApiTest.scala
+++ b/discussion/test/discussion/DiscussionApiTest.scala
@@ -12,7 +12,7 @@ import scala.language.postfixOps
 
 @DoNotDiscover class DiscussionApiTest extends FreeSpec with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
 
-  case class UrlValidatorDiscussionAPI(expectedUrl: String, val wsClient: WSClient = wsClient) extends DiscussionApiLike {
+  class UrlValidatorDiscussionAPI(expectedUrl: String, val wsClient: WSClient = wsClient) extends DiscussionApiLike {
     override protected def GET(url: String, headers: (String, String)*): Future[WSResponse] = {
       assert(expectedUrl === url)
       Future {null} // Don't care what is returned for this test
@@ -21,7 +21,7 @@ import scala.language.postfixOps
     protected val apiRoot: String = ""
   }
 
-  def urlValidator(expectedUrl: String) : DiscussionApiLike = UrlValidatorDiscussionAPI(expectedUrl)
+  def urlValidator(expectedUrl: String) : DiscussionApiLike = new UrlValidatorDiscussionAPI(expectedUrl)
 
   def waitFor(f: Future[_], timeout: Duration = 2 seconds) = Await.ready(f, timeout)
 

--- a/discussion/test/package.scala
+++ b/discussion/test/package.scala
@@ -7,7 +7,7 @@ import play.api.libs.ws.ning.NingWSResponse
 import recorder.HttpRecorder
 import com.ning.http.client.{Response => NingResponse, FluentCaseInsensitiveStringsMap}
 import com.ning.http.client.uri.Uri;
-import play.api.libs.ws.{WS, WSResponse}
+import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.Application
 import java.util
 import java.net.URI
@@ -56,8 +56,7 @@ object DiscussionApiHttpRecorder extends HttpRecorder[WSResponse] {
   }
 }
 
-class DiscussionApiStub extends DiscussionApi {
-  import play.api.Play.current
+class DiscussionApiStub(wsClient: WSClient) extends DiscussionApi {
   protected val clientHeaderValue: String =""
 
   protected val apiRoot =
@@ -69,7 +68,7 @@ class DiscussionApiStub extends DiscussionApi {
   protected val apiTimeout = conf.Configuration.discussion.apiTimeout
 
   override protected def GET(url: String, headers: (String, String)*) = DiscussionApiHttpRecorder.load(url, Map.empty){
-    WS.url(url).withRequestTimeout(2000).get()
+    wsClient.url(url).withRequestTimeout(2000).get()
   }
 }
 
@@ -86,5 +85,5 @@ class DiscussionTestSuite extends Suites (
   override lazy val port: Int = new HealthCheck().testPort
 
   // Inject stub api.
-  controllers.delegate.api = new DiscussionApiStub()
+  controllers.delegate.api = new DiscussionApiStub(wsClient)
 }

--- a/discussion/test/package.scala
+++ b/discussion/test/package.scala
@@ -5,16 +5,17 @@ import controllers.HealthCheck
 import org.scalatest.Suites
 import play.api.libs.ws.ning.NingWSResponse
 import recorder.HttpRecorder
-import com.ning.http.client.{Response => NingResponse, FluentCaseInsensitiveStringsMap}
-import com.ning.http.client.uri.Uri;
+import com.ning.http.client.{FluentCaseInsensitiveStringsMap, Response => NingResponse}
+import com.ning.http.client.uri.Uri
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.Application
 import java.util
 import java.net.URI
 import java.io.{File, InputStream}
 import java.nio.ByteBuffer
+
 import play.api.Plugin
-import discussion.DiscussionApi
+import discussion.{DiscussionApi, DiscussionApiLike}
 
 private case class Resp(getResponseBody: String) extends NingResponse {
   def getContentType: String = "application/json"
@@ -56,7 +57,7 @@ object DiscussionApiHttpRecorder extends HttpRecorder[WSResponse] {
   }
 }
 
-class DiscussionApiStub(wsClient: WSClient) extends DiscussionApi {
+class DiscussionApiStub(val wsClient: WSClient) extends DiscussionApiLike {
   protected val clientHeaderValue: String =""
 
   protected val apiRoot =
@@ -83,7 +84,4 @@ class DiscussionTestSuite extends Suites (
   new ProfileTest
   ) with SingleServerSuite {
   override lazy val port: Int = new HealthCheck().testPort
-
-  // Inject stub api.
-  controllers.delegate.api = new DiscussionApiStub(wsClient)
 }


### PR DESCRIPTION
## What does this change?

Removing call to `WS.url` in Discussion app. 🔪 
## What is the value of this and can you measure success?

🏃  => Play 2.5
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
