### PR TITLE
Removing call to WS.url (Continue #8)

### DIFF
--- a/admin-jobs/app/AppLoader.scala
+++ b/admin-jobs/app/AppLoader.scala
@@ -14,6 +14,7 @@ import play.api.http.HttpRequestHandler
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
+import play.api.libs.ws.WSClient
 import services.ConfigAgentLifecycle
 import router.Routes
 
@@ -22,6 +23,7 @@ class AppLoader extends FrontendApplicationLoader {
 }
 
 trait Controllers extends AdminJobsControllers {
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
 }
 

--- a/admin-jobs/app/controllers/HealthCheck.scala
+++ b/admin-jobs/app/controllers/HealthCheck.scala
@@ -1,8 +1,10 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
   9015,
   NeverExpiresSingleHealthCheck("/news-alert/alerts")
 )

--- a/admin-jobs/test/AdminJobsTestSuite.scala
+++ b/admin-jobs/test/AdminJobsTestSuite.scala
@@ -1,13 +1,14 @@
 import controllers.BreakingNews.{BreakingNewsUpdaterTest, BreakingNewsApiTest}
 import controllers.HealthCheck
-import org.scalatest.Suites
-import test.SingleServerSuite
+import org.scalatest.{BeforeAndAfterAll, Suites}
+import test.{SingleServerSuite, WithTestWsClient}
 
 class AdminJobsTestSuite extends Suites (
   new BreakingNewsApiTest,
   new BreakingNewsUpdaterTest,
   new controllers.NewsAlertControllerTest
-)
-with SingleServerSuite {
+) with SingleServerSuite
+with BeforeAndAfterAll
+with WithTestWsClient {
   override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/admin-jobs/test/AdminJobsTestSuite.scala
+++ b/admin-jobs/test/AdminJobsTestSuite.scala
@@ -9,5 +9,5 @@ class AdminJobsTestSuite extends Suites (
   new controllers.NewsAlertControllerTest
 )
 with SingleServerSuite {
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/admin/app/AppLoader.scala
+++ b/admin/app/AppLoader.scala
@@ -38,6 +38,7 @@ trait AdminServices {
 }
 
 trait Controllers extends AdminControllers {
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
 }

--- a/admin/app/controllers/HealthCheck.scala
+++ b/admin/app/controllers/HealthCheck.scala
@@ -1,5 +1,9 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(9001, NeverExpiresSingleHealthCheck("/login"))
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
+  9001,
+  NeverExpiresSingleHealthCheck("/login"))

--- a/admin/test/package.scala
+++ b/admin/test/package.scala
@@ -14,6 +14,6 @@ class AdminTestSuite extends Suites (
   new controllers.admin.DeploysNotifyControllerTest
 ) with SingleServerSuite {
 
-  override lazy val port: Int = new controllers.HealthCheck().testPort
+  override lazy val port: Int = new controllers.HealthCheck(wsClient).testPort
 }
 

--- a/admin/test/package.scala
+++ b/admin/test/package.scala
@@ -1,6 +1,6 @@
 package test
 
-import org.scalatest.Suites
+import org.scalatest.{BeforeAndAfterAll, Suites}
 import pagepresser.InteractiveHtmlCleanerTest
 
 class AdminTestSuite extends Suites (
@@ -12,7 +12,9 @@ class AdminTestSuite extends Suites (
   new pagepresser.InteractiveHtmlCleanerTest,
   new controllers.admin.DeploysRadiatorControllerTest,
   new controllers.admin.DeploysNotifyControllerTest
-) with SingleServerSuite {
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   override lazy val port: Int = new controllers.HealthCheck(wsClient).testPort
 }

--- a/applications/app/AppLoader.scala
+++ b/applications/app/AppLoader.scala
@@ -1,9 +1,9 @@
-import app.{FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common.dfp.DfpAgentLifecycle
-import common.{EmailSubsciptionMetrics, ContentApiMetrics, ApplicationMetrics, CloudWatchMetricsLifecycle}
+import common.{ApplicationMetrics, CloudWatchMetricsLifecycle, ContentApiMetrics, EmailSubsciptionMetrics}
 import common.Logback.LogstashLifecycle
-import conf.{CommonFilters, CachedHealthCheckLifeCycle}
+import conf.{CachedHealthCheckLifeCycle, CommonFilters}
 import conf.switches.SwitchboardLifecycle
 import contentapi.SectionsLookUpLifecycle
 import controllers._
@@ -15,9 +15,10 @@ import ophan.SurgingContentAgentLifecycle
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
 import play.api.http.{HttpErrorHandler, HttpRequestHandler}
+import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
-import services.{IndexListingsLifecycle, ConfigAgentLifecycle}
+import services.{ConfigAgentLifecycle, IndexListingsLifecycle}
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
@@ -26,6 +27,7 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait Controllers extends ApplicationsControllers {
   self: FrontendComponents =>
+  def wsClient: WSClient
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val healthCheck = wire[HealthCheck]
   lazy val assets = wire[Assets]

--- a/applications/app/controllers/HealthCheck.scala
+++ b/applications/app/controllers/HealthCheck.scala
@@ -2,11 +2,13 @@ package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import contentapi.SectionsLookUp
+import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent}
 
 import scala.concurrent.Future
 
-class HealthCheck extends AllGoodCachedHealthCheck(
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
   9002,
   NeverExpiresSingleHealthCheck("/books"),
   NeverExpiresSingleHealthCheck("/books/harrypotter"),

--- a/applications/test/package.scala
+++ b/applications/test/package.scala
@@ -39,5 +39,5 @@ class ApplicationsTestSuite extends Suites (
   new NewspaperControllerTest
 ) with SingleServerSuite {
 
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/applications/test/package.scala
+++ b/applications/test/package.scala
@@ -2,7 +2,7 @@ package test
 
 import java.util.{ List => JList }
 import controllers.HealthCheck
-import org.scalatest.Suites
+import org.scalatest.{BeforeAndAfterAll, Suites}
 import services.NewspaperControllerTest
 import collection.JavaConversions._
 
@@ -37,7 +37,9 @@ class ApplicationsTestSuite extends Suites (
   new ShareLinksTest,
   new CrosswordDataTest,
   new NewspaperControllerTest
-) with SingleServerSuite {
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/archive/app/AppLoader.scala
+++ b/archive/app/AppLoader.scala
@@ -1,10 +1,10 @@
 import http.CorsHttpErrorHandler
-import app.{FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{CommonFilters, CachedHealthCheckLifeCycle}
+import conf.{CachedHealthCheckLifeCycle, CommonFilters}
 import controllers.{ArchiveController, HealthCheck}
 import dev.DevParametersHttpRequestHandler
 import model.ApplicationIdentity
@@ -13,6 +13,7 @@ import play.api.http.{HttpErrorHandler, HttpRequestHandler}
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
+import play.api.libs.ws.WSClient
 import services.ArchiveMetrics
 import router.Routes
 
@@ -21,6 +22,7 @@ class AppLoader extends FrontendApplicationLoader {
 }
 
 trait Controllers {
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val archiveController = wire[ArchiveController]
 }

--- a/archive/app/controllers/HealthCheck.scala
+++ b/archive/app/controllers/HealthCheck.scala
@@ -1,5 +1,9 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(9003, NeverExpiresSingleHealthCheck("/404/www.theguardian.com/Adzip/adzip-fb.html"))
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
+  9003,
+  NeverExpiresSingleHealthCheck("/404/www.theguardian.com/Adzip/adzip-fb.html"))

--- a/archive/test/package.scala
+++ b/archive/test/package.scala
@@ -2,7 +2,8 @@ package test
 
 import java.util.{ List => JList }
 import controllers.HealthCheck
-import org.scalatest.Suites
+import org.scalatest.{BeforeAndAfterAll, Suites}
+
 import collection.JavaConversions._
 
 object `package` {
@@ -13,7 +14,10 @@ object `package` {
 }
 
 class ArchiveTestSuite extends Suites (
-  new ArchiveControllerTest ) with SingleServerSuite {
+  new ArchiveControllerTest
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/archive/test/package.scala
+++ b/archive/test/package.scala
@@ -15,5 +15,5 @@ object `package` {
 class ArchiveTestSuite extends Suites (
   new ArchiveControllerTest ) with SingleServerSuite {
 
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/article/app/AppLoader.scala
+++ b/article/app/AppLoader.scala
@@ -1,11 +1,11 @@
 import http.CorsHttpErrorHandler
-import app.{FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
 import common.dfp.DfpAgentLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{CommonFilters, CachedHealthCheckLifeCycle}
+import conf.{CachedHealthCheckLifeCycle, CommonFilters}
 import controllers.{ArticleControllers, HealthCheck}
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
 import model.ApplicationIdentity
@@ -15,6 +15,7 @@ import play.api.http.{HttpErrorHandler, HttpRequestHandler}
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
+import play.api.libs.ws.WSClient
 import services.NewspaperBooksAndSectionsAutoRefresh
 import router.Routes
 
@@ -24,6 +25,7 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait Controllers extends ArticleControllers {
   self: BuiltInComponents =>
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
 }

--- a/article/app/controllers/HealthCheck.scala
+++ b/article/app/controllers/HealthCheck.scala
@@ -1,8 +1,10 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
   9004,
   NeverExpiresSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
 )

--- a/article/test/CdnHealthCheckTest.scala
+++ b/article/test/CdnHealthCheckTest.scala
@@ -1,11 +1,17 @@
 package test
 
 import controllers.HealthCheck
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, DoNotDiscover, FlatSpec, Matchers}
 import play.api.test.Helpers._
 import org.scalatest.concurrent.ScalaFutures
 
-@DoNotDiscover class CdnHealthCheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with ScalaFutures {
+@DoNotDiscover class CdnHealthCheckTest
+  extends FlatSpec
+  with Matchers
+  with ConfiguredTestSuite
+  with ScalaFutures
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   "CDN health check" should "mimic the instance health check" in {
     val controller = new HealthCheck(wsClient)

--- a/article/test/CdnHealthCheckTest.scala
+++ b/article/test/CdnHealthCheckTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.concurrent.ScalaFutures
 @DoNotDiscover class CdnHealthCheckTest extends FlatSpec with Matchers with ConfiguredTestSuite with ScalaFutures {
 
   "CDN health check" should "mimic the instance health check" in {
-    val controller = new HealthCheck()
+    val controller = new HealthCheck(wsClient)
     // Cache internal healthCheck results before to test endpoints
     whenReady(controller.runChecks) { _ =>
       status(controller.healthCheck()(TestRequest("/_healthcheck"))) should be (200)

--- a/article/test/package.scala
+++ b/article/test/package.scala
@@ -1,7 +1,7 @@
 package test
 
 import controllers.HealthCheck
-import org.scalatest.{Suites, Tag}
+import org.scalatest.{BeforeAndAfterAll, Suites, Tag}
 
 object ArticleComponents extends Tag("article components")
 
@@ -14,7 +14,9 @@ class ArticleTestSuite extends Suites (
   new SectionsNavigationFeatureTest,
   new MembershipAccessTest,
   new PublicationControllerTest
-) with SingleServerSuite {
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/article/test/package.scala
+++ b/article/test/package.scala
@@ -16,5 +16,5 @@ class ArticleTestSuite extends Suites (
   new PublicationControllerTest
 ) with SingleServerSuite {
 
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/commercial/app/AppLoader.scala
+++ b/commercial/app/AppLoader.scala
@@ -1,6 +1,6 @@
 import commercial.CommercialLifecycle
 import http.CorsHttpErrorHandler
-import app.{FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import _root_.commercial.feeds.{FeedsFetcher, FeedsParser}
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import model.commercial.books.{BestsellersAgent, BookFinder, MagentoService}
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{CommonFilters, CachedHealthCheckLifeCycle}
+import conf.{CachedHealthCheckLifeCycle, CommonFilters}
 import controllers.HealthCheck
 import controllers.commercial.CommercialControllers
 import dev.{DevAssetsController, DevParametersHttpRequestHandler}
@@ -27,6 +27,7 @@ class AppLoader extends FrontendApplicationLoader {
 }
 
 trait Controllers extends CommercialControllers {
+  def wsClient: WSClient
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val healthCheck = wire[HealthCheck]
 }

--- a/commercial/app/controllers/HealthCheck.scala
+++ b/commercial/app/controllers/HealthCheck.scala
@@ -1,8 +1,10 @@
 package controllers
 
 import conf.{AnyGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AnyGoodCachedHealthCheck(
+class HealthCheck(override val wsClient: WSClient) extends AnyGoodCachedHealthCheck(
+  wsClient,
   9005,
   NeverExpiresSingleHealthCheck("/commercial/soulmates/mixed.json"),
   NeverExpiresSingleHealthCheck("/commercial/masterclasses.json"),

--- a/commercial/test/test/CommercialTestSuite.scala
+++ b/commercial/test/test/CommercialTestSuite.scala
@@ -3,7 +3,7 @@ package test
 import controllers.HealthCheck
 import model.commercial._
 import model.commercial.books._
-import org.scalatest.Suites
+import org.scalatest.{BeforeAndAfterAll, Suites}
 
 class CommercialTestSuite extends Suites (
   new controllers.commercial.TravelOffersControllerTest,
@@ -16,7 +16,9 @@ class CommercialTestSuite extends Suites (
   new LookupTest,
   new BookFinderTest,
   new BookTest
-  ) with SingleServerSuite {
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/commercial/test/test/CommercialTestSuite.scala
+++ b/commercial/test/test/CommercialTestSuite.scala
@@ -18,5 +18,5 @@ class CommercialTestSuite extends Suites (
   new BookTest
   ) with SingleServerSuite {
 
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/common/test/conf/CachedHealthCheckTest.scala
+++ b/common/test/conf/CachedHealthCheckTest.scala
@@ -29,8 +29,8 @@ class CachedHealthCheckTest extends WordSpec with Matchers with SingleServerSuit
     // Create a CachedHealthCheck controller with mock results
     val mockHealthChecks: Seq[SingleHealthCheck] = mockResults.map(result => ExpiringSingleHealthCheck(result.url))
     val mockTestPort: Int = 9100
-    val controller = new CachedHealthCheck(policy, mockTestPort, mockHealthChecks:_*) {
-      override val cache = new HealthCheckCache {
+    val controller = new CachedHealthCheck(policy, wsClient, mockTestPort, mockHealthChecks:_*) {
+      override val cache = new HealthCheckCache(wsClient) {
         override def fetchResults(testPort: Int, paths: SingleHealthCheck*): Future[Seq[HealthCheckResult]] = {
           Future.successful(mockResults)
         }

--- a/common/test/conf/CachedHealthCheckTest.scala
+++ b/common/test/conf/CachedHealthCheckTest.scala
@@ -2,17 +2,25 @@ package conf
 
 import common.ExecutionContexts
 import org.joda.time.DateTime
-import org.scalatest.{WordSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import test.SingleServerSuite
+import test.{SingleServerSuite, WithTestWsClient}
 import org.scalatest.concurrent.ScalaFutures
+
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random
 
-class CachedHealthCheckTest extends WordSpec with Matchers with SingleServerSuite with ScalaFutures with ExecutionContexts {
+class CachedHealthCheckTest
+  extends WordSpec
+  with Matchers
+  with SingleServerSuite
+  with ScalaFutures
+  with ExecutionContexts
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   //Helper method to construct mock Results
   def mockResult(statusCode: Int, date: DateTime = DateTime.now, expiration: HealthCheckExpiration = HealthCheckExpires.Duration(10.seconds)): HealthCheckResult = {

--- a/diagnostics/app/AppLoader.scala
+++ b/diagnostics/app/AppLoader.scala
@@ -1,15 +1,16 @@
-import app.{FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{CommonGzipFilter, CachedHealthCheckLifeCycle}
+import conf.{CachedHealthCheckLifeCycle, CommonGzipFilter}
 import controllers.{Assets, DiagnosticsControllers, HealthCheck}
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
+import play.api.libs.ws.WSClient
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
@@ -18,6 +19,7 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait Controllers extends DiagnosticsControllers {
   self: BuiltInComponents =>
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val assets = wire[Assets]
 }

--- a/diagnostics/app/controllers/HealthCheck.scala
+++ b/diagnostics/app/controllers/HealthCheck.scala
@@ -1,5 +1,9 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(9006, NeverExpiresSingleHealthCheck("/robots.txt"))
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
+  9006,
+  NeverExpiresSingleHealthCheck("/robots.txt"))

--- a/diagnostics/test/package.scala
+++ b/diagnostics/test/package.scala
@@ -1,11 +1,13 @@
 package test
 
 import controllers.HealthCheck
-import org.scalatest.Suites
+import org.scalatest.{BeforeAndAfterAll, Suites}
 
 class DiagnosticsTestSuite extends Suites (
   // Add you test classes here
-) with SingleServerSuite {
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/diagnostics/test/package.scala
+++ b/diagnostics/test/package.scala
@@ -7,5 +7,5 @@ class DiagnosticsTestSuite extends Suites (
   // Add you test classes here
 ) with SingleServerSuite {
 
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/discussion/app/AppLoader.scala
+++ b/discussion/app/AppLoader.scala
@@ -22,6 +22,7 @@ class AppLoader extends FrontendApplicationLoader {
 }
 
 trait Controllers extends DiscussionControllers {
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
 }

--- a/discussion/app/controllers/HealthCheck.scala
+++ b/discussion/app/controllers/HealthCheck.scala
@@ -1,5 +1,9 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(9007, NeverExpiresSingleHealthCheck("/discussion/p/37v3a"))
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
+  9007,
+  NeverExpiresSingleHealthCheck("/discussion/p/37v3a"))

--- a/discussion/test/package.scala
+++ b/discussion/test/package.scala
@@ -2,7 +2,7 @@ package test
 
 import conf.Configuration
 import controllers.HealthCheck
-import org.scalatest.Suites
+import org.scalatest.{BeforeAndAfterAll, Suites}
 import play.api.libs.ws.ning.NingWSResponse
 import recorder.HttpRecorder
 import com.ning.http.client.{FluentCaseInsensitiveStringsMap, Response => NingResponse}
@@ -82,6 +82,8 @@ class DiscussionTestSuite extends Suites (
   new discussion.DiscussionApiTest,
   new CommentCountControllerTest,
   new ProfileTest
-  ) with SingleServerSuite {
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
   override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/discussion/test/package.scala
+++ b/discussion/test/package.scala
@@ -83,5 +83,5 @@ class DiscussionTestSuite extends Suites (
   new CommentCountControllerTest,
   new ProfileTest
   ) with SingleServerSuite {
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/facia-press/app/AppLoader.scala
+++ b/facia-press/app/AppLoader.scala
@@ -1,4 +1,5 @@
 import app.{FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
@@ -19,6 +20,7 @@ class AppLoader extends FrontendApplicationLoader {
 }
 
 trait Controllers {
+  def wsClient: WSClient
   def toolPressQueueWorker: ToolPressQueueWorker
   def liveFapiFrontPress: LiveFapiFrontPress
   def draftFapiFrontPress: DraftFapiFrontPress

--- a/facia/app/AppLoader.scala
+++ b/facia/app/AppLoader.scala
@@ -33,6 +33,7 @@ trait FapiServices {
 
 trait Controllers extends FaciaControllers {
   self: BuiltInComponents =>
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val assets = wire[Assets]

--- a/facia/app/controllers/HealthCheck.scala
+++ b/facia/app/controllers/HealthCheck.scala
@@ -1,5 +1,9 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(9008, NeverExpiresSingleHealthCheck("/uk/business"))
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
+  9008,
+  NeverExpiresSingleHealthCheck("/uk/business"))

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -5,7 +5,7 @@ import java.io.File
 import controllers.{FaciaController, HealthCheck, front}
 import controllers.front.{FrontJsonFapi, FrontJsonFapiLive}
 import org.fluentlenium.core.domain.FluentWebElement
-import org.scalatest.Suites
+import org.scalatest.{BeforeAndAfterAll, Suites}
 import play.api.libs.ws.WSClient
 import recorder.HttpRecorder
 
@@ -49,6 +49,8 @@ class FaciaTestSuite extends Suites (
   new views.fragments.nav.NavigationTest,
   new FaciaControllerTest,
   new metadata.FaciaMetaDataTest
-) with SingleServerSuite {
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
   override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/facia/test/package.scala
+++ b/facia/test/package.scala
@@ -50,5 +50,5 @@ class FaciaTestSuite extends Suites (
   new FaciaControllerTest,
   new metadata.FaciaMetaDataTest
 ) with SingleServerSuite {
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/identity/app/AppLoader.scala
+++ b/identity/app/AppLoader.scala
@@ -1,16 +1,17 @@
 import http.IdentityHttpErrorHandler
-import app.{FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common.CloudWatchMetricsLifecycle
 import common.Logback.LogstashLifecycle
 import conf._
 import conf.switches.SwitchboardLifecycle
-import controllers.{IdentityControllers, Assets, HealthCheck}
+import controllers.{Assets, HealthCheck, IdentityControllers}
 import dev.DevAssetsController
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api._
 import play.api.http.HttpErrorHandler
+import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import router.Routes
@@ -22,6 +23,7 @@ class AppLoader extends FrontendApplicationLoader {
 
 trait Controllers extends IdentityControllers {
   self: BuiltInComponents with IdentityConfigurationComponents =>
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
   lazy val assets = wire[Assets]

--- a/identity/app/controllers/HealthCheck.scala
+++ b/identity/app/controllers/HealthCheck.scala
@@ -1,5 +1,9 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(9010, NeverExpiresSingleHealthCheck("/signin"))
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
+  9010,
+  NeverExpiresSingleHealthCheck("/signin"))

--- a/identity/test/controllers/IdentityTestSuite.scala
+++ b/identity/test/controllers/IdentityTestSuite.scala
@@ -8,5 +8,5 @@ class IdentityTestSuite extends Suites(
   new EmailControllerTest,
   new SignoutControllerTest
 ) with SingleServerSuite {
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/identity/test/controllers/IdentityTestSuite.scala
+++ b/identity/test/controllers/IdentityTestSuite.scala
@@ -1,12 +1,14 @@
 package controllers
 
-import org.scalatest.Suites
-import test.SingleServerSuite
+import org.scalatest.{BeforeAndAfterAll, Suites}
+import test.{SingleServerSuite, WithTestWsClient}
 
 class IdentityTestSuite extends Suites(
   new EditProfileControllerTest,
   new EmailControllerTest,
   new SignoutControllerTest
-) with SingleServerSuite {
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
   override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/onward/app/AppLoader.scala
+++ b/onward/app/AppLoader.scala
@@ -15,6 +15,7 @@ import play.api.http.{HttpErrorHandler, HttpRequestHandler}
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
+import play.api.libs.ws.WSClient
 import router.Routes
 
 class AppLoader extends FrontendApplicationLoader {
@@ -22,6 +23,7 @@ class AppLoader extends FrontendApplicationLoader {
 }
 
 trait Controllers extends OnwardControllers {
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
 }

--- a/onward/app/controllers/HealthCheck.scala
+++ b/onward/app/controllers/HealthCheck.scala
@@ -1,8 +1,10 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
   9011,
   NeverExpiresSingleHealthCheck("/top-stories.json"),
   NeverExpiresSingleHealthCheck("/most-read/society.json")

--- a/onward/test/package.scala
+++ b/onward/test/package.scala
@@ -1,7 +1,7 @@
 package test
 
 import controllers.HealthCheck
-import org.scalatest.Suites
+import org.scalatest.{BeforeAndAfterAll, Suites}
 
 class OnwardTestSuite extends Suites (
   new controllers.ChangeEditionControllerTest,
@@ -14,7 +14,10 @@ class OnwardTestSuite extends Suites (
   new SeriesControllerTest,
   new TopStoriesControllerTest,
   new VideoInSectionTest,
-  new RichLinkControllerTest ) with SingleServerSuite {
+  new RichLinkControllerTest
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/onward/test/package.scala
+++ b/onward/test/package.scala
@@ -16,5 +16,5 @@ class OnwardTestSuite extends Suites (
   new VideoInSectionTest,
   new RichLinkControllerTest ) with SingleServerSuite {
 
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 }

--- a/preview/app/AppLoader.scala
+++ b/preview/app/AppLoader.scala
@@ -1,11 +1,12 @@
-import app.{LifecycleComponent, FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
-import conf.{StandaloneFilters, CachedHealthCheckLifeCycle}
-import controllers.{ResponsiveViewerController, StandaloneControllerComponents, HealthCheck}
+import conf.{CachedHealthCheckLifeCycle, StandaloneFilters}
+import controllers.{HealthCheck, ResponsiveViewerController, StandaloneControllerComponents}
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api._
 import play.api.http.HttpErrorHandler
+import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import router.Routes
@@ -15,6 +16,7 @@ class AppLoader extends FrontendApplicationLoader {
 }
 
 trait Controllers {
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val responsiveViewerController = wire[ResponsiveViewerController]
 }

--- a/preview/app/controllers/HealthCheck.scala
+++ b/preview/app/controllers/HealthCheck.scala
@@ -1,8 +1,10 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(
- 9017,
- NeverExpiresSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
+  9017,
+  NeverExpiresSingleHealthCheck("/world/2012/sep/11/barcelona-march-catalan-independence")
 )

--- a/preview/test/PreviewServerTest.scala
+++ b/preview/test/PreviewServerTest.scala
@@ -6,7 +6,7 @@ class PreviewTestSuite extends Suites (
   new PreviewServerTest
 ) with SingleServerSuite {
 
-  override lazy val port: Int = new controllers.HealthCheck().testPort
+  override lazy val port: Int = new controllers.HealthCheck(wsClient).testPort
 }
 
 @DoNotDiscover class PreviewServerTest extends FlatSpec with Matchers with ConfiguredTestSuite {

--- a/preview/test/PreviewServerTest.scala
+++ b/preview/test/PreviewServerTest.scala
@@ -1,10 +1,12 @@
 package test
 
-import org.scalatest.{Suites, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest._
 
 class PreviewTestSuite extends Suites (
   new PreviewServerTest
-) with SingleServerSuite {
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   override lazy val port: Int = new controllers.HealthCheck(wsClient).testPort
 }

--- a/rss/app/AppLoader.scala
+++ b/rss/app/AppLoader.scala
@@ -1,11 +1,11 @@
-import app.{LifecycleComponent, FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{CommonFilters, CachedHealthCheckLifeCycle}
+import conf.{CachedHealthCheckLifeCycle, CommonFilters}
 import contentapi.SectionsLookUpLifecycle
-import controllers.{RssController, HealthCheck}
+import controllers.{HealthCheck, RssController}
 import dev.DevParametersHttpRequestHandler
 import model.ApplicationIdentity
 import ophan.SurgingContentAgentLifecycle
@@ -14,6 +14,7 @@ import play.api.http.HttpRequestHandler
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api._
+import play.api.libs.ws.WSClient
 import services.ConfigAgentLifecycle
 import router.Routes
 
@@ -22,6 +23,7 @@ class AppLoader extends FrontendApplicationLoader {
 }
 
 trait Controllers {
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val rssController = wire[RssController]
 }

--- a/rss/app/controllers/HealthCheck.scala
+++ b/rss/app/controllers/HealthCheck.scala
@@ -1,8 +1,10 @@
 package controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
   9014,
   NeverExpiresSingleHealthCheck("/books/harrypotter/rss")
 )

--- a/sport/app/AppLoader.scala
+++ b/sport/app/AppLoader.scala
@@ -1,10 +1,10 @@
 import http.CorsHttpErrorHandler
-import app.{FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents}
 import com.softwaremill.macwire._
 import common._
 import common.Logback.LogstashLifecycle
 import conf.switches.SwitchboardLifecycle
-import conf.{FootballLifecycle, CommonFilters, CachedHealthCheckLifeCycle}
+import conf.{CachedHealthCheckLifeCycle, CommonFilters, FootballLifecycle}
 import cricket.conf.CricketLifecycle
 import cricket.controllers.CricketControllers
 import cricketPa.PaFeed
@@ -38,6 +38,7 @@ trait SportServices {
 }
 
 trait Controllers extends FootballControllers with CricketControllers with RugbyControllers {
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
   lazy val devAssetsController = wire[DevAssetsController]
 }

--- a/sport/app/football/controllers/HealthCheck.scala
+++ b/sport/app/football/controllers/HealthCheck.scala
@@ -1,8 +1,10 @@
 package football.controllers
 
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
+import play.api.libs.ws.WSClient
 
-class HealthCheck extends AllGoodCachedHealthCheck(
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
   9013,
   NeverExpiresSingleHealthCheck("/football/live"),
   NeverExpiresSingleHealthCheck("/football/premierleague/results")

--- a/sport/test/package.scala
+++ b/sport/test/package.scala
@@ -38,7 +38,7 @@ class SportTestSuite extends Suites (
   new rugby.model.MatchParserTest
 ) with SingleServerSuite with FootballTestData with BeforeAndAfterAll with WithTestWsClient {
 
-  override lazy val port: Int = new HealthCheck().testPort
+  override lazy val port: Int = new HealthCheck(wsClient).testPort
 
   // Inject stub api.
   FootballClient.http = new TestHttp(wsClient)

--- a/training-preview/app/AppLoader.scala
+++ b/training-preview/app/AppLoader.scala
@@ -1,10 +1,11 @@
-import app.{LifecycleComponent, FrontendComponents, FrontendApplicationLoader}
+import app.{FrontendApplicationLoader, FrontendComponents, LifecycleComponent}
 import com.softwaremill.macwire._
-import conf.{StandaloneFilters, CachedHealthCheckLifeCycle}
-import controllers.{StandaloneControllerComponents, HealthCheck}
+import conf.{CachedHealthCheckLifeCycle, StandaloneFilters}
+import controllers.{HealthCheck, StandaloneControllerComponents}
 import model.ApplicationIdentity
 import play.api.ApplicationLoader.Context
 import play.api._
+import play.api.libs.ws.WSClient
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import router.Routes
@@ -14,6 +15,7 @@ class AppLoader extends FrontendApplicationLoader {
 }
 
 trait Controllers {
+  def wsClient: WSClient
   lazy val healthCheck = wire[HealthCheck]
 }
 

--- a/training-preview/app/controllers/HealthCheck.scala
+++ b/training-preview/app/controllers/HealthCheck.scala
@@ -3,9 +3,11 @@ package controllers
 import common.ExecutionContexts
 import conf.{AllGoodCachedHealthCheck, NeverExpiresSingleHealthCheck}
 import dispatch.{FunctionHandler, Http}
+
 import scala.concurrent.Future
 import contentapi.{ContentApiClient, Response}
 import conf.Configuration.contentApi.previewAuth
+import play.api.libs.ws.WSClient
 
 class TrainingHttp extends contentapi.Http with ExecutionContexts {
 
@@ -38,9 +40,10 @@ class TrainingHttp extends contentapi.Http with ExecutionContexts {
   }
 }
 
-class HealthCheck extends AllGoodCachedHealthCheck(
- 9016,
- NeverExpiresSingleHealthCheck("/info/developer-blog/2016/apr/14/training-preview-healthcheck")
+class HealthCheck(override val wsClient: WSClient) extends AllGoodCachedHealthCheck(
+  wsClient,
+  9016,
+  NeverExpiresSingleHealthCheck("/info/developer-blog/2016/apr/14/training-preview-healthcheck")
 ) {
   init()
 

--- a/training-preview/test/PreviewServerTest.scala
+++ b/training-preview/test/PreviewServerTest.scala
@@ -6,7 +6,7 @@ class TrainingTestSuite extends Suites (
   new TrainingServerTest
 ) with SingleServerSuite {
 
-  override lazy val port: Int = new controllers.HealthCheck().testPort
+  override lazy val port: Int = new controllers.HealthCheck(wsClient).testPort
 }
 
 @DoNotDiscover class TrainingServerTest extends FlatSpec with Matchers with ConfiguredTestSuite {

--- a/training-preview/test/PreviewServerTest.scala
+++ b/training-preview/test/PreviewServerTest.scala
@@ -1,10 +1,12 @@
 package test
 
-import org.scalatest.{Suites, DoNotDiscover, FlatSpec, Matchers}
+import org.scalatest._
 
 class TrainingTestSuite extends Suites (
   new TrainingServerTest
-) with SingleServerSuite {
+) with SingleServerSuite
+  with BeforeAndAfterAll
+  with WithTestWsClient {
 
   override lazy val port: Int = new controllers.HealthCheck(wsClient).testPort
 }


### PR DESCRIPTION
## What does this change?

Removing call to WS.url in HealthCheck
## What is the value of this and can you measure success?

=> Play 2.5
## Does this affect other platforms - Amp, Apps, etc?

No
## Request for comment

@alexduf 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
