### PR TITLE
Zootropolis article fixes

### DIFF
--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -55,10 +55,10 @@
                                             Nick Wilde is a slick hustler who uses a combination of charm, wit and cunning in his work as a con artist. This sly fox is always on the move and claims to know everyone in Zootropolis, which makes him a valuable asset to Judy in her search for a missing mammal.
                                         </p>
                                         <p>
-                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank">Download character poster</a>
+                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank" data-link-name="Nick - The con artist - download poster">Download character poster (18MB)</a>
                                         </p>
                                         <p>
-                                            <a href="@{page.customData.colouringPdf}" class="animal__download" target="_blank">Download the colouring images</a>
+                                            <a href="@{page.customData.colouringPdf}" class="animal__download" target="_blank" data-link-name="Nick - The con artist - download colouring images">Download the colouring images (2.6MB)</a>
                                         </p>
                                     </div>
                                 </div>
@@ -87,10 +87,10 @@
                                             Judy Hopps is an idealistic, optimistic and extremely resolute bunny! She had dreamed of becoming a police officer since she was little and living in Bunnyburrow. She finished at the top of her class at the Police Academy and would be the first rabbit police officer in the ZPD. Judy is ambitious, and more than anything wants to make the world a better place. She might be small compared to the other officers, but she is very brave and never hesitates to chase a bad guy or help a friend in danger.
                                         </p>
                                         <p>
-                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank">Download character poster</a>
+                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank" data-link-name="Judy - The rookie - download poster">Download character poster (18MB)</a>
                                         </p>
                                         <p>
-                                            <a href="@{page.customData.colouringPdf}" class="animal__download" target="_blank">Download the colouring images</a>
+                                            <a href="@{page.customData.colouringPdf}" class="animal__download" target="_blank" data-link-name="Judy - The rookie - download colouring images">Download the colouring images (2.6MB)</a>
                                         </p>
                                     </div>
                                 </div>
@@ -119,10 +119,10 @@
                                             According to safari experts, elephants never forget, but Cape Buffalo never forgive - which pretty much sums up Chief Bogo. A quick thinker with a steady hand, Bogo is the chief of Zootropolis police force. He likes to joke around, but he expects a lot from the cops on his squad - specifically speed, strength and size. So when idealistic bunny Judy Hopps reports to work Bogo decides she’s not exactly cut out for field work and assigns her to meter-maid duty instead. Gruff and demanding, Bogo will give credit where it is due - but he doubts that little bunny will ever be able to prove herself.
                                         </p>
                                         <p>
-                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank">Download character poster</a>
+                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank" data-link-name="Bogo - The chief - download poster">Download character poster (18MB)</a>
                                         </p>
                                         <p>
-                                            <a href="@{page.customData.colouringPdf}" class="animal__download" target="_blank">Download the colouring images</a>
+                                            <a href="@{page.customData.colouringPdf}" class="animal__download" target="_blank" data-link-name="Bogo - The chief - download colouring images">Download the colouring images (2.6MB)</a>
                                         </p>
                                     </div>
                                 </div>
@@ -151,10 +151,10 @@
                                             Flash is the fastest sloth working at the DMV - of course, that’s not saying much. As a sloth, Flash tends to do everything - like talking - at his own particular pace. He’s as helpful as he can be and when his pal needs a rush job, Flash springs into action (as much as this sloth can spring, anyway).
                                         </p>
                                         <p>
-                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank">Download character poster</a>
+                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank" data-link-name="Flash - The DMV employee - download poster">Download character poster (18MB)</a>
                                         </p>
                                         <p>
-                                            <a href="@{page.customData.colouringPdf}" class="animal__download" target="_blank">Download the colouring images</a>
+                                            <a href="@{page.customData.colouringPdf}" class="animal__download" target="_blank" data-link-name="Flash - The DMV employee - download colouring images">Download the colouring images (2.6MB)</a>
                                         </p>
                                     </div>
                                 </div>
@@ -183,7 +183,7 @@
                                             Everyone thinks he is just a flabby, donut-loving cop, and officer Benjamin Clawhauser is … exactly like that! But he is also a gentle, honest cheetah and the first friend Judy makes at the ZPD.
                                         </p>
                                         <p>
-                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank">Download character poster</a>
+                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank" data-link-name="Benjamin Clawhauser - The desk clerk - download poster">Download character poster (18MB)</a>
                                         </p>
                                     </div>
                                 </div>
