### PR TITLE
Ignore protocol when deciding if a click is an internal link

### DIFF
--- a/static/src/javascripts/projects/common/modules/ui/clickstream.js
+++ b/static/src/javascripts/projects/common/modules/ui/clickstream.js
@@ -16,6 +16,9 @@ define([
 
         opts = opts || {};
 
+        // Allow a fake window.location to be passed in for testing
+        var location = opts.location || window.location;
+
         var filters = opts.filter || [],
             filterSource = function (element) {
                 return filters.filter(function (f) {
@@ -24,27 +27,24 @@ define([
             },
             compareHosts = function (url) {
                 var urlHost,
-                    urlProtocol,
-                    host,
-                    protocol;
+                    host;
 
                 url = url || '';
                 urlHost = url.match(/:\/\/(.[^\/]+)/);
 
                 if (urlHost) {
                     urlHost = urlHost[1];
-                    urlProtocol = url.match(/^(https?:)\/\//);
-                    urlProtocol = urlProtocol ? urlProtocol[1] : undefined;
-                    host = window.location.hostname;
-                    protocol = window.location.protocol;
+                    host = location.hostname;
                 }
 
                 if (url.indexOf('mailto:') === 0) {
                     return false;
                 }
 
-                // Lack of a urlHost implies a relative url
-                return !urlHost || (urlHost === host && urlProtocol === protocol);
+                // Lack of a urlHost implies a relative url.
+                // For absolute urls we are protocol-agnostic,
+                // e.g. we should treat https://gu.com/foo -> http://gu.com/bar as a same-host link.
+                return !urlHost || urlHost === host;
             },
             getClickSpec = function (spec, forceValid) {
                 if (!spec.el) {

--- a/static/test/javascripts/spec/common/analytics/clickstream.spec.js
+++ b/static/test/javascripts/spec/common/analytics/clickstream.spec.js
@@ -3,7 +3,7 @@ define(['common/modules/ui/clickstream', 'bean', 'common/utils/mediator', 'helpe
 
     describe('Clickstream', function () {
         var fixtureId = 'clickstream-fixture',
-        clickIds = ['click-me', 'click-me-ancestor', 'click-me-descendant', 'click-me-quick', 'click-me-internal', 'click-me-external'];
+        clickIds = ['click-me', 'click-me-ancestor', 'click-me-descendant', 'click-me-quick', 'click-me-internal', 'click-me-internal-http', 'click-me-internal-https', 'click-me-external'];
 
         beforeEach(function () {
 
@@ -25,6 +25,8 @@ define(['common/modules/ui/clickstream', 'bean', 'common/utils/mediator', 'helpe
                                 '<button id="click-me-button" data-link-name="the button">Span Link</button>' +
                                 '<p href="#hello" id="click-me-slow" data-link-name="paragraph">Paragraph Link</p>' +
                                 '<a href="/foo" id="click-me-internal" data-link-name="internal link">Same-host link</a>' +
+                                '<a href="http://www.theguardian.com/foo" id="click-me-internal-http" data-link-name="internal link (HTTP)">Same-host HTTP link</a>' +
+                                '<a href="https://www.theguardian.com/foo" id="click-me-internal-https" data-link-name="internal link (HTTPS)">Same-host HTTPS link</a>' +
                                 '<a href="http://google.com/foo" id="click-me-external" data-link-name="external link">Other-host link</a>' +
                                 '<span data-link-context="the outer context">' +
                                     '<span data-link-context-path="the inner context path" data-link-context-name="the inner context name">' +
@@ -148,6 +150,54 @@ define(['common/modules/ui/clickstream', 'bean', 'common/utils/mediator', 'helpe
                     sameHost: true,
                     validTarget: true,
                     tag: 'outer div | internal link',
+                    customEventProperties: {}
+                };
+
+            mediator.on('module:clickstream:click', spy);
+
+            bean.fire(el, 'click');
+        });
+
+        it('should indicate if a click emanates from an absolute same-host HTTP link when the current page is on HTTPS', function (done) {
+
+            new Clickstream({ filter: ['a'], withEvent: false, location: { protocol: 'https:', hostname: 'www.theguardian.com' } });
+
+            var object = { method: function (p) {
+                    clickSpec.target = p.target;
+                    expect(spy.withArgs(clickSpec)).toHaveBeenCalledOnce();
+                    done();
+                }},
+                spy = sinon.spy(object, 'method'),
+                el = document.getElementById('click-me-internal-http'),
+                clickSpec = {
+                    samePage: false,
+                    sameHost: true,
+                    validTarget: true,
+                    tag: 'outer div | internal link (HTTP)',
+                    customEventProperties: {}
+                };
+
+            mediator.on('module:clickstream:click', spy);
+
+            bean.fire(el, 'click');
+        });
+
+        it('should indicate if a click emanates from an absolute same-host HTTPS link when the current page is on HTTP', function (done) {
+
+            new Clickstream({ filter: ['a'], withEvent: false, location: { protocol: 'http:', hostname: 'www.theguardian.com' } });
+
+            var object = { method: function (p) {
+                    clickSpec.target = p.target;
+                    expect(spy.withArgs(clickSpec)).toHaveBeenCalledOnce();
+                    done();
+                }},
+                spy = sinon.spy(object, 'method'),
+                el = document.getElementById('click-me-internal-https'),
+                clickSpec = {
+                    samePage: false,
+                    sameHost: true,
+                    validTarget: true,
+                    tag: 'outer div | internal link (HTTPS)',
                     customEventProperties: {}
                 };
 


### PR DESCRIPTION
## What does this change?

When deciding whether a clicked link is an internal (same-host) link, we should be protocol-agnostic. e.g. a link from `https://www.theguardian.com/uk` to `http://www.theguardian.com/politics/foo` should be treated as an internal link, not an external one.
## What is the value of this and can you measure success?

Click events are tracked correctly in GA and Omniture.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

n/a
## Request for comment

@mchv

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
