### PR TITLE
Fix hosted thrasher return value

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/creatives/hosted-thrasher-multi.js
+++ b/static/src/javascripts/projects/common/modules/commercial/creatives/hosted-thrasher-multi.js
@@ -28,6 +28,8 @@ define([
             if (this.params.trackingPixel) {
                 addTrackingPixel(this.$adSlot, this.params.trackingPixel + this.params.cacheBuster);
             }
+
+            return true;
         }, this);
     };
 


### PR DESCRIPTION
A creative is responsible for telling the commercial code whether it was rendered successfully or not. Failing to do that may have side effect like having the Outbrain widget appear where it should not:

Admittedly, failing to be displayed is exceptional and we should rather raise an exception for that. We'll change that in another PR.

cc @Calanthe @lps88 
