### PR TITLE
Move the client logging check to client-side

### DIFF
--- a/diagnostics/app/controllers/DiagnosticsController.scala
+++ b/diagnostics/app/controllers/DiagnosticsController.scala
@@ -55,9 +55,7 @@ class DiagnosticsController extends Controller with Logging {
   def cspOptions = postOptions
 
   def commercialReport = Action(jsonParser) { implicit request =>
-    if (mvt.CommercialClientLoggingVariant.isParticipating(request)) {
-      Report.report(request.body)
-    }
+    Report.report(request.body)
 
     TinyResponse.noContent()
   }

--- a/static/src/javascripts/projects/common/modules/commercial/dfp/private/ophan-tracking.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/private/ophan-tracking.js
@@ -1,9 +1,10 @@
 define([
     'raven',
+    'common/utils/config',
     'common/utils/user-timing',
     'common/modules/analytics/beacon',
     'common/modules/commercial/dfp/private/get-advert-by-id'
-], function (raven, userTiming, beacon, getAdvertById) {
+], function (raven, config, userTiming, beacon, getAdvertById) {
 
     var performanceLog = {
             viewId: 'unknown',
@@ -163,11 +164,13 @@ define([
     }
 
     function reportTrackingData() {
-        require(['ophan/ng'], function (ophan) {
-            performanceLog.viewId = ophan.viewId;
+        if (config.tests.commercialClientLogging) {
+            require(['ophan/ng'], function (ophan) {
+                performanceLog.viewId = ophan.viewId;
 
-            beacon.postJson('/commercial-report', JSON.stringify(performanceLog), true);
-        });
+                beacon.postJson('/commercial-report', JSON.stringify(performanceLog), true);
+            });
+        }
     }
 
     return {


### PR DESCRIPTION
Another bug. Fastly needs to interpret the cookie and set the mvt header as appropriate, but of course diagnostics does not run requests through Fastly. So the mvt participation check has to be done client-side.
