### PR TITLE
Alter the email list for the email preferences page

### DIFF
--- a/identity/app/model/EmailSubscriptions.scala
+++ b/identity/app/model/EmailSubscriptions.scala
@@ -143,39 +143,6 @@ object EmailSubscriptions {
     )
   )
 
-  def moreFromTheguardianEmails(subscribedListIds: Iterable[String] = None) = List(
-    // Guardian favourites
-    EmailSubscription(
-      "Guardian Masterclasses",
-      "guardian favourites",
-      "Courses and training",
-      "News on the latest classes, blog content and competitions from the Guardian's learning programme. Plus inspiring tips from world-class tutors on everything from journalism and creative writing to culture and general knowledge, delivered to your inbox.",
-      "Twice a week",
-      "3561",
-      subscribedTo = subscribedListIds.exists{ x => x == "3561" }
-    ),
-
-    EmailSubscription(
-      "Guardian Gardener",
-      "guardian favourites",
-      "Gardening",
-      "Tips and seasonal advice from our expert gardeners to help you care for any green space: whether you have acres or plant pots. Plus shop for bulbs, plants and garden hardware sourced from our favourite independent suppliers.",
-      "1-2 times per week",
-      "3562",
-      subscribedTo = subscribedListIds.exists{ x => x == "3562" }
-    ),
-
-    EmailSubscription(
-      "Guardian Bookshop",
-      "guardian favourites",
-      "Books",
-      "Every week you’ll receive our hand-picked edits of books we know you’ll enjoy. From thought-provoking collections, round-ups of the Guardian and Observer weekend reviews and special offers plus from time to time we’ll give you first preview of the books we publish and new and noteworthy titles to look out for each month.",
-      "Every Wednesday, Saturday and Sunday",
-      "3563",
-      subscribedTo = subscribedListIds.exists{ x => x == "3563" }
-    )
-  )
-
   def newsEmails(subscribedListIds: Iterable[String] = None) = List(
     EmailSubscription(
       "The Long Read",
@@ -329,5 +296,5 @@ object EmailSubscriptions {
       subscribedTo = subscribedListIds.exists{ x => x == "220" },
       exampleUrl = Some("http://www.theguardian.com/sport/series/thespin/latest/email")
     )
-  ) ++ newsEmails(subscribedListIds) ++ australianEmails(subscribedListIds) ++ cultureEmails(subscribedListIds) ++ moreFromTheguardianEmails(subscribedListIds))
+  ) ++ newsEmails(subscribedListIds) ++ australianEmails(subscribedListIds) ++ cultureEmails(subscribedListIds))
 }

--- a/identity/app/model/EmailSubscriptions.scala
+++ b/identity/app/model/EmailSubscriptions.scala
@@ -203,6 +203,16 @@ object EmailSubscriptions {
       exampleUrl = Some("http://www.theguardian.com/environment/series/green-light/latest/email")
     ),
     EmailSubscription(
+      "Lab notes",
+      "news",
+      "Science",
+      "Get a weekly round-up of the biggest stories in science, insider knowledge from our network of bloggers, and some distractingly good fun and games.",
+      "Every Friday",
+      "3701",
+      subscribedTo = subscribedListIds.exists{ x => x == "3701" },
+      exampleUrl = Some("https://www.theguardian.com/science/series/lab-notes/latest/email")
+    ),
+    EmailSubscription(
       "Poverty matters",
       "news",
       "Global development",

--- a/identity/app/views/profile/emailPrefs.scala.html
+++ b/identity/app/views/profile/emailPrefs.scala.html
@@ -45,7 +45,7 @@
               <div class="form__error">@emailPrefsForm.globalErrors.map(_.message).mkString(", ")</div>
             }
             <div class="email-subscriptions">
-                @List("news", "sport", "culture", "lifestyle", "comment", "guardian favourites").zipWithIndex.map { case(theme, index) =>
+                @List("news", "sport", "culture", "lifestyle", "comment").zipWithIndex.map { case(theme, index) =>
                   @emailListCategoryList(theme, emailSubscriptions.subscriptions.filter(_.theme == theme), index == 0)
                 }
             </div>


### PR DESCRIPTION
## What does this change?
- Remove the 'Guardian Favourites' section and subscriptions from the email preferences page
- Add 'Lab notes' as an option on the email preferences page

(https://profile.theguardian.com/email-prefs)
## What is the value of this and can you measure success?
- Users no longer see inactive emails listed as options
- Users can manage their subscription to 'Lab notes'
## Does this affect other platforms - Amp, Apps, etc?

No
## Screenshots
### Updated sections list:

<img width="836" alt="picture 149" src="https://cloud.githubusercontent.com/assets/8607683/17326822/c4817080-58ab-11e6-9ae8-86d70e01e7e7.png">
### Lab notes:

<img width="835" alt="picture 148" src="https://cloud.githubusercontent.com/assets/8607683/17326829/d2f2e3a6-58ab-11e6-8222-9fe03795ba3c.png">
## Request for comment
