### PR TITLE
Update the Foresee survey definition to support GA

### DIFF
--- a/static/src/javascripts/vendor/foresee/20150703/foresee-surveydef.js
+++ b/static/src/javascripts/vendor/foresee/20150703/foresee-surveydef.js
@@ -245,6 +245,18 @@ FSR.properties = {
                 var tester = test.length > 11 ? test.substring(7, test.length - 4) : "";
                 return tester;
             }
+        },
+        GA_UID: {
+            source: 'function',
+            value: function () {
+                var out = "";
+                if (typeof ga != 'undefined' && ga != null) {
+                    if (typeof ga.getAll === 'function' && ga.getAll()[0] != null) {
+                        out += ga.getAll()[0].get('clientId');
+                    }
+                }
+                return out;
+            }
         }
     },
     


### PR DESCRIPTION
## What does this change?

Just copy-pasting some code we received from Foresee. 

The code extracts the Google Analytics client ID from one of the GA trackers. We have 3 trackers but I checked that they all return the same value, so it doesn't matter which one we use.
## What is the value of this and can you measure success?

Needed to track Foresee survey completions using GA
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

anyone

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
