### PR TITLE
Remove ads from hosted articles

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
+++ b/static/src/javascripts/projects/common/modules/commercial/commercial-features.js
@@ -34,6 +34,8 @@ define([
 
         var isLiveBlog = config.page.isLiveBlog;
 
+        var isHosted = config.page.tones === 'Hosted';
+
         var isMatchReport = config.hasTone('Match reports');
 
         var isIdentityPage =
@@ -59,6 +61,7 @@ define([
             !isMinuteArticle &&
             isArticle &&
             !isLiveBlog &&
+            !isHosted &&
             switches.standardAdverts;
 
         this.articleAsideAdverts =


### PR DESCRIPTION
These weirdly only appear when you use iPhone 5 device mode in chrome:

![image](https://cloud.githubusercontent.com/assets/6290008/17292831/4638344c-57e4-11e6-9371-3215624d6590.png)
