### PR TITLE
Hide content footer in AMP live blog

### DIFF
--- a/article/app/views/liveblog/liveBlogBody.scala.html
+++ b/article/app/views/liveblog/liveBlogBody.scala.html
@@ -123,7 +123,9 @@
         </div>
     </article>
 
-    @fragments.contentFooter(article, model.related)
+    @if(!amp) {
+        @fragments.contentFooter(article, model.related)
+    }
 
 </div>
 }


### PR DESCRIPTION
## What does this change?

Discussion on AMP is superfluous and is dependant on JavaScript that is not available to AMP pages. This change will remove the content footer from the AMP live blog, and with it the discussion functionality, as well as other components that AMP documents do not support. This will achieve parity with the AMP version of the article body, which also excludes the `contentFooter` fragment.

The user will still see a "View comments" link that links to the canonical non-AMP live blog comments. 
## Screenshots
### Before

![picture 52](https://cloud.githubusercontent.com/assets/5931528/17301774/b61896f4-5810-11e6-8114-b68f8ad2f4cf.png)
### After

![picture 53](https://cloud.githubusercontent.com/assets/5931528/17301783/c6487c06-5810-11e6-846a-30a54d1f2336.png)
## Request for comment

@johnduffell @TBonnin @NataliaLKB 
