### PR TITLE
Messenger.js: remove all responses to frames we're not sure of

### DIFF
--- a/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
+++ b/static/src/javascripts/projects/common/modules/commercial/dfp/messenger.js
@@ -6,9 +6,7 @@ define([
     var listeners = {};
     var registeredListeners = 0;
 
-    var error400 = { code: 400, message: 'Bad request' };
     var error405 = { code: 405, message: 'Service %% not implemented' };
-    var error418 = { code: 418, message: 'I\'m a teapot' };
     var error500 = { code: 500, message: 'Internal server error\n\n%%' };
 
     return {
@@ -56,7 +54,6 @@ define([
     function onMessage(event) {
         // We only allow communication with ads created by DFP
         if (event.origin !== currentHost) {
-            respond(error400, null);
             return;
         }
 
@@ -66,12 +63,10 @@ define([
             // Source: https://bugs.chromium.org/p/chromium/issues/detail?id=536620#c11
             var data = JSON.parse(event.data);
         } catch( ex ) {
-            respond(error418, null);
             return;
         }
 
         if (!isValidPayload(data)) {
-            respond(error400, null);
             return;
         }
 

--- a/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
+++ b/static/test/javascripts/spec/common/commercial/dfp/messenger.spec.js
@@ -51,33 +51,28 @@ define([
             expect(mockWindow.removeEventListener).toHaveBeenCalled();
         });
 
-        it('should respond with a 400 code when origin is not whitelisted', function () {
+        it('should not respond when origin is not whitelisted', function () {
             onMessage({ origin: 'http://google.com', source: mockFrame });
-            expect(mockFrame.postMessage).toHaveBeenCalled();
-            expect(response.error.code).toBe(400);
+            expect(mockFrame.postMessage).not.toHaveBeenCalled();
         });
 
-        it('should respond with a 418 code when sending malformed JSON', function () {
+        it('should not respond when sending malformed JSON', function () {
             onMessage({ origin: 'http://localhost:9876', data: '{', source: mockFrame });
-            expect(mockFrame.postMessage).toHaveBeenCalled();
-            expect(response.error.code).toBe(418);
+            expect(mockFrame.postMessage).not.toHaveBeenCalled();
         });
 
-        it('should respond with a 400 code when sending incomplete payload', function () {
+        it('should not respond when sending incomplete payload', function () {
             var payloads = [
                 { type: 'missing data' },
                 { value: 'missing type' },
                 { type: 'unregistered', value: 'type' }
             ];
             onMessage({ origin: 'http://localhost:9876', data: JSON.stringify(payloads[0]), source: mockFrame });
-            expect(mockFrame.postMessage).toHaveBeenCalled();
-            expect(response.error.code).toBe(400);
+            expect(mockFrame.postMessage).not.toHaveBeenCalled();
             onMessage({ origin: 'http://localhost:9876', data: JSON.stringify(payloads[1]), source: mockFrame });
-            expect(mockFrame.postMessage).toHaveBeenCalled();
-            expect(response.error.code).toBe(400);
+            expect(mockFrame.postMessage).not.toHaveBeenCalled();
             onMessage({ origin: 'http://localhost:9876', data: JSON.stringify(payloads[2]), source: mockFrame });
-            expect(mockFrame.postMessage).toHaveBeenCalled();
-            expect(response.error.code).toBe(400);
+            expect(mockFrame.postMessage).not.toHaveBeenCalled();
         });
 
         it('should respond with a 405 code when no listener is attached to a message type', function () {


### PR DESCRIPTION
The `messenger.js` module was too loquacious and eager to reply to any message coming its way, which is believed to slow down pages too much.

This fix removes all responses geared from messages we're not sure if they are bona fide messenger requests.

cc @guardian/commercial-dev 
