### PR TITLE
Hosted pages - logo position fix

### DIFF
--- a/static/src/stylesheets/module/commercial/glabs/_hosted.scss
+++ b/static/src/stylesheets/module/commercial/glabs/_hosted.scss
@@ -75,14 +75,6 @@ $hosted-video-height: 540px;
             height: 50px;
         }
     }
-
-    @include mq(leftCol) {
-        margin-right: 90px;
-    }
-
-    @include mq(wide) {
-        margin-right: 170px;
-    }
 }
 
 .hosted__glogotext {
@@ -94,13 +86,25 @@ $hosted-video-height: 540px;
     color: rgba(255, 255, 255, .5);
 }
 
-.hosted-video-page .hosted__container.adverts {
-    position: relative;
-    background: transparent;
-    color: #ffffff;
+.hosted-video-page {
+    .hosted__container.adverts {
+        position: relative;
+        background: transparent;
+        color: #ffffff;
 
-    @include mq($until: desktop) {
-        padding: 0;
+        @include mq($until: desktop) {
+            padding: 0;
+        }
+    }
+
+    .hosted__glogo {
+        @include mq(leftCol) {
+            margin-right: 90px;
+        }
+
+        @include mq(wide) {
+            margin-right: 170px;
+        }
     }
 }
 


### PR DESCRIPTION
## What does this change?

The fix of the logo position (https://github.com/guardian/frontend/pull/13785) should be applied only on hosted video pages not gallery or article. 
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
