### PR TITLE
AMP live blog: live list

### DIFF
--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -2,11 +2,12 @@
 @import model.Article
 @import model.liveblog.{LiveBlogDate,BodyBlock}
 @import views.BodyCleaner
+@import conf.switches.Switches.LiveUpdateAmpSwitch
 
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader)
 
 @blocks.map { block =>
-    <div id="block-@block.id" @if(amp){ data-sort-time="@block.publishedCreatedTimestamp()" } class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
+    <div id="block-@block.id" @if(amp && LiveUpdateAmpSwitch.isSwitchedOn){ data-sort-time="@block.publishedCreatedTimestamp()" } class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
         <p class="block-time published-time">
             <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
             @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))

--- a/article/app/views/liveblog/liveBlogBlocks.scala.html
+++ b/article/app/views/liveblog/liveBlogBlocks.scala.html
@@ -6,7 +6,7 @@
 @(blocks: Seq[BodyBlock], article: Article, timezone: DateTimeZone, amp: Boolean = false)(implicit request: RequestHeader)
 
 @blocks.map { block =>
-    <div id="block-@block.id" class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
+    <div id="block-@block.id" @if(amp){ data-sort-time="@block.publishedCreatedTimestamp()" } class="block block--content@block.eventClass" itemprop="liveBlogUpdate" itemscope="" itemtype="http://schema.org/BlogPosting">
         <p class="block-time published-time">
             <a href="/@article.metadata.id?page=with:block-@block.id#block-@block.id" itemprop="url" class="block-time__link">
             @views.html.liveblog.dateBlock(block.publishedCreatedDate(timezone))
@@ -31,4 +31,3 @@
         @views.html.fragments.share.blockLevelSharing(s"block-${block.id}", article.sharelinks.elementShares(s"block-${block.id}", None), article.metadata.contentType, amp)
     </div>
 }
-

--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -88,10 +88,16 @@
                     </div>
 
                     @if(amp) {
-                        @views.html.liveblog.liveBlogBodyContent(model, amp)
+                        @views.html.liveblog.liveBlogBodyContentAMP(model)
+                        @fragments.submeta(article)
+                        <div class="after-article js-after-article"></div>
+                        <div class="js-bottom-marker"></div>
                     } else {
                         @fragments.dropdown("Live feed", Some("live-feed"), true) {
-                            @views.html.liveblog.liveBlogBodyContent(model, amp)
+                            @views.html.liveblog.liveBlogBodyContent(model)
+                            @fragments.submeta(article)
+                            <div class="after-article js-after-article"></div>
+                            <div class="js-bottom-marker"></div>
                         }
                     }
                 </div>

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -21,7 +21,6 @@
         itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
             @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone)
         </div>
-        @* Remove LiveFilter and the fragment once Toast comes out of AB test status *@
         @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
     </div>
 }

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -1,76 +1,27 @@
-@import model.Article
-
-@(model: LiveBlogPage, amp: Boolean = false)(implicit request: RequestHeader)
+@(model: LiveBlogPage)(implicit request: RequestHeader)
 
 @import common.Edition
-@import views.support.{AmpAd, AmpAdDataSlot}
-@import org.joda.time.DateTimeZone
-
-@liveBlogBlocksAMP(article: Article, timezone: DateTimeZone) = {
-    @model.currentPage.currentPage.blocks.sliding(5, 5).zipWithIndex.map { case (blockGroup, index) =>
-        @views.html.liveblog.liveBlogBlocks(blockGroup, article, timezone, amp)
-
-        @* Add advert every 5 blog posts, up to a maximum of 8 *@
-        @if(blockGroup.length == 5 && index < 8) {
-            @* AMP requires children of `<div items>` to have an `id` and a `data-sort-time` *@
-            <div id="amp-ad-@index" data-sort-time="1" class="block amp-ad-container amp-ad-container--live-blog">
-                <amp-ad width="300" height="250" type="doubleclick"
-                json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
-                data-slot=@AmpAdDataSlot(article).toString()>
-                </amp-ad>
-            </div>
-        }
-    }
-}
 
 @defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
     <div class="js-article__container" data-component="body">
-        @if(!amp) {
-            <div class="toast__space-reserver">
-                <div id="toast__tofix" class="toast__container">
-                    <button class="toast__button toast__button--closed button button--large">
-                        <span class="toast__text"></span>
-                        @fragments.inlineSvg("refresh", "icon", List(""))
-                    </button>
-                </div>
+        <div class="toast__space-reserver">
+            <div id="toast__tofix" class="toast__container">
+                <button class="toast__button toast__button--closed button button--large">
+                    <span class="toast__text"></span>
+                    @fragments.inlineSvg("refresh", "icon", List(""))
+                </button>
             </div>
-        }
+        </div>
         @if(model.currentPage.currentPage.isArchivePage) {
             @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
         }
