### PR TITLE
Removing call to WS.url (Continue #7)

### DIFF
--- a/admin/app/controllers/DeploysNotifyController.scala
+++ b/admin/app/controllers/DeploysNotifyController.scala
@@ -80,8 +80,8 @@ class DeploysNotifyControllerImpl(val wsClient: WSClient) extends DeploysNotifyC
   override val apiKey = Configuration.DeploysNotify.apiKey.getOrElse(
     throw new RuntimeException("Deploys-notify API Key not set")
   )
-  val httpClient = HttpClient(wsClient)
-  override val riffRaff = RiffRaffService(httpClient)
-  override val teamcity = TeamcityService(httpClient)
+  val httpClient = new HttpClient(wsClient)
+  override val riffRaff = new RiffRaffService(httpClient)
+  override val teamcity = new TeamcityService(httpClient)
 }
 

--- a/admin/app/controllers/DeploysRadiatorController.scala
+++ b/admin/app/controllers/DeploysRadiatorController.scala
@@ -30,8 +30,8 @@ trait DeploysRadiatorController extends Controller with Logging with AuthLogging
 }
 
 class DeploysRadiatorControllerImpl(wsClient: WSClient) extends DeploysRadiatorController {
-  val httpClient = HttpClient(wsClient)
-  override val riffRaff = RiffRaffService(httpClient)
-  override val teamcity = TeamcityService(httpClient)
+  val httpClient = new HttpClient(wsClient)
+  override val riffRaff = new RiffRaffService(httpClient)
+  override val teamcity = new TeamcityService(httpClient)
 }
 

--- a/admin/app/controllers/DeploysRadiatorController.scala
+++ b/admin/app/controllers/DeploysRadiatorController.scala
@@ -8,6 +8,7 @@ import model.deploys.{RiffRaffService, ApiResults}
 import play.api.mvc._
 import play.api.libs.concurrent.Execution.Implicits._
 import model.deploys._
+import play.api.libs.ws.WSClient
 
 trait DeploysRadiatorController extends Controller with Logging with AuthLogging with Requests {
 
@@ -28,8 +29,9 @@ trait DeploysRadiatorController extends Controller with Logging with AuthLogging
 
 }
 
