### PR TITLE
Don't send duplicate array indexes for email subscriptions

### DIFF
--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -11,7 +11,7 @@
                 "email-subscription" -> true,
                 "email-subscription--subscribed" -> subscription.subscribedTo,
                 "email-subscription--first" -> row.isFirst))">
-                @if(subscription.subscribedTo){<input type="hidden" name="emailSubscription[@row.rowNum]" value="@subscription.listId" />}
+                @if(subscription.subscribedTo){<input type="hidden" name="emailSubscription[]" value="@subscription.listId" />}
                 <div class="email-subscription__name">@subscription.name</div>
 
                 <div class="email-subscription__description">@subscription.description @if(subscription.exampleUrl.isDefined){<br><a href="@subscription.exampleUrl" target="preview-email-@subscription.listId">See the latest email</a>}</div>


### PR DESCRIPTION
Fixes a very long-standing bug in the email preferences page.

After a form POST, the state of all of the subscriptions is determined not by another request to ExactTarget but instead by the posted data. So each time, although the user is only changing the state of one subscription, all the other active subscriptions get posted and these are used to determine which buttons should be "on".

Unfortunately, because each section of the page is played out in a separate loop and we use a numerical index for a form field which becomes a `List`, different sections of the page can "overwrite" each other.

So, for example, "The Guardian Today - UK" at the top of the first section:

![picture 237](https://cloud.githubusercontent.com/assets/5122968/17298678/df1ba63a-5802-11e6-963f-7b23287f2634.png)

gets given the same index as "Sleeve notes" which is at the top of the Culture section:

![picture 236](https://cloud.githubusercontent.com/assets/5122968/17298681/e3c92ef0-5802-11e6-8c05-0ce8ebf41d53.png)

so this gets sent to the server:

![picture 239](https://cloud.githubusercontent.com/assets/5122968/17298684/e74e8020-5802-11e6-809a-a330a8686d11.png)

and weirdness ensues. (The second `emailSubscription[1]` seems to be ignored, and "Sleeve notes" appears as unsubscribed as in the screenshot. On a GET reload of the page "Sleeve notes" reappears with its correct subscribed status).

@katebee 
