### PR TITLE
Hosted Video - fix control bar alignments

### DIFF
--- a/commercial/app/views/hosted/guardianHostedShareButtons.scala.html
+++ b/commercial/app/views/hosted/guardianHostedShareButtons.scala.html
@@ -26,7 +26,7 @@
         <li class="social__item social__item--email" data-link-name="email">
             <a class="social__action social-icon-wrapper"
             data-link-name="email-social-share-1"
-            href="mailto:?subject=@{URLEncoder.encode(page.emailText, "utf-8")}&body=@{URLEncoder.encode(page.pageUrl, "utf-8")}"
+            href="mailto:?subject=@{page.emailText}&body=@{URLEncoder.encode(page.pageUrl, "utf-8")}"
             target="_blank"
             title="email">
                 <span class='inline-icon__fallback button share-modal__item share-modal__item--email'>Share via email</span>

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -254,7 +254,7 @@ $hosted-video-height: 540px;
         }
     }
 
-    .vjs-play-control {
+    .vjs-play-control.vjs-control {
         width: 50px;
         height: 50px;
         margin: 12px 16px;


### PR DESCRIPTION
## What does this change?
- The timestamp is now lined up with the title. Bug probably introduced by CSS refactor (new order of css imports)
- Share by email button doesn't need encoded subject line
### Before

![image](https://cloud.githubusercontent.com/assets/6290008/17214679/043ee23a-54d2-11e6-8faf-4060af769265.png)
### After

![image](https://cloud.githubusercontent.com/assets/6290008/17214771/65c87b24-54d2-11e6-89ce-99699aa2d982.png)

@Calanthe 
