### PR TITLE
Fix Google Analytics in video embeds

### DIFF
--- a/applications/app/views/videoEmbed.scala.html
+++ b/applications/app/views/videoEmbed.scala.html
@@ -71,6 +71,18 @@
             config: @Html(templates.js.javaScriptConfig(model.SimpleContentPage(video)).body),
             adBlockers: { onDetect: [] }
         };
+        @* Decide the Ophan PV ID here so we can share it with Google Analytics *@
+        guardian.config.ophan = {
+            // This is duplicated from
+            // https://github.com/guardian/ophan/blob/master/tracker-js/assets/coffee/ophan/transmit.coffee
+            // Please do not change this without talking to the Ophan project first.
+            pageViewId: new Date().getTime().toString(36) + 'xxxxxxxxxxxx'.replace(/x/g, function () {
+                return Math.floor(Math.random() * 36).toString(36);
+            })
+        };
+        @* Find the Ophan browser ID as well, for sharing with GA *@
+        @Html(templates.inlineJS.nonBlocking.js.ophanConfig().body)
+
         var docClass = document.documentElement.className;
 
         @* Get iframes parent url: http://www.nczonline.net/blog/2013/04/16/getting-the-url-of-an-iframes-parent/ *@


### PR DESCRIPTION
## What does this change?

Embeds were throwing a JS error and failing to send the GA hit because they relied on some Ophan-related config code that was not being run.

Note: with this change, the Ophan pageview ID is now generated by frontend and passed to the Ophan JS via config, just like on normal frontend pages.
## What is the value of this and can you measure success?

Track video embeds using GA
## Does this affect other platforms - Amp, Apps, etc?

Affects anywhere we use video embeds, e.g. Facebook Instant Articles
## Screenshots

n/a
## Request for comment

@akash1810 @obrienm 

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