-class DeploysRadiatorControllerImpl extends DeploysRadiatorController {
-  override val riffRaff = RiffRaffService
-  override val teamcity = TeamcityService
+class DeploysRadiatorControllerImpl(wsClient: WSClient) extends DeploysRadiatorController {
+  val httpClient = HttpClient(wsClient)
+  override val riffRaff = RiffRaffService(httpClient)
+  override val teamcity = TeamcityService(httpClient)
 }
 

--- a/admin/app/model/deploys/HttpClient.scala
+++ b/admin/app/model/deploys/HttpClient.scala
@@ -7,7 +7,7 @@ trait HttpLike {
   def GET(url: String, queryString: Map[String, String] = Map.empty, headers: Map[String, String] = Map.empty): Future[WSResponse]
 }
 
-case class HttpClient(wsClient: WSClient) extends HttpLike {
+class HttpClient(wsClient: WSClient) extends HttpLike {
 
   override def GET(url: String, queryString: Map[String, String] = Map.empty, headers: Map[String, String] = Map.empty): Future[WSResponse] = {
     wsClient.url(url).withQueryString(queryString.toSeq: _*).withHeaders(headers.toSeq: _*).withRequestTimeout(10000).get()

--- a/admin/app/model/deploys/HttpClient.scala
+++ b/admin/app/model/deploys/HttpClient.scala
@@ -1,14 +1,16 @@
 package model.deploys
 
-import play.api.libs.ws.{WSResponse, WS}
+import play.api.libs.ws.{WSResponse, WSClient}
 import scala.concurrent.Future
-import play.api.Play.current
 
-trait HttpClient {
+trait HttpLike {
+  def GET(url: String, queryString: Map[String, String] = Map.empty, headers: Map[String, String] = Map.empty): Future[WSResponse]
+}
 
-  def GET(url: String, queryString: Map[String, String] = Map.empty, headers: Map[String, String] = Map.empty): Future[WSResponse] = {
-    WS.url(url).withQueryString(queryString.toSeq: _*).withHeaders(headers.toSeq: _*).withRequestTimeout(10000).get()
+case class HttpClient(wsClient: WSClient) extends HttpLike {
+
+  override def GET(url: String, queryString: Map[String, String] = Map.empty, headers: Map[String, String] = Map.empty): Future[WSResponse] = {
+    wsClient.url(url).withQueryString(queryString.toSeq: _*).withHeaders(headers.toSeq: _*).withRequestTimeout(10000).get()
   }
 
 }
-object HttpClient extends HttpClient

--- a/admin/app/model/deploys/RiffRaff.scala
+++ b/admin/app/model/deploys/RiffRaff.scala
@@ -3,6 +3,8 @@ package model.deploys
 import conf.Configuration
 import model.deploys.ApiResults.{ApiResponse, ApiErrors, ApiError}
 import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.libs.ws.WSClient
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -15,9 +17,7 @@ case class RiffRaffDeploy(uuid: String,
                           time: String)
 object RiffRaffDeploy { implicit val format = Json.format[RiffRaffDeploy] }
 
-trait RiffRaffService {
-
-  val httpClient: HttpClient
+case class RiffRaffService(httpClient: HttpLike) {
 
   def getRiffRaffDeploys(pageSize: Option[String], projectName: Option[String], stage: Option[String]): Future[ApiResponse[List[RiffRaffDeploy]]] = {
     val url = s"${Configuration.riffraff.url}/api/history"
@@ -41,7 +41,3 @@ trait RiffRaffService {
     }
   }
 }
-object RiffRaffService extends RiffRaffService {
-  override val httpClient = HttpClient
-}
-

--- a/admin/app/model/deploys/RiffRaff.scala
+++ b/admin/app/model/deploys/RiffRaff.scala
@@ -17,7 +17,7 @@ case class RiffRaffDeploy(uuid: String,
                           time: String)
 object RiffRaffDeploy { implicit val format = Json.format[RiffRaffDeploy] }
 
-case class RiffRaffService(httpClient: HttpLike) {
+class RiffRaffService(httpClient: HttpLike) {
 
   def getRiffRaffDeploys(pageSize: Option[String], projectName: Option[String], stage: Option[String]): Future[ApiResponse[List[RiffRaffDeploy]]] = {
     val url = s"${Configuration.riffraff.url}/api/history"

--- a/admin/app/model/deploys/Teamcity.scala
+++ b/admin/app/model/deploys/Teamcity.scala
@@ -1,9 +1,11 @@
 package model.deploys
 
 import conf.Configuration
-import ApiResults.{ApiErrors, ApiError, ApiResponse}
+import ApiResults.{ApiError, ApiErrors, ApiResponse}
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
+import play.api.libs.ws.WSClient
+
 import scala.concurrent.Future
 import scala.language.postfixOps
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -49,9 +51,7 @@ object TeamCityBuild {
     )(TeamCityBuild.apply _)
 }
 
-trait TeamcityService {
-
-  val httpClient: HttpClient
+case class TeamcityService(httpClient: HttpLike) {
 
   def getTeamCityBuild(number: String): Future[ApiResponse[TeamCityBuild]] = {
     val apiPath = "/guestAuth/app/rest"
@@ -75,7 +75,3 @@ trait TeamcityService {
   }
 
 }
-object TeamcityService extends TeamcityService {
-  override val httpClient = HttpClient
-}
-

--- a/admin/app/model/deploys/Teamcity.scala
+++ b/admin/app/model/deploys/Teamcity.scala
@@ -51,7 +51,7 @@ object TeamCityBuild {
     )(TeamCityBuild.apply _)
 }
 
-case class TeamcityService(httpClient: HttpLike) {
+class TeamcityService(httpClient: HttpLike) {
 
   def getTeamCityBuild(number: String): Future[ApiResponse[TeamCityBuild]] = {
     val apiPath = "/guestAuth/app/rest"

--- a/admin/test/controllers/DeploysNotifyControllerTest.scala
+++ b/admin/test/controllers/DeploysNotifyControllerTest.scala
@@ -5,7 +5,7 @@ import controllers.Helpers.DeploysTestHttpRecorder
 import model.deploys._
 import org.scalatest.{DoNotDiscover, Matchers, WordSpec}
 import play.api.libs.json.Json
-import play.api.libs.ws.WS
+import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
 import play.api.test.{FakeHeaders, FakeRequest}
 import test.ConfiguredTestSuite
@@ -17,32 +17,30 @@ import scala.concurrent.Future
   val existingBuild = "1629"
   val fakeApiKey = "fake-api-key"
 
-  val RecordingHttpClient = new HttpClient {
+  case class RecordingHttpClient(wsClient: WSClient) extends HttpLike {
     override def GET(url: String, queryString: Map[String, String] = Map.empty, headers: Map[String, String] = Map.empty) = {
       val extentedHeaders = headers + ("X-Url" -> (url + queryString.mkString))
       DeploysTestHttpRecorder.load(url, extentedHeaders) {
-        WS.url(url).withQueryString(queryString.toSeq: _*).withHeaders(headers.toSeq: _*).withRequestTimeout(10000).get()
+        wsClient.url(url).withQueryString(queryString.toSeq: _*).withHeaders(headers.toSeq: _*).withRequestTimeout(10000).get()
       }
     }
   }
 
-  class DeploysNotifyControllerStub extends DeploysNotifyController {
+
+
+  class DeploysNotifyControllerStub(override val wsClient: WSClient) extends DeploysNotifyController {
     lazy val apiKey = fakeApiKey
 
-    override val teamcity = new TeamcityService {
-      override val httpClient: HttpClient = RecordingHttpClient
-    }
-
-    override val riffRaff = new RiffRaffService {
-      override val httpClient: HttpClient = RecordingHttpClient
-    }
+	  val recordingHttpClient = RecordingHttpClient(wsClient)
+    override val teamcity = TeamcityService(recordingHttpClient)
+    override val riffRaff = RiffRaffService(recordingHttpClient)
 
     override protected def sendNotice(step: NoticeStep, notice: Notice): Future[NoticeResponse] = {
       Future.successful(NoticeResponse(notice, "Fake response"))
     }
   }
 
-  val controller = new DeploysNotifyControllerStub()
+  val controller = new DeploysNotifyControllerStub(wsClient)
 
     s"POST /deploys-radiator/api/builds/${existingBuild}/notify" when {
 

--- a/admin/test/controllers/DeploysNotifyControllerTest.scala
+++ b/admin/test/controllers/DeploysNotifyControllerTest.scala
@@ -23,7 +23,7 @@ import scala.concurrent.Future
   val existingBuild = "1629"
   val fakeApiKey = "fake-api-key"
 
-  case class RecordingHttpClient(wsClient: WSClient) extends HttpLike {
+  class RecordingHttpClient(wsClient: WSClient) extends HttpLike {
     override def GET(url: String, queryString: Map[String, String] = Map.empty, headers: Map[String, String] = Map.empty) = {
       val extentedHeaders = headers + ("X-Url" -> (url + queryString.mkString))
       DeploysTestHttpRecorder.load(url, extentedHeaders) {
@@ -37,9 +37,9 @@ import scala.concurrent.Future
   class DeploysNotifyControllerStub(override val wsClient: WSClient) extends DeploysNotifyController {
     lazy val apiKey = fakeApiKey
 
-	  val recordingHttpClient = RecordingHttpClient(wsClient)
-    override val teamcity = TeamcityService(recordingHttpClient)
-    override val riffRaff = RiffRaffService(recordingHttpClient)
+    val recordingHttpClient = new RecordingHttpClient(wsClient)
+    override val teamcity = new TeamcityService(recordingHttpClient)
+    override val riffRaff = new RiffRaffService(recordingHttpClient)
 
     override protected def sendNotice(step: NoticeStep, notice: Notice): Future[NoticeResponse] = {
       Future.successful(NoticeResponse(notice, "Fake response"))

--- a/admin/test/controllers/DeploysNotifyControllerTest.scala
+++ b/admin/test/controllers/DeploysNotifyControllerTest.scala
@@ -3,16 +3,22 @@ package controllers.admin
 import common.ExecutionContexts
 import controllers.Helpers.DeploysTestHttpRecorder
 import model.deploys._
-import org.scalatest.{DoNotDiscover, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, Matchers, WordSpec}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
 import play.api.test.{FakeHeaders, FakeRequest}
-import test.ConfiguredTestSuite
+import test.{ConfiguredTestSuite, WithTestWsClient}
 
 import scala.concurrent.Future
 
-@DoNotDiscover class DeploysNotifyControllerTest extends WordSpec with Matchers with ConfiguredTestSuite with ExecutionContexts {
+@DoNotDiscover class DeploysNotifyControllerTest
+  extends WordSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with ExecutionContexts
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   val existingBuild = "1629"
   val fakeApiKey = "fake-api-key"

--- a/admin/test/controllers/DeploysRadiatorControllerTest.scala
+++ b/admin/test/controllers/DeploysRadiatorControllerTest.scala
@@ -5,7 +5,7 @@ import controllers.Helpers.DeploysTestHttpRecorder
 import model.deploys._
 import org.scalatest.{DoNotDiscover, Matchers, WordSpec}
 import play.api.libs.json.JsArray
-import play.api.libs.ws.WS
+import play.api.libs.ws.WSClient
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import test.ConfiguredTestSuite
@@ -14,23 +14,20 @@ import test.ConfiguredTestSuite
 
   val existingBuild = "1621"
 
-  val RecordingHttpClient = new HttpClient {
+  class TestHttpClient(wsClient: WSClient) extends HttpLike {
     override def GET(url: String, queryString: Map[String, String] = Map.empty, headers: Map[String, String] = Map.empty) = {
       val extentedHeaders = headers + ("X-Url" -> (url + queryString.mkString))
       DeploysTestHttpRecorder.load(url, extentedHeaders) {
-        WS.url(url).withQueryString(queryString.toSeq: _*).withHeaders(headers.toSeq: _*).withRequestTimeout(10000).get()
+        wsClient.url(url).withQueryString(queryString.toSeq: _*).withHeaders(headers.toSeq: _*).withRequestTimeout(10000).get()
       }
     }
   }
 
-  class DeploysRadiatorControllerStub extends DeploysRadiatorController {
-    override val teamcity = new TeamcityService {
-      override val httpClient: HttpClient = RecordingHttpClient
-    }
+  val recordingHttpClient = new TestHttpClient(wsClient)
 
-    override val riffRaff = new RiffRaffService {
-      override val httpClient: HttpClient = RecordingHttpClient
-    }
+  class DeploysRadiatorControllerStub extends DeploysRadiatorController {
+    override val teamcity = TeamcityService(recordingHttpClient)
+    override val riffRaff = RiffRaffService(recordingHttpClient)
   }
 
   val controller = new DeploysRadiatorControllerStub()

--- a/admin/test/controllers/DeploysRadiatorControllerTest.scala
+++ b/admin/test/controllers/DeploysRadiatorControllerTest.scala
@@ -3,14 +3,20 @@ package controllers.admin
 import common.ExecutionContexts
 import controllers.Helpers.DeploysTestHttpRecorder
 import model.deploys._
-import org.scalatest.{DoNotDiscover, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, Matchers, WordSpec}
 import play.api.libs.json.JsArray
 import play.api.libs.ws.WSClient
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import test.ConfiguredTestSuite
+import test.{ConfiguredTestSuite, WithTestWsClient}
 
-@DoNotDiscover class DeploysRadiatorControllerTest extends WordSpec with Matchers with ConfiguredTestSuite with ExecutionContexts {
+@DoNotDiscover class DeploysRadiatorControllerTest
+  extends WordSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with ExecutionContexts
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   val existingBuild = "1621"
 

--- a/admin/test/controllers/DeploysRadiatorControllerTest.scala
+++ b/admin/test/controllers/DeploysRadiatorControllerTest.scala
@@ -32,8 +32,8 @@ import test.{ConfiguredTestSuite, WithTestWsClient}
   val recordingHttpClient = new TestHttpClient(wsClient)
 
   class DeploysRadiatorControllerStub extends DeploysRadiatorController {
-    override val teamcity = TeamcityService(recordingHttpClient)
-    override val riffRaff = RiffRaffService(recordingHttpClient)
+    override val teamcity = new TeamcityService(recordingHttpClient)
+    override val riffRaff = new RiffRaffService(recordingHttpClient)
   }
 
   val controller = new DeploysRadiatorControllerStub()

--- a/archive/app/AppLoader.scala
+++ b/archive/app/AppLoader.scala
@@ -14,15 +14,21 @@ import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
 import play.api.libs.ws.WSClient
-import services.ArchiveMetrics
+import services.{ArchiveMetrics, DynamoDB}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
   override def buildComponents(context: Context): FrontendComponents = new BuiltInComponentsFromContext(context) with AppComponents
 }
 
+trait ArchiveServices {
+  def wsClient: WSClient
+  lazy val dynamoDB = wire[DynamoDB]
+}
+
 trait Controllers {
   def wsClient: WSClient
+  def dynamoDB: DynamoDB
   lazy val healthCheck = wire[HealthCheck]
   lazy val archiveController = wire[ArchiveController]
 }
@@ -39,7 +45,7 @@ trait AppLifecycleComponents {
   )
 }
 
-trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers {
+trait AppComponents extends FrontendComponents with AppLifecycleComponents with Controllers with ArchiveServices {
 
   lazy val router: Router = wire[Routes]
 

--- a/archive/app/controllers/ArchiveController.scala
+++ b/archive/app/controllers/ArchiveController.scala
@@ -9,7 +9,7 @@ import java.net.URLDecoder
 import model.Cached
 import scala.concurrent.Future
 
-class ArchiveController extends Controller with Logging with ExecutionContexts {
+class ArchiveController(dynamoDB: DynamoDB) extends Controller with Logging with ExecutionContexts {
 
   private val R1ArtifactUrl = """www.theguardian.com/(.*)/[0|1]?,[\d]*,(-?\d+),[\d]*(.*)""".r
   private val ShortUrl = """^(www\.theguardian\.com/p/[\w\d]+).*$""".r
@@ -93,7 +93,7 @@ class ArchiveController extends Controller with Logging with ExecutionContexts {
     }
   }
 
-  private def destinationFor(path: String): Future[Option[Destination]] = DynamoDB.destinationFor(normalise(path))
+  private def destinationFor(path: String): Future[Option[Destination]] = dynamoDB.destinationFor(normalise(path))
 
   private object Combiner {
     def unapply(path: String): Option[String] = {

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -5,10 +5,11 @@ import play.api.mvc.Result
 import play.api.test.Helpers._
 import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
 import scala.concurrent.Future
+import services.DynamoDB
 
 @DoNotDiscover class ArchiveControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
 
-  lazy val archiveController = new ArchiveController
+  lazy val archiveController = new ArchiveController(new DynamoDB(wsClient))
 
   it should "return a normalised r1 path" in {
     val tests = List(

--- a/archive/test/ArchiveControllerTest.scala
+++ b/archive/test/ArchiveControllerTest.scala
@@ -3,11 +3,17 @@ package test
 import controllers.ArchiveController
 import play.api.mvc.Result
 import play.api.test.Helpers._
-import org.scalatest.{DoNotDiscover, Matchers, FlatSpec}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
+
 import scala.concurrent.Future
 import services.DynamoDB
 
-@DoNotDiscover class ArchiveControllerTest extends FlatSpec with Matchers with ConfiguredTestSuite {
+@DoNotDiscover class ArchiveControllerTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   lazy val archiveController = new ArchiveController(new DynamoDB(wsClient))
 

--- a/identity/app/formstack/FormStackComponents.scala
+++ b/identity/app/formstack/FormStackComponents.scala
@@ -1,8 +1,11 @@
 package formstack
 
 import com.softwaremill.macwire._
+import play.api.libs.ws.WSClient
 
 trait FormStackComponents {
+  def wsClient: WSClient
+
   lazy val formstackApi = wire[FormstackApi]
   lazy val wsFormstackHttp = wire[WsFormstackHttp]
 }

--- a/identity/app/formstack/FormstackHttp.scala
+++ b/identity/app/formstack/FormstackHttp.scala
@@ -2,8 +2,7 @@ package formstack
 
 import com.gu.contentapi.client.GuardianContentApiError
 import common.ExecutionContexts
-import play.api.Play.current
-import play.api.libs.ws.WS
+import play.api.libs.ws.WSClient
 
 import scala.concurrent.Future
 
@@ -13,9 +12,9 @@ trait FormstackHttp {
 
 case class FormstackHttpResponse(body: String, status: Int, statusText: String)
 
-class WsFormstackHttp extends FormstackHttp with ExecutionContexts {
+class WsFormstackHttp(wsClient: WSClient) extends FormstackHttp with ExecutionContexts {
   override def GET(url: String, parameters: Seq[(String, String)] = Nil): Future[FormstackHttpResponse] = {
-    WS.url(url)
+    wsClient.url(url)
       .withRequestTimeout(2000)
       .withQueryString(parameters:_*)
       .get()


### PR DESCRIPTION
## What does this change?

Removing call to WS.url in:
- DeployRadiator
- DynamoDB
- WsFormstackHttp
## What is the value of this and can you measure success?

=> Play 2.5
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