-            @if(amp) {
-                <amp-live-list id="live-list" data-poll-interval="15000" data-max-items-per-page="20"
-                    class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
-                        _root_.liveblog.LatestBlock(article.blocks)
-                    }" data-test-id="live-blog-blocks"
-                    itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
-                    <div update on="tap:live-list.update" class="toast__space-reserver">
-                        <div id="toast__tofix" class="toast__container">
-                            <button class="toast__button toast__button--closed button button--large">
-                                <span class="toast__text">New updates</span>
-                                @fragments.inlineSvg("refresh", "icon", List(""))
-                            </button>
-                        </div>
-                    </div>
-                    <div items>
-                        @liveBlogBlocksAMP(article, timezone)
-                    </div>
-                </amp-live-list>
-            } else {
-                <div class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
-                    _root_.liveblog.LatestBlock(article.blocks)
-                }" data-test-id="live-blog-blocks"
-                itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
-                    @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone, amp)
-                </div>
-            }
+        <div class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
+            _root_.liveblog.LatestBlock(article.blocks)
+        }" data-test-id="live-blog-blocks"
+        itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
+            @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone)
+        </div>
         @* Remove LiveFilter and the fragment once Toast comes out of AB test status *@
         @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
     </div>
-
-    @fragments.submeta(article)
-
-    <div class="after-article js-after-article"></div>
-
-    <div class="js-bottom-marker"></div>
 }

--- a/article/app/views/liveblog/liveBlogBodyContent.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContent.scala.html
@@ -12,7 +12,8 @@
 
         @* Add advert every 5 blog posts, up to a maximum of 8 *@
         @if(blockGroup.length == 5 && index < 8) {
-            <div class="block amp-ad-container amp-ad-container--live-blog">
+            @* AMP requires children of `<div items>` to have an `id` and a `data-sort-time` *@
+            <div id="amp-ad-@index" data-sort-time="1" class="block amp-ad-container amp-ad-container--live-blog">
                 <amp-ad width="300" height="250" type="doubleclick"
                 json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
                 data-slot=@AmpAdDataSlot(article).toString()>
@@ -37,16 +38,32 @@
         @if(model.currentPage.currentPage.isArchivePage) {
             @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
         }
-        <div class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
-            _root_.liveblog.LatestBlock(article.blocks)
-        }" data-test-id="live-blog-blocks"
-        itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
             @if(amp) {
-                @liveBlogBlocksAMP(article, timezone)
+                <amp-live-list id="live-list" data-poll-interval="15000" data-max-items-per-page="20"
+                    class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
+                        _root_.liveblog.LatestBlock(article.blocks)
+                    }" data-test-id="live-blog-blocks"
+                    itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
+                    <div update on="tap:live-list.update" class="toast__space-reserver">
+                        <div id="toast__tofix" class="toast__container">
+                            <button class="toast__button toast__button--closed button button--large">
+                                <span class="toast__text">New updates</span>
+                                @fragments.inlineSvg("refresh", "icon", List(""))
+                            </button>
+                        </div>
+                    </div>
+                    <div items>
+                        @liveBlogBlocksAMP(article, timezone)
+                    </div>
+                </amp-live-list>
             } else {
-                @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone, amp)
+                <div class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
+                    _root_.liveblog.LatestBlock(article.blocks)
+                }" data-test-id="live-blog-blocks"
+                itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
+                    @views.html.liveblog.liveBlogBlocks(model.currentPage.currentPage.blocks, article, timezone, amp)
+                </div>
             }
-        </div>
         @* Remove LiveFilter and the fragment once Toast comes out of AB test status *@
         @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
     </div>

--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -35,7 +35,7 @@
             }" data-test-id="live-blog-blocks"
             itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
                 <div update on="tap:live-list.update" class="toast__space-reserver">
-                    <div id="toast__tofix" class="toast__container">
+                    <div id="toast__tofix" class="toast__container is-sticky">
                         <button class="toast__button toast__button--closed button button--large">
                             <span class="toast__text">New updates</span>
                             @fragments.inlineSvg("refresh", "icon", List(""))

--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -54,8 +54,6 @@
                 @liveBlogBlocksAMP(article, timezone)
             </div>
         }
