### PR TITLE
AU Membership Banner

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
+++ b/static/src/javascripts/projects/common/modules/commercial/membership-messages.js
@@ -25,6 +25,7 @@ define([
     var membershipEndpoints = {
         UK:   'https://membership.theguardian.com/supporter',
         US:   'https://membership.theguardian.com/us/supporter',
+        AU:   'https://membership.theguardian.com/au/supporter',
         INT:   'https://membership.theguardian.com/supporter'
     };
 
@@ -50,6 +51,15 @@ define([
             minVisited:    10,
             data: {
                 messageText: 'Support open, independent journalism. Become a Supporter for just $4.99 per month.',
+                linkText: 'Find out more'
+            }
+        },
+        AU: {
+            campaign:      'MEMBERSHIP_SUPPORTER_BANNER_AU',
+            code:          'membership-message-au-2016-08-01',
+            minVisited:    10,
+            data: {
+                messageText: 'We need you to help support our fearless independent journalism. Become a Guardian Australia Member for just $100 a year.',
                 linkText: 'Find out more'
             }
         },


### PR DESCRIPTION
## What does this change?

Adds an Australian variant of the membership banner.
## What is the value of this and can you measure success?

Increase in conversions of members on the Australian edition.
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots

<img width="1131" alt="screen shot 2016-08-01 at 17 31 11" src="https://cloud.githubusercontent.com/assets/406099/17301480/2fa1a9cc-580f-11e6-86c9-943d53f54c03.png">
## Request for comment

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
