### PR TITLE
Removing call to WS.url (Continue #6)

### DIFF
--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -168,7 +168,7 @@ object S3FrontsApi extends S3 {
     getLastModified(getLiveFapiPressedKeyForPath(path)).map(_.toString)
 }
 
-case class SecureS3Request(wsClient: WSClient) extends implicits.Dates with Logging {
+class SecureS3Request(wsClient: WSClient) extends implicits.Dates with Logging {
   val algorithm: String = "HmacSHA1"
   val frontendBucket: String = Configuration.aws.bucket
   val frontendStore: String = Configuration.frontend.store

--- a/common/app/services/S3.scala
+++ b/common/app/services/S3.scala
@@ -14,7 +14,7 @@ import common.Logging
 import conf.Configuration
 import org.joda.time.DateTime
 import play.Play
-import play.api.libs.ws.{WS, WSRequest}
+import play.api.libs.ws.{WSClient, WSRequest}
 import sun.misc.BASE64Encoder
 
 import scala.io.{Codec, Source}
@@ -168,8 +168,7 @@ object S3FrontsApi extends S3 {
     getLastModified(getLiveFapiPressedKeyForPath(path)).map(_.toString)
 }
 
-trait SecureS3Request extends implicits.Dates with Logging {
-  import play.api.Play.current
+case class SecureS3Request(wsClient: WSClient) extends implicits.Dates with Logging {
   val algorithm: String = "HmacSHA1"
   val frontendBucket: String = Configuration.aws.bucket
   val frontendStore: String = Configuration.frontend.store
@@ -196,7 +195,7 @@ trait SecureS3Request extends implicits.Dates with Logging {
 
 
 
-    WS.url(s"$frontendStore/$id").withHeaders(headers:_*)
+    wsClient.url(s"$frontendStore/$id").withHeaders(headers:_*)
   }
 
   //Other HTTP verbs may need other information such as Content-MD5 and Content-Type
@@ -222,8 +221,6 @@ trait SecureS3Request extends implicits.Dates with Logging {
     }
   }
 }
-
-object SecureS3Request extends SecureS3Request
 
 object S3Archive extends S3 {
  override lazy val bucket = if (Configuration.environment.isNonProd) "aws-frontend-archive-code" else "aws-frontend-archive"

--- a/dev-build/app/AppLoader.scala
+++ b/dev-build/app/AppLoader.scala
@@ -54,7 +54,7 @@ trait Controllers
   lazy val surveyPageController = wire[SurveyPageController]
 }
 
-trait AppComponents extends FrontendComponents with Controllers with AdminServices with SportServices with CommercialServices with DiscussionServices {
+trait AppComponents extends FrontendComponents with Controllers with AdminServices with SportServices with CommercialServices with DiscussionServices with FapiServices {
 
   override def router: Router = wire[Routes]
   override def appIdentity: ApplicationIdentity = ApplicationIdentity("dev-build")

--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -4,11 +4,13 @@ import common._
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
 import controllers.{Application, HealthCheck}
+import frontpress.{DraftFapiFrontPress, FrontPressCron, LiveFapiFrontPress, ToolPressQueueWorker}
 import lifecycle.FaciaPressLifecycle
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.routing.Router
 import play.api._
+import play.api.libs.ws.WSClient
 import services.ConfigAgentLifecycle
 import router.Routes
 
@@ -17,12 +19,23 @@ class AppLoader extends FrontendApplicationLoader {
 }
 
 trait Controllers {
+  def toolPressQueueWorker: ToolPressQueueWorker
+  def liveFapiFrontPress: LiveFapiFrontPress
+  def draftFapiFrontPress: DraftFapiFrontPress
   lazy val healthCheck = wire[HealthCheck]
-  lazy val applicationController = wire[Application]
+  lazy val applicationController: Application = wire[Application]
 }
 
-trait AppLifecycleComponents {
-  self: FrontendComponents with Controllers =>
+trait FapiFrontPresses {
+  def wsClient: WSClient
+  lazy val liveFapiFrontPress = wire[LiveFapiFrontPress]
+  lazy val draftFapiFrontPress = wire[DraftFapiFrontPress]
+  lazy val toolPressQueueWorker = wire[ToolPressQueueWorker]
+  lazy val frontPressCron = wire[FrontPressCron]
+}
+
+trait AppLifecycleComponents extends FapiFrontPresses {
+  self: FrontendComponents =>
 
   override lazy val lifecycleComponents = List(
     wire[LogstashLifecycle],

--- a/facia-press/app/controllers/Application.scala
+++ b/facia-press/app/controllers/Application.scala
@@ -11,7 +11,8 @@ import services.ConfigAgent
 
 import scala.concurrent.Future
 
-class Application extends Controller with ExecutionContexts {
+class Application(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFrontPress: DraftFapiFrontPress) extends Controller with ExecutionContexts {
+
   def index = Action {
     NoCache(Ok("Hello, I am the Facia Press."))
   }
@@ -21,7 +22,7 @@ class Application extends Controller with ExecutionContexts {
   }
 
   def generateLivePressedFor(path: String) = Action.async { request =>
-    LiveFapiFrontPress.getPressedFrontForPath(path)
+    liveFapiFrontPress.getPressedFrontForPath(path)
       .map(Json.toJson(_))
       .map(Json.prettyPrint)
       .map(Ok.apply(_))
@@ -41,17 +42,17 @@ class Application extends Controller with ExecutionContexts {
       Future.successful(NoCache(ServiceUnavailable(s"This service has been disabled by the switch: ${FaciaPressOnDemand.name}")))}
 
   def pressLiveForPath(path: String) = Action.async {
-    handlePressRequest(path, "live")(LiveFapiFrontPress.pressByPathId)
+    handlePressRequest(path, "live")(liveFapiFrontPress.pressByPathId)
   }
 
   def pressDraftForPath(path: String) = Action.async {
-    handlePressRequest(path, "draft")(DraftFapiFrontPress.pressByPathId)
+    handlePressRequest(path, "draft")(draftFapiFrontPress.pressByPathId)
   }
 
   def pressDraftForAll() = Action.async {
     ConfigAgent.getPathIds.foldLeft(Future.successful(List[(String, Result)]())){ case (lastFuture, path) =>
       lastFuture
-        .flatMap(resultList => handlePressRequest(path, "draft")(DraftFapiFrontPress.pressByPathId)
+        .flatMap(resultList => handlePressRequest(path, "draft")(draftFapiFrontPress.pressByPathId)
           .map(path -> _)
           .map(resultList :+ _))
     }.map { pressedPaths =>

--- a/facia-press/app/controllers/HealthCheck.scala
+++ b/facia-press/app/controllers/HealthCheck.scala
@@ -7,13 +7,13 @@ import org.joda.time.DateTime
 
 import scala.concurrent.Future.successful
 
-class HealthCheck extends HealthCheckController with Results {
+class HealthCheck(toolPressQueueWorker: ToolPressQueueWorker) extends HealthCheckController with Results {
   val ConsecutiveProcessingErrorsThreshold = 5
   override def healthCheck() = Action.async{
-    if (!ToolPressQueueWorker.lastReceipt.exists(_.plusMinutes(1).isAfter(DateTime.now))) {
+    if (!toolPressQueueWorker.lastReceipt.exists(_.plusMinutes(1).isAfter(DateTime.now))) {
       successful(Results.InternalServerError("Have not been able to retrieve a message from the tool queue for at least a minute"))
-    } else if (ToolPressQueueWorker.consecutiveErrors >= ConsecutiveProcessingErrorsThreshold) {
-      successful(Results.InternalServerError(s"The last ${ToolPressQueueWorker.consecutiveErrors} presses have resulted in internal errors"))
+    } else if (toolPressQueueWorker.consecutiveErrors >= ConsecutiveProcessingErrorsThreshold) {
+      successful(Results.InternalServerError(s"The last ${toolPressQueueWorker.consecutiveErrors} presses have resulted in internal errors"))
     } else {
       successful(Ok("OK"))
     }

--- a/facia-press/app/frontpress/ToolPressQueueWorker.scala
+++ b/facia-press/app/frontpress/ToolPressQueueWorker.scala
@@ -11,7 +11,7 @@ import services._
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-object ToolPressQueueWorker extends JsonQueueWorker[PressJob] with Logging {
+class ToolPressQueueWorker(liveFapiFrontPress: LiveFapiFrontPress, draftFapiFrontPress: DraftFapiFrontPress) extends JsonQueueWorker[PressJob] with Logging {
   override val queue = (Configuration.faciatool.frontPressToolQueue map { queueUrl =>
     val credentials = Configuration.aws.mandatoryCredentials
 
@@ -36,8 +36,8 @@ object ToolPressQueueWorker extends JsonQueueWorker[PressJob] with Logging {
     log.info(s"Processing job from tool to update $path on $pressType")
 
     lazy val pressFuture: Future[Unit] = pressType match {
-      case Draft => DraftFapiFrontPress.pressByPathId(path)
-      case Live => LiveFapiFrontPress.pressByPathId(path)}
+      case Draft => draftFapiFrontPress.pressByPathId(path)
+      case Live => liveFapiFrontPress.pressByPathId(path)}
 
     lazy val forceConfigUpdateFuture: Future[_] =
       if (forceConfigUpdate.exists(identity)) {

--- a/facia-press/app/lifecycle/FaciaPressLifecycle.scala
+++ b/facia-press/app/lifecycle/FaciaPressLifecycle.scala
@@ -7,16 +7,16 @@ import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.{Future, ExecutionContext}
 
-class FaciaPressLifecycle(appLifecycle: ApplicationLifecycle)(implicit ec: ExecutionContext) extends LifecycleComponent {
+class FaciaPressLifecycle(appLifecycle: ApplicationLifecycle, frontPressCron: FrontPressCron, toolPressQueueWorker: ToolPressQueueWorker)(implicit ec: ExecutionContext) extends LifecycleComponent {
 
   appLifecycle.addStopHook { () => Future {
-    ToolPressQueueWorker.stop()
+    toolPressQueueWorker.stop()
   }}
 
   override def start(): Unit = {
-    ToolPressQueueWorker.start()
+    toolPressQueueWorker.start()
     if (Configuration.faciatool.frontPressCronQueue.isDefined) {
-      FrontPressCron.start()
+      frontPressCron.start()
     }
   }
 }

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -4,7 +4,8 @@ import common._
 import common.Logback.LogstashLifecycle
 import common.dfp.FaciaDfpAgentLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{CommonFilters, CachedHealthCheckLifeCycle}
+import conf.{CachedHealthCheckLifeCycle, CommonFilters}
+import controllers.front.{FrontJsonFapiDraft, FrontJsonFapiLive}
 import controllers.{Assets, FaciaControllers, HealthCheck}
 import crosswords.TodaysCrosswordGridLifecycle
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
@@ -16,11 +17,18 @@ import play.api.http.HttpRequestHandler
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
-import services.{IndexListingsLifecycle, ConfigAgentLifecycle}
+import play.api.libs.ws.WSClient
+import services.{ConfigAgentLifecycle, IndexListingsLifecycle}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
+}
+
+trait FapiServices {
+  def wsClient: WSClient
+  lazy val frontJsonFapiLive = wire[FrontJsonFapiLive]
+  lazy val frontJsonFapiDraft = wire[FrontJsonFapiDraft]
 }
 
 trait Controllers extends FaciaControllers {
@@ -47,7 +55,7 @@ trait AppLifecycleComponents {
   )
 }
 
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers {
+trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with FapiServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/facia/app/controllers/DedupedController.scala
+++ b/facia/app/controllers/DedupedController.scala
@@ -6,9 +6,7 @@ import layout.Front
 import play.api.libs.json.Json
 import play.api.mvc.{Action, Controller}
 
-class DedupedController extends Controller with Logging with ExecutionContexts {
-
-  val frontJsonFapi: FrontJsonFapi = FrontJsonFapiLive
+class DedupedController(frontJsonFapi: FrontJsonFapiLive) extends Controller with Logging with ExecutionContexts {
 
   def getDedupedForPath(path: String) = Action.async { request =>
     frontJsonFapi.get(path).map {
@@ -20,5 +18,3 @@ class DedupedController extends Controller with Logging with ExecutionContexts {
     }
   }
 }
-
-object DedupedController extends DedupedController

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -246,8 +246,5 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
   }
 }
 
-class FaciaControllerImpl extends FaciaController {
-  val frontJsonFapi: FrontJsonFapi = FrontJsonFapiLive
-}
+case class FaciaControllerImpl(val frontJsonFapi: FrontJsonFapiLive) extends FaciaController
 
-object FaciaController extends FaciaControllerImpl

--- a/facia/app/controllers/FaciaController.scala
+++ b/facia/app/controllers/FaciaController.scala
@@ -246,5 +246,5 @@ trait FaciaController extends Controller with Logging with ExecutionContexts wit
   }
 }
 
-case class FaciaControllerImpl(val frontJsonFapi: FrontJsonFapiLive) extends FaciaController
+class FaciaControllerImpl(val frontJsonFapi: FrontJsonFapiLive) extends FaciaController
 

--- a/facia/app/controllers/FaciaControllers.scala
+++ b/facia/app/controllers/FaciaControllers.scala
@@ -1,8 +1,10 @@
 package controllers
 
 import com.softwaremill.macwire._
+import controllers.front.FrontJsonFapiLive
 
 trait FaciaControllers {
+  def frontJsonFapiLive: FrontJsonFapiLive
   lazy val dedupedController = wire[DedupedController]
   lazy val faciaController = wire[FaciaControllerImpl]
 }

--- a/facia/app/controllers/front/FrontJsonFapi.scala
+++ b/facia/app/controllers/front/FrontJsonFapi.scala
@@ -14,7 +14,7 @@ trait FrontJsonFapi extends Logging with ExecutionContexts {
   val bucketLocation: String
 
   val wsClient: WSClient
-  val secureS3Request = SecureS3Request(wsClient)
+  val secureS3Request = new SecureS3Request(wsClient)
 
   private def getAddressForPath(path: String): String = s"$bucketLocation/${path.replaceAll("""\+""","%2B")}/fapi/pressed.json"
 
@@ -68,10 +68,10 @@ trait FrontJsonFapi extends Logging with ExecutionContexts {
   }
 }
 
-case class FrontJsonFapiLive(val wsClient: WSClient) extends FrontJsonFapi {
+class FrontJsonFapiLive(val wsClient: WSClient) extends FrontJsonFapi {
   override val bucketLocation: String = s"$stage/frontsapi/pressed/live"
 }
 
-case class FrontJsonFapiDraft(val wsClient: WSClient) extends FrontJsonFapi {
+class FrontJsonFapiDraft(val wsClient: WSClient) extends FrontJsonFapi {
   val bucketLocation: String = s"$stage/frontsapi/pressed/draft"
 }

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -12,7 +12,7 @@ import org.scalatest._
 import controllers.FaciaControllerImpl
 
 @DoNotDiscover class FaciaControllerTest extends FlatSpec with Matchers with ExecutionContexts with ConfiguredTestSuite
-  with BeforeAndAfterAll with FakeRequests with BeforeAndAfterEach {
+  with BeforeAndAfterAll with FakeRequests with BeforeAndAfterEach with WithTestWsClient {
 
   val faciaController = new FaciaControllerImpl(new TestFrontJsonFapi(wsClient))
   val articleUrl = "/environment/2012/feb/22/capitalise-low-carbon-future"

--- a/facia/test/FaciaControllerTest.scala
+++ b/facia/test/FaciaControllerTest.scala
@@ -1,7 +1,7 @@
 package test
 
-import com.gu.facia.client.models.{FrontJson, ConfigJson}
-import common.editions.{Us, Uk}
+import com.gu.facia.client.models.{ConfigJson, FrontJson}
+import common.editions.{Uk, Us}
 import implicits.FakeRequests
 import play.api.libs.json.JsArray
 import play.api.test._
@@ -9,10 +9,12 @@ import play.api.test.Helpers._
 import common.ExecutionContexts
 import services.ConfigAgent
 import org.scalatest._
+import controllers.FaciaControllerImpl
 
 @DoNotDiscover class FaciaControllerTest extends FlatSpec with Matchers with ExecutionContexts with ConfiguredTestSuite
   with BeforeAndAfterAll with FakeRequests with BeforeAndAfterEach {
 
+  val faciaController = new FaciaControllerImpl(new TestFrontJsonFapi(wsClient))
   val articleUrl = "/environment/2012/feb/22/capitalise-low-carbon-future"
   val callbackName = "aFunction"
   val frontJson = FrontJson(Nil, None, None, None, None, None, None, None, None, None, None, None, None, None)
@@ -29,7 +31,7 @@ import org.scalatest._
   }
 
   it should "serve an X-Accel-Redirect for something it doesn't know about" in {
-    val result = test.faciaController.renderFront("does-not-exist")(TestRequest()) //Film is actually a facia front ON PROD
+    val result = faciaController.renderFront("does-not-exist")(TestRequest()) //Film is actually a facia front ON PROD
     status(result) should be(200)
     header("X-Accel-Redirect", result) should be (Some("/applications/does-not-exist"))
   }
@@ -37,7 +39,7 @@ import org.scalatest._
   it should "serve an X-Accel-Redirect for /rss that it doesn't know about" in {
     val fakeRequest = FakeRequest("GET", "/does-not-exist/rss")
 
-    val result = test.faciaController.renderFrontRss("does-not-exist")(fakeRequest)
+    val result = faciaController.renderFrontRss("does-not-exist")(fakeRequest)
     status(result) should be(200)
     header("X-Accel-Redirect", result) should be (Some("/rss_server/does-not-exist/rss"))
   }
@@ -45,7 +47,7 @@ import org.scalatest._
   it should "keep query params for X-Accel-Redirect" in {
     val fakeRequest = FakeRequest("GET", "/does-not-exist?page=77")
 
-    val result = test.faciaController.renderFront("does-not-exist")(fakeRequest)
+    val result = faciaController.renderFront("does-not-exist")(fakeRequest)
     status(result) should be(200)
     header("X-Accel-Redirect", result) should be (Some("/applications/does-not-exist?page=77"))
   }
@@ -53,7 +55,7 @@ import org.scalatest._
   it should "keep query params for X-Accel-Redirect with RSS" in {
     val fakeRequest = FakeRequest("GET", "/does-not-exist/rss?page=77")
 
-    val result = test.faciaController.renderFrontRss("does-not-exist")(fakeRequest)
+    val result = faciaController.renderFrontRss("does-not-exist")(fakeRequest)
     status(result) should be(200)
     header("X-Accel-Redirect", result) should be (Some("/rss_server/does-not-exist/rss?page=77"))
   }
@@ -61,14 +63,14 @@ import org.scalatest._
   it should "not serve X-Accel for a path facia serves" in {
     val fakeRequest = FakeRequest("GET", "/music")
 
-    val result = test.faciaController.renderFront("music")(fakeRequest)
+    val result = faciaController.renderFront("music")(fakeRequest)
     header("X-Accel-Redirect", result) should be (None)
   }
 
   it should "redirect to applications when 'page' query param" in {
     val fakeRequest = FakeRequest("GET", "/music?page=77")
 
-    val result = test.faciaController.renderFront("music")(fakeRequest)
+    val result = faciaController.renderFront("music")(fakeRequest)
     status(result) should be(200)
     header("X-Accel-Redirect", result) should be (Some("/applications/music?page=77"))
   }
@@ -76,27 +78,27 @@ import org.scalatest._
   it should "not redirect to applications when any other query param" in {
     val fakeRequest = FakeRequest("GET", "/music?id=77")
 
-    val result = test.faciaController.renderFront("music")(fakeRequest)
+    val result = faciaController.renderFront("music")(fakeRequest)
     header("X-Accel-Redirect", result) should be (None)
   }
 
   it should "redirect to editionalised fronts" in {
     val ukRequest = FakeRequest("GET", "/").from(Uk)
-    val ukResult = test.faciaController.renderFront("")(ukRequest)
+    val ukResult = faciaController.renderFront("")(ukRequest)
     header("Location", ukResult).head should endWith ("/uk")
 
     val usRequest = FakeRequest("GET", "/").from(Us)
-    val usResult = test.faciaController.renderFront("")(usRequest)
+    val usResult = faciaController.renderFront("")(usRequest)
     header("Location", usResult).head should endWith ("/us")
   }
 
   it should "redirect to editionalised pages" in {
     val ukRequest = FakeRequest("GET", "/technology").from(Uk)
-    val ukResult = test.faciaController.renderFront("technology")(ukRequest)
+    val ukResult = faciaController.renderFront("technology")(ukRequest)
     header("Location", ukResult).head should endWith ("/uk/technology")
 
     val usRequest = FakeRequest("GET", "/technology").from(Us)
-    val usResult = test.faciaController.renderFront("technology")(usRequest)
+    val usResult = faciaController.renderFront("technology")(usRequest)
     header("Location", usResult).head should endWith ("/us/technology")
   }
 
@@ -104,7 +106,7 @@ import org.scalatest._
 
 
     val international = FakeRequest("GET", "/").withHeaders("X-GU-Edition" -> "INT")
-    val redirectToInternational = test.faciaController.renderFront("")(international)
+    val redirectToInternational = faciaController.renderFront("")(international)
     header("Location", redirectToInternational).head should endWith ("/international")
   }
 
@@ -114,33 +116,33 @@ import org.scalatest._
       "X-GU-Edition" -> "INT",
       "X-GU-Edition-From-Cookie" -> "true"
     )
-    val redirectToUk = test.faciaController.renderFront("")(control)
+    val redirectToUk = faciaController.renderFront("")(control)
     header("Location", redirectToUk).head should endWith ("/international")
   }
 
   it should "send international traffic ot the UK version of editionalised sections" in {
     val international = FakeRequest("GET", "/commentisfree").withHeaders("X-GU-Edition" -> "INTL", "X-GU-International" -> "international")
-    val redirectToInternational = test.faciaController.renderFront("commentisfree")(international)
+    val redirectToInternational = faciaController.renderFront("commentisfree")(international)
     header("Location", redirectToInternational).head should endWith ("/uk/commentisfree")
   }
 
   it should "list the alterative options for a path by section and edition" in {
-    test.faciaController.alternativeEndpoints("uk/lifeandstyle") should be (List("lifeandstyle", "uk"))
-    test.faciaController.alternativeEndpoints("uk") should be (List("uk"))
-    test.faciaController.alternativeEndpoints("uk/business/stock-markets") should be (List("business", "uk"))
+    faciaController.alternativeEndpoints("uk/lifeandstyle") should be (List("lifeandstyle", "uk"))
+    faciaController.alternativeEndpoints("uk") should be (List("uk"))
+    faciaController.alternativeEndpoints("uk/business/stock-markets") should be (List("business", "uk"))
   }
 
   it should "render fronts with content that has been pre-fetched from facia-press" in {
     // make sure you switch on facia inline-embeds switch before you press to make this pass
     val request = FakeRequest("GET", "/inline-embeds").from(Uk)
-    val future = test.faciaController.renderFront("inline-embeds")(request)
+    val future = faciaController.renderFront("inline-embeds")(request)
     contentAsString(future) should include ("""<div class="keep-it-in-the-ground__wrapper""")
   }
 
   it should "render correct amount of fronts in mf2 format (no section or edition provided)" in {
     val count = 3
     val request = FakeRequest("GET", s"/container/count/${count}/offset/0/mf2.json")
-    val result = test.faciaController.renderSomeFrontContainersMf2(count, 0)(request)
+    val result = faciaController.renderSomeFrontContainersMf2(count, 0)(request)
     status(result) should be(200)
     (contentAsJson(result) \ "items").as[JsArray].value.size should be(count)
   }
@@ -149,7 +151,7 @@ import org.scalatest._
     val section = "music"
     val count = 3
     val request = FakeRequest("GET", s"/container/count/${count}/offset/0/section/${section}/mf2.json")
-    val result = test.faciaController.renderSomeFrontContainersMf2(count, 0, section)(request)
+    val result = faciaController.renderSomeFrontContainersMf2(count, 0, section)(request)
     status(result) should be(200)
     (contentAsJson(result) \ "items").as[JsArray].value.size should be(count)
   }
@@ -158,7 +160,7 @@ import org.scalatest._
     val edition = "uk"
     val count = 3
     val request = FakeRequest("GET", s"/container/count/${count}/offset/0/edition/${edition}/mf2.json")
-    val result = test.faciaController.renderSomeFrontContainersMf2(count, 0, edition = edition)(request)
+    val result = faciaController.renderSomeFrontContainersMf2(count, 0, edition = edition)(request)
     status(result) should be(200)
     (contentAsJson(result) \ "items").as[JsArray].value.size should be(count)
   }
@@ -168,7 +170,7 @@ import org.scalatest._
     val edition = "au"
     val count = 3
     val request = FakeRequest("GET", s"/container/count/${count}/offset/0/section/${section}/edition/${edition}/mf2.json")
-    val result = test.faciaController.renderSomeFrontContainersMf2(count, 0, section, edition)(request)
+    val result = faciaController.renderSomeFrontContainersMf2(count, 0, section, edition)(request)
     status(result) should be(200)
     (contentAsJson(result) \ "items").as[JsArray].value.size should be(count)
   }

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -7,9 +7,9 @@ import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.libs.json._
 import play.api.test.Helpers._
 import services.ConfigAgent
-import test.{ConfiguredTestSuite, TestFrontJsonFapi, TestRequest}
+import test.{ConfiguredTestSuite, TestFrontJsonFapi, TestRequest, WithTestWsClient}
 
-@DoNotDiscover class FaciaMetaDataTest extends FlatSpec with Matchers with ConfiguredTestSuite with BeforeAndAfterAll {
+@DoNotDiscover class FaciaMetaDataTest extends FlatSpec with Matchers with ConfiguredTestSuite with BeforeAndAfterAll with WithTestWsClient {
 
   override def beforeAll() {
     ConfigAgent.refreshWith(

--- a/facia/test/FaciaMetaDataTest.scala
+++ b/facia/test/FaciaMetaDataTest.scala
@@ -1,13 +1,13 @@
 package metadata
 
-import com.gu.facia.client.models.{FrontJson, ConfigJson}
+import com.gu.facia.client.models.{ConfigJson, FrontJson}
+import controllers.FaciaControllerImpl
 import org.jsoup.Jsoup
 import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.libs.json._
 import play.api.test.Helpers._
-
 import services.ConfigAgent
-import test.{TestRequest, ConfiguredTestSuite}
+import test.{ConfiguredTestSuite, TestFrontJsonFapi, TestRequest}
 
 @DoNotDiscover class FaciaMetaDataTest extends FlatSpec with Matchers with ConfiguredTestSuite with BeforeAndAfterAll {
 
@@ -19,20 +19,21 @@ import test.{TestRequest, ConfiguredTestSuite}
     )
   }
 
+  val faciaController = new FaciaControllerImpl(new TestFrontJsonFapi(wsClient))
   val articleUrl = "music"
 
   it should "Include organisation metadata" in {
-    val result = test.faciaController.renderFront(articleUrl)(TestRequest())
+    val result = faciaController.renderFront(articleUrl)(TestRequest())
     MetaDataMatcher.ensureOrganisation(result)
   }
 
   it should "Include webpage metadata" in {
-    val result = test.faciaController.renderFront(articleUrl)(TestRequest(articleUrl))
+    val result = faciaController.renderFront(articleUrl)(TestRequest(articleUrl))
     MetaDataMatcher.ensureWebPage(result, articleUrl)
   }
 
   it should "Include item list metadata" in {
-    val result = test.faciaController.renderFront(articleUrl)(TestRequest(articleUrl))
+    val result = faciaController.renderFront(articleUrl)(TestRequest(articleUrl))
     val body = Jsoup.parseBodyFragment(contentAsString(result))
     status(result) should be(200)
 

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -2,10 +2,11 @@ package test
 
 import java.io.File
 
-import controllers.{HealthCheck, front, FaciaController}
-import controllers.front.FrontJsonFapi
+import controllers.{FaciaController, HealthCheck, front}
+import controllers.front.{FrontJsonFapi, FrontJsonFapiLive}
 import org.fluentlenium.core.domain.FluentWebElement
 import org.scalatest.Suites
+import play.api.libs.ws.WSClient
 import recorder.HttpRecorder
 
 import scala.concurrent.Future
@@ -14,31 +15,29 @@ object `package` {
 
   implicit class WebElement2rich(element: FluentWebElement) {
     lazy val href = element.getAttribute("href")
+
     def hasAttribute(name: String) = element.getAttribute(name) != null
   }
 
-  // need a facia controller that stores S3 locally so it can run without deps in the unit tests
-  val faciaController = new FaciaController {
+  // need a front api that stores S3 locally so it can run without deps in the unit tests
+  class TestFrontJsonFapi(override val wsClient: WSClient) extends FrontJsonFapiLive(wsClient) {
 
-    override val frontJsonFapi: FrontJsonFapi = new front.FrontJsonFapi {
-      override val bucketLocation: String = front.FrontJsonFapiLive.bucketLocation
-
-      override def getRaw(path: String): Future[Option[String]] = {
-        recorder.load(path, Map()) {
-          super.getRaw(path)
-        }
-      }
-
-      val recorder = new HttpRecorder[Option[String]] {
-        override lazy val baseDir = new File(System.getProperty("user.dir"), "data/pressedPage")
-
-        //No transformation for now as we only store content that's there.
-        override def toResponse(str: String): Option[String] = Some(str)
-
-        override def fromResponse(response: Option[String]): String = response.get // we don't need to test None yet
+    override def getRaw(path: String): Future[Option[String]] = {
+      recorder.load(path, Map()) {
+        super.getRaw(path)
       }
     }
+
+    val recorder = new HttpRecorder[Option[String]] {
+      override lazy val baseDir = new File(System.getProperty("user.dir"), "data/pressedPage")
+
+      //No transformation for now as we only store content that's there.
+      override def toResponse(str: String): Option[String] = Some(str)
+
+      override def fromResponse(response: Option[String]): String = response.get // we don't need to test None yet
+    }
   }
+
 }
 
 class FaciaTestSuite extends Suites (

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -5,11 +5,11 @@ import controllers.front.FrontJsonFapi
 import play.api.libs.ws.WSClient
 import services.ConfigAgent
 
-case class FrontJsonFapiDraft(val wsClient: WSClient) extends FrontJsonFapi {
+class FrontJsonFapiDraft(val wsClient: WSClient) extends FrontJsonFapi {
   val bucketLocation: String = s"$stage/frontsapi/pressed/draft"
 }
 
-case class FaciaDraftController(val frontJsonFapi: FrontJsonFapi) extends FaciaController {
+class FaciaDraftController(val frontJsonFapi: FrontJsonFapi) extends FaciaController {
 
   override def renderFront(path: String) = {
     log.info(s"Serving Path: $path")

--- a/preview/app/controllers/FaciaDraftController.scala
+++ b/preview/app/controllers/FaciaDraftController.scala
@@ -2,14 +2,14 @@ package controllers.preview
 
 import controllers.FaciaController
 import controllers.front.FrontJsonFapi
+import play.api.libs.ws.WSClient
 import services.ConfigAgent
 
-object FrontJsonFapiDraft extends FrontJsonFapi {
+case class FrontJsonFapiDraft(val wsClient: WSClient) extends FrontJsonFapi {
   val bucketLocation: String = s"$stage/frontsapi/pressed/draft"
 }
 
-object FaciaDraftController extends FaciaController {
-  val frontJsonFapi: FrontJsonFapi = FrontJsonFapiDraft
+case class FaciaDraftController(val frontJsonFapi: FrontJsonFapi) extends FaciaController {
 
   override def renderFront(path: String) = {
     log.info(s"Serving Path: $path")

--- a/standalone/app/StandaloneLifecycleComponents.scala
+++ b/standalone/app/StandaloneLifecycleComponents.scala
@@ -10,7 +10,7 @@ import feed.OnwardJourneyLifecycle
 import rugby.conf.RugbyLifecycle
 import services.ConfigAgentLifecycle
 
-trait StandaloneLifecycleComponents extends SportServices with CommercialServices {
+trait StandaloneLifecycleComponents extends SportServices with CommercialServices with FapiServices {
   self: FrontendComponents =>
   def standaloneLifecycleComponents: List[LifecycleComponent] = List(
     wire[LogstashLifecycle],

--- a/standalone/app/controllers/FaciaDraftController.scala
+++ b/standalone/app/controllers/FaciaDraftController.scala
@@ -1,18 +1,13 @@
 package controllers
 
 import com.gu.contentapi.client.model.v1.ItemResponse
-import controllers.front.FrontJsonFapi
+import controllers.front.FrontJsonFapiDraft
 import play.api.mvc.{RequestHeader, Result}
 import services.ConfigAgent
 
 import scala.concurrent.Future
 
-object FrontJsonFapiDraft extends FrontJsonFapi {
-  val bucketLocation: String = s"$stage/frontsapi/pressed/draft"
-}
-
-class FaciaDraftController extends FaciaController with RendersItemResponse {
-  val frontJsonFapi: FrontJsonFapi = FrontJsonFapiDraft
+class FaciaDraftController(val frontJsonFapi: FrontJsonFapiDraft) extends FaciaController with RendersItemResponse {
 
   override def renderItem(path: String)(implicit request: RequestHeader): Future[Result] = {
     log.info(s"Serving Path: $path")
@@ -26,7 +21,4 @@ class FaciaDraftController extends FaciaController with RendersItemResponse {
   override def canRender(path: String): Boolean = ConfigAgent.getPathIds.contains(path)
 
   override def canRender(item: ItemResponse): Boolean = controllers.IndexController.canRender(item)
-
 }
-
-object FaciaDraftController extends FaciaDraftController

--- a/standalone/app/controllers/ItemController.scala
+++ b/standalone/app/controllers/ItemController.scala
@@ -1,11 +1,11 @@
 package controllers
 
 // If you add to this, don't forget the one in dev-build
-class ItemController(articleController: ArticleController) extends ItemResponseController(
+class ItemController(articleController: ArticleController, faciaDraftController: FaciaDraftController) extends ItemResponseController(
   articleController,
   GalleryController,
   MediaController,
   InteractiveController,
   ImageContentController,
-  FaciaDraftController
+  faciaDraftController
 )

--- a/standalone/app/controllers/StandaloneControllerComponents.scala
+++ b/standalone/app/controllers/StandaloneControllerComponents.scala
@@ -2,6 +2,7 @@ package controllers
 
 import com.softwaremill.macwire._
 import controllers.commercial.CommercialControllers
+import controllers.front.FrontJsonFapiDraft
 import cricket.controllers.CricketControllers
 import dev.DevAssetsController
 import football.controllers._
@@ -22,11 +23,12 @@ trait StandaloneControllerComponents
   self: BuiltInComponents =>
 
   def wsClient: WSClient
+  def frontJsonFapiDraft: FrontJsonFapiDraft
 
   lazy val assets = wire[Assets]
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val emailSignupController = wire[EmailSignupController]
-  lazy val faciaDraftController: FaciaDraftController = wire[FaciaDraftController]
+  lazy val faciaDraftController = wire[FaciaDraftController]
   lazy val faviconController = wire[FaviconController]
   lazy val itemController = wire[ItemController]
   lazy val oAuthLoginController = wire[OAuthLoginController]


### PR DESCRIPTION
## What does this change?

Removing call to `WS.url` in Facia
## What is the value of this and can you measure success?

=> Play 2.5
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