@@ -212,7 +212,7 @@
                                             Gazelle is very popular in the world of Zootropolis, having many fans, including Judy Hopps and Clawhauser. Her importance and popularity stem from the fact that she is very socially minded and is all about acceptance and equality for all.
                                         </p>
                                         <p>
-                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank">Download character poster</a>
+                                            <a href="@{page.customData.posterPdf}" class="animal__download" target="_blank" data-link-name="Gazelle - The pop star - download poster">Download character poster (18MB)</a>
                                         </p>
                                     </div>
                                 </div>

--- a/commercial/app/views/hosted/guardianHostedArticle.scala.html
+++ b/commercial/app/views/hosted/guardianHostedArticle.scala.html
@@ -14,7 +14,6 @@
         <article id="article" data-test-id="article-root" class="content content--article has-feature-showcase-element section-stage content--advertisement-feature" role="main">
             <div class="media-primary media-content media-primary--showcase" style="background-image: url(@{page.mainPicture});">
                 <h2 class="title">Meet the characters of Zootropolis</h2>
-                <span class="caption hosted-tone--zootropolis">Disney Zootroplis for the Guardian</span>
             </div><!--End of top banner !-->
             <div class="content__main">
                 <div class="gs-container">

--- a/common/app/common/commercial/hosted/HostedArticlePage.scala
+++ b/common/app/common/commercial/hosted/HostedArticlePage.scala
@@ -15,8 +15,6 @@ case class HostedArticlePage(
   cta: HostedCallToAction,
   ctaBanner: String,
   mainPicture: String,
-  twitterTxt: String,
-  emailTxt: String,
   facebookShareText: Option[String] = None,
   twitterShareText: Option[String] = None,
   emailSubjectText: Option[String] = None,

--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -75,15 +75,15 @@ object ZootropolisHostedPages {
     title = "Meet the characters of Zootropolis",
     standfirst = "Hosted content is used to describe content that is paid for and supplied by the advertiser. Find out more with our",
     standfirstLink = "commercial content explainer.",
-    // todo: this is going to change
     facebookImageUrl = "https://media.guim.co.uk/cb60581783874e022209cde845481bd4334cb7a0/0_116_1300_385/1300.png",
     cta,
     ctaBanner = "https://static.theguardian.com/commercial/hosted/disney-zootropolis/zootropolis_banner.jpg",
     mainPicture = "https://media.guim.co.uk/cb60581783874e022209cde845481bd4334cb7a0/0_116_1300_385/1300.png",
-    twitterTxt = "Disney Zootropolis asset pack on the Guardian #ad",
-    emailTxt = "Disney Zootropolis asset pack on the Guardian",
-    twitterShareText = Some("Disney Zootropolis asset pack on the Guardian"),
-    emailSubjectText = Some("Disney Zootropolis asset pack on the Guardian"),
+    facebookShareText = Some("Get to know the colourful characters of Disney’s Zootropolis with these printable colouring-in sheets and " +
+      "character posters! Zootropolis is packed with snappy action, witty dialogue & belly laughs.  It’s an adorable movie that shouldn’t be missed." +
+      " Download instantly with Sky Store & get the DVD in the post (no Sky subscription required)!"),
+    twitterShareText = Some("Get to know the residents of Zootropolis and find out where to download the film instantly"),
+    emailSubjectText = Some("Get to know the residents of Zootropolis!"),
     customData = customData
   )
 

--- a/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted-article.scss
@@ -45,31 +45,6 @@ $zootropolisColor: #2ec869; //need to remove references to brand colours here ev
             left: $gs-column-width * 4 + 20;
         }
     }
-    .caption {
-        position: absolute;
-        left: 10px;
-        top: 390px;
-        right: unset;
-
-        @include mq(tablet) {
-            left: $gs-gutter * 1.5;
-        }
-
-        @include mq(desktop) {
-            left: unset;
-            right: $gs-column-width + 10;
-            width: $gs-column-width * 3 + 40;
-        }
-
-        @include mq(leftCol) {
-            right: 10px;
-        }
-    }
-    .content__meta-container {
-        @include mq($until: desktop) {
-            margin-top: 48px;
-        }
-    }
     .content[class*='-advertisement-feature'] {
         .social__item--pinterest {
             display: block;


### PR DESCRIPTION
## What does this change?

A few fixes:
- proper social sharing text
- 'download link' tracking with data-attributes
- caption under the image is removed
- info about the asset sizes added next to the download buttons
## Screenshots

![screen shot 2016-07-28 at 15 47 57](https://cloud.githubusercontent.com/assets/489567/17216981/af750cc6-54da-11e6-999f-2ff1bbe78216.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
