### PR TITLE
Update failing commercial feeds link to use HTTPS

### DIFF
--- a/admin/app/views/commercial/commercialMenu.scala.html
+++ b/admin/app/views/commercial/commercialMenu.scala.html
@@ -111,7 +111,7 @@
                     <ul>
                         <li><a href="https://github.com/guardian/commercial-tools">Commercial tools repo</a></li>
                         <li><a href="https://dfp-playground.appspot.com/59739193">DFP API playground</a></li>
-                        <li><a href="http://kibana.gu-web.net/goto/1955d282a7b6cc452b673cdb9c27f1af">
+                        <li><a href="https://kibana.gu-web.net/goto/1955d282a7b6cc452b673cdb9c27f1af">
                             Failing Commercial Feeds
                         </a></li>
                     </ul>


### PR DESCRIPTION
Not going to change the world this one... but it does mean that the link to our Kibana dashboard on our admin page actually works (there isn't a redirect to HTTPS when accessing Kibana via HTTP so it currently just fails).
