### PR TITLE
Fix json parse for commercial reports

### DIFF
--- a/diagnostics/app/model/diagnostics/commercial/CommercialReport.scala
+++ b/diagnostics/app/model/diagnostics/commercial/CommercialReport.scala
@@ -13,7 +13,7 @@ case class Advert(
   dfpReceived: Option[Double],
   dfpRendered: Option[Double],
   id: Option[String],
-  isEmpty: Option[String],
+  isEmpty: Option[Boolean],
   lazyWaitComplete: Option[Double],
   loadingMethod: Option[String],
   startLoading: Option[Double],


### PR DESCRIPTION
The structure was expecting a string, but the js app reports a boolean
