### PR TITLE
Add olympics (rio 2016) link to the uk sport nav

### DIFF
--- a/common/app/common/Navigation.scala
+++ b/common/app/common/Navigation.scala
@@ -100,6 +100,7 @@ trait Navigation {
   val boxing = SectionLink("sport", "boxing", "Boxing", "/sport/boxing")
   val formulaOne = SectionLink("sport", "F1", "Formula one", "/sport/formulaone")
   val racing = SectionLink("sport", "racing", "Racing", "/sport/horse-racing")
+  val rioOlympics = SectionLink("sport", "olympics", "Olympics", "/sport/rio-2016")
 
   val nfl = SectionLink("sport", "NFL", "NFL", "/sport/nfl")
   val mlb = SectionLink("sport", "MLB", "MLB", "/sport/mlb")

--- a/common/app/common/editions/Uk.scala
+++ b/common/app/common/editions/Uk.scala
@@ -17,6 +17,7 @@ object Uk extends Edition(
   implicit val UK = Uk
 
   val sportLocalNav: Seq[SectionLink] = Seq(
+    rioOlympics,
     football,
     cricket,
     rugbyunion,


### PR DESCRIPTION
## What does this change?

Adds an "olympics" link to the uk sport nav, which directs to the rio 2016 front.  We were given leeway to remove "US sports" if there wasn't enough room, but that doesn't appear to be a problem even at reduced widths.
## Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/8754692/17297315/22d3d682-57fd-11e6-9fe2-61b530404a09.png)

After:
![image](https://cloud.githubusercontent.com/assets/8754692/17297341/43264b68-57fd-11e6-8c34-8240519817ae.png)

![image](https://cloud.githubusercontent.com/assets/8754692/17297480/ce1469c6-57fd-11e6-9ee2-3393556cabe0.png)
## Request for comment

@SiAdcock @NataliaLKB 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
