### PR TITLE
Tweak GA custom dimensions

### DIFF
--- a/common/app/model/meta.scala
+++ b/common/app/model/meta.scala
@@ -632,7 +632,7 @@ final case class Tags(
 
   lazy val keywordIds = keywords.map { _.id }
 
-  lazy val commissioningDesk = tracking.map(_.id).collect { case Tags.CommissioningDesk(desk) => desk }.headOption
+  lazy val commissioningDesks = tracking.map(_.id).collect { case Tags.CommissioningDesk(desk) => desk }
 
   def javascriptConfig: Map[String, JsValue] = Map(
     ("keywords", JsString(keywords.map { _.name }.mkString(","))),
@@ -647,7 +647,7 @@ final case class Tags(
     ("toneIds", JsString(tones.map(_.id).mkString(","))),
     ("blogs", JsString(blogs.map { _.name }.mkString(","))),
     ("blogIds", JsString(blogs.map(_.id).mkString(","))),
-    ("commissioningDesk", JsString(commissioningDesk.getOrElse("")))
+    ("commissioningDesks", JsString(commissioningDesks.mkString(",")))
   )
 }
 

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -4,6 +4,17 @@
 
 <script id='google_analytics'>
 
+(function() {
+
+    // Remove spaces from content type and convert it to lower case
+    function convertContentType(contentType) {
+        var result = contentType;
+        if (typeof contentType === 'string') {
+            result = contentType.toLowerCase().split(' ').join('');
+        }
+        return result;
+    }
+
     @***************************************************************************************
     * Standard copy 'n paste Google Analytics code                                         *
     ***************************************************************************************@
@@ -36,8 +47,8 @@
         * Some of these will be undefined for non-content pages, but that's fine.              *
         ***************************************************************************************@
         ga('@{trackerName}.set', 'dimension4', guardian.config.page.section);
-        ga('@{trackerName}.set', 'dimension5', guardian.config.page.contentType);
-        ga('@{trackerName}.set', 'dimension6', guardian.config.page.commissioningDesk);
+        ga('@{trackerName}.set', 'dimension5', convertContentType(guardian.config.page.contentType));
+        ga('@{trackerName}.set', 'dimension6', guardian.config.page.commissioningDesks);
         ga('@{trackerName}.set', 'dimension7', guardian.config.page.contentId);
         ga('@{trackerName}.set', 'dimension8', guardian.config.page.authorIds);
         ga('@{trackerName}.set', 'dimension9', guardian.config.page.keywordIds);
@@ -78,6 +89,9 @@
         } catch (e) { }
 
     }
+
+})();
+
 </script>
 
 @*

--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -19,7 +19,7 @@
         ga('create', '@tracker.trackingId', 'auto', '@tracker.trackerName');
     }
 
-    @defining(GoogleAnalyticsAccount.editorialTracker.trackerName) { trackerName =>
+    @for(trackerName <- Seq(GoogleAnalyticsAccount.editorialProd.trackerName, GoogleAnalyticsAccount.editorialTest.trackerName)) {
         ga('@{trackerName}.set', 'forceSSL', true);
 
         ga('@{trackerName}.set', 'title', guardian.config.page.webTitle);
@@ -43,6 +43,9 @@
         ga('@{trackerName}.set', 'dimension9', guardian.config.page.keywordIds);
         ga('@{trackerName}.set', 'dimension10', guardian.config.page.toneIds);
         ga('@{trackerName}.set', 'dimension11', guardian.config.page.seriesId);
+    }
+
+    @defining(GoogleAnalyticsAccount.editorialTracker.trackerName) { trackerName =>
 
         ga('@{trackerName}.send', 'pageview', {
             hitCallback: function() {


### PR DESCRIPTION
## What does this change?

Just a couple of small changes to match what the mobile apps are planning to send:
- Articles can have multiple commissioning desks, so make it a comma-separated list
- Normalise the content type (no spaces, lowercase)

Also set the custom dimensions on both the prod and test trackers, so you get the same results no matter which tracker you are using.
## What is the value of this and can you measure success?

GA data will be consistent across the frontend and the mobile apps.
## Does this affect other platforms - Amp, Apps, etc?

Yes, apps
## Screenshots

n/a
## Request for comment

@marialivia16 @mohammad-haque

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