-
-        @* Remove LiveFilter and the fragment once Toast comes out of AB test status *@
         @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
     </div>
 }

--- a/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
+++ b/article/app/views/liveblog/liveBlogBodyContentAMP.scala.html
@@ -1,0 +1,61 @@
+@import model.Article
+
+@(model: LiveBlogPage)(implicit request: RequestHeader)
+
+@import common.Edition
+@import conf.switches.Switches.LiveUpdateAmpSwitch
+@import views.support.{AmpAd, AmpAdDataSlot}
+@import org.joda.time.DateTimeZone
+
+@liveBlogBlocksAMP(article: Article, timezone: DateTimeZone) = {
+    @model.currentPage.currentPage.blocks.sliding(5, 5).zipWithIndex.map { case (blockGroup, index) =>
+        @views.html.liveblog.liveBlogBlocks(blockGroup, article, timezone, amp = true)
+
+        @* Add advert every 5 blog posts, up to a maximum of 8 *@
+        @if(blockGroup.length == 5 && index < 8) {
+            <div @if(LiveUpdateAmpSwitch.isSwitchedOn) { id="amp-ad-@index" data-sort-time="1" } class="block amp-ad-container amp-ad-container--live-blog">
+                <amp-ad width="300" height="250" type="doubleclick"
+                json=@AmpAd(article, request.path, Edition(request).id.toLowerCase()).toString()
+                data-slot=@AmpAdDataSlot(article).toString()>
+                </amp-ad>
+            </div>
+        }
+    }
+}
+
+@defining((model.article, Edition(request).timezone)) { case (article, timezone) =>
+    <div class="js-article__container" data-component="body">
+        @if(model.currentPage.currentPage.isArchivePage) {
+            @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
+        }
+        @if(LiveUpdateAmpSwitch.isSwitchedOn) {
+            <amp-live-list id="live-list" data-poll-interval="15000" data-max-items-per-page="20"
+            class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
+                _root_.liveblog.LatestBlock(article.blocks)
+            }" data-test-id="live-blog-blocks"
+            itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
+                <div update on="tap:live-list.update" class="toast__space-reserver">
+                    <div id="toast__tofix" class="toast__container">
+                        <button class="toast__button toast__button--closed button button--large">
+                            <span class="toast__text">New updates</span>
+                            @fragments.inlineSvg("refresh", "icon", List(""))
+                        </button>
+                    </div>
+                </div>
+                <div items>
+                    @liveBlogBlocksAMP(article, timezone)
+                </div>
+            </amp-live-list>
+        } else {
+            <div class="js-liveblog-body u-cf from-content-api js-blog-blocks blocks @if(article.fields.isLive) {live-blog}" data-most-recent-block="block-@{
+                _root_.liveblog.LatestBlock(article.blocks)
+            }" data-test-id="live-blog-blocks"
+            itemprop="@if(article.tags.isReview) {reviewBody} else {articleBody}">
+                @liveBlogBlocksAMP(article, timezone)
+            </div>
+        }
+
+        @* Remove LiveFilter and the fragment once Toast comes out of AB test status *@
+        @fragments.liveBlogNavigation(article.content.metadata.id, model.currentPage)
+    </div>
+}

--- a/common/app/conf/switches/FeatureSwitches.scala
+++ b/common/app/conf/switches/FeatureSwitches.scala
@@ -387,6 +387,16 @@ trait FeatureSwitches {
     exposeClientSide = false
   )
 
