### PR TITLE
use unique magneto key name

### DIFF
--- a/common/app/common/configuration.scala
+++ b/common/app/common/configuration.scala
@@ -365,7 +365,7 @@ class GuardianConfiguration extends Logging {
       lazy val domain = configuration.getStringProperty("magento.domain")
       lazy val consumerKey = configuration.getStringProperty("magento.consumer.key")
       lazy val consumerSecret = configuration.getStringProperty("magento.consumer.secret")
-      lazy val accessToken = configuration.getStringProperty("magento.access.token")
+      lazy val accessToken = configuration.getStringProperty("magento.access.token.key")
       lazy val accessTokenSecret = configuration.getStringProperty("magento.access.token.secret")
       lazy val authorizationPath = configuration.getStringProperty("magento.auth.path")
       lazy val isbnLookupPath = configuration.getStringProperty("magento.isbn.lookup.path")


### PR DESCRIPTION
This changes the magneto key to have a unique name.  In java properties, dot is not a special charater.  In typesafe config it defines a hierarchy.  Unfortunately we had two keys where one was a parent of the other in the new world, this means there was a collision and it wasn't sure what to do, leading to a None.get in dev-build.

@NataliaLKB 
