### PR TITLE
Hosted video Zootropolis renamed

### DIFF
--- a/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
+++ b/common/app/common/commercial/hosted/hardcoded/ZootropolisHostedPages.scala
@@ -26,7 +26,7 @@ object ZootropolisHostedPages {
   )
 
   private lazy val videoPageWithoutNextPage: HostedVideoPage = {
-    val videoTitle = "Disney’s Zootropolis: Download & keep today!"
+    val videoTitle = "Disney’s Zootropolis: Download and keep today!"
     HostedVideoPage(
       campaign,
       pageUrl = s"$host/advertiser-content/${campaign.id}/$videoPageName",


### PR DESCRIPTION
## What does this change?

The Hosted video Zootropolis page is renamed from "Disney’s Zootropolis: Download & keep today!" to "Disney’s Zootropolis: Download and keep today!"
## Request for comment

@lps88 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