+  val LiveUpdateAmpSwitch = Switch(
+    SwitchGroup.Feature,
+    "live-update-amp",
+    "If this switch is on, amp-live-list will be included in live blogs",
+    owners = Seq(Owner.withGithub("SiAdcock")),
+    safeState = Off,
+    sellByDate = new LocalDate(2016, 9, 2),
+    exposeClientSide = false
+  )
+
   val R2PagePressServiceSwitch = Switch(
     SwitchGroup.Feature,
     "r2-page-press-service",

--- a/common/app/dev/DevParametersHttpRequestHandler.scala
+++ b/common/app/dev/DevParametersHttpRequestHandler.scala
@@ -41,7 +41,9 @@ class DevParametersHttpRequestHandler(
     "pageSize",
     "projectName",
     "stage",
-    "amp" // used in dev to request the amp version of a specific url
+    "amp", // used in dev to request the amp version of a specific url
+    "__amp_source_origin", // used by amp-live-list to enforce CORS
+    "amp_latest_update_time" // used by amp-live-list to check for latest updates
   )
 
   val commercialParams = Seq(

--- a/common/app/model/liveblog/BodyBlock.scala
+++ b/common/app/model/liveblog/BodyBlock.scala
@@ -91,6 +91,7 @@ case class BodyBlock(
 
   def publishedCreatedDate(timezone: DateTimeZone) = firstPublishedDate.orElse(createdDate).map(LiveBlogDate.apply(_, timezone))
 
+  def publishedCreatedTimestamp() = firstPublishedDate.orElse(createdDate).map(_.getMillis())
 }
 
 object LiveBlogDate {

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -149,6 +149,11 @@
     display: block;
 }
 
+.toast__container {
+    text-align: center;
+    top: 12px;
+}
+
 .toast__container--open {
     z-index: 1015;
 }
@@ -195,4 +200,10 @@
     position: absolute;
     top: 8px;
     left: 8px;
+}
+
+.is-sticky {
+    position: fixed;
+    left: 0;
+    right: 0;
 }

--- a/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
+++ b/common/app/views/fragments/amp/stylesheets/liveBlog.scala.html
@@ -139,3 +139,60 @@
     text-align: center;
     padding-bottom: 1.5rem;
 }
+
+/* Toast
+========================================= */
+
+.toast__space-reserver {
+    height: 36px;
+    margin-bottom: -36px;
+    display: block;
+}
+
+.toast__container--open {
+    z-index: 1015;
+}
+
+.toast__button {
+    position: relative;
+    display: inline-block;
+    box-sizing: border-box;
+    overflow: hidden;
+    height: 36px;
+    width: auto;
+    max-width: 300px;
+    vertical-align: top;
+    font-size: 12px;
+    line-height: 16px;
+    font-family: "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+    font-weight: bold;
+    text-decoration: none;
+    background-color: #cc2b12;
+    color: #ffffff;
+    border: 0;
+    border-radius: 1000px;
+    margin-right: 0;
+    padding: 0 12px;
+}
+
+.toast__text {
+    display: inline-block;
+    font-weight: 700;
+    float: right;
+    opacity: 1;
+    padding-left: 25px;
+    transition: opacity .3s ease-in-out;
+}
+
+.inline-refresh {
+    fill: #ffffff;
+}
+
+.inline-refresh__svg {
+    height: 20px;
+    width: 20px;
+    display: inline-block;
+    position: absolute;
+    top: 8px;
+    left: 8px;
+}

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -20,7 +20,7 @@
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
         <script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async ></script>
-        @if(LiveUpdateAmpSwitch.isSwitchedOn) {
+        @if(content.tags.isLiveBlog && LiveUpdateAmpSwitch.isSwitchedOn) {
             <script custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js" async></script>
         }
         <script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async ></script>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -2,6 +2,7 @@
 
 @import common.{AnalyticsHost, CanonicalLink, LinkTo}
 @import conf.Configuration
+@import conf.switches.Switches.LiveUpdateAmpSwitch
 @import views.support.OmnitureAnalyticsData
 @import views.support.FBPixel
 
@@ -19,7 +20,9 @@
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
         <script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async ></script>
-        <script custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js" async></script>
+        @if(LiveUpdateAmpSwitch.isSwitchedOn) {
+            <script custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js" async></script>
+        }
         <script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async ></script>
         @* Required for outbrain served in an amp-iframe *@
         <script custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js" async></script>

--- a/common/app/views/mainAMP.scala.html
+++ b/common/app/views/mainAMP.scala.html
@@ -19,6 +19,7 @@
         <script custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js" async></script>
         <script custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js" async></script>
         <script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async ></script>
+        <script custom-element="amp-live-list" src="https://cdn.ampproject.org/v0/amp-live-list-0.1.js" async></script>
         <script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async ></script>
         @* Required for outbrain served in an amp-iframe *@
         <script custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js" async></script>


### PR DESCRIPTION
## What does this change?

This will add live update functionality to AMP live blogs. 

The `amp-live-list` component is [currently in beta](https://amphtml.wordpress.com/2016/07/26/live-updating-amps/) and thus is not recommended for use in production. I have therefore added a feature switch that will allow us to enable live update functionality as and when it stabilises.
## Screenshots

![live-blog-live-update](https://cloud.githubusercontent.com/assets/5931528/17298867/aaf79138-5803-11e6-8b74-b2968f788be5.gif)
## Request for comment

@johnduffell @TBonnin @NataliaLKB 
