### PR TITLE
fetch with custom headers and body

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/football.js
+++ b/static/src/javascripts/bootstraps/enhanced/football.js
@@ -2,11 +2,12 @@ define([
     'bean',
     'bonzo',
     'common/utils/$',
-    'common/utils/ajax',
     'common/utils/config',
     'common/utils/detect',
+    'common/utils/fetch-json',
     'common/utils/mediator',
     'common/utils/page',
+    'common/utils/report-error',
     'common/modules/charts/table-doughnut',
     'common/modules/sport/football/football',
     'common/modules/sport/football/match-info',
@@ -18,11 +19,12 @@ define([
     bean,
     bonzo,
     $,
-    ajax,
     config,
     detect,
+    fetchJson,
     mediator,
     page,
+    reportError,
     Doughnut,
     football,
     MatchInfo,
@@ -252,9 +254,8 @@ define([
         bean.on(document.body, 'click', '.js-show-more-football-matches', function (e) {
             e.preventDefault();
             var el = e.currentTarget;
-            ajax({
-                url: el.getAttribute('href') + '.json'
-            }).then(function (resp) {
+            fetchJson(el.getAttribute('href') + '.json')
+            .then(function (resp) {
                 $.create(resp.html).each(function (html) {
                     $('[data-show-more-contains="' + el.getAttribute('data-puts-more-into') + '"]')
                         .append($(el.getAttribute('data-shows-more'), html));
@@ -265,6 +266,11 @@ define([
                     } else {
                         bonzo(el).remove();
                     }
+                });
+            })
+            .catch(function (ex) {
+                reportError(ex, {
+                    feature: 'football-show-more'
                 });
             });
         });

--- a/static/src/javascripts/bootstraps/enhanced/sport.js
+++ b/static/src/javascripts/bootstraps/enhanced/sport.js
@@ -1,9 +1,7 @@
 define([
-    'bonzo',
     'bean',
     'common/utils/$',
     'common/utils/template',
-    'common/utils/ajax',
     'common/utils/config',
     'common/utils/detect',
     'common/utils/page',
@@ -12,11 +10,9 @@ define([
     'common/modules/sport/score-board',
     'common/modules/ui/rhc'
 ], function (
-    bonzo,
     bean,
     $,
     template,
-    ajax,
     config,
     detect,
     page,

--- a/static/src/javascripts/projects/common/modules/business/stocks.js
+++ b/static/src/javascripts/projects/common/modules/business/stocks.js
@@ -1,7 +1,8 @@
 define([
     'common/utils/$',
-    'common/utils/ajax',
     'common/utils/config',
+    'common/utils/fetch-json',
+    'common/utils/report-error',
     'common/utils/template',
     'common/views/svgs',
     'text!common/views/business/stock-value.html',
@@ -10,8 +11,9 @@ define([
     'lodash/collections/map'
 ], function (
     $,
-    ajax,
     config,
+    fetchJson,
+    reportError,
     template,
     svgs,
     stockValueTemplate,
@@ -24,11 +26,13 @@ define([
     }
 
     function getStocksData() {
-        return ajax({
-            url: '/business-data/stocks.json',
-            type: 'json',
-            method: 'get',
-            crossOrigin: true
+        return fetchJson('/business-data/stocks.json', {
+            mode: 'cors'
+        })
+        .catch(function (ex) {
+            reportError(ex, {
+                feature: 'stocks'
+            });
         });
     }
 

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -3,10 +3,12 @@ define([
     'bonzo',
     'qwery',
     'common/utils/$',
-    'common/utils/ajax-promise',
     'common/utils/config',
+    'common/utils/fetch-json',
     'common/utils/mediator',
+    'common/utils/report-error',
     'common/utils/scroller',
+    'common/utils/url',
     'common/modules/component',
     'common/modules/discussion/api',
     'common/modules/discussion/comment-box',
@@ -19,10 +21,12 @@ define([
     bonzo,
     qwery,
     $,
-    ajaxPromise,
     config,
+    fetchJson,
     mediator,
+    reportError,
     scroller,
+    urlUtil,
     Component,
     DiscussionApi,
     CommentBox,
@@ -148,7 +152,7 @@ Comments.prototype.fetchComments = function(options) {
 
     var url = '/discussion/' +
         (options.comment ? 'comment-context/' + options.comment : this.options.discussionId) +
-        '.json?' + (options.page ? '&page=' + options.page : '');
+        '.json';
 
     var orderBy = options.order || this.options.order;
     if (orderBy === 'recommendations') {
@@ -161,36 +165,37 @@ Comments.prototype.fetchComments = function(options) {
         displayThreaded: this.options.threading !== 'unthreaded'
     };
 
+    if (options.page) {
+        queryParams.page = options.page;
+    }
+
     if (!options.comment && this.options.threading === 'collapsed') {
         queryParams.maxResponses = 3;
     }
 
     var promise,
-        ajaxParams = {
-            url: url,
-            type: 'json',
-            method: 'get',
-            crossOrigin: true,
-            data: queryParams
-        };
+        ajaxParams = { mode: 'cors' };
+
     if (this.isAllPageSizeActive()) {
         promise = new WholeDiscussion({
             discussionId: this.options.discussionId,
             orderBy: queryParams.orderBy,
             displayThreaded: queryParams.displayThreaded,
             maxResponses: queryParams.maxResponses
-        }).loadAllComments().catch(function() {
+        })
+        .loadAllComments()
+        .catch(function() {
             this.wholeDiscussionErrors = true;
             queryParams.pageSize = 100;
-            return ajaxPromise(ajaxParams);
-            }.bind(this));
+            return fetchJson(url + '?' + urlUtil.constructQuery(queryParams), ajaxParams);
+        }.bind(this));
     } else {
         // It is possible that the user has chosen to view all comments,
         // but the WholeDiscussion module has failed. Fall back to 100 comments.
         if (queryParams.pageSize === 'All') {
             queryParams.pageSize = 100;
         }
-        promise = ajaxPromise(ajaxParams);
+        promise = fetchJson(url + '?' + urlUtil.constructQuery(queryParams), ajaxParams);
     }
     return promise.then(this.renderComments.bind(this));
 };
@@ -263,13 +268,10 @@ Comments.prototype.getMoreReplies = function(event) {
     li.innerHTML = 'Loading…';
 
     var source = bonzo(event.target).data('source-comment');
+    var commentId = event.currentTarget.getAttribute('data-comment-id');
 
-    ajaxPromise({
-        url: '/discussion/comment/' + event.currentTarget.getAttribute('data-comment-id') + '.json',
-        type: 'json',
-        method: 'get',
-        data: {displayThreaded: true},
-        crossOrigin: true
+    fetchJson('/discussion/comment/' + commentId + '.json?displayThreaded=true', {
+        mode: 'cors'
     }).then(function (resp) {
         var comment = bonzo.create(resp.html),
             replies = qwery(this.getClass('reply'), comment);
@@ -282,7 +284,12 @@ Comments.prototype.getMoreReplies = function(event) {
         if (shouldMakeTimestampsRelative()) {
             this.relativeDates();
         }
-    }.bind(this));
+    }.bind(this))
+    .catch(function (ex) {
+        reportError(ex, {
+            feature: 'comments-more-replies'
+        });
+    });
 };
 
 Comments.prototype.isReadOnly = function() {

--- a/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
+++ b/static/src/javascripts/projects/common/modules/discussion/whole-discussion.js
@@ -4,8 +4,8 @@ define([
     'qwery',
     'Promise',
     'common/utils/$',
-    'common/utils/ajax-promise',
-    'lodash/collections/forEach',
+    'common/utils/fetch-json',
+    'common/utils/url',
     'lodash/arrays/range'
 ], function (
     bean,
@@ -13,8 +13,8 @@ define([
     qwery,
     Promise,
     $,
-    ajaxPromise,
-    forEach,
+    fetchJson,
+    urlUtil,
     range
 ) {
     // This size effectively determines how many calls this module needs to make.
@@ -52,7 +52,7 @@ define([
 
             var initialItems = items.splice(0, concurrentLimit);
 
-            forEach(initialItems, start);
+            initialItems.forEach(start);
         });
     }
 
@@ -112,12 +112,10 @@ define([
             queryParams.maxResponses = this.params.maxResponses;
         }
 
-        return ajaxPromise({
-            url: '/discussion/' + this.discussionId + '.json',
-            type: 'json',
-            method: 'get',
-            crossOrigin: true,
-            data: queryParams
+        var url = '/discussion/' + this.discussionId + '.json?' + urlUtil.constructQuery(queryParams);
+
+        return fetchJson(url, {
+            mode: 'cors'
         });
     };
 

--- a/static/src/javascripts/projects/common/modules/email/email.js
+++ b/static/src/javascripts/projects/common/modules/email/email.js
@@ -3,20 +3,20 @@ define([
     'bean',
     'bonzo',
     'qwery',
-    'common/utils/$',
-    'common/utils/ajax-promise',
-    'common/utils/config',
     'fastdom',
     'Promise',
+    'common/utils/$',
+    'common/utils/config',
+    'common/utils/detect',
+    'common/utils/fetch',
     'common/utils/mediator',
+    'common/utils/template',
+    'common/utils/robust',
     'lodash/functions/debounce',
     'lodash/collections/contains',
-    'common/utils/template',
     'common/views/svgs',
     'text!common/views/email/submissionResponse.html',
     'text!common/views/ui/close-button.html',
-    'common/utils/robust',
-    'common/utils/detect',
     'common/modules/identity/api',
     'common/modules/user-prefs',
     'lodash/arrays/uniq'
@@ -25,20 +25,20 @@ define([
     bean,
     bonzo,
     qwery,
-    $,
-    ajax,
-    config,
     fastdom,
     Promise,
+    $,
+    config,
+    detect,
+    fetch,
     mediator,
+    template,
+    robust,
     debounce,
     contains,
-    template,
     svgs,
     successHtml,
     closeHtml,
-    robust,
-    detect,
     Id,
     userPrefs,
     uniq
@@ -266,12 +266,16 @@ define([
                         return getOmniture().then(function (omniture) {
                             omniture.trackLinkImmediate(analyticsInfo.replace('%action%', 'subscribe clicked'));
 
-                            return ajax({
-                                url: url,
+                            return fetch(config.page.ajaxUrl + url, {
                                 method: 'post',
-                                data: data,
+                                body: data,
                                 headers: {
                                     'Accept': 'application/json'
+                                }
+                            })
+                            .then(function (response) {
+                                if (!response.ok) {
+                                    throw new Error('Fetch error: ' + response.status + ' ' + response.statusText);
                                 }
                             })
                             .then(function () {

--- a/static/src/javascripts/projects/common/utils/fetch.js
+++ b/static/src/javascripts/projects/common/utils/fetch.js
@@ -17,8 +17,6 @@ define([
      * - - input can only be a string, Request is not supported
      * - - does not support JSONP
      * - - headers can only be specified as an object literal, the Headers interface is not supported
-     * - Request
-     * - - there's no way to send a body
      * - Response
      * - - blob is not supported
      * - - formData is not supported

--- a/static/src/javascripts/projects/common/utils/fetch.js
+++ b/static/src/javascripts/projects/common/utils/fetch.js
@@ -16,7 +16,7 @@ define([
      * - fetch
      * - - input can only be a string, Request is not supported
      * - - does not support JSONP
-     * - - headers can't be specified
+     * - - headers can only be specified as an object literal, the Headers interface is not supported
      * - Request
      * - - there's no way to send a body
      * - Response
@@ -27,6 +27,7 @@ define([
      * If you're still wondering what it actually supports
      * - CORS
      * - credentials
+     * - body, any body that you want to add to your request except for GET or HEAD
      * - response.text() and response.json()
      * - response.ok .status .statusText
      */
@@ -60,6 +61,8 @@ define([
             type: 'text',
             method: options.method || 'GET',
             crossOrigin: isCors,
+            headers: options.headers,
+            data: options.body,
             withCredentials: withCredentials
         };
     }

--- a/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
+++ b/static/src/javascripts/projects/facia/modules/ui/live-blog-updates.js
@@ -1,13 +1,14 @@
 define([
     'bonzo',
-    'common/utils/$',
-    'common/utils/ajax',
-    'common/utils/storage',
     'common/modules/ui/relativedates',
-    'common/utils/template',
-    'common/utils/mediator',
+    'common/utils/$',
+    'common/utils/chain',
     'common/utils/detect',
     'common/utils/fastdom-promise',
+    'common/utils/fetch-json',
+    'common/utils/mediator',
+    'common/utils/storage',
+    'common/utils/template',
     'text!facia/views/liveblog-block.html',
     'lodash/arrays/compact',
     'lodash/objects/isUndefined',
@@ -15,18 +16,18 @@ define([
     'lodash/functions/debounce',
     'lodash/collections/filter',
     'lodash/objects/isEmpty',
-    'lodash/collections/map',
-    'common/utils/chain'
+    'lodash/collections/map'
 ], function (
     bonzo,
-    $,
-    ajax,
-    storage,
     relativeDates,
-    template,
-    mediator,
+    $,
+    chain,
     detect,
     fastdomPromise,
+    fetchJson,
+    mediator,
+    storage,
+    template,
     blockTemplate,
     compact,
     isUndefined,
@@ -34,8 +35,7 @@ define([
     debounce,
     filter,
     isEmpty,
-    map,
-    chain
+    map
 ) {
     var animateDelayMs = 2000,
         animateAfterScrollDelayMs = 500,
@@ -174,10 +174,8 @@ define([
                 oldBlockDates = storage.session.get(sessionStorageKey) || {};
 
                 forEach(elementsById, function (elements, articleId) {
-                    ajax({
-                        url: '/' + articleId + '.json?rendered=false',
-                        type: 'json',
-                        crossOrigin: true
+                    fetchJson('/' + articleId + '.json?rendered=false', {
+                        mode: 'cors'
                     })
                     .then(function (response) {
                         var blocks = response && sanitizeBlocks(response.blocks);
@@ -187,7 +185,8 @@ define([
                             oldBlockDates[articleId] = blocks[0].publishedDateTime;
                             storage.session.set(sessionStorageKey, oldBlockDates);
                         }
-                    });
+                    })
+                    .catch(function () {});
                 });
 
                 if (refreshMaxTimes) {


### PR DESCRIPTION
## What does this change?

Implement custom headers and body for fetch polyfill.

Rewrite some modules to use `fetch` instead of `ajax` or `ajax-promise`
- Email
- Comments show more, page navigation and size
- Football show more
- Live blog updates on fronts
- Stocks

There's only one module left requiring `ajax-promise`, it's using timeout, which I haven't implemented yet, next PR.
## What is the value of this and can you measure success?

One step closer to removing `ajax-promise`
## Request for comment

@sndrs @regiskuckaertz 

Special mention to @stephanfowler : Live blog updates seem to often return 404 (tested on code because we don't have live blogs on prod right now). Because of this I've decided to ignore errors instead of reporting to sentry, maybe errors are a feature...

Another special mention to @gtrufitt : Can you help me test the email sign up? I don't know how to do it locally
