### PR TITLE
Hosted pages fixes

### DIFF
--- a/common/app/common/commercial/hosted/HostedPage.scala
+++ b/common/app/common/commercial/hosted/HostedPage.scala
@@ -17,7 +17,7 @@ trait HostedPage extends StandalonePage {
 
   def twitterText = twitterShareText.getOrElse(if(standfirst.length < 136) standfirst else title) + " #ad"
   def facebookText = facebookShareText.getOrElse(standfirst)
-  def emailText = emailSubjectText.getOrElse(title)
+  def emailText = "Advertiser Content hosted by the Guardian " + emailSubjectText.getOrElse(title)
 
   final val toneId = "tone/hosted"
   final val toneName = "Hosted"

--- a/static/src/javascripts/bootstraps/enhanced/common.js
+++ b/static/src/javascripts/bootstraps/enhanced/common.js
@@ -284,7 +284,7 @@ define([
             },
 
             loadBreakingNews: function () {
-                if (config.switches.breakingNews && config.page.section !== 'identity') {
+                if (config.switches.breakingNews && config.page.section !== 'identity' && config.page.tones !== 'Hosted') {
                     breakingNews();
                 }
             },

--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -75,6 +75,14 @@ $hosted-video-height: 540px;
             height: 50px;
         }
     }
+
+    @include mq(leftCol) {
+        margin-right: 90px;
+    }
+
+    @include mq(wide) {
+        margin-right: 170px;
+    }
 }
 
 .hosted__glogotext {


### PR DESCRIPTION
## What does this change?

A few fixes for the hosted pages:
- proper share email text
- breaking news alert will not be shown on hosted pages
- the 'hosted by the Guardian' logo should be aligned to the video correctly

Before:
![screen shot 2016-08-01 at 11 37 35](https://cloud.githubusercontent.com/assets/489567/17291524/5fe4fb6c-57dc-11e6-94a8-31f8bb031d7d.png)

After:
![screen shot 2016-08-01 at 11 36 32](https://cloud.githubusercontent.com/assets/489567/17291529/6532e548-57dc-11e6-96c9-67037eedee49.png)
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
