### PR TITLE
Promote recommendation to its own module

### DIFF
--- a/discussion/app/views/discussionComments/commentsList.scala.html
+++ b/discussion/app/views/discussionComments/commentsList.scala.html
@@ -18,6 +18,7 @@
     </div>
 
     @fragments.reportComment()
+    @fragments.recommendationTooltip()
 </div>
 
 @userMessageForLargeDiscussion = {

--- a/discussion/app/views/fragments/comment.scala.html
+++ b/discussion/app/views/fragments/comment.scala.html
@@ -69,6 +69,7 @@
                 <div
                     class="d-comment__recommend js-recommend-comment"
                     data-comment-id="@comment.id"
+                    data-comment-url="@comment.webUrl"
                     data-user-id="@comment.profile.userId"
                     data-recommend-count="@comment.numRecommends"
                     title="@comment.numRecommends recommendations">

--- a/discussion/app/views/fragments/recommendationTooltip.scala.html
+++ b/discussion/app/views/fragments/recommendationTooltip.scala.html
@@ -1,0 +1,16 @@
+<div class="tooltip-box tooltip-box--neutral tooltip-box--width4 tooltip-box-hidden js-rec-tooltip">
+    <button
+        class="tooltip-box__close js-rec-tooltip-close u-button-reset"
+        data-link-name="Close recommendation tooltip"
+        aria-label="Close tooltip"
+    >
+        <i class="i i-close-icon-dark-small"></i>
+    </button>
+
+    <p class="tooltip-box__p">
+        <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN">Sign in</a>
+        or
+        <a href="@Configuration.id.url/register?INTCMP=DOTCOM_COMMENTS_REG">create your Guardian account</a>
+        to recommend a comment
+    </p>
+</div>

--- a/discussion/app/views/fragments/recommendationTooltip.scala.html
+++ b/discussion/app/views/fragments/recommendationTooltip.scala.html
@@ -1,4 +1,4 @@
-<div class="tooltip-box tooltip-box--neutral tooltip-box--width4 tooltip-box-hidden js-rec-tooltip">
+<div hidden class="tooltip-box tooltip-box--neutral tooltip-box--width4 js-rec-tooltip">
     <button
         class="tooltip-box__close js-rec-tooltip-close u-button-reset"
         data-link-name="Close recommendation tooltip"

--- a/discussion/app/views/fragments/recommendationTooltip.scala.html
+++ b/discussion/app/views/fragments/recommendationTooltip.scala.html
@@ -8,9 +8,15 @@
     </button>
 
     <p class="tooltip-box__p">
-        <a href="@Configuration.id.url/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN">Sign in</a>
+        <a
+            class="js-rec-tooltip-link"
+            href="@Configuration.id.url/signin?INTCMP=DOTCOM_COMMENTS_SIGNIN_RECOMM"
+        >Sign in</a>
         or
-        <a href="@Configuration.id.url/register?INTCMP=DOTCOM_COMMENTS_REG">create your Guardian account</a>
+        <a
+            class="js-rec-tooltip-link"
+            href="@Configuration.id.url/register?INTCMP=DOTCOM_COMMENTS_REG_RECOMM"
+        >create your Guardian account</a>
         to recommend a comment
     </p>
 </div>

--- a/discussion/app/views/fragments/reportComment.scala.html
+++ b/discussion/app/views/fragments/reportComment.scala.html
@@ -1,7 +1,7 @@
-<form class="tooltip-box tooltip-box--neutral tooltip-box--width4 tooltip-box-hidden js-report-comment-form">
-    <div class="d-discussion__error js-discussion__report-comment-error d-discussion__error--hidden">
+<form hidden class="tooltip-box tooltip-box--neutral tooltip-box--width4 js-report-comment-form">
+    <div hidden class="d-discussion__error js-discussion__report-comment-error">
         <i class="i i-alert"></i>
-        <span class="d-discussion__error-text">Sorry there was an error. Please try again later. If the problem persists, please <a data-link-name="report comment eeeor : mailto : userhelp" href="mailto:userhelp@@theguardian.com">Userhelp</a></span>
+        <span class="d-discussion__error-text">Sorry there was an error. Please try again later. If the problem persists, please contact <a data-link-name="report comment error : mailto : userhelp" href="mailto:userhelp@@theguardian.com">Userhelp</a></span>
     </div>
 
     <button

--- a/discussion/app/views/fragments/reportComment.scala.html
+++ b/discussion/app/views/fragments/reportComment.scala.html
@@ -1,4 +1,4 @@
-<form class="d-report-comment-form js-report-comment-form u-h">
+<form class="tooltip-box tooltip-box--neutral tooltip-box--width4 tooltip-box-hidden js-report-comment-form">
     <div class="d-discussion__error js-discussion__report-comment-error d-discussion__error--hidden">
         <i class="i i-alert"></i>
         <span class="d-discussion__error-text">Sorry there was an error. Please try again later. If the problem persists, please <a data-link-name="report comment eeeor : mailto : userhelp" href="mailto:userhelp@@theguardian.com">Userhelp</a></span>

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -104,7 +104,7 @@ Comments.prototype.ready = function() {
     this.emit('ready');
 
     this.on('click', '.js-report-comment-close', function() {
-        $('.js-report-comment-form').addClass('tooltip-box-hidden');
+        document.querySelector('.js-report-comment-form').setAttribute('hidden', '');
     });
 };
 
@@ -424,6 +424,7 @@ Comments.prototype.reportComment = function(e) {
         commentId = e.currentTarget.getAttribute('data-comment-id');
 
     $('.js-report-comment-form').first().each(function(form) {
+        form.removeAttribute('hidden');
         bean.one(form, 'submit', function(e) {
             e.preventDefault();
             var category = form.elements.category,
@@ -441,16 +442,16 @@ Comments.prototype.reportComment = function(e) {
         });
     }).appendTo(
         $('#comment-' + commentId + ' .js-report-comment-container').first()
-    ).removeClass('tooltip-box-hidden');
+    );
 };
 
 Comments.prototype.reportCommentSuccess = function(form) {
-    bonzo(form).addClass('tooltip-box-hidden');
+    form.setAttribute('hidden', '');
 };
 
 Comments.prototype.reportCommentFailure = function() {
-    $('.js-discussion__report-comment-error').removeClass('d-discussion__error--hidden');
-    $('.d-report-comment__close').addClass('d-report-comment__close--error');
+    document.querySelector('.js-discussion__report-comment-error').removeAttribute('hidden');
+    document.querySelector('.d-report-comment__close').classList.add('d-report-comment__close--error');
 };
 
 Comments.prototype.addUser = function(user) {

--- a/static/src/javascripts/projects/common/modules/discussion/comments.js
+++ b/static/src/javascripts/projects/common/modules/discussion/comments.js
@@ -104,7 +104,7 @@ Comments.prototype.ready = function() {
     this.emit('ready');
 
     this.on('click', '.js-report-comment-close', function() {
-        $('.js-report-comment-form').addClass('u-h');
+        $('.js-report-comment-form').addClass('tooltip-box-hidden');
     });
 };
 
@@ -441,11 +441,11 @@ Comments.prototype.reportComment = function(e) {
         });
     }).appendTo(
         $('#comment-' + commentId + ' .js-report-comment-container').first()
-    ).removeClass('u-h');
+    ).removeClass('tooltip-box-hidden');
 };
 
 Comments.prototype.reportCommentSuccess = function(form) {
-    bonzo(form).addClass('u-h');
+    bonzo(form).addClass('tooltip-box-hidden');
 };
 
 Comments.prototype.reportCommentFailure = function() {

--- a/static/src/javascripts/projects/common/modules/discussion/loader.js
+++ b/static/src/javascripts/projects/common/modules/discussion/loader.js
@@ -16,6 +16,7 @@ define([
     'common/modules/discussion/api',
     'common/modules/discussion/comment-box',
     'common/modules/discussion/comments',
+    'common/modules/discussion/upvote',
     'common/modules/identity/api',
     'common/modules/user-prefs',
     'lodash/objects/isNumber'
@@ -37,6 +38,7 @@ define([
     DiscussionApi,
     CommentBox,
     Comments,
+    upvote,
     Id,
     userPrefs,
     isNumber
@@ -246,26 +248,12 @@ Loader.prototype.initToolbar = function() {
     }
 };
 
-Loader.prototype.isOpenForRecommendations = function() {
-    return qwery('.d-discussion--recommendations-open', this.elem).length !== 0;
-};
-
 Loader.prototype.initRecommend = function() {
     this.on('click', '.js-recommend-comment', function(e) {
-        if (this.user && this.isOpenForRecommendations()) {
-            var elem = e.currentTarget,
-                $el = bonzo(elem);
-
-            $el.removeClass('js-recommend-comment');
-
-            var id = elem.getAttribute('data-comment-id'),
-                result = DiscussionApi.recommendComment(id);
-
-            $el.addClass('d-comment__recommend--clicked');
-            return result.then(
-                $el.addClass.bind($el, 'd-comment__recommend--recommended')
-            );
-        }
+        upvote.handle(e.currentTarget, this.elem, this.user, DiscussionApi);
+    });
+    this.on('click', '.js-rec-tooltip-close', function() {
+        upvote.closeTooltip();
     });
 };
 

--- a/static/src/javascripts/projects/common/modules/discussion/upvote.js
+++ b/static/src/javascripts/projects/common/modules/discussion/upvote.js
@@ -1,9 +1,13 @@
 define([
+    'common/utils/assign',
     'common/utils/fastdom-promise',
-    'common/utils/report-error'
+    'common/utils/report-error',
+    'common/utils/url'
 ], function (
+    assign,
     fastdom,
-    reportError
+    reportError,
+    urlUtil
 ) {
     var RECOMMENDATION_CLASS = 'js-recommend-comment';
     var TOOLTIP_CLASS = 'js-rec-tooltip';
@@ -11,6 +15,7 @@ define([
 
     function handle (target, container, user, discussionApi) {
         if (!user) {
+            target.setAttribute('data-link-name', 'Recommend comment anonymous');
             return showSignInTooltip(target);
         } else if (isOpenForRecommendations(container)) {
             var id = target.getAttribute('data-comment-id');
@@ -57,10 +62,26 @@ define([
 
     function showSignInTooltip (target) {
         var tooltip = document.querySelector('.' + TOOLTIP_CLASS);
+        var links = tooltip.querySelectorAll('.js-rec-tooltip-link');
+
         return fastdom.write(function () {
+            updateReturnUrl(links, target.getAttribute('data-comment-url'));
             tooltip.classList.remove(HIDE_TOOLTIP_CLASS);
             target.appendChild(tooltip);
         });
+    }
+
+    function updateReturnUrl (links, returnLink) {
+        for (var i = 0, len = links.length; i < len; i += 1) {
+            var url = links[i].getAttribute('href');
+            var baseUrl = url.split('?')[0];
+            var query = urlUtil.getUrlVars({
+                query: url.split('?')[1] || '&'
+            });
+            links[i].setAttribute('href', baseUrl + '?' + urlUtil.constructQuery(assign(query, {
+                returnUrl: returnLink
+            })));
+        }
     }
 
     function closeTooltip () {

--- a/static/src/javascripts/projects/common/modules/discussion/upvote.js
+++ b/static/src/javascripts/projects/common/modules/discussion/upvote.js
@@ -1,0 +1,76 @@
+define([
+    'common/utils/fastdom-promise',
+    'common/utils/report-error'
+], function (
+    fastdom,
+    reportError
+) {
+    var RECOMMENDATION_CLASS = 'js-recommend-comment';
+    var TOOLTIP_CLASS = 'js-rec-tooltip';
+    var HIDE_TOOLTIP_CLASS = 'tooltip-box-hidden';
+
+    function handle (target, container, user, discussionApi) {
+        if (!user) {
+            return showSignInTooltip(target);
+        } else if (isOpenForRecommendations(container)) {
+            var id = target.getAttribute('data-comment-id');
+
+            return Promise.all([
+                setClicked(target),
+                discussionApi.recommendComment(id)
+            ])
+            .then(function () {
+                return setRecommended(target);
+            })
+            .catch(function (ex) {
+                unsetClicked(target);
+                reportError(ex, {
+                    feature: 'comments-recommend'
+                });
+            });
+        }
+    }
+
+    function isOpenForRecommendations (element) {
+        return !!element.querySelector('.d-discussion--recommendations-open');
+    }
+
+    function setClicked (target) {
+        return fastdom.write(function () {
+            target.classList.remove(RECOMMENDATION_CLASS);
+            target.classList.add('d-comment__recommend--clicked');
+        });
+    }
+
+    function unsetClicked (target) {
+        return fastdom.write(function () {
+            target.classList.add(RECOMMENDATION_CLASS);
+            target.classList.remove('d-comment__recommend--clicked');
+        });
+    }
+
+    function setRecommended (target) {
+        return fastdom.write(function () {
+            target.classList.add('d-comment__recommend--recommended');
+        });
+    }
+
+    function showSignInTooltip (target) {
+        var tooltip = document.querySelector('.' + TOOLTIP_CLASS);
+        return fastdom.write(function () {
+            tooltip.classList.remove(HIDE_TOOLTIP_CLASS);
+            target.appendChild(tooltip);
+        });
+    }
+
+    function closeTooltip () {
+        return fastdom.write(function () {
+            document.querySelector('.' + TOOLTIP_CLASS).classList.add(HIDE_TOOLTIP_CLASS);
+        });
+    }
+
+    return {
+        handle: handle,
+        closeTooltip: closeTooltip
+    };
+});

--- a/static/src/javascripts/projects/common/modules/discussion/upvote.js
+++ b/static/src/javascripts/projects/common/modules/discussion/upvote.js
@@ -11,7 +11,6 @@ define([
 ) {
     var RECOMMENDATION_CLASS = 'js-recommend-comment';
     var TOOLTIP_CLASS = 'js-rec-tooltip';
-    var HIDE_TOOLTIP_CLASS = 'tooltip-box-hidden';
 
     function handle (target, container, user, discussionApi) {
         if (!user) {
@@ -66,7 +65,7 @@ define([
 
         return fastdom.write(function () {
             updateReturnUrl(links, target.getAttribute('data-comment-url'));
-            tooltip.classList.remove(HIDE_TOOLTIP_CLASS);
+            tooltip.removeAttribute('hidden');
             target.appendChild(tooltip);
         });
     }
@@ -86,7 +85,7 @@ define([
 
     function closeTooltip () {
         return fastdom.write(function () {
-            document.querySelector('.' + TOOLTIP_CLASS).classList.add(HIDE_TOOLTIP_CLASS);
+            document.querySelector('.' + TOOLTIP_CLASS).setAttribute('hidden', '');
         });
     }
 

--- a/static/src/stylesheets/_common.scss
+++ b/static/src/stylesheets/_common.scss
@@ -6,6 +6,7 @@
 @import 'module/_tabs';
 @import 'module/_headline-list';
 @import 'module/_rich-links';
+@import 'module/_tooltip';
 @import 'pasteup/buttons/styles';
 @import 'module/facia/_pagination';
 @import 'module/_release-message';

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -995,12 +995,6 @@ $comment-recommend-button-size: 19px;
     margin-bottom: $gs-baseline / 2;
     width: auto;
 }
-.d-report-comment__close--error-hidden {
-    display: none;
-}
-.d-report-comment__close--error {
-    margin-top: -$gs-baseline * 6;
-}
 
 
 /* Top Comments
@@ -1232,10 +1226,6 @@ $comment-recommend-button-size: 19px;
 
     }
     .i-alert { position: absolute; }
-}
-
-.d-discussion__error--hidden {
-    display: none;
 }
 
 .d-comment-box__error-meta {

--- a/static/src/stylesheets/module/_discussion.scss
+++ b/static/src/stylesheets/module/_discussion.scss
@@ -722,7 +722,6 @@ $comment-recommend-button-size: 19px;
     right: 0;
     top: $gs-baseline / 2;
     height: $comment-recommend-button-size;
-    z-index: 1;
 
     @include mq(desktop) {
         min-width: 28px;
@@ -975,21 +974,6 @@ $comment-recommend-button-size: 19px;
 /* Report
    ======================================================= */
 
-.d-report-comment-form {
-    top: 0;
-    right: 0;
-    z-index: $zindex-content;
-    width: gs-span(4);
-    color: $neutral-1;
-    padding: $gs-baseline / 2 $gs-gutter / 2;
-    border: 2px solid $neutral-6;
-    background: #ffffff;
-}
-
-.d-comment .d-report-comment-form {
-    position: absolute;
-}
-
 .d-report-comment__label,
 .d-report-comment__field {
     box-sizing: border-box;
@@ -1241,7 +1225,7 @@ $comment-recommend-button-size: 19px;
         display: inline-block;
         margin-left: $gs-gutter * 1.2;
 
-        .d-report-comment-form & {
+        .tooltip-box & {
             margin-left: 0;
             margin-bottom: .25rem;
         }

--- a/static/src/stylesheets/module/_tooltip.scss
+++ b/static/src/stylesheets/module/_tooltip.scss
@@ -10,14 +10,10 @@
     padding: $gs-baseline / 2 $gs-gutter / 2;
 }
 
-.tooltip-box-hidden {
-    display: none;
-}
-
 .tooltip-box--neutral {
     color: $neutral-1;
     border: 2px solid $neutral-6;
-    background: #FFF;
+    background: #ffffff;
 }
 
 .tooltip-box--width4 {

--- a/static/src/stylesheets/module/_tooltip.scss
+++ b/static/src/stylesheets/module/_tooltip.scss
@@ -1,0 +1,36 @@
+/* Tooltip Box
+   Box that sits on top of the content, absolutely positioned
+   Larger than a standard tooltip and allows a close icon */
+
+.tooltip-box {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: $zindex-content;
+    padding: $gs-baseline / 2 $gs-gutter / 2;
+}
+
+.tooltip-box-hidden {
+    display: none;
+}
+
+.tooltip-box--neutral {
+    color: $neutral-1;
+    border: 2px solid $neutral-6;
+    background: #FFF;
+}
+
+.tooltip-box--width4 {
+    width: gs-span(4);
+}
+
+.tooltip-box__close {
+    float: right;
+    margin-bottom: $gs-baseline / 2;
+    width: auto;
+}
+
+.tooltip-box__p {
+    margin-top: $gs-baseline / 2;
+    text-align: left;
+}

--- a/static/test/javascripts/spec/common/discussion/recommendation.spec.js
+++ b/static/test/javascripts/spec/common/discussion/recommendation.spec.js
@@ -22,7 +22,7 @@ function (
                         'icon',
                     '</div>',
                     // Tooltip
-                    '<div class="js-rec-tooltip tooltip-box-hidden">',
+                    '<div class="js-rec-tooltip" hidden>',
                         '<a class="js-rec-tooltip-link" href="http://theguardian.com/test/signin?keep=this">Sign in</a>',
                     '</div>',
                     // Comment list, used to understand if we're open for recommendations
@@ -95,13 +95,13 @@ function (
             .then(function () {
                 expect(discussionApi.recommendComment).not.toHaveBeenCalled();
                 expect(target.classList.contains('d-comment__recommend--recommended')).toBe(false, 'clicked classList');
-                expect(tooltip.classList.contains('tooltip-box-hidden')).toBe(false, 'hidden classList');
+                expect(tooltip.hasAttribute('hidden')).toBe(false, 'hidden attribute');
                 expect(link.getAttribute('href')).toBe('http://theguardian.com/test/signin?keep=this&returnUrl=http://theguardian.com/comment-1');
 
                 return upvote.closeTooltip();
             })
             .then(function () {
-                expect(tooltip.classList.contains('tooltip-box-hidden')).toBe(true, 'hidden classList');
+                expect(tooltip.hasAttribute('hidden')).toBe(true, 'hidden attribute');
             })
             .then(done)
             .catch(done.fail);

--- a/static/test/javascripts/spec/common/discussion/recommendation.spec.js
+++ b/static/test/javascripts/spec/common/discussion/recommendation.spec.js
@@ -1,0 +1,110 @@
+define([
+    'common/utils/$',
+    'common/modules/discussion/upvote'
+],
+function (
+    $,
+    upvote
+) {
+    describe('Recommendations of comments', function () {
+        var discussionApi = {
+            recommendComment: function () {}
+        };
+
+        beforeEach(function () {
+            // The contract to keep in mind is that comments loader calls
+            // `upvote.handle` when clicking on a recommendation
+            // `upvote.closeTooltip` when clicking on the tooltip close
+            $('body').append([
+                '<div class="recommendation-test">',
+                    // Upvote icon
+                    '<div class="js-recommend-comment" data-comment-id="1" data-comment-url="http://theguardian.com/comment-1">',
+                        'icon',
+                    '</div>',
+                    // Tooltip
+                    '<div class="js-rec-tooltip tooltip-box-hidden">',
+                        '<a class="js-rec-tooltip-link" href="http://theguardian.com/test/signin?keep=this">Sign in</a>',
+                    '</div>',
+                    // Comment list, used to understand if we're open for recommendations
+                    '<div class="d-discussion--recommendations-open"></div>',
+                '</div>'
+            ].join(''));
+        });
+
+        afterEach(function () {
+            $('.recommendation-test').remove();
+        });
+
+        it('should send a request to discussion API if the user is logged in', function (done) {
+            spyOn(discussionApi, 'recommendComment').and.callFake(function () {
+                return Promise.resolve();
+            });
+            var target = document.querySelector('.js-recommend-comment');
+
+            upvote.handle(
+                target,
+                document.querySelector('.recommendation-test'),
+                'fabio',
+                discussionApi
+            )
+            .then(function () {
+                expect(discussionApi.recommendComment).toHaveBeenCalled();
+                expect(target.classList.contains('d-comment__recommend--recommended')).toBe(true, 'clicked classList');
+                expect(target.classList.contains('js-recommend-comment')).toBe(false, 'action classList');
+            })
+            .then(done)
+            .catch(done.fail);
+        });
+
+        it('should allow retry if the discussion api returns an error', function (done) {
+            spyOn(discussionApi, 'recommendComment').and.callFake(function () {
+                return Promise.reject(new Error('discussion api error'));
+            });
+            var target = document.querySelector('.js-recommend-comment');
+
+            upvote.handle(
+                target,
+                document.querySelector('.recommendation-test'),
+                'fabio',
+                discussionApi
+            )
+            .then(done.fail)
+            .catch(function () {
+                expect(discussionApi.recommendComment).toHaveBeenCalled();
+                expect(target.classList.contains('d-comment__recommend--recommended')).toBe(false, 'clicked classList');
+                expect(target.classList.contains('js-recommend-comment')).toBe(true, 'action classList');
+            })
+            .then(done)
+            .catch(done.fail);
+        });
+
+        it('should show a tooltip with a return link to the upvoted comment', function (done) {
+            spyOn(discussionApi, 'recommendComment').and.callFake(function () {
+                return Promise.reject(new Error('discussion api error'));
+            });
+            var target = document.querySelector('.js-recommend-comment');
+            var tooltip = document.querySelector('.js-rec-tooltip');
+            var link = document.querySelector('.js-rec-tooltip-link');
+
+            upvote.handle(
+                target,
+                document.querySelector('.recommendation-test'),
+                null,
+                discussionApi
+            )
+            .then(function () {
+                expect(discussionApi.recommendComment).not.toHaveBeenCalled();
+                expect(target.classList.contains('d-comment__recommend--recommended')).toBe(false, 'clicked classList');
+                expect(tooltip.classList.contains('tooltip-box-hidden')).toBe(false, 'hidden classList');
+                expect(link.getAttribute('href')).toBe('http://theguardian.com/test/signin?keep=this&returnUrl=http://theguardian.com/comment-1');
+
+                return upvote.closeTooltip();
+            })
+            .then(function () {
+                expect(tooltip.classList.contains('tooltip-box-hidden')).toBe(true, 'hidden classList');
+            })
+            .then(done)
+            .catch(done.fail);
+        });
+    });
+});


### PR DESCRIPTION
## What does this change?
- refactor: move the recommendation logic in its own file and report errors
- feature: show a tooltip when anonymous users click on recommend
## What is the value of this and can you measure success?

Maybe more logins? Actually it's just because a button doing nothing is stupid.
## Does this affect other platforms - Amp, Apps, etc?

Nope
## Screenshots

![screen shot 2016-08-01 at 17 32 23](https://cloud.githubusercontent.com/assets/680284/17301551/7ff0b29c-580f-11e6-8b0a-134c9702a29f.png)
## Request for comment

@NathanielBennett I've reuse the CSS of `report` comment, moving it to a generic `tooltip` module.

@sndrs not sure if I can use atomic CSS already

The wording might require some work, UX is on it.
## TODO
- [x] Unit tests
- [x] UX
