### PR TITLE
messaging for geo-blocked video

### DIFF
--- a/static/src/javascripts/bootstraps/enhanced/media/main.js
+++ b/static/src/javascripts/bootstraps/enhanced/media/main.js
@@ -119,7 +119,7 @@ define([
 
         return player;
     }
-    
+
     function removeCaptionLink(){
         bonzo($('.caption--main a')).remove();
     }
@@ -240,109 +240,138 @@ define([
                     player.controlBar.dispose();
                 });
             } else {
-                blockVideoAds = videoInfo.shouldHideAdverts;
-                withPreroll = shouldPreroll && !blockVideoAds;
-
-                // Location of this is important.
-                events.bindErrorHandler(player);
-                player.guMediaType = mediaType;
-
-                playerSetupComplete = new Promise(function (resolve) {
-                    player.ready(function () {
-                        var vol;
-
-                        deferToAnalytics(function () {
-                            events.initOmnitureTracking(player, mediaId);
-                            events.initOphanTracking(player, mediaId);
-
-                            events.bindGlobalEvents(player);
-                            events.bindContentEvents(player);
-                            if (withPreroll) {
-                                events.bindPrerollEvents(player);
-                            }
-                        });
-
-                        initLoadingSpinner(player);
-                        upgradeVideoPlayerAccessibility(player);
-
-                        player.one('playing', function() {
-                            beacon.counts('video-tech-html5');
-                        });
-
-                        // unglitching the volume on first load
-                        vol = player.volume();
-                        if (vol) {
-                            player.volume(0);
-                            player.volume(vol);
-                        }
-
-                        player.persistvolume({namespace: 'gu.vjs'});
-
-                        // preroll for videos only
-                        if (mediaType === 'video') {
-                            player.fullscreener();
-
-                            if (showEndSlate && detect.isBreakpoint({ min: 'desktop' })) {
-                                initEndSlate(player, endSlateUri);
-                            }
-
-                            if (withPreroll) {
-                                raven.wrap(
-                                    { tags: { feature: 'media' } },
-                                    function () {
-                                        player.ima({
-                                            id: mediaId,
-                                            adTagUrl: getAdUrl(),
-                                            prerollTimeout: 1000,
-                                            // We set this sightly higher so contrib-ads never timeouts before ima.
-                                            contribAdsSettings: {
-                                                timeout: 2000
-                                            }
-                                        });
-                                        player.on('adstart', function() {
-                                            player.skipAd(mediaType, 15);
-                                        });
-                                        player.ima.requestAds();
-
-                                        // Video analytics event.
-                                        player.trigger(events.constructEventName('preroll:request', player));
-                                        resolve();
-                                    }
-                                )();
-                            } else {
-                                resolve();
-                            }
-                        } else {
-                            player.playlist({
-                                mediaType: 'audio',
-                                continuous: false
-                            });
-                            resolve();
-                        }
-
-                        // built in vjs-user-active is buggy so using custom implementation
-                        player.on('mousemove', function () {
-                            clearTimeout(mouseMoveIdle);
-                            fastdom.write(function () {
-                                player.addClass('vjs-mousemoved');
-                            });
-
-                            mouseMoveIdle = setTimeout(function () {
-                                fastdom.write(function () {
-                                    player.removeClass('vjs-mousemoved');
-                                });
-                            }, 500);
-                        });
+                var geoBlocked = new Promise(function(resolve) {
+                    ajax({
+                        url: $el[0].currentSrc,
+                        crossOrigin: true,
+                        method: 'head'
+                    }).then(function() {
+                        resolve(false);
+                    }, function (response) {
+                        // videos are blocked at the CDN level
+                        resolve(response.status === 403);
                     });
                 });
 
-                playerSetupComplete.then(function () {
-                    if(ab.isInVariant('VideoCaption','caption-overlay')) {
-                        addTitleBar();
-                    }
+                geoBlocked.then(function (isGeoBlocked) {
+                    if(isGeoBlocked) {
+                        player.ready(function() {
+                            player.error({
+                                code: 0,
+                                type: 'Video Unavailable',
+                                message: 'Sorry, this video is not available in your region.'
+                            });
+                            player.bigPlayButton.dispose();
+                            player.errorDisplay.open();
+                            player.controlBar.dispose();
+                        });
+                    } else {
+                        blockVideoAds = videoInfo.shouldHideAdverts;
+                        withPreroll = shouldPreroll && !blockVideoAds;
 
-                    if (autoplay) {
-                        player.play();
+                        // Location of this is important.
+                        events.bindErrorHandler(player);
+                        player.guMediaType = mediaType;
+
+                        playerSetupComplete = new Promise(function (resolve) {
+                            player.ready(function () {
+                                var vol;
+
+                                deferToAnalytics(function () {
+                                    events.initOmnitureTracking(player, mediaId);
+                                    events.initOphanTracking(player, mediaId);
+
+                                    events.bindGlobalEvents(player);
+                                    events.bindContentEvents(player);
+                                    if (withPreroll) {
+                                        events.bindPrerollEvents(player);
+                                    }
+                                });
+
+                                initLoadingSpinner(player);
+                                upgradeVideoPlayerAccessibility(player);
+
+                                player.one('playing', function() {
+                                    beacon.counts('video-tech-html5');
+                                });
+
+                                // unglitching the volume on first load
+                                vol = player.volume();
+                                if (vol) {
+                                    player.volume(0);
+                                    player.volume(vol);
+                                }
+
+                                player.persistvolume({namespace: 'gu.vjs'});
+
+                                // preroll for videos only
+                                if (mediaType === 'video') {
+                                    player.fullscreener();
+
+                                    if (showEndSlate && detect.isBreakpoint({ min: 'desktop' })) {
+                                        initEndSlate(player, endSlateUri);
+                                    }
+
+                                    if (withPreroll) {
+                                        raven.wrap(
+                                            { tags: { feature: 'media' } },
+                                            function () {
+                                                player.ima({
+                                                    id: mediaId,
+                                                    adTagUrl: getAdUrl(),
+                                                    prerollTimeout: 1000,
+                                                    // We set this sightly higher so contrib-ads never timeouts before ima.
+                                                    contribAdsSettings: {
+                                                        timeout: 2000
+                                                    }
+                                                });
+                                                player.on('adstart', function() {
+                                                    player.skipAd(mediaType, 15);
+                                                });
+                                                player.ima.requestAds();
+
+                                                // Video analytics event.
+                                                player.trigger(events.constructEventName('preroll:request', player));
+                                                resolve();
+                                            }
+                                        )();
+                                    } else {
+                                        resolve();
+                                    }
+                                } else {
+                                    player.playlist({
+                                        mediaType: 'audio',
+                                        continuous: false
+                                    });
+                                    resolve();
+                                }
+
+                                // built in vjs-user-active is buggy so using custom implementation
+                                player.on('mousemove', function () {
+                                    clearTimeout(mouseMoveIdle);
+                                    fastdom.write(function () {
+                                        player.addClass('vjs-mousemoved');
+                                    });
+
+                                    mouseMoveIdle = setTimeout(function () {
+                                        fastdom.write(function () {
+                                            player.removeClass('vjs-mousemoved');
+                                        });
+                                    }, 500);
+                                });
+                            });
+                        });
+
+                        playerSetupComplete.then(function () {
+                            if(ab.isInVariant('VideoCaption','caption-overlay')) {
+                                addTitleBar();
+                            }
+
+                            if (autoplay) {
+                                player.play();
+                            }
+                        });
+
                     }
                 });
             }


### PR DESCRIPTION
## What does this change?

We can currently geo-block videos, this adds some messaging to the video element if you're in a blocked region.

The videos are blocked at the CDN level. Annoyingly, videojs doesn't make it easy to view the status code, so lets just make a HEAD request to get the response code. If its a 403, then we say the video isn't available. Any other status code is handled how they usually are.
## What is the value of this and can you measure success?

Better UX as the user gets some feedback vs the current loading animation.
## Does this affect other platforms - Amp, Apps, etc?

No.
## Screenshots

![screen shot 2016-08-01 at 18 41 23](https://cloud.githubusercontent.com/assets/836140/17303199/9f31f406-5817-11e6-8d57-87b9a3de3a85.jpeg)
## Request for comment

@guardian/guardian-frontend as @gidsg is at a conference and (@jamesgorrie has gone somewhere...)

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
